### PR TITLE
feat(web): pantalla de listas de precio sobre la maquina generica (etapa 3, slice 6)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -9,12 +9,14 @@ import { Empresas } from './paginas/Empresas'
 import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
 import { NuevoTenant } from './paginas/NuevoTenant'
+import { PaginaCatalogo } from './paginas/PaginaCatalogo'
 import { Parametros } from './paginas/Parametros'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
 import { Tenants } from './paginas/Tenants'
 import { Usuarios } from './paginas/Usuarios'
+import { descriptorListasPrecio } from './api/catalogos'
 import { ROL } from './api/tipos'
 
 export function App() {
@@ -64,6 +66,18 @@ export function App() {
               }
             />
 
+            {/* stage-3-articulos-y-precios (Slice 6, design: ABM Composition): ruta propia
+                (no /catalogos/:recurso) — reusa la máquina genérica directamente, mismo
+                criterio que /catalogos/categorias, para no competir con el switch de
+                RutaCatalogo ni con GET /api/listas-precio (selector de solo lectura, stage 2). */}
+            <Route
+              path="/listas-precio"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                  <PaginaCatalogo definicion={descriptorListasPrecio} />
+                </RutaProtegida>
+              }
+            />
             {/* Escape hatch de ADR-11: árbol propio, no la máquina genérica. react-router
                 prioriza segmentos literales sobre ":recurso" sin importar el orden de
                 declaración, pero queda declarada antes por legibilidad. */}

--- a/src/Ways.Web/src/api/catalogos.ts
+++ b/src/Ways.Web/src/api/catalogos.ts
@@ -238,7 +238,7 @@ export const descriptorListasPrecio: DescriptorDeCatalogo<ListaPrecioListado, Li
       visibleSi: (valores) => valores.modo === 'Derivada',
       opcionesDesdeListado: (items, idActual) =>
         (items as ListaPrecioListado[])
-          .filter((item) => item.modo === 'Fija' && item.id !== idActual)
+          .filter((item) => item.activo && item.modo === 'Fija' && item.id !== idActual)
           .map((item) => ({ valor: String(item.id), etiqueta: item.nombre })),
     },
     {

--- a/src/Ways.Web/src/api/catalogos.ts
+++ b/src/Ways.Web/src/api/catalogos.ts
@@ -19,10 +19,13 @@ import type {
   CondicionFiscalListado,
   GrupoAlta,
   GrupoListado,
+  ListaPrecioAlta,
+  ListaPrecioListado,
   MarcaAlta,
   MarcaListado,
   MedioPagoAlta,
   MedioPagoListado,
+  ModoLista,
   TipoComprobanteListado,
 } from './tipos'
 import { COMPORTAMIENTOS_MEDIO_PAGO } from './tipos'
@@ -41,6 +44,16 @@ export type CampoDescriptor = {
   /** Se muestra también como columna extra en la tabla de listado, no solo en el formulario. */
   columnaEnListado?: boolean
   formatearListado?: (item: unknown) => string
+  /** stage-3-articulos-y-precios (Slice 6): campo condicional a otro campo del mismo
+   * formulario — se oculta (no solo se deshabilita) cuando el predicado da `false`, así un
+   * campo `requerido` oculto no bloquea el envío. Único uso hoy: `idListaBase`/`porcentaje`
+   * solo aplican cuando `modo = Derivada`. */
+  visibleSi?: (valores: Record<string, ValorDeCampo>) => boolean
+  /** stage-3-articulos-y-precios (Slice 6): alternativa a `opciones` estáticas — arma las
+   * opciones del select a partir del listado que la pantalla ya tiene cargado (el selector de
+   * lista base ofrece las demás listas de la misma pantalla, no un catálogo aparte). El
+   * descriptor concreto hace el cast desde `unknown[]` a su propio `TListado`. */
+  opcionesDesdeListado?: (items: unknown[], idActual: number | null) => { valor: string; etiqueta: string }[]
 }
 
 export type DescriptorDeCatalogo<TListado extends CatalogoListado, TAlta> = {
@@ -190,6 +203,71 @@ export const descriptorCategorias: DescriptorDeCatalogo<CategoriaListado, Catego
   valoresPorDefecto: {},
   aValores: () => ({}),
   aAlta: (nombre, activo) => ({ nombre, idEmpresa: null, activo, orden: 1, idCategoriaPadre: null }),
+}
+
+/**
+ * stage-3-articulos-y-precios (Slice 6, design: ABM Composition): `listas_precio` reusa la
+ * máquina genérica igual que `descriptorCategorias`, con ruta propia (`/listas-precio`, no
+ * `/catalogos/:recurso`) — mismo criterio que `categorias`, no se agrega a
+ * `DESCRIPTORES_DE_CATALOGO`. `idListaBase`/`porcentaje` solo aplican en modo `Derivada`
+ * (`visibleSi`); el swap de `esDefault` y las guardas de modo/desactivación las valida el
+ * servidor — esta pantalla solo muestra el mensaje que devuelve (`ErrorApi.message`).
+ */
+export const descriptorListasPrecio: DescriptorDeCatalogo<ListaPrecioListado, ListaPrecioAlta> = {
+  recurso: 'listas-precio',
+  titulo: 'Listas de precio',
+  tituloSingular: 'lista de precio',
+  campos: [
+    { clave: 'esDefault', etiqueta: 'Lista default', tipo: 'booleano', columnaEnListado: true },
+    {
+      clave: 'modo',
+      etiqueta: 'Modo',
+      tipo: 'select',
+      requerido: true,
+      columnaEnListado: true,
+      opciones: [
+        { valor: 'Fija', etiqueta: 'Fija' },
+        { valor: 'Derivada', etiqueta: 'Derivada (calculada sobre otra lista)' },
+      ],
+    },
+    {
+      clave: 'idListaBase',
+      etiqueta: 'Lista base',
+      tipo: 'select',
+      requerido: true,
+      visibleSi: (valores) => valores.modo === 'Derivada',
+      opcionesDesdeListado: (items, idActual) =>
+        (items as ListaPrecioListado[])
+          .filter((item) => item.modo === 'Fija' && item.id !== idActual)
+          .map((item) => ({ valor: String(item.id), etiqueta: item.nombre })),
+    },
+    {
+      clave: 'porcentaje',
+      etiqueta: 'Porcentaje sobre la base (%)',
+      tipo: 'numeroDecimal',
+      requerido: true,
+      visibleSi: (valores) => valores.modo === 'Derivada',
+    },
+  ],
+  valoresPorDefecto: { esDefault: false, modo: 'Fija', idListaBase: '', porcentaje: '' },
+  aValores: (item) => ({
+    esDefault: item.esDefault,
+    modo: item.modo,
+    idListaBase: item.idListaBase === null ? '' : String(item.idListaBase),
+    porcentaje: item.porcentaje === null ? '' : String(item.porcentaje),
+  }),
+  aAlta: (nombre, activo, valores) => {
+    const esDerivada = valores.modo === 'Derivada'
+    return {
+      nombre,
+      idEmpresa: null,
+      activo,
+      esDefault: Boolean(valores.esDefault),
+      modo: (valores.modo as ModoLista) ?? 'Fija',
+      idListaBase: esDerivada ? numeroOVacio(valores.idListaBase) : null,
+      porcentaje: esDerivada ? numeroOVacio(valores.porcentaje) : null,
+    }
+  },
 }
 
 // --- Catálogos fiscales (globales, solo lectura — ADR-11, gate #4) ---

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -303,6 +303,27 @@ export type EdicionCliente = AltaCliente
  * (design decision 1, spec: listas_precio ABM Is Out of Scope This Stage). */
 export type ListaPrecioAsignable = { id: number; nombre: string; esDefault: boolean }
 
+// --- Listas de precio (stage-3-articulos-y-precios, Slice 4/6): ABM completo, ambos modos ---
+
+export type ModoLista = 'Fija' | 'Derivada'
+
+export type ListaPrecioListado = CatalogoListado & {
+  esDefault: boolean
+  modo: ModoLista
+  idListaBase: number | null
+  porcentaje: number | null
+}
+
+export type ListaPrecioAlta = {
+  nombre: string
+  idEmpresa: number | null
+  esDefault: boolean
+  modo: ModoLista
+  idListaBase: number | null
+  porcentaje: number | null
+  activo: boolean
+}
+
 // --- Proveedores (stage-2-clientes-proveedores) ---
 // Entidad dedicada, no la máquina genérica de catálogos (design decision 1): dedupe por `cuit`
 // tenant-wide (partial index, NULL permitido y no comparado), no por nombre/empresa-par.

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -51,6 +51,11 @@ export function Layout() {
                         Proveedores
                       </NavLink>
                     </li>
+                    <li className="nav-item">
+                      <NavLink className="nav-link" to="/listas-precio">
+                        Listas de precio
+                      </NavLink>
+                    </li>
                     {Object.values(DESCRIPTORES_DE_CATALOGO).map((d) => (
                       <li className="nav-item" key={d.recurso}>
                         <NavLink className="nav-link" to={`/catalogos/${d.recurso}`}>

--- a/src/Ways.Web/src/paginas/PaginaCatalogo.tsx
+++ b/src/Ways.Web/src/paginas/PaginaCatalogo.tsx
@@ -215,6 +215,16 @@ export function PaginaCatalogo<TListado extends CatalogoListado, TAlta>({
   )
 }
 
+/** Resuelve la etiqueta de un valor seleccionado que ya no está entre las opciones vigentes
+ * del select (p. ej. la lista base de una `Derivada` fue desactivada después, o quedó fuera
+ * de `items` porque "Incluir inactivos" está apagado). Evita que el `<select>` controlado
+ * quede con un valor sin `<option>` que lo respalde. */
+function etiquetaParaValorFaltante(valorActual: string, items: unknown[]): string {
+  const item = (items as CatalogoListado[]).find((i) => String(i.id) === valorActual)
+  if (!item) return `Opción no disponible (${valorActual})`
+  return item.activo ? item.nombre : `${item.nombre} (inactiva)`
+}
+
 function formatearValorDeColumna(campo: CampoDescriptor, valor: ValorDeCampo | undefined) {
   if (campo.tipo === 'booleano') return valor ? 'Sí' : 'No'
   if (campo.tipo === 'select') {
@@ -279,6 +289,10 @@ function FormularioCatalogo({
       {camposVisibles.map((campo) => {
         const opciones = campo.opcionesDesdeListado ? campo.opcionesDesdeListado(items, valor.id) : (campo.opciones ?? [])
         const valorActual = String(valor.valores[campo.clave] ?? '')
+        const opcionFaltante =
+          campo.tipo === 'select' && valorActual !== '' && !opciones.some((o) => o.valor === valorActual)
+            ? { valor: valorActual, etiqueta: etiquetaParaValorFaltante(valorActual, items) }
+            : null
 
         return (
           <div className="col-md-3" key={campo.clave}>
@@ -304,6 +318,9 @@ function FormularioCatalogo({
                 required={campo.requerido}
               >
                 {valorActual === '' && <option value="">— Elegí una opción —</option>}
+                {opcionFaltante && (
+                  <option value={opcionFaltante.valor}>{opcionFaltante.etiqueta}</option>
+                )}
                 {opciones.map((o) => (
                   <option key={o.valor} value={o.valor}>
                     {o.etiqueta}

--- a/src/Ways.Web/src/paginas/PaginaCatalogo.tsx
+++ b/src/Ways.Web/src/paginas/PaginaCatalogo.tsx
@@ -140,6 +140,7 @@ export function PaginaCatalogo<TListado extends CatalogoListado, TAlta>({
             campos={campos}
             tituloSingular={tituloSingular}
             guardando={guardando}
+            items={items}
             onCambio={setFormulario}
             onGuardar={guardar}
             onCancelar={() => setFormulario(null)}
@@ -227,6 +228,7 @@ function FormularioCatalogo({
   campos,
   tituloSingular,
   guardando,
+  items,
   onCambio,
   onGuardar,
   onCancelar,
@@ -235,11 +237,13 @@ function FormularioCatalogo({
   campos: CampoDescriptor[]
   tituloSingular: string
   guardando: boolean
+  items: unknown[]
   onCambio: (f: Formulario) => void
   onGuardar: () => void
   onCancelar: () => void
 }) {
   const esNuevo = valor.id === null
+  const camposVisibles = campos.filter((campo) => !campo.visibleSi || campo.visibleSi(valor.valores))
 
   function cambiarValorPropio(clave: string, nuevo: ValorDeCampo) {
     onCambio({ ...valor, valores: { ...valor.valores, [clave]: nuevo } })
@@ -272,48 +276,54 @@ function FormularioCatalogo({
         />
       </div>
 
-      {campos.map((campo) => (
-        <div className="col-md-3" key={campo.clave}>
-          <label className="form-label" htmlFor={`f-${campo.clave}`}>
-            {campo.etiqueta}
-          </label>
-          {campo.tipo === 'booleano' ? (
-            <div className="form-check pt-2">
+      {camposVisibles.map((campo) => {
+        const opciones = campo.opcionesDesdeListado ? campo.opcionesDesdeListado(items, valor.id) : (campo.opciones ?? [])
+        const valorActual = String(valor.valores[campo.clave] ?? '')
+
+        return (
+          <div className="col-md-3" key={campo.clave}>
+            <label className="form-label" htmlFor={`f-${campo.clave}`}>
+              {campo.etiqueta}
+            </label>
+            {campo.tipo === 'booleano' ? (
+              <div className="form-check pt-2">
+                <input
+                  id={`f-${campo.clave}`}
+                  type="checkbox"
+                  className="form-check-input"
+                  checked={Boolean(valor.valores[campo.clave])}
+                  onChange={(e) => cambiarValorPropio(campo.clave, e.target.checked)}
+                />
+              </div>
+            ) : campo.tipo === 'select' ? (
+              <select
+                id={`f-${campo.clave}`}
+                className="form-select rounded-0"
+                value={valorActual}
+                onChange={(e) => cambiarValorPropio(campo.clave, e.target.value)}
+                required={campo.requerido}
+              >
+                {valorActual === '' && <option value="">— Elegí una opción —</option>}
+                {opciones.map((o) => (
+                  <option key={o.valor} value={o.valor}>
+                    {o.etiqueta}
+                  </option>
+                ))}
+              </select>
+            ) : (
               <input
                 id={`f-${campo.clave}`}
-                type="checkbox"
-                className="form-check-input"
-                checked={Boolean(valor.valores[campo.clave])}
-                onChange={(e) => cambiarValorPropio(campo.clave, e.target.checked)}
+                type="number"
+                step={campo.tipo === 'numeroDecimal' ? '0.01' : '1'}
+                className="form-control rounded-0"
+                value={valorActual}
+                onChange={(e) => cambiarValorPropio(campo.clave, e.target.value)}
+                required={campo.requerido}
               />
-            </div>
-          ) : campo.tipo === 'select' ? (
-            <select
-              id={`f-${campo.clave}`}
-              className="form-select rounded-0"
-              value={String(valor.valores[campo.clave] ?? '')}
-              onChange={(e) => cambiarValorPropio(campo.clave, e.target.value)}
-              required={campo.requerido}
-            >
-              {(campo.opciones ?? []).map((o) => (
-                <option key={o.valor} value={o.valor}>
-                  {o.etiqueta}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <input
-              id={`f-${campo.clave}`}
-              type="number"
-              step={campo.tipo === 'numeroDecimal' ? '0.01' : '1'}
-              className="form-control rounded-0"
-              value={String(valor.valores[campo.clave] ?? '')}
-              onChange={(e) => cambiarValorPropio(campo.clave, e.target.value)}
-              required={campo.requerido}
-            />
-          )}
-        </div>
-      ))}
+            )}
+          </div>
+        )
+      })}
 
       <div className="col-md-2">
         <label className="form-label" htmlFor="f-activo">


### PR DESCRIPTION
Closes #23

## Summary

- Slice 6 of `stage-3-articulos-y-precios`: the Listas de Precio web screen, reusing the generic catalog descriptor machine as designed.
- Extends `CampoDescriptor` minimally with `visibleSi` (conditional fields: `id_lista_base`/`porcentaje` only for `modo = Derivada`) and `opcionesDesdeListado` (base-list selector fed from the loaded listing, filtered to active Fija listas, self-excluded on edit).
- Judgment-day round 1 confirmed one defect cluster (inactive listas selectable as base; controlled select rendering a value with no matching option, risking a silent base change) — fixed with the `activo` filter plus a synthetic option for the currently-bound value (labeled "(inactiva)" when applicable). Round 2: clean.
- `/listas-precio` route + nav entry, Admin-gated, no collision with the stage-2 read-only `GET /api/listas-precio` selector.

## Test Plan

- [x] `npx tsc -b` — clean
- [x] `npx oxlint` — no new warnings (one pre-existing unrelated in AuthContext.tsx)
- [x] `npx vite build` — clean
- [x] Behavior-neutrality for pre-existing catalogs (areas/marcas/grupos/medios-pago/categorias) verified by both judges: none define the new descriptor fields, placeholder/orphan-option branches never fire for them
- [x] judgment-day: APPROVED — R1: 1 confirmed CRITICAL cluster fixed; R2: both judges clean (remaining items theoretical/suggestions, recorded)

## Notes

- Front-end only: zero backend/schema changes.
- INFO recorded for follow-up: scope the orphan-option fallback to list-backed selects; stand up Ways.Web unit-test infra (repeated-gap skills-loop task spawned).
- Remaining for the stage: slice 5 (articulos screen, in judgment-day) + verify + archive.