### PR TITLE
feat(clientes): fundacion de clientes, proveedores y listas de precio (etapa 2, slice 1)

### DIFF
--- a/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
+++ b/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
@@ -205,3 +205,103 @@ None. Slice 1 is fully done.
 ## TDD Cycle Evidence (batch 2)
 
 Same as batch 1 — Standard Mode, no strict-TDD signal from the orchestrator for this run.
+
+---
+
+## Batch 3 — judgment-day round 1 fixes (branch `feat/stage2-slice1-fundacion`)
+
+**Trigger:** first judgment-day round (dual blind review) over the batch 1–2 diff surfaced 1
+CRITICAL, 1 GATE-APPROVED schema hardening item (approved by the user 2026-08-02, same
+session as the original DB CHANGE GATE), 2 confirmed items, and 3 hardening items, plus 3
+comment-only items. All applied this batch.
+
+### Completed in batch 3
+
+1. **Per-artifact backfill idempotency (CRITICAL)** — `BackfillDeClientesYListasPrecioAsync`'s
+   coverage check was a UNION of tenants-with-CF and tenants-with-default-lista: a tenant with
+   only ONE of the two rows (partial backfill from an earlier failed run, or hand-migrated
+   data) was permanently skipped. Rewritten to evaluate each artifact independently — the
+   default lista is created if the tenant has none, the CF cliente is created if the tenant
+   has none — still one transaction per tenant. New test
+   `BackfillPorArtefactoTests.UnTenantConSoloListaYOtroConSoloClienteCfGananLaMitadFaltantePorBackfill`
+   (own `WaysApiFixture`, to avoid the "seed before first `CreateClient()`" trick depending on
+   test-method execution order within a shared fixture) seeds one tenant with only the lista
+   and another with only the CF cliente, and asserts each gains exactly its missing half
+   without duplicating the half it already had.
+2. **Composite `fk_clientes_lista_precio` (GATE-APPROVED schema hardening)** — the FK was a
+   single column against `listas_precio.id_lista_precio` (PK, globally unique across tenants):
+   an `id_lista_precio` belonging to ANOTHER tenant was a row that genuinely exists, so the FK
+   never rejected it — only RLS did, at runtime. Added alternate key `(Id, IdTenant)` on
+   `ListaPrecio` (`ak_listas_precio_id_tenant`) and changed the FK to composite
+   `(IdListaPrecio, IdTenant) → listas_precio(Id, IdTenant)`. The unmerged migration
+   `20260802172552_ClientesYProveedoresEtapa2` was edited in place (Up/Down, `.Designer.cs`,
+   `WaysDbContextModelSnapshot.cs`) rather than regenerated wholesale — a `migrations remove` +
+   `migrations add` cycle was tried first and discarded: it picked up an unrelated spurious
+   `AddCheckConstraint`/`DropCheckConstraint` pair for `ck_categorias_padre_no_self` (already
+   present since the `CatalogosDeTenant` migration) as an EF diffing artifact of reverting and
+   rescaffolding, and it also dropped the hand-written `HabilitarRlsDeTenant(...)` calls that
+   aren't part of the model and only exist because a human added them to the original
+   migration. Hand-editing avoided both regressions. `dotnet ef migrations
+   has-pending-model-changes` confirmed clean after the edit. New smoke test
+   `BackstopClientesYProveedoresTests.UnClienteConIdListaPrecioDeOtroTenantViolaLaFkCompuesta`
+   inserts a cliente whose `id_lista_precio` is a real row of a DIFFERENT tenant → 23503.
+3. **42501 INSERT proofs (confirmed)** — `ClientesYProveedoresRlsTests` only had SELECT/UPDATE
+   cross-tenant proofs; added `UnInsertConIdTenantAjenoSeRechaza` (mirrors
+   `CatalogosDeTenantRlsTests`'s method of the same name) as a `[Theory]` over
+   clientes/proveedores/listas_precio/numeraciones_clientes → 42501, plus one EF-level (LINQ)
+   cross-tenant-read proof,
+   `ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas`, mirroring
+   `AislamientoDeTenantTests.ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant` for the 3 new
+   EF-tracked entities (`NumeracionCliente` is SQL-crudo-only by design, out of this proof).
+   Class docstring updated to describe what the class now actually covers.
+4. **Composite-FK smoke tests (triaged real)** — added the 4 missing cases to
+   `BackstopClientesYProveedoresTests`: `fk_clientes_empresa`, `fk_proveedores_empresa`,
+   `fk_listas_precio_empresa` (all composite, nullable `id_empresa` with a non-null-but-bogus
+   value to force MATCH SIMPLE to evaluate) and `fk_listas_precio_lista_base` (simple,
+   self-referencing) — all 23503, `ConstraintName` asserted on each.
+5. **Counter concurrency test (hardening)** — new
+   `AsignadorDeNumeroClienteConcurrenciaTests.DosAsignacionesConcurrentesDelMismoTenantDanNumerosDistintosYConsecutivos`:
+   3 rounds of 2 concurrent `AsignadorDeNumeroCliente.AsignarSiguienteAsync` calls against the
+   same tenant's counter, against real Postgres. No rendezvous interceptor needed (unlike
+   `ParametrosTests`'s race test) — the `UPDATE ... RETURNING` on the counter row is
+   unconditional, so Postgres's own row lock serializes the two transactions. All 6 assigned
+   numbers collected across the 3 rounds and asserted to be exactly consecutive, no gaps or
+   duplicates.
+6. **`NumeracionCliente` ChangeTracker guard (hardening)** — `NumeracionCliente`'s doc comment
+   already claimed `AsignadorDeNumeroCliente` (raw SQL) is its only legitimate writer, but
+   nothing enforced it: an `Added`/`Modified` entry reaching `SaveChanges` via the
+   `ChangeTracker` went through silently. New `WaysDbContext.RechazarEscriturasDeNumeracionCliente`
+   (called first inside `EstamparTenant`) throws `InvalidOperationException` for any such
+   entry — same defense-in-depth pattern as the `IdTenant` tamper guard. 3 new unit tests
+   (`GuardDeNumeracionClienteTests`, InMemory provider, no Postgres needed since the guard
+   throws before `base.SaveChanges()` ever runs) cover Added-rejected, Modified-rejected, and
+   Unchanged-passes-through. `ClientesYProveedoresRlsTests.NumeracionesClientesEsInvisibleParaOtroTenant`
+   (the one existing test that wrote a `NumeracionCliente` via `db.NumeracionesClientes.Add`)
+   was migrated to `AsignadorDeNumeroCliente.AsegurarContadorAsync`, the now-only-legal path.
+7. **Spanish comments (3 items)** — exemption notes on the `_cuit`/`_numero` branches of
+   `ManejadorDeErrores.ClasificarUnicidad` explaining why they're exempt from the
+   `db-error-backstops` race-test requirement until Slice 2/3's create endpoints exist (tasks
+   2.5/3.5 will add the race tests then); a note on `ReglaDeClientes` documenting the known
+   renumber-then-delete two-step bypass of `ck_clientes_cf_protegido` and why closing it is
+   explicitly out of scope for this slice (closed by `ServicioDeClientes`'s service-level guard
+   in Slice 2); a note on `BackfillDeClientesYListasPrecioAsync`'s doc comment listing the two
+   invariants its per-artifact coverage check depends on.
+
+### Verification performed this batch
+
+- `dotnet build Ways.slnx` → 0 errors, 0 warnings.
+- `dotnet ef migrations has-pending-model-changes` → clean, after the in-place composite-FK
+  edit.
+- `dotnet test Ways.slnx`, run **twice** for stability, identical results both times:
+  - `Ways.Domain.Tests`: **69/69** (unchanged — no Domain-layer tests touched this batch).
+  - `Ways.Application.Tests`: **94/94** (91 + 3 new `GuardDeNumeracionClienteTests`).
+  - `Ways.IntegrationTests`: **103/103** (91 + 12 new: 5 `BackstopClientesYProveedoresTests` +
+    5 `ClientesYProveedoresRlsTests` (4-case `UnInsertConIdTenantAjenoSeRechaza` theory + 1
+    EF-level fact) + 1 `BackfillPorArtefactoTests` + 1
+    `AsignadorDeNumeroClienteConcurrenciaTests`). The pre-existing `ParametrosTests`
+    rendezvous-flake risk documented in batch 1F/1.13 did not surface in either run. Docker up
+    (Testcontainers-backed real Postgres) both times.
+
+### Blocked
+
+None.

--- a/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
+++ b/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
@@ -1,0 +1,118 @@
+# Apply progress: Stage 2 — Clientes y Proveedores
+
+## Batch 1 (this apply)
+
+**Scope:** Slice 1 only (`tasks.md` § Slice 1: Schema, Domain Foundation & Provisioning),
+stopped at the DB CHANGE GATE (task 1.1) as instructed. No EF Core migration was generated
+or applied. Branch `feat/stage2-slice1-fundacion` off `main`, work-unit commits, no push/PR.
+
+### Completed
+
+- **1.2–1.5** — Domain: `Cliente : EntidadTenant` (`Ways.Domain/Clientes`), `Proveedor :
+  EntidadTenant` (`Ways.Domain/Proveedores`), `ListaPrecio : CatalogoSimple`
+  (`Ways.Domain/Catalogos`, reuses the generic EF base per design decision 1),
+  `NumeracionCliente` (standalone, `id_tenant` PK — no `EntidadBase`), `TipoDocumento`/
+  `ModoLista` native-enum-shaped C# enums.
+- **1.6** — `ReglaDeClientes.ValidarNoConsumidorFinal`/`EsConsumidorFinal` (pure, no DB) +
+  6 unit tests (`tests/Ways.Domain.Tests/Clientes/ReglaDeClientesTests.cs`).
+- **1.8** — `AsignadorDeNumeroCliente` (`Ways.Application/Clientes`, static — no DI
+  lifecycle, `IWaysDbContext` passed per call): `AsegurarContadorAsync` (idempotent
+  `INSERT ... ON CONFLICT DO NOTHING`) + `AsignarSiguienteAsync` (`UPDATE ... RETURNING`),
+  raw ADO.NET on `Database.GetDbConnection()`/`CurrentTransaction`, never
+  `SqlQuery<T>()`/`FromSqlRaw<T>()` (design decisions 2/3, stage-1 slice-2 precedent). Opens
+  via `Database.OpenConnectionAsync()` when the connection isn't already open, so
+  `InterceptorDeContextoDeTenant` fires and sets the RLS GUCs — never a raw
+  `conexion.OpenAsync()` on the ADO.NET connection directly.
+- **1.9** — `PlantillaDeAprovisionamiento.V1` extended in place (design decision 5): added
+  `ListaPrecioGeneral`/`ClienteConsumidorFinal` records, removed the now-closed
+  `ItemsDiferidos` gap declaration. 2 unit tests replace the old `ItemsDiferidos` test.
+- **1.12** — `ManejadorDeErrores`: new `23514` case for `ck_clientes_cf_protegido` → 409
+  `consumidor_final_protegido`; `ClasificarUnicidad` extended with `_cuit` →
+  `cuit_duplicado`, `_numero` → `numero_duplicado`, `_default` → `default_duplicado` (the
+  existing `_nombre`/`fk_` prefix mappings already cover `listas_precio`'s nombre pair and
+  all 4 tables' new FKs — confirmed, no change needed there).
+- **1.13** — `ParametrosTests.InterceptorDeRendezVous.EsperarSiCorresponde`: `gate.Wait()` →
+  `gate.Wait(TimeSpan.FromSeconds(10))` + `Assert.True(...)` with a message, so a broken
+  rendezvous fails fast instead of hanging the test session.
+- **EF configurations** (not a separate numbered task, but required for 1.2–1.5 to be
+  usable): `ClienteConfiguration`, `ProveedorConfiguration`, `ListaPrecioConfiguration`
+  (extends `ConfiguracionDeCatalogo<ListaPrecio>`), `NumeracionClienteConfiguration` — all 4
+  tables' full column/index/FK/check-constraint shape from `design.md` § Table Shapes,
+  wired into `WaysDbContext` (new `DbSet`s + a hand-written `NumeracionCliente` tenant query
+  filter, same pattern as `Tenant`'s) and `IWaysDbContext`. `TipoDocumento`/`ModoLista`
+  registered as native Postgres enums in `WaysDbContextFactory` and
+  `DependencyInjection.ConfigurarNpgsql` (prod), plus `WaysApiFixture`'s two test-only
+  Npgsql configuration points — same "model ahead of migration" precedent as stage-1's
+  `CatalogosDeTenant` (`bc59d37`), confirmed safe: `db.Model.FindEntityType(...)` builds and
+  validates the model without a live connection, and `MapEnum` registration ahead of the
+  actual Postgres type didn't break anything on its own (see Deviations below for what DID
+  break and how it was resolved).
+- **1.14–1.17 (integration, GATED)** — `ClientesYProveedoresRlsTests.cs` (RLS SELECT/UPDATE
+  proofs for `clientes`/`proveedores`/`listas_precio` + a `numeraciones_clientes` visibility
+  test), `BackstopClientesYProveedoresTests.cs` (`ck_clientes_cf_protegido` 23514 backstop +
+  4 FK smoke tests, one theory covering all 4 tables' `fk_*_tenant`),
+  `ClientesProvisioningYBackfillTests.cs` (provisioning creates CF+General list; a
+  pre-existing tenant gains both via backfill and a second host start doesn't duplicate
+  them). All marked `[Fact(Skip = ...)]`/`[Theory(Skip = ...)]` — real assertions written
+  against the real API/EF surface, not stubs, but they cannot run until the migration exists
+  (10 skipped entries in the full run, see Verification below).
+- **Model-shape unit tests (no DB)** — `ModeloDeClientesYProveedoresTests.cs` (Application.Tests):
+  builds `WaysDbContext`'s Npgsql model without connecting, asserts `ux_clientes_numero`,
+  the 4 `clientes` FKs, `numero_documento` has no unique index anywhere, `ux_proveedores_cuit`
+  shape, the `listas_precio` default pair alongside the reused nombre pair, and
+  `numeraciones_clientes`'s `id_tenant`-as-PK/no-identity shape. Mirrors
+  `ModeloDeCatalogosTests`/`ModeloDeOrganizacionTests`.
+- **1.18** — Regression confirmed green: see Verification.
+
+### Deferred (deviation from the literal task list — see below)
+
+- **1.10** — Wiring `ServicioDeAprovisionamiento.CrearTenantAsync` to create the General
+  `listas_precio` row + the Consumidor Final `Cliente` inside the provisioning transaction
+  was written, then **reverted**, in this same batch.
+- **1.11** — `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync` was written,
+  then **not wired** into `EjecutarAsync` (call site never added) in this same batch.
+
+Both pieces of code touch `clientes`/`listas_precio`, which don't exist until the migration
+lands. `InicializadorDeBaseDeDatos.EjecutarAsync` runs on **every** integration test's first
+`CreateClient()` (`WaysApiFixture`) — wiring the backfill call broke the ENTIRE integration
+suite (63/74 failing, `42P01: relation "clientes" does not exist`), not just the new
+clientes-specific tests. Wiring `ServicioDeAprovisionamiento` alone (backfill left unwired)
+narrowed the blast radius to exactly `AprovisionamientoTests`' 2 tests that call
+`CrearTenantAsync` for real — still an existing-suite regression (task 1.18 requires the
+existing suites to stay green), and re-commenting the code out to "defer" it would violate
+this repo's own `S125`/`S1144` analyzer severities (`error`, `.editorconfig` lines 303-304 /
+354-355: no commented-out code, no unused private members). The only option that satisfies
+both "implement it" and "don't break the existing suite" was: write it once to confirm it
+compiles and reads correctly against the real entities (confirmed, then reverted via `git
+checkout --`), and defer the actual wiring to the batch that generates the migration — this
+also matches `tasks.md`'s own ordering, which places 1C (Migration, task 1.7) BEFORE 1D
+(counter/provisioning/backfill, tasks 1.8–1.11): 1.10/1.11's *wiring* genuinely depends on
+1.7 already having landed, even though 1.8/1.9 (the counter helper and the template data)
+don't. `AsignadorDeNumeroCliente` and the `Cliente`/`ListaPrecio` entities/configs are fully
+ready for both call sites to wire in with a two-line diff once the migration exists.
+
+### Blocked
+
+- **1.1** — DB CHANGE GATE: model summary presented to the user below (see the executor's
+  final response for this batch); awaiting explicit approval.
+- **1.7** — Generate migration `ClientesYProveedoresEtapa2`. Blocked on 1.1.
+- **1.10, 1.11** — See Deferred above. Unblocked by 1.7 landing (same batch).
+
+## Verification
+
+- `dotnet build Ways.slnx` — 0 warnings, 0 errors.
+- `dotnet test Ways.slnx`:
+  - `Ways.Domain.Tests`: 69/69 (baseline 61 + 8: 6 `ReglaDeClientesTests` + net +1 from
+    replacing `LosItemsDiferidosEstanDeclaradosNoDescartadosEnSilencio` with 2 new
+    `PlantillaDeAprovisionamientoTests`).
+  - `Ways.Application.Tests`: 91/91 (baseline 85 + 6 `ModeloDeClientesYProveedoresTests`).
+  - `Ways.IntegrationTests`: 74 passed + 10 skipped = 84 total (baseline 74 passed, 0
+    regressions, +10 new GATED tests skipped pending the migration). Docker was up
+    (Testcontainers-backed real Postgres) for this run.
+
+## TDD Cycle Evidence
+
+Strict TDD mode was not signaled by the orchestrator for this run (no
+`sdd-init/{project}` testing-capabilities injection was provided in the launch prompt); this
+batch followed Standard Mode — implementation followed by test coverage per task, not a
+RED-GREEN-REFACTOR cycle log.

--- a/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
+++ b/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
@@ -305,3 +305,32 @@ comment-only items. All applied this batch.
 ### Blocked
 
 None.
+
+## Post-verdict INFO fixes (judgment-day, feat/stage2-slice1-fundacion)
+
+Two INFO-level (non-blocking) items applied after the APPROVED judgment-day verdict on the
+`feat/stage2-slice1-fundacion` slice:
+
+1. **Tolerant default-list lookup** —
+   `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync`'s
+   `idListaDefaultPorTenant` lookup now filters `l.EsDefault && l.IdEmpresa == null` instead of
+   just `l.EsDefault`. The unfiltered `ToDictionaryAsync(l => l.IdTenant, l => l.Id)` would throw
+   on a duplicate key if a tenant ever ended up with both a shared default and a per-empresa
+   default lista at once; scoping to the documented "compartida" invariant makes that future
+   state degrade gracefully instead of crashing startup. Comment above the query updated to
+   explain the filter and the degrade-not-crash rationale.
+2. **AK naming convention** — renamed `ak_listas_precio_id_tenant` to
+   `ak_listas_precio_id_lista_precio_id_tenant` (matching `ak_empresas_id_empresa_id_tenant` and
+   siblings) in all four locations: `ListaPrecioConfiguration.cs`,
+   `20260802172552_ClientesYProveedoresEtapa2.cs`, its `.Designer.cs`, and
+   `WaysDbContextModelSnapshot.cs`.
+
+### Verification performed this batch
+
+- `dotnet build Ways.slnx` → 0 errors, 0 warnings.
+- `dotnet ef migrations has-pending-model-changes` → clean.
+- `dotnet test Ways.slnx`:
+  - `Ways.Domain.Tests`: **69/69**.
+  - `Ways.Application.Tests`: **94/94**.
+  - `Ways.IntegrationTests`: **103/103**.
+  - Baseline unchanged (69/94/103), all green.

--- a/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
+++ b/openspec/changes/stage-2-clientes-proveedores/apply-progress.md
@@ -110,9 +110,98 @@ ready for both call sites to wire in with a two-line diff once the migration exi
     regressions, +10 new GATED tests skipped pending the migration). Docker was up
     (Testcontainers-backed real Postgres) for this run.
 
-## TDD Cycle Evidence
+## TDD Cycle Evidence (batch 1)
 
 Strict TDD mode was not signaled by the orchestrator for this run (no
 `sdd-init/{project}` testing-capabilities injection was provided in the launch prompt); this
 batch followed Standard Mode — implementation followed by test coverage per task, not a
 RED-GREEN-REFACTOR cycle log.
+
+---
+
+## Batch 2 (this apply)
+
+**Trigger:** DB CHANGE GATE (task 1.1) **APPROVED by the user, 2026-08-02**, exactly as
+presented in batch 1 — all 4 tables, enums, RLS, partial unique indexes (incl. both
+single-default guarantees on `listas_precio` and the tenant-wide `cuit` index),
+`ck_clientes_cf_protegido`, and the full backfill plan (CF + General list per pre-existing
+tenant, transactional per tenant, idempotent).
+
+**Status:** Slice 1 **complete and runtime-verified**. Migration generated and applied
+(via `WaysApiFixture`'s owner-role `MigrateAsync` in every integration test run — no
+standalone local Postgres was migrated by hand, same as stage 1's pattern), tasks 1.10/1.11
+wired, all 10 previously-gated integration tests un-skipped and green, full suite run twice
+for stability with identical results both times.
+
+### Completed in batch 2
+
+- **1.7** — Generated `ClientesYProveedoresEtapa2` via `dotnet ef migrations add`. Before
+  generating, added 4 explicit snake_case index names to the EF configurations
+  (`ix_clientes_condicion_fiscal`, `ix_clientes_lista_precio`,
+  `ix_proveedores_condicion_fiscal`, `ix_listas_precio_lista_base`) — without them, EF's
+  scaffolder names FK-support indexes with its own convention (`IX_clientes_id_condicion_fiscal`
+  etc.), which would have been the first `IX_`-prefixed index in the entire migration history
+  (grepped: zero prior occurrences), breaking the doc-10 snake_case convention every other
+  migration keeps without exception. Regenerated after the fix — the migration diff matches
+  the approved model exactly, with clean names throughout. Hand-added
+  `migrationBuilder.HabilitarRlsDeTenant(...)` for all 4 tables at the end of `Up()` (EF's
+  scaffolder has no way to know about this raw-SQL convention), same pattern as
+  `CatalogosDeTenant`. `dotnet ef migrations has-pending-model-changes` confirms clean both
+  right after generation and again after wiring 1.10/1.11 (no model drift from the wiring).
+  File: `src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs`.
+- **1.10** — `ServicioDeAprovisionamiento.CrearTenantAsync` re-wired exactly as written (and
+  reverted) in batch 1: after seeding área/medios de pago, creates the General `listas_precio`
+  row, looks up the seeded `CF` `CondicionFiscal`, calls
+  `AsignadorDeNumeroCliente.AsegurarContadorAsync`/`AsignarSiguienteAsync` for the new tenant
+  (always returns `1` on a fresh counter), then inserts the Consumidor Final `Cliente` — all
+  inside the existing provisioning transaction (spec: Tenant Provisioning With Template Seed).
+- **1.11** — `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync` re-wired into
+  `EjecutarAsync`, running after `SembrarCatalogosFiscalesAsync` (needs `CF` to already exist).
+  Finds tenants missing *both* a `numero = 1` cliente and an `es_default` lista_precio,
+  processes each in its own transaction (execution-strategy wrapped, same pattern as
+  `ServicioDeAprovisionamiento`), explicit `IdTenant` per entity (platform mode, no
+  impersonation needed or supported by `TenantActualFijo`).
+- **1.14–1.17** — `[Skip]` removed from all 10 gated `[Fact]`/`[Theory]` methods across
+  `ClientesYProveedoresRlsTests.cs`, `BackstopClientesYProveedoresTests.cs`,
+  `ClientesProvisioningYBackfillTests.cs`. All green against Postgres real.
+- **Incidental fix, found while running the full suite** — `CatalogosGlobalesRlsTests.cs` had
+  3 methods (`LaPlataformaPuedeEscribirEnUnCatalogoGlobal`,
+  `UnaSesionDeTenantNoPuedeInsertarEnUnCatalogoGlobal`,
+  `SinContextoResueltoNoSePuedeEscribirEnUnCatalogoGlobal`) that only ever opened raw
+  connections (`AbrirConexionCrudaAsync`), never `fixture.CreateClient()` — a pre-existing
+  latent test-ordering fragility that this slice was the first to expose. When one of those 3
+  ran before any method that *does* call `CreateClient()` (order is not guaranteed within a
+  class), it seeded a raw `condiciones_fiscales` row directly, which made
+  `SembrarCatalogosFiscalesAsync`'s idempotency guard (`AnyAsync()` over the *whole* table,
+  not the specific base codes it's about to insert) see a non-empty table and skip seeding the
+  base 5 rows — including `CF`. Harmless before this slice (nothing depended on `CF`
+  specifically existing); now fatal, since `BackfillDeClientesYListasPrecioAsync` does. Fixed
+  by making all 3 methods call `fixture.CreateClient()` first, matching the convention every
+  other method in that class (and virtually every other integration test in the suite)
+  already follows. Test-only change — no production behavior touched, and the class's own RLS
+  assertions are unaffected (still checking the same policies against the same real Postgres).
+- **1.18** — Regression re-confirmed, twice, after all wiring: see Verification.
+
+### Blocked
+
+None. Slice 1 is fully done.
+
+## Verification (batch 2, final)
+
+- `dotnet build Ways.slnx` — 0 warnings, 0 errors.
+- `dotnet ef migrations has-pending-model-changes` — clean, both after generating the
+  migration and after wiring 1.10/1.11.
+- `dotnet test Ways.slnx`, run **twice** for stability, identical results both times:
+  - `Ways.Domain.Tests`: **69/69**.
+  - `Ways.Application.Tests`: **91/91**.
+  - `Ways.IntegrationTests`: **91/91**, 0 skipped (baseline 74 + 17 newly-active test cases:
+    the 10 un-skipped `[Fact]`/`[Theory]` methods include 2 theories with `MemberData`
+    (3 tables × 2 = 6 cases) and 1 theory with `InlineData` (4 tables) — Skip collapses a
+    theory to 1 reported entry regardless of row count, active theories expand to one result
+    per data row, which is why batch 1's "10 skipped" becomes "17 additional passing" here;
+    the math reconciles exactly: 7 (RLS theories + 1 fact) + 8 (backstop theory + 4 facts) +
+    2 (provisioning/backfill facts) = 17). Docker up (Testcontainers-backed real Postgres).
+
+## TDD Cycle Evidence (batch 2)
+
+Same as batch 1 — Standard Mode, no strict-TDD signal from the orchestrator for this run.

--- a/openspec/changes/stage-2-clientes-proveedores/design.md
+++ b/openspec/changes/stage-2-clientes-proveedores/design.md
@@ -1,0 +1,76 @@
+# Design: Stage 2 — Clientes y Proveedores
+
+## Technical Approach
+
+Add 4 tables (`listas_precio`, `numeraciones_clientes`, `clientes`, `proveedores`) as
+catalog-scoped (`id_tenant` + `id_empresa NULL`, doc 09), each with `HabilitarRlsDeTenant`.
+`listas_precio` reuses the stage-1 generic catalog EF base (`CatalogoSimple` /
+`ConfiguracionDeCatalogo<T>`) because its shape genuinely matches (name + flags); no
+service/API this stage (no ABM in scope — stage 3 adds one against the same table, no
+rework). `clientes` and `proveedores` do **not** reuse `ServicioDeCatalogo<T>` — see
+Decision 1. `numero` is assigned by a small dedicated Application helper reused by
+creation, provisioning bootstrap, and backfill (DRY, one atomic-assignment code path).
+
+## Architecture Decisions
+
+| # | Decision | Choice | Rejected alternative | Rationale |
+|---|---|---|---|---|
+| 1 | Generic catalog machine fit | `clientes`/`proveedores` get dedicated `Entidad`/EF config/`Servicio*`/screen. `listas_precio` reuses `CatalogoSimple`+`ConfiguracionDeCatalogo<T>` (EF layer only). | Force all 3 through `ServicioDeCatalogo<T>` (proposal's "proveedores likely fits closer" guess) | `ConfiguracionDeCatalogo<T>` hardcodes a nombre-based shared/private unique-index pair. `proveedores` dedupes by `cuit` tenant-wide (resolved decision #1), not by name/empresa-pair — forcing it through the base class would add a wrong uniqueness rule. `clientes` has no single "nombre" identity (nombre+apellido+razón social) and its numero is service-assigned, not user input. `listas_precio`'s shape (nombre+flags, standard dedupe) genuinely matches, so only that one reuses the base. |
+| 2 | Numero atomicity | Counter table `numeraciones_clientes(id_tenant PK, proximo_numero)` + `UPDATE ... SET proximo_numero = proximo_numero + 1 RETURNING proximo_numero - 1` inside the write transaction, keyed by `id_tenant` (not `id_punto_venta` — clientes is catalog-scoped, shared across a tenant's empresas). | Per-tenant Postgres `SEQUENCE` objects | Same family as `numeraciones_comprobante` (doc 09), proven pattern, no dynamic per-tenant DDL, row-level lock gives atomicity for free, gaps only on rollback (already accepted precedent). |
+| 3 | Numero read path | Raw ADO.NET command (`Database.GetDbConnection()` + the transaction's `DbTransaction`), not `Database.SqlQuery<T>()`/`FromSqlRaw<T>()`. | EF `SqlQuery<T>()` | Stage-1 slice-2 confirmed `SqlQuery<T>()` throws `IndexOutOfRangeException` against this project's model (`NavigationExpandingExpressionVisitor` bug, pre-existing, reproduces on `main`). `VerificarRolSinBypassAsync` already works around it the same way — reused here rather than rediscovered. |
+| 4 | Consumidor Final protection | Domain guard in `ServicioDeClientes` (block edit/delete when `Numero == 1`) **plus** DB CHECK `ck_clientes_cf_protegido CHECK (numero <> 1 OR deleted_at IS NULL)`. | Trigger-based protection; app guard only | A CHECK constraint is cheap, declarative, and matches existing convention (`ofertas`' `num_nonnulls` checks) — no triggers exist anywhere in this codebase, would be new machinery. It only blocks the irreversible path (soft-delete), which is the highest-severity bypass risk (proposal Risk row); other CF field edits stay behind the app guard, consistent with "domain guard, not just UI hiding." |
+| 5 | Provisioning template shape | Extend `PlantillaV1` in place (fill the `ItemsDiferidos` gap it already declared), not a `V2` bump. | `V2` version (literal proposal wording) | ADR-16's versioning rule is for a *different vertical template*, not staged completion of the same vertical. `ItemsDiferidos` already documented CF/General-list as V1's own roadmap gap; closing it finishes V1, a `V2` would falsely imply a parallel business vertical exists. |
+| 6 | ADR-10 (`DeLaEmpresa`) | Stays deferred, not re-raised. | — | Both tables use the exact same `id_tenant`/`id_empresa` catalog shape stage 1 already ships without it; no new querying gap found. |
+
+## Table Shapes (all `[catálogo]`, `HabilitarRlsDeTenant`)
+
+- **`listas_precio`**: `CatalogoSimple` shape + `es_default bool`, `modo modo_lista` (enum: `fija`|`derivada`), `id_lista_base int? → listas_precio`, `porcentaje numeric(5,2)?`. Indexes: standard nombre compartido/propio pair (reused) + a **second** compartido/propio pair on `es_default` (`ux_listas_precio_default_compartido/empresa`, same partial-NULL technique, guards "one default per scope").
+- **`numeraciones_clientes`**: `id_tenant int PK`, `proximo_numero int NOT NULL DEFAULT 1`, `fk_numeraciones_clientes_tenant`.
+- **`clientes`**: `id_cliente`, `id_tenant`, `id_empresa?`, `numero int NOT NULL`, `nombre citext NOT NULL`, `apellido citext?`, `razon_social citext?`, `tipo_documento tipo_documento?` (enum dni|cuit|cuil|pasaporte|otro — nullable, CF has none), `numero_documento citext?` (no unique index, resolved decision #2), `id_condicion_fiscal int NOT NULL → condiciones_fiscales` (app defaults to seeded `CF` row when omitted), `nacimiento date?`, `domicilio/telefono/celular/email citext?`, `observaciones text?`, `id_lista_precio int NOT NULL → listas_precio`, `limite_credito numeric(14,2) DEFAULT 0`, `credito_ilimitado bool DEFAULT false`, `saldo numeric(14,2) DEFAULT 0`, `activo`. Indexes: `ux_clientes_numero (id_tenant, numero) WHERE deleted_at IS NULL`; `ck_clientes_cf_protegido`; `ix_clientes_tenant`, `ix_clientes_empresa`; `fk_clientes_{tenant,empresa,condicion_fiscal,lista_precio}`.
+- **`proveedores`**: `id_proveedor`, `id_tenant`, `id_empresa?`, `razon_social citext NOT NULL`, `nombre_fantasia citext?`, `cuit varchar(13)?`, `id_condicion_fiscal int NOT NULL`, `domicilio/telefono/email citext?`, `vendedor/celular_vendedor/supervisor/celular_supervisor citext?`, `margen numeric(5,2)?`, `observaciones text?`, `activo`. Indexes: `ux_proveedores_cuit (id_tenant, cuit) WHERE deleted_at IS NULL AND cuit IS NOT NULL` (no empresa in the key — tenant-wide, resolved decision #1); `ix_proveedores_tenant/empresa`; `fk_proveedores_{tenant,empresa,condicion_fiscal}`.
+
+## Numero Assignment Flow
+
+    ServicioDeClientes.CrearAsync
+        └─→ AsignadorDeNumeroCliente.AsignarSiguienteAsync(idTenant)  [raw ADO.NET, same tx]
+                └─→ UPDATE numeraciones_clientes SET proximo_numero = proximo_numero+1
+                    WHERE id_tenant = @t RETURNING proximo_numero - 1
+        └─→ Conjunto.Add(cliente with Numero = asignado) → SaveChangesAsync
+
+`AsignadorDeNumeroCliente` also exposes `AsegurarContadorAsync` (idempotent `INSERT ...
+ON CONFLICT (id_tenant) DO NOTHING`), reused by `ServicioDeAprovisionamiento` (CF
+bootstrap: ensure counter → assign → insert `numero = 1` cliente) and by
+`InicializadorDeBaseDeDatos`'s new `BackfillDeClientesYListaPreciosAsync` step for
+existing tenants (idempotent: skip a tenant that already has its General list / CF row).
+
+## Backstop Map (db-error-backstops)
+
+| Constraint | SQLSTATE | `ManejadorDeErrores` mapping | Race test |
+|---|---|---|---|
+| `ux_proveedores_cuit` | 23505 | extend suffix classifier: `_cuit` → `cuit_duplicado` | 2 concurrent creates, same CUIT → 1×201 + 1×409 |
+| `ux_clientes_numero` | 23505 | extend suffix classifier: `_numero` → `numero_duplicado` | 2 concurrent `CrearAsync` → both succeed, distinct sequential `numero` (proves the atomic path never hits this 23505 in normal operation) |
+| `ux_listas_precio_default_*` | 23505 | covered generically (`_nombre`/new `_default` suffix) | seed-only this stage, no client write path — documented exemption per skill's decision gate |
+| `ck_clientes_cf_protegido` | 23514 | new case: → 409 `consumidor_final_protegido` | direct raw-SQL `UPDATE ... SET deleted_at=now() WHERE numero=1` bypassing the service asserts 23514/409 |
+| `fk_clientes_*`, `fk_proveedores_*` | 23503 | already generic (`fk_` prefix) | one smoke test per new FK, cross-tenant id |
+
+## Migration Sequencing (DB CHANGE GATE)
+
+**One migration**, `ClientesYProveedoresEtapa2`: creates all 4 tables, all indexes/FKs/CHECK
+above, RLS on each via `HabilitarRlsDeTenant`, registers `tipo_documento`/`modo_lista`
+native enums (`WaysDbContextFactory` + prod DI, same pattern as `comportamiento_medio_pago`).
+**[DB CHANGE GATE — mandatory, blocking]**: full model summary (tables/columns/indexes/
+constraints/RLS) **and** the backfill plan (which tenants get CF/General-list rows)
+presented together, per resolved decision #3, before generation.
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|---|---|---|
+| Unit (Domain) | CF protection rule, field validators | Pure functions, no DB (mirrors `PoliticaDeRoles`) |
+| Integration | RLS raw-SQL proofs (4 new tables) | Cross-tenant SELECT/UPDATE/DELETE blocked, real Postgres |
+| Integration | Backstop map races (table above) | SQLSTATE-asserted, real Postgres |
+| Integration | Provisioning + backfill | New tenant → CF+General+counter exist; backfill run twice → idempotent no-op on 2nd run |
+
+## Open Questions
+
+None blocking.

--- a/openspec/changes/stage-2-clientes-proveedores/state.yaml
+++ b/openspec/changes/stage-2-clientes-proveedores/state.yaml
@@ -3,8 +3,8 @@
 # openspec/specs/tenant-organization/spec.md — this change's future archive must merge
 # against that baseline.
 change: stage-2-clientes-proveedores
-phase: propose
-status: proposal-drafted-awaiting-question-round-review
+phase: apply
+status: slice-1-batch-1-applied-awaiting-db-change-gate-approval
 artifact_store: openspec
 phases:
   explore:
@@ -13,13 +13,25 @@ phases:
     status: done
     artifact: proposal.md
   spec:
-    status: pending
+    status: done
+    artifact: specs/
   design:
-    status: pending
+    status: done
+    artifact: design.md
   tasks:
-    status: pending
+    status: done
+    artifact: tasks.md
   apply:
-    status: pending
+    status: in-progress
+    artifact: apply-progress.md
+    note: >-
+      Slice 1 batch 1 applied: domain entities, EF configs, ReglaDeClientes,
+      AsignadorDeNumeroCliente, PlantillaDeAprovisionamiento extension,
+      ManejadorDeErrores backstop mappings, ParametrosTests hygiene fix, and
+      gated (Skip) integration tests for RLS/backstops/provisioning-backfill are
+      done. Blocked on DB CHANGE GATE (task 1.1) approval before generating the
+      migration (task 1.7); tasks 1.10/1.11 (provisioning/backfill wiring)
+      deferred to the same batch as the migration, per apply-progress.md.
   verify:
     status: pending
   archive:
@@ -38,3 +50,4 @@ notes:
   - "DB CHANGE GATE (CLAUDE.md) applies before any EF Core migration is generated during apply -- same unconditional rule as stage 1."
   - "Delivery: chained PRs, stacked-to-main (session decision, per protocolo-pr-solo-dev). Exact slicing deferred to sdd-tasks Review Workload Forecast."
   - "Proposal question round written into proposal.md ('## Proposal question round') per sdd-propose Step 0 -- not blocking artifact creation since this is a single-shot delegated write, but explicitly flagged for user review before spec/design lock in the resulting assumptions: (1) proveedores.cuit uniqueness undecided by doc 10, (2) clientes.numero_documento uniqueness undecided by doc 10, (3) Consumidor Final backfill-on-existing-tenants timing/approval, (4) ADR-10 DeLaEmpresa re-flagged per scope note. Default assumptions stated in the proposal if no correction arrives."
+  - "design.md (2026-08-02): clientes/proveedores do NOT reuse ServicioDeCatalogo<T>/ConfiguracionDeCatalogo<T> (dedicated entity+EF config+service+screen each) -- proveedores' cuit-based tenant-wide uniqueness and clientes' multi-field identity/service-assigned numero break the generic base's hardcoded nombre-pair uniqueness; only listas_precio genuinely fits the generic EF base (no service/API this stage, no ABM in scope). numero assigned via numeraciones_clientes counter table (UPDATE...RETURNING, doc-09 pattern family, keyed by id_tenant) through a shared AsignadorDeNumeroCliente helper reused by CrearAsync, provisioning CF bootstrap, and backfill -- raw ADO.NET, not Database.SqlQuery<T>()/FromSqlRaw<T>() (stage-1 slice-2 confirmed SqlQuery<T>() throws IndexOutOfRangeException against this model). Consumidor Final protected by a domain guard (ServicioDeClientes blocks edit/delete when Numero==1) plus a DB CHECK ck_clientes_cf_protegido (numero<>1 OR deleted_at IS NULL) as the irreversible-delete backstop -- no trigger (no precedent in this codebase). PlantillaDeAprovisionamiento extended in place (fills its own documented ItemsDiferidos gap) rather than bumped to V2 -- ADR-16 versioning is for a different vertical template, not staged completion; flagged as a deviation from the proposal's literal 'versioned bump' wording, not from a resolved binding decision. ADR-10 DeLaEmpresa reconfirmed deferred, no new gap found. One combined migration + one DB CHANGE GATE for all 4 tables (schema + backfill plan together, per resolved decision #3)."

--- a/openspec/changes/stage-2-clientes-proveedores/state.yaml
+++ b/openspec/changes/stage-2-clientes-proveedores/state.yaml
@@ -4,7 +4,7 @@
 # against that baseline.
 change: stage-2-clientes-proveedores
 phase: apply
-status: slice-1-batch-1-applied-awaiting-db-change-gate-approval
+status: slice-1-complete-runtime-verified-ready-for-judgment-day
 artifact_store: openspec
 phases:
   explore:
@@ -22,16 +22,17 @@ phases:
     status: done
     artifact: tasks.md
   apply:
-    status: in-progress
+    status: slice-1-done
     artifact: apply-progress.md
     note: >-
-      Slice 1 batch 1 applied: domain entities, EF configs, ReglaDeClientes,
-      AsignadorDeNumeroCliente, PlantillaDeAprovisionamiento extension,
-      ManejadorDeErrores backstop mappings, ParametrosTests hygiene fix, and
-      gated (Skip) integration tests for RLS/backstops/provisioning-backfill are
-      done. Blocked on DB CHANGE GATE (task 1.1) approval before generating the
-      migration (task 1.7); tasks 1.10/1.11 (provisioning/backfill wiring)
-      deferred to the same batch as the migration, per apply-progress.md.
+      Slice 1 complete (batches 1+2). DB CHANGE GATE (task 1.1) approved by the
+      user 2026-08-02, exactly as presented. Migration ClientesYProveedoresEtapa2
+      generated and applied (task 1.7); tasks 1.10/1.11 (provisioning/backfill
+      wiring) landed in the same batch. All 18 Slice 1 tasks done. Full suite
+      runtime-verified twice for stability: Domain 69/69, Application 91/91,
+      IntegrationTests 91/91 (0 skipped, 0 regressions). Branch
+      feat/stage2-slice1-fundacion, work-unit commits, no push/PR yet — awaiting
+      judgment-day (orchestrated separately) before PR.
   verify:
     status: pending
   archive:

--- a/openspec/changes/stage-2-clientes-proveedores/state.yaml
+++ b/openspec/changes/stage-2-clientes-proveedores/state.yaml
@@ -4,7 +4,7 @@
 # against that baseline.
 change: stage-2-clientes-proveedores
 phase: apply
-status: slice-1-complete-runtime-verified-ready-for-judgment-day
+status: slice-1-approved-ready-for-pr
 artifact_store: openspec
 phases:
   explore:

--- a/openspec/changes/stage-2-clientes-proveedores/tasks.md
+++ b/openspec/changes/stage-2-clientes-proveedores/tasks.md
@@ -42,12 +42,15 @@ list backfilled + provisioned, tests green. **Rollback**: down-migration (additi
 
 ### 1A. DB CHANGE GATE — BLOCKING
 
-- [ ] 1.1 **STOP.** Present the migration model summary (tables/columns/indexes/
+- [x] 1.1 **STOP.** Present the migration model summary (tables/columns/indexes/
   constraints/RLS for `clientes`, `proveedores`, `listas_precio`,
   `numeraciones_clientes`) **together with** the full backfill section (which
   pre-existing tenants get a CF cliente + General list) and wait for explicit
   approval before generating anything. *(resolved decision #3; CLAUDE.md)*
-  — Presented in apply batch 1; awaiting explicit approval.
+  — Presented in apply batch 1; **APPROVED by the user 2026-08-02**, exactly as
+  presented (all 4 tables, enums, RLS, partial unique indexes incl. the two
+  single-default guarantees on `listas_precio` and the tenant-wide `cuit`
+  index, `ck_clientes_cf_protegido`, and the full backfill plan).
 
 ### 1B. Domain
 
@@ -67,12 +70,15 @@ list backfilled + provisioned, tests green. **Rollback**: down-migration (additi
 
 ### 1C. Migration (only after 1.1 approved)
 
-- [ ] 1.7 Generate migration `ClientesYProveedoresEtapa2`: 4 tables,
+- [x] 1.7 Generate migration `ClientesYProveedoresEtapa2`: 4 tables,
   `tipo_documento`/`modo_lista` enums, `ux_clientes_numero`,
   `ux_proveedores_cuit`, `ux_listas_precio_default_compartido/empresa`,
   `ck_clientes_cf_protegido`, all FKs, `HabilitarRlsDeTenant` on all 4 tables,
   enum registration in `WaysDbContextFactory` + prod DI (per `comportamiento_medio_pago`
-  precedent). *(design: Migration Sequencing)*
+  precedent). *(design: Migration Sequencing)* — generated exactly as approved;
+  also hand-named 4 FK-support indexes in snake_case (EF's default naming would
+  have produced `IX_*` PascalCase, breaking the doc-10 convention) before
+  generating. `dotnet ef migrations has-pending-model-changes` confirms clean.
 
 ### 1D. Numero counter + provisioning + backfill
 
@@ -83,19 +89,18 @@ list backfilled + provisioned, tests green. **Rollback**: down-migration (additi
 - [x] 1.9 Extend `PlantillaDeAprovisionamiento.V1` in place: add the Consumidor
   Final cliente item + General `listas_precio` item (closes the `ItemsDiferidos`
   gap) + unit tests. *(design decision 5)*
-- [ ] 1.10 Wire `ServicioDeAprovisionamiento.CrearTenantAsync`: ensure counter →
+- [x] 1.10 Wire `ServicioDeAprovisionamiento.CrearTenantAsync`: ensure counter →
   assign `numero = 1` → insert CF cliente + General lista_precio inside the
   provisioning transaction. *(spec: tenant-organization / Tenant Provisioning With
   Template Seed)*
-  — DEFERRED to the migration batch: written and confirmed compiling in apply
-  batch 1, then reverted (`clientes`/`listas_precio` don't exist yet; wiring this
-  broke `AprovisionamientoTests`' 2 existing tests). See apply-progress.md.
-- [ ] 1.11 Add `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync`:
+  — Wired in apply batch 2, after the migration landed (deferred from batch 1
+  for the reason recorded there and in apply-progress.md).
+- [x] 1.11 Add `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync`:
   idempotent, skips a tenant that already has its CF/General row, runs after
   migrations. *(spec: tenant-organization / Backfill for Pre-Existing Tenants)*
-  — DEFERRED to the migration batch: same reason as 1.10, but higher blast
-  radius (wiring it broke 63/74 integration tests — `EjecutarAsync` runs on every
-  test's first `CreateClient()`). See apply-progress.md.
+  — Wired in apply batch 2. Runtime-verified: exercised for real by
+  `ClientesProvisioningYBackfillTests` against Postgres real (Docker), including
+  the idempotent-second-run assertion.
 
 ### 1E. db-error-backstops mapping
 
@@ -116,23 +121,28 @@ list backfilled + provisioned, tests green. **Rollback**: down-migration (additi
 - [x] 1.14 [P] Integration: RLS proofs for all 4 new tables (EF filter blocks
   cross-tenant read; raw-SQL/`IgnoreQueryFilters` blocked), mirroring
   `AislamientoDeTenantTests`. *(spec: clientes/proveedores/listas-precio-minimal /
-  Tenant Isolation)* — implemented, `[Skip]`-gated on the migration (task 1.7).
+  Tenant Isolation)* — **runtime-verified**: `[Skip]` removed in apply batch 2,
+  green against Postgres real (Docker), run twice for stability.
 - [x] 1.15 [P] Integration: provisioning creates CF cliente (`numero = 1`, CF
   condición fiscal) + General lista_precio; backfill on a pre-existing tenant
   creates the same; backfill run twice is a no-op. *(spec: tenant-organization /
   Backfill for Pre-Existing Tenants; listas-precio-minimal / One Default List)*
-  — implemented, `[Skip]`-gated on the migration AND on 1.10/1.11's wiring
-  (same batch as the migration).
+  — **runtime-verified** in apply batch 2, after 1.10/1.11 were wired.
 - [x] 1.16 Integration: direct raw-SQL `UPDATE clientes SET deleted_at = now()
   WHERE numero = 1` bypassing the service asserts 23514 → 409
-  `consumidor_final_protegido`. *(backstop map)* — implemented, `[Skip]`-gated on
-  the migration.
+  `consumidor_final_protegido`. *(backstop map)* — **runtime-verified** in apply
+  batch 2.
 - [x] 1.17 [P] Integration: one FK smoke test per new FK (`fk_clientes_*`,
   `fk_proveedores_*`), cross-tenant/nonexistent id → 23503/400. *(backstop map)*
-  — implemented, `[Skip]`-gated on the migration.
+  — **runtime-verified** in apply batch 2.
 - [x] 1.18 Regression: existing Domain/Application/IntegrationTests suites
-  unedited and green. — 69/69 Domain, 91/91 Application, 74 passed + 10 skipped
-  Integration (0 regressions).
+  unedited and green. — Final (apply batch 2): 69/69 Domain, 91/91 Application,
+  91/91 Integration (baseline 74 + 17 newly-active test cases from the 10
+  un-skipped `[Fact]`/`[Theory]` methods — theories with `MemberData`/`InlineData`
+  expand to one result per row once active). Run twice, identical both times.
+  One incidental pre-existing test-order fragility found and fixed in
+  `CatalogosGlobalesRlsTests` (see apply-progress.md) — no production behavior
+  changed by that fix, test-only.
 
 ---
 

--- a/openspec/changes/stage-2-clientes-proveedores/tasks.md
+++ b/openspec/changes/stage-2-clientes-proveedores/tasks.md
@@ -1,0 +1,241 @@
+# Tasks: Stage 2 — Clientes y Proveedores
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2,250–3,150 total (incl. EF migration boilerplate) |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → (PR 2 ∥ PR 3) → PR 4 |
+| Delivery strategy | chained PRs, stacked-to-main (resolved, cached decision) |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No — resolved: chained PRs, stacked-to-main.
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main — each slice PR merges to main in order; Slice 1 alone
+(~1,100–1,500 lines, migration-heavy, one combined migration per the DB CHANGE GATE) may
+still exceed the 400-line budget with no further reasonable split — if so at apply-time,
+record `size:exception` for that PR only, same precedent as stage 1's Slices 3/4. Slices
+2 and 3 are independent (both depend only on Slice 1) and can run in parallel.
+400-line budget risk: High (mitigated by the split below; Slice 1 may need `size:exception`)
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Schema (4 tables, DB CHANGE GATE), domain entities, numero counter, provisioning template extension, backfill, backstop mappings | PR 1 | ~1,100–1,500 lines. Base: `main`. One combined migration under one gate (schema + backfill together, resolved decision #3). |
+| 2 | Clientes service + API + tests | PR 2 | ~350–500 lines. Depends on PR 1. Independent of PR 3. |
+| 3 | Proveedores service + API + tests | PR 3 | ~300–450 lines. Depends on PR 1. Independent of PR 2. |
+| 4 | Web ABMs (clientes + proveedores) | PR 4 | ~500–700 lines. Depends on PR 2 + PR 3 (consumes both API surfaces). |
+
+Each slice: start = base branch state, finish = its own tests green, verification = its
+own unit/integration tests, rollback = down-migration (Slice 1 only) or new-routes-only
+removal (Slices 2–4), per proposal.md § Rollback Plan.
+
+---
+
+## Slice 1: Schema, Domain Foundation & Provisioning (PR 1)
+
+**Start**: `main`. **Finish**: migration applied, RLS proven on all 4 tables, CF/General
+list backfilled + provisioned, tests green. **Rollback**: down-migration (additive only).
+
+### 1A. DB CHANGE GATE — BLOCKING
+
+- [ ] 1.1 **STOP.** Present the migration model summary (tables/columns/indexes/
+  constraints/RLS for `clientes`, `proveedores`, `listas_precio`,
+  `numeraciones_clientes`) **together with** the full backfill section (which
+  pre-existing tenants get a CF cliente + General list) and wait for explicit
+  approval before generating anything. *(resolved decision #3; CLAUDE.md)*
+  — Presented in apply batch 1; awaiting explicit approval.
+
+### 1B. Domain
+
+- [x] 1.2 [P] Add `Cliente : EntidadTenant` (identity/contact, tipo_documento/
+  numero_documento, credit fields, FKs) in `Ways.Domain/Clientes`. *(spec: clientes
+  / Cliente Schema At Rest)*
+- [x] 1.3 [P] Add `Proveedor : EntidadTenant` in `Ways.Domain/Proveedores`. *(spec:
+  proveedores / Proveedor Schema At Rest)*
+- [x] 1.4 [P] Add `ListaPrecio : CatalogoSimple` (`es_default`, `modo`,
+  `id_lista_base?`, `porcentaje?`) reusing `ConfiguracionDeCatalogo<T>` EF base, no
+  service/API. *(design decision 1; spec: listas-precio-minimal)*
+- [x] 1.5 [P] Add `NumeracionCliente` entity (`id_tenant` PK, `proximo_numero`) + EF
+  config. *(design table shapes)*
+- [x] 1.6 Add pure `ReglaDeClientes.ValidarNoConsumidorFinal` (blocks edit/delete
+  when `Numero == 1`) + unit tests (CF blocked, non-CF allowed). *(spec: clientes /
+  Consumidor Final Protected Row)*
+
+### 1C. Migration (only after 1.1 approved)
+
+- [ ] 1.7 Generate migration `ClientesYProveedoresEtapa2`: 4 tables,
+  `tipo_documento`/`modo_lista` enums, `ux_clientes_numero`,
+  `ux_proveedores_cuit`, `ux_listas_precio_default_compartido/empresa`,
+  `ck_clientes_cf_protegido`, all FKs, `HabilitarRlsDeTenant` on all 4 tables,
+  enum registration in `WaysDbContextFactory` + prod DI (per `comportamiento_medio_pago`
+  precedent). *(design: Migration Sequencing)*
+
+### 1D. Numero counter + provisioning + backfill
+
+- [x] 1.8 Add `AsignadorDeNumeroCliente.AsignarSiguienteAsync`/
+  `AsegurarContadorAsync` (raw ADO.NET on the tx's `DbConnection`/`DbTransaction`,
+  not `SqlQuery<T>`/`FromSqlRaw<T>` — reuse `VerificarRolSinBypassAsync`'s
+  workaround). *(design decisions 2, 3)*
+- [x] 1.9 Extend `PlantillaDeAprovisionamiento.V1` in place: add the Consumidor
+  Final cliente item + General `listas_precio` item (closes the `ItemsDiferidos`
+  gap) + unit tests. *(design decision 5)*
+- [ ] 1.10 Wire `ServicioDeAprovisionamiento.CrearTenantAsync`: ensure counter →
+  assign `numero = 1` → insert CF cliente + General lista_precio inside the
+  provisioning transaction. *(spec: tenant-organization / Tenant Provisioning With
+  Template Seed)*
+  — DEFERRED to the migration batch: written and confirmed compiling in apply
+  batch 1, then reverted (`clientes`/`listas_precio` don't exist yet; wiring this
+  broke `AprovisionamientoTests`' 2 existing tests). See apply-progress.md.
+- [ ] 1.11 Add `InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync`:
+  idempotent, skips a tenant that already has its CF/General row, runs after
+  migrations. *(spec: tenant-organization / Backfill for Pre-Existing Tenants)*
+  — DEFERRED to the migration batch: same reason as 1.10, but higher blast
+  radius (wiring it broke 63/74 integration tests — `EjecutarAsync` runs on every
+  test's first `CreateClient()`). See apply-progress.md.
+
+### 1E. db-error-backstops mapping
+
+- [x] 1.12 Extend `ManejadorDeErrores` suffix classifier: `_cuit` →
+  `cuit_duplicado` (409), `_numero` → `numero_duplicado` (409); add a new 23514
+  case for `ck_clientes_cf_protegido` → 409 `consumidor_final_protegido`; confirm
+  the existing generic `_nombre`/`_default`/`fk_` mappings already cover
+  `listas_precio` and all new FKs. *(design: Backstop Map)*
+
+### 1F. Hygiene (carried from stage 1)
+
+- [x] 1.13 Add timeout + assert to the rendezvous `gate.Wait()` in
+  `ParametrosTests.cs` (stage-1 INFO carried forward; hardens the pattern before
+  Slices 2–3 reuse it for the numero/cuit race tests). *(stage-1 state.yaml INFO)*
+
+### 1G. Tests
+
+- [x] 1.14 [P] Integration: RLS proofs for all 4 new tables (EF filter blocks
+  cross-tenant read; raw-SQL/`IgnoreQueryFilters` blocked), mirroring
+  `AislamientoDeTenantTests`. *(spec: clientes/proveedores/listas-precio-minimal /
+  Tenant Isolation)* — implemented, `[Skip]`-gated on the migration (task 1.7).
+- [x] 1.15 [P] Integration: provisioning creates CF cliente (`numero = 1`, CF
+  condición fiscal) + General lista_precio; backfill on a pre-existing tenant
+  creates the same; backfill run twice is a no-op. *(spec: tenant-organization /
+  Backfill for Pre-Existing Tenants; listas-precio-minimal / One Default List)*
+  — implemented, `[Skip]`-gated on the migration AND on 1.10/1.11's wiring
+  (same batch as the migration).
+- [x] 1.16 Integration: direct raw-SQL `UPDATE clientes SET deleted_at = now()
+  WHERE numero = 1` bypassing the service asserts 23514 → 409
+  `consumidor_final_protegido`. *(backstop map)* — implemented, `[Skip]`-gated on
+  the migration.
+- [x] 1.17 [P] Integration: one FK smoke test per new FK (`fk_clientes_*`,
+  `fk_proveedores_*`), cross-tenant/nonexistent id → 23503/400. *(backstop map)*
+  — implemented, `[Skip]`-gated on the migration.
+- [x] 1.18 Regression: existing Domain/Application/IntegrationTests suites
+  unedited and green. — 69/69 Domain, 91/91 Application, 74 passed + 10 skipped
+  Integration (0 regressions).
+
+---
+
+## Slice 2: Clientes service + API (PR 2)
+
+**Depends on**: Slice 1. **Start**: PR 1 merged/branch. **Finish**: cliente CRUD live
+through the API, atomic numero proven under concurrency, tests green. **Rollback**:
+new routes only.
+
+### 2A. Application
+
+- [ ] 2.1 Add `ServicioDeClientes` (list/create/edit/soft-delete): create calls
+  `AsignadorDeNumeroCliente`, defaults `id_lista_precio` to the tenant's
+  `es_default` list when omitted, enforces `ReglaDeClientes.ValidarNoConsumidorFinal`
+  on edit/delete, `GestionDeCatalogo` policy. *(spec: clientes / Cliente ABM
+  Lifecycle and Authorization)*
+- [ ] 2.2 Add cliente contracts (`ClienteListado`/`Alta`/`Edicion`).
+
+### 2B. API
+
+- [ ] 2.3 Add `ClientesEndpoints`: list/create/edit/soft-delete,
+  `GestionDeCatalogo` policy (tenant admin only).
+
+### 2C. Tests
+
+- [ ] 2.4 [P] Unit (InMemory): default credit fields (0/false/0), required
+  `id_lista_precio`/`id_condicion_fiscal` validation, CF guard blocks edit/delete
+  of `numero = 1`, vendedor blocked, admin allowed.
+- [ ] 2.5 [P] Integration: concurrent create race (2 requests, tenant 1) →
+  sequential distinct `numero`, no 23505 surfaced (db-error-backstops race test
+  for the atomic `ux_clientes_numero` path — reuse 1.13's hardened rendezvous);
+  duplicate/NULL `numero_documento` accepted; admin create→soft-delete round
+  trip; vendedor 403; cross-tenant cliente id → 404. *(spec: clientes / Atomic
+  Per-Tenant Numero Assignment; numero_documento Has No Uniqueness Constraint)*
+- [ ] 2.6 Regression: Slice 1 suites unedited and green.
+
+---
+
+## Slice 3: Proveedores service + API (PR 3)
+
+**Depends on**: Slice 1 (independent of Slice 2). **Start**: PR 1 merged/branch.
+**Finish**: proveedor CRUD live, cuit uniqueness proven under concurrency, tests
+green. **Rollback**: new routes only.
+
+### 3A. Application
+
+- [ ] 3.1 Add `ServicioDeProveedores` (list/create/edit/soft-delete),
+  `GestionDeCatalogo` policy. *(spec: proveedores / Proveedor ABM Lifecycle and
+  Authorization)*
+- [ ] 3.2 Add proveedor contracts.
+
+### 3B. API
+
+- [ ] 3.3 Add `ProveedoresEndpoints`.
+
+### 3C. Tests
+
+- [ ] 3.4 [P] Unit (InMemory): create without `cuit` succeeds, required
+  `id_condicion_fiscal` validation, vendedor blocked.
+- [ ] 3.5 [P] Integration: db-error-backstops race test for `ux_proveedores_cuit`
+  (2 concurrent same-cuit creates → 1×201 + 1×409 via translated domain code, not
+  exception type — reuse 1.13's hardened rendezvous); same cuit across 2 tenants
+  allowed; `NULL` cuit never collides; soft-deleted cuit reusable; cross-tenant id
+  → 404. *(spec: proveedores / cuit Uniqueness Is Scoped Per Tenant)*
+- [ ] 3.6 Regression: Slice 1 suites unedited and green.
+
+---
+
+## Slice 4: Web ABMs (PR 4)
+
+**Depends on**: Slices 2 + 3. **Start**: PR 2/PR 3 branch per chosen chain
+strategy. **Finish**: both screens functional against the API, smoke-verified.
+**Rollback**: new routes only, no existing screen touched.
+
+### 4A. Screens
+
+- [ ] 4.1 Add dedicated `Clientes.tsx` ABM (not the generic catalog machine, per
+  design decision 1): list/create/edit/soft-delete, credit fields in the form; CF
+  row (`numero = 1`) rendered read-only with edit/delete disabled (defense in
+  depth on top of the domain guard). *(spec: clientes / Cliente ABM Lifecycle;
+  Consumidor Final Protected Row)*
+- [ ] 4.2 Add dedicated `Proveedores.tsx` ABM: list/create/edit/soft-delete.
+  *(spec: proveedores / Proveedor ABM Lifecycle)*
+
+### 4B. Wiring + smoke
+
+- [ ] 4.3 Wire routes + nav entries; add `tipos.ts` additions and API clients
+  (`clientes.ts`, `proveedores.ts`).
+- [ ] 4.4 Smoke-verify both screens against integration test expectations
+  (`tsc -b`/`oxlint`/`vite build` clean + contract smoke against a real API host,
+  per ADR-17's no-e2e-harness gap, same approach as stage 1's 4.9).
+
+---
+
+## Dependency Summary
+
+```
+Slice 1 (schema + domain + provisioning + backfill)
+   ├─▶ Slice 2 (clientes service + API)
+   └─▶ Slice 3 (proveedores service + API)
+            Slice 2, Slice 3 ─▶ Slice 4 (web ABMs)
+```
+
+Within each slice, `[P]`-tagged tasks are parallelizable; all others are
+sequential (schema → infra → application → tests; the DB CHANGE GATE always
+blocks the migration-generation task).

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -43,6 +43,13 @@ public class ManejadorDeErrores(
                 when ClasificarUnicidad(ux) is { } familia =>
                 (StatusCodes.Status409Conflict, familia.Titulo, familia.Codigo),
 
+            // Backstop de la constraint que cierra la baja irreversible del Consumidor Final
+            // (stage-2-clientes-proveedores, design decision 4, task 1.12): ReglaDeClientes.
+            // ValidarNoConsumidorFinal ya bloquea el camino normal de ServicioDeClientes —
+            // esto es el backstop ante un UPDATE/DELETE que la esquive directamente.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: "ck_clientes_cf_protegido" } } =>
+                (StatusCodes.Status409Conflict, "El cliente Consumidor Final no se puede editar ni eliminar.", "consumidor_final_protegido"),
+
             // Backstop genérico para las FKs compuestas nuevas (fk_*_empresa, fk_categorias_padre,
             // fk_parametros_punto_venta, …): una referencia a una fila que no existe (o que
             // pertenece a otro tenant, invisible bajo RLS) llega acá como 23503 en vez de
@@ -106,6 +113,21 @@ public class ManejadorDeErrores(
             return ("parametro_duplicado", "Ya existe un parámetro con esa clave en este alcance.");
         }
 
+        // stage-2-clientes-proveedores (task 1.12, backstop map): ux_proveedores_cuit —
+        // spec "cuit Uniqueness Is Scoped Per Tenant".
+        if (nombreDeIndice.Contains("_cuit", StringComparison.Ordinal))
+        {
+            return ("cuit_duplicado", "Ya existe un proveedor con ese CUIT en este tenant.");
+        }
+
+        // stage-2-clientes-proveedores (task 1.12, backstop map): ux_clientes_numero —
+        // backstop del contador atómico de ClienteAsignadorDeNumero (spec: Atomic Per-Tenant
+        // Numero Assignment); nunca debería chocar acá bajo operación normal.
+        if (nombreDeIndice.Contains("_numero", StringComparison.Ordinal))
+        {
+            return ("numero_duplicado", "Ya existe un cliente con ese número en este tenant.");
+        }
+
         if (nombreDeIndice.Contains("_nombre", StringComparison.Ordinal))
         {
             return ("nombre_duplicado", "Ya existe un registro con ese nombre en este alcance.");
@@ -114,6 +136,15 @@ public class ManejadorDeErrores(
         if (nombreDeIndice.Contains("_codigo", StringComparison.Ordinal))
         {
             return ("codigo_duplicado", "Ya existe un registro con ese código.");
+        }
+
+        // ux_listas_precio_default_compartido/empresa (stage-2-clientes-proveedores, backstop
+        // map): sin camino de escritura de cliente esta etapa (spec: listas_precio ABM Is Out
+        // of Scope This Stage) — sembrado solo por provisioning/backfill, exento de race test
+        // por el mismo motivo que la familia codigo_duplicado de los catálogos fiscales.
+        if (nombreDeIndice.Contains("_default", StringComparison.Ordinal))
+        {
+            return ("default_duplicado", "Ya existe una lista de precios default en este alcance.");
         }
 
         return null;

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -114,7 +114,12 @@ public class ManejadorDeErrores(
         }
 
         // stage-2-clientes-proveedores (task 1.12, backstop map): ux_proveedores_cuit —
-        // spec "cuit Uniqueness Is Scoped Per Tenant".
+        // spec "cuit Uniqueness Is Scoped Per Tenant". Exención de la prueba de carrera
+        // exigida por el skill db-error-backstops (judgment-day ronda 1, item de comentario):
+        // el endpoint de alta de proveedores (ServicioDeProveedores.CrearAsync) todavía no
+        // existe, esta etapa solo llega hasta el esquema/backstop map — la prueba de carrera
+        // queda para la Slice 3 (tasks.md, task 3.5), que sí tiene el camino de escritura real
+        // para ejercerla.
         if (nombreDeIndice.Contains("_cuit", StringComparison.Ordinal))
         {
             return ("cuit_duplicado", "Ya existe un proveedor con ese CUIT en este tenant.");
@@ -122,7 +127,10 @@ public class ManejadorDeErrores(
 
         // stage-2-clientes-proveedores (task 1.12, backstop map): ux_clientes_numero —
         // backstop del contador atómico de ClienteAsignadorDeNumero (spec: Atomic Per-Tenant
-        // Numero Assignment); nunca debería chocar acá bajo operación normal.
+        // Numero Assignment); nunca debería chocar acá bajo operación normal. Misma exención
+        // que ux_proveedores_cuit arriba: sin ServicioDeClientes.CrearAsync todavía (esta
+        // etapa no lo incluye), la prueba de carrera queda para la Slice 2 (tasks.md, task
+        // 2.5), que reusa el rendezvous endurecido en el batch 1.13/1F de esta slice.
         if (nombreDeIndice.Contains("_numero", StringComparison.Ordinal))
         {
             return ("numero_duplicado", "Ya existe un cliente con ese número en este tenant.");

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
 using Ways.Domain.Usuarios;
 
 namespace Ways.Application.Abstracciones;
@@ -27,6 +29,14 @@ public interface IWaysDbContext
     DbSet<AlicuotaIva> AlicuotasIva { get; }
     DbSet<TipoComprobante> TiposComprobante { get; }
     DbSet<Parametro> Parametros { get; }
+
+    // Stage 2 (clientes-proveedores): AsignadorDeNumeroCliente/ServicioDeAprovisionamiento
+    // consumen estos 4 desde este mismo lote (a diferencia de los catálogos de tenant de
+    // arriba, sin consumidor de Application todavía).
+    DbSet<Cliente> Clientes { get; }
+    DbSet<Proveedor> Proveedores { get; }
+    DbSet<ListaPrecio> ListasPrecio { get; }
+    DbSet<NumeracionCliente> NumeracionesClientes { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/Clientes/AsignadorDeNumeroCliente.cs
+++ b/src/Ways.Application/Clientes/AsignadorDeNumeroCliente.cs
@@ -1,0 +1,91 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+
+namespace Ways.Application.Clientes;
+
+/// <summary>
+/// Asigna <c>clientes.numero</c> de forma atómica por tenant (design decisions 2 y 3):
+/// <c>UPDATE numeraciones_clientes SET proximo_numero = proximo_numero + 1 ... RETURNING</c>
+/// vía ADO.NET crudo sobre la conexión/transacción activa de <paramref name="db"/>, nunca
+/// <c>Database.SqlQuery&lt;T&gt;()</c>/<c>FromSqlRaw&lt;T&gt;()</c> — confirmado en stage-1
+/// slice 2 que esos dos revientan con <c>IndexOutOfRangeException</c> contra este modelo
+/// (<see cref="Ways.Infrastructure.Persistencia.InicializadorDeBaseDeDatos"/>'s
+/// <c>VerificarRolSinBypassAsync</c> documenta el mismo hallazgo y usa el mismo workaround).
+///
+/// Sin estado propio ni <see cref="IWaysDbContext"/> por constructor: cada método recibe el
+/// contexto por parámetro para poder reusarse contra los tres scopes de DI distintos que lo
+/// llaman con su propia transacción — <c>ServicioDeClientes.CrearAsync</c> (slice 2, sesión
+/// de tenant), <c>ServicioDeAprovisionamiento.CrearTenantAsync</c> (bootstrap del Consumidor
+/// Final) e <c>InicializadorDeBaseDeDatos</c>'s backfill (contexto de plataforma).
+///
+/// Abre la conexión con <c>Database.OpenConnectionAsync()</c> cuando hace falta, nunca con
+/// <c>conexion.OpenAsync()</c> directo sobre el <see cref="DbConnection"/> crudo: ese segundo
+/// camino no dispara <c>InterceptorDeContextoDeTenant</c> (que corre atado al ciclo de vida
+/// de conexión de EF Core, no al del ADO.NET subyacente) y la conexión quedaría sin los GUC
+/// de tenant que RLS necesita para autorizar la escritura. En el camino normal (dentro de la
+/// transacción de <c>BeginTransactionAsync</c> de cada llamador) la conexión ya está abierta
+/// por EF desde antes, así que esto es un no-op — solo importa cuando algún llamador futuro
+/// invoque estos métodos fuera de una transacción ya abierta.
+///
+/// Estática a propósito: sin campos, sin ciclo de vida de DI que administrar — cada método
+/// recibe el <see cref="IWaysDbContext"/> del llamador de turno.
+/// </summary>
+public static class AsignadorDeNumeroCliente
+{
+    public static async Task AsegurarContadorAsync(IWaysDbContext db, int idTenant, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "INSERT INTO numeraciones_clientes (id_tenant, proximo_numero) VALUES ($1, 1) " +
+            "ON CONFLICT (id_tenant) DO NOTHING";
+
+        AgregarParametro(comando, idTenant);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    public static async Task<int> AsignarSiguienteAsync(IWaysDbContext db, int idTenant, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "UPDATE numeraciones_clientes SET proximo_numero = proximo_numero + 1 " +
+            "WHERE id_tenant = $1 RETURNING proximo_numero - 1";
+
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException(
+                $"No existe contador de numeraciones para el tenant {idTenant}: " +
+                $"llamá a {nameof(AsegurarContadorAsync)} antes de asignar.");
+
+        return Convert.ToInt32(resultado);
+    }
+
+    private static async Task<DbConnection> ObtenerConexionAbiertaAsync(IWaysDbContext db, CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, int valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -12,6 +12,10 @@ public static class DependencyInjection
     public static IServiceCollection AgregarApplication(this IServiceCollection services)
     {
         services.AddSingleton<IRelojDelSistema, RelojDelSistema>();
+
+        // AsignadorDeNumeroCliente (Ways.Application.Clientes) es estática, sin ciclo de
+        // vida de DI que registrar — el IWaysDbContext llega por parámetro en cada llamada.
+
         services.AddScoped<ServicioDeAutenticacion>();
         services.AddScoped<ServicioDeUsuarios>();
 

--- a/src/Ways.Application/Organizacion/ServicioDeAprovisionamiento.cs
+++ b/src/Ways.Application/Organizacion/ServicioDeAprovisionamiento.cs
@@ -1,7 +1,9 @@
 using System.Security.Cryptography;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
+using Ways.Application.Clientes;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Common;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
@@ -103,6 +105,43 @@ public class ServicioDeAprovisionamiento(
                     UpdatedAt = ahora
                 });
             }
+
+            await db.SaveChangesAsync(ct);
+
+            // 3.5. lista de precios General (es_default) + cliente Consumidor Final
+            // (design decision 5, stage-2-clientes-proveedores): misma transacción atómica
+            // que el resto — si cualquiera de los dos falla, no queda ni el tenant ni la
+            // empresa a medio crear (spec: Tenant Provisioning With Template Seed).
+            var listaPrecioGeneral = new ListaPrecio
+            {
+                Nombre = PlantillaDeAprovisionamiento.V1.ListaPrecioGeneral.Nombre,
+                EsDefault = true,
+                Modo = ModoLista.Fija,
+                Activo = true,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            db.ListasPrecio.Add(listaPrecioGeneral);
+
+            var condicionFiscalCf = await db.CondicionesFiscales.SingleAsync(
+                c => c.Codigo == PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.CodigoCondicionFiscal, ct);
+
+            // SaveChanges antes de asignar el numero: listaPrecioGeneral.Id todavía no
+            // existe (identity), y clientes.id_lista_precio lo necesita.
+            await db.SaveChangesAsync(ct);
+
+            await AsignadorDeNumeroCliente.AsegurarContadorAsync(db, tenant.Id, ct);
+            var numeroConsumidorFinal = await AsignadorDeNumeroCliente.AsignarSiguienteAsync(db, tenant.Id, ct);
+
+            db.Clientes.Add(new Cliente
+            {
+                Numero = numeroConsumidorFinal,
+                Nombre = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.Nombre,
+                IdCondicionFiscal = condicionFiscalCf.Id,
+                IdListaPrecio = listaPrecioGeneral.Id,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            });
 
             await db.SaveChangesAsync(ct);
 

--- a/src/Ways.Domain/Catalogos/ListaPrecio.cs
+++ b/src/Ways.Domain/Catalogos/ListaPrecio.cs
@@ -1,0 +1,27 @@
+namespace Ways.Domain.Catalogos;
+
+/// <summary>
+/// Lista de precios del tenant (doc 10 §3). Reusa <see cref="CatalogoSimple"/> (design
+/// decision 1): a diferencia de <c>Cliente</c>/<c>Proveedor</c>, su forma (nombre + flags,
+/// dedupe estándar por nombre/alcance) calza genuinamente con la base genérica — solo capa
+/// EF esta etapa, sin <c>Servicio*</c>/API (spec: listas_precio ABM Is Out of Scope This
+/// Stage). <see cref="Modo"/>/<see cref="IdListaBase"/>/<see cref="Porcentaje"/> existen ya
+/// (doc 10, principio de modelo completo por adelantado) pero solo <see cref="ModoLista.Fija"/>
+/// se usa en esta etapa — <c>precios</c> y las listas derivadas llegan en la etapa 3.
+/// </summary>
+public class ListaPrecio : CatalogoSimple
+{
+    /// <summary>Exactamente una fila por alcance (tenant compartido o tenant+empresa) tiene
+    /// que tener <c>true</c> — <c>ux_listas_precio_default_compartido/empresa</c> lo exige a
+    /// nivel de esquema.</summary>
+    public bool EsDefault { get; set; }
+
+    public ModoLista Modo { get; set; } = ModoLista.Fija;
+
+    /// <summary>Solo tiene sentido cuando <see cref="Modo"/> es <see cref="ModoLista.Derivada"/>
+    /// — sin uso hasta la etapa 3.</summary>
+    public int? IdListaBase { get; set; }
+
+    /// <summary>Idem <see cref="IdListaBase"/>: sin uso hasta la etapa 3.</summary>
+    public decimal? Porcentaje { get; set; }
+}

--- a/src/Ways.Domain/Catalogos/ModoLista.cs
+++ b/src/Ways.Domain/Catalogos/ModoLista.cs
@@ -1,0 +1,13 @@
+namespace Ways.Domain.Catalogos;
+
+/// <summary>
+/// Modo de una lista de precios (doc 10 §3). Enum nativo de Postgres (<c>modo_lista</c>).
+/// Esta etapa solo crea listas <see cref="Fija"/> (la General, <c>es_default = true</c>);
+/// <see cref="Derivada"/> y las columnas que la acompañan (<c>id_lista_base</c>,
+/// <c>porcentaje</c>) quedan declaradas para la etapa 3 (spec: listas-precio-minimal).
+/// </summary>
+public enum ModoLista
+{
+    Fija,
+    Derivada
+}

--- a/src/Ways.Domain/Clientes/Cliente.cs
+++ b/src/Ways.Domain/Clientes/Cliente.cs
@@ -1,0 +1,67 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Clientes;
+
+/// <summary>
+/// Cliente del tenant (doc 10 §2, catálogo-scoped: <c>id_tenant</c> + <c>id_empresa</c>
+/// opcional, doc 09). Entidad dedicada (design decision 1): no reusa
+/// <c>ConfiguracionDeCatalogo&lt;T&gt;</c>/<c>ServicioDeCatalogo&lt;T&gt;</c> porque su
+/// identidad no es un <c>nombre</c> único por alcance (es nombre+apellido+razón social,
+/// combinable) y su <see cref="Numero"/> lo asigna
+/// <see cref="Application.Clientes.AsignadorDeNumeroCliente"/> (contador atómico), no es
+/// input de usuario deduplicado por unicidad de nombre.
+///
+/// <see cref="Numero"/> == 1 identifica siempre al Consumidor Final protegido de su tenant
+/// (<see cref="ReglaDeClientes"/>, <c>ck_clientes_cf_protegido</c>). No hay motor de cuenta
+/// corriente todavía (etapa 7): <see cref="Saldo"/> queda en su default fuera de la siembra
+/// del Consumidor Final.
+/// </summary>
+public class Cliente : EntidadTenant
+{
+    public int Id { get; set; }
+
+    /// <summary><c>NULL</c> ⇒ compartido por todas las empresas del tenant (mismo criterio
+    /// que <c>CatalogoSimple.IdEmpresa</c>, ADR-10).</summary>
+    public int? IdEmpresa { get; set; }
+
+    /// <summary>Correlativo atómico por tenant (design decision 2). <c>1</c> ⇒ Consumidor
+    /// Final.</summary>
+    public int Numero { get; set; }
+
+    public required string Nombre { get; set; }
+    public string? Apellido { get; set; }
+    public string? RazonSocial { get; set; }
+
+    /// <summary><c>NULL</c> para el Consumidor Final y para clientes históricos sin
+    /// documento cargado.</summary>
+    public TipoDocumento? TipoDocumento { get; set; }
+
+    /// <summary>Sin restricción de unicidad a ningún alcance (spec: numero_documento Has No
+    /// Uniqueness Constraint) — decisión de producto documentada, no un olvido.</summary>
+    public string? NumeroDocumento { get; set; }
+
+    public int IdCondicionFiscal { get; set; }
+
+    public DateOnly? Nacimiento { get; set; }
+
+    public string? Domicilio { get; set; }
+    public string? Telefono { get; set; }
+    public string? Celular { get; set; }
+    public string? Email { get; set; }
+
+    public string? Observaciones { get; set; }
+
+    public int IdListaPrecio { get; set; }
+
+    public decimal LimiteCredito { get; set; }
+    public bool CreditoIlimitado { get; set; }
+
+    /// <summary>Sin motor de movimientos de cuenta corriente todavía (etapa 7): se
+    /// mantiene en su valor de siembra/default, nunca lo mueve un caso de uso de esta
+    /// etapa.</summary>
+    public decimal Saldo { get; set; }
+
+    public bool Activo { get; set; } = true;
+
+    public bool EsConsumidorFinal => ReglaDeClientes.EsConsumidorFinal(Numero);
+}

--- a/src/Ways.Domain/Clientes/NumeracionCliente.cs
+++ b/src/Ways.Domain/Clientes/NumeracionCliente.cs
@@ -1,0 +1,19 @@
+namespace Ways.Domain.Clientes;
+
+/// <summary>
+/// Contador atómico de <c>clientes.numero</c> por tenant (design decision 2, doc 09
+/// <c>numeraciones_comprobante</c> family): <c>id_tenant</c> ES la PK, no una FK opcional —
+/// exactamente un contador por tenant, nunca cero ni más de uno. No hereda de
+/// <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/> a propósito: no tiene
+/// baja lógica (el contador de un tenant vive mientras el tenant exista) y su identidad no
+/// necesita una PK separada como el resto de las tablas de tenant.
+/// <see cref="Application.Clientes.AsignadorDeNumeroCliente"/> es el único punto de escritura:
+/// lee/actualiza esta fila con SQL crudo dentro de la transacción de creación (design
+/// decision 3), nunca vía <c>SaveChangesAsync</c>.
+/// </summary>
+public class NumeracionCliente
+{
+    public int IdTenant { get; set; }
+
+    public int ProximoNumero { get; set; } = 1;
+}

--- a/src/Ways.Domain/Clientes/ReglaDeClientes.cs
+++ b/src/Ways.Domain/Clientes/ReglaDeClientes.cs
@@ -1,0 +1,38 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Clientes;
+
+/// <summary>
+/// Protección del cliente Consumidor Final (design decision 4, spec: Consumidor Final
+/// Protected Row). Regla de negocio pura, sin dependencias — se testea sin base de datos
+/// (mirror de <see cref="Usuarios.PoliticaDeRoles"/>). El guard vive acá, no solo en la UI:
+/// todo camino de edición/baja de <see cref="Cliente"/> tiene que pasar por acá antes de
+/// tocar la fila. La constraint <c>ck_clientes_cf_protegido</c> es el backstop de esquema
+/// para la baja (design decision 4) — esta regla cubre además la edición, que la constraint
+/// no alcanza a bloquear.
+/// </summary>
+public static class ReglaDeClientes
+{
+    /// <summary><c>clientes.numero = 1</c> es, por construcción, siempre el Consumidor
+    /// Final de su tenant (provisionado o backfilleado, nunca asignado por el flujo normal
+    /// de alta — <see cref="Application.Clientes.AsignadorDeNumeroCliente"/> solo lo entrega
+    /// una vez, a la primera asignación de un contador recién creado).</summary>
+    public const int NumeroConsumidorFinal = 1;
+
+    public static bool EsConsumidorFinal(int numero) => numero == NumeroConsumidorFinal;
+
+    /// <summary>Rechaza editar o eliminar la fila Consumidor Final. Se llama antes de
+    /// aplicar cualquier cambio de edición/baja sobre un cliente existente (alta queda
+    /// afuera: un cliente recién creado nunca puede tener <c>numero = 1</c>, ese valor está
+    /// reservado al bootstrap de aprovisionamiento/backfill).</summary>
+    public static void ValidarNoConsumidorFinal(int numero)
+    {
+        if (EsConsumidorFinal(numero))
+        {
+            throw new ErrorDominio(
+                "consumidor_final_protegido",
+                "El cliente Consumidor Final no se puede editar ni eliminar.",
+                409);
+        }
+    }
+}

--- a/src/Ways.Domain/Clientes/ReglaDeClientes.cs
+++ b/src/Ways.Domain/Clientes/ReglaDeClientes.cs
@@ -10,6 +10,17 @@ namespace Ways.Domain.Clientes;
 /// tocar la fila. La constraint <c>ck_clientes_cf_protegido</c> es el backstop de esquema
 /// para la baja (design decision 4) — esta regla cubre además la edición, que la constraint
 /// no alcanza a bloquear.
+///
+/// Gap conocido, fuera de alcance de esta slice (judgment-day ronda 1, item de comentario):
+/// <c>ck_clientes_cf_protegido</c> solo lee <c>numero</c> en el momento del UPDATE/DELETE —
+/// un bypass de dos pasos (1: UPDATE que cambia <c>numero</c> de 1 a otro valor libre, 2:
+/// DELETE de esa misma fila ya renumerada) esquiva tanto la constraint como esta regla, que
+/// tampoco corre sobre un SQL directo. Ninguna de las dos escrituras de esa secuencia es en sí
+/// misma la operación que la constraint prohíbe. El guard real contra ese bypass es el que va
+/// a vivir en <c>ServicioDeClientes</c> (Slice 2, tasks.md 2A) — <see cref="ValidarNoConsumidorFinal"/>
+/// ya se llama antes de cualquier UPDATE que la Slice 2 emita, así que el camino de servicio
+/// nunca llega a habilitar el primer paso del bypass. Cerrarlo a nivel de esquema (p.ej. un
+/// trigger que también valide el valor ANTERIOR de <c>numero</c>) queda fuera de esta slice.
 /// </summary>
 public static class ReglaDeClientes
 {

--- a/src/Ways.Domain/Clientes/TipoDocumento.cs
+++ b/src/Ways.Domain/Clientes/TipoDocumento.cs
@@ -1,0 +1,15 @@
+namespace Ways.Domain.Clientes;
+
+/// <summary>
+/// Tipo de documento de un cliente (doc 10 §2). Enum nativo de Postgres
+/// (<c>tipo_documento</c>), mismo criterio que <c>estado_tenant</c>/<c>estado_usuario</c>.
+/// Nullable en <see cref="Cliente"/>: el Consumidor Final no tiene documento.
+/// </summary>
+public enum TipoDocumento
+{
+    Dni,
+    Cuit,
+    Cuil,
+    Pasaporte,
+    Otro
+}

--- a/src/Ways.Domain/Organizacion/PlantillaDeAprovisionamiento.cs
+++ b/src/Ways.Domain/Organizacion/PlantillaDeAprovisionamiento.cs
@@ -6,6 +6,12 @@ namespace Ways.Domain.Organizacion;
 /// Contenido con el que se provisiona un tenant nuevo (ADR-16). Versionada a propósito
 /// (<see cref="V1"/>): una plantilla nueva para un vertical futuro se agrega como versión,
 /// no se edita ésta.
+///
+/// <see cref="PlantillaV1.ClienteConsumidorFinal"/>/<see cref="PlantillaV1.ListaPrecioGeneral"/>
+/// (stage-2-clientes-proveedores, design decision 5) cierran el gap que <c>ItemsDiferidos</c>
+/// dejaba declarado desde la etapa 1: ahora que <c>clientes</c>/<c>listas_precio</c> existen,
+/// completar V1 en el lugar es terminar su propio roadmap, no agregar un vertical de negocio
+/// distinto — por eso no es un bump a V2 (ADR-16 es para eso otro).
 /// </summary>
 public static class PlantillaDeAprovisionamiento
 {
@@ -17,22 +23,27 @@ public static class PlantillaDeAprovisionamiento
                 "Efectivo", ComportamientoMedioPago.Efectivo, AdmiteVuelto: true, RequiereReferencia: false),
             new PlantillaMedioPago(
                 "Transferencia", ComportamientoMedioPago.Electronico, AdmiteVuelto: false, RequiereReferencia: true)
-        ]);
+        ],
+        ListaPrecioGeneral: new PlantillaListaPrecio("General"),
+        ClienteConsumidorFinal: new PlantillaClienteConsumidorFinal("Consumidor Final", "CF"));
 }
 
-public sealed record PlantillaV1(string Area, IReadOnlyList<PlantillaMedioPago> MediosDePago)
-{
-    /// <summary>Extensiones declaradas para etapas 2/3, deliberadamente NO creadas en esta
-    /// etapa (ADR-16): la lista de precios genérica y el cliente "Consumidor Final" necesitan
-    /// tablas que todavía no existen (<c>listas_precio</c>, <c>clientes</c>). Se dejan
-    /// nombradas acá para que un tenant provisionado hoy quede con un gap visible y
-    /// documentado, no silenciosamente incompleto.</summary>
-    public static readonly IReadOnlyList<string> ItemsDiferidos =
-    [
-        "lista_precio_general (etapa 3: listas_precio no existe todavía)",
-        "cliente_consumidor_final (etapa 2: clientes no existe todavía)"
-    ];
-}
+public sealed record PlantillaV1(
+    string Area,
+    IReadOnlyList<PlantillaMedioPago> MediosDePago,
+    PlantillaListaPrecio ListaPrecioGeneral,
+    PlantillaClienteConsumidorFinal ClienteConsumidorFinal);
 
 public sealed record PlantillaMedioPago(
     string Nombre, ComportamientoMedioPago Comportamiento, bool AdmiteVuelto, bool RequiereReferencia);
+
+/// <summary>Se crea con <c>modo = fija</c>, <c>es_default = true</c> (design: Table Shapes).
+/// <c>numero</c> no aparece acá: lo entrega
+/// <c>AsignadorDeNumeroCliente.AsignarSiguienteAsync</c> sobre un contador recién creado,
+/// siempre <c>1</c> por construcción.</summary>
+public sealed record PlantillaListaPrecio(string Nombre);
+
+/// <summary><paramref name="CodigoCondicionFiscal"/> resuelve contra <c>condiciones_fiscales</c>
+/// (catálogo global, sembrado por <c>InicializadorDeBaseDeDatos.SembrarCatalogosFiscalesAsync</c>
+/// — siempre disponible antes de que se aprovisione o backfillee cualquier tenant).</summary>
+public sealed record PlantillaClienteConsumidorFinal(string Nombre, string CodigoCondicionFiscal);

--- a/src/Ways.Domain/Proveedores/Proveedor.cs
+++ b/src/Ways.Domain/Proveedores/Proveedor.cs
@@ -1,0 +1,42 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Proveedores;
+
+/// <summary>
+/// Proveedor del tenant (doc 10 §2, catálogo-scoped: <c>id_tenant</c> + <c>id_empresa</c>
+/// opcional, doc 09). Entidad dedicada (design decision 1): no reusa
+/// <c>ConfiguracionDeCatalogo&lt;T&gt;</c>/<c>ServicioDeCatalogo&lt;T&gt;</c> porque dedupe
+/// por <see cref="Cuit"/> tenant-wide (spec: cuit Uniqueness Is Scoped Per Tenant), no por
+/// nombre/empresa-par como esa base asume.
+/// </summary>
+public class Proveedor : EntidadTenant
+{
+    public int Id { get; set; }
+
+    /// <summary><c>NULL</c> ⇒ compartido por todas las empresas del tenant (ADR-10).</summary>
+    public int? IdEmpresa { get; set; }
+
+    public required string RazonSocial { get; set; }
+    public string? NombreFantasia { get; set; }
+
+    /// <summary>Único por tenant (partial index, <c>NULL</c> permitido y no comparado) —
+    /// no por <c>(id_tenant, id_empresa)</c>: el mismo proveedor puede repetirse entre
+    /// empresas del mismo tenant sin que sea un duplicado de carga de datos.</summary>
+    public string? Cuit { get; set; }
+
+    public int IdCondicionFiscal { get; set; }
+
+    public string? Domicilio { get; set; }
+    public string? Telefono { get; set; }
+    public string? Email { get; set; }
+
+    public string? Vendedor { get; set; }
+    public string? CelularVendedor { get; set; }
+    public string? Supervisor { get; set; }
+    public string? CelularSupervisor { get; set; }
+
+    public decimal? Margen { get; set; }
+    public string? Observaciones { get; set; }
+
+    public bool Activo { get; set; } = true;
+}

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
@@ -86,6 +87,8 @@ public static class DependencyInjection
             npgsql.MapEnum<EstadoTenant>("estado_tenant");
             npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
             npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+            npgsql.MapEnum<TipoDocumento>("tipo_documento");
+            npgsql.MapEnum<ModoLista>("modo_lista");
             npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
         });
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
@@ -1,0 +1,168 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Cliente"/> (design decision 1, Table Shapes): entidad dedicada, no
+/// <c>ConfiguracionDeCatalogo&lt;T&gt;</c> — su índice único es por <c>numero</c> (asignado
+/// por el contador), no por <c>nombre</c>.
+/// </summary>
+public class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
+{
+    public void Configure(EntityTypeBuilder<Cliente> builder)
+    {
+        // Design decision 4 / backstop map: la constraint de esquema que cierra la baja
+        // irreversible del Consumidor Final — ReglaDeClientes.ValidarNoConsumidorFinal ya
+        // bloquea el camino normal (edición + baja), esto es el backstop ante un bypass
+        // directo del servicio.
+        builder.ToTable("clientes", t => t.HasCheckConstraint(
+            "ck_clientes_cf_protegido", "numero <> 1 OR deleted_at IS NULL"));
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id)
+            .HasColumnName("id_cliente")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(c => c.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(c => c.IdEmpresa)
+            .HasColumnName("id_empresa");
+
+        builder.Property(c => c.Numero)
+            .HasColumnName("numero")
+            .IsRequired();
+
+        builder.Property(c => c.Nombre)
+            .HasColumnName("nombre")
+            .HasColumnType("citext")
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(c => c.Apellido)
+            .HasColumnName("apellido")
+            .HasColumnType("citext")
+            .HasMaxLength(150);
+
+        builder.Property(c => c.RazonSocial)
+            .HasColumnName("razon_social")
+            .HasColumnType("citext")
+            .HasMaxLength(150);
+
+        builder.Property(c => c.TipoDocumento)
+            .HasColumnName("tipo_documento")
+            .HasColumnType("tipo_documento");
+
+        builder.Property(c => c.NumeroDocumento)
+            .HasColumnName("numero_documento")
+            .HasColumnType("citext")
+            .HasMaxLength(30);
+
+        builder.Property(c => c.IdCondicionFiscal)
+            .HasColumnName("id_condicion_fiscal")
+            .IsRequired();
+
+        builder.Property(c => c.Nacimiento)
+            .HasColumnName("nacimiento")
+            .HasColumnType("date");
+
+        builder.Property(c => c.Domicilio)
+            .HasColumnName("domicilio")
+            .HasColumnType("citext")
+            .HasMaxLength(255);
+
+        builder.Property(c => c.Telefono)
+            .HasColumnName("telefono")
+            .HasColumnType("citext")
+            .HasMaxLength(50);
+
+        builder.Property(c => c.Celular)
+            .HasColumnName("celular")
+            .HasColumnType("citext")
+            .HasMaxLength(50);
+
+        builder.Property(c => c.Email)
+            .HasColumnName("email")
+            .HasColumnType("citext")
+            .HasMaxLength(255);
+
+        builder.Property(c => c.Observaciones)
+            .HasColumnName("observaciones")
+            .HasColumnType("text");
+
+        builder.Property(c => c.IdListaPrecio)
+            .HasColumnName("id_lista_precio")
+            .IsRequired();
+
+        builder.Property(c => c.LimiteCredito)
+            .HasColumnName("limite_credito")
+            .HasColumnType("numeric(14,2)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(c => c.CreditoIlimitado)
+            .HasColumnName("credito_ilimitado")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(c => c.Saldo)
+            .HasColumnName("saldo")
+            .HasColumnType("numeric(14,2)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(c => c.Activo)
+            .HasColumnName("activo")
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(c => c.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(c => c.EstaEliminada);
+        builder.Ignore(c => c.EsConsumidorFinal);
+
+        // Design decision 2 / spec "Atomic Per-Tenant Numero Assignment": backstop del
+        // contador — bajo operación normal el contador atómico nunca choca acá, esto cubre
+        // un bypass directo del camino de escritura.
+        builder.HasIndex(c => new { c.IdTenant, c.Numero })
+            .HasDatabaseName("ux_clientes_numero")
+            .HasFilter("deleted_at IS NULL")
+            .IsUnique();
+
+        builder.HasIndex(c => c.IdTenant).HasDatabaseName("ix_clientes_tenant");
+        builder.HasIndex(c => new { c.IdEmpresa, c.IdTenant }).HasDatabaseName("ix_clientes_empresa");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(c => c.IdTenant)
+            .HasConstraintName("fk_clientes_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Empresa>()
+            .WithMany()
+            .HasForeignKey(c => new { c.IdEmpresa, c.IdTenant })
+            .HasPrincipalKey(e => new { e.Id, e.IdTenant })
+            .HasConstraintName("fk_clientes_empresa")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<CondicionFiscal>()
+            .WithMany()
+            .HasForeignKey(c => c.IdCondicionFiscal)
+            .HasConstraintName("fk_clientes_condicion_fiscal")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ListaPrecio>()
+            .WithMany()
+            .HasForeignKey(c => c.IdListaPrecio)
+            .HasConstraintName("fk_clientes_lista_precio")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
@@ -140,6 +140,13 @@ public class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
         builder.HasIndex(c => c.IdTenant).HasDatabaseName("ix_clientes_tenant");
         builder.HasIndex(c => new { c.IdEmpresa, c.IdTenant }).HasDatabaseName("ix_clientes_empresa");
 
+        // Nombre explícito en snake_case (doc 10): sin esto, EF nombra el índice de soporte
+        // de la FK con su convención propia (IX_clientes_id_condicion_fiscal), rompiendo la
+        // convención que el resto del esquema mantiene sin excepciones (p.ej.
+        // ix_categorias_padre para id_categoria_padre).
+        builder.HasIndex(c => c.IdCondicionFiscal).HasDatabaseName("ix_clientes_condicion_fiscal");
+        builder.HasIndex(c => c.IdListaPrecio).HasDatabaseName("ix_clientes_lista_precio");
+
         builder.HasOne<Tenant>()
             .WithMany()
             .HasForeignKey(c => c.IdTenant)

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ClienteConfiguration.cs
@@ -145,7 +145,11 @@ public class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
         // convención que el resto del esquema mantiene sin excepciones (p.ej.
         // ix_categorias_padre para id_categoria_padre).
         builder.HasIndex(c => c.IdCondicionFiscal).HasDatabaseName("ix_clientes_condicion_fiscal");
-        builder.HasIndex(c => c.IdListaPrecio).HasDatabaseName("ix_clientes_lista_precio");
+
+        // (IdListaPrecio, IdTenant), no solo IdListaPrecio: mismo criterio que
+        // ix_clientes_empresa, columnas en el mismo orden que la FK compuesta de abajo, para
+        // que EF no genere un segundo índice de soporte con su propia convención de nombre.
+        builder.HasIndex(c => new { c.IdListaPrecio, c.IdTenant }).HasDatabaseName("ix_clientes_lista_precio");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -166,9 +170,14 @@ public class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
             .HasConstraintName("fk_clientes_condicion_fiscal")
             .OnDelete(DeleteBehavior.Restrict);
 
+        // DB CHANGE GATE aprobado 2026-08-02 (judgment-day ronda 1, hardening de esquema):
+        // FK compuesta (IdListaPrecio, IdTenant) contra la clave alterna de ListaPrecioConfiguration
+        // -- una FK simple sobre id_lista_precio (PK global, única entre tenants) dejaba pasar el
+        // id de una lista de OTRO tenant sin violar la constraint, y solo RLS lo frenaba en runtime.
         builder.HasOne<ListaPrecio>()
             .WithMany()
-            .HasForeignKey(c => c.IdListaPrecio)
+            .HasForeignKey(c => new { c.IdListaPrecio, c.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdTenant })
             .HasConstraintName("fk_clientes_lista_precio")
             .OnDelete(DeleteBehavior.Restrict);
     }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
@@ -40,6 +40,9 @@ public class ListaPrecioConfiguration : ConfiguracionDeCatalogo<ListaPrecio>
             .HasConstraintName("fk_listas_precio_lista_base")
             .OnDelete(DeleteBehavior.Restrict);
 
+        // Nombre explícito en snake_case (doc 10), mismo motivo que ClienteConfiguration.
+        builder.HasIndex(l => l.IdListaBase).HasDatabaseName("ix_listas_precio_lista_base");
+
         builder.HasIndex(l => new { l.IdTenant, l.EsDefault })
             .HasDatabaseName("ux_listas_precio_default_compartido")
             .HasFilter("id_empresa IS NULL AND deleted_at IS NULL AND es_default = true")

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// <see cref="ListaPrecio"/> sí reusa <see cref="ConfiguracionDeCatalogo{T}"/> (design
+/// decision 1): su forma (nombre + flags) calza con la base genérica. Acá solo se agregan
+/// sus columnas propias y el segundo par de índices únicos parciales que garantiza "una
+/// lista <c>es_default</c> por alcance" (design: Table Shapes).
+/// </summary>
+public class ListaPrecioConfiguration : ConfiguracionDeCatalogo<ListaPrecio>
+{
+    protected override string Tabla => "listas_precio";
+    protected override string ColumnaId => "id_lista_precio";
+
+    protected override void ConfigurarPropio(EntityTypeBuilder<ListaPrecio> builder)
+    {
+        builder.Property(l => l.EsDefault)
+            .HasColumnName("es_default")
+            .IsRequired();
+
+        builder.Property(l => l.Modo)
+            .HasColumnName("modo")
+            .HasColumnType("modo_lista")
+            .HasDefaultValue(ModoLista.Fija)
+            .IsRequired();
+
+        builder.Property(l => l.IdListaBase)
+            .HasColumnName("id_lista_base");
+
+        builder.Property(l => l.Porcentaje)
+            .HasColumnName("porcentaje")
+            .HasColumnType("numeric(5,2)");
+
+        builder.HasOne<ListaPrecio>()
+            .WithMany()
+            .HasForeignKey(l => l.IdListaBase)
+            .HasConstraintName("fk_listas_precio_lista_base")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(l => new { l.IdTenant, l.EsDefault })
+            .HasDatabaseName("ux_listas_precio_default_compartido")
+            .HasFilter("id_empresa IS NULL AND deleted_at IS NULL AND es_default = true")
+            .IsUnique();
+
+        builder.HasIndex(l => new { l.IdTenant, l.IdEmpresa, l.EsDefault })
+            .HasDatabaseName("ux_listas_precio_default_empresa")
+            .HasFilter("id_empresa IS NOT NULL AND deleted_at IS NULL AND es_default = true")
+            .IsUnique();
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
@@ -34,6 +34,15 @@ public class ListaPrecioConfiguration : ConfiguracionDeCatalogo<ListaPrecio>
             .HasColumnName("porcentaje")
             .HasColumnType("numeric(5,2)");
 
+        // DB CHANGE GATE aprobado 2026-08-02 (judgment-day ronda 1, hardening de esquema):
+        // clave alterna (Id, IdTenant) para que fk_clientes_lista_precio pueda ser compuesta
+        // -- mismo patrón que Empresa.HasAlternateKey/fk_clientes_empresa, fk_proveedores_empresa
+        // y fk_listas_precio_empresa. Sin esto, un id_lista_precio de OTRO tenant pasaba la FK
+        // simple (la columna referenciada, id_lista_precio, es única globalmente por ser PK) y
+        // solo RLS lo frenaba -- con la clave compuesta, la propia FK ya lo rechaza (23503).
+        builder.HasAlternateKey(l => new { l.Id, l.IdTenant })
+            .HasName("ak_listas_precio_id_tenant");
+
         builder.HasOne<ListaPrecio>()
             .WithMany()
             .HasForeignKey(l => l.IdListaBase)

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ListaPrecioConfiguration.cs
@@ -41,7 +41,7 @@ public class ListaPrecioConfiguration : ConfiguracionDeCatalogo<ListaPrecio>
         // simple (la columna referenciada, id_lista_precio, es única globalmente por ser PK) y
         // solo RLS lo frenaba -- con la clave compuesta, la propia FK ya lo rechaza (23503).
         builder.HasAlternateKey(l => new { l.Id, l.IdTenant })
-            .HasName("ak_listas_precio_id_tenant");
+            .HasName("ak_listas_precio_id_lista_precio_id_tenant");
 
         builder.HasOne<ListaPrecio>()
             .WithMany()

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionClienteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionClienteConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="NumeracionCliente"/> (design: Table Shapes): <c>id_tenant</c> ES la PK,
+/// sin identity propia. Solo <c>AsignadorDeNumeroCliente</c> escribe esta tabla, y lo hace
+/// con SQL crudo (design decision 3) — este mapeo existe para que el modelo de EF conozca
+/// la forma de la tabla (RLS, FK, lecturas de diagnóstico), no para que <c>SaveChangesAsync</c>
+/// la toque.
+/// </summary>
+public class NumeracionClienteConfiguration : IEntityTypeConfiguration<NumeracionCliente>
+{
+    public void Configure(EntityTypeBuilder<NumeracionCliente> builder)
+    {
+        builder.ToTable("numeraciones_clientes");
+
+        builder.HasKey(n => n.IdTenant);
+
+        builder.Property(n => n.IdTenant)
+            .HasColumnName("id_tenant")
+            .ValueGeneratedNever();
+
+        builder.Property(n => n.ProximoNumero)
+            .HasColumnName("proximo_numero")
+            .HasDefaultValue(1)
+            .IsRequired();
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(n => n.IdTenant)
+            .HasConstraintName("fk_numeraciones_clientes_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ProveedorConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ProveedorConfiguration.cs
@@ -1,0 +1,139 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Proveedor"/> (design decision 1, Table Shapes): entidad dedicada, dedupe
+/// por <c>cuit</c> tenant-wide, no por <c>nombre</c>/empresa como
+/// <c>ConfiguracionDeCatalogo&lt;T&gt;</c>.
+/// </summary>
+public class ProveedorConfiguration : IEntityTypeConfiguration<Proveedor>
+{
+    public void Configure(EntityTypeBuilder<Proveedor> builder)
+    {
+        builder.ToTable("proveedores");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Id)
+            .HasColumnName("id_proveedor")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(p => p.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(p => p.IdEmpresa)
+            .HasColumnName("id_empresa");
+
+        builder.Property(p => p.RazonSocial)
+            .HasColumnName("razon_social")
+            .HasColumnType("citext")
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(p => p.NombreFantasia)
+            .HasColumnName("nombre_fantasia")
+            .HasColumnType("citext")
+            .HasMaxLength(150);
+
+        // Sin citext (a diferencia del resto de los campos de texto de esta tabla): el cuit
+        // es un valor formateado, no un texto buscado case-insensitive (mismo criterio que
+        // Empresa.Cuit).
+        builder.Property(p => p.Cuit)
+            .HasColumnName("cuit")
+            .HasMaxLength(13);
+
+        builder.Property(p => p.IdCondicionFiscal)
+            .HasColumnName("id_condicion_fiscal")
+            .IsRequired();
+
+        builder.Property(p => p.Domicilio)
+            .HasColumnName("domicilio")
+            .HasColumnType("citext")
+            .HasMaxLength(255);
+
+        builder.Property(p => p.Telefono)
+            .HasColumnName("telefono")
+            .HasColumnType("citext")
+            .HasMaxLength(50);
+
+        builder.Property(p => p.Email)
+            .HasColumnName("email")
+            .HasColumnType("citext")
+            .HasMaxLength(255);
+
+        builder.Property(p => p.Vendedor)
+            .HasColumnName("vendedor")
+            .HasColumnType("citext")
+            .HasMaxLength(150);
+
+        builder.Property(p => p.CelularVendedor)
+            .HasColumnName("celular_vendedor")
+            .HasColumnType("citext")
+            .HasMaxLength(50);
+
+        builder.Property(p => p.Supervisor)
+            .HasColumnName("supervisor")
+            .HasColumnType("citext")
+            .HasMaxLength(150);
+
+        builder.Property(p => p.CelularSupervisor)
+            .HasColumnName("celular_supervisor")
+            .HasColumnType("citext")
+            .HasMaxLength(50);
+
+        builder.Property(p => p.Margen)
+            .HasColumnName("margen")
+            .HasColumnType("numeric(5,2)");
+
+        builder.Property(p => p.Observaciones)
+            .HasColumnName("observaciones")
+            .HasColumnType("text");
+
+        builder.Property(p => p.Activo)
+            .HasColumnName("activo")
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Property(p => p.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(p => p.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(p => p.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(p => p.EstaEliminada);
+
+        // Spec "cuit Uniqueness Is Scoped Per Tenant": único por tenant, sin id_empresa en
+        // la clave (a propósito — el mismo proveedor puede repetirse entre empresas del
+        // mismo tenant), NULL permitido y no comparado.
+        builder.HasIndex(p => new { p.IdTenant, p.Cuit })
+            .HasDatabaseName("ux_proveedores_cuit")
+            .HasFilter("deleted_at IS NULL AND cuit IS NOT NULL")
+            .IsUnique();
+
+        builder.HasIndex(p => p.IdTenant).HasDatabaseName("ix_proveedores_tenant");
+        builder.HasIndex(p => new { p.IdEmpresa, p.IdTenant }).HasDatabaseName("ix_proveedores_empresa");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(p => p.IdTenant)
+            .HasConstraintName("fk_proveedores_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Empresa>()
+            .WithMany()
+            .HasForeignKey(p => new { p.IdEmpresa, p.IdTenant })
+            .HasPrincipalKey(e => new { e.Id, e.IdTenant })
+            .HasConstraintName("fk_proveedores_empresa")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<CondicionFiscal>()
+            .WithMany()
+            .HasForeignKey(p => p.IdCondicionFiscal)
+            .HasConstraintName("fk_proveedores_condicion_fiscal")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ProveedorConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ProveedorConfiguration.cs
@@ -117,6 +117,9 @@ public class ProveedorConfiguration : IEntityTypeConfiguration<Proveedor>
         builder.HasIndex(p => p.IdTenant).HasDatabaseName("ix_proveedores_tenant");
         builder.HasIndex(p => new { p.IdEmpresa, p.IdTenant }).HasDatabaseName("ix_proveedores_empresa");
 
+        // Nombre explícito en snake_case (doc 10), mismo motivo que ClienteConfiguration.
+        builder.HasIndex(p => p.IdCondicionFiscal).HasDatabaseName("ix_proveedores_condicion_fiscal");
+
         builder.HasOne<Tenant>()
             .WithMany()
             .HasForeignKey(p => p.IdTenant)

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -3,8 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Ways.Application.Abstracciones;
+using Ways.Application.Clientes;
 using Ways.Application.Usuarios;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 
@@ -93,6 +95,7 @@ public class InicializadorDeBaseDeDatos(
         await SembrarOrganizacionAsync(ct);
         await BackfillDeUsuariosAsync(ct);
         await SembrarCatalogosFiscalesAsync(ct);
+        await BackfillDeClientesYListasPrecioAsync(ct);
     }
 
     /// <summary>
@@ -429,6 +432,107 @@ public class InicializadorDeBaseDeDatos(
             await db.SaveChangesAsync(ct);
             log.LogInformation("Sembrados {Cantidad} tipos de comprobante.", TiposComprobanteBase.Length);
         }
+    }
+
+    /// <summary>
+    /// Backfill de Consumidor Final + lista de precios General para tenants preexistentes
+    /// (task 1.11, stage-2-clientes-proveedores, spec: Backfill for Pre-Existing Tenants):
+    /// mismo patrón que <see cref="BackfillDeUsuariosAsync"/> (ADR-14) — corre después de
+    /// las migraciones, y solo toca un tenant que todavía no tiene ninguna de las dos filas.
+    ///
+    /// Corre en modo plataforma: a diferencia de <c>ServicioDeAprovisionamiento</c> (que
+    /// suplanta la sesión HTTP mutable, ADR-16), acá alcanza con setear <c>IdTenant</c>
+    /// explícito en cada entidad antes de <c>SaveChangesAsync</c> — mismo criterio que
+    /// <see cref="SembrarOrganizacionAsync"/>: <c>EstamparTenant</c> lo exige bajo modo
+    /// plataforma, y RLS lo deja pasar (<c>WITH CHECK app_es_plataforma()</c>).
+    /// <c>TenantActualFijo</c> ni siquiera soporta suplantación.
+    ///
+    /// Idempotente por tenant: si ya tiene un cliente <c>numero = 1</c> (Consumidor Final) O
+    /// una lista <c>es_default</c>, no se toca — un tenant aprovisionado con
+    /// <c>ServicioDeAprovisionamiento</c> (que crea las dos filas juntas) nunca se duplica
+    /// acá, y un tenant a mitad de backfill (una fila sin la otra, por un fallo previo del
+    /// proceso) no vuelve a intentar la parte que ya tiene.
+    /// </summary>
+    private async Task BackfillDeClientesYListasPrecioAsync(CancellationToken ct)
+    {
+        var tenantsConCf = await db.Clientes
+            .IgnoreQueryFilters(["BajaLogica"])
+            .Where(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal)
+            .Select(c => c.IdTenant)
+            .ToListAsync(ct);
+
+        var tenantsConListaDefault = await db.ListasPrecio
+            .IgnoreQueryFilters(["BajaLogica"])
+            .Where(l => l.EsDefault)
+            .Select(l => l.IdTenant)
+            .ToListAsync(ct);
+
+        var tenantsYaCubiertos = new HashSet<int>(tenantsConCf);
+        tenantsYaCubiertos.UnionWith(tenantsConListaDefault);
+
+        var tenantsPendientes = await db.Tenants
+            .IgnoreQueryFilters(["BajaLogica"])
+            .Where(t => !tenantsYaCubiertos.Contains(t.Id))
+            .OrderBy(t => t.Id)
+            .ToListAsync(ct);
+
+        if (tenantsPendientes.Count == 0)
+        {
+            return;
+        }
+
+        var condicionFiscalCf = await db.CondicionesFiscales
+            .IgnoreQueryFilters(["BajaLogica"])
+            .SingleAsync(
+                c => c.Codigo == PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.CodigoCondicionFiscal, ct);
+
+        var ahora = reloj.Ahora;
+        var estrategia = db.Database.CreateExecutionStrategy();
+
+        foreach (var tenant in tenantsPendientes)
+        {
+            await estrategia.ExecuteAsync(async () =>
+            {
+                await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+                var listaPrecioGeneral = new ListaPrecio
+                {
+                    IdTenant = tenant.Id,
+                    Nombre = PlantillaDeAprovisionamiento.V1.ListaPrecioGeneral.Nombre,
+                    EsDefault = true,
+                    Modo = ModoLista.Fija,
+                    Activo = true,
+                    CreatedAt = ahora,
+                    UpdatedAt = ahora
+                };
+                db.ListasPrecio.Add(listaPrecioGeneral);
+
+                // SaveChanges antes de asignar el numero: listaPrecioGeneral.Id todavía no
+                // existe (identity), y clientes.id_lista_precio lo necesita.
+                await db.SaveChangesAsync(ct);
+
+                await AsignadorDeNumeroCliente.AsegurarContadorAsync(db, tenant.Id, ct);
+                var numeroConsumidorFinal = await AsignadorDeNumeroCliente.AsignarSiguienteAsync(db, tenant.Id, ct);
+
+                db.Clientes.Add(new Cliente
+                {
+                    IdTenant = tenant.Id,
+                    Numero = numeroConsumidorFinal,
+                    Nombre = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.Nombre,
+                    IdCondicionFiscal = condicionFiscalCf.Id,
+                    IdListaPrecio = listaPrecioGeneral.Id,
+                    CreatedAt = ahora,
+                    UpdatedAt = ahora
+                });
+
+                await db.SaveChangesAsync(ct);
+                await transaccion.CommitAsync(ct);
+            });
+        }
+
+        log.LogInformation(
+            "Backfill: Consumidor Final + lista General creados para {Cantidad} tenants preexistentes.",
+            tenantsPendientes.Count);
     }
 }
 

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -438,7 +438,7 @@ public class InicializadorDeBaseDeDatos(
     /// Backfill de Consumidor Final + lista de precios General para tenants preexistentes
     /// (task 1.11, stage-2-clientes-proveedores, spec: Backfill for Pre-Existing Tenants):
     /// mismo patrón que <see cref="BackfillDeUsuariosAsync"/> (ADR-14) — corre después de
-    /// las migraciones, y solo toca un tenant que todavía no tiene ninguna de las dos filas.
+    /// las migraciones.
     ///
     /// Corre en modo plataforma: a diferencia de <c>ServicioDeAprovisionamiento</c> (que
     /// suplanta la sesión HTTP mutable, ADR-16), acá alcanza con setear <c>IdTenant</c>
@@ -447,34 +447,54 @@ public class InicializadorDeBaseDeDatos(
     /// plataforma, y RLS lo deja pasar (<c>WITH CHECK app_es_plataforma()</c>).
     /// <c>TenantActualFijo</c> ni siquiera soporta suplantación.
     ///
-    /// Idempotente por tenant: si ya tiene un cliente <c>numero = 1</c> (Consumidor Final) O
-    /// una lista <c>es_default</c>, no se toca — un tenant aprovisionado con
-    /// <c>ServicioDeAprovisionamiento</c> (que crea las dos filas juntas) nunca se duplica
-    /// acá, y un tenant a mitad de backfill (una fila sin la otra, por un fallo previo del
-    /// proceso) no vuelve a intentar la parte que ya tiene.
+    /// Idempotente POR ARTEFACTO, no por par (judgment-day, ronda 1, item CRITICAL): la
+    /// versión anterior calculaba "cubierto" como la UNIÓN de tenants-con-CF y
+    /// tenants-con-lista-default, así que un tenant con solo UNA de las dos filas (por un
+    /// fallo previo del proceso a mitad de camino, o un dato migrado a mano) quedaba
+    /// "cubierto" y el backfill nunca completaba la mitad faltante. Acá cada artefacto se
+    /// evalúa por separado: la lista General se crea si el tenant no tiene ninguna
+    /// <c>es_default</c>, y el cliente Consumidor Final se crea si el tenant no tiene ningún
+    /// <c>numero = 1</c> — independiente uno del otro, pero siguen viviendo en la misma
+    /// transacción por tenant (si hay que crear los dos, los dos se confirman juntos o
+    /// ninguno). Un tenant aprovisionado con <c>ServicioDeAprovisionamiento</c> (que crea las
+    /// dos filas juntas) nunca se toca acá; un tenant con las dos filas ya presentes tampoco.
+    ///
+    /// Supuestos de los que depende el chequeo de cobertura (judgment-day ronda 1, item de
+    /// comentario): (1) <c>Cliente.Numero == 1</c> identifica al Consumidor Final de forma
+    /// unívoca por tenant — invariante de <see cref="ReglaDeClientes"/>, nunca asignado por el
+    /// flujo normal de alta; (2) a lo sumo una <c>ListaPrecio.EsDefault</c> compartida (sin
+    /// <c>IdEmpresa</c>) existe por tenant — invariante de esquema, <c>ux_listas_precio_default_compartido</c>.
+    /// Si cualquiera de las dos deja de sostenerse (p.ej. una lista default por EMPRESA en vez
+    /// de compartida, una vez que <c>listas_precio</c> ABM salga de scope en una etapa futura),
+    /// este chequeo de "no tiene ninguna" deja de ser suficiente y hay que revisarlo.
     /// </summary>
     private async Task BackfillDeClientesYListasPrecioAsync(CancellationToken ct)
     {
-        var tenantsConCf = await db.Clientes
+        var todosLosTenants = await db.Tenants
+            .IgnoreQueryFilters(["BajaLogica"])
+            .OrderBy(t => t.Id)
+            .ToListAsync(ct);
+
+        if (todosLosTenants.Count == 0)
+        {
+            return;
+        }
+
+        var tenantsConCf = (await db.Clientes
             .IgnoreQueryFilters(["BajaLogica"])
             .Where(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal)
             .Select(c => c.IdTenant)
-            .ToListAsync(ct);
+            .ToListAsync(ct))
+            .ToHashSet();
 
-        var tenantsConListaDefault = await db.ListasPrecio
+        var idListaDefaultPorTenant = await db.ListasPrecio
             .IgnoreQueryFilters(["BajaLogica"])
             .Where(l => l.EsDefault)
-            .Select(l => l.IdTenant)
-            .ToListAsync(ct);
+            .ToDictionaryAsync(l => l.IdTenant, l => l.Id, ct);
 
-        var tenantsYaCubiertos = new HashSet<int>(tenantsConCf);
-        tenantsYaCubiertos.UnionWith(tenantsConListaDefault);
-
-        var tenantsPendientes = await db.Tenants
-            .IgnoreQueryFilters(["BajaLogica"])
-            .Where(t => !tenantsYaCubiertos.Contains(t.Id))
-            .OrderBy(t => t.Id)
-            .ToListAsync(ct);
+        var tenantsPendientes = todosLosTenants
+            .Where(t => !tenantsConCf.Contains(t.Id) || !idListaDefaultPorTenant.ContainsKey(t.Id))
+            .ToList();
 
         if (tenantsPendientes.Count == 0)
         {
@@ -488,6 +508,8 @@ public class InicializadorDeBaseDeDatos(
 
         var ahora = reloj.Ahora;
         var estrategia = db.Database.CreateExecutionStrategy();
+        var listasCreadas = 0;
+        var clientesCreados = 0;
 
         foreach (var tenant in tenantsPendientes)
         {
@@ -495,44 +517,58 @@ public class InicializadorDeBaseDeDatos(
             {
                 await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
-                var listaPrecioGeneral = new ListaPrecio
+                var idListaPrecio = idListaDefaultPorTenant.GetValueOrDefault(tenant.Id);
+
+                if (idListaPrecio == default)
                 {
-                    IdTenant = tenant.Id,
-                    Nombre = PlantillaDeAprovisionamiento.V1.ListaPrecioGeneral.Nombre,
-                    EsDefault = true,
-                    Modo = ModoLista.Fija,
-                    Activo = true,
-                    CreatedAt = ahora,
-                    UpdatedAt = ahora
-                };
-                db.ListasPrecio.Add(listaPrecioGeneral);
+                    var listaPrecioGeneral = new ListaPrecio
+                    {
+                        IdTenant = tenant.Id,
+                        Nombre = PlantillaDeAprovisionamiento.V1.ListaPrecioGeneral.Nombre,
+                        EsDefault = true,
+                        Modo = ModoLista.Fija,
+                        Activo = true,
+                        CreatedAt = ahora,
+                        UpdatedAt = ahora
+                    };
+                    db.ListasPrecio.Add(listaPrecioGeneral);
 
-                // SaveChanges antes de asignar el numero: listaPrecioGeneral.Id todavía no
-                // existe (identity), y clientes.id_lista_precio lo necesita.
-                await db.SaveChangesAsync(ct);
+                    // SaveChanges antes de asignar el numero: listaPrecioGeneral.Id todavía
+                    // no existe (identity), y clientes.id_lista_precio lo necesita.
+                    await db.SaveChangesAsync(ct);
 
-                await AsignadorDeNumeroCliente.AsegurarContadorAsync(db, tenant.Id, ct);
-                var numeroConsumidorFinal = await AsignadorDeNumeroCliente.AsignarSiguienteAsync(db, tenant.Id, ct);
+                    idListaPrecio = listaPrecioGeneral.Id;
+                    listasCreadas++;
+                }
 
-                db.Clientes.Add(new Cliente
+                if (!tenantsConCf.Contains(tenant.Id))
                 {
-                    IdTenant = tenant.Id,
-                    Numero = numeroConsumidorFinal,
-                    Nombre = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.Nombre,
-                    IdCondicionFiscal = condicionFiscalCf.Id,
-                    IdListaPrecio = listaPrecioGeneral.Id,
-                    CreatedAt = ahora,
-                    UpdatedAt = ahora
-                });
+                    await AsignadorDeNumeroCliente.AsegurarContadorAsync(db, tenant.Id, ct);
+                    var numeroConsumidorFinal = await AsignadorDeNumeroCliente.AsignarSiguienteAsync(db, tenant.Id, ct);
 
-                await db.SaveChangesAsync(ct);
+                    db.Clientes.Add(new Cliente
+                    {
+                        IdTenant = tenant.Id,
+                        Numero = numeroConsumidorFinal,
+                        Nombre = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.Nombre,
+                        IdCondicionFiscal = condicionFiscalCf.Id,
+                        IdListaPrecio = idListaPrecio,
+                        CreatedAt = ahora,
+                        UpdatedAt = ahora
+                    });
+
+                    await db.SaveChangesAsync(ct);
+                    clientesCreados++;
+                }
+
                 await transaccion.CommitAsync(ct);
             });
         }
 
         log.LogInformation(
-            "Backfill: Consumidor Final + lista General creados para {Cantidad} tenants preexistentes.",
-            tenantsPendientes.Count);
+            "Backfill: {Listas} listas General y {Clientes} clientes Consumidor Final " +
+            "creados para completar {Cantidad} tenants preexistentes.",
+            listasCreadas, clientesCreados, tenantsPendientes.Count);
     }
 }
 

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -487,9 +487,13 @@ public class InicializadorDeBaseDeDatos(
             .ToListAsync(ct))
             .ToHashSet();
 
+        // Se filtra a IdEmpresa == null (lista default compartida) porque es el único caso que
+        // este backfill necesita cubrir; además evita que ToDictionaryAsync explote con clave
+        // duplicada si algún tenant llegara a tener una default compartida y otra por empresa a
+        // la vez (estado que hoy no debería darse, pero degrada mejor así que con un crash).
         var idListaDefaultPorTenant = await db.ListasPrecio
             .IgnoreQueryFilters(["BajaLogica"])
-            .Where(l => l.EsDefault)
+            .Where(l => l.EsDefault && l.IdEmpresa == null)
             .ToDictionaryAsync(l => l.IdTenant, l => l.Id, ct);
 
         var tenantsPendientes = todosLosTenants

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
@@ -432,7 +432,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                     b.HasKey("Id");
 
                     b.HasAlternateKey("Id", "IdTenant")
-                        .HasName("ak_listas_precio_id_tenant");
+                        .HasName("ak_listas_precio_id_lista_precio_id_tenant");
 
                     b.HasIndex("IdListaBase")
                         .HasDatabaseName("ix_listas_precio_lista_base");

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
@@ -431,6 +431,9 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
 
                     b.HasKey("Id");
 
+                    b.HasAlternateKey("Id", "IdTenant")
+                        .HasName("ak_listas_precio_id_tenant");
+
                     b.HasIndex("IdListaBase")
                         .HasDatabaseName("ix_listas_precio_lista_base");
 
@@ -875,7 +878,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                     b.HasIndex("IdCondicionFiscal")
                         .HasDatabaseName("ix_clientes_condicion_fiscal");
 
-                    b.HasIndex("IdListaPrecio")
+                    b.HasIndex("IdListaPrecio", "IdTenant")
                         .HasDatabaseName("ix_clientes_lista_precio");
 
                     b.HasIndex("IdTenant")
@@ -1488,7 +1491,8 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
 
                     b.HasOne("Ways.Domain.Catalogos.ListaPrecio", null)
                         .WithMany()
-                        .HasForeignKey("IdListaPrecio")
+                        .HasForeignKey("IdListaPrecio", "IdTenant")
+                        .HasPrincipalKey("Id", "IdTenant")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired()
                         .HasConstraintName("fk_clientes_lista_precio");

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Catalogos;
@@ -15,9 +16,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802172552_ClientesYProveedoresEtapa2")]
+    partial class ClientesYProveedoresEtapa2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
@@ -50,6 +50,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_listas_precio", x => x.id_lista_precio);
+                    table.UniqueConstraint("ak_listas_precio_id_tenant", x => new { x.id_lista_precio, x.id_tenant });
                     table.ForeignKey(
                         name: "fk_listas_precio_empresa",
                         columns: x => new { x.id_empresa, x.id_tenant },
@@ -185,9 +186,9 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                         onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "fk_clientes_lista_precio",
-                        column: x => x.id_lista_precio,
+                        columns: x => new { x.id_lista_precio, x.id_tenant },
                         principalTable: "listas_precio",
-                        principalColumn: "id_lista_precio",
+                        principalColumns: new[] { "id_lista_precio", "id_tenant" },
                         onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "fk_clientes_tenant",
@@ -210,7 +211,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
             migrationBuilder.CreateIndex(
                 name: "ix_clientes_lista_precio",
                 table: "clientes",
-                column: "id_lista_precio");
+                columns: new[] { "id_lista_precio", "id_tenant" });
 
             migrationBuilder.CreateIndex(
                 name: "ix_clientes_tenant",

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
@@ -50,7 +50,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_listas_precio", x => x.id_lista_precio);
-                    table.UniqueConstraint("ak_listas_precio_id_tenant", x => new { x.id_lista_precio, x.id_tenant });
+                    table.UniqueConstraint("ak_listas_precio_id_lista_precio_id_tenant", x => new { x.id_lista_precio, x.id_tenant });
                     table.ForeignKey(
                         name: "fk_listas_precio_empresa",
                         columns: x => new { x.id_empresa, x.id_tenant },

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260802172552_ClientesYProveedoresEtapa2.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class ClientesYProveedoresEtapa2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "listas_precio",
+                columns: table => new
+                {
+                    id_lista_precio = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    es_default = table.Column<bool>(type: "boolean", nullable: false),
+                    modo = table.Column<ModoLista>(type: "modo_lista", nullable: false, defaultValue: ModoLista.Fija),
+                    id_lista_base = table.Column<int>(type: "integer", nullable: true),
+                    porcentaje = table.Column<decimal>(type: "numeric(5,2)", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    nombre = table.Column<string>(type: "citext", maxLength: 150, nullable: false),
+                    activo = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    id_empresa = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_listas_precio", x => x.id_lista_precio);
+                    table.ForeignKey(
+                        name: "fk_listas_precio_empresa",
+                        columns: x => new { x.id_empresa, x.id_tenant },
+                        principalTable: "empresas",
+                        principalColumns: new[] { "id_empresa", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_listas_precio_lista_base",
+                        column: x => x.id_lista_base,
+                        principalTable: "listas_precio",
+                        principalColumn: "id_lista_precio",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_listas_precio_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "numeraciones_clientes",
+                columns: table => new
+                {
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    proximo_numero = table.Column<int>(type: "integer", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_numeraciones_clientes", x => x.id_tenant);
+                    table.ForeignKey(
+                        name: "fk_numeraciones_clientes_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "proveedores",
+                columns: table => new
+                {
+                    id_proveedor = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_empresa = table.Column<int>(type: "integer", nullable: true),
+                    razon_social = table.Column<string>(type: "citext", maxLength: 150, nullable: false),
+                    nombre_fantasia = table.Column<string>(type: "citext", maxLength: 150, nullable: true),
+                    cuit = table.Column<string>(type: "character varying(13)", maxLength: 13, nullable: true),
+                    id_condicion_fiscal = table.Column<int>(type: "integer", nullable: false),
+                    domicilio = table.Column<string>(type: "citext", maxLength: 255, nullable: true),
+                    telefono = table.Column<string>(type: "citext", maxLength: 50, nullable: true),
+                    email = table.Column<string>(type: "citext", maxLength: 255, nullable: true),
+                    vendedor = table.Column<string>(type: "citext", maxLength: 150, nullable: true),
+                    celular_vendedor = table.Column<string>(type: "citext", maxLength: 50, nullable: true),
+                    supervisor = table.Column<string>(type: "citext", maxLength: 150, nullable: true),
+                    celular_supervisor = table.Column<string>(type: "citext", maxLength: 50, nullable: true),
+                    margen = table.Column<decimal>(type: "numeric(5,2)", nullable: true),
+                    observaciones = table.Column<string>(type: "text", nullable: true),
+                    activo = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_proveedores", x => x.id_proveedor);
+                    table.ForeignKey(
+                        name: "fk_proveedores_condicion_fiscal",
+                        column: x => x.id_condicion_fiscal,
+                        principalTable: "condiciones_fiscales",
+                        principalColumn: "id_condicion_fiscal",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_proveedores_empresa",
+                        columns: x => new { x.id_empresa, x.id_tenant },
+                        principalTable: "empresas",
+                        principalColumns: new[] { "id_empresa", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_proveedores_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "clientes",
+                columns: table => new
+                {
+                    id_cliente = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_empresa = table.Column<int>(type: "integer", nullable: true),
+                    numero = table.Column<int>(type: "integer", nullable: false),
+                    nombre = table.Column<string>(type: "citext", maxLength: 150, nullable: false),
+                    apellido = table.Column<string>(type: "citext", maxLength: 150, nullable: true),
+                    razon_social = table.Column<string>(type: "citext", maxLength: 150, nullable: true),
+                    tipo_documento = table.Column<TipoDocumento>(type: "tipo_documento", nullable: true),
+                    numero_documento = table.Column<string>(type: "citext", maxLength: 30, nullable: true),
+                    id_condicion_fiscal = table.Column<int>(type: "integer", nullable: false),
+                    nacimiento = table.Column<DateOnly>(type: "date", nullable: true),
+                    domicilio = table.Column<string>(type: "citext", maxLength: 255, nullable: true),
+                    telefono = table.Column<string>(type: "citext", maxLength: 50, nullable: true),
+                    celular = table.Column<string>(type: "citext", maxLength: 50, nullable: true),
+                    email = table.Column<string>(type: "citext", maxLength: 255, nullable: true),
+                    observaciones = table.Column<string>(type: "text", nullable: true),
+                    id_lista_precio = table.Column<int>(type: "integer", nullable: false),
+                    limite_credito = table.Column<decimal>(type: "numeric(14,2)", nullable: false, defaultValue: 0m),
+                    credito_ilimitado = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    saldo = table.Column<decimal>(type: "numeric(14,2)", nullable: false, defaultValue: 0m),
+                    activo = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_clientes", x => x.id_cliente);
+                    table.CheckConstraint("ck_clientes_cf_protegido", "numero <> 1 OR deleted_at IS NULL");
+                    table.ForeignKey(
+                        name: "fk_clientes_condicion_fiscal",
+                        column: x => x.id_condicion_fiscal,
+                        principalTable: "condiciones_fiscales",
+                        principalColumn: "id_condicion_fiscal",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_clientes_empresa",
+                        columns: x => new { x.id_empresa, x.id_tenant },
+                        principalTable: "empresas",
+                        principalColumns: new[] { "id_empresa", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_clientes_lista_precio",
+                        column: x => x.id_lista_precio,
+                        principalTable: "listas_precio",
+                        principalColumn: "id_lista_precio",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_clientes_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_clientes_condicion_fiscal",
+                table: "clientes",
+                column: "id_condicion_fiscal");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_clientes_empresa",
+                table: "clientes",
+                columns: new[] { "id_empresa", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_clientes_lista_precio",
+                table: "clientes",
+                column: "id_lista_precio");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_clientes_tenant",
+                table: "clientes",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_clientes_numero",
+                table: "clientes",
+                columns: new[] { "id_tenant", "numero" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_listas_precio_empresa",
+                table: "listas_precio",
+                columns: new[] { "id_empresa", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_listas_precio_lista_base",
+                table: "listas_precio",
+                column: "id_lista_base");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_listas_precio_tenant",
+                table: "listas_precio",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_listas_precio_default_compartido",
+                table: "listas_precio",
+                columns: new[] { "id_tenant", "es_default" },
+                unique: true,
+                filter: "id_empresa IS NULL AND deleted_at IS NULL AND es_default = true");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_listas_precio_default_empresa",
+                table: "listas_precio",
+                columns: new[] { "id_tenant", "id_empresa", "es_default" },
+                unique: true,
+                filter: "id_empresa IS NOT NULL AND deleted_at IS NULL AND es_default = true");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_listas_precio_nombre_compartido",
+                table: "listas_precio",
+                columns: new[] { "id_tenant", "nombre" },
+                unique: true,
+                filter: "id_empresa IS NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_listas_precio_nombre_empresa",
+                table: "listas_precio",
+                columns: new[] { "id_tenant", "id_empresa", "nombre" },
+                unique: true,
+                filter: "id_empresa IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_proveedores_condicion_fiscal",
+                table: "proveedores",
+                column: "id_condicion_fiscal");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_proveedores_empresa",
+                table: "proveedores",
+                columns: new[] { "id_empresa", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_proveedores_tenant",
+                table: "proveedores",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_proveedores_cuit",
+                table: "proveedores",
+                columns: new[] { "id_tenant", "cuit" },
+                unique: true,
+                filter: "deleted_at IS NULL AND cuit IS NOT NULL");
+
+            // RLS (ADR-4/ADR-15, DB CHANGE GATE aprobado 2026-08-02): las 4 tablas nuevas
+            // activan su policy en la misma migración que las crea. app_tenant_actual()/
+            // app_modo()/app_es_plataforma() ya existen desde la migración 1 (Organizacion).
+            migrationBuilder.HabilitarRlsDeTenant("listas_precio");
+            migrationBuilder.HabilitarRlsDeTenant("numeraciones_clientes");
+            migrationBuilder.HabilitarRlsDeTenant("proveedores");
+            migrationBuilder.HabilitarRlsDeTenant("clientes");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "clientes");
+
+            migrationBuilder.DropTable(
+                name: "numeraciones_clientes");
+
+            migrationBuilder.DropTable(
+                name: "proveedores");
+
+            migrationBuilder.DropTable(
+                name: "listas_precio");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
@@ -429,7 +429,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                     b.HasKey("Id");
 
                     b.HasAlternateKey("Id", "IdTenant")
-                        .HasName("ak_listas_precio_id_tenant");
+                        .HasName("ak_listas_precio_id_lista_precio_id_tenant");
 
                     b.HasIndex("IdListaBase")
                         .HasDatabaseName("ix_listas_precio_lista_base");

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
@@ -428,6 +428,9 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
 
                     b.HasKey("Id");
 
+                    b.HasAlternateKey("Id", "IdTenant")
+                        .HasName("ak_listas_precio_id_tenant");
+
                     b.HasIndex("IdListaBase")
                         .HasDatabaseName("ix_listas_precio_lista_base");
 
@@ -872,7 +875,7 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                     b.HasIndex("IdCondicionFiscal")
                         .HasDatabaseName("ix_clientes_condicion_fiscal");
 
-                    b.HasIndex("IdListaPrecio")
+                    b.HasIndex("IdListaPrecio", "IdTenant")
                         .HasDatabaseName("ix_clientes_lista_precio");
 
                     b.HasIndex("IdTenant")
@@ -1485,7 +1488,8 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
 
                     b.HasOne("Ways.Domain.Catalogos.ListaPrecio", null)
                         .WithMany()
-                        .HasForeignKey("IdListaPrecio")
+                        .HasForeignKey("IdListaPrecio", "IdTenant")
+                        .HasPrincipalKey("Id", "IdTenant")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired()
                         .HasConstraintName("fk_clientes_lista_precio");

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
+using Ways.Application.Clientes;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
@@ -116,6 +117,8 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
     private void EstamparTenant()
     {
+        RechazarEscriturasDeNumeracionCliente();
+
         foreach (var entrada in ChangeTracker.Entries<EntidadTenant>())
         {
             switch (entrada.State)
@@ -155,6 +158,31 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
             {
                 throw new InvalidOperationException(
                     "El id_tenant de una fila existente no se puede modificar.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Judgment-day (ronda 1, item de hardening): <see cref="NumeracionCliente"/> documenta
+    /// que <see cref="AsignadorDeNumeroCliente"/> es su único punto de
+    /// escritura legítimo, y que lo hace con SQL crudo dentro de la transacción del llamador
+    /// — nunca vía <c>SaveChangesAsync</c> (design decision 3). Ese contrato dependía
+    /// enteramente de que nadie escribiera la entidad por el <c>ChangeTracker</c> por error;
+    /// este guard lo convierte en un rechazo explícito, mismo patrón defense-in-depth que
+    /// <see cref="EstamparTenant"/> aplica sobre <c>IdTenant</c>: un <c>Added</c>/<c>Modified</c>
+    /// de <see cref="NumeracionCliente"/> que llega hasta acá solo puede ser un bypass del
+    /// contador atómico (una carrera lo corrompería), así que se frena antes de tocar la base.
+    /// </summary>
+    private void RechazarEscriturasDeNumeracionCliente()
+    {
+        foreach (var entrada in ChangeTracker.Entries<NumeracionCliente>())
+        {
+            if (entrada.State is EntityState.Added or EntityState.Modified)
+            {
+                throw new InvalidOperationException(
+                    "numeraciones_clientes solo se escribe con SQL crudo, vía " +
+                    $"{nameof(AsignadorDeNumeroCliente)} — nunca por " +
+                    $"{nameof(SaveChanges)}/{nameof(SaveChangesAsync)}.");
             }
         }
     }

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Common;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
 using Ways.Domain.Usuarios;
 
 namespace Ways.Infrastructure.Persistencia;
@@ -31,6 +33,17 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<AlicuotaIva> AlicuotasIva => Set<AlicuotaIva>();
     public DbSet<TipoComprobante> TiposComprobante => Set<TipoComprobante>();
     public DbSet<Parametro> Parametros => Set<Parametro>();
+
+    // Stage 2 (clientes-proveedores, DB CHANGE GATE pendiente): modelo adelantado a la
+    // migración, mismo trámite que las 5 catálogos de tenant en stage 1 (ver el comentario
+    // de WaysApiFixture.ConfigureWebHost). Los 4 sí están en IWaysDbContext desde este lote:
+    // AsignadorDeNumeroCliente/ServicioDeAprovisionamiento/InicializadorDeBaseDeDatos ya los
+    // consumen acá (a diferencia de los catálogos de tenant, que no tenían consumidor de
+    // Application en su propio lote).
+    public DbSet<Cliente> Clientes => Set<Cliente>();
+    public DbSet<Proveedor> Proveedores => Set<Proveedor>();
+    public DbSet<ListaPrecio> ListasPrecio => Set<ListaPrecio>();
+    public DbSet<NumeracionCliente> NumeracionesClientes => Set<NumeracionCliente>();
 
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
@@ -63,6 +76,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenant(modelBuilder);
         AplicarFiltroDeTenantEnTenant(modelBuilder);
         AplicarFiltroDeTenantEnUsuario(modelBuilder);
+        AplicarFiltroDeTenantEnNumeracionCliente(modelBuilder);
     }
 
     /// <summary>
@@ -251,6 +265,23 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         var filtro = Expression.OrElse(Expression.OrElse(esPlataforma, esLogin), comparacion);
 
         entidad.SetQueryFilter("Tenant", Expression.Lambda(filtro, parametro));
+    }
+
+    /// <summary>
+    /// <see cref="NumeracionCliente"/> no hereda de <see cref="EntidadTenant"/> (su
+    /// <c>IdTenant</c> ES la PK, no una FK opcional — mismo motivo que <see cref="Tenant"/>),
+    /// así que necesita la variante escrita a mano en vez de la del loop de
+    /// <see cref="AplicarFiltroDeTenant"/>.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnNumeracionCliente(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(NumeracionCliente))!;
+
+        var parametro = Expression.Parameter(typeof(NumeracionCliente), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(NumeracionCliente.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
     }
 
     /// <summary><c>e => this.TenantActual.EsPlataforma || propiedadDeAlcance == this.TenantActual.Id</c>.

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
@@ -26,6 +27,8 @@ public class WaysDbContextFactory : IDesignTimeDbContextFactory<WaysDbContext>
                 npgsql.MapEnum<EstadoTenant>("estado_tenant");
                 npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
                 npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
             })
             .Options;
 

--- a/tests/Ways.Application.Tests/Persistencia/GuardDeNumeracionClienteTests.cs
+++ b/tests/Ways.Application.Tests/Persistencia/GuardDeNumeracionClienteTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Domain.Clientes;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.Application.Tests.Persistencia;
+
+/// <summary>
+/// Judgment-day ronda 1 (item de hardening): <c>WaysDbContext.RechazarEscriturasDeNumeracionCliente</c>
+/// — mismo patrón defense-in-depth que <c>EstamparTenant</c> sobre <c>IdTenant</c>, acá
+/// rechazando cualquier <c>Added</c>/<c>Modified</c> de <see cref="NumeracionCliente"/> que
+/// llegue por el <c>ChangeTracker</c> (design decision 3: <c>AsignadorDeNumeroCliente</c> con
+/// SQL crudo es el único punto de escritura legítimo). Usa el proveedor InMemory: el guard
+/// tira ANTES de que <c>SaveChanges</c> llegue a tocar la base, así que no hace falta Postgres
+/// para probarlo — mismo criterio que <c>FiltroDeTenantTests</c>.
+/// </summary>
+public class GuardDeNumeracionClienteTests
+{
+    private static WaysDbContext CrearContexto() =>
+        new(new DbContextOptionsBuilder<WaysDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options,
+            TenantActualFijo.Plataforma);
+
+    [Fact]
+    public void UnNumeracionClienteAgregadoPorElChangeTrackerSeRechaza()
+    {
+        using var db = CrearContexto();
+
+        db.NumeracionesClientes.Add(new NumeracionCliente { IdTenant = 1, ProximoNumero = 1 });
+
+        var excepcion = Assert.Throws<InvalidOperationException>(() => db.SaveChanges());
+        Assert.Contains("numeraciones_clientes", excepcion.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnNumeracionClienteModificadoPorElChangeTrackerSeRechaza()
+    {
+        using var db = CrearContexto();
+
+        var entrada = db.Attach(new NumeracionCliente { IdTenant = 1, ProximoNumero = 1 });
+        entrada.Entity.ProximoNumero = 2;
+        entrada.State = EntityState.Modified;
+
+        var excepcion = Assert.Throws<InvalidOperationException>(() => db.SaveChanges());
+        Assert.Contains("numeraciones_clientes", excepcion.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnNumeracionClienteSinCambiosNoDisparaElGuard()
+    {
+        using var db = CrearContexto();
+
+        db.Attach(new NumeracionCliente { IdTenant = 1, ProximoNumero = 1 });
+
+        // EntityState.Unchanged (el default de Attach): no es una escritura, así que
+        // SaveChanges no tiene que tirar por esta fila -- confirma que el guard es específico
+        // de Added/Modified, no un rechazo ciego de cualquier entrada trackeada.
+        var excepcion = Record.Exception(() => db.SaveChanges());
+        Assert.Null(excepcion);
+    }
+}

--- a/tests/Ways.Application.Tests/Persistencia/ModeloDeClientesYProveedoresTests.cs
+++ b/tests/Ways.Application.Tests/Persistencia/ModeloDeClientesYProveedoresTests.cs
@@ -1,0 +1,147 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.Application.Tests.Persistencia;
+
+/// <summary>
+/// Stage-2-clientes-proveedores, Slice 1 (tarea 1G, "tests that don't need the migration"):
+/// construye el modelo real de <see cref="WaysDbContext"/> contra el proveedor de Npgsql sin
+/// conectar a una base (mismo patrón que <c>ModeloDeCatalogosTests</c>/
+/// <c>ModeloDeOrganizacionTests</c>) — alcanza para confirmar índices/FKs/constraint antes
+/// de que exista la migración (DB CHANGE GATE pendiente).
+/// </summary>
+public class ModeloDeClientesYProveedoresTests
+{
+    private static WaysDbContext CrearContexto()
+    {
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(
+                "Host=localhost;Port=5432;Database=probe;Username=probe;Password=probe",
+                npgsql =>
+                {
+                    npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                    npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                    npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                    npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                    npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                    npgsql.MapEnum<ModoLista>("modo_lista");
+                })
+            .Options;
+
+        return new WaysDbContext(opciones, TenantActualFijo.Plataforma);
+    }
+
+    [Fact]
+    public void ClientesTieneElIndiceUnicoDeNumero()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(Cliente))!;
+
+        var indiceNumero = entidad.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "ux_clientes_numero");
+        Assert.True(indiceNumero.IsUnique);
+        Assert.Equal("deleted_at IS NULL", indiceNumero.GetFilter());
+        Assert.Equal(
+            [nameof(Cliente.IdTenant), nameof(Cliente.Numero)],
+            indiceNumero.Properties.Select(p => p.Name));
+
+        // La check constraint ck_clientes_cf_protegido vive en el modelo de design-time
+        // (GetCheckConstraints() no está disponible sobre el modelo "read-optimized" de
+        // runtime que expone db.Model) — cubierta en runtime por
+        // ClientesYProveedoresRlsTests (gated, pendiente de la migración) en vez de acá.
+    }
+
+    [Fact]
+    public void ClientesTieneLasCuatroFksEsperadas()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(Cliente))!;
+        var nombresDeFk = entidad.GetForeignKeys().Select(f => f.GetConstraintName()).ToList();
+
+        Assert.Contains("fk_clientes_tenant", nombresDeFk);
+        Assert.Contains("fk_clientes_empresa", nombresDeFk);
+        Assert.Contains("fk_clientes_condicion_fiscal", nombresDeFk);
+        Assert.Contains("fk_clientes_lista_precio", nombresDeFk);
+    }
+
+    [Fact]
+    public void ClientesNumeroDocumentoNoTieneNingunIndiceUnico()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(Cliente))!;
+        var indicesConNumeroDocumento = entidad.GetIndexes()
+            .Where(i => i.Properties.Any(p => p.Name == nameof(Cliente.NumeroDocumento)));
+
+        Assert.Empty(indicesConNumeroDocumento);
+    }
+
+    [Fact]
+    public void ProveedoresTieneElIndiceUnicoDeCuitSinIdEmpresaEnLaClave()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(Proveedor))!;
+
+        var indiceCuit = entidad.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "ux_proveedores_cuit");
+        Assert.True(indiceCuit.IsUnique);
+        Assert.Equal("deleted_at IS NULL AND cuit IS NOT NULL", indiceCuit.GetFilter());
+        Assert.Equal(
+            [nameof(Proveedor.IdTenant), nameof(Proveedor.Cuit)],
+            indiceCuit.Properties.Select(p => p.Name));
+
+        var nombresDeFk = entidad.GetForeignKeys().Select(f => f.GetConstraintName()).ToList();
+        Assert.Contains("fk_proveedores_tenant", nombresDeFk);
+        Assert.Contains("fk_proveedores_empresa", nombresDeFk);
+        Assert.Contains("fk_proveedores_condicion_fiscal", nombresDeFk);
+    }
+
+    [Fact]
+    public void ListasPrecioReusaElParDeIndicesDeNombreYAgregaElParDeDefault()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(ListaPrecio))!;
+        var indices = entidad.GetIndexes().ToList();
+
+        Assert.Contains(indices, i => i.GetDatabaseName() == "ux_listas_precio_nombre_compartido");
+        Assert.Contains(indices, i => i.GetDatabaseName() == "ux_listas_precio_nombre_empresa");
+
+        var defaultCompartido = indices.Single(i => i.GetDatabaseName() == "ux_listas_precio_default_compartido");
+        Assert.True(defaultCompartido.IsUnique);
+        Assert.Equal("id_empresa IS NULL AND deleted_at IS NULL AND es_default = true", defaultCompartido.GetFilter());
+
+        var defaultEmpresa = indices.Single(i => i.GetDatabaseName() == "ux_listas_precio_default_empresa");
+        Assert.True(defaultEmpresa.IsUnique);
+        Assert.Equal(
+            "id_empresa IS NOT NULL AND deleted_at IS NULL AND es_default = true", defaultEmpresa.GetFilter());
+    }
+
+    [Fact]
+    public void NumeracionesClientesTieneIdTenantComoPkSinIdentity()
+    {
+        using var db = CrearContexto();
+
+        var entidad = db.Model.FindEntityType(typeof(NumeracionCliente))!;
+
+        var pk = entidad.FindPrimaryKey();
+        Assert.NotNull(pk);
+        Assert.Equal([nameof(NumeracionCliente.IdTenant)], pk!.Properties.Select(p => p.Name));
+
+        var idTenant = entidad.FindProperty(nameof(NumeracionCliente.IdTenant))!;
+        Assert.Equal(Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.Never, idTenant.ValueGenerated);
+
+        var fk = entidad.GetForeignKeys().Single();
+        Assert.Equal("fk_numeraciones_clientes_tenant", fk.GetConstraintName());
+        Assert.Equal(typeof(Tenant), fk.PrincipalEntityType.ClrType);
+    }
+}

--- a/tests/Ways.Domain.Tests/Clientes/ReglaDeClientesTests.cs
+++ b/tests/Ways.Domain.Tests/Clientes/ReglaDeClientesTests.cs
@@ -1,0 +1,41 @@
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Tests.Clientes;
+
+public class ReglaDeClientesTests
+{
+    [Fact]
+    public void NumeroUnoEsConsumidorFinal()
+    {
+        Assert.True(ReglaDeClientes.EsConsumidorFinal(1));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(100)]
+    [InlineData(0)]
+    public void CualquierOtroNumeroNoEsConsumidorFinal(int numero)
+    {
+        Assert.False(ReglaDeClientes.EsConsumidorFinal(numero));
+    }
+
+    [Fact]
+    public void ValidarNoConsumidorFinalRechazaElNumeroUno()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeClientes.ValidarNoConsumidorFinal(1));
+
+        Assert.Equal("consumidor_final_protegido", error.Codigo);
+        Assert.Equal(409, error.EstadoHttp);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(50)]
+    public void ValidarNoConsumidorFinalPermiteCualquierOtroNumero(int numero)
+    {
+        var excepcion = Record.Exception(() => ReglaDeClientes.ValidarNoConsumidorFinal(numero));
+
+        Assert.Null(excepcion);
+    }
+}

--- a/tests/Ways.Domain.Tests/Organizacion/PlantillaDeAprovisionamientoTests.cs
+++ b/tests/Ways.Domain.Tests/Organizacion/PlantillaDeAprovisionamientoTests.cs
@@ -30,10 +30,17 @@ public class PlantillaDeAprovisionamientoTests
     }
 
     [Fact]
-    public void LosItemsDiferidosEstanDeclaradosNoDescartadosEnSilencio()
+    public void V1TieneLaListaDePreciosGeneralComoDefault()
     {
-        Assert.Equal(2, PlantillaV1.ItemsDiferidos.Count);
-        Assert.Contains(PlantillaV1.ItemsDiferidos, i => i.Contains("lista_precio_general"));
-        Assert.Contains(PlantillaV1.ItemsDiferidos, i => i.Contains("cliente_consumidor_final"));
+        Assert.Equal("General", PlantillaDeAprovisionamiento.V1.ListaPrecioGeneral.Nombre);
+    }
+
+    [Fact]
+    public void V1TieneElConsumidorFinalConCondicionFiscalCf()
+    {
+        var cf = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal;
+
+        Assert.Equal("Consumidor Final", cf.Nombre);
+        Assert.Equal("CF", cf.CodigoCondicionFiscal);
     }
 }

--- a/tests/Ways.IntegrationTests/AsignadorDeNumeroClienteConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/AsignadorDeNumeroClienteConcurrenciaTests.cs
@@ -1,0 +1,84 @@
+using Ways.Application.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Judgment-day ronda 1 (item de hardening): <see cref="AsignadorDeNumeroCliente.AsignarSiguienteAsync"/>
+/// bajo concurrencia real contra Postgres — dos asignaciones simultáneas sobre el MISMO
+/// contador de tenant no pueden repetir ni saltear un número.
+///
+/// A diferencia de <c>ParametrosTests.DosEstablecimientosConcurrentesConLaMismaClaveYElMismoAlcanceDisparanElBackstopDelSaveChanges</c>,
+/// acá no hace falta un <c>InterceptorDeRendezVous</c> que fuerce el timing a mano: la carrera
+/// de <c>ParametrosTests</c> es sobre un INSERT condicional (busca "existente" antes de
+/// insertar, así que dos requests pueden ver "no existe" los dos si no se los sincroniza), pero
+/// <c>AsignadorDeNumeroCliente.AsignarSiguienteAsync</c> es un <c>UPDATE ... RETURNING</c>
+/// incondicional — el propio row lock de Postgres sobre la fila del contador serializa las dos
+/// transacciones sin ayuda externa: la segunda espera a que la primera confirme (o revierta)
+/// antes de tomar el lock, así que el <c>Task.WhenAll</c> real ya alcanza para forzar la carrera
+/// genuina (design decisions 2/3, doc del propio <see cref="AsignadorDeNumeroCliente"/>).
+///
+/// Corre 3 rondas (2 asignaciones concurrentes por ronda, 6 en total) para la estabilidad
+/// pedida — junta los 6 números y confirma que son exactamente consecutivos, sin huecos ni
+/// duplicados, no solo que cada par de una ronda lo sea.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AsignadorDeNumeroClienteConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const int CantidadDeRondas = 3;
+
+    [Fact]
+    public async Task DosAsignacionesConcurrentesDelMismoTenantDanNumerosDistintosYConsecutivos()
+    {
+        using var _ = fixture.CreateClient();
+
+        int idTenant;
+        await using (var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            var tenant = new Tenant
+            {
+                Nombre = nameof(DosAsignacionesConcurrentesDelMismoTenantDanNumerosDistintosYConsecutivos),
+                Estado = EstadoTenant.Activo,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.Tenants.Add(tenant);
+            await siembra.SaveChangesAsync();
+            idTenant = tenant.Id;
+
+            await AsignadorDeNumeroCliente.AsegurarContadorAsync(siembra, idTenant);
+        }
+
+        var todosLosNumeros = new List<int>();
+
+        for (var ronda = 0; ronda < CantidadDeRondas; ronda++)
+        {
+            var tareaA = AsignarUnoAsync(idTenant);
+            var tareaB = AsignarUnoAsync(idTenant);
+
+            var numeros = await Task.WhenAll(tareaA, tareaB);
+
+            Assert.NotEqual(numeros[0], numeros[1]);
+            todosLosNumeros.AddRange(numeros);
+        }
+
+        var minimo = todosLosNumeros.Min();
+        var esperados = Enumerable.Range(minimo, todosLosNumeros.Count);
+
+        Assert.Equal(esperados, todosLosNumeros.OrderBy(n => n));
+        Assert.Equal(todosLosNumeros.Count, todosLosNumeros.Distinct().Count());
+    }
+
+    private async Task<int> AsignarUnoAsync(int idTenant)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccion = await db.Database.BeginTransactionAsync();
+
+        var numero = await AsignadorDeNumeroCliente.AsignarSiguienteAsync(db, idTenant);
+
+        await transaccion.CommitAsync();
+        return numero;
+    }
+}

--- a/tests/Ways.IntegrationTests/BackfillPorArtefactoTests.cs
+++ b/tests/Ways.IntegrationTests/BackfillPorArtefactoTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Judgment-day ronda 1 (item CRITICAL confirmado): antes del fix, <c>InicializadorDeBaseDeDatos.
+/// BackfillDeClientesYListasPrecioAsync</c> calculaba "cubierto" como la UNIÓN de
+/// tenants-con-CF y tenants-con-lista-default, así que un tenant con solo UNA de las dos filas
+/// quedaba "cubierto" y nunca ganaba la mitad faltante. Esta prueba sembra, ANTES del primer
+/// <c>CreateClient()</c> de un fixture propio, un tenant con solo la lista (sin CF) y otro con
+/// solo el CF (sin lista default) — el fix tiene que completar exactamente la mitad que falta
+/// en cada uno, sin duplicar la mitad que ya tenían.
+///
+/// Clase propia con su propio <see cref="WaysApiFixture"/> (a diferencia de agregar el método a
+/// <c>ClientesProvisioningYBackfillTests</c>): el truco de "sembrar antes del primer
+/// CreateClient()" solo es válido para el primer método que arranca el host de ESE fixture —
+/// una clase dedicada, con un solo <c>[Fact]</c>, elimina cualquier dependencia del orden de
+/// ejecución entre métodos de prueba.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class BackfillPorArtefactoTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    [Fact]
+    public async Task UnTenantConSoloListaYOtroConSoloClienteCfGananLaMitadFaltantePorBackfill()
+    {
+        int idTenantSoloLista;
+        int idTenantSoloCf;
+        int idListaNoDefaultDelTenantSoloCf;
+
+        // Sembrado ANTES del primer CreateClient() de este fixture (mismo trámite que
+        // ClientesProvisioningYBackfillTests): así los dos tenants existen, con su cobertura
+        // parcial, cuando InicializadorDeBaseDeDatos.EjecutarAsync corre por primera vez.
+        await using (var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+
+            var tenantSoloLista = new Tenant
+            {
+                Nombre = nameof(UnTenantConSoloListaYOtroConSoloClienteCfGananLaMitadFaltantePorBackfill) + "-SoloLista",
+                Estado = EstadoTenant.Activo,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            var tenantSoloCf = new Tenant
+            {
+                Nombre = nameof(UnTenantConSoloListaYOtroConSoloClienteCfGananLaMitadFaltantePorBackfill) + "-SoloCf",
+                Estado = EstadoTenant.Activo,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.Tenants.AddRange(tenantSoloLista, tenantSoloCf);
+            await siembra.SaveChangesAsync();
+
+            // Tenant con solo la lista General (sin CF): el backfill le tiene que agregar el
+            // cliente Consumidor Final, reusando esta lista existente.
+            var listaDefaultDelTenantSoloLista = new ListaPrecio
+            {
+                IdTenant = tenantSoloLista.Id,
+                Nombre = "General",
+                EsDefault = true,
+                Modo = ModoLista.Fija,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.ListasPrecio.Add(listaDefaultDelTenantSoloLista);
+
+            // Tenant con solo el cliente CF (sin lista default): el CF preexistente necesita
+            // una lista_precio para su FK NOT NULL — una que a propósito NO sea la default,
+            // para no tapar por accidente la falta de la lista General.
+            var listaNoDefaultDelTenantSoloCf = new ListaPrecio
+            {
+                IdTenant = tenantSoloCf.Id,
+                Nombre = "No Default",
+                EsDefault = false,
+                Modo = ModoLista.Fija,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.ListasPrecio.Add(listaNoDefaultDelTenantSoloCf);
+
+            // Código "CF" a propósito, no uno inventado: SembrarCatalogosFiscalesAsync
+            // decide si siembra las 5 condiciones fiscales base mirando si la tabla YA tiene
+            // alguna fila (AnyAsync sobre toda la tabla, no los códigos puntuales) — un código
+            // distinto la dejaría con una fila, saltearía la siembra de las 5 base, y el
+            // propio backfill fallaría más abajo buscando "CF" (mismo hallazgo incidental que
+            // documenta el batch 2 de apply-progress.md para CatalogosGlobalesRlsTests).
+            var condicionFiscalCf = new CondicionFiscal
+            {
+                Codigo = PlantillaDeAprovisionamiento.V1.ClienteConsumidorFinal.CodigoCondicionFiscal,
+                Nombre = "Consumidor Final",
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.CondicionesFiscales.Add(condicionFiscalCf);
+            await siembra.SaveChangesAsync();
+
+            siembra.Clientes.Add(new Cliente
+            {
+                IdTenant = tenantSoloCf.Id,
+                Numero = ReglaDeClientes.NumeroConsumidorFinal,
+                Nombre = "Consumidor Final preexistente",
+                IdCondicionFiscal = condicionFiscalCf.Id,
+                IdListaPrecio = listaNoDefaultDelTenantSoloCf.Id,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            });
+            await siembra.SaveChangesAsync();
+
+            idTenantSoloLista = tenantSoloLista.Id;
+            idTenantSoloCf = tenantSoloCf.Id;
+            idListaNoDefaultDelTenantSoloCf = listaNoDefaultDelTenantSoloCf.Id;
+        }
+
+        // Arranca el host: dispara el backfill para los dos tenants, cada uno completando
+        // solo la mitad que le falta.
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        // Tenant con solo lista: gana el Consumidor Final, sin duplicar la lista existente.
+        var clientesDelTenantSoloLista = await db.Clientes
+            .Where(c => c.IdTenant == idTenantSoloLista)
+            .ToListAsync();
+        var listasDelTenantSoloLista = await db.ListasPrecio
+            .Where(l => l.IdTenant == idTenantSoloLista)
+            .ToListAsync();
+
+        var consumidorFinalNuevo = Assert.Single(clientesDelTenantSoloLista);
+        Assert.Equal(ReglaDeClientes.NumeroConsumidorFinal, consumidorFinalNuevo.Numero);
+        var listaExistente = Assert.Single(listasDelTenantSoloLista);
+        Assert.Equal(listaExistente.Id, consumidorFinalNuevo.IdListaPrecio);
+
+        // Tenant con solo CF: gana la lista General default, sin duplicar el CF existente.
+        var clientesDelTenantSoloCf = await db.Clientes
+            .Where(c => c.IdTenant == idTenantSoloCf)
+            .ToListAsync();
+        var listasDelTenantSoloCf = await db.ListasPrecio
+            .Where(l => l.IdTenant == idTenantSoloCf)
+            .ToListAsync();
+
+        Assert.Single(clientesDelTenantSoloCf);
+        Assert.Equal(2, listasDelTenantSoloCf.Count);
+        var listaDefaultNueva = Assert.Single(listasDelTenantSoloCf, l => l.EsDefault);
+        Assert.Equal("General", listaDefaultNueva.Nombre);
+        Assert.Contains(listasDelTenantSoloCf, l => l.Id == idListaNoDefaultDelTenantSoloCf && !l.EsDefault);
+    }
+}

--- a/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
+++ b/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
@@ -12,16 +12,12 @@ namespace Ways.IntegrationTests;
 /// backstop map de <c>ManejadorDeErrores</c> — la constraint <c>ck_clientes_cf_protegido</c>
 /// (23514) y una prueba de humo por cada FK nueva (23503).
 ///
-/// GATED: mismo motivo que <c>ClientesYProveedoresRlsTests</c> — bloqueado hasta que la
-/// migración <c>ClientesYProveedoresEtapa2</c> se genere y apruebe (DB CHANGE GATE, task 1.7).
+/// DB CHANGE GATE aprobado 2026-08-02 y migración <c>ClientesYProveedoresEtapa2</c> aplicada:
+/// pruebas activas contra Postgres real.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
-    private const string RazonDeGate =
-        "Gated: clientes/proveedores no existen hasta que la migración " +
-        "ClientesYProveedoresEtapa2 se genere y apruebe (DB CHANGE GATE, task 1.7).";
-
     private async Task<(int IdTenant, int IdCondicionFiscal, int IdListaPrecio)> SembrarTenantConCatalogosAsync(string nombre)
     {
         using var _ = fixture.CreateClient();
@@ -49,7 +45,7 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
 
     /// <summary>Spec: Consumidor Final Protected Row — bypass directo del servicio (raw SQL,
     /// no <c>ServicioDeClientes</c>) sobre la fila Consumidor Final asserts 23514.</summary>
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task UnUpdateDirectoPorSqlSobreElConsumidorFinalViolaLaCheckConstraint()
     {
         var (idTenant, idCondicionFiscal, idListaPrecio) =
@@ -81,7 +77,7 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
         Assert.Equal("ck_clientes_cf_protegido", excepcion.ConstraintName);
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task UnClienteConIdListaPrecioInexistenteViolaLaFk()
     {
         var (idTenant, idCondicionFiscal, _) =
@@ -101,7 +97,7 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
         Assert.Equal("fk_clientes_lista_precio", excepcion.ConstraintName);
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task UnClienteConIdCondicionFiscalInexistenteViolaLaFk()
     {
         var (idTenant, _, idListaPrecio) =
@@ -121,7 +117,7 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
         Assert.Equal("fk_clientes_condicion_fiscal", excepcion.ConstraintName);
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task UnProveedorConIdCondicionFiscalInexistenteViolaLaFk()
     {
         var (idTenant, _, _) =
@@ -140,7 +136,7 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
         Assert.Equal("fk_proveedores_condicion_fiscal", excepcion.ConstraintName);
     }
 
-    [Theory(Skip = RazonDeGate)]
+    [Theory]
     [InlineData("clientes", "fk_clientes_tenant")]
     [InlineData("proveedores", "fk_proveedores_tenant")]
     [InlineData("listas_precio", "fk_listas_precio_tenant")]

--- a/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
+++ b/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
@@ -1,0 +1,175 @@
+using Npgsql;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Stage-2-clientes-proveedores, Slice 1 (tasks 1.16-1.17, db-error-backstops skill):
+/// backstop map de <c>ManejadorDeErrores</c> — la constraint <c>ck_clientes_cf_protegido</c>
+/// (23514) y una prueba de humo por cada FK nueva (23503).
+///
+/// GATED: mismo motivo que <c>ClientesYProveedoresRlsTests</c> — bloqueado hasta que la
+/// migración <c>ClientesYProveedoresEtapa2</c> se genere y apruebe (DB CHANGE GATE, task 1.7).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string RazonDeGate =
+        "Gated: clientes/proveedores no existen hasta que la migración " +
+        "ClientesYProveedoresEtapa2 se genere y apruebe (DB CHANGE GATE, task 1.7).";
+
+    private async Task<(int IdTenant, int IdCondicionFiscal, int IdListaPrecio)> SembrarTenantConCatalogosAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = tenant.Id, Nombre = nombre, EsDefault = true, Modo = ModoLista.Fija,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        return (tenant.Id, condicionFiscal.Id, lista.Id);
+    }
+
+    /// <summary>Spec: Consumidor Final Protected Row — bypass directo del servicio (raw SQL,
+    /// no <c>ServicioDeClientes</c>) sobre la fila Consumidor Final asserts 23514.</summary>
+    [Fact(Skip = RazonDeGate)]
+    public async Task UnUpdateDirectoPorSqlSobreElConsumidorFinalViolaLaCheckConstraint()
+    {
+        var (idTenant, idCondicionFiscal, idListaPrecio) =
+            await SembrarTenantConCatalogosAsync(nameof(UnUpdateDirectoPorSqlSobreElConsumidorFinalViolaLaCheckConstraint));
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Clientes.Add(new Cliente
+        {
+            IdTenant = idTenant,
+            Numero = ReglaDeClientes.NumeroConsumidorFinal,
+            Nombre = "Consumidor Final",
+            IdCondicionFiscal = idCondicionFiscal,
+            IdListaPrecio = idListaPrecio,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "UPDATE clientes SET deleted_at = now() WHERE numero = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = ReglaDeClientes.NumeroConsumidorFinal });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_clientes_cf_protegido", excepcion.ConstraintName);
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task UnClienteConIdListaPrecioInexistenteViolaLaFk()
+    {
+        var (idTenant, idCondicionFiscal, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnClienteConIdListaPrecioInexistenteViolaLaFk));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO clientes (id_tenant, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+            "VALUES ($1, 2, 'intruso', $2, 999999, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idCondicionFiscal });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_clientes_lista_precio", excepcion.ConstraintName);
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task UnClienteConIdCondicionFiscalInexistenteViolaLaFk()
+    {
+        var (idTenant, _, idListaPrecio) =
+            await SembrarTenantConCatalogosAsync(nameof(UnClienteConIdCondicionFiscalInexistenteViolaLaFk));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO clientes (id_tenant, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+            "VALUES ($1, 2, 'intruso', 999999, $2, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idListaPrecio });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_clientes_condicion_fiscal", excepcion.ConstraintName);
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task UnProveedorConIdCondicionFiscalInexistenteViolaLaFk()
+    {
+        var (idTenant, _, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnProveedorConIdCondicionFiscalInexistenteViolaLaFk));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO proveedores (id_tenant, razon_social, id_condicion_fiscal, created_at, updated_at) " +
+            "VALUES ($1, 'intruso', 999999, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_proveedores_condicion_fiscal", excepcion.ConstraintName);
+    }
+
+    [Theory(Skip = RazonDeGate)]
+    [InlineData("clientes", "fk_clientes_tenant")]
+    [InlineData("proveedores", "fk_proveedores_tenant")]
+    [InlineData("listas_precio", "fk_listas_precio_tenant")]
+    [InlineData("numeraciones_clientes", "fk_numeraciones_clientes_tenant")]
+    public async Task UnIdTenantInexistenteEnCadaTablaNuevaViolaSuFk(string tabla, string nombreDeFk)
+    {
+        _ = nombreDeFk;
+        using var host = fixture.CreateClient();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("plataforma", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = tabla switch
+        {
+            "clientes" =>
+                "INSERT INTO clientes (id_tenant, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+                "VALUES (999999, 2, 'intruso', 1, 1, now(), now())",
+            "proveedores" =>
+                "INSERT INTO proveedores (id_tenant, razon_social, id_condicion_fiscal, created_at, updated_at) " +
+                "VALUES (999999, 'intruso', 1, now(), now())",
+            "listas_precio" =>
+                "INSERT INTO listas_precio (id_tenant, nombre, es_default, modo, activo, created_at, updated_at) " +
+                "VALUES (999999, 'intrusa', false, 'fija', true, now(), now())",
+            "numeraciones_clientes" =>
+                "INSERT INTO numeraciones_clientes (id_tenant, proximo_numero) VALUES (999999, 1)",
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+    }
+}

--- a/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
+++ b/tests/Ways.IntegrationTests/BackstopClientesYProveedoresTests.cs
@@ -136,6 +136,125 @@ public class BackstopClientesYProveedoresTests(WaysApiFixture fixture) : IClassF
         Assert.Equal("fk_proveedores_condicion_fiscal", excepcion.ConstraintName);
     }
 
+    /// <summary>Judgment-day ronda 1 (item 2, GATE-APPROVED 2026-08-02): prueba de humo de la
+    /// FK compuesta <c>fk_clientes_lista_precio</c> — antes del hardening, un <c>id_lista_precio</c>
+    /// de OTRO tenant era una fila EXISTENTE (pasaba la FK simple, que solo exige que el id
+    /// exista en algún lado) y únicamente RLS lo frenaba en runtime. Con la FK compuesta
+    /// <c>(id_lista_precio, id_tenant) → listas_precio(id_lista_precio, id_tenant)</c>, la
+    /// propia constraint la rechaza.</summary>
+    [Fact]
+    public async Task UnClienteConIdListaPrecioDeOtroTenantViolaLaFkCompuesta()
+    {
+        var (idTenantA, idCondicionFiscalA, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnClienteConIdListaPrecioDeOtroTenantViolaLaFkCompuesta) + "-A");
+        var (_, _, idListaPrecioB) =
+            await SembrarTenantConCatalogosAsync(nameof(UnClienteConIdListaPrecioDeOtroTenantViolaLaFkCompuesta) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantA);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO clientes (id_tenant, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+            "VALUES ($1, 2, 'intruso', $2, $3, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenantA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idCondicionFiscalA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idListaPrecioB });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_clientes_lista_precio", excepcion.ConstraintName);
+    }
+
+    /// <summary>Judgment-day ronda 1 (item 4): prueba de humo faltante para
+    /// <c>fk_clientes_empresa</c> — <c>id_empresa</c> es nullable (MATCH SIMPLE), así que la
+    /// prueba tiene que mandar un valor no nulo pero inexistente para disparar la FK.</summary>
+    [Fact]
+    public async Task UnClienteConIdEmpresaInexistenteViolaLaFkCompuesta()
+    {
+        var (idTenant, idCondicionFiscal, idListaPrecio) =
+            await SembrarTenantConCatalogosAsync(nameof(UnClienteConIdEmpresaInexistenteViolaLaFkCompuesta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO clientes (id_tenant, id_empresa, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+            "VALUES ($1, 999999, 2, 'intruso', $2, $3, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idCondicionFiscal });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idListaPrecio });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_clientes_empresa", excepcion.ConstraintName);
+    }
+
+    /// <summary>Judgment-day ronda 1 (item 4): prueba de humo faltante para
+    /// <c>fk_proveedores_empresa</c>.</summary>
+    [Fact]
+    public async Task UnProveedorConIdEmpresaInexistenteViolaLaFkCompuesta()
+    {
+        var (idTenant, idCondicionFiscal, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnProveedorConIdEmpresaInexistenteViolaLaFkCompuesta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO proveedores (id_tenant, id_empresa, razon_social, id_condicion_fiscal, created_at, updated_at) " +
+            "VALUES ($1, 999999, 'intruso', $2, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idCondicionFiscal });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_proveedores_empresa", excepcion.ConstraintName);
+    }
+
+    /// <summary>Judgment-day ronda 1 (item 4): prueba de humo faltante para
+    /// <c>fk_listas_precio_empresa</c>.</summary>
+    [Fact]
+    public async Task UnaListaDePrecioConIdEmpresaInexistenteViolaLaFkCompuesta()
+    {
+        var (idTenant, _, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnaListaDePrecioConIdEmpresaInexistenteViolaLaFkCompuesta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO listas_precio (id_tenant, id_empresa, nombre, es_default, modo, activo, created_at, updated_at) " +
+            "VALUES ($1, 999999, 'intrusa', false, 'fija', true, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_listas_precio_empresa", excepcion.ConstraintName);
+    }
+
+    /// <summary>Judgment-day ronda 1 (item 4): prueba de humo faltante para
+    /// <c>fk_listas_precio_lista_base</c> — FK simple (no compuesta, self-referencing por
+    /// <c>id_lista_precio</c>): un <c>id_lista_base</c> inexistente la viola sin importar el
+    /// tenant.</summary>
+    [Fact]
+    public async Task UnaListaDePrecioConIdListaBaseInexistenteViolaLaFk()
+    {
+        var (idTenant, _, _) =
+            await SembrarTenantConCatalogosAsync(nameof(UnaListaDePrecioConIdListaBaseInexistenteViolaLaFk));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO listas_precio (id_tenant, id_lista_base, nombre, es_default, modo, activo, created_at, updated_at) " +
+            "VALUES ($1, 999999, 'intrusa', false, 'fija', true, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_listas_precio_lista_base", excepcion.ConstraintName);
+    }
+
     [Theory]
     [InlineData("clientes", "fk_clientes_tenant")]
     [InlineData("proveedores", "fk_proveedores_tenant")]

--- a/tests/Ways.IntegrationTests/CatalogosGlobalesRlsTests.cs
+++ b/tests/Ways.IntegrationTests/CatalogosGlobalesRlsTests.cs
@@ -11,6 +11,16 @@ namespace Ways.IntegrationTests;
 /// (<see cref="RlsMigrationBuilderExtensions.HabilitarRlsDeCatalogoGlobal"/>). La superficie de
 /// API sigue siendo de solo lectura para un tenant, sin cambios — esto prueba la segunda capa
 /// independiente detrás. Todo con conexión cruda como <c>ways_app</c>, sin pasar por EF.
+///
+/// TODOS los métodos de esta clase arrancan el host (<c>fixture.CreateClient()</c>) antes de
+/// tocar <c>condiciones_fiscales</c> por SQL crudo, aunque no siempre lo necesiten para su
+/// propia aserción (encontrado en stage-2-clientes-proveedores, Slice 1 batch 2): si un test
+/// que NO arranca el host corre primero y siembra una fila cruda en esa tabla,
+/// <c>InicializadorDeBaseDeDatos.SembrarCatalogosFiscalesAsync</c> (que arranca recién con el
+/// primer test que sí llama <c>CreateClient()</c>) ve la tabla no-vacía y se salta sembrar la
+/// condición fiscal <c>CF</c> — que <c>BackfillDeClientesYListasPrecioAsync</c> necesita para
+/// existir siempre. Arrancar el host primero, en todos los métodos, cierra esa ventana de
+/// orden sin importar en qué orden xUnit corra los tests de esta clase.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class CatalogosGlobalesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -51,6 +61,8 @@ public class CatalogosGlobalesRlsTests(WaysApiFixture fixture) : IClassFixture<W
     [Fact]
     public async Task UnaSesionDeTenantNoPuedeInsertarEnUnCatalogoGlobal()
     {
+        using var _ = fixture.CreateClient(); // arranca el host (idempotencia del seed, ver SembrarCondicionFiscalAsync)
+
         await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", 1);
 
         await using var comando = cruda.CreateCommand();
@@ -117,6 +129,8 @@ public class CatalogosGlobalesRlsTests(WaysApiFixture fixture) : IClassFixture<W
     [Fact]
     public async Task LaPlataformaPuedeEscribirEnUnCatalogoGlobal()
     {
+        using var _ = fixture.CreateClient(); // arranca el host (idempotencia del seed, ver SembrarCondicionFiscalAsync)
+
         await using var cruda = await fixture.AbrirConexionCrudaAsync("plataforma", null);
 
         await using var comando = cruda.CreateCommand();
@@ -137,6 +151,8 @@ public class CatalogosGlobalesRlsTests(WaysApiFixture fixture) : IClassFixture<W
         // Falla cerrado (ADR-4): un GUC sin setear hace que app_es_plataforma() sea falso, lo
         // mismo que en modo tenant — la lectura sigue abierta (USING (true) no depende del
         // GUC), pero la escritura se rechaza igual.
+        using var _ = fixture.CreateClient(); // arranca el host (idempotencia del seed, ver SembrarCondicionFiscalAsync)
+
         await using var cruda = await fixture.AbrirConexionCrudaAsync(string.Empty, null);
 
         await using var comando = cruda.CreateCommand();

--- a/tests/Ways.IntegrationTests/ClientesProvisioningYBackfillTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesProvisioningYBackfillTests.cs
@@ -16,22 +16,15 @@ namespace Ways.IntegrationTests;
 /// Consumidor Final + la lista General nacen con el tenant (provisioning) o se completan para
 /// un tenant preexistente (backfill), y el backfill es idempotente.
 ///
-/// GATED — doble motivo: (1) la migración <c>ClientesYProveedoresEtapa2</c> está bloqueada por
-/// el DB CHANGE GATE (task 1.7); (2) el cableado de <c>ServicioDeAprovisionamiento</c> (task
-/// 1.10) e <c>InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync</c> (task 1.11)
-/// queda comentado hasta ese mismo lote — cablearlos ahora rompe el arranque del host en TODAS
-/// las pruebas de integración (las tablas todavía no existen). <c>Skip</c> se saca junto con
-/// la migración y el cableado, en el mismo lote.
+/// DB CHANGE GATE aprobado 2026-08-02, migración <c>ClientesYProveedoresEtapa2</c> aplicada, y
+/// <c>ServicioDeAprovisionamiento</c>/<c>InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync</c>
+/// cableados (tasks 1.10/1.11): pruebas activas contra Postgres real.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class ClientesProvisioningYBackfillTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
-
-    private const string RazonDeGate =
-        "Gated: clientes/listas_precio no existen (DB CHANGE GATE, task 1.7) y el cableado de " +
-        "ServicioDeAprovisionamiento/InicializadorDeBaseDeDatos queda comentado hasta ese lote (tasks 1.10/1.11).";
 
     private async Task<HttpClient> ClienteComoRootAsync()
     {
@@ -41,7 +34,7 @@ public class ClientesProvisioningYBackfillTests(WaysApiFixture fixture) : IClass
         return cliente;
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task ProvisionarUnTenantCreaElConsumidorFinalYLaListaGeneral()
     {
         using var cliente = await ClienteComoRootAsync();
@@ -69,7 +62,7 @@ public class ClientesProvisioningYBackfillTests(WaysApiFixture fixture) : IClass
         Assert.Equal(listaGeneral.Id, consumidorFinal.IdListaPrecio);
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task UnTenantPreexistenteSinClientesNiListasGanaAmbosPorBackfillYElBackfillEsIdempotente()
     {
         // Sembrado ANTES del primer CreateClient() de este fixture (mismo trámite que

--- a/tests/Ways.IntegrationTests/ClientesProvisioningYBackfillTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesProvisioningYBackfillTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Stage-2-clientes-proveedores, Slice 1 (task 1.15, spec: Tenant Provisioning With Template
+/// Seed / Backfill for Pre-Existing Tenants / listas-precio-minimal One Default List): el
+/// Consumidor Final + la lista General nacen con el tenant (provisioning) o se completan para
+/// un tenant preexistente (backfill), y el backfill es idempotente.
+///
+/// GATED — doble motivo: (1) la migración <c>ClientesYProveedoresEtapa2</c> está bloqueada por
+/// el DB CHANGE GATE (task 1.7); (2) el cableado de <c>ServicioDeAprovisionamiento</c> (task
+/// 1.10) e <c>InicializadorDeBaseDeDatos.BackfillDeClientesYListasPrecioAsync</c> (task 1.11)
+/// queda comentado hasta ese mismo lote — cablearlos ahora rompe el arranque del host en TODAS
+/// las pruebas de integración (las tablas todavía no existen). <c>Skip</c> se saca junto con
+/// la migración y el cableado, en el mismo lote.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ClientesProvisioningYBackfillTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private const string RazonDeGate =
+        "Gated: clientes/listas_precio no existen (DB CHANGE GATE, task 1.7) y el cableado de " +
+        "ServicioDeAprovisionamiento/InicializadorDeBaseDeDatos queda comentado hasta ese lote (tasks 1.10/1.11).";
+
+    private async Task<HttpClient> ClienteComoRootAsync()
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task ProvisionarUnTenantCreaElConsumidorFinalYLaListaGeneral()
+    {
+        using var cliente = await ClienteComoRootAsync();
+
+        var solicitud = new SolicitudDeAprovisionamiento(
+            NombreTenant: nameof(ProvisionarUnTenantCreaElConsumidorFinalYLaListaGeneral),
+            RazonSocialEmpresa: "Empresa de prueba",
+            NombrePuntoVenta: "Local 1",
+            MailAdmin: $"{nameof(ProvisionarUnTenantCreaElConsumidorFinalYLaListaGeneral)}@ways.test");
+
+        var respuesta = await cliente.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
+        Assert.NotNull(resultado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var listaGeneral = await db.ListasPrecio.SingleAsync(l => l.IdTenant == resultado!.IdTenant && l.EsDefault);
+        Assert.Equal("General", listaGeneral.Nombre);
+
+        var consumidorFinal = await db.Clientes.SingleAsync(
+            c => c.IdTenant == resultado!.IdTenant && c.Numero == ReglaDeClientes.NumeroConsumidorFinal);
+        Assert.Equal("Consumidor Final", consumidorFinal.Nombre);
+        Assert.Equal(listaGeneral.Id, consumidorFinal.IdListaPrecio);
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task UnTenantPreexistenteSinClientesNiListasGanaAmbosPorBackfillYElBackfillEsIdempotente()
+    {
+        // Sembrado ANTES del primer CreateClient() de este fixture (mismo trámite que
+        // InicializadorDeBaseDeDatosTests): así el tenant existe sin clientes/listas_precio
+        // cuando InicializadorDeBaseDeDatos.EjecutarAsync corre por primera vez en esta
+        // prueba, forzando el camino real de backfill en vez de provisioning.
+        int idTenant;
+        await using (var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            var tenant = new Tenant
+            {
+                Nombre = nameof(UnTenantPreexistenteSinClientesNiListasGanaAmbosPorBackfillYElBackfillEsIdempotente),
+                Estado = EstadoTenant.Activo,
+                CreatedAt = ahora,
+                UpdatedAt = ahora
+            };
+            siembra.Tenants.Add(tenant);
+            await siembra.SaveChangesAsync();
+            idTenant = tenant.Id;
+        }
+
+        // Arranca el host: dispara InicializadorDeBaseDeDatos.EjecutarAsync, que corre el
+        // backfill para el tenant recién sembrado.
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var listaGeneral = await db.ListasPrecio.SingleAsync(l => l.IdTenant == idTenant && l.EsDefault);
+        var consumidorFinal = await db.Clientes.SingleAsync(
+            c => c.IdTenant == idTenant && c.Numero == ReglaDeClientes.NumeroConsumidorFinal);
+        Assert.Equal(listaGeneral.Id, consumidorFinal.IdListaPrecio);
+
+        // Un segundo arranque (nuevo cliente HTTP, mismo fixture/contenedor) no duplica nada:
+        // BackfillDeClientesYListasPrecioAsync se salta el tenant que ya tiene sus dos filas.
+        using var _segundoArranque = fixture.CreateClient();
+
+        var cantidadClientes = await db.Clientes.CountAsync(c => c.IdTenant == idTenant);
+        var cantidadListas = await db.ListasPrecio.CountAsync(l => l.IdTenant == idTenant);
+        Assert.Equal(1, cantidadClientes);
+        Assert.Equal(1, cantidadListas);
+    }
+}

--- a/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
@@ -1,4 +1,7 @@
+using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Clientes;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
@@ -11,7 +14,10 @@ namespace Ways.IntegrationTests;
 /// Stage-2-clientes-proveedores, Slice 1 (task 1.14, spec: Tenant Isolation for
 /// clientes/proveedores/listas_precio): mismo patrón que <c>CatalogosDeTenantRlsTests</c> —
 /// SQL crudo, independiente de EF, 0 filas para SELECT/UPDATE cross-tenant, 42501 para el
-/// INSERT que viola <c>WITH CHECK</c>.
+/// INSERT que viola <c>WITH CHECK</c> (judgment-day ronda 1, item confirmado: agregado acá,
+/// antes solo estaba SELECT/UPDATE); además un proof a nivel EF (LINQ, sin SQL crudo) de que
+/// el filtro de tenant también bloquea la lectura por el ORM, mismo patrón que
+/// <c>AislamientoDeTenantTests.ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant</c>.
 ///
 /// DB CHANGE GATE aprobado 2026-08-02 y migración <c>ClientesYProveedoresEtapa2</c> aplicada:
 /// pruebas activas contra Postgres real.
@@ -133,8 +139,10 @@ public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixtur
         db.Tenants.AddRange(tenantA, tenantB);
         await db.SaveChangesAsync();
 
-        db.NumeracionesClientes.Add(new NumeracionCliente { IdTenant = tenantA.Id, ProximoNumero = 1 });
-        await db.SaveChangesAsync();
+        // AsignadorDeNumeroCliente.AsegurarContadorAsync (SQL crudo), no db.NumeracionesClientes.Add:
+        // el WaysDbContext.RechazarEscriturasDeNumeracionCliente rechaza cualquier Added/Modified
+        // de NumeracionCliente que llegue por el ChangeTracker (judgment-day ronda 1).
+        await AsignadorDeNumeroCliente.AsegurarContadorAsync(db, tenantA.Id);
 
         await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
 
@@ -145,5 +153,87 @@ public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixtur
         var total = (long)(await comando.ExecuteScalarAsync())!;
 
         Assert.Equal(0, total);
+    }
+
+    public static TheoryData<string> TablasParaInsertRechazado => new()
+    {
+        "clientes",
+        "proveedores",
+        "listas_precio",
+        "numeraciones_clientes"
+    };
+
+    /// <summary>Judgment-day ronda 1 (item confirmado): faltaba el proof de INSERT (42501) para
+    /// las 4 tablas nuevas — mismo mecanismo y mismo nombre de método que
+    /// <c>CatalogosDeTenantRlsTests.UnInsertConIdTenantAjenoSeRechaza</c>: <c>WITH CHECK</c>
+    /// rechaza el INSERT antes de que la fila exista, sin importar si el resto de columnas
+    /// referencia algo inválido (por eso los ids de catálogo van con un valor cualquiera,
+    /// <c>999999</c> — la FK ni llega a evaluarse).</summary>
+    [Theory]
+    [MemberData(nameof(TablasParaInsertRechazado))]
+    public async Task UnInsertConIdTenantAjenoSeRechaza(string tabla)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var nombreBase = $"{nameof(UnInsertConIdTenantAjenoSeRechaza)}-{tabla}";
+
+        var tenantA = new Tenant { Nombre = $"{nombreBase}-A", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        var tenantB = new Tenant { Nombre = $"{nombreBase}-B", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.AddRange(tenantA, tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantA.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = tabla switch
+        {
+            "clientes" =>
+                "INSERT INTO clientes (id_tenant, numero, nombre, id_condicion_fiscal, id_lista_precio, created_at, updated_at) " +
+                "VALUES ($1, 2, 'intruso', 999999, 999999, now(), now())",
+            "proveedores" =>
+                "INSERT INTO proveedores (id_tenant, razon_social, id_condicion_fiscal, created_at, updated_at) " +
+                "VALUES ($1, 'intruso', 999999, now(), now())",
+            "listas_precio" =>
+                "INSERT INTO listas_precio (id_tenant, nombre, es_default, modo, activo, created_at, updated_at) " +
+                "VALUES ($1, 'intrusa', false, 'fija', true, now(), now())",
+            "numeraciones_clientes" =>
+                "INSERT INTO numeraciones_clientes (id_tenant, proximo_numero) VALUES ($1, 1)",
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+        comando.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    /// <summary>Judgment-day ronda 1 (item confirmado): proof a nivel EF (LINQ) de que el
+    /// query filter de tenant (<c>WaysDbContext.AplicarFiltroDeTenant</c>) también bloquea a
+    /// las 3 entidades nuevas que sí pasan por el ORM (<c>NumeracionCliente</c> queda afuera:
+    /// design decision 3, solo se escribe/lee con SQL crudo) — mismo patrón que
+    /// <c>AislamientoDeTenantTests.ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant</c>, acá para
+    /// las 3 entidades de este slice en un solo método.</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas()
+    {
+        var (_, idClienteDeA, idTenantB1) = await SembrarFilaDeTenantAAsync(
+            "clientes", nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas) + "-clientes");
+        var (_, idProveedorDeA, idTenantB2) = await SembrarFilaDeTenantAAsync(
+            "proveedores", nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas) + "-proveedores");
+        var (_, idListaDeA, idTenantB3) = await SembrarFilaDeTenantAAsync(
+            "listas_precio", nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas) + "-listas");
+
+        await using var sesionB1 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB1));
+        var clientesVisibles = await sesionB1.Clientes.Where(c => c.Id == idClienteDeA).ToListAsync();
+        Assert.Empty(clientesVisibles);
+
+        await using var sesionB2 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB2));
+        var proveedoresVisibles = await sesionB2.Proveedores.Where(p => p.Id == idProveedorDeA).ToListAsync();
+        Assert.Empty(proveedoresVisibles);
+
+        await using var sesionB3 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB3));
+        var listasVisibles = await sesionB3.ListasPrecio.Where(l => l.Id == idListaDeA).ToListAsync();
+        Assert.Empty(listasVisibles);
     }
 }

--- a/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
@@ -13,18 +13,12 @@ namespace Ways.IntegrationTests;
 /// SQL crudo, independiente de EF, 0 filas para SELECT/UPDATE cross-tenant, 42501 para el
 /// INSERT que viola <c>WITH CHECK</c>.
 ///
-/// GATED: <c>clientes</c>/<c>proveedores</c>/<c>listas_precio</c>/<c>numeraciones_clientes</c>
-/// no existen todavía — la migración <c>ClientesYProveedoresEtapa2</c> está bloqueada por el
-/// DB CHANGE GATE (task 1.7). <c>Skip</c> se saca en el mismo lote que genera y aplica esa
-/// migración.
+/// DB CHANGE GATE aprobado 2026-08-02 y migración <c>ClientesYProveedoresEtapa2</c> aplicada:
+/// pruebas activas contra Postgres real.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
-    private const string RazonDeGate =
-        "Gated: clientes/proveedores/listas_precio/numeraciones_clientes no existen hasta que " +
-        "la migración ClientesYProveedoresEtapa2 se genere y apruebe (DB CHANGE GATE, task 1.7).";
-
     public static TheoryData<string, string> TablasDeTenant => new()
     {
         { "clientes", "id_cliente" },
@@ -92,7 +86,7 @@ public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixtur
         return (tenantA.Id, idFila, tenantB.Id);
     }
 
-    [Theory(Skip = RazonDeGate)]
+    [Theory]
     [MemberData(nameof(TablasDeTenant))]
     public async Task UnaSesionDeOtroTenantNoVeLaFilaPorSelect(string tabla, string columnaId)
     {
@@ -110,7 +104,7 @@ public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixtur
         Assert.NotEqual(idTenantA, idTenantB);
     }
 
-    [Theory(Skip = RazonDeGate)]
+    [Theory]
     [MemberData(nameof(TablasDeTenant))]
     public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila(string tabla, string columnaId)
     {
@@ -126,7 +120,7 @@ public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixtur
         Assert.Equal(0, filas);
     }
 
-    [Fact(Skip = RazonDeGate)]
+    [Fact]
     public async Task NumeracionesClientesEsInvisibleParaOtroTenant()
     {
         using var _ = fixture.CreateClient();

--- a/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesYProveedoresRlsTests.cs
@@ -1,0 +1,155 @@
+using Npgsql;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Stage-2-clientes-proveedores, Slice 1 (task 1.14, spec: Tenant Isolation for
+/// clientes/proveedores/listas_precio): mismo patrón que <c>CatalogosDeTenantRlsTests</c> —
+/// SQL crudo, independiente de EF, 0 filas para SELECT/UPDATE cross-tenant, 42501 para el
+/// INSERT que viola <c>WITH CHECK</c>.
+///
+/// GATED: <c>clientes</c>/<c>proveedores</c>/<c>listas_precio</c>/<c>numeraciones_clientes</c>
+/// no existen todavía — la migración <c>ClientesYProveedoresEtapa2</c> está bloqueada por el
+/// DB CHANGE GATE (task 1.7). <c>Skip</c> se saca en el mismo lote que genera y aplica esa
+/// migración.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ClientesYProveedoresRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string RazonDeGate =
+        "Gated: clientes/proveedores/listas_precio/numeraciones_clientes no existen hasta que " +
+        "la migración ClientesYProveedoresEtapa2 se genere y apruebe (DB CHANGE GATE, task 1.7).";
+
+    public static TheoryData<string, string> TablasDeTenant => new()
+    {
+        { "clientes", "id_cliente" },
+        { "proveedores", "id_proveedor" },
+        { "listas_precio", "id_lista_precio" }
+    };
+
+    private async Task<(int IdTenantA, int IdFila, int IdTenantB)> SembrarFilaDeTenantAAsync(string tabla, string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenantA = new Tenant { Nombre = $"{nombre}-A", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        var tenantB = new Tenant { Nombre = $"{nombre}-B", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.AddRange(tenantA, tenantB);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = tenantA.Id, Nombre = nombre, EsDefault = true, Modo = ModoLista.Fija,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        int idFila;
+        switch (tabla)
+        {
+            case "clientes":
+                var cliente = new Cliente
+                {
+                    IdTenant = tenantA.Id, Numero = 2, Nombre = nombre,
+                    IdCondicionFiscal = condicionFiscal.Id, IdListaPrecio = lista.Id,
+                    CreatedAt = ahora, UpdatedAt = ahora
+                };
+                db.Clientes.Add(cliente);
+                await db.SaveChangesAsync();
+                idFila = cliente.Id;
+                break;
+
+            case "proveedores":
+                var proveedor = new Proveedor
+                {
+                    IdTenant = tenantA.Id, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+                    CreatedAt = ahora, UpdatedAt = ahora
+                };
+                db.Proveedores.Add(proveedor);
+                await db.SaveChangesAsync();
+                idFila = proveedor.Id;
+                break;
+
+            case "listas_precio":
+                idFila = lista.Id;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.");
+        }
+
+        return (tenantA.Id, idFila, tenantB.Id);
+    }
+
+    [Theory(Skip = RazonDeGate)]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoVeLaFilaPorSelect(string tabla, string columnaId)
+    {
+        var (idTenantA, idFila, idTenantB) = await SembrarFilaDeTenantAAsync(tabla, nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"SELECT count(*) FROM {tabla} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+        Assert.NotEqual(idTenantA, idTenantB);
+    }
+
+    [Theory(Skip = RazonDeGate)]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila(string tabla, string columnaId)
+    {
+        var (_, idFila, idTenantB) = await SembrarFilaDeTenantAAsync(tabla, nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"UPDATE {tabla} SET updated_at = now() WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    [Fact(Skip = RazonDeGate)]
+    public async Task NumeracionesClientesEsInvisibleParaOtroTenant()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenantA = new Tenant { Nombre = nameof(NumeracionesClientesEsInvisibleParaOtroTenant) + "-A", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        var tenantB = new Tenant { Nombre = nameof(NumeracionesClientesEsInvisibleParaOtroTenant) + "-B", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.AddRange(tenantA, tenantB);
+        await db.SaveChangesAsync();
+
+        db.NumeracionesClientes.Add(new NumeracionCliente { IdTenant = tenantA.Id, ProximoNumero = 1 });
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM numeraciones_clientes WHERE id_tenant = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tenantA.Id });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+    }
+}

--- a/tests/Ways.IntegrationTests/ParametrosTests.cs
+++ b/tests/Ways.IntegrationTests/ParametrosTests.cs
@@ -261,7 +261,15 @@ public class ParametrosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixt
             }
 
             gate.Signal();
-            gate.Wait();
+
+            // stage-1 INFO carried into stage-2 (task 1.13): sin timeout, un bug futuro que
+            // rompa el rendezvous (p.ej. una sola query llega a matchear en vez de dos)
+            // cuelga la prueba en vez de fallarla — la sesión de test corre para siempre en
+            // vez de reportar el problema. El timeout convierte ese cuelgue en un Assert.True
+            // con mensaje, endureciendo el patrón antes de que las pruebas de carrera de
+            // numero/cuit de las Slices 2-3 lo reusen.
+            var senializo = gate.Wait(TimeSpan.FromSeconds(10));
+            Assert.True(senializo, "El rendezvous de InterceptorDeRendezVous no llegó a los 2 participantes a tiempo.");
         }
     }
 }

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -10,6 +10,7 @@ using Npgsql;
 using Testcontainers.PostgreSql;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure;
@@ -195,6 +196,8 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoTenant>("estado_tenant");
                 npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
                 npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
                 npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
             })
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
@@ -218,6 +221,8 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoTenant>("estado_tenant");
                 npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
                 npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;


### PR DESCRIPTION
Closes #9

## Summary

- Slice 1 (foundation) of `stage-2-clientes-proveedores`: schema, domain, and provisioning groundwork for clientes and proveedores.
- 4 new tables under one gate-approved migration: `clientes` (full doc 10 §2 schema incl. credit fields at rest, per-tenant unique `numero`, protected Consumidor Final via domain rule + `ck_clientes_cf_protegido` CHECK), `proveedores` (tenant-wide unique `cuit` allowing NULLs), minimal `listas_precio` (General/default list with single-default partial unique guarantees), and the `numeraciones_clientes` atomic counter (raw ADO.NET through EF-opened connections, ChangeTracker guard making the helper the only legal writer).
- All FKs composite where tenant-scoped (incl. `fk_clientes_lista_precio`, gate-approved hardening — Postgres FK checks bypass RLS, so the schema itself now prevents cross-tenant list assignment).
- Provisioning template extended (General list + Consumidor Final) and per-artifact idempotent backfill for pre-existing tenants (schema + backfill approved together at the DB gate).
- Full `db-error-backstops` compliance: every constraint mapped or documented-exempt, FK smoke tests with ConstraintName assertions, RLS proofs (0-rows vs 42501) for all 4 tables, counter concurrency test.

## Test Plan

- [x] `dotnet build Ways.slnx` — 0 errors, 0 warnings; `dotnet ef migrations has-pending-model-changes` clean
- [x] `dotnet test` — Domain 69/69, Application 94/94, Integration 103/103 (real Postgres 17; incl. partial-backfill recovery, concurrent counter assignment, cross-tenant composite-FK rejection)
- [x] DB CHANGE GATE: 4-table model + backfill approved by the owner before generation (2026-08-02), plus the composite-FK hardening mini-gate
- [x] judgment-day: APPROVED after 2 rounds — R1: 1 confirmed CRITICAL (union-based backfill idempotency skipped half-covered tenants) + coverage gaps, fixed; R2: APPROVED (2 INFO items applied post-verdict while the migration was still editable)

## Notes

- `size:exception` per the tasks forecast: the single-migration/single-gate requirement makes this slice unsplittable below the budget.
- Slices 2 (clientes service/ABM) and 3 (proveedores service/ABM) build on this; race tests for `ux_clientes_numero`/`ux_proveedores_cuit` land with their write paths (documented exemptions inline).
