### PR TITLE
feat(web): pantalla dedicada de ofertas (etapa 4, slice 4)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -10,6 +10,7 @@ import { Empresas } from './paginas/Empresas'
 import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
 import { NuevoTenant } from './paginas/NuevoTenant'
+import { Ofertas } from './paginas/Ofertas'
 import { PaginaCatalogo } from './paginas/PaginaCatalogo'
 import { Parametros } from './paginas/Parametros'
 import { Proveedores } from './paginas/Proveedores'
@@ -87,6 +88,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Admin]}>
                   <PaginaCatalogo definicion={descriptorListasPrecio} />
+                </RutaProtegida>
+              }
+            />
+
+            {/* Entidad dedicada (stage-4-ofertas, Slice 4, design decision 9): árbol propio,
+                no la máquina genérica de catálogos — depende solo del CRUD de la Slice 2. */}
+            <Route
+              path="/ofertas"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                  <Ofertas />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/ofertas.test.ts
+++ b/src/Ways.Web/src/api/ofertas.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+import { aAltaOferta, aValoresOferta, formularioOfertaVacio, opcionesDeLista, resumenDeBeneficio } from './ofertas'
+import type { ListaPrecioListado, OfertaListado } from './tipos'
+
+function ofertaFixture(sobrescribir: Partial<OfertaListado> = {}): OfertaListado {
+  return {
+    id: 1,
+    nombre: 'Oferta base',
+    idEmpresa: null,
+    idArticulo: null,
+    idGrupo: null,
+    idCategoria: null,
+    fechaDesde: null,
+    fechaHasta: null,
+    horaDesde: null,
+    horaHasta: null,
+    diasSemana: [],
+    cantidadMinima: null,
+    precioUnitario: null,
+    porcentaje: null,
+    importeFijo: null,
+    prioridad: 0,
+    acumulable: false,
+    activo: true,
+    idsListas: [],
+    ...sobrescribir,
+  }
+}
+
+function listaFixture(sobrescribir: Partial<ListaPrecioListado> = {}): ListaPrecioListado {
+  return {
+    id: 1,
+    nombre: 'Lista mayorista',
+    activo: true,
+    idEmpresa: null,
+    esDefault: false,
+    modo: 'Fija',
+    idListaBase: null,
+    porcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+describe('aAltaOferta — exclusividad de alcance', () => {
+  it('fuerza idGrupo e idCategoria a null cuando el alcance es Articulo', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      alcance: 'Articulo',
+      idArticulo: 5,
+      idGrupo: 9,
+      idCategoria: 9,
+    })
+
+    expect(alta.idArticulo).toBe(5)
+    expect(alta.idGrupo).toBeNull()
+    expect(alta.idCategoria).toBeNull()
+  })
+
+  it('fuerza idArticulo e idCategoria a null cuando el alcance es Grupo', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      alcance: 'Grupo',
+      idArticulo: 5,
+      idGrupo: 9,
+      idCategoria: 9,
+    })
+
+    expect(alta.idGrupo).toBe(9)
+    expect(alta.idArticulo).toBeNull()
+    expect(alta.idCategoria).toBeNull()
+  })
+
+  it('fuerza idArticulo e idGrupo a null cuando el alcance es Categoria', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      alcance: 'Categoria',
+      idArticulo: 5,
+      idGrupo: 9,
+      idCategoria: 3,
+    })
+
+    expect(alta.idCategoria).toBe(3)
+    expect(alta.idArticulo).toBeNull()
+    expect(alta.idGrupo).toBeNull()
+  })
+})
+
+describe('aAltaOferta — exclusividad de beneficio', () => {
+  it('fuerza porcentaje e importeFijo a null cuando el beneficio es PrecioUnitario', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      beneficio: 'PrecioUnitario',
+      precioUnitario: '100',
+      porcentaje: '20',
+      importeFijo: '15',
+    })
+
+    expect(alta.precioUnitario).toBe(100)
+    expect(alta.porcentaje).toBeNull()
+    expect(alta.importeFijo).toBeNull()
+  })
+
+  it('fuerza precioUnitario e importeFijo a null cuando el beneficio es Porcentaje', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      beneficio: 'Porcentaje',
+      precioUnitario: '100',
+      porcentaje: '20',
+      importeFijo: '15',
+    })
+
+    expect(alta.porcentaje).toBe(20)
+    expect(alta.precioUnitario).toBeNull()
+    expect(alta.importeFijo).toBeNull()
+  })
+
+  it('fuerza precioUnitario y porcentaje a null cuando el beneficio es ImporteFijo', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: 'Oferta',
+      beneficio: 'ImporteFijo',
+      precioUnitario: '100',
+      porcentaje: '20',
+      importeFijo: '15',
+    })
+
+    expect(alta.importeFijo).toBe(15)
+    expect(alta.precioUnitario).toBeNull()
+    expect(alta.porcentaje).toBeNull()
+  })
+})
+
+describe('aAltaOferta — coerción y strings vacíos', () => {
+  it('convierte cantidadMinima vacía a null y no vacía a número', () => {
+    const vacia = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', cantidadMinima: '' })
+    const cargada = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', cantidadMinima: '3.5' })
+
+    expect(vacia.cantidadMinima).toBeNull()
+    expect(cargada.cantidadMinima).toBe(3.5)
+  })
+
+  it('convierte fechaDesde/fechaHasta vacías a null', () => {
+    const alta = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', fechaDesde: '', fechaHasta: '2026-08-01' })
+
+    expect(alta.fechaDesde).toBeNull()
+    expect(alta.fechaHasta).toBe('2026-08-01')
+  })
+
+  it('completa los segundos de horaDesde/horaHasta al enviar y deja null si están vacías', () => {
+    const alta = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', horaDesde: '10:00', horaHasta: '' })
+
+    expect(alta.horaDesde).toBe('10:00:00')
+    expect(alta.horaHasta).toBeNull()
+  })
+
+  it('convierte un diasSemana vacío a null y uno cargado queda ordenado', () => {
+    const vacio = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', diasSemana: [] })
+    const cargado = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', diasSemana: [7, 1, 3] })
+
+    expect(vacio.diasSemana).toBeNull()
+    expect(cargado.diasSemana).toEqual([1, 3, 7])
+  })
+
+  it('convierte idEmpresa vacío a null y prioridad vacía a 0', () => {
+    const alta = aAltaOferta({ ...formularioOfertaVacio(), nombre: 'A', idEmpresa: '', prioridad: '' })
+
+    expect(alta.idEmpresa).toBeNull()
+    expect(alta.prioridad).toBe(0)
+  })
+
+  it('recorta el nombre y pasa acumulable/idsListas/activo sin transformar', () => {
+    const alta = aAltaOferta({
+      ...formularioOfertaVacio(),
+      nombre: '  2x1 Verano  ',
+      acumulable: true,
+      idsListas: [2, 4],
+      activo: false,
+    })
+
+    expect(alta.nombre).toBe('2x1 Verano')
+    expect(alta.acumulable).toBe(true)
+    expect(alta.idsListas).toEqual([2, 4])
+    expect(alta.activo).toBe(false)
+  })
+})
+
+describe('aValoresOferta — deriva alcance y beneficio', () => {
+  it('deriva alcance Articulo cuando idArticulo no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 7 }))
+    expect(valores.alcance).toBe('Articulo')
+    expect(valores.idArticulo).toBe(7)
+  })
+
+  it('deriva alcance Grupo cuando idGrupo no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idGrupo: 3 }))
+    expect(valores.alcance).toBe('Grupo')
+  })
+
+  it('deriva alcance Categoria cuando idCategoria no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idCategoria: 9 }))
+    expect(valores.alcance).toBe('Categoria')
+  })
+
+  it('deriva beneficio PrecioUnitario cuando precioUnitario no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, precioUnitario: 50 }))
+    expect(valores.beneficio).toBe('PrecioUnitario')
+    expect(valores.precioUnitario).toBe('50')
+  })
+
+  it('deriva beneficio Porcentaje cuando porcentaje no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, porcentaje: 15.5 }))
+    expect(valores.beneficio).toBe('Porcentaje')
+    expect(valores.porcentaje).toBe('15.5')
+  })
+
+  it('deriva beneficio ImporteFijo cuando importeFijo no es null', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, importeFijo: 20 }))
+    expect(valores.beneficio).toBe('ImporteFijo')
+    expect(valores.importeFijo).toBe('20')
+  })
+
+  it('mapea campos numéricos null a string vacío', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, porcentaje: 10, cantidadMinima: null }))
+    expect(valores.cantidadMinima).toBe('')
+  })
+
+  it('recorta los segundos de horaDesde/horaHasta al leer', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, porcentaje: 10, horaDesde: '10:00:00', horaHasta: '14:30:00' }))
+    expect(valores.horaDesde).toBe('10:00')
+    expect(valores.horaHasta).toBe('14:30')
+  })
+
+  it('mapea idEmpresa null a string vacío', () => {
+    const valores = aValoresOferta(ofertaFixture({ idArticulo: 1, porcentaje: 10, idEmpresa: null }))
+    expect(valores.idEmpresa).toBe('')
+  })
+})
+
+describe('opcionesDeLista', () => {
+  it('filtra las listas inactivas', () => {
+    const listas = [
+      listaFixture({ id: 1, nombre: 'Activa', activo: true }),
+      listaFixture({ id: 2, nombre: 'Inactiva', activo: false }),
+    ]
+
+    const opciones = opcionesDeLista(listas)
+
+    expect(opciones).toEqual([{ valor: '1', etiqueta: 'Activa' }])
+  })
+
+  it('mapea cada opción a { valor: String(id), etiqueta: nombre }', () => {
+    const listas = [listaFixture({ id: 3, nombre: 'Mayorista', activo: true })]
+
+    expect(opcionesDeLista(listas)).toEqual([{ valor: '3', etiqueta: 'Mayorista' }])
+  })
+})
+
+describe('resumenDeBeneficio', () => {
+  it('formatea el beneficio por porcentaje', () => {
+    expect(resumenDeBeneficio(ofertaFixture({ idArticulo: 1, porcentaje: 20 }))).toBe('20% de descuento')
+  })
+
+  it('formatea el beneficio por importe fijo', () => {
+    expect(resumenDeBeneficio(ofertaFixture({ idArticulo: 1, importeFijo: 15 }))).toBe('$15 fijo por unidad')
+  })
+
+  it('formatea el beneficio por precio unitario', () => {
+    expect(resumenDeBeneficio(ofertaFixture({ idArticulo: 1, precioUnitario: 500 }))).toBe('Precio unitario $500')
+  })
+})

--- a/src/Ways.Web/src/api/ofertas.ts
+++ b/src/Ways.Web/src/api/ofertas.ts
@@ -1,0 +1,179 @@
+/**
+ * Cliente de ofertas (stage-4-ofertas, Slice 4): ABM dedicado, no la máquina genérica de
+ * catálogos (design decision 9) — `AltaOferta`/`EdicionOferta` no tienen ninguna columna
+ * inmutable en edición, así que un solo mapper de escritura (`aAltaOferta`) alcanza para
+ * crear y actualizar. Los mappers viven acá, fuera de `Ofertas.tsx`, para que
+ * `web-descriptor-tests` siga aplicando (el criterio de la skill es el helper, no el
+ * descriptor literal).
+ */
+import { api } from './cliente'
+import type { AltaOferta, EdicionOferta, ListaPrecioListado, OfertaListado } from './tipos'
+
+export const clienteDeOfertas = {
+  listar: (incluirEliminados: boolean) =>
+    api.get<OfertaListado[]>(`/ofertas${incluirEliminados ? '?incluirEliminados=true' : ''}`),
+  /** El listado no completa `idsListas` (evita el N+1) — antes de editar hay que pedir el
+   * detalle puntual para no perder el subconjunto real de listas objetivo. */
+  obtener: (id: number) => api.get<OfertaListado>(`/ofertas/${id}`),
+  crear: (datos: AltaOferta) => api.post<OfertaListado>('/ofertas', datos),
+  actualizar: (id: number, datos: EdicionOferta) => api.put<OfertaListado>(`/ofertas/${id}`, datos),
+  eliminar: (id: number) => api.delete(`/ofertas/${id}`),
+}
+
+export type AlcanceOferta = 'Articulo' | 'Grupo' | 'Categoria'
+export type BeneficioOferta = 'PrecioUnitario' | 'Porcentaje' | 'ImporteFijo'
+
+/** Estado controlado del formulario: todo campo numérico/temporal se maneja como texto (mismo
+ * criterio que `Formulario` en `Articulos.tsx`); `alcance`/`beneficio` son la representación en
+ * UI de la exclusividad de cada grupo — `aAltaOferta` los proyecta de vuelta a las tres
+ * columnas nullable, forzando a `null` las dos no elegidas. */
+export type FormularioOferta = {
+  id: number | null
+  nombre: string
+  idEmpresa: number | ''
+  alcance: AlcanceOferta
+  idArticulo: number | ''
+  nombreArticulo: string
+  idGrupo: number | ''
+  idCategoria: number | ''
+  fechaDesde: string
+  fechaHasta: string
+  horaDesde: string
+  horaHasta: string
+  diasSemana: number[]
+  cantidadMinima: string
+  beneficio: BeneficioOferta
+  precioUnitario: string
+  porcentaje: string
+  importeFijo: string
+  prioridad: string
+  acumulable: boolean
+  idsListas: number[]
+  activo: boolean
+}
+
+export function formularioOfertaVacio(): FormularioOferta {
+  return {
+    id: null,
+    nombre: '',
+    idEmpresa: '',
+    alcance: 'Articulo',
+    idArticulo: '',
+    nombreArticulo: '',
+    idGrupo: '',
+    idCategoria: '',
+    fechaDesde: '',
+    fechaHasta: '',
+    horaDesde: '',
+    horaHasta: '',
+    diasSemana: [],
+    cantidadMinima: '',
+    beneficio: 'Porcentaje',
+    precioUnitario: '',
+    porcentaje: '',
+    importeFijo: '',
+    prioridad: '0',
+    acumulable: false,
+    idsListas: [],
+    activo: true,
+  }
+}
+
+function numeroOpcional(valor: string): number | null {
+  const limpio = valor.trim()
+  return limpio === '' ? null : Number(limpio)
+}
+
+function fechaOpcional(valor: string): string | null {
+  return valor === '' ? null : valor
+}
+
+/** El `<input type="time">` entrega/espera `HH:mm`; el servidor entrega `TimeOnly` como
+ * `HH:mm:ss` — se completan los segundos al enviar y se recortan al leer (`aValoresOferta`). */
+function horaOpcional(valor: string): string | null {
+  if (valor === '') return null
+  return valor.length === 5 ? `${valor}:00` : valor
+}
+
+/**
+ * `Formulario → AltaOferta`/`EdicionOferta` (mismo shape, ver el comentario del tipo en
+ * `tipos.ts`). El campo no elegido de cada grupo exclusivo se fuerza a `null` sin importar lo
+ * que haya quedado tipeado en el formulario — evita enviar un alcance/beneficio ambiguo tras
+ * cambiar el radio.
+ */
+export function aAltaOferta(f: FormularioOferta): AltaOferta {
+  return {
+    nombre: f.nombre.trim(),
+    idEmpresa: f.idEmpresa === '' ? null : f.idEmpresa,
+    idArticulo: f.alcance === 'Articulo' ? (f.idArticulo === '' ? null : f.idArticulo) : null,
+    idGrupo: f.alcance === 'Grupo' ? (f.idGrupo === '' ? null : f.idGrupo) : null,
+    idCategoria: f.alcance === 'Categoria' ? (f.idCategoria === '' ? null : f.idCategoria) : null,
+    fechaDesde: fechaOpcional(f.fechaDesde),
+    fechaHasta: fechaOpcional(f.fechaHasta),
+    horaDesde: horaOpcional(f.horaDesde),
+    horaHasta: horaOpcional(f.horaHasta),
+    diasSemana: f.diasSemana.length === 0 ? null : [...f.diasSemana].sort((a, b) => a - b),
+    cantidadMinima: numeroOpcional(f.cantidadMinima),
+    precioUnitario: f.beneficio === 'PrecioUnitario' ? numeroOpcional(f.precioUnitario) : null,
+    porcentaje: f.beneficio === 'Porcentaje' ? numeroOpcional(f.porcentaje) : null,
+    importeFijo: f.beneficio === 'ImporteFijo' ? numeroOpcional(f.importeFijo) : null,
+    prioridad: f.prioridad.trim() === '' ? 0 : Number(f.prioridad),
+    acumulable: f.acumulable,
+    idsListas: f.idsListas,
+    activo: f.activo,
+  }
+}
+
+/**
+ * `OfertaListado → Formulario`: deriva `alcance`/`beneficio` de cuál de las tres columnas
+ * nullable de cada grupo viene completa (invariante ya garantizado por el servidor — nunca hay
+ * cero ni más de una). `nombreArticulo` queda vacío acá a propósito: el detalle de oferta no
+ * trae el nombre del artículo referenciado, así que el picker lo resuelve por separado cuando
+ * el alcance es `Articulo` (ver `Ofertas.tsx`).
+ */
+export function aValoresOferta(o: OfertaListado): FormularioOferta {
+  const alcance: AlcanceOferta = o.idArticulo !== null ? 'Articulo' : o.idGrupo !== null ? 'Grupo' : 'Categoria'
+  const beneficio: BeneficioOferta =
+    o.precioUnitario !== null ? 'PrecioUnitario' : o.porcentaje !== null ? 'Porcentaje' : 'ImporteFijo'
+
+  return {
+    id: o.id,
+    nombre: o.nombre,
+    idEmpresa: o.idEmpresa ?? '',
+    alcance,
+    idArticulo: o.idArticulo ?? '',
+    nombreArticulo: '',
+    idGrupo: o.idGrupo ?? '',
+    idCategoria: o.idCategoria ?? '',
+    fechaDesde: o.fechaDesde ?? '',
+    fechaHasta: o.fechaHasta ?? '',
+    horaDesde: o.horaDesde ? o.horaDesde.slice(0, 5) : '',
+    horaHasta: o.horaHasta ? o.horaHasta.slice(0, 5) : '',
+    diasSemana: o.diasSemana,
+    cantidadMinima: o.cantidadMinima === null ? '' : String(o.cantidadMinima),
+    beneficio,
+    precioUnitario: o.precioUnitario === null ? '' : String(o.precioUnitario),
+    porcentaje: o.porcentaje === null ? '' : String(o.porcentaje),
+    importeFijo: o.importeFijo === null ? '' : String(o.importeFijo),
+    prioridad: String(o.prioridad),
+    acumulable: o.acumulable,
+    idsListas: o.idsListas,
+    activo: o.activo,
+  }
+}
+
+/** Opciones del multi-select de listas objetivo: solo listas activas (una lista dada de baja no
+ * tiene sentido como target nuevo, mismo criterio que el resto de los selectores de referencia
+ * de la pantalla de artículos). */
+export function opcionesDeLista(listas: ListaPrecioListado[]): { valor: string; etiqueta: string }[] {
+  return listas.filter((l) => l.activo).map((l) => ({ valor: String(l.id), etiqueta: l.nombre }))
+}
+
+/** Resumen de una sola línea del beneficio para la columna de listado — no persiste ni valida
+ * nada, solo formatea lo que el servidor ya validó como exclusivo. */
+export function resumenDeBeneficio(o: OfertaListado): string {
+  if (o.porcentaje !== null) return `${o.porcentaje}% de descuento`
+  if (o.importeFijo !== null) return `$${o.importeFijo} fijo por unidad`
+  if (o.precioUnitario !== null) return `Precio unitario $${o.precioUnitario}`
+  return '—'
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -452,6 +452,74 @@ export type ProgramarPrecio = {
 export type PrecioVigente = { idArticulo: number; idListaPrecio: number; precio: number | null; fecha: string }
 export type HistorialDePrecio = { id: number; precio: number; vigenteDesde: string; vigenteHasta: string | null }
 
+// --- Ofertas (stage-4-ofertas) ---
+// Entidad dedicada (design decision 9): alcance (id_articulo/id_grupo/id_categoria) y
+// beneficio (precio_unitario/porcentaje/importe_fijo) viajan como las tres columnas nullable
+// crudas de cada grupo (design decision 1) — la exclusividad la valida el servidor
+// (ReglaDeOfertas), acá solo se refleja/arma.
+
+/** ISO-8601: 1 = lunes … 7 = domingo. */
+export const DIAS_SEMANA: { valor: number; etiqueta: string }[] = [
+  { valor: 1, etiqueta: 'Lunes' },
+  { valor: 2, etiqueta: 'Martes' },
+  { valor: 3, etiqueta: 'Miércoles' },
+  { valor: 4, etiqueta: 'Jueves' },
+  { valor: 5, etiqueta: 'Viernes' },
+  { valor: 6, etiqueta: 'Sábado' },
+  { valor: 7, etiqueta: 'Domingo' },
+]
+
+/** `idsListas` vacío ⇒ la oferta aplica a todas las listas del tenant (spec: Multi-Lista
+ * Targeting via ofertas_listas). El listado no completa `idsListas` por fila (evita el N+1,
+ * mismo criterio que `ArticuloListado.idsEmpresas`) — solo `obtener`/`crear`/`actualizar` lo
+ * completan con el subconjunto real. */
+export type OfertaListado = {
+  id: number
+  nombre: string
+  idEmpresa: number | null
+  idArticulo: number | null
+  idGrupo: number | null
+  idCategoria: number | null
+  fechaDesde: string | null
+  fechaHasta: string | null
+  horaDesde: string | null
+  horaHasta: string | null
+  diasSemana: number[]
+  cantidadMinima: number | null
+  precioUnitario: number | null
+  porcentaje: number | null
+  importeFijo: number | null
+  prioridad: number
+  acumulable: boolean
+  activo: boolean
+  idsListas: number[]
+}
+
+/** Mismo shape para alta y edición: a diferencia de `ArticuloListado.codigoInterno`, acá no hay
+ * ninguna columna inmutable en edición (backend: `Contratos.cs`, task 2.3). */
+export type AltaOferta = {
+  nombre: string
+  idEmpresa: number | null
+  idArticulo: number | null
+  idGrupo: number | null
+  idCategoria: number | null
+  fechaDesde: string | null
+  fechaHasta: string | null
+  horaDesde: string | null
+  horaHasta: string | null
+  diasSemana: number[] | null
+  cantidadMinima: number | null
+  precioUnitario: number | null
+  porcentaje: number | null
+  importeFijo: number | null
+  prioridad: number
+  acumulable: boolean
+  idsListas: number[] | null
+  activo: boolean
+}
+
+export type EdicionOferta = AltaOferta
+
 // --- Aprovisionamiento de tenants (ADR-16, plataforma) ---
 
 export type SolicitudDeAprovisionamiento = {

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -61,6 +61,11 @@ export function Layout() {
                         Listas de precio
                       </NavLink>
                     </li>
+                    <li className="nav-item">
+                      <NavLink className="nav-link" to="/ofertas">
+                        Ofertas
+                      </NavLink>
+                    </li>
                     {Object.values(DESCRIPTORES_DE_CATALOGO).map((d) => (
                       <li className="nav-item" key={d.recurso}>
                         <NavLink className="nav-link" to={`/catalogos/${d.recurso}`}>

--- a/src/Ways.Web/src/paginas/Ofertas.test.tsx
+++ b/src/Ways.Web/src/paginas/Ofertas.test.tsx
@@ -237,4 +237,61 @@ describe('Ofertas — ventana deshabilitada durante el guardado (react-async-sta
     resolverCreacion(ofertaFixture())
     await screen.findByText('Oferta "Oferta nueva" creada.')
   })
+
+  it('mientras el POST está en vuelo, Editar/Nuevo/Baja no disparan fetch ni pisan el formulario en guardado', async () => {
+    const ofertaExistente = ofertaFixture({ id: 2, nombre: 'Oferta existente' })
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ofertas') return Promise.resolve<OfertaListado[]>([ofertaExistente])
+      if (ruta === '/catalogos/grupos') return Promise.resolve([grupoBebidas])
+      if (ruta === '/catalogos/categorias') return Promise.resolve([])
+      if (ruta === '/empresas') return Promise.resolve([])
+      if (ruta === '/catalogos/listas-precio') return Promise.resolve([listaMayorista])
+      if (ruta.startsWith('/articulos?')) {
+        const pagina: PaginaDe<ArticuloListado> = { items: [articuloCoca], total: 1, pagina: 1, tamanio: 20 }
+        return Promise.resolve(pagina)
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    let resolverCreacion: (valor: OfertaListado) => void = () => {}
+    apiPostMock.mockImplementation(
+      () =>
+        new Promise<OfertaListado>((resolve) => {
+          resolverCreacion = resolve
+        }),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<Ofertas />)
+    await screen.findByText('Oferta existente')
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+    await userEvent.type(screen.getByLabelText('Nombre'), 'Oferta nueva')
+    await userEvent.type(screen.getByLabelText('Porcentaje (%)'), '10')
+    await userEvent.type(screen.getByPlaceholderText('Buscar por nombre o código interno…'), 'coca')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+    await userEvent.selectOptions(await screen.findByRole('listbox'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+    expect(apiPostMock).toHaveBeenCalledTimes(1)
+    apiGetMock.mockClear()
+
+    // Con el guardado en vuelo, intentamos las tres acciones que podrían pisar la edición en curso.
+    await userEvent.click(screen.getByRole('button', { name: 'Editar' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Nuevo' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Baja' }))
+
+    expect(apiGetMock).not.toHaveBeenCalledWith(expect.stringMatching(/^\/ofertas\/\d+$/))
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Nueva oferta')).toBeInTheDocument()
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Oferta nueva')
+    expect(apiPostMock).toHaveBeenCalledTimes(1)
+    expect(apiPutMock).not.toHaveBeenCalled()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+
+    resolverCreacion(ofertaFixture())
+    await screen.findByText('Oferta "Oferta nueva" creada.')
+
+    confirmSpy.mockRestore()
+  })
 })

--- a/src/Ways.Web/src/paginas/Ofertas.test.tsx
+++ b/src/Ways.Web/src/paginas/Ofertas.test.tsx
@@ -1,0 +1,240 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Ofertas } from './Ofertas'
+import type { ArticuloListado, GrupoListado, ListaPrecioListado, OfertaListado, PaginaDe } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+const apiDeleteMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
+    delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {},
+}))
+
+function grupoFixture(sobrescribir: Partial<GrupoListado> = {}): GrupoListado {
+  return { id: 1, nombre: 'Bebidas', activo: true, idEmpresa: null, margen: null, ...sobrescribir }
+}
+
+function listaFixture(sobrescribir: Partial<ListaPrecioListado> = {}): ListaPrecioListado {
+  return {
+    id: 1,
+    nombre: 'Lista mayorista',
+    activo: true,
+    idEmpresa: null,
+    esDefault: false,
+    modo: 'Fija',
+    idListaBase: null,
+    porcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloListado {
+  return {
+    id: 1,
+    codigoInterno: 'A0001',
+    nombre: 'Coca Cola 1L',
+    descripcion: null,
+    idArea: 1,
+    idCategoria: null,
+    idMarca: null,
+    idGrupo: null,
+    idProveedorHabitual: null,
+    idAlicuotaIva: 1,
+    unidadVenta: 'Unidad',
+    unidadesPorBulto: null,
+    esProducto: true,
+    costoLista: null,
+    descuentoProveedor: null,
+    costoNominal: null,
+    disponibleParaTodas: true,
+    idsEmpresas: [],
+    activo: true,
+    ...sobrescribir,
+  }
+}
+
+function ofertaFixture(sobrescribir: Partial<OfertaListado> = {}): OfertaListado {
+  return {
+    id: 1,
+    nombre: 'Oferta A',
+    idEmpresa: null,
+    idArticulo: 1,
+    idGrupo: null,
+    idCategoria: null,
+    fechaDesde: null,
+    fechaHasta: null,
+    horaDesde: null,
+    horaHasta: null,
+    diasSemana: [],
+    cantidadMinima: null,
+    precioUnitario: null,
+    porcentaje: 10,
+    importeFijo: null,
+    prioridad: 0,
+    acumulable: false,
+    activo: true,
+    idsListas: [],
+    ...sobrescribir,
+  }
+}
+
+const grupoBebidas = grupoFixture({ id: 1, nombre: 'Bebidas' })
+const listaMayorista = listaFixture({ id: 3, nombre: 'Lista mayorista' })
+const articuloCoca = articuloFixture({ id: 1, nombre: 'Coca Cola 1L' })
+
+function mockearApiGet() {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/ofertas') return Promise.resolve<OfertaListado[]>([])
+    if (ruta === '/catalogos/grupos') return Promise.resolve([grupoBebidas])
+    if (ruta === '/catalogos/categorias') return Promise.resolve([])
+    if (ruta === '/empresas') return Promise.resolve([])
+    if (ruta === '/catalogos/listas-precio') return Promise.resolve([listaMayorista])
+    if (ruta.startsWith('/articulos?')) {
+      const pagina: PaginaDe<ArticuloListado> = { items: [articuloCoca], total: 1, pagina: 1, tamanio: 20 }
+      return Promise.resolve(pagina)
+    }
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiPutMock.mockReset()
+  apiDeleteMock.mockReset()
+  mockearApiGet()
+})
+
+describe('Ofertas — radio de alcance (visibleSi análogo)', () => {
+  it('con alcance Artículo (default) muestra el buscador de artículo y no los selects de grupo/categoría', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    expect(screen.getByLabelText('Buscar artículo')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Grupo objetivo')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Categoría objetivo')).not.toBeInTheDocument()
+  })
+
+  it('cambiar el radio a Grupo hace aparecer el select de grupo y oculta el buscador de artículo', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Grupo' }))
+
+    expect(screen.getByLabelText('Grupo objetivo')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Buscar por nombre o código interno…')).not.toBeInTheDocument()
+  })
+
+  it('cambiar el radio a Categoría hace aparecer el select de categoría', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Categoría' }))
+
+    expect(screen.getByLabelText('Categoría objetivo')).toBeInTheDocument()
+  })
+})
+
+describe('Ofertas — radio de beneficio (visibleSi análogo)', () => {
+  it('con beneficio Porcentaje (default) muestra el input de porcentaje y no los otros dos', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    expect(screen.getByLabelText('Porcentaje (%)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Importe fijo por unidad ($)')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Precio unitario ($)')).not.toBeInTheDocument()
+  })
+
+  it('cambiar el radio a Importe fijo hace aparecer ese input y oculta el de porcentaje', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Importe fijo por unidad' }))
+
+    expect(screen.getByLabelText('Importe fijo por unidad ($)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Porcentaje (%)')).not.toBeInTheDocument()
+  })
+
+  it('cambiar el radio a Precio unitario hace aparecer ese input', async () => {
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Precio unitario' }))
+
+    expect(screen.getByLabelText('Precio unitario ($)')).toBeInTheDocument()
+  })
+})
+
+describe('Ofertas — multi-select de listas', () => {
+  it('sin marcar ninguna lista, el guardado envía idsListas vacío (aplica a todas)', async () => {
+    apiPostMock.mockResolvedValue(ofertaFixture())
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.type(screen.getByLabelText('Nombre'), 'Oferta nueva')
+    await userEvent.type(screen.getByLabelText('Porcentaje (%)'), '10')
+
+    // Alcance por defecto es Artículo: se busca y selecciona uno para poder enviar el form.
+    await userEvent.type(screen.getByPlaceholderText('Buscar por nombre o código interno…'), 'coca')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+    await userEvent.selectOptions(await screen.findByRole('listbox'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    expect(apiPostMock).toHaveBeenCalledWith('/ofertas', expect.objectContaining({ idsListas: [] }))
+  })
+
+  it('marcar una lista la incluye en idsListas al guardar', async () => {
+    apiPostMock.mockResolvedValue(ofertaFixture())
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.type(screen.getByLabelText('Nombre'), 'Oferta nueva')
+    await userEvent.type(screen.getByLabelText('Porcentaje (%)'), '10')
+    await userEvent.click(screen.getByLabelText('Lista mayorista'))
+
+    await userEvent.type(screen.getByPlaceholderText('Buscar por nombre o código interno…'), 'coca')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+    await userEvent.selectOptions(await screen.findByRole('listbox'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    expect(apiPostMock).toHaveBeenCalledWith('/ofertas', expect.objectContaining({ idsListas: [3] }))
+  })
+})
+
+describe('Ofertas — ventana deshabilitada durante el guardado (react-async-state rule 5/9)', () => {
+  it('mientras el POST está en vuelo, el campo nombre queda deshabilitado', async () => {
+    let resolverCreacion: (valor: OfertaListado) => void = () => {}
+    apiPostMock.mockImplementation(
+      () =>
+        new Promise<OfertaListado>((resolve) => {
+          resolverCreacion = resolve
+        }),
+    )
+    render(<Ofertas />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Nuevo' }))
+
+    await userEvent.type(screen.getByLabelText('Nombre'), 'Oferta nueva')
+    await userEvent.type(screen.getByLabelText('Porcentaje (%)'), '10')
+    await userEvent.type(screen.getByPlaceholderText('Buscar por nombre o código interno…'), 'coca')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+    await userEvent.selectOptions(await screen.findByRole('listbox'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    expect(screen.getByLabelText('Nombre')).toBeDisabled()
+
+    resolverCreacion(ofertaFixture())
+    await screen.findByText('Oferta "Oferta nueva" creada.')
+  })
+})

--- a/src/Ways.Web/src/paginas/Ofertas.tsx
+++ b/src/Ways.Web/src/paginas/Ofertas.tsx
@@ -1,0 +1,858 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { clienteDeArticulos } from '../api/articulos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import {
+  aAltaOferta,
+  aValoresOferta,
+  clienteDeOfertas,
+  formularioOfertaVacio,
+  opcionesDeLista,
+  resumenDeBeneficio,
+  type AlcanceOferta,
+  type BeneficioOferta,
+  type FormularioOferta,
+} from '../api/ofertas'
+import { clienteDePrecios } from '../api/precios'
+import { DIAS_SEMANA } from '../api/tipos'
+import type { ArticuloListado, CategoriaListado, EmpresaListado, GrupoListado, ListaPrecioListado, OfertaListado } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const clienteGrupos = { listar: () => api.get<GrupoListado[]>('/catalogos/grupos') }
+
+function validarFormulario(f: FormularioOferta): string | null {
+  if (!f.nombre.trim()) return 'Ingresá un nombre para la oferta.'
+  if (f.alcance === 'Articulo' && f.idArticulo === '') return 'Elegí un artículo para el alcance.'
+  if (f.alcance === 'Grupo' && f.idGrupo === '') return 'Elegí un grupo para el alcance.'
+  if (f.alcance === 'Categoria' && f.idCategoria === '') return 'Elegí una categoría para el alcance.'
+  if (f.beneficio === 'PrecioUnitario' && f.precioUnitario.trim() === '') return 'Ingresá el precio unitario del beneficio.'
+  if (f.beneficio === 'Porcentaje' && f.porcentaje.trim() === '') return 'Ingresá el porcentaje del beneficio.'
+  if (f.beneficio === 'ImporteFijo' && f.importeFijo.trim() === '') return 'Ingresá el importe fijo del beneficio.'
+  return null
+}
+
+function textoAlcance(o: OfertaListado, grupos: GrupoListado[], categorias: CategoriaListado[]): string {
+  if (o.idArticulo !== null) return `Artículo #${o.idArticulo}`
+  if (o.idGrupo !== null) return `Grupo: ${grupos.find((g) => g.id === o.idGrupo)?.nombre ?? o.idGrupo}`
+  return `Categoría: ${categorias.find((c) => c.id === o.idCategoria)?.nombre ?? o.idCategoria}`
+}
+
+/**
+ * ABM dedicado de ofertas (design decision 9: no la máquina genérica de catálogos, no la
+ * pantalla genérica de descriptores) — Slice 4, dependiente solo del CRUD de la Slice 2. El
+ * listado del servidor no completa `idsListas` por fila (evita el N+1, ver el doc-comment de
+ * `OfertaListado`), así que la tabla nunca muestra el targeting de listas: eso solo se ve/edita
+ * en el detalle, después de `obtener`.
+ */
+export function Ofertas() {
+  const [ofertas, setOfertas] = useState<OfertaListado[] | null>(null)
+  const [grupos, setGrupos] = useState<GrupoListado[]>([])
+  const [categorias, setCategorias] = useState<CategoriaListado[]>([])
+  const [empresas, setEmpresas] = useState<EmpresaListado[]>([])
+  const [listasPrecio, setListasPrecio] = useState<ListaPrecioListado[]>([])
+  const [avisosCatalogos, setAvisosCatalogos] = useState<string[]>([])
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const [aviso, setAviso] = useState('')
+  const [formulario, setFormulario] = useState<FormularioOferta | null>(null)
+  const [guardando, setGuardando] = useState(false)
+  const [eliminando, setEliminando] = useState(false)
+  const tokenEdicionRef = useRef(0)
+  const generacionCargaRef = useRef(0)
+  const cargaInicialHechaRef = useRef(false)
+  const ocupado = guardando || eliminando
+
+  function invalidarEdicionEnCurso(): number {
+    return (tokenEdicionRef.current += 1)
+  }
+
+  function agregarAvisoCatalogo(mensaje: string) {
+    setAvisosCatalogos((prev) => (prev.includes(mensaje) ? prev : [...prev, mensaje]))
+  }
+
+  const cargar = useCallback(async (opciones?: { relanzarError?: boolean }) => {
+    const generacion = (generacionCargaRef.current += 1)
+    setCargando(true)
+    setError('')
+    try {
+      const lista = await clienteDeOfertas.listar(false)
+      if (generacionCargaRef.current !== generacion) return
+      setOfertas(lista)
+    } catch (e) {
+      if (generacionCargaRef.current === generacion) {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las ofertas.')
+      }
+      if (opciones?.relanzarError && generacionCargaRef.current === generacion) throw e
+    } finally {
+      if (generacionCargaRef.current === generacion) {
+        setCargando(false)
+        cargaInicialHechaRef.current = true
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void cargar()
+    clienteGrupos
+      .listar()
+      .then(setGrupos)
+      .catch(() => {
+        setGrupos([])
+        agregarAvisoCatalogo('No se pudieron cargar los grupos: el alcance por grupo no va a estar disponible hasta recargar la página.')
+      })
+    api
+      .get<CategoriaListado[]>('/catalogos/categorias')
+      .then(setCategorias)
+      .catch(() => {
+        setCategorias([])
+        agregarAvisoCatalogo(
+          'No se pudieron cargar las categorías: el alcance por categoría no va a estar disponible hasta recargar la página.',
+        )
+      })
+    clienteDeOrganizacion
+      .listarEmpresas()
+      .then(setEmpresas)
+      .catch(() => {
+        setEmpresas([])
+        agregarAvisoCatalogo(
+          'No se pudieron cargar las empresas: el selector de empresa no va a estar disponible (la oferta se crea para todo el tenant).',
+        )
+      })
+    clienteDePrecios
+      .listasDePrecio()
+      .then(setListasPrecio)
+      .catch(() => {
+        setListasPrecio([])
+        agregarAvisoCatalogo(
+          'No se pudieron cargar las listas de precio: el targeting manual de listas no va a estar disponible (la oferta va a aplicar a todas las listas).',
+        )
+      })
+  }, [cargar])
+
+  async function abrirNuevo() {
+    if (ocupado) return
+    invalidarEdicionEnCurso()
+    setGuardando(false)
+    setFormulario(formularioOfertaVacio())
+    setAviso('')
+    setError('')
+  }
+
+  function cancelarEdicion() {
+    if (ocupado) return
+    invalidarEdicionEnCurso()
+    setGuardando(false)
+    setFormulario(null)
+  }
+
+  async function abrirEdicion(o: OfertaListado) {
+    if (ocupado) return
+    setError('')
+    const token = invalidarEdicionEnCurso()
+    try {
+      const detalle = await clienteDeOfertas.obtener(o.id)
+      if (tokenEdicionRef.current !== token) return
+
+      let nombreArticulo = ''
+      if (detalle.idArticulo !== null) {
+        try {
+          const articulo = await clienteDeArticulos.obtener(detalle.idArticulo)
+          if (tokenEdicionRef.current !== token) return
+          nombreArticulo = articulo.nombre
+        } catch {
+          if (tokenEdicionRef.current !== token) return
+          nombreArticulo = ''
+        }
+      }
+
+      if (tokenEdicionRef.current !== token) return
+      setFormulario({ ...aValoresOferta(detalle), nombreArticulo })
+      setGuardando(false)
+      setAviso('')
+    } catch (e) {
+      if (tokenEdicionRef.current !== token) return
+      setGuardando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir la oferta.')
+    }
+  }
+
+  async function guardar() {
+    if (ocupado) return
+    if (!formulario) return
+
+    const mensajeInvalido = validarFormulario(formulario)
+    if (mensajeInvalido) {
+      setError(mensajeInvalido)
+      return
+    }
+
+    const token = invalidarEdicionEnCurso()
+    setGuardando(true)
+    setError('')
+    setAviso('')
+
+    try {
+      if (formulario.id === null) {
+        const creada = await clienteDeOfertas.crear(aAltaOferta(formulario))
+        if (tokenEdicionRef.current === token) {
+          setAviso(`Oferta "${formulario.nombre}" creada.`)
+          setFormulario({ ...aValoresOferta(creada), nombreArticulo: formulario.nombreArticulo })
+        }
+      } else {
+        const actualizada = await clienteDeOfertas.actualizar(formulario.id, aAltaOferta(formulario))
+        if (tokenEdicionRef.current === token) {
+          setAviso(`Oferta "${formulario.nombre}" actualizada.`)
+          setFormulario({ ...aValoresOferta(actualizada), nombreArticulo: formulario.nombreArticulo })
+        }
+      }
+
+      // El refresco de la tabla no pertenece al token de edición: un fallo acá es solo de
+      // vista, el guardado ya tuvo éxito (mismo criterio que Articulos.tsx).
+      try {
+        await cargar({ relanzarError: true })
+      } catch {
+        if (tokenEdicionRef.current === token) {
+          setError('La oferta se guardó, pero no se pudo actualizar el listado. Volvé a entrar para verla.')
+        }
+      }
+    } catch (e) {
+      if (tokenEdicionRef.current === token) {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar la oferta.')
+      }
+    } finally {
+      if (tokenEdicionRef.current === token) setGuardando(false)
+    }
+  }
+
+  async function eliminar(o: OfertaListado) {
+    if (ocupado) return
+    if (!confirm(`¿Dar de baja la oferta "${o.nombre}"?`)) return
+
+    invalidarEdicionEnCurso()
+    setError('')
+    setAviso('')
+    setEliminando(true)
+    try {
+      await clienteDeOfertas.eliminar(o.id)
+      setAviso(`Oferta "${o.nombre}" dada de baja.`)
+      if (formulario?.id === o.id) setFormulario(null)
+      try {
+        await cargar({ relanzarError: true })
+      } catch {
+        setError('La oferta se dio de baja, pero no se pudo actualizar el listado. Volvé a entrar para verla.')
+      }
+    } catch (e) {
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo dar de baja la oferta.')
+    } finally {
+      setEliminando(false)
+    }
+  }
+
+  const herramientas = (
+    <nav className="p-2 d-flex gap-2">
+      <button type="button" className="btn btn-sm btn-success rounded-0 text-nowrap" disabled={ocupado} onClick={abrirNuevo}>
+        Nuevo
+      </button>
+    </nav>
+  )
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Ofertas" variante="inverse" herramientas={herramientas}>
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {avisosCatalogos.length > 0 && (
+          <div className="alert alert-warning rounded-0">{avisosCatalogos.join(' ')}</div>
+        )}
+
+        {formulario && (
+          <FormularioOfertaCampos
+            key={formulario.id ?? 'nuevo'}
+            valor={formulario}
+            grupos={grupos}
+            categorias={categorias}
+            empresas={empresas}
+            listasPrecio={listasPrecio}
+            guardando={guardando}
+            ocupado={ocupado}
+            onCambio={setFormulario}
+            onGuardar={guardar}
+            onCancelar={cancelarEdicion}
+          />
+        )}
+
+        {cargando && !cargaInicialHechaRef.current ? (
+          <Cargando />
+        ) : (
+          <div className="table-responsive">
+            <table className="table table-striped table-hover table-bordered align-middle">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>Alcance</th>
+                  <th>Beneficio</th>
+                  <th>Prioridad</th>
+                  <th>Acumulable</th>
+                  <th>Estado</th>
+                  <th className="text-end">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ofertas?.map((o) => (
+                  <tr key={o.id}>
+                    <td>{o.nombre}</td>
+                    <td>{textoAlcance(o, grupos, categorias)}</td>
+                    <td>{resumenDeBeneficio(o)}</td>
+                    <td>{o.prioridad}</td>
+                    <td>{o.acumulable ? 'Sí' : 'No'}</td>
+                    <td>
+                      <span className={`badge rounded-0 ${o.activo ? 'text-bg-success' : 'text-bg-secondary'}`}>
+                        {o.activo ? 'Activa' : 'Inactiva'}
+                      </span>
+                    </td>
+                    <td className="text-end text-nowrap">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-primary rounded-0 me-1"
+                        disabled={ocupado}
+                        onClick={() => abrirEdicion(o)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger rounded-0"
+                        disabled={ocupado}
+                        onClick={() => eliminar(o)}
+                      >
+                        Baja
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {ofertas !== null && ofertas.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="text-center text-muted py-4">
+                      No hay ofertas cargadas.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Box>
+    </div>
+  )
+}
+
+function FormularioOfertaCampos({
+  valor,
+  grupos,
+  categorias,
+  empresas,
+  listasPrecio,
+  guardando,
+  ocupado,
+  onCambio,
+  onGuardar,
+  onCancelar,
+}: {
+  valor: FormularioOferta
+  grupos: GrupoListado[]
+  categorias: CategoriaListado[]
+  empresas: EmpresaListado[]
+  listasPrecio: ListaPrecioListado[]
+  guardando: boolean
+  ocupado: boolean
+  onCambio: (f: FormularioOferta) => void
+  onGuardar: () => void
+  onCancelar: () => void
+}) {
+  const esNuevo = valor.id === null
+  const opcionesLista = opcionesDeLista(listasPrecio)
+
+  function alternarDia(dia: number) {
+    const yaEsta = valor.diasSemana.includes(dia)
+    onCambio({ ...valor, diasSemana: yaEsta ? valor.diasSemana.filter((d) => d !== dia) : [...valor.diasSemana, dia] })
+  }
+
+  function alternarLista(id: number) {
+    const yaEsta = valor.idsListas.includes(id)
+    onCambio({ ...valor, idsListas: yaEsta ? valor.idsListas.filter((x) => x !== id) : [...valor.idsListas, id] })
+  }
+
+  return (
+    <div className="border p-3 mb-4 bg-white">
+      <form
+        autoComplete="off"
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (ocupado) return
+          onGuardar()
+        }}
+      >
+        {/* fieldset disabled: cascada nativa a todos los controles anidados mientras hay un
+            guardado en vuelo (react-async-state rule 5/9), mismo criterio que Articulos.tsx. */}
+        <fieldset disabled={ocupado} className="row g-3 border-0 p-0 m-0">
+          <div className="col-12">
+            <strong>{esNuevo ? 'Nueva oferta' : `Editando oferta "${valor.nombre}"`}</strong>
+          </div>
+
+          <div className="col-12">
+            <strong className="text-muted small text-uppercase">Identificación</strong>
+          </div>
+
+          <div className="col-md-5">
+            <label className="form-label" htmlFor="of-nombre">
+              Nombre
+            </label>
+            <input
+              id="of-nombre"
+              className="form-control rounded-0"
+              maxLength={150}
+              value={valor.nombre}
+              onChange={(e) => onCambio({ ...valor, nombre: e.target.value })}
+              required
+            />
+          </div>
+
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="of-prioridad">
+              Prioridad
+            </label>
+            <input
+              id="of-prioridad"
+              type="number"
+              step="1"
+              className="form-control rounded-0"
+              value={valor.prioridad}
+              onChange={(e) => onCambio({ ...valor, prioridad: e.target.value })}
+            />
+          </div>
+
+          <div className="col-md-2 d-flex align-items-end">
+            <div className="form-check">
+              <input
+                id="of-acumulable"
+                type="checkbox"
+                className="form-check-input rounded-0"
+                checked={valor.acumulable}
+                onChange={(e) => onCambio({ ...valor, acumulable: e.target.checked })}
+              />
+              <label className="form-check-label" htmlFor="of-acumulable">
+                Acumulable
+              </label>
+            </div>
+          </div>
+
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-empresa">
+              Empresa
+            </label>
+            <select
+              id="of-empresa"
+              className="form-select rounded-0"
+              value={valor.idEmpresa}
+              onChange={(e) => onCambio({ ...valor, idEmpresa: e.target.value === '' ? '' : Number(e.target.value) })}
+            >
+              <option value="">Todo el tenant</option>
+              {empresas.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.razonSocial}
+                  {e.nombreFantasia ? ` (${e.nombreFantasia})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-12">
+            <strong className="text-muted small text-uppercase">Alcance (exactamente uno)</strong>
+          </div>
+
+          <div className="col-12 d-flex gap-3">
+            {(['Articulo', 'Grupo', 'Categoria'] as AlcanceOferta[]).map((opcion) => (
+              <div className="form-check" key={opcion}>
+                <input
+                  id={`of-alcance-${opcion}`}
+                  type="radio"
+                  name="of-alcance"
+                  className="form-check-input rounded-0"
+                  checked={valor.alcance === opcion}
+                  onChange={() => onCambio({ ...valor, alcance: opcion })}
+                />
+                <label className="form-check-label" htmlFor={`of-alcance-${opcion}`}>
+                  {opcion === 'Articulo' ? 'Artículo' : opcion === 'Grupo' ? 'Grupo' : 'Categoría'}
+                </label>
+              </div>
+            ))}
+          </div>
+
+          {valor.alcance === 'Articulo' && (
+            <div className="col-12">
+              <SelectorDeArticulo
+                idArticulo={valor.idArticulo}
+                nombreArticulo={valor.nombreArticulo}
+                disabled={ocupado}
+                onSeleccionar={(id, nombre) => onCambio({ ...valor, idArticulo: id, nombreArticulo: nombre })}
+              />
+            </div>
+          )}
+
+          {valor.alcance === 'Grupo' && (
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="of-grupo">
+                Grupo objetivo
+              </label>
+              <select
+                id="of-grupo"
+                className="form-select rounded-0"
+                value={valor.idGrupo}
+                onChange={(e) => onCambio({ ...valor, idGrupo: e.target.value === '' ? '' : Number(e.target.value) })}
+              >
+                <option value="" disabled>
+                  Elegir…
+                </option>
+                {grupos.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {valor.alcance === 'Categoria' && (
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="of-categoria">
+                Categoría objetivo
+              </label>
+              <select
+                id="of-categoria"
+                className="form-select rounded-0"
+                value={valor.idCategoria}
+                onChange={(e) => onCambio({ ...valor, idCategoria: e.target.value === '' ? '' : Number(e.target.value) })}
+              >
+                <option value="" disabled>
+                  Elegir…
+                </option>
+                {categorias.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="col-12">
+            <strong className="text-muted small text-uppercase">Vigencia</strong>
+          </div>
+
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-fecha-desde">
+              Fecha desde
+            </label>
+            <input
+              id="of-fecha-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={valor.fechaDesde}
+              onChange={(e) => onCambio({ ...valor, fechaDesde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-fecha-hasta">
+              Fecha hasta
+            </label>
+            <input
+              id="of-fecha-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={valor.fechaHasta}
+              onChange={(e) => onCambio({ ...valor, fechaHasta: e.target.value })}
+            />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-hora-desde">
+              Hora desde
+            </label>
+            <input
+              id="of-hora-desde"
+              type="time"
+              className="form-control rounded-0"
+              value={valor.horaDesde}
+              onChange={(e) => onCambio({ ...valor, horaDesde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-hora-hasta">
+              Hora hasta
+            </label>
+            <input
+              id="of-hora-hasta"
+              type="time"
+              className="form-control rounded-0"
+              value={valor.horaHasta}
+              onChange={(e) => onCambio({ ...valor, horaHasta: e.target.value })}
+            />
+          </div>
+
+          <div className="col-12">
+            <div className="form-text mb-1">Días de la semana (sin marcar ninguno = todos los días).</div>
+            <div className="d-flex flex-wrap gap-3">
+              {DIAS_SEMANA.map((d) => (
+                <div className="form-check" key={d.valor}>
+                  <input
+                    id={`of-dia-${d.valor}`}
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={valor.diasSemana.includes(d.valor)}
+                    onChange={() => alternarDia(d.valor)}
+                  />
+                  <label className="form-check-label" htmlFor={`of-dia-${d.valor}`}>
+                    {d.etiqueta}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="of-cantidad-minima">
+              Cantidad mínima
+            </label>
+            <input
+              id="of-cantidad-minima"
+              type="number"
+              step="0.001"
+              min="0"
+              className="form-control rounded-0"
+              placeholder="Sin mínimo (oferta directa)"
+              value={valor.cantidadMinima}
+              onChange={(e) => onCambio({ ...valor, cantidadMinima: e.target.value })}
+            />
+          </div>
+
+          <div className="col-12">
+            <strong className="text-muted small text-uppercase">Beneficio (exactamente uno)</strong>
+          </div>
+
+          <div className="col-12 d-flex gap-3">
+            {(['Porcentaje', 'ImporteFijo', 'PrecioUnitario'] as BeneficioOferta[]).map((opcion) => (
+              <div className="form-check" key={opcion}>
+                <input
+                  id={`of-beneficio-${opcion}`}
+                  type="radio"
+                  name="of-beneficio"
+                  className="form-check-input rounded-0"
+                  checked={valor.beneficio === opcion}
+                  onChange={() => onCambio({ ...valor, beneficio: opcion })}
+                />
+                <label className="form-check-label" htmlFor={`of-beneficio-${opcion}`}>
+                  {opcion === 'Porcentaje' ? 'Porcentaje' : opcion === 'ImporteFijo' ? 'Importe fijo por unidad' : 'Precio unitario'}
+                </label>
+              </div>
+            ))}
+          </div>
+
+          {valor.beneficio === 'Porcentaje' && (
+            <div className="col-md-3">
+              <label className="form-label" htmlFor="of-porcentaje">
+                Porcentaje (%)
+              </label>
+              <input
+                id="of-porcentaje"
+                type="number"
+                step="0.01"
+                min="0"
+                max="100"
+                className="form-control rounded-0"
+                value={valor.porcentaje}
+                onChange={(e) => onCambio({ ...valor, porcentaje: e.target.value })}
+              />
+            </div>
+          )}
+
+          {valor.beneficio === 'ImporteFijo' && (
+            <div className="col-md-3">
+              <label className="form-label" htmlFor="of-importe-fijo">
+                Importe fijo por unidad ($)
+              </label>
+              <input
+                id="of-importe-fijo"
+                type="number"
+                step="0.01"
+                min="0"
+                className="form-control rounded-0"
+                value={valor.importeFijo}
+                onChange={(e) => onCambio({ ...valor, importeFijo: e.target.value })}
+              />
+            </div>
+          )}
+
+          {valor.beneficio === 'PrecioUnitario' && (
+            <div className="col-md-3">
+              <label className="form-label" htmlFor="of-precio-unitario">
+                Precio unitario ($)
+              </label>
+              <input
+                id="of-precio-unitario"
+                type="number"
+                step="0.01"
+                min="0"
+                className="form-control rounded-0"
+                value={valor.precioUnitario}
+                onChange={(e) => onCambio({ ...valor, precioUnitario: e.target.value })}
+              />
+            </div>
+          )}
+
+          <div className="col-12">
+            <strong className="text-muted small text-uppercase">Listas de precio</strong>
+          </div>
+
+          <div className="col-12">
+            <div className="form-text mb-1">
+              Sin marcar ninguna lista, la oferta aplica a <strong>todas</strong> las listas del tenant.
+            </div>
+            <div className="d-flex flex-wrap gap-3">
+              {opcionesLista.map((o) => (
+                <div className="form-check" key={o.valor}>
+                  <input
+                    id={`of-lista-${o.valor}`}
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={valor.idsListas.includes(Number(o.valor))}
+                    onChange={() => alternarLista(Number(o.valor))}
+                  />
+                  <label className="form-check-label" htmlFor={`of-lista-${o.valor}`}>
+                    {o.etiqueta}
+                  </label>
+                </div>
+              ))}
+              {opcionesLista.length === 0 && <span className="text-muted small">No hay listas de precio activas.</span>}
+            </div>
+          </div>
+
+          <div className="col-md-3 d-flex align-items-end">
+            <div className="form-check">
+              <input
+                id="of-activo"
+                type="checkbox"
+                className="form-check-input rounded-0"
+                checked={valor.activo}
+                onChange={(e) => onCambio({ ...valor, activo: e.target.checked })}
+              />
+              <label className="form-check-label" htmlFor="of-activo">
+                Activa
+              </label>
+            </div>
+          </div>
+
+          <div className="col-12 d-flex gap-2">
+            <button type="submit" className="btn btn-success rounded-0" disabled={ocupado}>
+              {guardando ? 'Guardando…' : 'Guardar'}
+            </button>
+            <button type="button" className="btn btn-outline-secondary rounded-0" onClick={onCancelar} disabled={ocupado}>
+              Cancelar
+            </button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  )
+}
+
+/**
+ * Picker de artículo (design: "articulo search/select"): sin catálogo completo cargado en
+ * memoria (podrían ser miles), busca contra `/api/articulos` con el mismo cliente que la
+ * pantalla de artículos. Búsqueda generacional (react-async-state rule 2): una respuesta tardía
+ * de una búsqueda anterior no puede pisar los resultados de la más reciente.
+ */
+function SelectorDeArticulo({
+  idArticulo,
+  nombreArticulo,
+  disabled,
+  onSeleccionar,
+}: {
+  idArticulo: number | ''
+  nombreArticulo: string
+  disabled: boolean
+  onSeleccionar: (id: number, nombre: string) => void
+}) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  async function buscar() {
+    if (buscando || disabled) return
+    const generacion = (generacionRef.current += 1)
+    setBuscando(true)
+    setError('')
+    try {
+      const pagina = await clienteDeArticulos.listar(termino, false)
+      if (generacionRef.current !== generacion) return
+      setResultados(pagina.items)
+    } catch (e) {
+      if (generacionRef.current === generacion) {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron buscar artículos.')
+      }
+    } finally {
+      if (generacionRef.current === generacion) setBuscando(false)
+    }
+  }
+
+  return (
+    <div>
+      <label className="form-label" htmlFor="of-buscar-articulo">
+        Buscar artículo
+      </label>
+      {idArticulo !== '' && (
+        <div className="mb-2">
+          Seleccionado: <strong>{nombreArticulo || `Artículo #${idArticulo}`}</strong>
+        </div>
+      )}
+      <div className="input-group mb-2" style={{ maxWidth: 420 }}>
+        <input
+          id="of-buscar-articulo"
+          type="search"
+          className="form-control rounded-0"
+          placeholder="Buscar por nombre o código interno…"
+          value={termino}
+          disabled={disabled}
+          onChange={(e) => setTermino(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), buscar())}
+        />
+        <button type="button" className="btn btn-outline-primary rounded-0" disabled={disabled || buscando} onClick={buscar}>
+          {buscando ? 'Buscando…' : 'Buscar'}
+        </button>
+      </div>
+      {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+      {resultados.length > 0 && (
+        <select
+          className="form-select rounded-0"
+          size={Math.min(resultados.length, 6)}
+          disabled={disabled}
+          value=""
+          onChange={(e) => {
+            const encontrado = resultados.find((a) => a.id === Number(e.target.value))
+            if (encontrado) onSeleccionar(encontrado.id, encontrado.nombre)
+          }}
+        >
+          <option value="" disabled>
+            Elegí un resultado…
+          </option>
+          {resultados.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.codigoInterno} — {a.nombre}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #33

## Summary

- Slice 4 of `stage-4-ofertas`: dedicated `Ofertas.tsx` ABM — exclusive scope picker (articulo search / grupo / categoria), vigencia block (date+time ranges, dias_semana toggles), exclusive benefit picker, prioridad/acumulable, multi-select listas (empty = all, stated in the UI), `/ofertas` route + nav, Admin-gated.
- Built compliant with `react-async-state` from day one (the stage-3 skill): ocupado mesh incl. table actions, token/generation gating everywhere incl. the save's own response, fieldset-disabled full window, first-line re-entrancy guards, keyed subtrees, honest non-blocking catalog avisos.
- `web-descriptor-tests` honored: pure mappers in `api/ofertas.ts` with 26 colocated Vitest tests (both exclusivity groups forced to null each direction, coercions, empty-listas semantics) + 10 component tests incl. an explicit rule-9 supersede-during-write test added at judgment-day's demand.

## Test Plan

- [x] `npx tsc -b` / `npx oxlint` / `npx vite build` — clean
- [x] `npx vitest run` — 57/57 (5 files)
- [x] judgment-day: APPROVED — R1: B CLEAN (9-rule trace, contract field-for-field); A: 1 real WARNING (rule-9 supersede path untested → test added, orchestrator-verified inline per the stage-3 test-only precedent) + 3 suggestions recorded as INFO.

## Notes

- `size:exception`: ~1.65k lines, single cohesive screen + its test suite.
- Listing omits a "Listas" column deliberately (listing endpoint doesn't populate idsListas per row — N+1 avoidance); targeting shows on detail/edit.
- INFO for future UX polish: min=0.001 on cantidad_minima, sin-resultados state in the articulo search, '—' fallback branch test.
- Slice 3 (resolution engine) runs in parallel; no file overlap.