### PR TITLE
feat(ofertas): schema y fundacion de dominio de ofertas (etapa 4, slice 1)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -270,6 +270,8 @@ ofertas (                     -- [catálogo]
 );
 CHECK (num_nonnulls(id_articulo, id_grupo, id_categoria) = 1);
 CHECK (num_nonnulls(precio_unitario, porcentaje, importe_fijo) = 1);
+CHECK (fecha_hasta >= fecha_desde AND hora_hasta >= hora_desde);  -- tolerante a NULL por eje
+CHECK (dias_semana IS NULL OR dias_semana <@ ARRAY[1,2,3,4,5,6,7]::smallint[]);
 
 ofertas_listas (               -- [catálogo] junction, sin auditoría (PK-only)
     id_oferta, id_lista_precio, id_tenant

--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -250,7 +250,8 @@ Las listas `derivadas` (ej. "10% descuento" sobre la general) no guardan filas e
 ```sql
 ofertas (                     -- [catálogo]
     id_oferta,
-    nombre          citext,                  -- lo que imprime el ticket
+    id_empresa integer NULL,                 -- NULL = toda empresa del tenant
+    nombre          citext,                  -- lo que imprime el ticket (no único)
     -- alcance: exactamente uno
     id_articulo integer NULL, id_grupo integer NULL, id_categoria integer NULL,
     -- vigencia
@@ -263,20 +264,31 @@ ofertas (                     -- [catálogo]
     precio_unitario numeric(14,2) NULL,      -- "a $X la unidad" (ex precioOferta/precioCant)
     porcentaje      numeric(5,2)  NULL,      -- "X% de descuento"
     importe_fijo    numeric(14,2) NULL,      -- "$X de descuento" / "3x2 a $X"
-    id_lista_precio integer NULL,            -- NULL = aplica a todas las listas
     prioridad       int NOT NULL DEFAULT 0,  -- ante solapamiento gana la mayor;
     acumulable      boolean NOT NULL DEFAULT false,  -- ¿se suma a otras o excluye?
     activo
 );
 CHECK (num_nonnulls(id_articulo, id_grupo, id_categoria) = 1);
 CHECK (num_nonnulls(precio_unitario, porcentaje, importe_fijo) = 1);
+
+ofertas_listas (               -- [catálogo] junction, sin auditoría (PK-only)
+    id_oferta, id_lista_precio, id_tenant
+);
+-- PK (id_oferta, id_lista_precio)
 ```
 
+**DEVIATION (stage-4-ofertas, aprobado 2026-08-03):** la columna única
+`id_lista_precio NULL` que este documento definía originalmente en `ofertas` se
+reemplaza por la junction `ofertas_listas` de arriba. Cero filas para una oferta
+significa que aplica a **todas** las listas del tenant (incluidas las `derivada`);
+una o más filas la restringen a exactamente esas listas — un targeting multi-lista
+que una sola columna nullable no podía expresar.
+
 Cubre todo el motor del legacy (por fecha, por hora, por cantidad, de grupo directa y
-por cantidad) más lo que le faltaba: días de semana, ofertas por categoría, oferta
-limitada a una lista, y reglas explícitas de solapamiento en lugar del `elseif`
-accidental de `funciones.php`. El descuento aplicado queda **en el item** que lo generó
-(ver abajo), no como línea fantasma con barra `OF...`.
+por cantidad) más lo que le faltaba: días de semana, ofertas por categoría, ofertas
+limitadas a un subconjunto de listas, y reglas explícitas de solapamiento en lugar del
+`elseif` accidental de `funciones.php`. El descuento aplicado queda **en el item** que
+lo generó (ver abajo), no como línea fantasma con barra `OF...`.
 
 ---
 

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -88,6 +88,11 @@ public class ManejadorDeErrores(
             // fk_codigos_barra_tenant/articulo, fk_precios_tenant/articulo/lista_precio,
             // fk_numeraciones_articulos_tenant): todas siguen la convención fk_* del resto del
             // esquema, así que no hace falta un caso nuevo acá.
+            //
+            // stage-4-ofertas (Slice 1, task 1.7): confirmado sin cambio de código — el mismo
+            // match por prefijo "fk_" ya cubre las 8 FKs nuevas de esta etapa
+            // (fk_ofertas_tenant/empresa/articulo/grupo/categoria,
+            // fk_ofertas_listas_tenant/oferta/lista_precio).
             DbUpdateException { InnerException: PostgresException { SqlState: "23503", ConstraintName: string fk } }
                 when fk.StartsWith("fk_", StringComparison.Ordinal) =>
                 LogYClasificarReferenciaInvalida(fk, log),
@@ -99,6 +104,31 @@ public class ManejadorDeErrores(
             // porque numeric_value_out_of_range aplica por igual a cualquier columna numeric(p,s).
             DbUpdateException { InnerException: PostgresException { SqlState: "22003" } } =>
                 (StatusCodes.Status400BadRequest, "El valor numérico está fuera de rango.", "valor_fuera_de_rango"),
+
+            // stage-4-ofertas (Slice 1, task 1.7, db-error-backstops, design decision 8):
+            // switch por nombre EXACTO detrás de un guard de prefijo "ck_ofertas_" — a
+            // diferencia de ClasificarUnicidad (match por Contains/sufijo), acá no hay riesgo
+            // de colisión de substring porque los cuatro nombres son literales completos y
+            // mutuamente exclusivos. Agregado DESPUÉS de las dos ramas exactas existentes
+            // (ck_clientes_cf_protegido/ck_precios_ventana_valida): cero cambio de
+            // comportamiento para esas dos. ReglaDeOfertas ya valida los cuatro invariantes en
+            // el camino de servicio (Slice 1, dominio; Slice 2, ServicioDeOfertas) — bajo
+            // operación normal ninguna de las cuatro ramas de abajo es alcanzable, quedan como
+            // backstop de una escritura cruda/fuera de banda (misma familia que las dos ramas
+            // de arriba).
+            DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckOferta } }
+                when ckOferta.StartsWith("ck_ofertas_", StringComparison.Ordinal) =>
+                ClasificarCheckDeOfertas(ckOferta),
+
+            // stage-4-ofertas (Slice 1, task 1.7): pk_ofertas_listas — la única superficie
+            // genuinamente racy de esta etapa (design: Backstop Map). El replace-set de
+            // ServicioDeOfertas (Slice 2: delete-all + insert transaccional, ids .Distinct()ed)
+            // ya evita el duplicado en el camino normal; esto cubre dos PUT concurrentes que
+            // reemplazan el mismo set de listas de una oferta y chocan acá — misma familia que
+            // pk_articulos_empresas.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string pkOfertasListas } }
+                when string.Equals(pkOfertasListas, "pk_ofertas_listas", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "La lista de precios ya está en el subconjunto de targeting de la oferta.", "oferta_lista_duplicada"),
 
             _ => (StatusCodes.Status500InternalServerError,
                   "Ocurrió un error inesperado.",
@@ -276,4 +306,38 @@ public class ManejadorDeErrores(
         log.LogWarning("Referencia inválida por la restricción {NombreDeFk}.", nombreDeFk);
         return (StatusCodes.Status400BadRequest, "La referencia indicada no existe.", "referencia_invalida");
     }
+
+    /// <summary>stage-4-ofertas (Slice 1, task 1.7, tasks.md "Orchestrator Decisions Recorded
+    /// This Phase" #1): switch por nombre EXACTO de las cuatro CHECKs de <c>ofertas</c> — el
+    /// código de las dos exclusividades sigue el código pineado por <c>specs/ofertas/spec.md</c>
+    /// (<c>oferta_alcance_invalido</c>/<c>oferta_beneficio_invalido</c>, no el nombre borrador
+    /// de <c>design.md</c>), las otras dos siguen el nombre de <c>design.md</c> tal cual
+    /// (ningún escenario de spec las pinea distinto).</summary>
+    private static (int EstadoHttp, string Titulo, string Codigo) ClasificarCheckDeOfertas(string nombreDeCheck) =>
+        nombreDeCheck switch
+        {
+            "ck_ofertas_alcance_exclusivo" =>
+                (StatusCodes.Status400BadRequest,
+                    "La oferta tiene que apuntar a exactamente un artículo, grupo o categoría.",
+                    "oferta_alcance_invalido"),
+
+            "ck_ofertas_beneficio_exclusivo" =>
+                (StatusCodes.Status400BadRequest,
+                    "La oferta tiene que definir exactamente un beneficio: precio unitario, porcentaje o importe fijo.",
+                    "oferta_beneficio_invalido"),
+
+            "ck_ofertas_ventana_valida" =>
+                (StatusCodes.Status400BadRequest,
+                    "La ventana de vigencia de la oferta es inválida.",
+                    "ventana_de_oferta_invalida"),
+
+            "ck_ofertas_dias_semana" =>
+                (StatusCodes.Status400BadRequest,
+                    "Los días de semana de la oferta tienen que ser valores de 1 a 7 sin repetir.",
+                    "dias_semana_invalidos"),
+
+            _ => throw new InvalidOperationException(
+                $"'{nombreDeCheck}' pasó el guard de prefijo 'ck_ofertas_' pero no tiene un caso — " +
+                "agregar la CHECK nueva a este switch.")
+        };
 }

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -117,8 +117,9 @@ public class ManejadorDeErrores(
             // backstop de una escritura cruda/fuera de banda (misma familia que las dos ramas
             // de arriba).
             DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckOferta } }
-                when ckOferta.StartsWith("ck_ofertas_", StringComparison.Ordinal) =>
-                ClasificarCheckDeOfertas(ckOferta),
+                when ckOferta.StartsWith("ck_ofertas_", StringComparison.Ordinal)
+                    && ClasificarCheckDeOfertas(ckOferta) is { } checkOferta =>
+                (checkOferta.EstadoHttp, checkOferta.Titulo, checkOferta.Codigo),
 
             // stage-4-ofertas (Slice 1, task 1.7): pk_ofertas_listas — la única superficie
             // genuinamente racy de esta etapa (design: Backstop Map). El replace-set de
@@ -313,7 +314,7 @@ public class ManejadorDeErrores(
     /// (<c>oferta_alcance_invalido</c>/<c>oferta_beneficio_invalido</c>, no el nombre borrador
     /// de <c>design.md</c>), las otras dos siguen el nombre de <c>design.md</c> tal cual
     /// (ningún escenario de spec las pinea distinto).</summary>
-    private static (int EstadoHttp, string Titulo, string Codigo) ClasificarCheckDeOfertas(string nombreDeCheck) =>
+    private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeOfertas(string nombreDeCheck) =>
         nombreDeCheck switch
         {
             "ck_ofertas_alcance_exclusivo" =>
@@ -336,8 +337,10 @@ public class ManejadorDeErrores(
                     "Los días de semana de la oferta tienen que ser valores de 1 a 7 sin repetir.",
                     "dias_semana_invalidos"),
 
-            _ => throw new InvalidOperationException(
-                $"'{nombreDeCheck}' pasó el guard de prefijo 'ck_ofertas_' pero no tiene un caso — " +
-                "agregar la CHECK nueva a este switch.")
+            // Nombre inesperado detrás del guard de prefijo "ck_ofertas_" (p.ej. una CHECK nueva
+            // agregada al esquema sin actualizar este switch): cae al mismo 500 genérico que
+            // cualquier otro caso no mapeado (mismo patrón que ClasificarUnicidad — null en vez
+            // de lanzar desde el exception handler).
+            _ => null
         };
 }

--- a/src/Ways.Domain/Ofertas/AlcanceDeOferta.cs
+++ b/src/Ways.Domain/Ofertas/AlcanceDeOferta.cs
@@ -1,0 +1,26 @@
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Proyección total del alcance de una <see cref="Oferta"/> (design decision 2): exactamente
+/// uno de los tres factory methods construye la instancia, así que el resolver (Slice 3)
+/// nunca ve las tres columnas nullable crudas — el invariante de exclusividad ya quedó
+/// resuelto por <see cref="ReglaDeOfertas.LeerAlcance"/> antes de que exista un valor de este
+/// tipo.
+/// </summary>
+public readonly record struct AlcanceDeOferta
+{
+    private AlcanceDeOferta(int? idArticulo, int? idGrupo, int? idCategoria)
+    {
+        IdArticulo = idArticulo;
+        IdGrupo = idGrupo;
+        IdCategoria = idCategoria;
+    }
+
+    public int? IdArticulo { get; }
+    public int? IdGrupo { get; }
+    public int? IdCategoria { get; }
+
+    public static AlcanceDeOferta DeArticulo(int idArticulo) => new(idArticulo, null, null);
+    public static AlcanceDeOferta DeGrupo(int idGrupo) => new(null, idGrupo, null);
+    public static AlcanceDeOferta DeCategoria(int idCategoria) => new(null, null, idCategoria);
+}

--- a/src/Ways.Domain/Ofertas/BeneficioDeOferta.cs
+++ b/src/Ways.Domain/Ofertas/BeneficioDeOferta.cs
@@ -1,0 +1,27 @@
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Proyección total del beneficio de una <see cref="Oferta"/> (design decision 2): mismo
+/// criterio que <see cref="AlcanceDeOferta"/> — exactamente uno de los tres factory methods
+/// construye la instancia, cada uno ya con su rango validado por
+/// <see cref="ReglaDeOfertas.LeerBeneficio"/>, así que el resolver (Slice 3) expresa la
+/// intención directamente (p.ej. <c>BeneficioDeOferta.DePorcentaje(10m)</c>) en vez de leer
+/// permutaciones de nullables.
+/// </summary>
+public readonly record struct BeneficioDeOferta
+{
+    private BeneficioDeOferta(decimal? precioUnitario, decimal? porcentaje, decimal? importeFijo)
+    {
+        PrecioUnitario = precioUnitario;
+        Porcentaje = porcentaje;
+        ImporteFijo = importeFijo;
+    }
+
+    public decimal? PrecioUnitario { get; }
+    public decimal? Porcentaje { get; }
+    public decimal? ImporteFijo { get; }
+
+    public static BeneficioDeOferta DePrecioUnitario(decimal precioUnitario) => new(precioUnitario, null, null);
+    public static BeneficioDeOferta DePorcentaje(decimal porcentaje) => new(null, porcentaje, null);
+    public static BeneficioDeOferta DeImporteFijo(decimal importeFijo) => new(null, null, importeFijo);
+}

--- a/src/Ways.Domain/Ofertas/Oferta.cs
+++ b/src/Ways.Domain/Ofertas/Oferta.cs
@@ -1,0 +1,72 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Regla de descuento del tenant (doc 10 §Ofertas, deviado por stage-4 decisión 4: la
+/// columna <c>id_lista_precio</c> del doc se reemplaza por la junction <see cref="OfertaLista"/>).
+/// Catálogo-scoped (<c>id_tenant</c> NOT NULL, <see cref="IdEmpresa"/> NULL = todo el tenant,
+/// doc 09 §Catálogo).
+///
+/// Design decision 1: mantiene las columnas nullable CRUDAS de doc 10 para los dos grupos
+/// exclusivos (alcance: articulo/grupo/categoria; beneficio: precio_unitario/porcentaje/
+/// importe_fijo) — el invariante vive en <see cref="ReglaDeOfertas"/> (pura) Y en las dos
+/// CHECKs de esquema (<c>ck_ofertas_alcance_exclusivo</c>/<c>ck_ofertas_beneficio_exclusivo</c>).
+/// Los tipos discriminados/owned types se descartaron: pelearían contra las CHECKs de
+/// <c>num_nonnulls</c> y contra la query de candidatos de la etapa de resolución (Slice 3),
+/// que necesita las columnas crudas como predicados <c>= ANY(...)</c> planos.
+/// </summary>
+public class Oferta : EntidadTenant
+{
+    public int Id { get; set; }
+
+    /// <summary><c>NULL</c> ⇒ toda empresa del tenant (default). Alcance opcional a una
+    /// empresa puntual, igual que el resto de los catálogos (doc 09 §Catálogo).</summary>
+    public int? IdEmpresa { get; set; }
+
+    /// <summary>Lo que imprime el ticket — a propósito NO es único (design decision 6): dos
+    /// ofertas "2x1 Verano" con ventanas distintas son legítimas.</summary>
+    public required string Nombre { get; set; }
+
+    /// <summary>Alcance: exactamente uno de los tres tiene que estar seteado —
+    /// <see cref="ReglaDeOfertas.LeerAlcance"/> valida el invariante antes de cualquier
+    /// escritura; <c>ck_ofertas_alcance_exclusivo</c> es el backstop de esquema.</summary>
+    public int? IdArticulo { get; set; }
+    public int? IdGrupo { get; set; }
+    public int? IdCategoria { get; set; }
+
+    /// <summary>Vigencia por fecha — cada eje es independientemente opcional (NULL = sin
+    /// restricción en ese eje), inclusivo en ambos extremos cuando está seteado.</summary>
+    public DateOnly? FechaDesde { get; set; }
+    public DateOnly? FechaHasta { get; set; }
+
+    /// <summary>Vigencia por hora del día — mismo criterio que <see cref="FechaDesde"/>.</summary>
+    public TimeOnly? HoraDesde { get; set; }
+    public TimeOnly? HoraHasta { get; set; }
+
+    /// <summary>Días de semana ISO-8601 (1 = lunes … 7 = domingo) en los que aplica —
+    /// <c>NULL</c>/vacío = todos. Mapea a <c>smallint[]</c> nativo de Npgsql, sin converter.</summary>
+    public short[]? DiasSemana { get; set; }
+
+    /// <summary><c>NULL</c> ⇒ la oferta aplica sin importar la cantidad ("oferta directa").
+    /// Seteada ⇒ aplica solo cuando la cantidad pedida es <c>&gt;=</c> este valor.</summary>
+    public decimal? CantidadMinima { get; set; }
+
+    /// <summary>Beneficio: exactamente uno de los tres tiene que estar seteado — mismo
+    /// invariante que <see cref="IdArticulo"/>/<see cref="IdGrupo"/>/<see cref="IdCategoria"/>,
+    /// validado por <see cref="ReglaDeOfertas.LeerBeneficio"/> y respaldado por
+    /// <c>ck_ofertas_beneficio_exclusivo</c>.</summary>
+    public decimal? PrecioUnitario { get; set; }
+    public decimal? Porcentaje { get; set; }
+    public decimal? ImporteFijo { get; set; }
+
+    /// <summary>Ante solapamiento de varias ofertas <c>acumulable = false</c>, gana la de
+    /// mayor prioridad (Slice 3: <c>ResolvedorDeOfertas</c>).</summary>
+    public int Prioridad { get; set; }
+
+    /// <summary><c>true</c> ⇒ se suma a otras ofertas aplicables; <c>false</c> ⇒ compite por
+    /// ser la base (Slice 3).</summary>
+    public bool Acumulable { get; set; }
+
+    public bool Activo { get; set; } = true;
+}

--- a/src/Ways.Domain/Ofertas/OfertaLista.cs
+++ b/src/Ways.Domain/Ofertas/OfertaLista.cs
@@ -1,0 +1,27 @@
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Junction de targeting multi-lista (doc 10 §Ofertas, deviado por stage-4 decisión 4:
+/// reemplaza la columna única <c>id_lista_precio NULL</c> del doc). Cero filas para una
+/// oferta ⇒ aplica a todas las listas del tenant, incluidas las <c>derivada</c>; una o más
+/// filas ⇒ la restringe a exactamente esas listas (spec: Multi-Lista Targeting via
+/// ofertas_listas).
+///
+/// PK-only, sin auditoría ni baja lógica — mismo criterio que <see cref="Articulos.ArticuloEmpresa"/>
+/// (no hereda de <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/>: agregar
+/// o quitar una lista del subconjunto es un INSERT/DELETE físico, no una edición con
+/// historial). La PK se nombra explícita <c>pk_ofertas_listas</c> — a diferencia de
+/// <c>PK_articulos_empresas</c> (default de EF, PascalCase), esta corrige esa inconsistencia
+/// en vez de copiarla.
+///
+/// <see cref="IdTenant"/> NO se auto-estampa (no hereda <see cref="Common.EntidadTenant"/>) —
+/// quien la construya DEBE asignarlo a mano; el RLS <c>WITH CHECK</c> rechaza el INSERT con
+/// SQLSTATE 42501 si falta. El camino de escritura real (<c>ServicioDeOfertas</c>, Slice 2)
+/// tiene que asignarlo explícitamente al armar cada fila del replace-set.
+/// </summary>
+public class OfertaLista
+{
+    public int IdOferta { get; set; }
+    public int IdListaPrecio { get; set; }
+    public int IdTenant { get; set; }
+}

--- a/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
+++ b/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
@@ -10,10 +10,8 @@ namespace Ways.Domain.Ofertas;
 /// cuatro CHECKs de esquema (<c>ck_ofertas_alcance_exclusivo</c>/
 /// <c>ck_ofertas_beneficio_exclusivo</c>/<c>ck_ofertas_ventana_valida</c>/
 /// <c>ck_ofertas_dias_semana</c>) son defensa en profundidad, alcanzables solo por una
-/// escritura cruda/fuera de banda (design: Backstop Map, reachability note) — con la
-/// excepción de <c>ck_ofertas_ventana_valida</c>, que esta clase deliberadamente NO valida
-/// (design: Protection Rules — la ventana de vigencia queda como backstop de esquema puro en
-/// esta etapa).
+/// escritura cruda/fuera de banda (design: Backstop Map, reachability note) — esta clase
+/// pre-valida los cuatro invariantes.
 /// </summary>
 public static class ReglaDeOfertas
 {
@@ -105,6 +103,31 @@ public static class ReglaDeOfertas
         {
             throw new ErrorDominio(
                 "cantidad_minima_invalida", "La cantidad mínima de la oferta tiene que ser mayor a cero.", 400);
+        }
+    }
+
+    /// <summary>Spec: Vigencia Window Semantics — cada eje de vigencia (fecha/hora) es
+    /// independientemente opcional (<c>NULL</c> = sin restricción en ese eje); seteados ambos
+    /// extremos de un eje, el "hasta" tiene que ser mayor o igual al "desde" (inclusive, mismo
+    /// criterio que <c>ck_ofertas_ventana_valida</c> — la CHECK usa <c>&gt;=</c>, no
+    /// <c>&gt;</c>).</summary>
+    public static void ValidarVentana(
+        DateOnly? fechaDesde, DateOnly? fechaHasta, TimeOnly? horaDesde, TimeOnly? horaHasta)
+    {
+        if (fechaDesde is { } desde && fechaHasta is { } hasta && hasta < desde)
+        {
+            throw new ErrorDominio(
+                "ventana_de_oferta_invalida",
+                "La ventana de vigencia de la oferta es inválida.",
+                400);
+        }
+
+        if (horaDesde is { } horaDesdeValor && horaHasta is { } horaHastaValor && horaHastaValor < horaDesdeValor)
+        {
+            throw new ErrorDominio(
+                "ventana_de_oferta_invalida",
+                "La ventana de vigencia de la oferta es inválida.",
+                400);
         }
     }
 

--- a/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
+++ b/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
@@ -1,0 +1,138 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Reglas de negocio puras, sin dependencias (design decisions 1, 2) — se testean sin base de
+/// datos (mismo criterio que <see cref="Articulos.ReglaDeArticulos"/>/<see
+/// cref="Catalogos.ReglaDeCategorias"/>). Todo camino de escritura de <see cref="Oferta"/>
+/// (Slice 2: <c>ServicioDeOfertas</c>) tiene que pasar por acá antes de tocar la fila; las
+/// cuatro CHECKs de esquema (<c>ck_ofertas_alcance_exclusivo</c>/
+/// <c>ck_ofertas_beneficio_exclusivo</c>/<c>ck_ofertas_ventana_valida</c>/
+/// <c>ck_ofertas_dias_semana</c>) son defensa en profundidad, alcanzables solo por una
+/// escritura cruda/fuera de banda (design: Backstop Map, reachability note) — con la
+/// excepción de <c>ck_ofertas_ventana_valida</c>, que esta clase deliberadamente NO valida
+/// (design: Protection Rules — la ventana de vigencia queda como backstop de esquema puro en
+/// esta etapa).
+/// </summary>
+public static class ReglaDeOfertas
+{
+    /// <summary>Proyecta el alcance de <paramref name="oferta"/> (spec: Ofertas Schema At
+    /// Rest, "Scope CHECK rejects zero or multiple scope columns" — acá es la validación de
+    /// dominio que corre ANTES de que la CHECK sea siquiera alcanzable, spec: "Domain guard
+    /// rejects invalid shapes before the database"). Total: siempre devuelve un valor o lanza,
+    /// nunca deja pasar un estado ambiguo.</summary>
+    public static AlcanceDeOferta LeerAlcance(Oferta oferta)
+    {
+        var cantidadDeColumnasSeteadas =
+            (oferta.IdArticulo is not null ? 1 : 0) +
+            (oferta.IdGrupo is not null ? 1 : 0) +
+            (oferta.IdCategoria is not null ? 1 : 0);
+
+        if (cantidadDeColumnasSeteadas != 1)
+        {
+            throw new ErrorDominio(
+                "oferta_alcance_invalido",
+                "La oferta tiene que apuntar a exactamente un artículo, grupo o categoría.",
+                400);
+        }
+
+        return oferta.IdArticulo is { } idArticulo ? AlcanceDeOferta.DeArticulo(idArticulo)
+            : oferta.IdGrupo is { } idGrupo ? AlcanceDeOferta.DeGrupo(idGrupo)
+            : AlcanceDeOferta.DeCategoria(oferta.IdCategoria!.Value);
+    }
+
+    /// <summary>Proyecta el beneficio de <paramref name="oferta"/> (spec: "Benefit CHECK
+    /// rejects zero or multiple benefit columns") y valida en el mismo paso el rango del valor
+    /// seteado (design: Protection Rules — <c>porcentaje ∈ (0,100]</c>, <c>importe_fijo ≥
+    /// 0</c>, <c>precio_unitario ≥ 0</c>): un beneficio con exclusividad correcta pero un valor
+    /// sin sentido de negocio (0% de descuento, un importe negativo) no es una proyección
+    /// válida tampoco.</summary>
+    public static BeneficioDeOferta LeerBeneficio(Oferta oferta)
+    {
+        var cantidadDeColumnasSeteadas =
+            (oferta.PrecioUnitario is not null ? 1 : 0) +
+            (oferta.Porcentaje is not null ? 1 : 0) +
+            (oferta.ImporteFijo is not null ? 1 : 0);
+
+        if (cantidadDeColumnasSeteadas != 1)
+        {
+            throw new ErrorDominio(
+                "oferta_beneficio_invalido",
+                "La oferta tiene que definir exactamente un beneficio: precio unitario, porcentaje o importe fijo.",
+                400);
+        }
+
+        if (oferta.PrecioUnitario is { } precioUnitario)
+        {
+            if (precioUnitario < 0)
+            {
+                throw new ErrorDominio(
+                    "oferta_precio_unitario_invalido", "El precio unitario de la oferta no puede ser negativo.", 400);
+            }
+
+            return BeneficioDeOferta.DePrecioUnitario(precioUnitario);
+        }
+
+        if (oferta.Porcentaje is { } porcentaje)
+        {
+            if (porcentaje <= 0 || porcentaje > 100)
+            {
+                throw new ErrorDominio(
+                    "oferta_porcentaje_invalido", "El porcentaje de la oferta tiene que estar entre 0 (exclusivo) y 100.", 400);
+            }
+
+            return BeneficioDeOferta.DePorcentaje(porcentaje);
+        }
+
+        var importeFijo = oferta.ImporteFijo!.Value;
+        if (importeFijo < 0)
+        {
+            throw new ErrorDominio(
+                "oferta_importe_fijo_invalido", "El importe fijo de la oferta no puede ser negativo.", 400);
+        }
+
+        return BeneficioDeOferta.DeImporteFijo(importeFijo);
+    }
+
+    /// <summary>Spec: cantidad_minima Trigger Semantics — <c>NULL</c> siempre matchea (oferta
+    /// directa); seteada tiene que ser estrictamente positiva (design: Protection Rules,
+    /// <c>cantidad_minima &gt; 0</c>) — un umbral cero o negativo no tiene sentido de
+    /// negocio.</summary>
+    public static void ValidarCantidadMinima(decimal? cantidadMinima)
+    {
+        if (cantidadMinima is <= 0)
+        {
+            throw new ErrorDominio(
+                "cantidad_minima_invalida", "La cantidad mínima de la oferta tiene que ser mayor a cero.", 400);
+        }
+    }
+
+    /// <summary>Spec: Vigencia Window Semantics ("dias_semana restricts to listed weekdays") —
+    /// <c>NULL</c>/vacío = todos los días. Seteado, cada valor tiene que ser un día ISO-8601
+    /// válido (1..7) sin duplicados (design: Protection Rules, mismo invariante que
+    /// <c>ck_ofertas_dias_semana</c> del lado de esquema — mismo código de dominio
+    /// <c>dias_semana_invalidos</c> que su backstop en <c>ManejadorDeErrores</c>, por ser la
+    /// misma regla enforced dos veces).</summary>
+    public static IReadOnlySet<int> LeerDiasSemana(short[]? diasSemana)
+    {
+        if (diasSemana is null || diasSemana.Length == 0)
+        {
+            return new HashSet<int>();
+        }
+
+        var conjunto = new HashSet<int>(diasSemana.Length);
+        foreach (var dia in diasSemana)
+        {
+            if (dia is < 1 or > 7 || !conjunto.Add(dia))
+            {
+                throw new ErrorDominio(
+                    "dias_semana_invalidos",
+                    "Los días de semana de la oferta tienen que ser valores de 1 a 7 sin repetir.",
+                    400);
+            }
+        }
+
+        return conjunto;
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/OfertaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/OfertaConfiguration.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Ofertas;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Oferta"/> (design decision 1, Table Shapes): entidad dedicada, catálogo
+/// scope con <see cref="Oferta.IdEmpresa"/> opcional — a diferencia de
+/// <c>ConfiguracionDeCatalogo&lt;T&gt;</c>, sin dedupe por nombre (design decision 6: el
+/// nombre es una etiqueta de ticket, deliberadamente no único — sin índice único sobre
+/// <c>nombre</c>, exención documentada, no un descuido).
+/// </summary>
+public class OfertaConfiguration : IEntityTypeConfiguration<Oferta>
+{
+    public void Configure(EntityTypeBuilder<Oferta> builder)
+    {
+        builder.ToTable("ofertas", t =>
+        {
+            // Las cuatro CHECKs son defensa en profundidad (design: Backstop Map,
+            // reachability note): ReglaDeOfertas ya valida los cuatro invariantes en el
+            // camino de servicio, así que en operación normal ninguna es alcanzable — quedan
+            // como respaldo de esquema ante una escritura cruda/fuera de banda.
+            t.HasCheckConstraint(
+                "ck_ofertas_alcance_exclusivo",
+                "num_nonnulls(id_articulo, id_grupo, id_categoria) = 1");
+
+            t.HasCheckConstraint(
+                "ck_ofertas_beneficio_exclusivo",
+                "num_nonnulls(precio_unitario, porcentaje, importe_fijo) = 1");
+
+            // NULL-tolerant en ambos ejes (fecha y hora): cada eje de vigencia es
+            // independientemente opcional (spec: Vigencia Window Semantics).
+            t.HasCheckConstraint(
+                "ck_ofertas_ventana_valida",
+                "(fecha_desde IS NULL OR fecha_hasta IS NULL OR fecha_hasta >= fecha_desde) " +
+                "AND (hora_desde IS NULL OR hora_hasta IS NULL OR hora_hasta >= hora_desde)");
+
+            t.HasCheckConstraint(
+                "ck_ofertas_dias_semana",
+                "dias_semana IS NULL OR dias_semana <@ ARRAY[1,2,3,4,5,6,7]::smallint[]");
+        });
+
+        builder.HasKey(o => o.Id);
+
+        builder.Property(o => o.Id)
+            .HasColumnName("id_oferta")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(o => o.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        // Habilita la FK compuesta del dependiente (ofertas_listas) — mismo patrón que
+        // Articulo/Empresa/Categoria/ListaPrecio (ADR-9).
+        builder.HasAlternateKey(o => new { o.Id, o.IdTenant })
+            .HasName("ak_ofertas_id_oferta_id_tenant");
+
+        builder.Property(o => o.IdEmpresa).HasColumnName("id_empresa");
+
+        builder.Property(o => o.Nombre)
+            .HasColumnName("nombre")
+            .HasColumnType("citext")
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(o => o.IdArticulo).HasColumnName("id_articulo");
+        builder.Property(o => o.IdGrupo).HasColumnName("id_grupo");
+        builder.Property(o => o.IdCategoria).HasColumnName("id_categoria");
+
+        builder.Property(o => o.FechaDesde).HasColumnName("fecha_desde").HasColumnType("date");
+        builder.Property(o => o.FechaHasta).HasColumnName("fecha_hasta").HasColumnType("date");
+        builder.Property(o => o.HoraDesde).HasColumnName("hora_desde").HasColumnType("time");
+        builder.Property(o => o.HoraHasta).HasColumnName("hora_hasta").HasColumnType("time");
+
+        // smallint[] nativo de Npgsql, sin converter (design: Migration Sequencing).
+        builder.Property(o => o.DiasSemana).HasColumnName("dias_semana").HasColumnType("smallint[]");
+
+        builder.Property(o => o.CantidadMinima)
+            .HasColumnName("cantidad_minima")
+            .HasColumnType("numeric(12,3)");
+
+        builder.Property(o => o.PrecioUnitario)
+            .HasColumnName("precio_unitario")
+            .HasColumnType("numeric(14,2)");
+
+        builder.Property(o => o.Porcentaje)
+            .HasColumnName("porcentaje")
+            .HasColumnType("numeric(5,2)");
+
+        builder.Property(o => o.ImporteFijo)
+            .HasColumnName("importe_fijo")
+            .HasColumnType("numeric(14,2)");
+
+        builder.Property(o => o.Prioridad)
+            .HasColumnName("prioridad")
+            .HasDefaultValue(0)
+            .IsRequired();
+
+        builder.Property(o => o.Acumulable)
+            .HasColumnName("acumulable")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(o => o.Activo)
+            .HasColumnName("activo")
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Property(o => o.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(o => o.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(o => o.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(o => o.EstaEliminada);
+
+        // Nombres explícitos en snake_case (doc 10): sin esto EF nombra los índices de
+        // soporte de cada FK con su convención propia (PascalCase) — mismo fix que
+        // ArticuloConfiguration (stage-3-articulos-y-precios).
+        builder.HasIndex(o => o.IdTenant).HasDatabaseName("ix_ofertas_tenant");
+        builder.HasIndex(o => new { o.IdEmpresa, o.IdTenant }).HasDatabaseName("ix_ofertas_empresa");
+        builder.HasIndex(o => new { o.IdArticulo, o.IdTenant }).HasDatabaseName("ix_ofertas_articulo");
+        builder.HasIndex(o => new { o.IdGrupo, o.IdTenant }).HasDatabaseName("ix_ofertas_grupo");
+        builder.HasIndex(o => new { o.IdCategoria, o.IdTenant }).HasDatabaseName("ix_ofertas_categoria");
+
+        // Deliberadamente SIN índice único sobre nombre (design decision 6, Table Shapes):
+        // "nombre" es una etiqueta de ticket, no un identificador de negocio — dos ofertas
+        // "2x1 Verano" con ventanas distintas son legítimas. Exención documentada del
+        // backstop map, no un descuido.
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(o => o.IdTenant)
+            .HasConstraintName("fk_ofertas_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // FK compuesta opcional a empresas (ADR-9): id_empresa NULL ⇒ todo el tenant, MATCH
+        // SIMPLE salta el chequeo cuando esa columna es NULL — mismo patrón que
+        // ConfiguracionDeCatalogo<T>.
+        builder.HasOne<Empresa>()
+            .WithMany()
+            .HasForeignKey(o => new { o.IdEmpresa, o.IdTenant })
+            .HasPrincipalKey(e => new { e.Id, e.IdTenant })
+            .HasConstraintName("fk_ofertas_empresa")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Articulo>()
+            .WithMany()
+            .HasForeignKey(o => new { o.IdArticulo, o.IdTenant })
+            .HasPrincipalKey(a => new { a.Id, a.IdTenant })
+            .HasConstraintName("fk_ofertas_articulo")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Grupo>()
+            .WithMany()
+            .HasForeignKey(o => new { o.IdGrupo, o.IdTenant })
+            .HasPrincipalKey(g => new { g.Id, g.IdTenant })
+            .HasConstraintName("fk_ofertas_grupo")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Categoria>()
+            .WithMany()
+            .HasForeignKey(o => new { o.IdCategoria, o.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_ofertas_categoria")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/OfertaListaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/OfertaListaConfiguration.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Ofertas;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="OfertaLista"/> (design decision 1, Table Shapes): junction PK-only, sin
+/// auditoría ni baja lógica — mismo criterio que <c>ArticuloEmpresaConfiguration</c>. La PK se
+/// nombra explícita <c>pk_ofertas_listas</c> (a diferencia del default de EF que dejó
+/// <c>PK_articulos_empresas</c> en PascalCase) y las tres FKs compuestas incluyen
+/// <c>id_tenant</c> — las claves alternas ya existen en las tres tablas referenciadas.
+/// </summary>
+public class OfertaListaConfiguration : IEntityTypeConfiguration<OfertaLista>
+{
+    public void Configure(EntityTypeBuilder<OfertaLista> builder)
+    {
+        builder.ToTable("ofertas_listas");
+
+        builder.HasKey(ol => new { ol.IdOferta, ol.IdListaPrecio }).HasName("pk_ofertas_listas");
+
+        builder.Property(ol => ol.IdOferta).HasColumnName("id_oferta");
+        builder.Property(ol => ol.IdListaPrecio).HasColumnName("id_lista_precio");
+
+        builder.Property(ol => ol.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.HasIndex(ol => ol.IdTenant).HasDatabaseName("ix_ofertas_listas_tenant");
+        builder.HasIndex(ol => new { ol.IdOferta, ol.IdTenant }).HasDatabaseName("ix_ofertas_listas_oferta");
+        builder.HasIndex(ol => new { ol.IdListaPrecio, ol.IdTenant }).HasDatabaseName("ix_ofertas_listas_lista_precio");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(ol => ol.IdTenant)
+            .HasConstraintName("fk_ofertas_listas_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Oferta>()
+            .WithMany()
+            .HasForeignKey(ol => new { ol.IdOferta, ol.IdTenant })
+            .HasPrincipalKey(o => new { o.Id, o.IdTenant })
+            .HasConstraintName("fk_ofertas_listas_oferta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ListaPrecio>()
+            .WithMany()
+            .HasForeignKey(ol => new { ol.IdListaPrecio, ol.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdTenant })
+            .HasConstraintName("fk_ofertas_listas_lista_precio")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804003300_OfertasEtapa4.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804003300_OfertasEtapa4.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -16,9 +17,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804003300_OfertasEtapa4")]
+    partial class OfertasEtapa4
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804003300_OfertasEtapa4.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804003300_OfertasEtapa4.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class OfertasEtapa4 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ofertas",
+                columns: table => new
+                {
+                    id_oferta = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_empresa = table.Column<int>(type: "integer", nullable: true),
+                    nombre = table.Column<string>(type: "citext", maxLength: 150, nullable: false),
+                    id_articulo = table.Column<int>(type: "integer", nullable: true),
+                    id_grupo = table.Column<int>(type: "integer", nullable: true),
+                    id_categoria = table.Column<int>(type: "integer", nullable: true),
+                    fecha_desde = table.Column<DateOnly>(type: "date", nullable: true),
+                    fecha_hasta = table.Column<DateOnly>(type: "date", nullable: true),
+                    hora_desde = table.Column<TimeOnly>(type: "time", nullable: true),
+                    hora_hasta = table.Column<TimeOnly>(type: "time", nullable: true),
+                    dias_semana = table.Column<short[]>(type: "smallint[]", nullable: true),
+                    cantidad_minima = table.Column<decimal>(type: "numeric(12,3)", nullable: true),
+                    precio_unitario = table.Column<decimal>(type: "numeric(14,2)", nullable: true),
+                    porcentaje = table.Column<decimal>(type: "numeric(5,2)", nullable: true),
+                    importe_fijo = table.Column<decimal>(type: "numeric(14,2)", nullable: true),
+                    prioridad = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    acumulable = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    activo = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ofertas", x => x.id_oferta);
+                    table.UniqueConstraint("ak_ofertas_id_oferta_id_tenant", x => new { x.id_oferta, x.id_tenant });
+                    table.CheckConstraint("ck_ofertas_alcance_exclusivo", "num_nonnulls(id_articulo, id_grupo, id_categoria) = 1");
+                    table.CheckConstraint("ck_ofertas_beneficio_exclusivo", "num_nonnulls(precio_unitario, porcentaje, importe_fijo) = 1");
+                    table.CheckConstraint("ck_ofertas_dias_semana", "dias_semana IS NULL OR dias_semana <@ ARRAY[1,2,3,4,5,6,7]::smallint[]");
+                    table.CheckConstraint("ck_ofertas_ventana_valida", "(fecha_desde IS NULL OR fecha_hasta IS NULL OR fecha_hasta >= fecha_desde) AND (hora_desde IS NULL OR hora_hasta IS NULL OR hora_hasta >= hora_desde)");
+                    table.ForeignKey(
+                        name: "fk_ofertas_articulo",
+                        columns: x => new { x.id_articulo, x.id_tenant },
+                        principalTable: "articulos",
+                        principalColumns: new[] { "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_categoria",
+                        columns: x => new { x.id_categoria, x.id_tenant },
+                        principalTable: "categorias",
+                        principalColumns: new[] { "id_categoria", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_empresa",
+                        columns: x => new { x.id_empresa, x.id_tenant },
+                        principalTable: "empresas",
+                        principalColumns: new[] { "id_empresa", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_grupo",
+                        columns: x => new { x.id_grupo, x.id_tenant },
+                        principalTable: "grupos",
+                        principalColumns: new[] { "id_grupo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ofertas_listas",
+                columns: table => new
+                {
+                    id_oferta = table.Column<int>(type: "integer", nullable: false),
+                    id_lista_precio = table.Column<int>(type: "integer", nullable: false),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_ofertas_listas", x => new { x.id_oferta, x.id_lista_precio });
+                    table.ForeignKey(
+                        name: "fk_ofertas_listas_lista_precio",
+                        columns: x => new { x.id_lista_precio, x.id_tenant },
+                        principalTable: "listas_precio",
+                        principalColumns: new[] { "id_lista_precio", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_listas_oferta",
+                        columns: x => new { x.id_oferta, x.id_tenant },
+                        principalTable: "ofertas",
+                        principalColumns: new[] { "id_oferta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_ofertas_listas_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_articulo",
+                table: "ofertas",
+                columns: new[] { "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_categoria",
+                table: "ofertas",
+                columns: new[] { "id_categoria", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_empresa",
+                table: "ofertas",
+                columns: new[] { "id_empresa", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_grupo",
+                table: "ofertas",
+                columns: new[] { "id_grupo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_tenant",
+                table: "ofertas",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_listas_lista_precio",
+                table: "ofertas_listas",
+                columns: new[] { "id_lista_precio", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_listas_oferta",
+                table: "ofertas_listas",
+                columns: new[] { "id_oferta", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ofertas_listas_tenant",
+                table: "ofertas_listas",
+                column: "id_tenant");
+
+            // RLS (ADR-4/ADR-15, DB CHANGE GATE aprobado 2026-08-03): las 2 tablas nuevas
+            // activan su policy en la misma migración que las crea.
+            migrationBuilder.HabilitarRlsDeTenant("ofertas");
+            migrationBuilder.HabilitarRlsDeTenant("ofertas_listas");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ofertas_listas");
+
+            migrationBuilder.DropTable(
+                name: "ofertas");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -8,6 +8,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
+using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Proveedores;
@@ -60,6 +61,13 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<NumeracionArticulo> NumeracionesArticulos => Set<NumeracionArticulo>();
     public DbSet<Precio> Precios => Set<Precio>();
 
+    // stage-4-ofertas, Slice 1 (schema/domain foundation, DB CHANGE GATE aprobado
+    // 2026-08-03): mismo trámite que articulos/precios en stage-3 Slice 1 — modelo adelantado
+    // a la migración, sin DbSet en IWaysDbContext todavía (ningún caso de uso de Application
+    // los consume en este lote; ServicioDeOfertas llega en la Slice 2).
+    public DbSet<Oferta> Ofertas => Set<Oferta>();
+    public DbSet<OfertaLista> OfertasListas => Set<OfertaLista>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>
@@ -94,6 +102,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenantEnNumeracionCliente(modelBuilder);
         AplicarFiltroDeTenantEnNumeracionArticulo(modelBuilder);
         AplicarFiltroDeTenantEnArticuloEmpresa(modelBuilder);
+        AplicarFiltroDeTenantEnOfertaLista(modelBuilder);
     }
 
     /// <summary>
@@ -385,6 +394,27 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
         var parametro = Expression.Parameter(typeof(ArticuloEmpresa), "e");
         var propiedadIdTenant = Expression.Property(parametro, nameof(ArticuloEmpresa.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// <see cref="OfertaLista"/> no hereda de <see cref="EntidadTenant"/> (junction PK-only,
+    /// mismo motivo que <see cref="ArticuloEmpresa"/>), así que necesita la misma variante
+    /// escrita a mano que <see cref="AplicarFiltroDeTenantEnArticuloEmpresa"/>.
+    ///
+    /// <see cref="OfertaLista.IdTenant"/> tampoco se auto-estampa acá — quien construya la fila
+    /// DEBE asignarlo, y el RLS <c>WITH CHECK</c> rechaza el INSERT con SQLSTATE 42501 si
+    /// falta. Pendiente para Slice 2 cuando aterrice el camino de escritura real
+    /// (<c>ServicioDeOfertas</c>, replace-set de <c>ofertas_listas</c>).
+    /// </summary>
+    private void AplicarFiltroDeTenantEnOfertaLista(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(OfertaLista))!;
+
+        var parametro = Expression.Parameter(typeof(OfertaLista), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(OfertaLista.IdTenant));
         var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
 
         entidad.SetQueryFilter("Tenant", filtro);

--- a/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
+++ b/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
@@ -1,0 +1,265 @@
+using Ways.Domain.Common;
+using Ways.Domain.Ofertas;
+
+namespace Ways.Domain.Tests.Ofertas;
+
+/// <summary>
+/// stage-4-ofertas, Slice 1 (task 1.9, spec: ofertas / Domain guard rejects invalid shapes
+/// before the database) — función pura, sin base de datos, mismo criterio que
+/// <see cref="Articulos.ReglaDeArticulosTests"/>/<see cref="Precios.ResolvedorDePreciosTests"/>.
+/// </summary>
+public class ReglaDeOfertasTests
+{
+    private static Oferta CrearOferta(
+        int? idArticulo = 1, int? idGrupo = null, int? idCategoria = null,
+        decimal? precioUnitario = null, decimal? porcentaje = 10m, decimal? importeFijo = null) =>
+        new()
+        {
+            IdTenant = 1,
+            Nombre = "oferta de prueba",
+            IdArticulo = idArticulo,
+            IdGrupo = idGrupo,
+            IdCategoria = idCategoria,
+            PrecioUnitario = precioUnitario,
+            Porcentaje = porcentaje,
+            ImporteFijo = importeFijo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    // --- LeerAlcance: exclusividad ---
+
+    [Fact]
+    public void LeerAlcanceConSoloArticuloDevuelveElAlcanceDeArticulo()
+    {
+        var alcance = ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: 5, idGrupo: null, idCategoria: null));
+
+        Assert.Equal(5, alcance.IdArticulo);
+        Assert.Null(alcance.IdGrupo);
+        Assert.Null(alcance.IdCategoria);
+    }
+
+    [Fact]
+    public void LeerAlcanceConSoloGrupoDevuelveElAlcanceDeGrupo()
+    {
+        var alcance = ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: null, idGrupo: 7, idCategoria: null));
+
+        Assert.Null(alcance.IdArticulo);
+        Assert.Equal(7, alcance.IdGrupo);
+        Assert.Null(alcance.IdCategoria);
+    }
+
+    [Fact]
+    public void LeerAlcanceConSoloCategoriaDevuelveElAlcanceDeCategoria()
+    {
+        var alcance = ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: null, idGrupo: null, idCategoria: 9));
+
+        Assert.Null(alcance.IdArticulo);
+        Assert.Null(alcance.IdGrupo);
+        Assert.Equal(9, alcance.IdCategoria);
+    }
+
+    [Fact]
+    public void LeerAlcanceSinNingunaColumnaSeteadaEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: null, idGrupo: null, idCategoria: null)));
+
+        Assert.Equal("oferta_alcance_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void LeerAlcanceConMasDeUnaColumnaSeteadaEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: 1, idGrupo: 2, idCategoria: null)));
+
+        Assert.Equal("oferta_alcance_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerAlcanceConLasTresColumnasSeteadasEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerAlcance(CrearOferta(idArticulo: 1, idGrupo: 2, idCategoria: 3)));
+
+        Assert.Equal("oferta_alcance_invalido", error.Codigo);
+    }
+
+    // --- LeerBeneficio: exclusividad ---
+
+    [Fact]
+    public void LeerBeneficioSinNingunBeneficioSeteadoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerBeneficio(CrearOferta(porcentaje: null)));
+
+        Assert.Equal("oferta_beneficio_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void LeerBeneficioConMasDeUnBeneficioSeteadoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerBeneficio(CrearOferta(precioUnitario: 100m, porcentaje: 10m)));
+
+        Assert.Equal("oferta_beneficio_invalido", error.Codigo);
+    }
+
+    // --- LeerBeneficio: rangos ---
+
+    [Fact]
+    public void LeerBeneficioConPorcentajeDentroDelRangoDevuelveElBeneficioDePorcentaje()
+    {
+        var beneficio = ReglaDeOfertas.LeerBeneficio(CrearOferta(porcentaje: 20m));
+
+        Assert.Equal(20m, beneficio.Porcentaje);
+        Assert.Null(beneficio.PrecioUnitario);
+        Assert.Null(beneficio.ImporteFijo);
+    }
+
+    [Fact]
+    public void LeerBeneficioConPorcentajeCienEsPermitidoInclusive()
+    {
+        var beneficio = ReglaDeOfertas.LeerBeneficio(CrearOferta(porcentaje: 100m));
+
+        Assert.Equal(100m, beneficio.Porcentaje);
+    }
+
+    [Fact]
+    public void LeerBeneficioConPorcentajeCeroEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.LeerBeneficio(CrearOferta(porcentaje: 0m)));
+
+        Assert.Equal("oferta_porcentaje_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerBeneficioConPorcentajeMayorACienEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.LeerBeneficio(CrearOferta(porcentaje: 100.01m)));
+
+        Assert.Equal("oferta_porcentaje_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerBeneficioConPrecioUnitarioCeroEsPermitido()
+    {
+        var beneficio = ReglaDeOfertas.LeerBeneficio(CrearOferta(precioUnitario: 0m, porcentaje: null));
+
+        Assert.Equal(0m, beneficio.PrecioUnitario);
+    }
+
+    [Fact]
+    public void LeerBeneficioConPrecioUnitarioNegativoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerBeneficio(CrearOferta(precioUnitario: -1m, porcentaje: null)));
+
+        Assert.Equal("oferta_precio_unitario_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerBeneficioConImporteFijoCeroEsPermitido()
+    {
+        var beneficio = ReglaDeOfertas.LeerBeneficio(CrearOferta(importeFijo: 0m, porcentaje: null));
+
+        Assert.Equal(0m, beneficio.ImporteFijo);
+    }
+
+    [Fact]
+    public void LeerBeneficioConImporteFijoNegativoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.LeerBeneficio(CrearOferta(importeFijo: -0.01m, porcentaje: null)));
+
+        Assert.Equal("oferta_importe_fijo_invalido", error.Codigo);
+    }
+
+    // --- ValidarCantidadMinima ---
+
+    [Fact]
+    public void ValidarCantidadMinimaConNullEsPermitido()
+    {
+        var excepcion = Record.Exception(() => ReglaDeOfertas.ValidarCantidadMinima(null));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarCantidadMinimaPositivaEsPermitido()
+    {
+        var excepcion = Record.Exception(() => ReglaDeOfertas.ValidarCantidadMinima(3m));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarCantidadMinimaCeroEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.ValidarCantidadMinima(0m));
+
+        Assert.Equal("cantidad_minima_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void ValidarCantidadMinimaNegativaEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.ValidarCantidadMinima(-1m));
+
+        Assert.Equal("cantidad_minima_invalida", error.Codigo);
+    }
+
+    // --- LeerDiasSemana ---
+
+    [Fact]
+    public void LeerDiasSemanaConNullDevuelveConjuntoVacio()
+    {
+        var dias = ReglaDeOfertas.LeerDiasSemana(null);
+
+        Assert.Empty(dias);
+    }
+
+    [Fact]
+    public void LeerDiasSemanaConArrayVacioDevuelveConjuntoVacio()
+    {
+        var dias = ReglaDeOfertas.LeerDiasSemana([]);
+
+        Assert.Empty(dias);
+    }
+
+    [Fact]
+    public void LeerDiasSemanaConValoresValidosDevuelveElConjunto()
+    {
+        var dias = ReglaDeOfertas.LeerDiasSemana([6, 7]);
+
+        Assert.Equal(new HashSet<int> { 6, 7 }, dias);
+    }
+
+    [Fact]
+    public void LeerDiasSemanaConCeroEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.LeerDiasSemana([0, 1]));
+
+        Assert.Equal("dias_semana_invalidos", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerDiasSemanaConOchoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.LeerDiasSemana([1, 8]));
+
+        Assert.Equal("dias_semana_invalidos", error.Codigo);
+    }
+
+    [Fact]
+    public void LeerDiasSemanaConDuplicadosEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeOfertas.LeerDiasSemana([3, 3]));
+
+        Assert.Equal("dias_semana_invalidos", error.Codigo);
+    }
+}

--- a/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
+++ b/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
@@ -178,6 +178,94 @@ public class ReglaDeOfertasTests
         Assert.Equal("oferta_importe_fijo_invalido", error.Codigo);
     }
 
+    // --- ValidarVentana ---
+
+    [Fact]
+    public void ValidarVentanaConFechaHastaAnteriorAFechaDesdeEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.ValidarVentana(
+                new DateOnly(2026, 8, 10), new DateOnly(2026, 8, 1), null, null));
+
+        Assert.Equal("ventana_de_oferta_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void ValidarVentanaConHoraHastaAnteriorAHoraDesdeEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeOfertas.ValidarVentana(
+                null, null, new TimeOnly(14, 0), new TimeOnly(10, 0)));
+
+        Assert.Equal("ventana_de_oferta_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void ValidarVentanaConFechasIgualesEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(
+                new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 1), null, null));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConHorasIgualesEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(
+                null, null, new TimeOnly(10, 0), new TimeOnly(10, 0)));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConFechaDesdeNulaEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(null, new DateOnly(2026, 8, 1), null, null));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConFechaHastaNulaEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(new DateOnly(2026, 8, 1), null, null, null));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConHoraDesdeNulaEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(null, null, null, new TimeOnly(10, 0)));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConHoraHastaNulaEsPermitido()
+    {
+        var excepcion = Record.Exception(() =>
+            ReglaDeOfertas.ValidarVentana(null, null, new TimeOnly(10, 0), null));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void ValidarVentanaConTodoNuloEsPermitido()
+    {
+        var excepcion = Record.Exception(() => ReglaDeOfertas.ValidarVentana(null, null, null, null));
+
+        Assert.Null(excepcion);
+    }
+
     // --- ValidarCantidadMinima ---
 
     [Fact]

--- a/tests/Ways.IntegrationTests/OfertasCheckBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasCheckBackstopTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-4-ofertas, Slice 1 (task 1.10, db-error-backstops skill, design: Backstop Map
+/// reachability note): raw-SQL INSERTs que bypasean por completo <c>ReglaDeOfertas</c> (no hay
+/// <c>ServicioDeOfertas</c> todavía, Slice 2) para probar las cuatro CHECKs de esquema
+/// directamente — SQLSTATE 23514 más el <c>ConstraintName</c> exacto que
+/// <c>ManejadorDeErrores.ClasificarCheckDeOfertas</c> traduce (mismo patrón que
+/// <c>BackstopClientesYProveedoresTests.UnUpdateDirectoPorSqlSobreElConsumidorFinalViolaLaCheckConstraint</c>:
+/// sin endpoint/servicio en este lote, el <c>ConstraintName</c> asertado ES la prueba de que la
+/// rama de <c>ManejadorDeErrores</c> matchea, porque el switch de acá es por nombre exacto).
+///
+/// Honesto sobre alcanzabilidad (design: Backstop Map): bajo operación normal (Slice 2 en
+/// adelante) ninguna de las cuatro ramas es alcanzable — <c>ReglaDeOfertas</c> ya rechaza los
+/// cuatro estados en el camino de servicio. Esto prueba la traducción de esquema, no un camino
+/// de cliente real.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OfertasCheckBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private async Task<(int IdTenant, int IdArticulo)> SembrarTenantConArticuloAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra alicuotas_iva)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return (tenant.Id, articulo.Id);
+    }
+
+    [Fact]
+    public async Task UnaOfertaSinNingunAlcanceSeteadoViolaLaCheckDeExclusividad()
+    {
+        var (idTenant, _) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaSinNingunAlcanceSeteadoViolaLaCheckDeExclusividad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, porcentaje, created_at, updated_at) " +
+            "VALUES ($1, 'sin-alcance', 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_alcance_exclusivo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaConDosAlcancesSeteadosViolaLaCheckDeExclusividad()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaConDosAlcancesSeteadosViolaLaCheckDeExclusividad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, id_grupo, porcentaje, created_at, updated_at) " +
+            "VALUES ($1, 'doble-alcance', $2, 999999, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_alcance_exclusivo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaSinNingunBeneficioSeteadoViolaLaCheckDeExclusividad()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaSinNingunBeneficioSeteadoViolaLaCheckDeExclusividad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, created_at, updated_at) " +
+            "VALUES ($1, 'sin-beneficio', $2, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_beneficio_exclusivo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaConDosBeneficiosSeteadosViolaLaCheckDeExclusividad()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaConDosBeneficiosSeteadosViolaLaCheckDeExclusividad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, porcentaje, importe_fijo, created_at, updated_at) " +
+            "VALUES ($1, 'doble-beneficio', $2, 10, 5, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_beneficio_exclusivo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaConFechaHastaAnteriorAFechaDesdeViolaLaCheckDeVentana()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaConFechaHastaAnteriorAFechaDesdeViolaLaCheckDeVentana));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, porcentaje, fecha_desde, fecha_hasta, created_at, updated_at) " +
+            "VALUES ($1, 'ventana-invertida', $2, 10, '2026-08-10', '2026-08-01', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_ventana_valida", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaConHoraHastaAnteriorAHoraDesdeViolaLaCheckDeVentana()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaConHoraHastaAnteriorAHoraDesdeViolaLaCheckDeVentana));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, porcentaje, hora_desde, hora_hasta, created_at, updated_at) " +
+            "VALUES ($1, 'hora-invertida', $2, 10, '14:00', '10:00', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_ventana_valida", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaOfertaConUnDiaDeSemanaFueraDeRangoViolaLaCheckDeDiasSemana()
+    {
+        var (idTenant, idArticulo) = await SembrarTenantConArticuloAsync(nameof(UnaOfertaConUnDiaDeSemanaFueraDeRangoViolaLaCheckDeDiasSemana));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas (id_tenant, nombre, id_articulo, porcentaje, dias_semana, created_at, updated_at) " +
+            "VALUES ($1, 'dia-invalido', $2, 10, ARRAY[8]::smallint[], now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticulo });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_ofertas_dias_semana", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/OfertasRlsTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasRlsTests.cs
@@ -1,0 +1,199 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Ofertas;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-4-ofertas, Slice 1 (task 1.8, spec: ofertas / Tenant Isolation for ofertas and
+/// ofertas_listas, ambos escenarios): mismo patrón que <c>ArticulosYPreciosRlsTests</c> — SQL
+/// crudo, independiente de EF, 0 filas para SELECT/UPDATE cross-tenant, 42501 para el INSERT
+/// que viola <c>WITH CHECK</c>, más un proof a nivel EF (LINQ) de que el filtro de tenant
+/// también bloquea la lectura por el ORM.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OfertasRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    public static TheoryData<string, string> TablasDeTenant => new()
+    {
+        { "ofertas", "id_oferta" },
+        { "ofertas_listas", "id_oferta" }
+    };
+
+    private async Task<(int IdTenantA, int IdFila, int IdTenantB, int IdOferta)> SembrarFilaDeTenantAAsync(
+        string tabla, string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra alicuotas_iva)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenantA = new Tenant { Nombre = $"{nombre}-A", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        var tenantB = new Tenant { Nombre = $"{nombre}-B", Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.AddRange(tenantA, tenantB);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenantA.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenantA.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var oferta = new Oferta
+        {
+            IdTenant = tenantA.Id,
+            Nombre = nombre,
+            IdArticulo = articulo.Id,
+            Porcentaje = 10m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Ofertas.Add(oferta);
+        await db.SaveChangesAsync();
+
+        int idFila;
+        switch (tabla)
+        {
+            case "ofertas":
+                idFila = oferta.Id;
+                break;
+
+            case "ofertas_listas":
+                var lista = new ListaPrecio
+                {
+                    IdTenant = tenantA.Id, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+                    CreatedAt = ahora, UpdatedAt = ahora
+                };
+                db.ListasPrecio.Add(lista);
+                await db.SaveChangesAsync();
+
+                db.OfertasListas.Add(new OfertaLista
+                {
+                    IdOferta = oferta.Id, IdListaPrecio = lista.Id, IdTenant = tenantA.Id
+                });
+                await db.SaveChangesAsync();
+                idFila = oferta.Id;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.");
+        }
+
+        return (tenantA.Id, idFila, tenantB.Id, oferta.Id);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoVeLaFilaPorSelect(string tabla, string columnaId)
+    {
+        var (idTenantA, idFila, idTenantB, _) = await SembrarFilaDeTenantAAsync(tabla, nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"SELECT count(*) FROM {tabla} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+        Assert.NotEqual(idTenantA, idTenantB);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila(string tabla, string columnaId)
+    {
+        var (_, idFila, idTenantB, _) = await SembrarFilaDeTenantAAsync(tabla, nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        // ofertas_listas no tiene updated_at (junction PK-only, sin auditoría): el UPDATE toca
+        // id_lista_precio en su lugar -- da lo mismo qué columna, lo que se prueba es que
+        // USING oculta la fila antes de que el UPDATE la alcance.
+        comando.CommandText = tabla == "ofertas_listas"
+            ? $"UPDATE {tabla} SET id_lista_precio = id_lista_precio WHERE {columnaId} = $1"
+            : $"UPDATE {tabla} SET updated_at = now() WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnInsertConIdTenantAjenoSeRechaza(string tabla, string columnaId)
+    {
+        _ = columnaId;
+        var (idTenantA, _, idTenantB, idOfertaDeA) = await SembrarFilaDeTenantAAsync(
+            tabla, nameof(UnInsertConIdTenantAjenoSeRechaza) + tabla);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantA);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = tabla switch
+        {
+            "ofertas" =>
+                "INSERT INTO ofertas (id_tenant, nombre, id_articulo, porcentaje, created_at, updated_at) " +
+                "VALUES ($1, 'intruso', 999999, 10, now(), now())",
+            "ofertas_listas" =>
+                "INSERT INTO ofertas_listas (id_oferta, id_lista_precio, id_tenant) VALUES ($2, 999999, $1)",
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenantB });
+        if (tabla is "ofertas_listas")
+        {
+            comando.Parameters.Add(new NpgsqlParameter { Value = idOfertaDeA });
+        }
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) -- se dispara antes de que
+        // cualquier FK compuesta llegue a evaluarse, sin importar si el resto de columnas
+        // referencia algo inválido (999999 nunca existe).
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ) de que el filtro de tenant también bloquea a las
+    /// entidades que sí pasan por el ORM — <see cref="OfertaLista"/> queda cubierta acá
+    /// también aunque use el filtro manual (no hereda <c>EntidadTenant</c>, ver el comentario
+    /// de <c>WaysDbContext.AplicarFiltroDeTenantEnOfertaLista</c>).</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas()
+    {
+        var (_, idOfertaDeA, idTenantB1, _) = await SembrarFilaDeTenantAAsync(
+            "ofertas", nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas) + "-ofertas");
+        var (_, idOfertaDeOfertaListaDeA, idTenantB2, _) = await SembrarFilaDeTenantAAsync(
+            "ofertas_listas", nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenantParaLasEntidadesNuevas) + "-ofertaslistas");
+
+        await using var sesionB1 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB1));
+        var ofertasVisibles = await sesionB1.Ofertas.Where(o => o.Id == idOfertaDeA).ToListAsync();
+        Assert.Empty(ofertasVisibles);
+
+        await using var sesionB2 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB2));
+        var ofertasListasVisibles = await sesionB2.OfertasListas
+            .Where(ol => ol.IdOferta == idOfertaDeOfertaListaDeA).ToListAsync();
+        Assert.Empty(ofertasListasVisibles);
+    }
+}


### PR DESCRIPTION
Closes #29

## Summary

- Slice 1 of `stage-4-ofertas`: `ofertas` + `ofertas_listas` tables (migration `OfertasEtapa4`) exactly as gate-approved — 4 CHECKs (`ck_ofertas_{alcance_exclusivo,beneficio_exclusivo,ventana_valida,dias_semana}`), composite FKs incl. `id_tenant`, hand-named snake_case indexes, explicit `pk_ofertas_listas`, RLS on both, purely additive, no seed.
- Domain foundation: `Oferta`/`OfertaLista` + pure `ReglaDeOfertas` (exclusive scope/benefit, ranges, `dias_semana`, and window-order validation added at judgment-day's demand so all four CHECKs are genuinely defense-in-depth) projecting into `AlcanceDeOferta`/`BeneficioDeOferta` record structs.
- First CHECK-driven backstop surface of the project: `ClasificarCheckDeOfertas` (exact-name match behind `ck_ofertas_` prefix guard, safe nullable fallback per file convention, spec-pinned codes), `pk_ofertas_listas` 23505→409, FK coverage confirmed.
- `docs/10-modelo-de-datos.md`: `ofertas_listas` junction deviation (user-approved) + full 4-CHECK listing.

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 121/121 (+35 ofertas), Application 190/190, Integration 232/232 (+7 RLS proofs, +7 SQLSTATE-asserted CHECK/PK backstops; real Postgres)
- [x] `dotnet ef migrations has-pending-model-changes` — clean
- [x] judgment-day: APPROVED — R1: 1 confirmed real WARNING (window validation missing → added with 9 unit tests) + safe classifier fallback; R2: B CLEAN, A docs-only (doc-10 CHECK listing completed inline under the trivial-docs exemption)

## Notes

- `size:exception`: ~4k lines of which ~2.3k are EF Designer boilerplate — same precedent as stage-3 slice 1.
- DB CHANGE GATE approved 2026-08-03 exactly as presented (recorded in tasks.md 1.1).
- Forward for Slice 2: `ServicioDeOfertas` wires `ReglaDeOfertas` (all four invariants incl. window) + `ofertas_listas` replace-set with the `pk_ofertas_listas` race test.