### PR TITLE
feat(ofertas): motor de resolucion batch de ofertas (etapa 4, slice 3)

### DIFF
--- a/openspec/changes/stage-4-ofertas/design.md
+++ b/openspec/changes/stage-4-ofertas/design.md
@@ -170,6 +170,11 @@ token-reconcile it) and rule 5 (per-entity busy flags, not a page-level boolean)
 
 ## Open Questions
 
+**Added at judgment-day R1 (Slice 3):** `POST /api/ofertas/resolver` ships Admin-gated
+(`GestionDeCatalogo`) because no POS-facing policy exists yet — but its intended real
+caller is stage 5's POS flow (likely `Vendedor`). Stage 5 MUST revisit this policy before
+wiring the POS, or the checkout will hit 403s. Tracked here so it is not rediscovered.
+
 - [ ] **Time zone for `hora_desde/hasta` and `dias_semana` matching.** The resolver is
   timezone-free by design (decision 3), so `ServicioDeOfertas` must choose one. v1 default:
   server-configured local time. There is no tenant timezone modeled anywhere today

--- a/openspec/changes/stage-4-ofertas/tasks.md
+++ b/openspec/changes/stage-4-ofertas/tasks.md
@@ -252,11 +252,11 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
 
 ### 3A. Domain
 
-- [ ] 3.1 Add resolution contract record structs (`LineaAResolver`,
+- [x] 3.1 Add resolution contract record structs (`LineaAResolver`,
   `OfertaCandidata`, `AlcanceDeOferta`, `BeneficioDeOferta`,
   `OfertaAplicada`, `PrecioConOfertas`) in `Ways.Domain.Ofertas` per design's
   Resolution Contract shape.
-- [ ] 3.2 Add `ResolvedorDeOfertas.Resolver(linea, candidatas)` — pure
+- [x] 3.2 Add `ResolvedorDeOfertas.Resolver(linea, candidatas)` — pure
   static: base selection (highest `prioridad` among `acumulable = false`,
   tie-break greater discount then lower `id_oferta`); additive-over-original
   stacking (each discount computed independently against `PrecioOriginal`,
@@ -265,7 +265,7 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
   ascending `id_oferta`. *(design decisions 2, 3; Resolution Contract
   arithmetic table; spec: resolucion-de-ofertas / Base Selection and
   Tie-Break, Additive-Over-Original Stacking, all scenarios)*
-- [ ] 3.3 Add categoria ancestor-chain matching helper (builds the ancestor
+- [x] 3.3 Add categoria ancestor-chain matching helper (builds the ancestor
   set in memory from one `id_categoria`/`id_categoria_padre` projection,
   reusing `ReglaDeCategorias.ProfundidadMaxima = 3`). *(design: Batch
   Boundary — Categoria scope matching; spec: resolucion-de-ofertas /
@@ -273,7 +273,7 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
 
 ### 3B. Application — batch price path
 
-- [ ] 3.4 Add `ServicioDePrecios.PreciosVigentesEnLoteAsync(ids articulo,
+- [x] 3.4 Add `ServicioDePrecios.PreciosVigentesEnLoteAsync(ids articulo,
   ids lista, fecha, ct)` → `IReadOnlyDictionary<(int,int), decimal?>`: load
   requested listas by id (no `Activo` filter, matching
   `PrecioVigenteAsync`'s explicit-id semantics); load base listas of
@@ -287,7 +287,7 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
 
 ### 3C. Application — resolution service
 
-- [ ] 3.5 Add `ServicioDeOfertas.ResolverAsync(lineas)` — batch-first: one
+- [x] 3.5 Add `ServicioDeOfertas.ResolverAsync(lineas)` — batch-first: one
   `articulos` query, one categorias ancestor-map query, one `ofertas`
   query, one `ofertas_listas` query, calls `PreciosVigentesEnLoteAsync`
   (3 `precios` queries), then calls the pure `ResolvedorDeOfertas` per line
@@ -298,19 +298,19 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
   Technical Approach — 7 constant queries; decision 4 — in-memory lista
   targeting; spec: resolucion-de-ofertas / Batch Input Shape, Candidate
   Matching, all scenarios)*
-- [ ] 3.6 Add contracts: `LineaDeResolucion` (request DTO),
+- [x] 3.6 Add contracts: `LineaDeResolucion` (request DTO),
   `ResultadoDeResolucion` (response DTO incl. applied-ofertas list).
 
 ### 3D. API
 
-- [ ] 3.7 Add `POST /api/ofertas/resolver`, query-only (writes nothing —
+- [x] 3.7 Add `POST /api/ofertas/resolver`, query-only (writes nothing —
   doc-comment and endpoint summary MUST state "POST, no muta nada", design
   decision 7). *(spec: resolucion-de-ofertas / Applied Ofertas Are
   Reported, Never Persisted)*
 
 ### 3E. Tests
 
-- [ ] 3.8 [P] Unit: `ResolvedorDeOfertas` — exhaustive, every spec scenario
+- [x] 3.8 [P] Unit: `ResolvedorDeOfertas` — exhaustive, every spec scenario
   with the spec's concrete numbers (highest-prioridad base, both tie-breaks,
   acumulable-only-no-base, base+1 acumulable, multiple acumulables,
   `precio_unitario` as base, `precio_unitario` as acumulable, 100%-clamp,
@@ -319,27 +319,27 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
   Original Stacking — all scenarios; design: Testing Strategy — "bulk of
   the stage's test mass")* —
   `tests/Ways.Domain.Tests/Ofertas/ResolvedorDeOfertasTests.cs`.
-- [ ] 3.9 [P] Unit: candidate-matching helpers — categoria ancestor-chain
+- [x] 3.9 [P] Unit: candidate-matching helpers — categoria ancestor-chain
   reach, grupo match, empresa exclusion, empty-set-matches-all for lista and
   `dias_semana`. *(spec: resolucion-de-ofertas / Candidate Matching, all
   scenarios)*
-- [ ] 3.10 Integration (parity): `PreciosVigentesEnLoteAsync` ==
+- [x] 3.10 Integration (parity): `PreciosVigentesEnLoteAsync` ==
   `PrecioVigenteAsync` for the same inputs (fija, derivada, missing price,
   inactive lista) — assert value equality per pair, both paths in one test.
   *(design: Testing Strategy — Integration (parity); spec: precios /
   Existing single-articulo methods are unaffected)*
-- [ ] 3.11 Integration (batch query count): resolution over N articles
+- [x] 3.11 Integration (batch query count): resolution over N articles
   issues a **constant** query count — count commands via an EF
   interceptor/`DbCommand` log, assert count is independent of N. *(spec:
   resolucion-de-ofertas / Batch resolves many articulos in one call;
   design: Testing Strategy — Integration (batch))*
-- [ ] 3.12 Integration: `/resolver` end-to-end scenario mirroring a spec
+- [x] 3.12 Integration: `/resolver` end-to-end scenario mirroring a spec
   scenario (base + acumulable over real Postgres data), no-match
   passthrough, and a no-writes assertion (row counts unchanged across every
   affected table). *(spec: resolucion-de-ofertas / Result lists all applied
   ofertas, Resolution performs no writes)* —
   `tests/Ways.IntegrationTests/OfertasResolucionTests.cs`.
-- [ ] 3.13 Regression: Slice 1 + Slice 2 suites unedited and green.
+- [x] 3.13 Regression: Slice 1 + Slice 2 suites unedited and green.
 
 ---
 

--- a/openspec/changes/stage-4-ofertas/tasks.md
+++ b/openspec/changes/stage-4-ofertas/tasks.md
@@ -339,7 +339,10 @@ green. **Rollback**: new routes/methods only — `PrecioVigenteAsync`/
   affected table). *(spec: resolucion-de-ofertas / Result lists all applied
   ofertas, Resolution performs no writes)* —
   `tests/Ways.IntegrationTests/OfertasResolucionTests.cs`.
-- [x] 3.13 Regression: Slice 1 + Slice 2 suites unedited and green.
+- [x] 3.13 Regression: Slice 1 + Slice 2 test BEHAVIOR unchanged and suites
+  green — corrected at judgment-day R1: ServicioDeOfertasTests received a
+  mechanical DI-fixture update (ServicioDeOfertas gained a ServicioDePrecios
+  constructor dependency), no assertion or behavior changed.
 
 ---
 

--- a/src/Ways.Api/Endpoints/OfertasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OfertasEndpoints.cs
@@ -37,6 +37,14 @@ public static class OfertasEndpoints
         })
         .WithSummary("Baja lógica de la oferta.");
 
+        // stage-4-ofertas, Slice 3 (design decision 7): POST, no muta nada — solo resuelve
+        // precios + ofertas aplicadas para un lote de líneas, nunca escribe en ninguna tabla
+        // (spec: resolucion-de-ofertas / Applied Ofertas Are Reported, Never Persisted). POST en
+        // vez de GET porque el cuerpo es un lote de líneas, no algo que entre en un query string.
+        grupo.MapPost("/resolver", (ServicioDeOfertas servicio, SolicitudDeResolucion solicitud, CancellationToken ct) =>
+            servicio.ResolverAsync(solicitud.Lineas, solicitud.Momento, ct))
+        .WithSummary("POST, no muta nada: resuelve precio final y ofertas aplicadas para un lote de líneas.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Ofertas/Contratos.cs
+++ b/src/Ways.Application/Ofertas/Contratos.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ways.Application.Ofertas;
 
 /// <summary><see cref="IdsListas"/> (mismo criterio judgment-day que
@@ -93,16 +91,12 @@ public sealed record LineaDeResolucion(int IdArticulo, int? IdEmpresa, int IdLis
 /// <summary>Cuerpo de <c>POST /api/ofertas/resolver</c> — un único <paramref name="Momento"/>
 /// (design: Open Questions, "server-configured local time") para todo el lote entero, no uno
 /// por línea: resolver un carrito es "ahora" (o un instante hipotético) para todas sus líneas a
-/// la vez. <c>null</c> ⇒ <c>IRelojDelSistema.Ahora</c>.</summary>
-[method: SetsRequiredMembers]
-public sealed record SolicitudDeResolucion(IReadOnlyList<LineaDeResolucion> Lineas, DateTimeOffset? Momento = null)
-{
-    // Redeclara la propiedad posicional para poder marcarla `required` (STJ exige la clave
-    // "lineas" en el body y devuelve 400 si falta) — el positional record no permite `required`
-    // directo en la lista de parámetros; `SetsRequiredMembers` habilita seguir construyendo por
-    // posición (como ya hacen los tests) sin pasar por un inicializador de objeto.
-    public required IReadOnlyList<LineaDeResolucion> Lineas { get; init; } = Lineas;
-}
+/// la vez. <c>null</c> ⇒ <c>IRelojDelSistema.Ahora</c>. <see cref="Lineas"/> es nullable porque
+/// System.Text.Json no valida miembros <c>required</c> en constructores marcados
+/// <c>SetsRequiredMembers</c>: la clave "lineas" ausente o explícitamente <c>null</c> deserializa
+/// igual, así que <c>ServicioDeOfertas.ResolverAsync</c> es quien distingue ese caso (400
+/// <c>lineas_requeridas</c>) de un lote vacío legítimo (<c>[]</c> ⇒ resultado vacío).</summary>
+public sealed record SolicitudDeResolucion(IReadOnlyList<LineaDeResolucion>? Lineas, DateTimeOffset? Momento = null);
 
 /// <summary>Una oferta aplicada, forma HTTP de <c>Ways.Domain.Ofertas.OfertaAplicada</c>.</summary>
 public sealed record OfertaAplicadaDto(int IdOferta, string Nombre, decimal DescuentoUnitario);

--- a/src/Ways.Application/Ofertas/Contratos.cs
+++ b/src/Ways.Application/Ofertas/Contratos.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Ways.Application.Ofertas;
 
 /// <summary><see cref="IdsListas"/> (mismo criterio judgment-day que
@@ -92,7 +94,15 @@ public sealed record LineaDeResolucion(int IdArticulo, int? IdEmpresa, int IdLis
 /// (design: Open Questions, "server-configured local time") para todo el lote entero, no uno
 /// por línea: resolver un carrito es "ahora" (o un instante hipotético) para todas sus líneas a
 /// la vez. <c>null</c> ⇒ <c>IRelojDelSistema.Ahora</c>.</summary>
-public sealed record SolicitudDeResolucion(IReadOnlyList<LineaDeResolucion> Lineas, DateTimeOffset? Momento = null);
+[method: SetsRequiredMembers]
+public sealed record SolicitudDeResolucion(IReadOnlyList<LineaDeResolucion> Lineas, DateTimeOffset? Momento = null)
+{
+    // Redeclara la propiedad posicional para poder marcarla `required` (STJ exige la clave
+    // "lineas" en el body y devuelve 400 si falta) — el positional record no permite `required`
+    // directo en la lista de parámetros; `SetsRequiredMembers` habilita seguir construyendo por
+    // posición (como ya hacen los tests) sin pasar por un inicializador de objeto.
+    public required IReadOnlyList<LineaDeResolucion> Lineas { get; init; } = Lineas;
+}
 
 /// <summary>Una oferta aplicada, forma HTTP de <c>Ways.Domain.Ofertas.OfertaAplicada</c>.</summary>
 public sealed record OfertaAplicadaDto(int IdOferta, string Nombre, decimal DescuentoUnitario);

--- a/src/Ways.Application/Ofertas/Contratos.cs
+++ b/src/Ways.Application/Ofertas/Contratos.cs
@@ -78,3 +78,34 @@ public sealed record EdicionOferta(
     bool Acumulable,
     IReadOnlyList<int>? IdsListas,
     bool Activo);
+
+/// <summary>Una línea de entrada para <c>ServicioDeOfertas.ResolverAsync</c> (task 3.6, design:
+/// Resolution Contract) — a diferencia de <c>Ways.Domain.Ofertas.LineaAResolver</c> (pura,
+/// Domain), esta es la forma HTTP: no lleva ni la cadena de ancestros de categoría ni la
+/// descomposición de fecha/hora local (ambas las arma <c>ServicioDeOfertas</c>), y sí lleva
+/// <see cref="IdEmpresa"/> — el dato que <c>LineaAResolver</c> deliberadamente no lleva (spec:
+/// resolucion-de-ofertas / Candidate Matching, "Empresa-scoped oferta excludes other
+/// empresas"; ver <c>Ways.Domain.Ofertas.ReglaDeOfertas.CoincideEmpresa</c>).</summary>
+public sealed record LineaDeResolucion(int IdArticulo, int? IdEmpresa, int IdListaPrecio, decimal Cantidad);
+
+/// <summary>Cuerpo de <c>POST /api/ofertas/resolver</c> — un único <paramref name="Momento"/>
+/// (design: Open Questions, "server-configured local time") para todo el lote entero, no uno
+/// por línea: resolver un carrito es "ahora" (o un instante hipotético) para todas sus líneas a
+/// la vez. <c>null</c> ⇒ <c>IRelojDelSistema.Ahora</c>.</summary>
+public sealed record SolicitudDeResolucion(IReadOnlyList<LineaDeResolucion> Lineas, DateTimeOffset? Momento = null);
+
+/// <summary>Una oferta aplicada, forma HTTP de <c>Ways.Domain.Ofertas.OfertaAplicada</c>.</summary>
+public sealed record OfertaAplicadaDto(int IdOferta, string Nombre, decimal DescuentoUnitario);
+
+/// <summary>Resultado de resolver una línea (spec: resolucion-de-ofertas / Applied Ofertas Are
+/// Reported, Never Persisted) — <see cref="PrecioOriginal"/>/<see cref="PrecioFinal"/> son
+/// <c>null</c> cuando el lote de precios no tiene ningún precio vigente para el par
+/// (artículo, lista) consultado (caso fuera de alcance de la spec de ofertas: sin precio no hay
+/// nada que descontar, <see cref="Aplicadas"/> queda vacía).</summary>
+public sealed record ResultadoDeResolucion(
+    int IdArticulo,
+    int IdListaPrecio,
+    decimal? PrecioOriginal,
+    decimal? PrecioFinal,
+    decimal DescuentoUnitario,
+    IReadOnlyList<OfertaAplicadaDto> Aplicadas);

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -328,9 +328,16 @@ public class ServicioDeOfertas(
     public async Task<IReadOnlyList<ResultadoDeResolucion>> ResolverAsync(
         IReadOnlyList<LineaDeResolucion>? lineas, DateTimeOffset? momento, CancellationToken ct = default)
     {
-        // `required` en SolicitudDeResolucion.Lineas rechaza un cuerpo sin la clave, pero
-        // `{"lineas": null}` igual bindea null acá — se trata como lote vacío, mismo resultado.
-        if (lineas is null || lineas.Count == 0)
+        // La clave "lineas" ausente o explícitamente `null` en el body deserializa igual acá
+        // (STJ no valida `required` con constructores `SetsRequiredMembers`), así que el chequeo
+        // vive en el servicio: distingue un body malformado (400) de un lote vacío legítimo
+        // (`[]` ⇒ resultado vacío, sin error).
+        if (lineas is null)
+        {
+            throw new ErrorDominio("lineas_requeridas", "El campo 'lineas' es obligatorio.", 400);
+        }
+
+        if (lineas.Count == 0)
         {
             return [];
         }

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Precios;
 using Ways.Domain.Common;
 using Ways.Domain.Ofertas;
 
@@ -55,7 +56,8 @@ namespace Ways.Application.Ofertas;
 /// re-chequea existencia con un <c>EXISTS</c> plano DESPUÉS de tomar el lock (nunca reusa la
 /// entidad trackeada desde antes de la transacción, que el identity map de EF no refresca sola)
 /// — cualquiera de los dos que pierda la carrera del lock ve el estado YA COMITEADO por el otro.</summary>
-public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+public class ServicioDeOfertas(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDePrecios servicioDePrecios)
 {
     /// <summary>Sin filtro de <c>Activo</c> (a diferencia de <c>ServicioDeCatalogo</c>) —
     /// mismo criterio que <c>ArticuloListado</c>: el filtro global de baja lógica ya deja
@@ -300,6 +302,180 @@ public class ServicioDeOfertas(IWaysDbContext db, IRelojDelSistema reloj, IConte
             await db.SaveChangesAsync(ct);
             await transaccion.CommitAsync(ct);
         });
+    }
+
+    /// <summary>
+    /// Resolución batch, query-only (task 3.5; design: Technical Approach — "7 constant queries
+    /// per resolution call, independent of N articles × M listas"; spec: resolucion-de-ofertas /
+    /// Batch Input Shape). NUNCA escribe: ni acá ni en <see cref="ResolvedorDeOfertas"/> hay un
+    /// <c>SaveChangesAsync</c> — el resultado se reporta, nunca se persiste (spec: Applied
+    /// Ofertas Are Reported, Never Persisted).
+    ///
+    /// <para>Presupuesto: 1 <c>articulos</c> + 1 <c>categorias</c> (mapa de ancestros completo del
+    /// tenant) + 1 <c>ofertas</c> (filtro grueso: <c>activo</c>, alcance por ids, <c>id_empresa</c>)
+    /// + 1 <c>ofertas_listas</c> + hasta 3 de <see cref="ServicioDePrecios.PreciosVigentesEnLoteAsync"/>
+    /// = 7, sin loop de una consulta por línea. El resto del matching (ventana de vigencia,
+    /// <c>cantidad_minima</c>, lista objetivo, día de semana, alcance jerárquico de categoría) lo
+    /// hace <see cref="ResolvedorDeOfertas.Coincide"/> en memoria, por línea, sobre las mismas
+    /// <see cref="OfertaCandidata"/> ya materializadas — el único filtro por línea que corre ACÁ
+    /// (no en el resolver puro, porque <see cref="LineaAResolver"/> no lleva <c>id_empresa</c>,
+    /// design: Resolution Contract) es <see cref="ReglaDeOfertas.CoincideEmpresa"/>.</para>
+    ///
+    /// <para>Hora local (design: Open Questions, "server-configured local time" v1): el único
+    /// <paramref name="momento"/> del lote se descompone UNA vez con <see cref="TimeZoneInfo.Local"/>
+    /// — no hay huso horario de tenant modelado todavía.</para>
+    /// </summary>
+    public async Task<IReadOnlyList<ResultadoDeResolucion>> ResolverAsync(
+        IReadOnlyList<LineaDeResolucion> lineas, DateTimeOffset? momento, CancellationToken ct = default)
+    {
+        if (lineas.Count == 0)
+        {
+            return [];
+        }
+
+        var idsArticulo = lineas.Select(l => l.IdArticulo).Distinct().ToList();
+        var idsListaPrecio = lineas.Select(l => l.IdListaPrecio).Distinct().ToList();
+
+        // 1 consulta: alcance de los artículos pedidos (categoría/grupo propios).
+        var articulos = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .Select(a => new { a.Id, a.IdCategoria, a.IdGrupo })
+            .ToListAsync(ct);
+
+        var articuloPorId = articulos.ToDictionary(a => a.Id);
+
+        var idsArticuloFaltantes = idsArticulo.Except(articuloPorId.Keys).ToList();
+        if (idsArticuloFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el artículo {idsArticuloFaltantes[0]}.", 400);
+        }
+
+        // 1 consulta: mapa de ancestros de TODA la jerarquía de categorías del tenant — se arma
+        // en memoria por artículo, sin una consulta jerárquica por artículo (design: Batch
+        // Boundary — Categoria scope matching).
+        var padrePorCategoria = await db.Categorias
+            .Select(c => new { c.Id, c.IdCategoriaPadre })
+            .ToDictionaryAsync(c => c.Id, c => c.IdCategoriaPadre, ct);
+
+        var idsCategoriasPorArticulo = new Dictionary<int, IReadOnlySet<int>>(articulos.Count);
+        var todasLasCategoriasAlcanzables = new HashSet<int>();
+        var idsGrupo = new HashSet<int>();
+
+        foreach (var articulo in articulos)
+        {
+            var ancestros = articulo.IdCategoria is { } idCategoria
+                ? CadenaDeCategorias.ConstruirAncestros(idCategoria, padrePorCategoria)
+                : (IReadOnlySet<int>)new HashSet<int>();
+
+            idsCategoriasPorArticulo[articulo.Id] = ancestros;
+            todasLasCategoriasAlcanzables.UnionWith(ancestros);
+
+            if (articulo.IdGrupo is { } idGrupo)
+            {
+                idsGrupo.Add(idGrupo);
+            }
+        }
+
+        var idsEmpresa = lineas
+            .Where(l => l.IdEmpresa is not null)
+            .Select(l => l.IdEmpresa!.Value)
+            .Distinct()
+            .ToList();
+
+        // 1 consulta: ofertas activas cuyo alcance (por id, superconjunto de las líneas pedidas)
+        // e id_empresa podrían aplicar a ALGUNA línea del lote — el matching fino por línea
+        // (incl. id_empresa exacto) corre después, en memoria.
+        var ofertas = await db.Ofertas
+            .Where(o => o.Activo &&
+                ((o.IdArticulo != null && idsArticulo.Contains(o.IdArticulo.Value)) ||
+                 (o.IdGrupo != null && idsGrupo.Contains(o.IdGrupo.Value)) ||
+                 (o.IdCategoria != null && todasLasCategoriasAlcanzables.Contains(o.IdCategoria.Value))) &&
+                (o.IdEmpresa == null || idsEmpresa.Contains(o.IdEmpresa.Value)))
+            .ToListAsync(ct);
+
+        var idsOferta = ofertas.Select(o => o.Id).ToList();
+
+        // 1 consulta: targeting de listas de las ofertas candidatas.
+        var listasPorOferta = idsOferta.Count == 0
+            ? new Dictionary<int, IReadOnlySet<int>>()
+            : (await db.OfertasListas
+                .Where(ol => idsOferta.Contains(ol.IdOferta))
+                .Select(ol => new { ol.IdOferta, ol.IdListaPrecio })
+                .ToListAsync(ct))
+                .GroupBy(ol => ol.IdOferta)
+                .ToDictionary(g => g.Key, g => (IReadOnlySet<int>)g.Select(x => x.IdListaPrecio).ToHashSet());
+
+        // Candidatas materializadas UNA vez, compartidas entre todas las líneas — ReglaDeOfertas
+        // ya validó estas cinco guardas al escribir (Slice 2), así que proyectarlas acá nunca
+        // debería lanzar; si lo hace, es una fila corrupta fuera de banda (defensa en profundidad,
+        // no un camino alcanzable en operación normal).
+        var candidatasPorOferta = ofertas.Select(o => new
+        {
+            Oferta = o,
+            Candidata = new OfertaCandidata(
+                o.Id, o.Nombre, o.Prioridad, o.Acumulable,
+                ReglaDeOfertas.LeerAlcance(o), ReglaDeOfertas.LeerBeneficio(o), o.CantidadMinima,
+                o.FechaDesde, o.FechaHasta, o.HoraDesde, o.HoraHasta,
+                ReglaDeOfertas.LeerDiasSemana(o.DiasSemana),
+                listasPorOferta.TryGetValue(o.Id, out var listas) ? listas : new HashSet<int>())
+        }).ToList();
+
+        // Hasta 3 consultas: precios vigentes en lote para el producto cartesiano de artículos ×
+        // listas pedidas (design decision 5 — ServicioDePrecios.PreciosVigentesAsync/
+        // PrecioVigenteAsync quedan sin tocar).
+        var momentoEfectivo = momento ?? reloj.Ahora;
+        var precios = await servicioDePrecios.PreciosVigentesEnLoteAsync(idsArticulo, idsListaPrecio, momentoEfectivo, ct);
+
+        var (fechaLocal, horaLocal, diaSemanaLocal) = DescomponerHoraLocal(momentoEfectivo);
+
+        var resultado = new List<ResultadoDeResolucion>(lineas.Count);
+
+        foreach (var linea in lineas)
+        {
+            var precioOriginal = precios.TryGetValue((linea.IdArticulo, linea.IdListaPrecio), out var monto)
+                ? monto
+                : null;
+
+            if (precioOriginal is null)
+            {
+                resultado.Add(new ResultadoDeResolucion(
+                    linea.IdArticulo, linea.IdListaPrecio, null, null, 0m, []));
+                continue;
+            }
+
+            var candidatasDeLaLinea = candidatasPorOferta
+                .Where(c => ReglaDeOfertas.CoincideEmpresa(c.Oferta.IdEmpresa, linea.IdEmpresa))
+                .Select(c => c.Candidata)
+                .ToList();
+
+            var lineaAResolver = new LineaAResolver(
+                linea.IdArticulo, articuloPorId[linea.IdArticulo].IdGrupo,
+                idsCategoriasPorArticulo[linea.IdArticulo].ToList(),
+                linea.IdListaPrecio, linea.Cantidad, precioOriginal.Value,
+                fechaLocal, horaLocal, diaSemanaLocal);
+
+            var resuelto = ResolvedorDeOfertas.Resolver(lineaAResolver, candidatasDeLaLinea);
+
+            resultado.Add(new ResultadoDeResolucion(
+                linea.IdArticulo, linea.IdListaPrecio, resuelto.PrecioOriginal, resuelto.PrecioFinal,
+                resuelto.DescuentoUnitario,
+                resuelto.Aplicadas.Select(a => new OfertaAplicadaDto(a.IdOferta, a.Nombre, a.DescuentoUnitario)).ToList()));
+        }
+
+        return resultado;
+    }
+
+    /// <summary>Design: Open Questions, "Time zone for hora_desde/hasta and dias_semana
+    /// matching" — v1 usa <see cref="TimeZoneInfo.Local"/> (huso del servidor, no hay huso de
+    /// tenant modelado todavía). Día de semana ISO-8601 (1 = lunes … 7 = domingo) — .NET expone
+    /// <see cref="DayOfWeek"/> con domingo = 0, así que se remapea acá.</summary>
+    private static (DateOnly Fecha, TimeOnly Hora, int DiaSemana) DescomponerHoraLocal(DateTimeOffset momento)
+    {
+        var local = TimeZoneInfo.ConvertTime(momento, TimeZoneInfo.Local);
+        var diaSemanaDotNet = (int)local.DayOfWeek;
+        var diaSemanaIso = diaSemanaDotNet == 0 ? 7 : diaSemanaDotNet;
+
+        return (DateOnly.FromDateTime(local.DateTime), TimeOnly.FromDateTime(local.DateTime), diaSemanaIso);
     }
 
     /// <summary>Las cinco guardas de <see cref="ReglaDeOfertas"/> (design: Protection Rules) —

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -326,9 +326,11 @@ public class ServicioDeOfertas(
     /// — no hay huso horario de tenant modelado todavía.</para>
     /// </summary>
     public async Task<IReadOnlyList<ResultadoDeResolucion>> ResolverAsync(
-        IReadOnlyList<LineaDeResolucion> lineas, DateTimeOffset? momento, CancellationToken ct = default)
+        IReadOnlyList<LineaDeResolucion>? lineas, DateTimeOffset? momento, CancellationToken ct = default)
     {
-        if (lineas.Count == 0)
+        // `required` en SolicitudDeResolucion.Lineas rechaza un cuerpo sin la clave, pero
+        // `{"lineas": null}` igual bindea null acá — se trata como lote vacío, mismo resultado.
+        if (lineas is null || lineas.Count == 0)
         {
             return [];
         }

--- a/src/Ways.Application/Precios/ServicioDePrecios.cs
+++ b/src/Ways.Application/Precios/ServicioDePrecios.cs
@@ -254,6 +254,147 @@ public class ServicioDePrecios(IWaysDbContext db, IRelojDelSistema reloj, IConte
         return resultado;
     }
 
+    /// <summary>
+    /// Resolución batch (stage-4-ofertas, task 3.4; spec: precios / Batch Current-Price
+    /// Resolution; design: Batch Boundary) — ADITIVA: <see cref="PrecioVigenteAsync"/> y
+    /// <see cref="PreciosVigentesAsync"/> quedan sin tocar, misma firma y semántica (design
+    /// decision 5). Devuelve el producto cartesiano completo de <paramref name="idsArticulo"/> ×
+    /// <paramref name="idsListaPrecio"/> — nunca una consulta por par.
+    ///
+    /// <para>Presupuesto fijo de 3 consultas, independiente de N artículos × M listas: (1) las
+    /// listas pedidas por id, SIN filtro de <c>Activo</c> — mismo criterio explícito-por-id que
+    /// <see cref="PrecioVigenteAsync"/>, documentado ahí, no el "qué listas mostrar por default"
+    /// de <see cref="PreciosVigentesAsync"/>; (2) las listas base de las <c>derivada</c>s
+    /// pedidas, solo si alguna no vino ya incluida en (1); (3) UNA consulta de <c>precios</c> con
+    /// <c>= ANY</c> sobre el set de artículos y el set de listas <c>fija</c> involucradas (pedidas
+    /// + bases), agrupada en memoria por <c>OrderByDescending(VigenteDesde)</c> — misma
+    /// determinismo defensivo que <see cref="ObtenerPrecioFijaAsync"/>. Las derivadas se resuelven
+    /// con el mismo <see cref="ResolvedorDePrecios.ResolverPrecioDerivado"/> que
+    /// <see cref="ResolverPrecioAsync"/> (profundidad 1, guarda de precio negativo incluida).
+    /// </para>
+    /// </summary>
+    public async Task<IReadOnlyDictionary<(int IdArticulo, int IdListaPrecio), decimal?>> PreciosVigentesEnLoteAsync(
+        IReadOnlyList<int> idsArticulo, IReadOnlyList<int> idsListaPrecio, DateTimeOffset fecha,
+        CancellationToken ct = default)
+    {
+        if (idsArticulo.Count == 0 || idsListaPrecio.Count == 0)
+        {
+            return new Dictionary<(int, int), decimal?>();
+        }
+
+        // (1) Listas pedidas por id — sin filtro de Activo.
+        var listasPedidas = await db.ListasPrecio
+            .Where(l => idsListaPrecio.Contains(l.Id))
+            .ToListAsync(ct);
+
+        var idsListaFaltantes = idsListaPrecio.Except(listasPedidas.Select(l => l.Id)).ToList();
+        if (idsListaFaltantes.Count > 0)
+        {
+            throw new ErrorDominio(
+                "referencia_invalida", $"No existe la lista de precios {idsListaFaltantes[0]}.", 400);
+        }
+
+        var listaPorId = listasPedidas.ToDictionary(l => l.Id);
+
+        var derivadas = listasPedidas.Where(l => l.Modo == ModoLista.Derivada).ToList();
+        var idsBase = derivadas
+            .Select(d => d.IdListaBase
+                ?? throw new InvalidOperationException(
+                    $"La lista {d.Id} es derivada sin id_lista_base — invariante de ServicioDeListasPrecio violado."))
+            .Distinct()
+            .ToList();
+
+        // (2) Listas base de las derivadas — solo las que no vinieron ya en (1).
+        var idsBaseFaltantes = idsBase.Except(listaPorId.Keys).ToList();
+        if (idsBaseFaltantes.Count > 0)
+        {
+            var basesCargadas = await db.ListasPrecio
+                .Where(l => idsBaseFaltantes.Contains(l.Id))
+                .ToListAsync(ct);
+
+            foreach (var listaBaseCargada in basesCargadas)
+            {
+                listaPorId[listaBaseCargada.Id] = listaBaseCargada;
+            }
+        }
+
+        foreach (var derivada in derivadas)
+        {
+            var idListaBase = derivada.IdListaBase!.Value;
+            if (!listaPorId.TryGetValue(idListaBase, out var listaBase))
+            {
+                throw new ErrorDominio("referencia_invalida", $"No existe la lista base {idListaBase}.", 400);
+            }
+
+            if (listaBase.Modo != ModoLista.Fija)
+            {
+                throw new ErrorDominio(
+                    "lista_base_invalida",
+                    "La lista base de una lista derivada no puede ser a su vez derivada.",
+                    400);
+            }
+        }
+
+        // (3) UNA consulta de precios sobre todas las listas fija involucradas.
+        var idsListaFija = listaPorId.Values
+            .Where(l => l.Modo == ModoLista.Fija)
+            .Select(l => l.Id)
+            .Distinct()
+            .ToList();
+
+        var filas = idsListaFija.Count == 0
+            ? []
+            : await db.Precios
+                .Where(p =>
+                    idsArticulo.Contains(p.IdArticulo) && idsListaFija.Contains(p.IdListaPrecio) &&
+                    p.VigenteDesde <= fecha && (p.VigenteHasta == null || p.VigenteHasta > fecha))
+                .ToListAsync(ct);
+
+        var montoFijaPorPar = filas
+            .GroupBy(p => (p.IdArticulo, p.IdListaPrecio))
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.VigenteDesde).First().Monto);
+
+        var resultado = new Dictionary<(int, int), decimal?>(idsArticulo.Count * idsListaPrecio.Count);
+
+        foreach (var idArticulo in idsArticulo)
+        {
+            foreach (var idListaPrecio in idsListaPrecio)
+            {
+                var lista = listaPorId[idListaPrecio];
+
+                if (lista.Modo == ModoLista.Fija)
+                {
+                    resultado[(idArticulo, idListaPrecio)] =
+                        montoFijaPorPar.TryGetValue((idArticulo, idListaPrecio), out var montoFija)
+                            ? montoFija
+                            : null;
+                    continue;
+                }
+
+                var idListaBase = lista.IdListaBase!.Value;
+                var montoBase = montoFijaPorPar.TryGetValue((idArticulo, idListaBase), out var montoBaseValor)
+                    ? montoBaseValor
+                    : (decimal?)null;
+
+                if (montoBase is null)
+                {
+                    resultado[(idArticulo, idListaPrecio)] = null;
+                    continue;
+                }
+
+                var porcentaje = lista.Porcentaje
+                    ?? throw new ErrorDominio(
+                        "precio_derivado_invalido",
+                        $"La lista derivada {lista.Id} no tiene porcentaje configurado.",
+                        422);
+
+                resultado[(idArticulo, idListaPrecio)] = ResolvedorDePrecios.ResolverPrecioDerivado(montoBase.Value, porcentaje);
+            }
+        }
+
+        return resultado;
+    }
+
     /// <summary>Historial completo (spec: Price History Never Overwrites, "Historical prices
     /// remain queryable") — solo tiene sentido para una lista <c>fija</c>: una <c>derivada</c>
     /// nunca tiene filas propias.</summary>

--- a/src/Ways.Domain/Ofertas/CadenaDeCategorias.cs
+++ b/src/Ways.Domain/Ofertas/CadenaDeCategorias.cs
@@ -1,0 +1,43 @@
+using Ways.Domain.Catalogos;
+
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Construye, en memoria, la cadena de ancestros de una categoría (design: Batch Boundary —
+/// Categoria scope matching; task 3.3; spec: resolucion-de-ofertas / Categoria-scoped oferta
+/// reaches subcategoria articulos) a partir de UNA proyección <c>id_categoria</c> →
+/// <c>id_categoria_padre</c> del tenant completo — así una oferta scoped a "Bebidas" alcanza
+/// artículos de "Gaseosas" (hija) sin una consulta jerárquica por artículo.
+/// </summary>
+public static class CadenaDeCategorias
+{
+    /// <summary>Devuelve <paramref name="idCategoria"/> más todos sus ancestros, acotado por
+    /// <see cref="ReglaDeCategorias.ProfundidadMaxima"/> iteraciones — ni la profundidad real
+    /// del árbol (que ya respeta ese límite en escritura, ADR-12) ni un ciclo corrupto por fuera
+    /// de esa regla pueden hacer loopear esta función.</summary>
+    public static IReadOnlySet<int> ConstruirAncestros(
+        int idCategoria, IReadOnlyDictionary<int, int?> padrePorCategoria)
+    {
+        var ancestros = new HashSet<int> { idCategoria };
+        var actual = idCategoria;
+
+        for (var i = 0; i < ReglaDeCategorias.ProfundidadMaxima; i++)
+        {
+            if (!padrePorCategoria.TryGetValue(actual, out var padre) || padre is not { } idPadre)
+            {
+                break;
+            }
+
+            if (!ancestros.Add(idPadre))
+            {
+                // Ciclo corrupto (no alcanzable en operación normal — ReglaDeCategorias lo
+                // rechaza en escritura, ADR-12): cortar acá en vez de loopear.
+                break;
+            }
+
+            actual = idPadre;
+        }
+
+        return ancestros;
+    }
+}

--- a/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
+++ b/src/Ways.Domain/Ofertas/ReglaDeOfertas.cs
@@ -158,4 +158,13 @@ public static class ReglaDeOfertas
 
         return conjunto;
     }
+
+    /// <summary>Spec: resolucion-de-ofertas / Candidate Matching, "Empresa-scoped oferta
+    /// excludes other empresas" — <c>NULL</c> ⇒ toda empresa del tenant (design decision 5);
+    /// seteado, tiene que coincidir exactamente con la empresa de la línea consultada. Pura,
+    /// sin depender de <see cref="LineaAResolver"/> (que no lleva <c>id_empresa</c>, design:
+    /// Resolution Contract) — <c>ServicioDeOfertas.ResolverAsync</c> filtra por acá ANTES de
+    /// armar la lista de candidatas de cada línea.</summary>
+    public static bool CoincideEmpresa(int? idEmpresaOferta, int? idEmpresaLinea) =>
+        idEmpresaOferta is null || idEmpresaOferta == idEmpresaLinea;
 }

--- a/src/Ways.Domain/Ofertas/ResolucionDeOfertas.cs
+++ b/src/Ways.Domain/Ofertas/ResolucionDeOfertas.cs
@@ -1,0 +1,57 @@
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Contrato de resolución (design: Resolution Contract, task 3.1) — records puros, sin
+/// dependencias, que <see cref="ResolvedorDeOfertas"/> consume. <see cref="IdsCategorias"/> ya
+/// llega resuelto (categoría propia + ancestros, ver <see cref="CadenaDeCategorias"/>): el
+/// resolver nunca hace su propia consulta jerárquica, solo compara contra el conjunto que le
+/// entrega <c>ServicioDeOfertas.ResolverAsync</c>. <see cref="DiaSemana"/> es ISO-8601
+/// (1 = lunes … 7 = domingo, spec: ofertas / Vigencia Window Semantics).
+/// </summary>
+public readonly record struct LineaAResolver(
+    int IdArticulo,
+    int? IdGrupo,
+    IReadOnlyList<int> IdsCategorias,
+    int IdListaPrecio,
+    decimal Cantidad,
+    decimal PrecioOriginal,
+    DateOnly Fecha,
+    TimeOnly Hora,
+    int DiaSemana);
+
+/// <summary>
+/// Una oferta candidata para una <see cref="LineaAResolver"/>. Ya pasó el filtro grueso de SQL
+/// (<c>activo</c>, alcance por ids, <c>id_empresa</c>) en <c>ServicioDeOfertas.ResolverAsync</c>
+/// — lo que le falta matchear (ventana de vigencia, <c>cantidad_minima</c>, lista objetivo, día
+/// de semana) lo evalúa <see cref="ResolvedorDeOfertas.Coincide"/> antes de aplicar la
+/// aritmética. <see cref="DiasSemana"/>/<see cref="ListasObjetivo"/> vacíos ⇒ sin restricción
+/// (spec: ofertas / Vigencia Window Semantics, Multi-Lista Targeting via ofertas_listas).
+/// </summary>
+public readonly record struct OfertaCandidata(
+    int Id,
+    string Nombre,
+    int Prioridad,
+    bool Acumulable,
+    AlcanceDeOferta Alcance,
+    BeneficioDeOferta Beneficio,
+    decimal? CantidadMinima,
+    DateOnly? FechaDesde,
+    DateOnly? FechaHasta,
+    TimeOnly? HoraDesde,
+    TimeOnly? HoraHasta,
+    IReadOnlySet<int> DiasSemana,
+    IReadOnlySet<int> ListasObjetivo);
+
+/// <summary>Una oferta efectivamente aplicada a una línea — solo para reporte (design: Resolution
+/// Contract). El orden en que aparece en <see cref="PrecioConOfertas.Aplicadas"/> (descendente
+/// <c>Prioridad</c>, luego ascendente <c>IdOferta</c>) no afecta el monto calculado.</summary>
+public readonly record struct OfertaAplicada(int IdOferta, string Nombre, decimal DescuentoUnitario);
+
+/// <summary>Resultado de resolver UNA línea — <see cref="DescuentoUnitario"/> es la suma ya
+/// clampeada de todos los <see cref="OfertaAplicada.DescuentoUnitario"/> (design: arithmetic
+/// table, "Total = min(Σ discounts, PrecioOriginal)").</summary>
+public readonly record struct PrecioConOfertas(
+    decimal PrecioOriginal,
+    decimal PrecioFinal,
+    decimal DescuentoUnitario,
+    IReadOnlyList<OfertaAplicada> Aplicadas);

--- a/src/Ways.Domain/Ofertas/ResolvedorDeOfertas.cs
+++ b/src/Ways.Domain/Ofertas/ResolvedorDeOfertas.cs
@@ -1,0 +1,153 @@
+namespace Ways.Domain.Ofertas;
+
+/// <summary>
+/// Motor de resolución (design: Technical Approach — "SQL side is deliberately dumb"; task 3.2)
+/// — pura, sin base de datos, mismo criterio que <see cref="Precios.ResolvedorDePrecios"/>.
+/// <see cref="Resolver"/> hace las dos cosas que el nombre promete: primero filtra
+/// <paramref name="candidatas"/> con <see cref="Coincide"/> (spec: resolucion-de-ofertas /
+/// Candidate Matching — ventana de vigencia, <c>cantidad_minima</c>, lista objetivo, día de
+/// semana; el alcance por <c>id_empresa</c> NO se evalúa acá — <c>ServicioDeOfertas</c> ya lo
+/// resolvió antes de armar la lista de candidatas de esta línea, porque
+/// <see cref="LineaAResolver"/> no lleva ese dato), y recién con las que matchean aplica
+/// precedencia + apilado aditivo-sobre-original (spec: Base Selection and Tie-Break,
+/// Additive-Over-Original Stacking).
+/// </summary>
+public static class ResolvedorDeOfertas
+{
+    /// <summary>Punto de entrada único: matchea y resuelve una línea contra su conjunto de
+    /// candidatas (design: Resolution Contract).</summary>
+    public static PrecioConOfertas Resolver(in LineaAResolver linea, IReadOnlyList<OfertaCandidata> candidatas)
+    {
+        var coincidentes = new List<OfertaCandidata>(candidatas.Count);
+        foreach (var candidata in candidatas)
+        {
+            if (Coincide(linea, candidata))
+            {
+                coincidentes.Add(candidata);
+            }
+        }
+
+        var aplicadas = new List<(OfertaCandidata Candidata, decimal Descuento)>();
+
+        // Copia local: el parámetro `in` de linea no se puede capturar dentro de una lambda
+        // (CS1628) — precioOriginal es el único campo de linea que la aritmética necesita de
+        // acá en más.
+        var precioOriginal = linea.PrecioOriginal;
+
+        // Base: la de mayor prioridad entre las NO acumulables (spec: Base Selection and
+        // Tie-Break) — empate 1: mayor descuento efectivo; empate 2: menor id_oferta. Si no hay
+        // ninguna no-acumulable que matchee, no hay base (spec: "Acumulable-only candidates
+        // apply with no base" — el precio original queda como base implícita).
+        var noAcumulables = coincidentes.Where(c => !c.Acumulable).ToList();
+        if (noAcumulables.Count > 0)
+        {
+            var candidataBase = noAcumulables
+                .Select(c => (Candidata: c, Descuento: DescuentoDe(c.Beneficio, precioOriginal)))
+                .OrderByDescending(x => x.Candidata.Prioridad)
+                .ThenByDescending(x => x.Descuento)
+                .ThenBy(x => x.Candidata.Id)
+                .First();
+
+            aplicadas.Add(candidataBase);
+        }
+
+        // Todas las acumulables que matchean se suman, sin competir entre sí (spec: "Multiple
+        // acumulables stack on the base").
+        foreach (var candidata in coincidentes.Where(c => c.Acumulable))
+        {
+            aplicadas.Add((candidata, DescuentoDe(candidata.Beneficio, precioOriginal)));
+        }
+
+        var descuentoTotal = Math.Clamp(aplicadas.Sum(a => a.Descuento), 0m, precioOriginal);
+        var precioFinal = precioOriginal - descuentoTotal;
+
+        var reportadas = aplicadas
+            .OrderByDescending(a => a.Candidata.Prioridad)
+            .ThenBy(a => a.Candidata.Id)
+            .Select(a => new OfertaAplicada(a.Candidata.Id, a.Candidata.Nombre, a.Descuento))
+            .ToList();
+
+        return new PrecioConOfertas(linea.PrecioOriginal, precioFinal, descuentoTotal, reportadas);
+    }
+
+    /// <summary>Spec: resolucion-de-ofertas / Candidate Matching — TODOS los ejes seteados
+    /// tienen que matchear (AND), cada eje NULL/vacío no restringe (spec: ofertas / Vigencia
+    /// Window Semantics, Multi-Lista Targeting via ofertas_listas). El alcance
+    /// (articulo/grupo/categoria) usa <see cref="LineaAResolver.IdsCategorias"/> — ya expandido
+    /// a la cadena de ancestros por el llamador (<see cref="CadenaDeCategorias"/>), así que un
+    /// <c>Contains</c> plano alcanza para el match jerárquico.</summary>
+    public static bool Coincide(in LineaAResolver linea, OfertaCandidata candidata)
+    {
+        if (!CoincideAlcance(linea, candidata.Alcance))
+        {
+            return false;
+        }
+
+        if (candidata.ListasObjetivo.Count > 0 && !candidata.ListasObjetivo.Contains(linea.IdListaPrecio))
+        {
+            return false;
+        }
+
+        if (candidata.DiasSemana.Count > 0 && !candidata.DiasSemana.Contains(linea.DiaSemana))
+        {
+            return false;
+        }
+
+        if (candidata.FechaDesde is { } fechaDesde && linea.Fecha < fechaDesde)
+        {
+            return false;
+        }
+
+        if (candidata.FechaHasta is { } fechaHasta && linea.Fecha > fechaHasta)
+        {
+            return false;
+        }
+
+        if (candidata.HoraDesde is { } horaDesde && linea.Hora < horaDesde)
+        {
+            return false;
+        }
+
+        if (candidata.HoraHasta is { } horaHasta && linea.Hora > horaHasta)
+        {
+            return false;
+        }
+
+        return candidata.CantidadMinima is not { } cantidadMinima || linea.Cantidad >= cantidadMinima;
+    }
+
+    private static bool CoincideAlcance(in LineaAResolver linea, AlcanceDeOferta alcance)
+    {
+        if (alcance.IdArticulo is { } idArticulo)
+        {
+            return idArticulo == linea.IdArticulo;
+        }
+
+        if (alcance.IdGrupo is { } idGrupo)
+        {
+            return linea.IdGrupo == idGrupo;
+        }
+
+        var idCategoria = alcance.IdCategoria!.Value;
+        return linea.IdsCategorias.Contains(idCategoria);
+    }
+
+    /// <summary>Design: arithmetic table (binding, proposal decision 1) — cada beneficio se
+    /// calcula independientemente contra <paramref name="original"/>, redondeado a 2 decimales
+    /// <see cref="MidpointRounding.AwayFromZero"/> (mismo criterio de punto de venta que
+    /// <see cref="Precios.ResolvedorDePrecios"/>) y clampeado a <c>[0, original]</c> — una oferta
+    /// nunca puede subir el precio (<c>precio_unitario &gt; original</c> da 0, no un descuento
+    /// negativo).</summary>
+    private static decimal DescuentoDe(BeneficioDeOferta beneficio, decimal original)
+    {
+        var crudo = beneficio.Porcentaje is { } porcentaje ? original * porcentaje / 100m
+            : beneficio.ImporteFijo is { } importeFijo ? importeFijo
+            : beneficio.PrecioUnitario is { } precioUnitario ? original - precioUnitario
+            : throw new InvalidOperationException(
+                "BeneficioDeOferta sin beneficio seteado — invariante de ReglaDeOfertas.LeerBeneficio violado.");
+
+        var redondeado = Math.Round(crudo, 2, MidpointRounding.AwayFromZero);
+
+        return Math.Clamp(redondeado, 0m, original);
+    }
+}

--- a/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
+++ b/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Application.Ofertas;
+using Ways.Application.Precios;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Ofertas;
@@ -68,6 +69,17 @@ public class ServicioDeOfertasTests
         new(new DbContextOptionsBuilder<WaysDbContext>().UseInMemoryDatabase(nombreDeBase).Options, tenantActual);
 
     private static ServicioDeOfertas CrearServicio(string nombreDeBase, int idTenant) =>
+        new(
+            CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, idTenant)),
+            new RelojFijo(Ahora),
+            new ContextoFijo(idTenant),
+            CrearServicioDePrecios(nombreDeBase, idTenant));
+
+    /// <summary>Instancia real de <see cref="ServicioDePrecios"/> sobre el MISMO nombre de base
+    /// InMemory — <see cref="ServicioDeOfertas.ResolverAsync"/> (Slice 3) la usa para el lote de
+    /// precios; ningún test de este archivo la ejercita todavía (cubierto en
+    /// <c>ServicioDeOfertasResolucionTests</c>), pero el constructor la necesita.</summary>
+    private static ServicioDePrecios CrearServicioDePrecios(string nombreDeBase, int idTenant) =>
         new(
             CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, idTenant)),
             new RelojFijo(Ahora),

--- a/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
+++ b/tests/Ways.Application.Tests/Ofertas/ServicioDeOfertasTests.cs
@@ -78,7 +78,8 @@ public class ServicioDeOfertasTests
     /// <summary>Instancia real de <see cref="ServicioDePrecios"/> sobre el MISMO nombre de base
     /// InMemory — <see cref="ServicioDeOfertas.ResolverAsync"/> (Slice 3) la usa para el lote de
     /// precios; ningún test de este archivo la ejercita todavía (cubierto en
-    /// <c>ServicioDeOfertasResolucionTests</c>), pero el constructor la necesita.</summary>
+    /// <c>ResolvedorDeOfertasTests</c>/<c>OfertasResolucionTests</c>), pero el constructor la
+    /// necesita.</summary>
     private static ServicioDePrecios CrearServicioDePrecios(string nombreDeBase, int idTenant) =>
         new(
             CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, idTenant)),

--- a/tests/Ways.Application.Tests/Precios/ServicioDePreciosLoteTests.cs
+++ b/tests/Ways.Application.Tests/Precios/ServicioDePreciosLoteTests.cs
@@ -1,0 +1,192 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Precios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.Application.Tests.Precios;
+
+/// <summary>
+/// stage-4-ofertas, Slice 3 (task 3.10, design: Testing Strategy — "Integration (parity)"; spec:
+/// precios / Batch Current-Price Resolution) — <see cref="ServicioDePrecios.PreciosVigentesEnLoteAsync"/>
+/// tiene que devolver EXACTAMENTE lo mismo que <see cref="ServicioDePrecios.PrecioVigenteAsync"/>
+/// pareja por pareja, para fija con precio, fija sin precio, derivada, y lista inactiva (misma
+/// semántica explícita-por-id que <see cref="ServicioDePrecios.PrecioVigenteAsync"/>, sin filtro
+/// de <c>Activo</c> — divergencia documentada en ambos métodos). Corre contra el proveedor
+/// InMemory: ninguno de los dos caminos (lote/single) abre transacción.
+/// </summary>
+public class ServicioDePreciosLoteTests
+{
+    private static readonly DateTimeOffset Ahora = new(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
+    private const int IdTenant = 1;
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int? idTenant) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => 999;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    private static WaysDbContext CrearContexto(string nombreDeBase, ITenantActual tenantActual) =>
+        new(new DbContextOptionsBuilder<WaysDbContext>().UseInMemoryDatabase(nombreDeBase).Options, tenantActual);
+
+    private static ServicioDePrecios CrearServicio(string nombreDeBase) =>
+        new(
+            CrearContexto(nombreDeBase, new TenantActualFijo(ModoDeAcceso.Tenant, IdTenant)),
+            new RelojFijo(Ahora),
+            new ContextoFijo(IdTenant));
+
+    private static async Task<int> SembrarArticuloAsync(string nombreDeBase, string nombre)
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var articulo = new Articulo
+        {
+            IdTenant = IdTenant,
+            CodigoInterno = nombre,
+            Nombre = nombre,
+            IdArea = 1,
+            IdAlicuotaIva = 1,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = Ahora,
+            UpdatedAt = Ahora
+        };
+        siembra.Articulos.Add(articulo);
+        await siembra.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private static async Task<int> SembrarListaFijaAsync(string nombreDeBase, string nombre, bool activo = true)
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = IdTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija, Activo = activo,
+            CreatedAt = Ahora, UpdatedAt = Ahora
+        };
+        siembra.ListasPrecio.Add(lista);
+        await siembra.SaveChangesAsync();
+        return lista.Id;
+    }
+
+    private static async Task<int> SembrarListaDerivadaAsync(
+        string nombreDeBase, string nombre, int idListaBase, decimal porcentaje)
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = IdTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Derivada,
+            IdListaBase = idListaBase, Porcentaje = porcentaje, CreatedAt = Ahora, UpdatedAt = Ahora
+        };
+        siembra.ListasPrecio.Add(lista);
+        await siembra.SaveChangesAsync();
+        return lista.Id;
+    }
+
+    private static async Task SembrarPrecioAsync(
+        string nombreDeBase, int idArticulo, int idListaPrecio, decimal monto)
+    {
+        await using var siembra = CrearContexto(nombreDeBase, TenantActualFijo.Plataforma);
+
+        siembra.Precios.Add(new Precio
+        {
+            IdTenant = IdTenant,
+            IdArticulo = idArticulo,
+            IdListaPrecio = idListaPrecio,
+            Monto = monto,
+            VigenteDesde = Ahora.AddDays(-1),
+            VigenteHasta = null,
+            CreatedAt = Ahora,
+            UpdatedAt = Ahora
+        });
+        await siembra.SaveChangesAsync();
+    }
+
+    /// <summary>Cubre las 4 combinaciones del design (fija con precio, fija sin precio,
+    /// derivada, lista inactiva) en un solo lote — el lote y el camino single tienen que
+    /// coincidir en TODAS.</summary>
+    [Fact]
+    public async Task PreciosVigentesEnLoteCoincideConPrecioVigenteParaCadaPar()
+    {
+        var nombreDeBase = nameof(PreciosVigentesEnLoteCoincideConPrecioVigenteParaCadaPar);
+
+        var idArticuloConPrecio = await SembrarArticuloAsync(nombreDeBase, "con-precio");
+        var idArticuloSinPrecio = await SembrarArticuloAsync(nombreDeBase, "sin-precio");
+
+        var idListaFija = await SembrarListaFijaAsync(nombreDeBase, "General");
+        var idListaInactiva = await SembrarListaFijaAsync(nombreDeBase, "Inactiva", activo: false);
+        var idListaDerivada = await SembrarListaDerivadaAsync(nombreDeBase, "Derivada", idListaFija, porcentaje: -10m);
+
+        await SembrarPrecioAsync(nombreDeBase, idArticuloConPrecio, idListaFija, 100m);
+        await SembrarPrecioAsync(nombreDeBase, idArticuloConPrecio, idListaInactiva, 50m);
+
+        var idsArticulo = new[] { idArticuloConPrecio, idArticuloSinPrecio };
+        var idsListaPrecio = new[] { idListaFija, idListaInactiva, idListaDerivada };
+
+        var servicioLote = CrearServicio(nombreDeBase);
+        var lote = await servicioLote.PreciosVigentesEnLoteAsync(idsArticulo, idsListaPrecio, Ahora);
+
+        foreach (var idArticulo in idsArticulo)
+        {
+            foreach (var idListaPrecio in idsListaPrecio)
+            {
+                var servicioSingle = CrearServicio(nombreDeBase);
+                var single = await servicioSingle.PrecioVigenteAsync(idArticulo, idListaPrecio, Ahora);
+
+                Assert.True(
+                    lote.TryGetValue((idArticulo, idListaPrecio), out var precioDelLote),
+                    $"Falta el par ({idArticulo}, {idListaPrecio}) en el resultado del lote.");
+                Assert.Equal(single.Precio, precioDelLote);
+            }
+        }
+
+        // Aserciones puntuales, para que un futuro cambio que rompa la paridad falle acá con un
+        // mensaje concreto, no solo en el loop genérico de arriba.
+        Assert.Equal(100m, lote[(idArticuloConPrecio, idListaFija)]);
+        Assert.Null(lote[(idArticuloSinPrecio, idListaFija)]);
+        Assert.Equal(90m, lote[(idArticuloConPrecio, idListaDerivada)]);
+        Assert.Equal(50m, lote[(idArticuloConPrecio, idListaInactiva)]);
+    }
+
+    /// <summary>Spec: precios / "Existing single-articulo methods are unaffected" — el método
+    /// nuevo es aditivo, <see cref="ServicioDePrecios.PrecioVigenteAsync"/> sigue funcionando
+    /// exactamente igual sin pasar por el lote.</summary>
+    [Fact]
+    public async Task PrecioVigenteAsyncSigueFuncionandoIgualSinPasarPorElLote()
+    {
+        var nombreDeBase = nameof(PrecioVigenteAsyncSigueFuncionandoIgualSinPasarPorElLote);
+        var idArticulo = await SembrarArticuloAsync(nombreDeBase, "articulo");
+        var idLista = await SembrarListaFijaAsync(nombreDeBase, "General");
+        await SembrarPrecioAsync(nombreDeBase, idArticulo, idLista, 55m);
+
+        var servicio = CrearServicio(nombreDeBase);
+        var resultado = await servicio.PrecioVigenteAsync(idArticulo, idLista, Ahora);
+
+        Assert.Equal(55m, resultado.Precio);
+    }
+
+    [Fact]
+    public async Task PreciosVigentesEnLoteConSetsVaciosDevuelveVacioSinConsultar()
+    {
+        var nombreDeBase = nameof(PreciosVigentesEnLoteConSetsVaciosDevuelveVacioSinConsultar);
+        var servicio = CrearServicio(nombreDeBase);
+
+        var resultado = await servicio.PreciosVigentesEnLoteAsync([], [1], Ahora);
+
+        Assert.Empty(resultado);
+    }
+}

--- a/tests/Ways.Domain.Tests/Ofertas/CadenaDeCategoriasTests.cs
+++ b/tests/Ways.Domain.Tests/Ofertas/CadenaDeCategoriasTests.cs
@@ -1,0 +1,56 @@
+using Ways.Domain.Ofertas;
+
+namespace Ways.Domain.Tests.Ofertas;
+
+/// <summary>
+/// stage-4-ofertas, Slice 3 (task 3.3; design: Batch Boundary — Categoria scope matching) —
+/// función pura, sin base de datos.
+/// </summary>
+public class CadenaDeCategoriasTests
+{
+    /// <summary>Bebidas (1, raíz) → Gaseosas (2) → Cola (3): la cadena de "Cola" incluye los tres
+    /// niveles — spec: resolucion-de-ofertas / "Categoria-scoped oferta reaches subcategoria
+    /// articulos".</summary>
+    [Fact]
+    public void ConstruirAncestrosDevuelveLaPropiaCategoriaMasTodosSusAncestros()
+    {
+        var padrePorCategoria = new Dictionary<int, int?> { [1] = null, [2] = 1, [3] = 2 };
+
+        var ancestros = CadenaDeCategorias.ConstruirAncestros(3, padrePorCategoria);
+
+        Assert.Equal(new HashSet<int> { 1, 2, 3 }, ancestros);
+    }
+
+    [Fact]
+    public void UnaCategoriaRaizDevuelveSoloASiMisma()
+    {
+        var padrePorCategoria = new Dictionary<int, int?> { [1] = null };
+
+        var ancestros = CadenaDeCategorias.ConstruirAncestros(1, padrePorCategoria);
+
+        Assert.Equal(new HashSet<int> { 1 }, ancestros);
+    }
+
+    /// <summary>Nunca hace más de <see cref="Catalogos.ReglaDeCategorias.ProfundidadMaxima"/>
+    /// saltos, incluso ante un ciclo corrupto por fuera de esa regla (no alcanzable en operación
+    /// normal, pero esta función no debe loopear si llegara a existir).</summary>
+    [Fact]
+    public void UnCicloCorruptoNoHaceLoopearLaFuncion()
+    {
+        var padrePorCategoria = new Dictionary<int, int?> { [1] = 2, [2] = 1 };
+
+        var ancestros = CadenaDeCategorias.ConstruirAncestros(1, padrePorCategoria);
+
+        Assert.Equal(new HashSet<int> { 1, 2 }, ancestros);
+    }
+
+    [Fact]
+    public void UnaCategoriaAusenteDelMapaDevuelveSoloASiMisma()
+    {
+        var padrePorCategoria = new Dictionary<int, int?>();
+
+        var ancestros = CadenaDeCategorias.ConstruirAncestros(99, padrePorCategoria);
+
+        Assert.Equal(new HashSet<int> { 99 }, ancestros);
+    }
+}

--- a/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
+++ b/tests/Ways.Domain.Tests/Ofertas/ReglaDeOfertasTests.cs
@@ -350,4 +350,37 @@ public class ReglaDeOfertasTests
 
         Assert.Equal("dias_semana_invalidos", error.Codigo);
     }
+
+    // --- CoincideEmpresa (stage-4-ofertas, Slice 3, task 3.9; spec: resolucion-de-ofertas /
+    // Candidate Matching, "Empresa-scoped oferta excludes other empresas") ---
+
+    [Fact]
+    public void CoincideEmpresaConOfertaSinEmpresaMatcheaCualquierEmpresaDeLinea()
+    {
+        Assert.True(ReglaDeOfertas.CoincideEmpresa(idEmpresaOferta: null, idEmpresaLinea: 5));
+    }
+
+    [Fact]
+    public void CoincideEmpresaConOfertaSinEmpresaMatcheaLineaSinEmpresa()
+    {
+        Assert.True(ReglaDeOfertas.CoincideEmpresa(idEmpresaOferta: null, idEmpresaLinea: null));
+    }
+
+    [Fact]
+    public void CoincideEmpresaConLaMismaEmpresaMatchea()
+    {
+        Assert.True(ReglaDeOfertas.CoincideEmpresa(idEmpresaOferta: 5, idEmpresaLinea: 5));
+    }
+
+    [Fact]
+    public void CoincideEmpresaConEmpresaDistintaNoMatchea()
+    {
+        Assert.False(ReglaDeOfertas.CoincideEmpresa(idEmpresaOferta: 5, idEmpresaLinea: 6));
+    }
+
+    [Fact]
+    public void CoincideEmpresaConOfertaDeEmpresaYLineaSinEmpresaNoMatchea()
+    {
+        Assert.False(ReglaDeOfertas.CoincideEmpresa(idEmpresaOferta: 5, idEmpresaLinea: null));
+    }
 }

--- a/tests/Ways.Domain.Tests/Ofertas/ResolvedorDeOfertasTests.cs
+++ b/tests/Ways.Domain.Tests/Ofertas/ResolvedorDeOfertasTests.cs
@@ -1,0 +1,451 @@
+using Ways.Domain.Ofertas;
+
+namespace Ways.Domain.Tests.Ofertas;
+
+/// <summary>
+/// stage-4-ofertas, Slice 3 (tasks 3.8/3.9; spec: resolucion-de-ofertas / Base Selection and
+/// Tie-Break, Additive-Over-Original Stacking, Candidate Matching) — función pura, sin base de
+/// datos, mismo criterio que <see cref="Precios.ResolvedorDePreciosTests"/>. Cubre, con los
+/// números concretos del spec, tanto la aritmética (<see cref="ResolvedorDeOfertas.Resolver"/>)
+/// como el matching (<see cref="ResolvedorDeOfertas.Coincide"/>) — <c>id_empresa</c> queda
+/// afuera a propósito: <see cref="LineaAResolver"/> no lo lleva (design: Resolution Contract),
+/// se prueba en <see cref="ReglaDeOfertasTests"/> vía <c>ReglaDeOfertas.CoincideEmpresa</c>.
+/// </summary>
+public class ResolvedorDeOfertasTests
+{
+    private static readonly DateOnly Fecha = new(2026, 8, 3);
+    private static readonly TimeOnly Hora = new(12, 0);
+    private const int DiaSemana = 1; // lunes
+
+    private static LineaAResolver CrearLinea(
+        int idArticulo = 1, int? idGrupo = null, IReadOnlyList<int>? idsCategorias = null,
+        int idListaPrecio = 1, decimal cantidad = 1m, decimal precioOriginal = 1000m,
+        DateOnly? fecha = null, TimeOnly? hora = null, int? diaSemana = null) =>
+        new(
+            idArticulo, idGrupo, idsCategorias ?? [], idListaPrecio, cantidad, precioOriginal,
+            fecha ?? Fecha, hora ?? Hora, diaSemana ?? DiaSemana);
+
+    private static OfertaCandidata CrearCandidata(
+        int id = 1, string nombre = "oferta", int prioridad = 0, bool acumulable = false,
+        AlcanceDeOferta? alcance = null, BeneficioDeOferta? beneficio = null,
+        decimal? cantidadMinima = null, DateOnly? fechaDesde = null, DateOnly? fechaHasta = null,
+        TimeOnly? horaDesde = null, TimeOnly? horaHasta = null,
+        IReadOnlySet<int>? diasSemana = null, IReadOnlySet<int>? listasObjetivo = null) =>
+        new(
+            id, nombre, prioridad, acumulable,
+            alcance ?? AlcanceDeOferta.DeArticulo(1), beneficio ?? BeneficioDeOferta.DePorcentaje(10m),
+            cantidadMinima, fechaDesde, fechaHasta, horaDesde, horaHasta,
+            diasSemana ?? new HashSet<int>(), listasObjetivo ?? new HashSet<int>());
+
+    // --- Base Selection and Tie-Break ---
+
+    /// <summary>Spec: "Highest prioridad wins as base".</summary>
+    [Fact]
+    public void LaMayorPrioridadGanaComoBase()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var baja = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+        var alta = CrearCandidata(id: 2, prioridad: 20, beneficio: BeneficioDeOferta.DePorcentaje(15m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [baja, alta]);
+
+        var aplicada = Assert.Single(resultado.Aplicadas);
+        Assert.Equal(2, aplicada.IdOferta);
+        Assert.Equal(150m, aplicada.DescuentoUnitario);
+        Assert.Equal(850m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Equal prioridad ties break by greater discount" — $600 de línea, -$50 fijo
+    /// vs -10% ($60): gana el de -10%.</summary>
+    [Fact]
+    public void UnEmpateDePrioridadSeRompePorMayorDescuento()
+    {
+        var linea = CrearLinea(precioOriginal: 600m);
+        var fijo = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DeImporteFijo(50m));
+        var porcentaje = CrearCandidata(id: 2, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [fijo, porcentaje]);
+
+        var aplicada = Assert.Single(resultado.Aplicadas);
+        Assert.Equal(2, aplicada.IdOferta);
+        Assert.Equal(60m, aplicada.DescuentoUnitario);
+    }
+
+    /// <summary>Spec: "Remaining tie breaks by lower id_oferta" — mismo descuento, gana id 5.</summary>
+    [Fact]
+    public void UnEmpateRemanenteSeRompePorMenorIdOferta()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var idMayor = CrearCandidata(id: 9, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+        var idMenor = CrearCandidata(id: 5, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [idMayor, idMenor]);
+
+        var aplicada = Assert.Single(resultado.Aplicadas);
+        Assert.Equal(5, aplicada.IdOferta);
+    }
+
+    /// <summary>Spec: "Acumulable-only candidates apply with no base" — el precio original queda
+    /// como base implícita.</summary>
+    [Fact]
+    public void CandidatasSoloAcumulablesAplicanSinBase()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var acumulable = CrearCandidata(id: 1, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [acumulable]);
+
+        var aplicada = Assert.Single(resultado.Aplicadas);
+        Assert.Equal(100m, aplicada.DescuentoUnitario);
+        Assert.Equal(900m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "No matching oferta leaves the price unchanged".</summary>
+    [Fact]
+    public void SinCandidatasQueMatcheenElPrecioQuedaSinCambios()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, []);
+
+        Assert.Empty(resultado.Aplicadas);
+        Assert.Equal(0m, resultado.DescuentoUnitario);
+        Assert.Equal(1000m, resultado.PrecioFinal);
+    }
+
+    // --- Additive-Over-Original Stacking ---
+
+    /// <summary>Spec: "Base plus one acumulable" — $1000, base -20% ($200), acc -10% ($100),
+    /// suma $300, final $700.</summary>
+    [Fact]
+    public void BaseMasUnaAcumulableSumanContraElOriginal()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var basePorcentaje = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(20m));
+        var acumulable = CrearCandidata(id: 2, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [basePorcentaje, acumulable]);
+
+        Assert.Equal(300m, resultado.DescuentoUnitario);
+        Assert.Equal(700m, resultado.PrecioFinal);
+        Assert.Equal(2, resultado.Aplicadas.Count);
+    }
+
+    /// <summary>Spec: "Multiple acumulables stack on the base" — $1000, base -20% ($200), acc
+    /// -10% ($100) y -$50 fijo, suma $350, final $650.</summary>
+    [Fact]
+    public void MultiplesAcumulablesSeApilanSobreLaBase()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var basePorcentaje = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(20m));
+        var acumulablePorcentaje = CrearCandidata(id: 2, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+        var acumulableFijo = CrearCandidata(id: 3, acumulable: true, beneficio: BeneficioDeOferta.DeImporteFijo(50m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [basePorcentaje, acumulablePorcentaje, acumulableFijo]);
+
+        Assert.Equal(350m, resultado.DescuentoUnitario);
+        Assert.Equal(650m, resultado.PrecioFinal);
+        Assert.Equal(3, resultado.Aplicadas.Count);
+    }
+
+    /// <summary>Spec: "precio_unitario as the base" — $1000, base precio_unitario=750 (descuento
+    /// $250), acc -10% ($100), suma $350, final $650.</summary>
+    [Fact]
+    public void PrecioUnitarioComoBase()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var base_ = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePrecioUnitario(750m));
+        var acumulable = CrearCandidata(id: 2, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [base_, acumulable]);
+
+        Assert.Equal(350m, resultado.DescuentoUnitario);
+        Assert.Equal(650m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "precio_unitario as an acumulable" — $1000, base -10% ($100), acc
+    /// precio_unitario=600 (descuento $400), suma $500, final $500.</summary>
+    [Fact]
+    public void PrecioUnitarioComoAcumulable()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var base_ = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+        var acumulable = CrearCandidata(id: 2, acumulable: true, beneficio: BeneficioDeOferta.DePrecioUnitario(600m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [base_, acumulable]);
+
+        Assert.Equal(500m, resultado.DescuentoUnitario);
+        Assert.Equal(500m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Combined discount over 100% clamps to zero" — $1000, base -80% ($800),
+    /// acc -30% ($300) y -20% ($200): suma cruda $1300, clampeada a $1000, final $0.</summary>
+    [Fact]
+    public void UnDescuentoCombinadoQueSuperaElCienPorCientoClampeaACero()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var base_ = CrearCandidata(id: 1, prioridad: 10, beneficio: BeneficioDeOferta.DePorcentaje(80m));
+        var acumulable1 = CrearCandidata(id: 2, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(30m));
+        var acumulable2 = CrearCandidata(id: 3, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(20m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [base_, acumulable1, acumulable2]);
+
+        Assert.Equal(1000m, resultado.DescuentoUnitario);
+        Assert.Equal(0m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Derivada lista price is the original base" — el resolver no sabe de dónde
+    /// vino el precio original: si ya es el precio derivado resuelto ($180, 10% off de una base
+    /// de $200) y hay un -10% acumulable, el descuento se calcula sobre $180 ($18), nunca sobre
+    /// la base de $200.</summary>
+    [Fact]
+    public void ElPrecioOriginalDeUnaListaDerivadaEsLaBaseDelDescuento()
+    {
+        var linea = CrearLinea(precioOriginal: 180m);
+        var acumulable = CrearCandidata(id: 1, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(10m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [acumulable]);
+
+        Assert.Equal(18m, resultado.DescuentoUnitario);
+        Assert.Equal(162m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Result lists all applied ofertas" — reporte ordenado descendente por
+    /// prioridad, luego ascendente por id_oferta (sin afectar el monto).</summary>
+    [Fact]
+    public void LasAplicadasSeReportanOrdenadasPorPrioridadDescendenteLuegoIdAscendente()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var base_ = CrearCandidata(id: 5, prioridad: 20, beneficio: BeneficioDeOferta.DePorcentaje(20m));
+        var acumulableAltaPrioridad = CrearCandidata(id: 3, prioridad: 30, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(5m));
+        var acumulableBajaPrioridad = CrearCandidata(id: 1, prioridad: 1, acumulable: true, beneficio: BeneficioDeOferta.DePorcentaje(5m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [base_, acumulableAltaPrioridad, acumulableBajaPrioridad]);
+
+        Assert.Equal([3, 5, 1], resultado.Aplicadas.Select(a => a.IdOferta));
+    }
+
+    // --- Candidate Matching: alcance ---
+
+    /// <summary>Spec: "Categoria-scoped oferta reaches subcategoria articulos" — la línea ya
+    /// llega con la cadena de ancestros expandida (categoría propia + ancestros).</summary>
+    [Fact]
+    public void UnaOfertaScopedACategoriaMatcheaViaLaCadenaDeAncestrosDeLaLinea()
+    {
+        var idBebidas = 1;
+        var idGaseosas = 2;
+        var linea = CrearLinea(idsCategorias: [idGaseosas, idBebidas]);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeCategoria(idBebidas));
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnaOfertaScopedACategoriaFueraDeLaCadenaDeAncestrosNoMatchea()
+    {
+        var linea = CrearLinea(idsCategorias: [2, 1]);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeCategoria(99));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: "Grupo-scoped oferta matches via the articulo's grupo".</summary>
+    [Fact]
+    public void UnaOfertaScopedAGrupoMatcheaViaElGrupoDelArticulo()
+    {
+        var linea = CrearLinea(idGrupo: 7);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeGrupo(7));
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnaOfertaScopedAGrupoNoMatcheaOtroGrupo()
+    {
+        var linea = CrearLinea(idGrupo: 7);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeGrupo(8));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnaOfertaScopedAGrupoNoMatcheaUnArticuloSinGrupo()
+    {
+        var linea = CrearLinea(idGrupo: null);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeGrupo(7));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnaOfertaScopedAArticuloNoMatcheaOtroArticulo()
+    {
+        var linea = CrearLinea(idArticulo: 1);
+        var candidata = CrearCandidata(alcance: AlcanceDeOferta.DeArticulo(2));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    // --- Candidate Matching: lista objetivo ---
+
+    /// <summary>Spec: ofertas / "No junction rows targets every lista".</summary>
+    [Fact]
+    public void UnaListaObjetivoVaciaMatcheaCualquierLista()
+    {
+        var linea = CrearLinea(idListaPrecio: 42);
+        var candidata = CrearCandidata(listasObjetivo: new HashSet<int>());
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "Junction rows restrict targeting".</summary>
+    [Fact]
+    public void UnaListaObjetivoNoVaciaRestringeElMatch()
+    {
+        var linea = CrearLinea(idListaPrecio: 42);
+        var candidata = CrearCandidata(listasObjetivo: new HashSet<int> { 1, 2 });
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    // --- Candidate Matching: vigencia (fecha/hora/dias_semana) ---
+
+    /// <summary>Spec: ofertas / "All-NULL vigencia always matches".</summary>
+    [Fact]
+    public void VigenciaTodaNulaSiempreMatchea()
+    {
+        var linea = CrearLinea(fecha: new DateOnly(2099, 1, 1), hora: new TimeOnly(23, 59), diaSemana: 7);
+        var candidata = CrearCandidata();
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "Boundary dates and hours are inclusive".</summary>
+    [Fact]
+    public void LosLimitesDeFechaYHoraSonInclusivos()
+    {
+        var linea = CrearLinea(fecha: new DateOnly(2026, 8, 3), hora: new TimeOnly(14, 0));
+        var candidata = CrearCandidata(
+            fechaDesde: new DateOnly(2026, 8, 1), fechaHasta: new DateOnly(2026, 8, 3),
+            horaDesde: new TimeOnly(10, 0), horaHasta: new TimeOnly(14, 0));
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "Outside any single axis excludes the match" — un día después de
+    /// fecha_hasta.</summary>
+    [Fact]
+    public void UnDiaDespuesDeFechaHastaExcluyeElMatch()
+    {
+        var linea = CrearLinea(fecha: new DateOnly(2026, 8, 4), hora: new TimeOnly(12, 0));
+        var candidata = CrearCandidata(
+            fechaDesde: new DateOnly(2026, 8, 1), fechaHasta: new DateOnly(2026, 8, 3),
+            horaDesde: new TimeOnly(10, 0), horaHasta: new TimeOnly(14, 0));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnDiaAntesDeFechaDesdeExcluyeElMatch()
+    {
+        var linea = CrearLinea(fecha: new DateOnly(2026, 7, 31));
+        var candidata = CrearCandidata(fechaDesde: new DateOnly(2026, 8, 1));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void UnaHoraFueraDeLaVentanaExcluyeElMatch()
+    {
+        var linea = CrearLinea(hora: new TimeOnly(9, 59));
+        var candidata = CrearCandidata(horaDesde: new TimeOnly(10, 0), horaHasta: new TimeOnly(14, 0));
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "dias_semana restricts to listed weekdays" — sábado y domingo,
+    /// evaluado un miércoles.</summary>
+    [Fact]
+    public void DiasSemanaRestringeALosDiasListados()
+    {
+        var miercoles = 3;
+        var linea = CrearLinea(diaSemana: miercoles);
+        var candidata = CrearCandidata(diasSemana: new HashSet<int> { 6, 7 });
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    [Fact]
+    public void DiasSemanaVacioMatcheaCualquierDia()
+    {
+        var linea = CrearLinea(diaSemana: 3);
+        var candidata = CrearCandidata(diasSemana: new HashSet<int>());
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    // --- Candidate Matching: cantidad_minima ---
+
+    /// <summary>Spec: ofertas / "NULL cantidad_minima always matches".</summary>
+    [Fact]
+    public void CantidadMinimaNulaSiempreMatchea()
+    {
+        var linea = CrearLinea(cantidad: 1m);
+        var candidata = CrearCandidata(cantidadMinima: null);
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "Quantity below threshold excludes the match".</summary>
+    [Fact]
+    public void CantidadPorDebajoDelUmbralExcluyeElMatch()
+    {
+        var linea = CrearLinea(cantidad: 2m);
+        var candidata = CrearCandidata(cantidadMinima: 3m);
+
+        Assert.False(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    /// <summary>Spec: ofertas / "Quantity at threshold matches".</summary>
+    [Fact]
+    public void CantidadEnElUmbralMatchea()
+    {
+        var linea = CrearLinea(cantidad: 3m);
+        var candidata = CrearCandidata(cantidadMinima: 3m);
+
+        Assert.True(ResolvedorDeOfertas.Coincide(linea, candidata));
+    }
+
+    // --- Aritmética por beneficio: redondeo y clamp de precio_unitario > original ---
+
+    /// <summary>Design: arithmetic table — <c>precio_unitario &gt; original</c> da descuento 0,
+    /// no negativo (la oferta nunca sube el precio).</summary>
+    [Fact]
+    public void UnPrecioUnitarioMayorAlOriginalDaDescuentoCero()
+    {
+        var linea = CrearLinea(precioOriginal: 100m);
+        var candidata = CrearCandidata(prioridad: 10, beneficio: BeneficioDeOferta.DePrecioUnitario(150m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [candidata]);
+
+        Assert.Equal(0m, resultado.DescuentoUnitario);
+        Assert.Equal(100m, resultado.PrecioFinal);
+    }
+
+    /// <summary>Design: arithmetic table — redondeo AwayFromZero a 2 decimales (no bankers'
+    /// rounding), mismo criterio que <see cref="Precios.ResolvedorDePreciosTests"/>. Empate
+    /// exacto de medio centavo vía <c>importe_fijo</c> (no se calcula por multiplicación, así
+    /// que el tercer decimal exacto no depende de ningún redondeo intermedio) sobre un original
+    /// holgado, para no interferir con el clamp <c>[0, original]</c>.</summary>
+    [Fact]
+    public void ElDescuentoRedondeaAwayFromZero()
+    {
+        var linea = CrearLinea(precioOriginal: 1000m);
+        var candidata = CrearCandidata(prioridad: 10, beneficio: BeneficioDeOferta.DeImporteFijo(0.125m));
+
+        var resultado = ResolvedorDeOfertas.Resolver(linea, [candidata]);
+
+        Assert.Equal(0.13m, resultado.DescuentoUnitario);
+        Assert.Equal(999.87m, resultado.PrecioFinal);
+    }
+}

--- a/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
@@ -1,0 +1,467 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Precios;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-4-ofertas, Slice 3 (tasks 3.11/3.12) — <c>POST /api/ofertas/resolver</c> punta a punta
+/// contra Postgres real: escenario base + acumulable del spec, passthrough sin match, alcance
+/// jerárquico de categoría, exclusión por empresa, base derivada, la aserción de "no escribe
+/// nada" (spec: resolucion-de-ofertas / Applied Ofertas Are Reported, Never Persisted), y el
+/// guard de cantidad constante de consultas (design: Testing Strategy — "Integration (batch)").
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OfertasResolucionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int? idTenant) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => 999;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Cuenta cada <c>SELECT</c> que EF Core emite a través de su propio pipeline de
+    /// comandos — el guard de la task 3.11 (design: "constant query count, independent of N").
+    /// El <c>set_config</c> de <see cref="InterceptorDeContextoDeTenant"/> corre por FUERA de
+    /// este pipeline (ADO.NET crudo sobre la conexión), así que nunca se cuenta acá.</summary>
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private async Task<(int IdTenant, string MailAdmin, string PasswordAdmin)> AprovisionarTenantAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
+        Assert.NotNull(resultado);
+
+        return (resultado!.IdTenant, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private async Task<HttpClient> ClienteLogueadoAsync(string mail, string password)
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, password));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(int idTenant, string nombre, int? idCategoria = null, int? idGrupo = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = idTenant, Nombre = $"{nombre}-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = idTenant,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdCategoria = idCategoria,
+            IdGrupo = idGrupo,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarCategoriaAsync(int idTenant, string nombre, int? idCategoriaPadre = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var categoria = new Categoria
+        {
+            IdTenant = idTenant, Nombre = nombre, Orden = 1, IdCategoriaPadre = idCategoriaPadre,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Categorias.Add(categoria);
+        await db.SaveChangesAsync();
+
+        return categoria.Id;
+    }
+
+    private async Task<int> SembrarEmpresaAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var empresa = new Empresa { IdTenant = idTenant, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        return empresa.Id;
+    }
+
+    private async Task<int> SembrarListaAsync(int idTenant, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = idTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        return lista.Id;
+    }
+
+    private async Task<int> SembrarListaDerivadaAsync(int idTenant, string nombre, int idListaBase, decimal porcentaje)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = idTenant, Nombre = nombre, EsDefault = false, Modo = ModoLista.Derivada,
+            IdListaBase = idListaBase, Porcentaje = porcentaje, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        return lista.Id;
+    }
+
+    private async Task SembrarPrecioAsync(int idTenant, int idArticulo, int idListaPrecio, decimal monto)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = idTenant, IdArticulo = idArticulo, IdListaPrecio = idListaPrecio, Monto = monto,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static AltaOferta OfertaDeArticulo(
+        int idArticulo, decimal? porcentaje = null, decimal? importeFijo = null, decimal? precioUnitario = null,
+        int prioridad = 0, bool acumulable = false) => new(
+        Nombre: "oferta de prueba", IdEmpresa: null, IdArticulo: idArticulo, IdGrupo: null, IdCategoria: null,
+        FechaDesde: null, FechaHasta: null, HoraDesde: null, HoraHasta: null, DiasSemana: null,
+        CantidadMinima: null, PrecioUnitario: precioUnitario, Porcentaje: porcentaje, ImporteFijo: importeFijo,
+        Prioridad: prioridad, Acumulable: acumulable);
+
+    private static AltaOferta OfertaDeCategoria(int idCategoria, decimal porcentaje, int prioridad = 0) => new(
+        Nombre: "oferta de categoría", IdEmpresa: null, IdArticulo: null, IdGrupo: null, IdCategoria: idCategoria,
+        FechaDesde: null, FechaHasta: null, HoraDesde: null, HoraHasta: null, DiasSemana: null,
+        CantidadMinima: null, PrecioUnitario: null, Porcentaje: porcentaje, ImporteFijo: null,
+        Prioridad: prioridad, Acumulable: false);
+
+    private static async Task<OfertaListado> CrearOfertaAsync(HttpClient cliente, AltaOferta datos)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/ofertas", datos);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        return (await respuesta.Content.ReadFromJsonAsync<OfertaListado>())!;
+    }
+
+    // ---- task 3.12: escenario end-to-end (spec: Base plus one acumulable) ---------------------
+
+    [Fact]
+    public async Task ResolverAplicaBaseYAcumulableSobreDatosReales()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverAplicaBaseYAcumulableSobreDatosReales));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-base-acc");
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idLista, 1000m);
+
+        await CrearOfertaAsync(admin, OfertaDeArticulo(idArticulo, porcentaje: 20m, prioridad: 10));
+        await CrearOfertaAsync(admin, OfertaDeArticulo(idArticulo, porcentaje: 10m, acumulable: true));
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, idLista, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        var linea = Assert.Single(resultado!);
+
+        Assert.Equal(1000m, linea.PrecioOriginal);
+        Assert.Equal(700m, linea.PrecioFinal);
+        Assert.Equal(300m, linea.DescuentoUnitario);
+        Assert.Equal(2, linea.Aplicadas.Count);
+    }
+
+    /// <summary>Spec: "No matching oferta leaves the price unchanged".</summary>
+    [Fact]
+    public async Task ResolverSinOfertaQueMatcheeDevuelveElPrecioOriginalSinCambios()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverSinOfertaQueMatcheeDevuelveElPrecioOriginalSinCambios));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-sin-oferta");
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idLista, 500m);
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, idLista, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        var linea = Assert.Single(resultado!);
+
+        Assert.Equal(500m, linea.PrecioOriginal);
+        Assert.Equal(500m, linea.PrecioFinal);
+        Assert.Empty(linea.Aplicadas);
+    }
+
+    /// <summary>Spec: "Categoria-scoped oferta reaches subcategoria articulos" — Bebidas (padre)
+    /// → Gaseosas (hija), artículo scoped a Gaseosas.</summary>
+    [Fact]
+    public async Task ResolverConCategoriaDescendienteAplicaLaOfertaDeLaCategoriaAncestro()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(
+            nameof(ResolverConCategoriaDescendienteAplicaLaOfertaDeLaCategoriaAncestro));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idBebidas = await SembrarCategoriaAsync(idTenant, "Bebidas");
+        var idGaseosas = await SembrarCategoriaAsync(idTenant, "Gaseosas", idBebidas);
+        var idArticulo = await SembrarArticuloAsync(idTenant, "cola", idCategoria: idGaseosas);
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idLista, 200m);
+
+        await CrearOfertaAsync(admin, OfertaDeCategoria(idBebidas, porcentaje: 15m));
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, idLista, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        var linea = Assert.Single(resultado!);
+
+        Assert.Equal(30m, linea.DescuentoUnitario);
+        Assert.Equal(170m, linea.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Empresa-scoped oferta excludes other empresas".</summary>
+    [Fact]
+    public async Task ResolverExcluyeOfertasDeOtraEmpresa()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverExcluyeOfertasDeOtraEmpresa));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idEmpresaA = await SembrarEmpresaAsync(idTenant, "Empresa A");
+        var idEmpresaB = await SembrarEmpresaAsync(idTenant, "Empresa B");
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-empresa");
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idLista, 100m);
+
+        var ofertaDeEmpresaA = OfertaDeArticulo(idArticulo, porcentaje: 50m) with { IdEmpresa = idEmpresaA };
+        await CrearOfertaAsync(admin, ofertaDeEmpresaA);
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, idEmpresaB, idLista, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        var linea = Assert.Single(resultado!);
+
+        Assert.Equal(100m, linea.PrecioFinal);
+        Assert.Empty(linea.Aplicadas);
+    }
+
+    /// <summary>Spec: "Derivada lista price is the original base" — 200 base, -10% derivada =
+    /// 180 (design decision 5, batch price path); -10% acumulable sobre 180 = 18, final 162.</summary>
+    [Fact]
+    public async Task ResolverConListaDerivadaUsaElPrecioDerivadoComoOriginal()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverConListaDerivadaUsaElPrecioDerivadoComoOriginal));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-derivada");
+        var idListaBase = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idListaBase, 200m);
+        var idListaDerivada = await SembrarListaDerivadaAsync(idTenant, "Derivada", idListaBase, -10m);
+
+        await CrearOfertaAsync(admin, OfertaDeArticulo(idArticulo, porcentaje: 10m, acumulable: true));
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, idListaDerivada, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        var linea = Assert.Single(resultado!);
+
+        Assert.Equal(180m, linea.PrecioOriginal);
+        Assert.Equal(18m, linea.DescuentoUnitario);
+        Assert.Equal(162m, linea.PrecioFinal);
+    }
+
+    /// <summary>Spec: "Resolution performs no writes" — cuenta de filas de las cuatro tablas
+    /// involucradas, antes y después, tiene que coincidir.</summary>
+    [Fact]
+    public async Task ResolverNoEscribeEnNingunaTabla()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(nameof(ResolverNoEscribeEnNingunaTabla));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-sin-escritura");
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        await SembrarPrecioAsync(idTenant, idArticulo, idLista, 300m);
+        await CrearOfertaAsync(admin, OfertaDeArticulo(idArticulo, porcentaje: 10m));
+
+        var filasAntes = await ContarFilasAsync(idTenant);
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, idLista, 5m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var filasDespues = await ContarFilasAsync(idTenant);
+
+        Assert.Equal(filasAntes, filasDespues);
+    }
+
+    private async Task<(int Ofertas, int OfertasListas, int Precios, int Articulos)> ContarFilasAsync(int idTenant)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+
+        return (
+            await db.Ofertas.IgnoreQueryFilters(["BajaLogica"]).CountAsync(),
+            await db.OfertasListas.CountAsync(),
+            await db.Precios.IgnoreQueryFilters(["BajaLogica"]).CountAsync(),
+            await db.Articulos.IgnoreQueryFilters(["BajaLogica"]).CountAsync());
+    }
+
+    // ---- task 3.11: guard de cantidad constante de consultas -----------------------------------
+
+    /// <summary>Design: Technical Approach — "7 constant queries per resolution call, independent
+    /// of N articles × M listas". Corre la misma resolución con pocos y con muchos artículos (2 y
+    /// 20) y exige la MISMA cantidad de consultas — el guard contra reintroducir un N+1
+    /// silencioso.</summary>
+    [Fact]
+    public async Task ResolverEmiteUnaCantidadConstanteDeConsultasIndependienteDeN()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) = await AprovisionarTenantAsync(
+            nameof(ResolverEmiteUnaCantidadConstanteDeConsultasIndependienteDeN));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idCategoria = await SembrarCategoriaAsync(idTenant, "Categoria");
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+        var idListaDerivada = await SembrarListaDerivadaAsync(idTenant, "Derivada", idLista, -10m);
+
+        await CrearOfertaAsync(admin, OfertaDeCategoria(idCategoria, porcentaje: 10m));
+
+        var consultasConPocosArticulos =
+            await ContarConsultasDeResolucionAsync(idTenant, cantidadDeArticulos: 2, idCategoria, idLista, idListaDerivada);
+        var consultasConMuchosArticulos =
+            await ContarConsultasDeResolucionAsync(idTenant, cantidadDeArticulos: 20, idCategoria, idLista, idListaDerivada);
+
+        Assert.Equal(consultasConPocosArticulos, consultasConMuchosArticulos);
+        Assert.True(
+            consultasConPocosArticulos <= 7,
+            $"Se esperaban a lo sumo 7 consultas (design: Technical Approach), se emitieron {consultasConPocosArticulos}.");
+    }
+
+    private async Task<int> ContarConsultasDeResolucionAsync(
+        int idTenant, int cantidadDeArticulos, int idCategoria, int idLista, int idListaDerivada)
+    {
+        var idsArticulo = new List<int>();
+        for (var i = 0; i < cantidadDeArticulos; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(idTenant, $"art-{Guid.NewGuid():N}", idCategoria: idCategoria);
+            await SembrarPrecioAsync(idTenant, idArticulo, idLista, 100m);
+            idsArticulo.Add(idArticulo);
+        }
+
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, idTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(idTenant);
+        var servicioDePrecios = new ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+
+        var lineas = idsArticulo
+            .SelectMany(idArticulo => new[] { idLista, idListaDerivada }
+                .Select(idListaPrecio => new LineaDeResolucion(idArticulo, null, idListaPrecio, 1m)))
+            .ToList();
+
+        await servicioDeOfertas.ResolverAsync(lineas, momento: null);
+
+        return contador.Consultas;
+    }
+}

--- a/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
@@ -453,22 +453,41 @@ public class OfertasResolucionTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Empty(resultado!);
     }
 
-    /// <summary>(judgment-day, item 1) <c>{"lineas": null}</c> crudo bindea <c>null</c> más allá
-    /// de <c>required</c> (STJ solo exige que la clave esté presente, no que sea no-nula) — el
-    /// guard de <c>ResolverAsync</c> lo trata igual que el lote vacío, nunca un 500.</summary>
+    /// <summary>(judgment-day, item 1 — revisado) <c>{"lineas": null}</c> crudo bindea
+    /// <c>null</c> más allá de <c>required</c> (STJ no valida miembros <c>required</c> en
+    /// constructores <c>SetsRequiredMembers</c>) — <c>ResolverAsync</c> lo distingue de un lote
+    /// vacío legítimo y devuelve 400 <c>lineas_requeridas</c>, nunca un 200 silencioso.</summary>
     [Fact]
-    public async Task ResolverConLineasNulasEnJsonCrudoDevuelve200ConResultadoVacio()
+    public async Task ResolverConLineasNulasEnJsonCrudoDevuelve400LineasRequeridas()
     {
         var (_, mailAdmin, passwordAdmin) =
-            await AprovisionarTenantAsync(nameof(ResolverConLineasNulasEnJsonCrudoDevuelve200ConResultadoVacio));
+            await AprovisionarTenantAsync(nameof(ResolverConLineasNulasEnJsonCrudoDevuelve400LineasRequeridas));
         using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
 
         using var contenido = new StringContent("{\"lineas\": null}", Encoding.UTF8, "application/json");
         var respuesta = await admin.PostAsync("/api/ofertas/resolver", contenido);
 
-        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
-        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
-        Assert.Empty(resultado!);
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lineas_requeridas", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>(judgment-day, item 1 — revisado) La clave <c>"lineas"</c> ausente del body es el
+    /// mismo caso que <c>null</c> desde el punto de vista de STJ (no hay validación de
+    /// <c>required</c> con <c>SetsRequiredMembers</c>): mismo 400 <c>lineas_requeridas</c>.</summary>
+    [Fact]
+    public async Task ResolverSinLaClaveLineasDevuelve400LineasRequeridas()
+    {
+        var (_, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverSinLaClaveLineasDevuelve400LineasRequeridas));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        using var contenido = new StringContent("{}", Encoding.UTF8, "application/json");
+        var respuesta = await admin.PostAsync("/api/ofertas/resolver", contenido);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lineas_requeridas", problema.GetProperty("codigo").GetString());
     }
 
     // ---- task 3.11: guard de cantidad constante de consultas -----------------------------------

--- a/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
@@ -1,6 +1,8 @@
 using System.Data.Common;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Ways.Application.Abstracciones;
@@ -388,6 +390,85 @@ public class OfertasResolucionTests(WaysApiFixture fixture) : IClassFixture<Ways
             await db.OfertasListas.CountAsync(),
             await db.Precios.IgnoreQueryFilters(["BajaLogica"]).CountAsync(),
             await db.Articulos.IgnoreQueryFilters(["BajaLogica"]).CountAsync());
+    }
+
+    // ---- judgment-day: caminos de error/borde sin cobertura previa -----------------------------
+
+    /// <summary>db-error-backstops: <c>idArticulo</c> inexistente en el lote — el pre-chequeo de
+    /// <see cref="ServicioDeOfertas.ResolverAsync"/> lo atrapa antes de tocar ninguna otra tabla,
+    /// mismo código que el resto del ABM de ofertas.</summary>
+    [Fact]
+    public async Task ResolverConIdArticuloInexistenteDevuelve400ReferenciaInvalida()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverConIdArticuloInexistenteDevuelve400ReferenciaInvalida));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idLista = await SembrarListaAsync(idTenant, "Lista de Prueba");
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(999_999, null, idLista, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>db-error-backstops: <c>idListaPrecio</c> inexistente — lo atrapa
+    /// <see cref="ServicioDePrecios.PreciosVigentesEnLoteAsync"/> (el lote de precios que
+    /// <c>ResolverAsync</c> delega, design decision 5), mismo código 400 observable desde el
+    /// endpoint.</summary>
+    [Fact]
+    public async Task ResolverConIdListaPrecioInexistenteDevuelve400ReferenciaInvalida()
+    {
+        var (idTenant, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverConIdListaPrecioInexistenteDevuelve400ReferenciaInvalida));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var idArticulo = await SembrarArticuloAsync(idTenant, "articulo-lista-inexistente");
+
+        var solicitud = new SolicitudDeResolucion([new LineaDeResolucion(idArticulo, null, 999_999, 1m)]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>(judgment-day, item 1) <c>lineas</c> vacío es un lote válido y trivial —
+    /// <c>ResolverAsync</c> devuelve el resultado vacío sin emitir ninguna consulta (early
+    /// return antes de la primera query de artículos).</summary>
+    [Fact]
+    public async Task ResolverConLineasVaciasDevuelve200ConResultadoVacio()
+    {
+        var (_, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverConLineasVaciasDevuelve200ConResultadoVacio));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var solicitud = new SolicitudDeResolucion([]);
+        var respuesta = await admin.PostAsJsonAsync("/api/ofertas/resolver", solicitud);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        Assert.Empty(resultado!);
+    }
+
+    /// <summary>(judgment-day, item 1) <c>{"lineas": null}</c> crudo bindea <c>null</c> más allá
+    /// de <c>required</c> (STJ solo exige que la clave esté presente, no que sea no-nula) — el
+    /// guard de <c>ResolverAsync</c> lo trata igual que el lote vacío, nunca un 500.</summary>
+    [Fact]
+    public async Task ResolverConLineasNulasEnJsonCrudoDevuelve200ConResultadoVacio()
+    {
+        var (_, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ResolverConLineasNulasEnJsonCrudoDevuelve200ConResultadoVacio));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        using var contenido = new StringContent("{\"lineas\": null}", Encoding.UTF8, "application/json");
+        var respuesta = await admin.PostAsync("/api/ofertas/resolver", contenido);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<List<ResultadoDeResolucion>>();
+        Assert.Empty(resultado!);
     }
 
     // ---- task 3.11: guard de cantidad constante de consultas -----------------------------------


### PR DESCRIPTION
Closes #35

## Summary

- Slice 3 (final) of `stage-4-ofertas`: pure `ResolvedorDeOfertas` owning every rule — candidate matching (scope incl. categoria ancestor-chain, multi-lista empty=all incl. derivadas, inclusive vigencia windows, ISO weekdays, cantidad >= minima), precedence (highest-prioridad non-acumulable base, deterministic tie-break), ADDITIVE-over-original stacking with per-candidate rounding and total clamp — plus `ResolverAsync` (batch, 7-constant-query budget with an interceptor-based guard test asserting identical query counts at N=2 vs N=20), `PreciosVigentesEnLoteAsync` (added path, parity-pinned against the shipped single-article methods incl. the documented Activo divergence), and `POST /api/ofertas/resolver` (query-only).
- Judgment-day (3 rounds): R1 — both judges hand-verified the arithmetic clean; confirmed a null-body NRE→500 and missing error-path tests → fixed. R2 — judge A DISPROVED the `required` fix with an isolated repro (`SetsRequiredMembers` makes STJ skip the required check, a documented BCL contract): `{}` silently resolved as "no offers" → replaced with an explicit contract: `lineas` absent/null → 400 `lineas_requeridas`, `[]` → 200 empty. R3 — CLEAN ×2.

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 162/162 (+41: 32 resolver facts + chain + regla), Application 207/207 (+3 parity), Integration 268/268 (+12: end-to-end resolution, empresa scoping, derivada bases, no-writes guarantee, constant-query-count guard, contract 400s; real Postgres)
- [x] judgment-day: APPROVED — R3 clean ×2

## Notes

- `size:exception`: engine + batch boundary + exhaustive test suite.
- Design note recorded: `/resolver` ships Admin-gated; stage 5 must revisit the policy before wiring the POS (tracked in design.md Open Questions).
- This completes the apply phase of stage 4 — next: `sdd-verify` + `sdd-archive`.