### PR TITLE
feat(ofertas): ABM de ofertas con targeting multi-lista (etapa 4, slice 2)

### DIFF
--- a/src/Ways.Api/Endpoints/OfertasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OfertasEndpoints.cs
@@ -1,0 +1,42 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Ofertas;
+
+namespace Ways.Api.Endpoints;
+
+public static class OfertasEndpoints
+{
+    public static IEndpointRouteBuilder MapearOfertas(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/ofertas")
+            .WithTags("Ofertas")
+            .RequireAuthorization(Politicas.GestionDeCatalogo);
+
+        grupo.MapGet("/", (ServicioDeOfertas servicio, bool? incluirEliminados, CancellationToken ct) =>
+            servicio.ListarAsync(incluirEliminados ?? false, ct))
+        .WithSummary("Lista las ofertas del tenant.");
+
+        grupo.MapGet("/{id:int}", (ServicioDeOfertas servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerAsync(id, ct))
+        .WithSummary("Obtiene una oferta, incluido su targeting actual de listas.");
+
+        grupo.MapPost("/", async (ServicioDeOfertas servicio, AltaOferta datos, CancellationToken ct) =>
+        {
+            var creada = await servicio.CrearAsync(datos, ct);
+            return Results.Created($"/api/ofertas/{creada.Id}", creada);
+        })
+        .WithSummary("Crea una oferta, incluidas las listas a las que aplica.");
+
+        grupo.MapPut("/{id:int}", (ServicioDeOfertas servicio, int id, EdicionOferta datos, CancellationToken ct) =>
+            servicio.ActualizarAsync(id, datos, ct))
+        .WithSummary("Actualiza una oferta; reemplaza por completo el subconjunto de listas.");
+
+        grupo.MapDelete("/{id:int}", async (ServicioDeOfertas servicio, int id, CancellationToken ct) =>
+        {
+            await servicio.EliminarAsync(id, ct);
+            return Results.NoContent();
+        })
+        .WithSummary("Baja lógica de la oferta.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -167,6 +167,7 @@ app.MapearOrganizacion();
 app.MapearClientes();
 app.MapearProveedores();
 app.MapearArticulos();
+app.MapearOfertas();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -131,6 +131,27 @@ public class ManejadorDeErrores(
                 when string.Equals(pkOfertasListas, "pk_ofertas_listas", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "La lista de precios ya está en el subconjunto de targeting de la oferta.", "oferta_lista_duplicada"),
 
+            // Defensa en profundidad genérica (judgment-day, item 2, stage-4-ofertas): EF
+            // interpreta un UPDATE/DELETE que afecta 0 filas de las esperadas (en vez de la 1
+            // esperada por su predicado de PK) como un conflicto de concurrencia y lanza
+            // DbUpdateConcurrencyException — p.ej. un segundo escritor cuyo DELETE apunta a filas
+            // que otro escritor ya borró y comiteó primero. Sin este caso, eso llegaba como 500
+            // crudo en vez de un 409 traducido.
+            //
+            // Colocado ACÁ, DESPUÉS de todos los casos `DbUpdateException { InnerException:
+            // PostgresException {...} }` de arriba y ANTES del catch-all `_`, en vez de arriba de
+            // todo junto a `ErrorDominio`: como `DbUpdateConcurrencyException` DERIVA de
+            // `DbUpdateException`, esta posición es la única que estructuralmente GARANTIZA que
+            // nunca puede eclipsar ninguno de esos casos más específicos (cada uno de ellos exige
+            // además un `InnerException` de tipo `PostgresException` con un `SqlState`/
+            // `ConstraintName` puntual — si alguna vez `DbUpdateConcurrencyException` llegara a
+            // traer ese mismo shape de `InnerException`, el switch ya lo habría resuelto arriba
+            // antes de llegar acá). Genérico a propósito (no ofertas-específico): cualquier
+            // replace-set/edición concurrente que EF detecte como "0 filas afectadas" en
+            // cualquier tabla cae acá con el mismo código estable.
+            DbUpdateConcurrencyException =>
+                (StatusCodes.Status409Conflict, "El registro fue modificado por otra operación concurrente; reintentá la operación.", "edicion_concurrente"),
+
             _ => (StatusCodes.Status500InternalServerError,
                   "Ocurrió un error inesperado.",
                   "error_interno")

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Proveedores;
@@ -52,6 +53,11 @@ public interface IWaysDbContext
     DbSet<CodigoBarra> CodigosBarra { get; }
     DbSet<ArticuloEmpresa> ArticulosEmpresas { get; }
     DbSet<Precio> Precios { get; }
+
+    // stage-4-ofertas, Slice 2: primer consumidor de Application — ServicioDeOfertas
+    // (list/create/edit/soft-delete + replace-set de ofertas_listas).
+    DbSet<Oferta> Ofertas { get; }
+    DbSet<OfertaLista> OfertasListas { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Ways.Application.Abstracciones;
 using Ways.Application.Articulos;
 using Ways.Application.Catalogos;
 using Ways.Application.Clientes;
+using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
 using Ways.Application.Parametros;
 using Ways.Application.Precios;
@@ -37,6 +38,7 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeProveedores>();
         services.AddScoped<ServicioDeArticulos>();
         services.AddScoped<ServicioDePrecios>();
+        services.AddScoped<ServicioDeOfertas>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Application/Ofertas/Contratos.cs
+++ b/src/Ways.Application/Ofertas/Contratos.cs
@@ -1,0 +1,80 @@
+namespace Ways.Application.Ofertas;
+
+/// <summary><see cref="IdsListas"/> (mismo criterio judgment-day que
+/// <c>ArticuloListado.IdsEmpresas</c>, stage-3 Slice 2, item 2) expone el subconjunto ACTUAL de
+/// <c>ofertas_listas</c> — vacío cuando la oferta aplica a todas las listas — para que un
+/// cliente HTTP pueda armar un PUT de no-op sin perder el targeting. <c>ListarAsync</c> lo deja
+/// vacío por fila (evita el N+1 de una query por oferta listada); el valor real solo se completa
+/// en <c>ObtenerAsync</c>/<c>CrearAsync</c>/<c>ActualizarAsync</c>.</summary>
+public sealed record OfertaListado(
+    int Id,
+    string Nombre,
+    int? IdEmpresa,
+    int? IdArticulo,
+    int? IdGrupo,
+    int? IdCategoria,
+    DateOnly? FechaDesde,
+    DateOnly? FechaHasta,
+    TimeOnly? HoraDesde,
+    TimeOnly? HoraHasta,
+    IReadOnlyList<int> DiasSemana,
+    decimal? CantidadMinima,
+    decimal? PrecioUnitario,
+    decimal? Porcentaje,
+    decimal? ImporteFijo,
+    int Prioridad,
+    bool Acumulable,
+    bool Activo,
+    IReadOnlyList<int> IdsListas);
+
+/// <summary>Alcance (<see cref="IdArticulo"/>/<see cref="IdGrupo"/>/<see cref="IdCategoria"/>) y
+/// beneficio (<see cref="PrecioUnitario"/>/<see cref="Porcentaje"/>/<see cref="ImporteFijo"/>)
+/// viajan como las tres columnas nullable crudas de doc 10 (design decision 1) — la
+/// exclusividad de cada grupo la valida <c>ReglaDeOfertas</c> del lado de
+/// <c>ServicioDeOfertas</c>, no un tipo discriminado acá. <see cref="IdsListas"/>: vacío/omitido
+/// ⇒ la oferta aplica a todas las listas del tenant (spec: Multi-Lista Targeting via
+/// ofertas_listas).</summary>
+public sealed record AltaOferta(
+    string Nombre,
+    int? IdEmpresa,
+    int? IdArticulo,
+    int? IdGrupo,
+    int? IdCategoria,
+    DateOnly? FechaDesde,
+    DateOnly? FechaHasta,
+    TimeOnly? HoraDesde,
+    TimeOnly? HoraHasta,
+    IReadOnlyList<int>? DiasSemana,
+    decimal? CantidadMinima,
+    decimal? PrecioUnitario,
+    decimal? Porcentaje,
+    decimal? ImporteFijo,
+    int Prioridad,
+    bool Acumulable,
+    IReadOnlyList<int>? IdsListas = null,
+    bool Activo = true);
+
+/// <summary>Mismo shape que <see cref="AltaOferta"/> — a diferencia de
+/// <c>EdicionArticulo</c>/<c>AltaArticulo</c>, acá no hay ninguna columna inmutable que excluir
+/// (<c>codigo_interno</c> no tiene equivalente en <c>ofertas</c>), así que los dos contratos
+/// llevan exactamente los mismos campos (task 2.3: contratos separados por nombre, sin
+/// diferencia de forma).</summary>
+public sealed record EdicionOferta(
+    string Nombre,
+    int? IdEmpresa,
+    int? IdArticulo,
+    int? IdGrupo,
+    int? IdCategoria,
+    DateOnly? FechaDesde,
+    DateOnly? FechaHasta,
+    TimeOnly? HoraDesde,
+    TimeOnly? HoraHasta,
+    IReadOnlyList<int>? DiasSemana,
+    decimal? CantidadMinima,
+    decimal? PrecioUnitario,
+    decimal? Porcentaje,
+    decimal? ImporteFijo,
+    int Prioridad,
+    bool Acumulable,
+    IReadOnlyList<int>? IdsListas,
+    bool Activo);

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -1,4 +1,7 @@
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Common;
 using Ways.Domain.Ofertas;
@@ -20,14 +23,26 @@ namespace Ways.Application.Ofertas;
 /// El alta abre transacción explícita (mismo patrón que
 /// <see cref="Articulos.ServicioDeArticulos.CrearAsync"/>): necesita el <c>Id</c> autogenerado
 /// de la oferta antes de poder insertar las filas de <see cref="OfertaLista"/> que la referencian,
-/// así que hacen falta dos <c>SaveChangesAsync</c> atómicos entre sí. La edición NO necesita
-/// transacción explícita: el replace-set de <c>ofertas_listas</c> (delete-all + insert, ids
-/// <c>.Distinct()</c>ed) entra en UN solo <c>SaveChangesAsync</c> — EF ya lo envuelve en una
-/// transacción implícita (design: Protection Rules, "Lista set replacement is atomic") — mismo
-/// motivo por el que <c>ServicioDeArticulos.ActualizarAsync</c> tampoco abre una explícita, y lo
-/// que permite cubrir <see cref="ActualizarAsync"/> completo contra el proveedor InMemory (a
-/// diferencia de <see cref="CrearAsync"/>, mismo "transaction-blocked-provider caveat" que
-/// <c>ServicioDeArticulosTests</c>).
+/// así que hacen falta dos <c>SaveChangesAsync</c> atómicos entre sí.
+///
+/// (judgment-day, item 1) <see cref="ActualizarAsync"/> TAMBIÉN abre transacción explícita —
+/// contrario a lo que decía este comentario antes del fix: el "un solo SaveChangesAsync ya es
+/// atómico" solo protegía el replace-set CONTRA SÍ MISMO, no contra otro PUT concurrente
+/// leyendo <c>filasActuales</c> ANTES de que el primero comiteara. Dos PUT concurrentes con
+/// targets DISTINTOS (p.ej. A → [1], B → [2]) pasaban las dos por un <c>filasActuales</c> vacío,
+/// y el orden de commit determinaba cuál sobrevivía — sin lock, ninguna elegía "la última en
+/// escribir gana" de forma confiable, y en el peor caso (B comitea, A comitea después con un
+/// DELETE que ya no afecta ninguna fila) el DELETE de A no fallaba pero tampoco revertía el
+/// INSERT de B, dejando la UNIÓN de ambos targets persistida — lost update silencioso. Mismo
+/// mecanismo que <see cref="Precios.ServicioDePrecios.AbrirNuevoPrecioAsync"/> lo resuelve acá:
+/// <see cref="TomarLockDeOfertaAsync"/> toma un <c>pg_advisory_xact_lock</c> determinístico por
+/// <c>(idTenant, idOferta)</c> ANTES de releer <c>filasActuales</c> — el segundo llamador espera
+/// a que el primero comitee, y al retomar el lock ve el estado YA COMITEADO, así que hace un
+/// reemplazo limpio en vez de competir a ciegas ("último committer gana", nunca una unión, nunca
+/// un DELETE de 0 filas). Esto mueve <see cref="ActualizarAsync"/> completo fuera del proveedor
+/// InMemory (mismo "transaction-blocked-provider caveat" que <see cref="CrearAsync"/>/
+/// <c>ServicioDeArticulosTests</c>) — las pruebas de <c>ServicioDeOfertasTests</c> que cubrían el
+/// replace-set persistido se movieron a <c>OfertasEndpointsTests</c> (Postgres real).
 /// </summary>
 public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
 {
@@ -168,41 +183,56 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
 
         var idTenant = ExigirTenantDeLaSesion();
 
-        oferta.Nombre = candidato.Nombre;
-        oferta.IdEmpresa = candidato.IdEmpresa;
-        oferta.IdArticulo = candidato.IdArticulo;
-        oferta.IdGrupo = candidato.IdGrupo;
-        oferta.IdCategoria = candidato.IdCategoria;
-        oferta.FechaDesde = candidato.FechaDesde;
-        oferta.FechaHasta = candidato.FechaHasta;
-        oferta.HoraDesde = candidato.HoraDesde;
-        oferta.HoraHasta = candidato.HoraHasta;
-        oferta.DiasSemana = candidato.DiasSemana;
-        oferta.CantidadMinima = candidato.CantidadMinima;
-        oferta.PrecioUnitario = candidato.PrecioUnitario;
-        oferta.Porcentaje = candidato.Porcentaje;
-        oferta.ImporteFijo = candidato.ImporteFijo;
-        oferta.Prioridad = candidato.Prioridad;
-        oferta.Acumulable = candidato.Acumulable;
-        oferta.Activo = candidato.Activo;
-        oferta.UpdatedAt = reloj.Ahora;
+        var estrategia = db.Database.CreateExecutionStrategy();
 
-        // Reemplaza el subconjunto entero (INSERT/DELETE físico, sin historial que preservar —
-        // OfertaLista es PK-only, Slice 1): design: Protection Rules, "Lista set replacement is
-        // atomic" — UN solo SaveChangesAsync más abajo hace que el delete-all + insert sea
-        // atómico entre sí (misma transacción implícita de EF), que es la superficie que
-        // pk_ofertas_listas protege bajo dos PUT concurrentes sobre la misma oferta.
-        var filasActuales = await db.OfertasListas.Where(ol => ol.IdOferta == id).ToListAsync(ct);
-        db.OfertasListas.RemoveRange(filasActuales);
-
-        if (idsListas is { Count: > 0 })
+        return await estrategia.ExecuteAsync(async () =>
         {
-            AgregarFilasDeListas(id, idTenant, idsListas);
-        }
+            await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
-        await db.SaveChangesAsync(ct);
+            // (judgment-day, item 1) Lock ANTES de tocar nada de ofertas_listas — serializa
+            // cualquier otro PUT concurrente sobre la MISMA oferta, exista o no una fila de
+            // targeting todavía. Recién con el lock tomado es seguro releer filasActuales:
+            // ningún otro escritor puede estar reemplazando el subconjunto en simultáneo.
+            await TomarLockDeOfertaAsync(idTenant, id, ct);
 
-        return Proyectar(oferta, (IReadOnlyList<int>?)idsListas ?? Array.Empty<int>());
+            oferta.Nombre = candidato.Nombre;
+            oferta.IdEmpresa = candidato.IdEmpresa;
+            oferta.IdArticulo = candidato.IdArticulo;
+            oferta.IdGrupo = candidato.IdGrupo;
+            oferta.IdCategoria = candidato.IdCategoria;
+            oferta.FechaDesde = candidato.FechaDesde;
+            oferta.FechaHasta = candidato.FechaHasta;
+            oferta.HoraDesde = candidato.HoraDesde;
+            oferta.HoraHasta = candidato.HoraHasta;
+            oferta.DiasSemana = candidato.DiasSemana;
+            oferta.CantidadMinima = candidato.CantidadMinima;
+            oferta.PrecioUnitario = candidato.PrecioUnitario;
+            oferta.Porcentaje = candidato.Porcentaje;
+            oferta.ImporteFijo = candidato.ImporteFijo;
+            oferta.Prioridad = candidato.Prioridad;
+            oferta.Acumulable = candidato.Acumulable;
+            oferta.Activo = candidato.Activo;
+            oferta.UpdatedAt = reloj.Ahora;
+
+            // Reemplaza el subconjunto entero (INSERT/DELETE físico, sin historial que preservar
+            // — OfertaLista es PK-only, Slice 1): design: Protection Rules, "Lista set
+            // replacement is atomic". Releído DESPUÉS del lock (judgment-day, item 1) — un
+            // segundo llamador que esperó el lock ve acá el estado YA COMITEADO por el primero,
+            // nunca la foto vieja que produciría la unión de ambos targets o un DELETE de 0
+            // filas.
+            var filasActuales = await db.OfertasListas.Where(ol => ol.IdOferta == id).ToListAsync(ct);
+            db.OfertasListas.RemoveRange(filasActuales);
+
+            if (idsListas is { Count: > 0 })
+            {
+                AgregarFilasDeListas(id, idTenant, idsListas);
+            }
+
+            await db.SaveChangesAsync(ct);
+            await transaccion.CommitAsync(ct);
+
+            return Proyectar(oferta, (IReadOnlyList<int>?)idsListas ?? Array.Empty<int>());
+        });
     }
 
     /// <summary>Baja lógica: escribe <c>deleted_at</c>, no borra la fila. Las filas de
@@ -291,15 +321,24 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
     /// <summary>Spec: "Junction row references must belong to the same tenant" — pre-chequeo
     /// tenant-scoped (filtro de EF, sin <c>IgnoreQueryFilters</c>, per db-error-backstops) antes
     /// de escribir cualquier fila de <see cref="OfertaLista"/>: cubre a la vez "no existe" y "es
-    /// de otro tenant" con el mismo 400, backstop real <c>fk_ofertas_listas_lista_precio</c>.</summary>
+    /// de otro tenant" con el mismo 400, backstop real <c>fk_ofertas_listas_lista_precio</c>.
+    ///
+    /// (judgment-day, item 4) Una sola consulta por conjunto en vez de un <c>AnyAsync</c> por id
+    /// — mismo resultado (400 <c>referencia_invalida</c> ante la primera referencia inválida, en
+    /// el orden de <paramref name="idsListas"/>), sin el round trip N+1 del <c>foreach</c>
+    /// anterior.</summary>
     private async Task ExigirListasValidasAsync(IReadOnlyList<int> idsListas, CancellationToken ct)
     {
-        foreach (var idLista in idsListas)
+        var idsExistentes = await db.ListasPrecio
+            .Where(l => idsListas.Contains(l.Id))
+            .Select(l => l.Id)
+            .ToListAsync(ct);
+
+        var idsInvalidos = idsListas.Except(idsExistentes).ToList();
+
+        if (idsInvalidos.Count > 0)
         {
-            if (!await db.ListasPrecio.AnyAsync(l => l.Id == idLista, ct))
-            {
-                throw new ErrorDominio("referencia_invalida", $"No existe la lista de precios {idLista}.", 400);
-            }
+            throw new ErrorDominio("referencia_invalida", $"No existe la lista de precios {idsInvalidos[0]}.", 400);
         }
     }
 
@@ -322,6 +361,48 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
             .OrderBy(ol => ol.IdListaPrecio)
             .Select(ol => ol.IdListaPrecio)
             .ToListAsync(ct);
+
+    /// <summary>(judgment-day, item 1) <c>pg_advisory_xact_lock</c> con alcance de TRANSACCIÓN
+    /// determinístico por <c>(idTenant, idOferta)</c> — a diferencia de
+    /// <see cref="Precios.ServicioDePrecios.ClaveDeLockDePar"/>, acá no hace falta combinar dos
+    /// ids en uno: el segundo argumento del lock ya ES <paramref name="idOferta"/> directo, sin
+    /// riesgo de colisión entre ofertas distintas del mismo tenant. Mismo criterio DELIBERADO
+    /// que Precios de NO usar <c>HashCode.Combine</c> (semilla aleatoria por proceso) — acá
+    /// directamente no aplica, no hay nada que combinar. Tomado ANTES de releer
+    /// <c>ofertas_listas</c> (ver <see cref="ActualizarAsync"/>): serializa cualquier otro PUT
+    /// concurrente sobre la MISMA oferta, exista o no una fila de targeting todavía.</summary>
+    private async Task TomarLockDeOfertaAsync(int idTenant, int idOferta, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText = "SELECT pg_advisory_xact_lock($1, $2)";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idOferta);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
 
     private async Task<Oferta> BuscarAsync(int id, CancellationToken ct) =>
         await db.Ofertas.FirstOrDefaultAsync(o => o.Id == id, ct)

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -43,7 +43,18 @@ namespace Ways.Application.Ofertas;
 /// InMemory (mismo "transaction-blocked-provider caveat" que <see cref="CrearAsync"/>/
 /// <c>ServicioDeArticulosTests</c>) — las pruebas de <c>ServicioDeOfertasTests</c> que cubrían el
 /// replace-set persistido se movieron a <c>OfertasEndpointsTests</c> (Postgres real).
-/// </summary>
+///
+/// (judgment-day ronda 2, item 1 — CRITICAL) El lock de <see cref="ActualizarAsync"/> serializaba
+/// PUT contra PUT, pero no PUT contra <see cref="EliminarAsync"/>: ese último ni abría transacción
+/// ni tomaba el lock, así que un PUT podía leer la oferta viva, un DELETE concurrente comiteaba
+/// primero (fuera de cualquier lock), y el PUT — que nunca volvía a chequear <c>DeletedAt</c> —
+/// terminaba pisando los campos editables sobre una fila YA ELIMINADA (ghost edit: 200 del PUT +
+/// <c>deleted_at</c> seteado, sin que ninguno de los dos escritores fallara). Ahora
+/// <see cref="EliminarAsync"/> abre la MISMA transacción explícita y toma el MISMO
+/// <see cref="TomarLockDeOfertaAsync"/> ANTES de leer la fila, y <see cref="ActualizarAsync"/>
+/// re-chequea existencia con un <c>EXISTS</c> plano DESPUÉS de tomar el lock (nunca reusa la
+/// entidad trackeada desde antes de la transacción, que el identity map de EF no refresca sola)
+/// — cualquiera de los dos que pierda la carrera del lock ve el estado YA COMITEADO por el otro.</summary>
 public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
 {
     /// <summary>Sin filtro de <c>Activo</c> (a diferencia de <c>ServicioDeCatalogo</c>) —
@@ -195,6 +206,24 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
             // ningún otro escritor puede estar reemplazando el subconjunto en simultáneo.
             await TomarLockDeOfertaAsync(idTenant, id, ct);
 
+            // (judgment-day ronda 2, item 1 — CRITICAL) Re-chequeo de existencia DESPUÉS del
+            // lock, vía un EXISTS plano (nunca materializa entidad, así que nunca pasa por el
+            // identity map) en vez de reusar `oferta` (ya trackeada desde ANTES de la
+            // transacción, con su `DeletedAt` de esa foto vieja). Sin esto: un DELETE
+            // concurrente que gana la carrera del lock, comitea PRIMERO y sale de la
+            // transacción deja la fila con `deleted_at` seteado en la DB — pero `oferta` en
+            // memoria seguía "viva" (el identity map de EF NO refresca una entidad ya
+            // trackeada con los valores de una query posterior), así que este PUT hubiera
+            // seguido de largo, pisado los campos editables y comiteado un 200 sobre una
+            // oferta YA ELIMINADA (ghost edit — ni el DELETE lo revertía, porque nunca tocó
+            // `DeletedAt`). El filtro `BajaLogica` ya excluye la fila del EXISTS si está
+            // borrada, así que el mismo 404 uniforme (ADR-8) que `BuscarAsync` cubre acá el
+            // caso "borrada por otro escritor mientras esperaba el lock".
+            if (!await db.Ofertas.AnyAsync(o => o.Id == id, ct))
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la oferta {id}.");
+            }
+
             oferta.Nombre = candidato.Nombre;
             oferta.IdEmpresa = candidato.IdEmpresa;
             oferta.IdArticulo = candidato.IdArticulo;
@@ -238,16 +267,39 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
     /// <summary>Baja lógica: escribe <c>deleted_at</c>, no borra la fila. Las filas de
     /// <see cref="OfertaLista"/> asociadas quedan como están — sin cascada, mismo criterio que
     /// <see cref="Articulos.ServicioDeArticulos.EliminarAsync"/> con
-    /// <see cref="Domain.Articulos.ArticuloEmpresa"/>.</summary>
+    /// <see cref="Domain.Articulos.ArticuloEmpresa"/>.
+    ///
+    /// (judgment-day ronda 2, item 1 — CRITICAL) Mismo <c>CreateExecutionStrategy</c> + transacción
+    /// explícita que <see cref="ActualizarAsync"/>/<see cref="CrearAsync"/>, con el
+    /// <c>pg_advisory_xact_lock</c> de <see cref="TomarLockDeOfertaAsync"/> tomado ANTES de leer
+    /// la fila: antes de este fix, el DELETE no abría transacción propia ni tomaba ningún lock, así
+    /// que un PUT concurrente podía leer la oferta ANTES de que este DELETE comiteara, pisar
+    /// campos editables con su propio <c>SaveChangesAsync</c> DESPUÉS, y dejar la fila con
+    /// <c>deleted_at</c> seteado (por este DELETE) a la vez que los campos frescos del PUT
+    /// (ghost edit — ninguno de los dos escritores fallaba). Con el lock, el DELETE solo lee la
+    /// fila DESPUÉS de tomarlo — si un PUT lo tiene tomado, este DELETE espera hasta que
+    /// comitee y recién ahí lee y marca el estado YA COMITEADO, nunca una foto vieja.</summary>
     public async Task EliminarAsync(int id, CancellationToken ct = default)
     {
-        var oferta = await BuscarAsync(id, ct);
+        var idTenant = ExigirTenantDeLaSesion();
 
-        var ahora = reloj.Ahora;
-        oferta.DeletedAt = ahora;
-        oferta.UpdatedAt = ahora;
+        var estrategia = db.Database.CreateExecutionStrategy();
 
-        await db.SaveChangesAsync(ct);
+        await estrategia.ExecuteAsync(async () =>
+        {
+            await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+            await TomarLockDeOfertaAsync(idTenant, id, ct);
+
+            var oferta = await BuscarAsync(id, ct);
+
+            var ahora = reloj.Ahora;
+            oferta.DeletedAt = ahora;
+            oferta.UpdatedAt = ahora;
+
+            await db.SaveChangesAsync(ct);
+            await transaccion.CommitAsync(ct);
+        });
     }
 
     /// <summary>Las cinco guardas de <see cref="ReglaDeOfertas"/> (design: Protection Rules) —

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -1,0 +1,394 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.Ofertas;
+
+namespace Ways.Application.Ofertas;
+
+/// <summary>
+/// ABM de ofertas + targeting de listas vía <c>ofertas_listas</c> (design decision 6: entidad/
+/// servicio dedicados, <c>Oferta</c> NO extiende <c>ServicioDeCatalogo&lt;T,TListado,TAlta&gt;</c>
+/// — <c>nombre</c> es una etiqueta de ticket deliberadamente no única, y las dos CHECKs de
+/// exclusividad más la junction son la misma clase de divergencia que ya tomaron
+/// <see cref="Articulos.ServicioDeArticulos"/>/<see cref="Precios.ServicioDePrecios"/>).
+/// Autorización: <c>Politicas.GestionDeCatalogo</c> aplicada en la capa de API.
+///
+/// Todo camino de escritura pasa por las cinco guardas de <see cref="ReglaDeOfertas"/> (pura,
+/// sin DB) ANTES de tocar la fila (design: Protection Rules) — las cuatro CHECKs de esquema
+/// quedan como defensa en profundidad, alcanzable solo por una escritura cruda/fuera de banda.
+///
+/// El alta abre transacción explícita (mismo patrón que
+/// <see cref="Articulos.ServicioDeArticulos.CrearAsync"/>): necesita el <c>Id</c> autogenerado
+/// de la oferta antes de poder insertar las filas de <see cref="OfertaLista"/> que la referencian,
+/// así que hacen falta dos <c>SaveChangesAsync</c> atómicos entre sí. La edición NO necesita
+/// transacción explícita: el replace-set de <c>ofertas_listas</c> (delete-all + insert, ids
+/// <c>.Distinct()</c>ed) entra en UN solo <c>SaveChangesAsync</c> — EF ya lo envuelve en una
+/// transacción implícita (design: Protection Rules, "Lista set replacement is atomic") — mismo
+/// motivo por el que <c>ServicioDeArticulos.ActualizarAsync</c> tampoco abre una explícita, y lo
+/// que permite cubrir <see cref="ActualizarAsync"/> completo contra el proveedor InMemory (a
+/// diferencia de <see cref="CrearAsync"/>, mismo "transaction-blocked-provider caveat" que
+/// <c>ServicioDeArticulosTests</c>).
+/// </summary>
+public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+{
+    /// <summary>Sin filtro de <c>Activo</c> (a diferencia de <c>ServicioDeCatalogo</c>) —
+    /// mismo criterio que <c>ArticuloListado</c>: el filtro global de baja lógica ya deja
+    /// afuera las eliminadas, y una oferta inactiva sigue siendo administrable desde el
+    /// listado. <see cref="OfertaListado.IdsListas"/> vacío por fila (evita el N+1 de una
+    /// query por oferta listada, mismo criterio que <c>ArticuloListado.IdsEmpresas</c>).</summary>
+    public async Task<IReadOnlyList<OfertaListado>> ListarAsync(
+        bool incluirEliminados = false, CancellationToken ct = default)
+    {
+        var query = db.Ofertas.AsQueryable();
+
+        if (incluirEliminados)
+        {
+            query = query.IgnoreQueryFilters(["BajaLogica"]);
+        }
+
+        var items = await query.OrderBy(o => o.Nombre).ToListAsync(ct);
+
+        return items.Select(o => Proyectar(o, Array.Empty<int>())).ToList();
+    }
+
+    public async Task<OfertaListado> ObtenerAsync(int id, CancellationToken ct = default)
+    {
+        var oferta = await BuscarAsync(id, ct);
+        var idsListas = await IdsListasDeAsync(oferta.Id, ct);
+
+        return Proyectar(oferta, idsListas);
+    }
+
+    public async Task<OfertaListado> CrearAsync(AltaOferta datos, CancellationToken ct = default)
+    {
+        var nombre = NormalizarRequerido(datos.Nombre, "nombre", 150);
+        var diasSemana = ConvertirDiasSemana(datos.DiasSemana);
+        var idsListas = datos.IdsListas?.Distinct().ToList();
+
+        var oferta = new Oferta
+        {
+            Nombre = nombre,
+            IdEmpresa = datos.IdEmpresa,
+            IdArticulo = datos.IdArticulo,
+            IdGrupo = datos.IdGrupo,
+            IdCategoria = datos.IdCategoria,
+            FechaDesde = datos.FechaDesde,
+            FechaHasta = datos.FechaHasta,
+            HoraDesde = datos.HoraDesde,
+            HoraHasta = datos.HoraHasta,
+            DiasSemana = diasSemana,
+            CantidadMinima = datos.CantidadMinima,
+            PrecioUnitario = datos.PrecioUnitario,
+            Porcentaje = datos.Porcentaje,
+            ImporteFijo = datos.ImporteFijo,
+            Prioridad = datos.Prioridad,
+            Acumulable = datos.Acumulable,
+            Activo = datos.Activo
+        };
+
+        var alcance = ValidarInvariantes(oferta);
+
+        await ExigirAlcanceValidoAsync(alcance, ct);
+        await ExigirEmpresaValidaAsync(datos.IdEmpresa, ct);
+
+        if (idsListas is { Count: > 0 })
+        {
+            await ExigirListasValidasAsync(idsListas, ct);
+        }
+
+        var idTenant = ExigirTenantDeLaSesion();
+
+        var ahora = reloj.Ahora;
+        oferta.CreatedAt = ahora;
+        oferta.UpdatedAt = ahora;
+
+        var estrategia = db.Database.CreateExecutionStrategy();
+
+        return await estrategia.ExecuteAsync(async () =>
+        {
+            await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+            db.Ofertas.Add(oferta);
+            await db.SaveChangesAsync(ct);
+
+            if (idsListas is { Count: > 0 })
+            {
+                AgregarFilasDeListas(oferta.Id, idTenant, idsListas);
+                await db.SaveChangesAsync(ct);
+            }
+
+            await transaccion.CommitAsync(ct);
+
+            return Proyectar(oferta, (IReadOnlyList<int>?)idsListas ?? Array.Empty<int>());
+        });
+    }
+
+    public async Task<OfertaListado> ActualizarAsync(int id, EdicionOferta datos, CancellationToken ct = default)
+    {
+        var oferta = await BuscarAsync(id, ct);
+
+        var nombre = NormalizarRequerido(datos.Nombre, "nombre", 150);
+        var diasSemana = ConvertirDiasSemana(datos.DiasSemana);
+        var idsListas = datos.IdsListas?.Distinct().ToList();
+
+        // Validar sobre un candidato transitorio (nunca agregado al DbSet) ANTES de tocar la
+        // fila trackeada: si ReglaDeOfertas rechaza el shape, `oferta` queda intacta en memoria
+        // (mismo espíritu de seguridad que ServicioDeArticulos.ActualizarAsync, que valida los
+        // datos crudos antes de asignar ningún campo).
+        var candidato = new Oferta
+        {
+            Nombre = nombre,
+            IdEmpresa = datos.IdEmpresa,
+            IdArticulo = datos.IdArticulo,
+            IdGrupo = datos.IdGrupo,
+            IdCategoria = datos.IdCategoria,
+            FechaDesde = datos.FechaDesde,
+            FechaHasta = datos.FechaHasta,
+            HoraDesde = datos.HoraDesde,
+            HoraHasta = datos.HoraHasta,
+            DiasSemana = diasSemana,
+            CantidadMinima = datos.CantidadMinima,
+            PrecioUnitario = datos.PrecioUnitario,
+            Porcentaje = datos.Porcentaje,
+            ImporteFijo = datos.ImporteFijo,
+            Prioridad = datos.Prioridad,
+            Acumulable = datos.Acumulable,
+            Activo = datos.Activo
+        };
+
+        var alcance = ValidarInvariantes(candidato);
+
+        await ExigirAlcanceValidoAsync(alcance, ct);
+        await ExigirEmpresaValidaAsync(datos.IdEmpresa, ct);
+
+        if (idsListas is { Count: > 0 })
+        {
+            await ExigirListasValidasAsync(idsListas, ct);
+        }
+
+        var idTenant = ExigirTenantDeLaSesion();
+
+        oferta.Nombre = candidato.Nombre;
+        oferta.IdEmpresa = candidato.IdEmpresa;
+        oferta.IdArticulo = candidato.IdArticulo;
+        oferta.IdGrupo = candidato.IdGrupo;
+        oferta.IdCategoria = candidato.IdCategoria;
+        oferta.FechaDesde = candidato.FechaDesde;
+        oferta.FechaHasta = candidato.FechaHasta;
+        oferta.HoraDesde = candidato.HoraDesde;
+        oferta.HoraHasta = candidato.HoraHasta;
+        oferta.DiasSemana = candidato.DiasSemana;
+        oferta.CantidadMinima = candidato.CantidadMinima;
+        oferta.PrecioUnitario = candidato.PrecioUnitario;
+        oferta.Porcentaje = candidato.Porcentaje;
+        oferta.ImporteFijo = candidato.ImporteFijo;
+        oferta.Prioridad = candidato.Prioridad;
+        oferta.Acumulable = candidato.Acumulable;
+        oferta.Activo = candidato.Activo;
+        oferta.UpdatedAt = reloj.Ahora;
+
+        // Reemplaza el subconjunto entero (INSERT/DELETE físico, sin historial que preservar —
+        // OfertaLista es PK-only, Slice 1): design: Protection Rules, "Lista set replacement is
+        // atomic" — UN solo SaveChangesAsync más abajo hace que el delete-all + insert sea
+        // atómico entre sí (misma transacción implícita de EF), que es la superficie que
+        // pk_ofertas_listas protege bajo dos PUT concurrentes sobre la misma oferta.
+        var filasActuales = await db.OfertasListas.Where(ol => ol.IdOferta == id).ToListAsync(ct);
+        db.OfertasListas.RemoveRange(filasActuales);
+
+        if (idsListas is { Count: > 0 })
+        {
+            AgregarFilasDeListas(id, idTenant, idsListas);
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        return Proyectar(oferta, (IReadOnlyList<int>?)idsListas ?? Array.Empty<int>());
+    }
+
+    /// <summary>Baja lógica: escribe <c>deleted_at</c>, no borra la fila. Las filas de
+    /// <see cref="OfertaLista"/> asociadas quedan como están — sin cascada, mismo criterio que
+    /// <see cref="Articulos.ServicioDeArticulos.EliminarAsync"/> con
+    /// <see cref="Domain.Articulos.ArticuloEmpresa"/>.</summary>
+    public async Task EliminarAsync(int id, CancellationToken ct = default)
+    {
+        var oferta = await BuscarAsync(id, ct);
+
+        var ahora = reloj.Ahora;
+        oferta.DeletedAt = ahora;
+        oferta.UpdatedAt = ahora;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Las cinco guardas de <see cref="ReglaDeOfertas"/> (design: Protection Rules) —
+    /// alcance y beneficio exclusivos, rango de <c>cantidad_minima</c>, ventana de vigencia
+    /// válida, <c>dias_semana</c> subset sin duplicados. Devuelve el <see cref="AlcanceDeOferta"/>
+    /// ya proyectado para que el llamador sepa qué referencia tenant-scoped validar a
+    /// continuación, sin tener que releer las tres columnas nullable crudas.</summary>
+    private static AlcanceDeOferta ValidarInvariantes(Oferta candidato)
+    {
+        var alcance = ReglaDeOfertas.LeerAlcance(candidato);
+        ReglaDeOfertas.LeerBeneficio(candidato);
+        ReglaDeOfertas.ValidarCantidadMinima(candidato.CantidadMinima);
+        ReglaDeOfertas.ValidarVentana(
+            candidato.FechaDesde, candidato.FechaHasta, candidato.HoraDesde, candidato.HoraHasta);
+        ReglaDeOfertas.LeerDiasSemana(candidato.DiasSemana);
+
+        return alcance;
+    }
+
+    /// <summary>db-error-backstops: pre-chequeo de existencia tenant-scoped antes del INSERT/
+    /// UPDATE — el backstop real sigue siendo la FK compuesta correspondiente
+    /// (<c>fk_ofertas_articulo</c>/<c>fk_ofertas_grupo</c>/<c>fk_ofertas_categoria</c>, 23503 →
+    /// 400 <c>referencia_invalida</c>, genérico desde la Slice 1). <paramref name="alcance"/> ya
+    /// garantiza que exactamente uno de los tres está seteado (<see cref="ValidarInvariantes"/>
+    /// corrió antes), así que este método solo despacha a la tabla correcta.</summary>
+    private async Task ExigirAlcanceValidoAsync(AlcanceDeOferta alcance, CancellationToken ct)
+    {
+        if (alcance.IdArticulo is { } idArticulo)
+        {
+            if (!await db.Articulos.AnyAsync(a => a.Id == idArticulo, ct))
+            {
+                throw new ErrorDominio("referencia_invalida", $"No existe el artículo {idArticulo}.", 400);
+            }
+
+            return;
+        }
+
+        if (alcance.IdGrupo is { } idGrupo)
+        {
+            if (!await db.Grupos.AnyAsync(g => g.Id == idGrupo, ct))
+            {
+                throw new ErrorDominio("referencia_invalida", $"No existe el grupo {idGrupo}.", 400);
+            }
+
+            return;
+        }
+
+        var idCategoria = alcance.IdCategoria!.Value;
+        if (!await db.Categorias.AnyAsync(c => c.Id == idCategoria, ct))
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe la categoría {idCategoria}.", 400);
+        }
+    }
+
+    /// <summary>Mismo criterio que <see cref="ExigirAlcanceValidoAsync"/>, para
+    /// <c>fk_ofertas_empresa</c> — <see cref="Oferta.IdEmpresa"/> es nullable (<c>NULL</c> =
+    /// todo el tenant, design decision 5).</summary>
+    private async Task ExigirEmpresaValidaAsync(int? idEmpresa, CancellationToken ct)
+    {
+        if (idEmpresa is null)
+        {
+            return;
+        }
+
+        if (!await db.Empresas.AnyAsync(e => e.Id == idEmpresa, ct))
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe la empresa {idEmpresa}.", 400);
+        }
+    }
+
+    /// <summary>Spec: "Junction row references must belong to the same tenant" — pre-chequeo
+    /// tenant-scoped (filtro de EF, sin <c>IgnoreQueryFilters</c>, per db-error-backstops) antes
+    /// de escribir cualquier fila de <see cref="OfertaLista"/>: cubre a la vez "no existe" y "es
+    /// de otro tenant" con el mismo 400, backstop real <c>fk_ofertas_listas_lista_precio</c>.</summary>
+    private async Task ExigirListasValidasAsync(IReadOnlyList<int> idsListas, CancellationToken ct)
+    {
+        foreach (var idLista in idsListas)
+        {
+            if (!await db.ListasPrecio.AnyAsync(l => l.Id == idLista, ct))
+            {
+                throw new ErrorDominio("referencia_invalida", $"No existe la lista de precios {idLista}.", 400);
+            }
+        }
+    }
+
+    private void AgregarFilasDeListas(int idOferta, int idTenant, IReadOnlyList<int> idsListas)
+    {
+        foreach (var idLista in idsListas)
+        {
+            db.OfertasListas.Add(new OfertaLista
+            {
+                IdOferta = idOferta,
+                IdListaPrecio = idLista,
+                IdTenant = idTenant
+            });
+        }
+    }
+
+    private async Task<IReadOnlyList<int>> IdsListasDeAsync(int idOferta, CancellationToken ct) =>
+        await db.OfertasListas
+            .Where(ol => ol.IdOferta == idOferta)
+            .OrderBy(ol => ol.IdListaPrecio)
+            .Select(ol => ol.IdListaPrecio)
+            .ToListAsync(ct);
+
+    private async Task<Oferta> BuscarAsync(int id, CancellationToken ct) =>
+        await db.Ofertas.FirstOrDefaultAsync(o => o.Id == id, ct)
+            // El filtro de EF (+ RLS por debajo) ya deja invisible la fila de otro tenant —
+            // esto solo cubre "no existe en absoluto" (ADR-8: mismo 404 en los dos casos).
+            ?? throw ErrorDominio.NoEncontrado($"No existe la oferta {id}.");
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            // GestionDeCatalogo (capa de API) ya exige admin de tenant — un actor de
+            // plataforma nunca llega hasta acá. Defensa en profundidad, no un camino
+            // alcanzable en operación normal.
+            ?? throw new InvalidOperationException(
+                "ServicioDeOfertas requiere un actor de tenant; GestionDeCatalogo es admin-only.");
+
+    /// <summary>Convierte el <c>int[]</c> del contrato HTTP al <c>short[]</c> nativo de
+    /// <see cref="Oferta.DiasSemana"/> (Npgsql <c>smallint[]</c>). El chequeo de rango de
+    /// <c>short</c> corre ACÁ, antes del cast, para que un valor fuera de rango nunca dé la
+    /// vuelta silenciosamente a un 1..7 que <see cref="ReglaDeOfertas.LeerDiasSemana"/> aceptaría
+    /// por error — esa función valida el subset 1..7 DESPUÉS del cast, no el rango del tipo.</summary>
+    private static short[]? ConvertirDiasSemana(IReadOnlyList<int>? dias)
+    {
+        if (dias is null || dias.Count == 0)
+        {
+            return null;
+        }
+
+        var convertidos = new short[dias.Count];
+        for (var i = 0; i < dias.Count; i++)
+        {
+            var valor = dias[i];
+            if (valor is < short.MinValue or > short.MaxValue)
+            {
+                throw new ErrorDominio(
+                    "dias_semana_invalidos",
+                    "Los días de semana de la oferta tienen que ser valores de 1 a 7 sin repetir.",
+                    400);
+            }
+
+            convertidos[i] = (short)valor;
+        }
+
+        return convertidos;
+    }
+
+    private static string NormalizarRequerido(string? valor, string campo, int largoMaximo)
+    {
+        var limpio = valor?.Trim() ?? string.Empty;
+
+        if (limpio.Length == 0)
+        {
+            throw new ErrorDominio($"{campo}_requerido", $"El campo {campo} es obligatorio.", 400);
+        }
+
+        if (limpio.Length > largoMaximo)
+        {
+            throw new ErrorDominio(
+                $"{campo}_muy_largo", $"El campo {campo} no puede superar los {largoMaximo} caracteres.", 400);
+        }
+
+        return limpio;
+    }
+
+    private static OfertaListado Proyectar(Oferta o, IReadOnlyList<int> idsListas) => new(
+        o.Id, o.Nombre, o.IdEmpresa, o.IdArticulo, o.IdGrupo, o.IdCategoria,
+        o.FechaDesde, o.FechaHasta, o.HoraDesde, o.HoraHasta,
+        o.DiasSemana is null ? Array.Empty<int>() : o.DiasSemana.Select(d => (int)d).ToArray(),
+        o.CantidadMinima, o.PrecioUnitario, o.Porcentaje, o.ImporteFijo,
+        o.Prioridad, o.Acumulable, o.Activo, idsListas);
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -61,10 +61,9 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<NumeracionArticulo> NumeracionesArticulos => Set<NumeracionArticulo>();
     public DbSet<Precio> Precios => Set<Precio>();
 
-    // stage-4-ofertas, Slice 1 (schema/domain foundation, DB CHANGE GATE aprobado
-    // 2026-08-03): mismo trámite que articulos/precios en stage-3 Slice 1 — modelo adelantado
-    // a la migración, sin DbSet en IWaysDbContext todavía (ningún caso de uso de Application
-    // los consume en este lote; ServicioDeOfertas llega en la Slice 2).
+    // stage-4-ofertas, Slice 2: ServicioDeOfertas es el primer consumidor de Application —
+    // los dos DbSet ya están expuestos en IWaysDbContext (Slice 1 solo adelantaba el modelo a
+    // la migración, sin consumidor todavía).
     public DbSet<Oferta> Ofertas => Set<Oferta>();
     public DbSet<OfertaLista> OfertasListas => Set<OfertaLista>();
 

--- a/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
+++ b/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
@@ -1,0 +1,444 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Ofertas;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.Application.Tests.Ofertas;
+
+/// <summary>
+/// <see cref="ServicioDeOfertas"/> sobre el proveedor InMemory.
+///
+/// <see cref="ServicioDeOfertas.CrearAsync"/> COMPLETO (round-trip persistido) NO se cubre acá a
+/// propósito: envuelve el INSERT en <c>Database.BeginTransactionAsync</c> (doc-comment de la
+/// clase) — el proveedor InMemory no lo soporta, mismo motivo por el que
+/// <c>ServicioDeArticulosTests</c> tampoco cubre <c>ServicioDeArticulos.CrearAsync</c> completo.
+/// Todas las validaciones de este archivo (incl. las cinco guardas de <c>ReglaDeOfertas</c> y
+/// los pre-chequeos de referencia) corren ANTES de abrir esa transacción, así que sí son
+/// alcanzables acá; el alta de punta a punta se prueba contra Postgres real en
+/// <c>OfertasEndpointsTests</c> (Ways.IntegrationTests).
+///
+/// <see cref="ServicioDeOfertas.ActualizarAsync"/> SÍ corre sin transacción explícita (el
+/// replace-set de <c>ofertas_listas</c> entra en UN solo <c>SaveChangesAsync</c>) — se cubre
+/// completo acá, incluido el reemplazo del subconjunto de listas.
+/// </summary>
+public class ServicioDeOfertasTests
+{
+    private static readonly DateTimeOffset Ahora = new(2026, 8, 4, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int? idTenant) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => 999;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    private static WaysDbContext CrearContexto(string nombreDeBase, ITenantActual tenantActual) =>
+        new(new DbContextOptionsBuilder<WaysDbContext>().UseInMemoryDatabase(nombreDeBase).Options, tenantActual);
+
+    private static ServicioDeOfertas CrearServicio(string nombreDeBase, int idTenant) =>
+        new(
+            CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, idTenant)),
+            new RelojFijo(Ahora),
+            new ContextoFijo(idTenant));
+
+    private static async Task<int> SembrarGrupoAsync(string nombreDeBase, int idTenant, string nombre = "Gaseosas")
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var grupo = new Grupo { IdTenant = idTenant, Nombre = nombre, CreatedAt = Ahora, UpdatedAt = Ahora };
+        siembra.Grupos.Add(grupo);
+        await siembra.SaveChangesAsync();
+
+        return grupo.Id;
+    }
+
+    private static async Task<int> SembrarListaAsync(string nombreDeBase, int idTenant, string nombre = "General")
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = idTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+            CreatedAt = Ahora, UpdatedAt = Ahora
+        };
+        siembra.ListasPrecio.Add(lista);
+        await siembra.SaveChangesAsync();
+
+        return lista.Id;
+    }
+
+    private static async Task<int> SembrarEmpresaAsync(string nombreDeBase, int idTenant)
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var empresa = new Empresa { IdTenant = idTenant, RazonSocial = "Empresa de prueba", CreatedAt = Ahora, UpdatedAt = Ahora };
+        siembra.Empresas.Add(empresa);
+        await siembra.SaveChangesAsync();
+
+        return empresa.Id;
+    }
+
+    private static async Task<Oferta> SembrarOfertaAsync(
+        string nombreDeBase, int idTenant, int idGrupo, string nombre = "2x1 Verano")
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var oferta = new Oferta
+        {
+            IdTenant = idTenant,
+            Nombre = nombre,
+            IdGrupo = idGrupo,
+            Porcentaje = 10m,
+            CreatedAt = Ahora,
+            UpdatedAt = Ahora
+        };
+        siembra.Ofertas.Add(oferta);
+        await siembra.SaveChangesAsync();
+
+        return oferta;
+    }
+
+    private static AltaOferta AltaValida(int idGrupo, IReadOnlyList<int>? idsListas = null) => new(
+        Nombre: "2x1 Verano",
+        IdEmpresa: null,
+        IdArticulo: null,
+        IdGrupo: idGrupo,
+        IdCategoria: null,
+        FechaDesde: null,
+        FechaHasta: null,
+        HoraDesde: null,
+        HoraHasta: null,
+        DiasSemana: null,
+        CantidadMinima: null,
+        PrecioUnitario: null,
+        Porcentaje: 10m,
+        ImporteFijo: null,
+        Prioridad: 0,
+        Acumulable: false,
+        IdsListas: idsListas);
+
+    private static EdicionOferta EdicionValida(int idGrupo, IReadOnlyList<int>? idsListas = null) => new(
+        Nombre: "2x1 Verano editada",
+        IdEmpresa: null,
+        IdArticulo: null,
+        IdGrupo: idGrupo,
+        IdCategoria: null,
+        FechaDesde: null,
+        FechaHasta: null,
+        HoraDesde: null,
+        HoraHasta: null,
+        DiasSemana: null,
+        CantidadMinima: null,
+        PrecioUnitario: null,
+        Porcentaje: 15m,
+        ImporteFijo: null,
+        Prioridad: 1,
+        Acumulable: true,
+        IdsListas: idsListas,
+        Activo: true);
+
+    // ---- required-field validation ----------------------------------------------------------
+
+    [Fact]
+    public async Task CrearSinNombreEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { Nombre = "   " };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("nombre_requerido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    // ---- spec: Domain guard rejects invalid shapes before the database -----------------------
+
+    [Fact]
+    public async Task CrearSinNingunAlcanceEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo: 0) with { IdGrupo = null };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("oferta_alcance_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConDosAlcancesEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { IdCategoria = 999 };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("oferta_alcance_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearSinNingunBeneficioEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { Porcentaje = null };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("oferta_beneficio_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConDosBeneficiosEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { ImporteFijo = 5m };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("oferta_beneficio_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConCantidadMinimaCeroEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { CantidadMinima = 0m };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("cantidad_minima_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConVentanaDeFechasInvertidaEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with
+        {
+            FechaDesde = new DateOnly(2026, 8, 10),
+            FechaHasta = new DateOnly(2026, 8, 1)
+        };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("ventana_de_oferta_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConDiaDeSemanaFueraDeRangoEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { DiasSemana = [8] };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("dias_semana_invalidos", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    // ---- spec: Invalid scope reference maps to 400 -------------------------------------------
+
+    [Fact]
+    public async Task CrearConIdGrupoInexistenteEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo: 999_999);
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("referencia_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    /// <summary>El filtro de EF ya deja afuera un grupo de OTRO tenant, así que da el mismo 400
+    /// que "no existe" — misma paridad que <c>ServicioDeArticulosTests.CrearConIdAreaDeOtroTenantEsRechazado</c>.</summary>
+    [Fact]
+    public async Task CrearConIdGrupoDeOtroTenantEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupoDeOtroTenant = await SembrarGrupoAsync(nombreDeBase, idTenant: 2);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupoDeOtroTenant);
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("referencia_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CrearConIdEmpresaDeOtroTenantEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var idEmpresaDeOtroTenant = await SembrarEmpresaAsync(nombreDeBase, idTenant: 2);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo) with { IdEmpresa = idEmpresaDeOtroTenant };
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("referencia_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    // ---- spec: Junction row references must belong to the same tenant ------------------------
+
+    [Fact]
+    public async Task CrearConIdListaDeOtroTenantEsRechazado()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var idListaDeOtroTenant = await SembrarListaAsync(nombreDeBase, idTenant: 2);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var datos = AltaValida(idGrupo, idsListas: [idListaDeOtroTenant]);
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.CrearAsync(datos));
+
+        Assert.Equal("referencia_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    // ---- ADR-8: cross-tenant 404 --------------------------------------------------------------
+
+    [Fact]
+    public async Task ObtenerUnaOfertaDeOtroTenantDevuelve404()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 2);
+        var ajena = await SembrarOfertaAsync(nombreDeBase, idTenant: 2, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.ObtenerAsync(ajena.Id));
+
+        Assert.Equal("no_encontrado", error.Codigo);
+        Assert.Equal(404, error.EstadoHttp);
+    }
+
+    // ---- ActualizarAsync: cubierto completo (sin transacción explícita) -----------------------
+
+    [Fact]
+    public async Task EditarUnaOfertaFunciona()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo));
+
+        Assert.Equal("2x1 Verano editada", editada.Nombre);
+        Assert.Equal(15m, editada.Porcentaje);
+        Assert.Equal(1, editada.Prioridad);
+        Assert.True(editada.Acumulable);
+    }
+
+    /// <summary>Spec: Multi-Lista Targeting — reemplaza el subconjunto entero (delete-all +
+    /// insert en un solo <c>SaveChangesAsync</c>), no un delta.</summary>
+    [Fact]
+    public async Task EditarReemplazaElSubconjuntoDeListas()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var idListaUno = await SembrarListaAsync(nombreDeBase, idTenant: 1, "Lista 1");
+        var idListaDos = await SembrarListaAsync(nombreDeBase, idTenant: 1, "Lista 2");
+        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idListaUno]));
+        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idListaDos]));
+
+        Assert.Equal([idListaDos], editada.IdsListas);
+
+        await using var lectura = CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, 1));
+        var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == oferta.Id).ToListAsync();
+        Assert.Single(filas);
+        Assert.Equal(idListaDos, filas[0].IdListaPrecio);
+    }
+
+    [Fact]
+    public async Task EditarConIdsListasDuplicadosInsertaUnaSolaFila()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var idLista = await SembrarListaAsync(nombreDeBase, idTenant: 1);
+        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idLista, idLista]));
+
+        Assert.Equal([idLista], editada.IdsListas);
+    }
+
+    [Fact]
+    public async Task ObtenerUnaOfertaSinFilasDeListasDevuelveConjuntoVacio()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        var detalle = await servicio.ObtenerAsync(oferta.Id);
+
+        Assert.Empty(detalle.IdsListas);
+    }
+
+    [Fact]
+    public async Task EliminarUnaOfertaFunciona()
+    {
+        var nombreDeBase = Guid.NewGuid().ToString();
+        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
+        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
+        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
+
+        await servicio.EliminarAsync(oferta.Id);
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.ObtenerAsync(oferta.Id));
+        Assert.Equal("no_encontrado", error.Codigo);
+    }
+}

--- a/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
+++ b/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
@@ -35,6 +35,16 @@ namespace Ways.Application.Tests.Ofertas;
 /// y <c>EditarConIdsListasDuplicadosPersisteUnaSolaFila</c>. Las validaciones que corren ANTES de
 /// abrir esa transacción (las cinco guardas de <c>ReglaDeOfertas</c>, los pre-chequeos de
 /// referencia) siguen alcanzables acá y NO se movieron.
+///
+/// <see cref="ServicioDeOfertas.EliminarAsync"/> TAMPOCO se cubre acá desde el fix de judgment-day
+/// ronda 2 (item 1, CRITICAL): ahora también abre <c>Database.BeginTransactionAsync</c> + toma el
+/// mismo <c>pg_advisory_xact_lock</c> por oferta que <see cref="ServicioDeOfertas.ActualizarAsync"/>
+/// (para serializarse contra un PUT concurrente y evitar el ghost edit) — mismo
+/// "transaction-blocked-provider caveat" de arriba. La prueba que vivía acá
+/// (<c>EliminarUnaOfertaFunciona</c>) ya estaba duplicada por
+/// <c>OfertasEndpointsTests.UnAdminCreaYDaDeBajaUnaOferta</c> (Postgres real, alta + baja + 404 +
+/// ausencia en el listado), así que se retira de acá sin reemplazo — esa prueba de integración
+/// sigue cubriendo el mismo camino.
 /// </summary>
 public class ServicioDeOfertasTests
 {
@@ -386,19 +396,5 @@ public class ServicioDeOfertasTests
         var detalle = await servicio.ObtenerAsync(oferta.Id);
 
         Assert.Empty(detalle.IdsListas);
-    }
-
-    [Fact]
-    public async Task EliminarUnaOfertaFunciona()
-    {
-        var nombreDeBase = Guid.NewGuid().ToString();
-        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
-        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
-        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
-
-        await servicio.EliminarAsync(oferta.Id);
-
-        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.ObtenerAsync(oferta.Id));
-        Assert.Equal("no_encontrado", error.Codigo);
     }
 }

--- a/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
+++ b/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
@@ -23,9 +23,18 @@ namespace Ways.Application.Tests.Ofertas;
 /// alcanzables acá; el alta de punta a punta se prueba contra Postgres real en
 /// <c>OfertasEndpointsTests</c> (Ways.IntegrationTests).
 ///
-/// <see cref="ServicioDeOfertas.ActualizarAsync"/> SÍ corre sin transacción explícita (el
-/// replace-set de <c>ofertas_listas</c> entra en UN solo <c>SaveChangesAsync</c>) — se cubre
-/// completo acá, incluido el reemplazo del subconjunto de listas.
+/// <see cref="ServicioDeOfertas.ActualizarAsync"/> COMPLETO (round-trip persistido, incluido el
+/// reemplazo del subconjunto de listas) TAMPOCO se cubre acá desde el fix de judgment-day (item
+/// 1, stage-4-ofertas): ahora también envuelve el replace-set en
+/// <c>Database.BeginTransactionAsync</c> + un <c>pg_advisory_xact_lock</c> por oferta (mismo
+/// motivo/mismo "transaction-blocked-provider caveat" que <see cref="ServicioDeOfertas.CrearAsync"/>
+/// de arriba). Las tres pruebas de round-trip que vivían acá (edición básica de campos, reemplazo
+/// del subconjunto de listas, de-dup de <c>IdsListas</c> repetidos) se movieron a
+/// <c>OfertasEndpointsTests</c> (Ways.IntegrationTests, Postgres real) — ver
+/// <c>EditarActualizaCamposBasicosDeLaOferta</c>, <c>EditarReemplazaElSubconjuntoDeListasPersistido</c>
+/// y <c>EditarConIdsListasDuplicadosPersisteUnaSolaFila</c>. Las validaciones que corren ANTES de
+/// abrir esa transacción (las cinco guardas de <c>ReglaDeOfertas</c>, los pre-chequeos de
+/// referencia) siguen alcanzables acá y NO se movieron.
 /// </summary>
 public class ServicioDeOfertasTests
 {
@@ -360,60 +369,11 @@ public class ServicioDeOfertasTests
         Assert.Equal(404, error.EstadoHttp);
     }
 
-    // ---- ActualizarAsync: cubierto completo (sin transacción explícita) -----------------------
-
-    [Fact]
-    public async Task EditarUnaOfertaFunciona()
-    {
-        var nombreDeBase = Guid.NewGuid().ToString();
-        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
-        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
-        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
-
-        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo));
-
-        Assert.Equal("2x1 Verano editada", editada.Nombre);
-        Assert.Equal(15m, editada.Porcentaje);
-        Assert.Equal(1, editada.Prioridad);
-        Assert.True(editada.Acumulable);
-    }
-
-    /// <summary>Spec: Multi-Lista Targeting — reemplaza el subconjunto entero (delete-all +
-    /// insert en un solo <c>SaveChangesAsync</c>), no un delta.</summary>
-    [Fact]
-    public async Task EditarReemplazaElSubconjuntoDeListas()
-    {
-        var nombreDeBase = Guid.NewGuid().ToString();
-        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
-        var idListaUno = await SembrarListaAsync(nombreDeBase, idTenant: 1, "Lista 1");
-        var idListaDos = await SembrarListaAsync(nombreDeBase, idTenant: 1, "Lista 2");
-        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
-        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
-
-        await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idListaUno]));
-        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idListaDos]));
-
-        Assert.Equal([idListaDos], editada.IdsListas);
-
-        await using var lectura = CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, 1));
-        var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == oferta.Id).ToListAsync();
-        Assert.Single(filas);
-        Assert.Equal(idListaDos, filas[0].IdListaPrecio);
-    }
-
-    [Fact]
-    public async Task EditarConIdsListasDuplicadosInsertaUnaSolaFila()
-    {
-        var nombreDeBase = Guid.NewGuid().ToString();
-        var idGrupo = await SembrarGrupoAsync(nombreDeBase, idTenant: 1);
-        var idLista = await SembrarListaAsync(nombreDeBase, idTenant: 1);
-        var oferta = await SembrarOfertaAsync(nombreDeBase, idTenant: 1, idGrupo);
-        var servicio = CrearServicio(nombreDeBase, idTenant: 1);
-
-        var editada = await servicio.ActualizarAsync(oferta.Id, EdicionValida(idGrupo, idsListas: [idLista, idLista]));
-
-        Assert.Equal([idLista], editada.IdsListas);
-    }
+    // ---- ActualizarAsync: round-trip persistido movido a OfertasEndpointsTests (judgment-day,
+    // item 1) — ActualizarAsync ahora abre transacción explícita (pg_advisory_xact_lock por
+    // oferta), fuera del alcance del proveedor InMemory. Ver
+    // EditarActualizaCamposBasicosDeLaOferta, EditarReemplazaElSubconjuntoDeListasPersistido y
+    // EditarConIdsListasDuplicadosPersisteUnaSolaFila en Ways.IntegrationTests.
 
     [Fact]
     public async Task ObtenerUnaOfertaSinFilasDeListasDevuelveConjuntoVacio()

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// db-error-backstops (judgment-day ronda 2, item 4b, triage Judge B): coverage gap del arco
+/// <c>DbUpdateConcurrencyException</c> → 409 <c>edicion_concurrente</c> de
+/// <see cref="ManejadorDeErrores"/> — ninguna prueba existente lo ejercita, porque a diferencia de
+/// las demás ramas del switch (23505/23503/23514 con <c>InnerException PostgresException</c>) esta
+/// excepción no depende de Postgres para construirse: alcanza con instanciarla "a mano". No hay
+/// una clase de test dedicada a <see cref="ManejadorDeErrores"/> todavía (las demás ramas se
+/// prueban indirectamente, forzando la excepción real vía los distintos *BackstopTests) — vive acá
+/// unit-style, sin <c>WaysApiFixture</c> ni Postgres, porque <see cref="ManejadorDeErrores"/> vive
+/// en <c>Ways.Api</c> y este es el único proyecto de test con referencia a ese ensamblado.
+/// </summary>
+public class ManejadorDeErroresTests
+{
+    private sealed class ServicioDeProblemDetailsFalso : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Ultimo { get; private set; }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.FromResult(true);
+        }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task UnaDbUpdateConcurrencyExceptionSeTraduceA409EdicionConcurrente()
+    {
+        var servicioDeProblemDetails = new ServicioDeProblemDetailsFalso();
+        var manejador = new ManejadorDeErrores(servicioDeProblemDetails, NullLogger<ManejadorDeErrores>.Instance);
+        var contexto = new DefaultHttpContext();
+
+        var manejado = await manejador.TryHandleAsync(contexto, new DbUpdateConcurrencyException(), CancellationToken.None);
+
+        Assert.True(manejado);
+        Assert.Equal(StatusCodes.Status409Conflict, contexto.Response.StatusCode);
+
+        Assert.NotNull(servicioDeProblemDetails.Ultimo);
+        var problema = servicioDeProblemDetails.Ultimo!.ProblemDetails;
+        Assert.Equal(StatusCodes.Status409Conflict, problema.Status);
+        Assert.Equal("edicion_concurrente", problema.Extensions["codigo"]);
+    }
+}

--- a/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 using Ways.Application.Abstracciones; // ModoDeAcceso
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
@@ -365,7 +366,14 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
     }
 
     /// <summary>Spec: Junction rows restrict targeting, aplicado a la edición — el PUT reemplaza
-    /// por completo el subconjunto anterior.</summary>
+    /// por completo el subconjunto anterior.
+    ///
+    /// (judgment-day ronda 2, item 3, triage Judge A) Antes solo aserteaba el <c>IdsListas</c>
+    /// ECOADO en la respuesta del PUT — eso prueba lo que <c>Proyectar</c> devuelve, no lo que
+    /// quedó escrito en <c>ofertas_listas</c>. Agrega una lectura independiente de la fila (GET +
+    /// consulta directa a la DB, mismo patrón que
+    /// <c>EditarConIdsListasVacioExplicitoRevierteAlAlcanceDeTodasLasListas</c>) para asertar el
+    /// estado PERSISTIDO, no el eco.</summary>
     [Fact]
     public async Task EditarReemplazaElSubconjuntoDeListasPersistido()
     {
@@ -382,6 +390,13 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
         var editada = await respuestaEdicion.Content.ReadFromJsonAsync<OfertaListado>();
         Assert.Equal([idListaDos], editada!.IdsListas);
+
+        var detalle = await admin.GetFromJsonAsync<OfertaListado>($"/api/ofertas/{creada.Id}");
+        Assert.Equal([idListaDos], detalle!.IdsListas);
+
+        await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+        var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
+        Assert.Equal([idListaDos], filas.Select(f => f.IdListaPrecio));
     }
 
     /// <summary>Movido desde <c>ServicioDeOfertasTests.EditarUnaOfertaFunciona</c> (judgment-day,
@@ -538,7 +553,14 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
     /// oferta — nunca un 500, y el conjunto final persistido es EXACTAMENTE el target de UNO de
     /// los dos llamadores (el último committer), nunca la unión de ambos ni un conjunto vacío por
     /// accidente. Repetido 3 veces con estado aislado por iteración (tenant/oferta nuevos) para
-    /// probar estabilidad — no un resultado de una sola corrida con suerte.</summary>
+    /// probar estabilidad — no un resultado de una sola corrida con suerte.
+    ///
+    /// (judgment-day ronda 2, item 2) Tolerar 409 acá era un falso negativo: el lock serializa de
+    /// verdad, así que las DOS escrituras SIEMPRE tienen que suceder (2×200) — exactamente lo que
+    /// ya asegura <c>DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasSeSerializanYAmbosSuceden</c>
+    /// para el caso de targets iguales. Un 409 acá indicaría que el reemplazo del perdedor volvió
+    /// a competir contra <c>pk_ofertas_listas</c> en vez de encontrar el estado ya comiteado tras
+    /// el lock — señal de que el fix se rompió, no un resultado válido a tolerar.</summary>
     [Fact]
     public async Task DosPutsConcurrentesConTargetsDistintosSeSerializanYElUltimoCommitPersisteExactamenteUnTarget()
     {
@@ -574,12 +596,9 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
             var estados = respuestas.Select(r => r.StatusCode).ToList();
 
             Assert.True(interceptor.Participantes >= 2, $"iteración={iteracion} participantes={interceptor.Participantes}");
-            Assert.DoesNotContain(HttpStatusCode.InternalServerError, estados);
-            // Serializado (ambos 200) o, si el perdedor todavía choca contra algo, un 409
-            // traducido — nunca un 500 ni un resultado sin traducir.
-            Assert.All(estados, e => Assert.True(
-                e is HttpStatusCode.OK or HttpStatusCode.Conflict,
-                $"iteración={iteracion} estado inesperado={e}"));
+            // (judgment-day ronda 2, item 2) Estrictamente las DOS 200 — el lock serializa de
+            // verdad, así que tolerar un 409 acá esconde una regresión (ver doc-comment).
+            Assert.All(estados, e => Assert.Equal(HttpStatusCode.OK, e));
 
             await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
             var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
@@ -588,6 +607,107 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
             // filas) — exactamente UNA fila, y es el target de A o el de B, nunca la previa.
             Assert.Single(filas);
             Assert.Contains(filas[0].IdListaPrecio, new[] { idListaA, idListaB });
+        }
+    }
+
+    /// <summary>db-error-backstops (judgment-day ronda 2, item 4a, triage Judge B): coverage gap
+    /// del backstop <c>pk_ofertas_listas</c> — hasta acá la única prueba de esta PK era la carrera
+    /// serializada por el lock (que nunca la alcanza, por diseño). Mismo patrón que
+    /// <c>ArticulosEndpointsTests.UnaFilaDeSubsetDuplicadaInsertadaPorFueraDelServicioViolaLaPk</c>:
+    /// INSERT crudo por SQL que bypasea <c>ServicioDeOfertas</c> por completo para forzar el
+    /// duplicado <c>(id_oferta, id_lista_precio)</c> directamente contra la constraint de
+    /// esquema.</summary>
+    [Fact]
+    public async Task UnaFilaDeOfertasListasDuplicadaInsertadaPorFueraDelServicioViolaLaPk()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnaFilaDeOfertasListasDuplicadaInsertadaPorFueraDelServicioViolaLaPk));
+        var idLista = await SembrarListaAsync(idTenant, "Lista backstop");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo, idsListas: [idLista]);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO ofertas_listas (id_oferta, id_lista_precio, id_tenant) VALUES ($1, $2, $3)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = creada.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idLista });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("pk_ofertas_listas", excepcion.ConstraintName);
+    }
+
+    /// <summary>NUEVO (judgment-day ronda 2, item 1 — CRITICAL): PUT y DELETE concurrentes sobre
+    /// la MISMA oferta. Antes del fix, <c>EliminarAsync</c> no abría transacción ni tomaba lock —
+    /// un PUT podía leer la oferta viva, un DELETE concurrente comiteaba primero fuera de
+    /// cualquier lock, y el PUT (que nunca revalidaba <c>DeletedAt</c>) terminaba pisando los
+    /// campos editables sobre una fila YA ELIMINADA: ghost edit, <c>deleted_at</c> seteado a la
+    /// vez que los campos/targeting frescos del PUT persistidos con un 200.
+    ///
+    /// Reusa <c>InterceptorDeRendezVousOfertas</c> para forzar DELETE-gana-el-lock de forma
+    /// DETERMINÍSTICA (no solo "concurrencia genuina"): el punto de rendezvous del DELETE es su
+    /// <c>BuscarAsync</c> POST-lock (<see cref="ServicioDeOfertas.EliminarAsync"/> ya no tiene
+    /// ninguna otra consulta a <c>ofertas</c>) — para que el DELETE llegue ahí, YA tiene que haber
+    /// tomado el <c>pg_advisory_xact_lock</c> primero. El punto de rendezvous del PUT es su
+    /// <c>BuscarAsync</c> PRE-transacción (antes de siquiera intentar el lock). El interceptor no
+    /// libera a ninguno de los dos hasta que AMBOS llegaron a su respectivo punto, así que,
+    /// estructuralmente, el DELETE siempre tiene el lock tomado ANTES de que el PUT llegue a
+    /// pedirlo — el PUT SIEMPRE espera detrás del DELETE, nunca al revés. Estable por
+    /// construcción, no por suerte de scheduling: se corre 3 veces (estado aislado por iteración)
+    /// para confirmarlo, no para "promediar" un resultado probabilístico.</summary>
+    [Fact]
+    public async Task UnPutYUnDeleteConcurrentesNuncaProducenUnGhostEdit()
+    {
+        for (var iteracion = 0; iteracion < 3; iteracion++)
+        {
+            var nombreDeCorrida = $"{nameof(UnPutYUnDeleteConcurrentesNuncaProducenUnGhostEdit)}-{iteracion}";
+            var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nombreDeCorrida);
+            var idListaPrevia = await SembrarListaAsync(idTenant, "Lista previa");
+            var idListaNueva = await SembrarListaAsync(idTenant, "Lista nueva");
+
+            using var admin0 = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+            var creada = await CrearOfertaAsync(admin0, idGrupo, idsListas: [idListaPrevia]);
+
+            var edicion = EdicionDesde(creada, idsListas: [idListaNueva]) with { Nombre = "2x1 Verano editada" };
+
+            using var gate = new CountdownEvent(2);
+            var interceptor = new InterceptorDeRendezVousOfertas(gate);
+            await using var factory = fixture.WithWebHostBuilder(builder =>
+                builder.ConfigureServices(services =>
+                    services.AddDbContext<WaysDbContext>((_, options) =>
+                        options.AddInterceptors(interceptor))));
+
+            using var admin = factory.CreateClient();
+            var login = await admin.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailAdmin, passwordAdmin));
+            Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+            var tareaPut = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+            var tareaDelete = admin.DeleteAsync($"/api/ofertas/{creada.Id}");
+
+            await Task.WhenAll(tareaPut, tareaDelete);
+            var respuestaPut = await tareaPut;
+            var respuestaDelete = await tareaDelete;
+
+            Assert.True(interceptor.Participantes >= 2, $"iteración={iteracion} participantes={interceptor.Participantes}");
+
+            // El DELETE siempre gana la carrera del lock (ver doc-comment de arriba) — el PUT ve
+            // la oferta ya eliminada y responde el 404 uniforme, nunca un 200 con campos pisados.
+            Assert.Equal(HttpStatusCode.NoContent, respuestaDelete.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, respuestaPut.StatusCode);
+
+            await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+            var ofertaFinal = await lectura.Ofertas.IgnoreQueryFilters(["BajaLogica"]).FirstAsync(o => o.Id == creada.Id);
+            var filasFinal = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
+
+            // Estado final: soft-deleted, con los campos y el targeting ORIGINALES — el PUT no
+            // tocó absolutamente nada, ni un campo ni una fila de ofertas_listas.
+            Assert.NotNull(ofertaFinal.DeletedAt);
+            Assert.Equal("2x1 Verano", ofertaFinal.Nombre);
+            Assert.Equal([idListaPrevia], filasFinal.Select(f => f.IdListaPrecio));
         }
     }
 

--- a/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
@@ -1,7 +1,10 @@
+using System.Data.Common;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones; // ModoDeAcceso
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
@@ -11,6 +14,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 using Ways.Infrastructure.Seguridad;
 
 namespace Ways.IntegrationTests;
@@ -20,8 +24,16 @@ namespace Ways.IntegrationTests;
 /// <c>OfertasEndpoints</c> punta a punta contra Postgres real — ABM completo con la policy
 /// <c>GestionDeCatalogo</c> (admin-only), el 404 uniforme cross-tenant (ADR-8), el estado
 /// persistido del targeting de listas (spec: Multi-Lista Targeting via ofertas_listas), la
-/// carrera genuina de <c>pk_ofertas_listas</c> (design: Backstop Map) y los FK smoke tests de
-/// las referencias nuevas de esta etapa.
+/// serialización real del replace-set de <c>ofertas_listas</c> bajo PUT concurrentes
+/// (judgment-day, item 1 — <c>pg_advisory_xact_lock</c> por oferta, mismo mecanismo que
+/// <see cref="Ways.Application.Precios.ServicioDePrecios"/>) y los FK smoke tests de las
+/// referencias nuevas de esta etapa.
+///
+/// (judgment-day, item 1) <see cref="ServicioDeOfertas.ActualizarAsync"/> completo (edición de
+/// campos básicos, reemplazo del subconjunto de listas, de-dup de <c>IdsListas</c>) se cubre
+/// ACÁ desde el fix del lock — antes vivía parcialmente en <c>ServicioDeOfertasTests</c>
+/// (Ways.Application.Tests, proveedor InMemory), que ya no lo soporta porque
+/// <c>ActualizarAsync</c> ahora abre transacción explícita.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -372,23 +384,129 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal([idListaDos], editada!.IdsListas);
     }
 
-    // ---- task 2.9: pk_ofertas_listas race -------------------------------------------------------
-
-    /// <summary>design: Backstop Map — <c>pk_ofertas_listas</c> es la única superficie
-    /// genuinamente racy de esta etapa. Dos PUT concurrentes reemplazando el MISMO conjunto de
-    /// listas de la MISMA oferta: sin ningún lock que serialice la carrera por construcción
-    /// (mismo criterio que <c>ArticulosEndpointsTests.LaCreacionConcurrenteConElMismoCodigoDeBarraDaExactamenteUnGanador</c>)
-    /// — exactamente un ganador (200), el perdedor un 409 traducido, nunca un 500.</summary>
+    /// <summary>Movido desde <c>ServicioDeOfertasTests.EditarUnaOfertaFunciona</c> (judgment-day,
+    /// item 1): <c>ActualizarAsync</c> ahora abre transacción explícita, fuera del alcance del
+    /// proveedor InMemory. Cubre la edición de campos básicos sin tocar el targeting de
+    /// listas.</summary>
     [Fact]
-    public async Task DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasDanExactamenteUnGanador()
+    public async Task EditarActualizaCamposBasicosDeLaOferta()
     {
-        var (idTenant, idGrupo, mailAdmin, passwordAdmin) =
-            await AprovisionarTenantAsync(nameof(DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasDanExactamenteUnGanador));
-        var idLista = await SembrarListaAsync(idTenant, "Lista carrera");
+        var (_, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(EditarActualizaCamposBasicosDeLaOferta));
         using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
 
         var creada = await CrearOfertaAsync(admin, idGrupo);
+        var edicion = EdicionDesde(creada, idsListas: null) with
+        {
+            Nombre = "2x1 Verano editada",
+            Porcentaje = 15m,
+            Prioridad = 1,
+            Acumulable = true
+        };
+
+        var respuesta = await admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var editada = await respuesta.Content.ReadFromJsonAsync<OfertaListado>();
+        Assert.Equal("2x1 Verano editada", editada!.Nombre);
+        Assert.Equal(15m, editada.Porcentaje);
+        Assert.Equal(1, editada.Prioridad);
+        Assert.True(editada.Acumulable);
+    }
+
+    /// <summary>Movido desde <c>ServicioDeOfertasTests.EditarConIdsListasDuplicadosInsertaUnaSolaFila</c>
+    /// (judgment-day, item 1) — mismo motivo que <c>EditarActualizaCamposBasicosDeLaOferta</c>.</summary>
+    [Fact]
+    public async Task EditarConIdsListasDuplicadosPersisteUnaSolaFila()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(EditarConIdsListasDuplicadosPersisteUnaSolaFila));
+        var idLista = await SembrarListaAsync(idTenant, "Lista");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo);
+        var edicion = EdicionDesde(creada, idsListas: [idLista, idLista]);
+
+        var respuesta = await admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var editada = await respuesta.Content.ReadFromJsonAsync<OfertaListado>();
+        Assert.Equal([idLista], editada!.IdsListas);
+    }
+
+    /// <summary>Spec: "No junction rows targets every lista", aplicado a la edición — revertir
+    /// una oferta previamente restringida a un subconjunto enviando <c>IdsListas: []</c>
+    /// explícito borra las filas de targeting existentes y no inserta ninguna nueva (orchestrator
+    /// triage, judgment-day item 3): el estado persistido vuelve a "aplica a todas las
+    /// listas".</summary>
+    [Fact]
+    public async Task EditarConIdsListasVacioExplicitoRevierteAlAlcanceDeTodasLasListas()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(EditarConIdsListasVacioExplicitoRevierteAlAlcanceDeTodasLasListas));
+        var idLista = await SembrarListaAsync(idTenant, "Lista restringida");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo, idsListas: [idLista]);
+        Assert.Equal([idLista], creada.IdsListas);
+
+        var edicion = EdicionDesde(creada, idsListas: Array.Empty<int>());
+        var respuesta = await admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var editada = await respuesta.Content.ReadFromJsonAsync<OfertaListado>();
+        Assert.Empty(editada!.IdsListas);
+
+        var detalle = await admin.GetFromJsonAsync<OfertaListado>($"/api/ofertas/{creada.Id}");
+        Assert.Empty(detalle!.IdsListas);
+
+        await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+        var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
+        Assert.Empty(filas);
+    }
+
+    // ---- task 2.9 / judgment-day item 1: pk_ofertas_listas race, serializada por el lock -------
+
+    /// <summary>design: Backstop Map — <c>pk_ofertas_listas</c> es la única superficie
+    /// genuinamente racy de esta etapa.
+    ///
+    /// <b>Reescrito en judgment-day (item 1), mismo criterio que
+    /// <c>PreciosEndpointsTests.LaCreacionConcurrenteDeDosPrimerosPreciosSeSerializaYAmbosSuceden</c>:</b>
+    /// antes de este fix, dos PUT concurrentes reemplazando el MISMO conjunto de listas de la
+    /// MISMA oferta competían sin ningún lock que serializara la carrera por construcción — un
+    /// ganador (200) y un perdedor (409 <c>oferta_lista_duplicada</c>). Ahora
+    /// <c>ServicioDeOfertas.ActualizarAsync</c> toma un <c>pg_advisory_xact_lock</c>
+    /// determinístico por oferta ANTES de releer <c>ofertas_listas</c> — el segundo llamador
+    /// espera el lock y, al retomarlo, ve el estado YA COMITEADO por el primero, así que hace un
+    /// reemplazo LIMPIO (delete-then-insert del MISMO par) en vez de competir contra el índice:
+    /// las dos escrituras se serializan de verdad y las DOS suceden (2×200), nunca un 409 ni un
+    /// 500. El backstop de esquema (<c>pk_ofertas_listas</c>, <c>ManejadorDeErrores</c> → 409
+    /// <c>oferta_lista_duplicada</c>) se mantiene igual como defensa de esquema — solo queda
+    /// alcanzable por una escritura cruda/fuera de banda que bypasee el servicio.
+    ///
+    /// El rendezvous con <c>InterceptorDeRendezVousOfertas</c> fuerza que las dos transacciones
+    /// arranquen genuinamente solapadas — sin esto, el pool/JIT ya calientes podrían dejar que la
+    /// primera termine antes de que la segunda arranque, y el lock nunca llegaría a contenderse
+    /// de verdad.</summary>
+    [Fact]
+    public async Task DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasSeSerializanYAmbosSuceden()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasSeSerializanYAmbosSuceden));
+        var idLista = await SembrarListaAsync(idTenant, "Lista carrera");
+
+        using var admin0 = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+        var creada = await CrearOfertaAsync(admin0, idGrupo);
         var edicion = EdicionDesde(creada, idsListas: [idLista]);
+
+        using var gate = new CountdownEvent(2);
+        var interceptor = new InterceptorDeRendezVousOfertas(gate);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) =>
+                    options.AddInterceptors(interceptor))));
+
+        using var admin = factory.CreateClient();
+        var login = await admin.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailAdmin, passwordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
 
         var tareaA = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
         var tareaB = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
@@ -396,20 +514,129 @@ public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
         var respuestas = await Task.WhenAll(tareaA, tareaB);
         var estados = respuestas.Select(r => r.StatusCode).ToList();
 
-        Assert.DoesNotContain(HttpStatusCode.InternalServerError, estados);
-        Assert.Contains(HttpStatusCode.OK, estados);
-        Assert.Contains(HttpStatusCode.Conflict, estados);
-
-        var respuestaConflicto = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
-        var problema = await respuestaConflicto.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal("oferta_lista_duplicada", problema.GetProperty("codigo").GetString());
+        Assert.True(interceptor.Participantes >= 2, $"participantes={interceptor.Participantes}");
+        Assert.All(estados, e => Assert.Equal(HttpStatusCode.OK, e));
 
         // El estado final es consistente: exactamente una fila de targeting sobrevive, no dos
-        // ni cero (el ganador la insertó, el perdedor nunca comiteó la suya).
+        // ni cero — el último committer reemplaza limpio, nunca una unión ni un DELETE fantasma.
         await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
         var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
         Assert.Single(filas);
         Assert.Equal(idLista, filas[0].IdListaPrecio);
+    }
+
+    /// <summary>NUEVO (judgment-day, item 3): dos PUT concurrentes reemplazando el conjunto de
+    /// listas de la MISMA oferta con targets DISTINTOS (A → lista uno, B → lista dos), sobre una
+    /// oferta PRE-POBLADA con un subconjunto previo. Antes del fix (item 1), esto era exactamente
+    /// el hallazgo CRITICAL confirmado por los dos jueces: sin ningún lock, las dos lecturas de
+    /// <c>filasActuales</c> partían del mismo estado previo, y el orden de commit podía dejar la
+    /// UNIÓN de ambos targets persistida (lost update silencioso) o, si las dos intentaban borrar
+    /// la misma fila previa, un <c>DbUpdateConcurrencyException</c> sin traducir (500 crudo) en
+    /// el perdedor.
+    ///
+    /// Con el fix: las dos escrituras se serializan por el <c>pg_advisory_xact_lock</c> por
+    /// oferta — nunca un 500, y el conjunto final persistido es EXACTAMENTE el target de UNO de
+    /// los dos llamadores (el último committer), nunca la unión de ambos ni un conjunto vacío por
+    /// accidente. Repetido 3 veces con estado aislado por iteración (tenant/oferta nuevos) para
+    /// probar estabilidad — no un resultado de una sola corrida con suerte.</summary>
+    [Fact]
+    public async Task DosPutsConcurrentesConTargetsDistintosSeSerializanYElUltimoCommitPersisteExactamenteUnTarget()
+    {
+        for (var iteracion = 0; iteracion < 3; iteracion++)
+        {
+            var nombreDeCorrida = $"{nameof(DosPutsConcurrentesConTargetsDistintosSeSerializanYElUltimoCommitPersisteExactamenteUnTarget)}-{iteracion}";
+            var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nombreDeCorrida);
+            var idListaPrevia = await SembrarListaAsync(idTenant, "Lista previa");
+            var idListaA = await SembrarListaAsync(idTenant, "Lista target A");
+            var idListaB = await SembrarListaAsync(idTenant, "Lista target B");
+
+            using var admin0 = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+            var creada = await CrearOfertaAsync(admin0, idGrupo, idsListas: [idListaPrevia]);
+
+            var edicionA = EdicionDesde(creada, idsListas: [idListaA]);
+            var edicionB = EdicionDesde(creada, idsListas: [idListaB]);
+
+            using var gate = new CountdownEvent(2);
+            var interceptor = new InterceptorDeRendezVousOfertas(gate);
+            await using var factory = fixture.WithWebHostBuilder(builder =>
+                builder.ConfigureServices(services =>
+                    services.AddDbContext<WaysDbContext>((_, options) =>
+                        options.AddInterceptors(interceptor))));
+
+            using var admin = factory.CreateClient();
+            var login = await admin.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailAdmin, passwordAdmin));
+            Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+            var tareaA = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicionA);
+            var tareaB = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicionB);
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+            var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+            Assert.True(interceptor.Participantes >= 2, $"iteración={iteracion} participantes={interceptor.Participantes}");
+            Assert.DoesNotContain(HttpStatusCode.InternalServerError, estados);
+            // Serializado (ambos 200) o, si el perdedor todavía choca contra algo, un 409
+            // traducido — nunca un 500 ni un resultado sin traducir.
+            Assert.All(estados, e => Assert.True(
+                e is HttpStatusCode.OK or HttpStatusCode.Conflict,
+                $"iteración={iteracion} estado inesperado={e}"));
+
+            await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+            var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
+
+            // Nunca la unión de los dos targets (2 filas) ni un conjunto vacío por accidente (0
+            // filas) — exactamente UNA fila, y es el target de A o el de B, nunca la previa.
+            Assert.Single(filas);
+            Assert.Contains(filas[0].IdListaPrecio, new[] { idListaA, idListaB });
+        }
+    }
+
+    /// <summary>Retiene la primera consulta EF a <c>ofertas</c> (la lectura de
+    /// <c>ServicioDeOfertas.BuscarAsync</c>, el primer acceso a datos de <c>ActualizarAsync</c>,
+    /// ANTES de que abra su transacción y tome el <c>pg_advisory_xact_lock</c>) hasta que ambos
+    /// participantes llegaron — mismo mecanismo que
+    /// <c>PreciosEndpointsTests.InterceptorDeRendezVousListasPrecio</c>. El filtro excluye
+    /// <c>ofertas_listas</c> explícitamente porque su nombre de tabla comparte el prefijo
+    /// "ofertas".</summary>
+    private sealed class InterceptorDeRendezVousOfertas(CountdownEvent gate) : DbCommandInterceptor
+    {
+        private int _participantes;
+
+        public int Participantes => _participantes;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            EsperarSiCorresponde(command);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            EsperarSiCorresponde(command);
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        private void EsperarSiCorresponde(DbCommand command)
+        {
+            if (!command.CommandText.Contains("ofertas", StringComparison.OrdinalIgnoreCase) ||
+                command.CommandText.Contains("ofertas_listas", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _participantes) > 2)
+            {
+                return;
+            }
+
+            gate.Signal();
+
+            var senializo = gate.Wait(TimeSpan.FromSeconds(10));
+            Assert.True(senializo, "El rendezvous de InterceptorDeRendezVousOfertas no llegó a los 2 participantes a tiempo.");
+        }
     }
 
     // ---- task 2.10: FK smoke tests ---------------------------------------------------------------

--- a/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasEndpointsTests.cs
@@ -1,0 +1,511 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones; // ModoDeAcceso
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios; // SolicitudDeLogin
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Slice 2 (tasks 2.6-2.10, db-error-backstops skill): <c>ServicioDeOfertas</c>/
+/// <c>OfertasEndpoints</c> punta a punta contra Postgres real — ABM completo con la policy
+/// <c>GestionDeCatalogo</c> (admin-only), el 404 uniforme cross-tenant (ADR-8), el estado
+/// persistido del targeting de listas (spec: Multi-Lista Targeting via ofertas_listas), la
+/// carrera genuina de <c>pk_ofertas_listas</c> (design: Backstop Map) y los FK smoke tests de
+/// las referencias nuevas de esta etapa.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OfertasEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "una-contraseña-larga";
+
+    private async Task<(int IdTenant, int IdGrupo, string MailAdmin, string PasswordAdmin)>
+        AprovisionarTenantAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
+        Assert.NotNull(resultado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var grupo = new Grupo { IdTenant = resultado!.IdTenant, Nombre = $"{nombre}-grupo", CreatedAt = ahora, UpdatedAt = ahora };
+        db.Grupos.Add(grupo);
+        await db.SaveChangesAsync();
+
+        return (resultado.IdTenant, grupo.Id, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private async Task<HttpClient> ClienteLogueadoAsync(string mail, string password)
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, password));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<string> SembrarVendedorAsync(int idTenant, string nombre)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = "vendedor",
+            Mail = mail,
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return mail;
+    }
+
+    private async Task<int> SembrarCategoriaAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var categoria = new Categoria { IdTenant = idTenant, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Categorias.Add(categoria);
+        await db.SaveChangesAsync();
+
+        return categoria.Id;
+    }
+
+    private async Task<int> SembrarArticuloAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = idTenant, Nombre = $"{nombre}-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = idTenant,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarEmpresaAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var empresa = new Empresa { IdTenant = idTenant, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        return empresa.Id;
+    }
+
+    private async Task<int> SembrarListaAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = idTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        return lista.Id;
+    }
+
+    private static AltaOferta AltaValida(int idGrupo, IReadOnlyList<int>? idsListas = null) => new(
+        Nombre: "2x1 Verano",
+        IdEmpresa: null,
+        IdArticulo: null,
+        IdGrupo: idGrupo,
+        IdCategoria: null,
+        FechaDesde: null,
+        FechaHasta: null,
+        HoraDesde: null,
+        HoraHasta: null,
+        DiasSemana: null,
+        CantidadMinima: null,
+        PrecioUnitario: null,
+        Porcentaje: 10m,
+        ImporteFijo: null,
+        Prioridad: 0,
+        Acumulable: false,
+        IdsListas: idsListas);
+
+    private static EdicionOferta EdicionDesde(OfertaListado oferta, IReadOnlyList<int>? idsListas) => new(
+        Nombre: oferta.Nombre,
+        IdEmpresa: oferta.IdEmpresa,
+        IdArticulo: oferta.IdArticulo,
+        IdGrupo: oferta.IdGrupo,
+        IdCategoria: oferta.IdCategoria,
+        FechaDesde: oferta.FechaDesde,
+        FechaHasta: oferta.FechaHasta,
+        HoraDesde: oferta.HoraDesde,
+        HoraHasta: oferta.HoraHasta,
+        DiasSemana: oferta.DiasSemana,
+        CantidadMinima: oferta.CantidadMinima,
+        PrecioUnitario: oferta.PrecioUnitario,
+        Porcentaje: oferta.Porcentaje,
+        ImporteFijo: oferta.ImporteFijo,
+        Prioridad: oferta.Prioridad,
+        Acumulable: oferta.Acumulable,
+        IdsListas: idsListas,
+        Activo: oferta.Activo);
+
+    private static async Task<OfertaListado> CrearOfertaAsync(
+        HttpClient cliente, int idGrupo, IReadOnlyList<int>? idsListas = null)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupo, idsListas));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        return (await respuesta.Content.ReadFromJsonAsync<OfertaListado>())!;
+    }
+
+    // ---- task 2.6: ABM round trip + autorización ----------------------------------------------
+
+    [Fact]
+    public async Task UnAdminCreaYDaDeBajaUnaOferta()
+    {
+        var (_, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(UnAdminCreaYDaDeBajaUnaOferta));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo);
+        Assert.Equal("2x1 Verano", creada.Nombre);
+
+        var baja = await admin.DeleteAsync($"/api/ofertas/{creada.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, baja.StatusCode);
+
+        var obtener = await admin.GetAsync($"/api/ofertas/{creada.Id}");
+        // Baja lógica: el filtro global de EF la deja invisible por el camino normal de lectura.
+        Assert.Equal(HttpStatusCode.NotFound, obtener.StatusCode);
+
+        var listado = await admin.GetFromJsonAsync<List<OfertaListado>>("/api/ofertas");
+        Assert.DoesNotContain(listado!, o => o.Id == creada.Id);
+    }
+
+    [Fact]
+    public async Task UnVendedorNoPuedeCrearOfertas()
+    {
+        var (idTenant, idGrupo, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorNoPuedeCrearOfertas));
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorNoPuedeCrearOfertas));
+        using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
+
+        var respuesta = await vendedor.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupo));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorNoPuedeEditarOfertas()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(UnVendedorNoPuedeEditarOfertas));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+        var creada = await CrearOfertaAsync(admin, idGrupo);
+
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorNoPuedeEditarOfertas));
+        using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
+
+        var respuesta = await vendedor.PutAsJsonAsync(
+            $"/api/ofertas/{creada.Id}", EdicionDesde(creada, idsListas: null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 2.7: cross-tenant → 404 uniforme (ADR-8) -----------------------------------------
+
+    [Fact]
+    public async Task UnaOfertaDeOtroTenantDevuelve404()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(UnaOfertaDeOtroTenantDevuelve404) + "-A");
+        var (_, _, mailAdminB, passwordAdminB) = await AprovisionarTenantAsync(nameof(UnaOfertaDeOtroTenantDevuelve404) + "-B");
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var ofertaDeA = await CrearOfertaAsync(adminA, idGrupoA);
+
+        using var adminB = await ClienteLogueadoAsync(mailAdminB, passwordAdminB);
+        var respuesta = await adminB.GetAsync($"/api/ofertas/{ofertaDeA.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnPutSobreUnaOfertaDeOtroTenantDevuelve404()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(UnPutSobreUnaOfertaDeOtroTenantDevuelve404) + "-A");
+        var (_, idGrupoB, mailAdminB, passwordAdminB) = await AprovisionarTenantAsync(nameof(UnPutSobreUnaOfertaDeOtroTenantDevuelve404) + "-B");
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var ofertaDeA = await CrearOfertaAsync(adminA, idGrupoA);
+
+        using var adminB = await ClienteLogueadoAsync(mailAdminB, passwordAdminB);
+        var edicion = EdicionDesde(ofertaDeA, idsListas: null) with { IdGrupo = idGrupoB };
+        var respuesta = await adminB.PutAsJsonAsync($"/api/ofertas/{ofertaDeA.Id}", edicion);
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnDeleteSobreUnaOfertaDeOtroTenantDevuelve404()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(UnDeleteSobreUnaOfertaDeOtroTenantDevuelve404) + "-A");
+        var (_, _, mailAdminB, passwordAdminB) = await AprovisionarTenantAsync(nameof(UnDeleteSobreUnaOfertaDeOtroTenantDevuelve404) + "-B");
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var ofertaDeA = await CrearOfertaAsync(adminA, idGrupoA);
+
+        using var adminB = await ClienteLogueadoAsync(mailAdminB, passwordAdminB);
+        var respuesta = await adminB.DeleteAsync($"/api/ofertas/{ofertaDeA.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- task 2.8: ofertas_listas ---------------------------------------------------------------
+
+    /// <summary>Spec: No junction rows targets every lista — a nivel de ABM (Slice 2, sin
+    /// resolver todavía) esto se prueba por el ESTADO PERSISTIDO: sin <c>IdsListas</c>, no se
+    /// crea ninguna fila de <c>ofertas_listas</c> (la semántica de "aplica a todas" la interpreta
+    /// el resolver, Slice 3).</summary>
+    [Fact]
+    public async Task CrearSinIdsListasNoCreaNingunaFilaDeJuncion()
+    {
+        var (_, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(CrearSinIdsListasNoCreaNingunaFilaDeJuncion));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo);
+
+        Assert.Empty(creada.IdsListas);
+
+        var detalle = await admin.GetFromJsonAsync<OfertaListado>($"/api/ofertas/{creada.Id}");
+        Assert.Empty(detalle!.IdsListas);
+    }
+
+    /// <summary>Spec: Junction rows restrict targeting — el estado persistido refleja
+    /// exactamente el subconjunto enviado.</summary>
+    [Fact]
+    public async Task CrearConIdsListasPersisteExactamenteEseSubconjunto()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(CrearConIdsListasPersisteExactamenteEseSubconjunto));
+        var idListaUno = await SembrarListaAsync(idTenant, "Lista 1");
+        var idListaDos = await SembrarListaAsync(idTenant, "Lista 2");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo, idsListas: [idListaUno, idListaDos]);
+
+        Assert.Equal([idListaUno, idListaDos], creada.IdsListas.OrderBy(i => i));
+    }
+
+    /// <summary>Spec: Junction row references must belong to the same tenant.</summary>
+    [Fact]
+    public async Task CrearConListaDeOtroTenantDevuelve400ReferenciaInvalida()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(CrearConListaDeOtroTenantDevuelve400ReferenciaInvalida) + "-A");
+        var (idTenantB, _, _, _) = await AprovisionarTenantAsync(nameof(CrearConListaDeOtroTenantDevuelve400ReferenciaInvalida) + "-B");
+        var idListaDeB = await SembrarListaAsync(idTenantB, "Lista de B");
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var respuesta = await adminA.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupoA, idsListas: [idListaDeB]));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Spec: Junction rows restrict targeting, aplicado a la edición — el PUT reemplaza
+    /// por completo el subconjunto anterior.</summary>
+    [Fact]
+    public async Task EditarReemplazaElSubconjuntoDeListasPersistido()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(EditarReemplazaElSubconjuntoDeListasPersistido));
+        var idListaUno = await SembrarListaAsync(idTenant, "Lista 1");
+        var idListaDos = await SembrarListaAsync(idTenant, "Lista 2");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo, idsListas: [idListaUno]);
+
+        var edicion = EdicionDesde(creada, idsListas: [idListaDos]);
+        var respuestaEdicion = await admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+        Assert.Equal(HttpStatusCode.OK, respuestaEdicion.StatusCode);
+
+        var editada = await respuestaEdicion.Content.ReadFromJsonAsync<OfertaListado>();
+        Assert.Equal([idListaDos], editada!.IdsListas);
+    }
+
+    // ---- task 2.9: pk_ofertas_listas race -------------------------------------------------------
+
+    /// <summary>design: Backstop Map — <c>pk_ofertas_listas</c> es la única superficie
+    /// genuinamente racy de esta etapa. Dos PUT concurrentes reemplazando el MISMO conjunto de
+    /// listas de la MISMA oferta: sin ningún lock que serialice la carrera por construcción
+    /// (mismo criterio que <c>ArticulosEndpointsTests.LaCreacionConcurrenteConElMismoCodigoDeBarraDaExactamenteUnGanador</c>)
+    /// — exactamente un ganador (200), el perdedor un 409 traducido, nunca un 500.</summary>
+    [Fact]
+    public async Task DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasDanExactamenteUnGanador()
+    {
+        var (idTenant, idGrupo, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(DosPutsConcurrentesReemplazandoElMismoConjuntoDeListasDanExactamenteUnGanador));
+        var idLista = await SembrarListaAsync(idTenant, "Lista carrera");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var creada = await CrearOfertaAsync(admin, idGrupo);
+        var edicion = EdicionDesde(creada, idsListas: [idLista]);
+
+        var tareaA = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+        var tareaB = admin.PutAsJsonAsync($"/api/ofertas/{creada.Id}", edicion);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+        Assert.DoesNotContain(HttpStatusCode.InternalServerError, estados);
+        Assert.Contains(HttpStatusCode.OK, estados);
+        Assert.Contains(HttpStatusCode.Conflict, estados);
+
+        var respuestaConflicto = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await respuestaConflicto.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("oferta_lista_duplicada", problema.GetProperty("codigo").GetString());
+
+        // El estado final es consistente: exactamente una fila de targeting sobrevive, no dos
+        // ni cero (el ganador la insertó, el perdedor nunca comiteó la suya).
+        await using var lectura = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+        var filas = await lectura.OfertasListas.Where(ol => ol.IdOferta == creada.Id).ToListAsync();
+        Assert.Single(filas);
+        Assert.Equal(idLista, filas[0].IdListaPrecio);
+    }
+
+    // ---- task 2.10: FK smoke tests ---------------------------------------------------------------
+
+    [Fact]
+    public async Task CrearConIdGrupoInexistenteDevuelve400()
+    {
+        var (_, _, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(CrearConIdGrupoInexistenteDevuelve400));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupo: 999_999));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task CrearConIdCategoriaDeOtroTenantDevuelve400()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(CrearConIdCategoriaDeOtroTenantDevuelve400) + "-A");
+        var (idTenantB, _, _, _) = await AprovisionarTenantAsync(nameof(CrearConIdCategoriaDeOtroTenantDevuelve400) + "-B");
+        var idCategoriaDeB = await SembrarCategoriaAsync(idTenantB, "Categoría de B");
+        _ = idGrupoA;
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var alta = AltaValida(idGrupo: 0) with { IdGrupo = null, IdCategoria = idCategoriaDeB };
+        var respuesta = await adminA.PostAsJsonAsync("/api/ofertas", alta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task CrearConIdArticuloInexistenteDevuelve400()
+    {
+        var (_, _, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(CrearConIdArticuloInexistenteDevuelve400));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var alta = AltaValida(idGrupo: 0) with { IdGrupo = null, IdArticulo = 999_999 };
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas", alta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task CrearConIdArticuloDeOtroTenantDevuelve400()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(CrearConIdArticuloDeOtroTenantDevuelve400) + "-A");
+        var (idTenantB, _, _, _) = await AprovisionarTenantAsync(nameof(CrearConIdArticuloDeOtroTenantDevuelve400) + "-B");
+        var idArticuloDeB = await SembrarArticuloAsync(idTenantB, "Artículo de B");
+        _ = idGrupoA;
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var alta = AltaValida(idGrupo: 0) with { IdGrupo = null, IdArticulo = idArticuloDeB };
+        var respuesta = await adminA.PostAsJsonAsync("/api/ofertas", alta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task CrearConIdEmpresaDeOtroTenantDevuelve400()
+    {
+        var (_, idGrupoA, mailAdminA, passwordAdminA) = await AprovisionarTenantAsync(nameof(CrearConIdEmpresaDeOtroTenantDevuelve400) + "-A");
+        var (idTenantB, _, _, _) = await AprovisionarTenantAsync(nameof(CrearConIdEmpresaDeOtroTenantDevuelve400) + "-B");
+        var idEmpresaDeB = await SembrarEmpresaAsync(idTenantB, "Empresa de B");
+
+        using var adminA = await ClienteLogueadoAsync(mailAdminA, passwordAdminA);
+        var alta = AltaValida(idGrupoA) with { IdEmpresa = idEmpresaDeB };
+        var respuesta = await adminA.PostAsJsonAsync("/api/ofertas", alta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.11: regression smoke -------------------------------------------------------------
+
+    [Fact]
+    public async Task ListarDevuelveLasOfertasDelTenantOrdenadasPorNombre()
+    {
+        var (_, idGrupo, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(ListarDevuelveLasOfertasDelTenantOrdenadasPorNombre));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        await admin.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupo) with { Nombre = "Zeta" });
+        await admin.PostAsJsonAsync("/api/ofertas", AltaValida(idGrupo) with { Nombre = "Alfa" });
+
+        var listado = await admin.GetFromJsonAsync<List<OfertaListado>>("/api/ofertas");
+
+        Assert.NotNull(listado);
+        var nombres = listado!.Select(o => o.Nombre).ToList();
+        Assert.Equal(nombres.OrderBy(n => n, StringComparer.Ordinal), nombres);
+    }
+}


### PR DESCRIPTION
Closes #31

## Summary

- Slice 2 of `stage-4-ofertas`: dedicated `ServicioDeOfertas` (list/get/create/edit/soft-delete) wiring all four `ReglaDeOfertas` invariants on every write path, tenant-scoped reference pre-checks (400 `referencia_invalida`), and the `ofertas_listas` replace-set (empty = all listas), plus `OfertasEndpoints` under `/api/ofertas` (`GestionDeCatalogo`, ADR-8 uniform 404).
- Judgment-day hardened the concurrency story across three rounds: the replace-set AND the soft-delete are now fully serialized via `pg_advisory_xact_lock(idTenant, idOferta)` (ServicioDePrecios precedent) with post-lock liveness re-check — concurrent PUT↔PUT can never persist a silent union or 500, and PUT↔DELETE can never ghost-edit a deleted oferta. Generic `DbUpdateConcurrencyException` → 409 `edicion_concurrente` added as defense in depth.
- Backstop coverage per db-error-backstops: raw-SQL SQLSTATE-asserted `pk_ofertas_listas` test + handler-level test for the new arm.

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 121/121, Application 204/204, Integration 256/256 (real Postgres; incl. same-target and different-target concurrency races, PUT↔DELETE ghost-edit interplay via rendezvous interceptor — all rerun 3× isolated, no flakes)
- [x] judgment-day: APPROVED — R1: 1 CRITICAL (unlocked read-then-write replace-set, two failure modes) fixed with the advisory-lock precedent; R2: 1 CRITICAL (PUT↔DELETE ghost edit) + test-coverage gaps fixed; R3: clean (suggestions only; a process finding — uncommitted fix work — was caught by judge B and landed before this PR)

## Notes

- `size:exception`: ~1.6k lines — service + endpoints + an extensive concurrency test suite.
- No schema changes (gate closed at slice 1).
- Pre-existing sibling gap in `ServicioDeArticulos`'s articulos_empresas replace-set (same unlocked pattern) recorded as a spawned follow-up task — not touched here.
- Unblocks Slices 3 (resolution engine) and 4 (web screen) in parallel.