### PR TITLE
feat(seguridad): politica OperacionDePos y superficie de lectura del POS (etapa 5, slice 1)

### DIFF
--- a/openspec/changes/stage-5-pos-ventas/tasks.md
+++ b/openspec/changes/stage-5-pos-ventas/tasks.md
@@ -79,43 +79,43 @@ Chain strategy: stacked-to-main
 writes stay on `GestionDeCatalogo`, omission guard + inverted tests green.
 **Rollback**: revert policy stacking — routes return to `GestionDeCatalogo`-only.
 
-- [ ] 1.1 Add `Politicas.OperacionDePos` (Vendedor + Admin, Root excluded) in
+- [x] 1.1 Add `Politicas.OperacionDePos` (Vendedor + Admin, Root excluded) in
   `src/Ways.Api/Seguridad/Politicas.cs`. *(design decision 6; spec:
   operacion-de-pos / OperacionDePos Policy Admits Vendedor and Admin)*
-- [ ] 1.2 Re-gate `ArticulosEndpoints` group (incl. `/precios`,
+- [x] 1.2 Re-gate `ArticulosEndpoints` group (incl. `/precios`,
   `/codigos-barra`, `/escaneo`) to `OperacionDePos`, stacking
   `GestionDeCatalogo` on POST/PUT/DELETE only. *(spec: articulos / Articulo
   ABM Lifecycle and Authorization; codigos-barra / Barcode Add/Remove/List
   Management)*
-- [ ] 1.3 [P] Re-gate `ClientesEndpoints` group to `OperacionDePos`, stacking
+- [x] 1.3 [P] Re-gate `ClientesEndpoints` group to `OperacionDePos`, stacking
   `GestionDeCatalogo` on writes. *(spec: clientes / Cliente ABM Lifecycle and
   Authorization)*
-- [ ] 1.4 [P] Re-gate `CatalogosEndpoints` and `ParametrosEndpoints` groups to
+- [x] 1.4 [P] Re-gate `CatalogosEndpoints` and `ParametrosEndpoints` groups to
   `OperacionDePos`, stacking `GestionDeCatalogo` on writes. *(spec:
   parametros-operativos / Read Access Under OperacionDePos For UI Preview)*
-- [ ] 1.5 Relax `OfertasEndpoints` group gate to `OperacionDePos`; stack
+- [x] 1.5 Relax `OfertasEndpoints` group gate to `OperacionDePos`; stack
   `GestionDeCatalogo` on POST `/`, PUT, DELETE — `POST /resolver` stays on
   the group gate only, closing the stage-4 carryover. *(spec:
   resolucion-de-ofertas / OperacionDePos Authorization For POST
   /api/ofertas/resolver)*
-- [ ] 1.6 Update `Cliente.cs`'s `Saldo` doc-comment ("never moves" →
+- [x] 1.6 Update `Cliente.cs`'s `Saldo` doc-comment ("never moves" →
   activated by Slice 3), per proposal Affected Areas.
-- [ ] 1.7 Add `SuperficieDeAutorizacionTests`: walk `EndpointDataSource`,
+- [x] 1.7 Add `SuperficieDeAutorizacionTests`: walk `EndpointDataSource`,
   assert every non-GET endpoint carries `GestionDeCatalogo` against an
   explicit allowlist (`POST /api/auth/*`, `POST /api/ofertas/resolver`,
   `POST /api/ventas`, `POST /api/ventas/{id}/anulacion`). *(design:
   Authorization Surface — omission guard, mandatory)*
-- [ ] 1.8 Update the two inverting tests:
+- [x] 1.8 Update the two inverting tests:
   `ClientesEndpointsTests.UnVendedorNoPuedeListarListasDePrecio` and
   `ArticulosEndpointsTests.UnVendedorNoPuedeListarCodigosDeBarra` become
   `…PuedeListar…`, with an explicit comment noting these are the two
   intentional inversions. *(design: Authorization Surface — "Two shipped
   tests invert")*
-- [ ] 1.9 [P] Integration: Vendedor reads succeed on every re-gated group
+- [x] 1.9 [P] Integration: Vendedor reads succeed on every re-gated group
   (articulos, clientes, catálogos, parámetros, `/resolver`); every other
   `UnVendedorNoPuede…` write test stays red. *(spec: articulos, clientes,
   codigos-barra, parametros-operativos — "Vendedor can …" scenarios)*
-- [ ] 1.10 Regression: full existing suite green, no behavior change beyond
+- [x] 1.10 Regression: full existing suite green, no behavior change beyond
   the auth relaxation.
 
 ---

--- a/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
@@ -10,7 +10,7 @@ public static class ArticulosEndpoints
     {
         var grupo = app.MapGroup("/api/articulos")
             .WithTags("Articulos")
-            .RequireAuthorization(Politicas.GestionDeCatalogo);
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         grupo.MapGet("/", (
             ServicioDeArticulos servicio,
@@ -33,11 +33,13 @@ public static class ArticulosEndpoints
             var creado = await servicio.CrearAsync(datos, ct);
             return Results.Created($"/api/articulos/{creado.Id}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Crea un artículo. El código interno se autogenera si se omite.");
 
         grupo.MapPut("/{id:int}", (
             ServicioDeArticulos servicio, int id, EdicionArticulo datos, CancellationToken ct) =>
             servicio.ActualizarAsync(id, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Actualiza un artículo, incluida su disponibilidad por empresa.");
 
         grupo.MapDelete("/{id:int}", async (
@@ -46,6 +48,7 @@ public static class ArticulosEndpoints
             await servicio.EliminarAsync(id, ct);
             return Results.NoContent();
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Baja lógica del artículo.");
 
         grupo.MapPost("/{id:int}/codigos-barra", async (
@@ -54,6 +57,7 @@ public static class ArticulosEndpoints
             var creado = await servicio.AgregarCodigoBarraAsync(id, datos, ct);
             return Results.Created($"/api/articulos/{id}/codigos-barra/{creado.Id}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Agrega un código de barras al artículo.");
 
         grupo.MapDelete("/{id:int}/codigos-barra/{idCodigoBarra:int}", async (
@@ -62,6 +66,7 @@ public static class ArticulosEndpoints
             await servicio.EliminarCodigoBarraAsync(id, idCodigoBarra, ct);
             return Results.NoContent();
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Quita un código de barras del artículo.");
 
         grupo.MapGet("/{id:int}/codigos-barra", (
@@ -84,6 +89,7 @@ public static class ArticulosEndpoints
             var creado = await servicio.EstablecerPrecioAsync(id, datos, ct);
             return Results.Created($"/api/articulos/{id}/precios/{datos.IdListaPrecio}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Establece el precio vigente de un artículo en una lista fija, efectivo ahora.");
 
         grupo.MapPost("/{id:int}/precios/programados", async (
@@ -92,6 +98,7 @@ public static class ArticulosEndpoints
             var creado = await servicio.ProgramarPrecioAsync(id, datos, ct);
             return Results.Created($"/api/articulos/{id}/precios/{datos.IdListaPrecio}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Programa un precio a futuro; reemplaza el pendiente existente solo con confirmarReemplazo.");
 
         grupo.MapGet("/{id:int}/precios", (

--- a/src/Ways.Api/Endpoints/CatalogosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CatalogosEndpoints.cs
@@ -20,7 +20,7 @@ public static class CatalogosEndpoints
     {
         var grupo = app.MapGroup($"/api/catalogos/{recurso}")
             .WithTags("Catálogos")
-            .RequireAuthorization(Politicas.GestionDeCatalogo);
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         grupo.MapGet("/", (TServicio servicio, bool? incluirInactivos, CancellationToken ct) =>
             servicio.ListarAsync(incluirInactivos ?? false, ct))
@@ -35,10 +35,12 @@ public static class CatalogosEndpoints
             var creado = await servicio.CrearAsync(datos, ct);
             return Results.Created($"/api/catalogos/{recurso}/{creado.Id}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary($"Crea un elemento de {recurso}.");
 
         grupo.MapPut("/{id:int}", (TServicio servicio, int id, TAlta datos, CancellationToken ct) =>
             servicio.ActualizarAsync(id, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary($"Actualiza un elemento de {recurso}.");
 
         grupo.MapDelete("/{id:int}", async (TServicio servicio, int id, CancellationToken ct) =>
@@ -46,6 +48,7 @@ public static class CatalogosEndpoints
             await servicio.EliminarAsync(id, ct);
             return Results.NoContent();
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary($"Baja lógica de un elemento de {recurso}.");
 
         return app;

--- a/src/Ways.Api/Endpoints/CatalogosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CatalogosEndpoints.cs
@@ -74,8 +74,12 @@ public static class CatalogosEndpoints
         // Los 3 catálogos globales (ADR-11, gate #4) son de solo lectura en esta etapa — no
         // hay POST/PUT/DELETE mapeados a propósito, ni siquiera detrás de una policy: la
         // ausencia de ruta es la superficie de API, RLS (HabilitarRlsDeCatalogoGlobal) es la
-        // segunda capa detrás. Cualquier sesión autenticada (tenant o plataforma) puede leer.
-        var fiscales = app.MapGroup("/api/catalogos-fiscales").WithTags("Catálogos fiscales");
+        // segunda capa detrás. La lectura ya no es "cualquier sesión autenticada" (criterio
+        // original de gate #4): stage-5-pos-ventas la reemplaza por OperacionDePos (design.md,
+        // Authorization Surface), coherente con el resto de la superficie de lectura del POS.
+        var fiscales = app.MapGroup("/api/catalogos-fiscales")
+            .WithTags("Catálogos fiscales")
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         fiscales.MapGet("/condiciones-fiscales", (
             ServicioDeCatalogosFiscales servicio, CancellationToken ct) =>

--- a/src/Ways.Api/Endpoints/ClientesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ClientesEndpoints.cs
@@ -9,7 +9,7 @@ public static class ClientesEndpoints
     {
         var grupo = app.MapGroup("/api/clientes")
             .WithTags("Clientes")
-            .RequireAuthorization(Politicas.GestionDeCatalogo);
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         grupo.MapGet("/", (
             ServicioDeClientes servicio,
@@ -31,11 +31,13 @@ public static class ClientesEndpoints
             var creado = await servicio.CrearAsync(datos, ct);
             return Results.Created($"/api/clientes/{creado.Id}", creado);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Crea un cliente. El numero lo asigna el servidor (contador atómico por tenant).");
 
         grupo.MapPut("/{id:int}", (
             ServicioDeClientes servicio, int id, EdicionCliente datos, CancellationToken ct) =>
             servicio.ActualizarAsync(id, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Actualiza un cliente. Rechazado sobre el Consumidor Final (numero = 1).");
 
         grupo.MapDelete("/{id:int}", async (
@@ -44,15 +46,17 @@ public static class ClientesEndpoints
             await servicio.EliminarAsync(id, ct);
             return Results.NoContent();
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Baja lógica del cliente. Rechazada sobre el Consumidor Final (numero = 1).");
 
         // Referencia de solo lectura para el selector de lista de precios del formulario —
         // no un ABM de listas_precio (design decision 1, spec: listas_precio ABM Is Out of
-        // Scope This Stage). Mismo criterio que /api/roles en UsuariosEndpoints.
+        // Scope This Stage). Mismo criterio que /api/roles en UsuariosEndpoints. Etapa 5
+        // (design decisión 6): pasa a OperacionDePos, la lectura la necesita el POS.
         app.MapGet("/api/listas-precio", (ServicioDeClientes servicio, CancellationToken ct) =>
             servicio.ListasDePrecioAsignablesAsync(ct))
         .WithTags("Clientes")
-        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .RequireAuthorization(Politicas.OperacionDePos)
         .WithSummary("Listas de precio asignables a un cliente. Sin ABM propio esta etapa.");
 
         return app;

--- a/src/Ways.Api/Endpoints/OfertasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OfertasEndpoints.cs
@@ -9,7 +9,7 @@ public static class OfertasEndpoints
     {
         var grupo = app.MapGroup("/api/ofertas")
             .WithTags("Ofertas")
-            .RequireAuthorization(Politicas.GestionDeCatalogo);
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         grupo.MapGet("/", (ServicioDeOfertas servicio, bool? incluirEliminados, CancellationToken ct) =>
             servicio.ListarAsync(incluirEliminados ?? false, ct))
@@ -24,10 +24,12 @@ public static class OfertasEndpoints
             var creada = await servicio.CrearAsync(datos, ct);
             return Results.Created($"/api/ofertas/{creada.Id}", creada);
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Crea una oferta, incluidas las listas a las que aplica.");
 
         grupo.MapPut("/{id:int}", (ServicioDeOfertas servicio, int id, EdicionOferta datos, CancellationToken ct) =>
             servicio.ActualizarAsync(id, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Actualiza una oferta; reemplaza por completo el subconjunto de listas.");
 
         grupo.MapDelete("/{id:int}", async (ServicioDeOfertas servicio, int id, CancellationToken ct) =>
@@ -35,12 +37,17 @@ public static class OfertasEndpoints
             await servicio.EliminarAsync(id, ct);
             return Results.NoContent();
         })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Baja lógica de la oferta.");
 
         // stage-4-ofertas, Slice 3 (design decision 7): POST, no muta nada — solo resuelve
         // precios + ofertas aplicadas para un lote de líneas, nunca escribe en ninguna tabla
         // (spec: resolucion-de-ofertas / Applied Ofertas Are Reported, Never Persisted). POST en
         // vez de GET porque el cuerpo es un lote de líneas, no algo que entre en un query string.
+        // stage-5-pos-ventas (design decisión 6, spec: resolucion-de-ofertas / OperacionDePos
+        // Authorization For POST /api/ofertas/resolver): queda solo en la policy del grupo — el
+        // POS necesita resolver precios sin ser admin, cierra el carryover de verify de la
+        // etapa 4.
         grupo.MapPost("/resolver", (ServicioDeOfertas servicio, SolicitudDeResolucion solicitud, CancellationToken ct) =>
             servicio.ResolverAsync(solicitud.Lineas, solicitud.Momento, ct))
         .WithSummary("POST, no muta nada: resuelve precio final y ofertas aplicadas para un lote de líneas.");

--- a/src/Ways.Api/Endpoints/ParametrosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ParametrosEndpoints.cs
@@ -9,7 +9,7 @@ public static class ParametrosEndpoints
     {
         var grupo = app.MapGroup("/api/parametros")
             .WithTags("Parámetros")
-            .RequireAuthorization(Politicas.GestionDeCatalogo);
+            .RequireAuthorization(Politicas.OperacionDePos);
 
         grupo.MapGet("/{clave}", (
             ServicioDeParametros servicio, string clave, int idEmpresa, int? idPuntoVenta, CancellationToken ct) =>
@@ -23,6 +23,7 @@ public static class ParametrosEndpoints
         grupo.MapPut("/", (
             ServicioDeParametros servicio, int idEmpresa, ParametroAlta datos, CancellationToken ct) =>
             servicio.EstablecerAsync(idEmpresa, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Crea o edita un parámetro (upsert por clave + punto de venta).");
 
         return app;

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -27,13 +27,14 @@ public static class Politicas
     /// distinto (organización, no cuentas).</summary>
     public const string GestionDeOrganizacion = "gestion_organizacion";
 
-    /// <summary>Vendedor o admin — la puerta de la superficie de lectura del POS (artículos,
-    /// códigos de barra, clientes, listas de precio, parámetros, catálogos fiscales/medios de
-    /// pago, resolución de ofertas) y del checkout/anulación/lectura de stock (etapa 5). Root
-    /// queda afuera, mismo criterio que <see cref="GestionDeCatalogo"/> ("root administra
-    /// tenants, no opera ninguno" — design.md decisión 6). ASP.NET Core compone políticas con
-    /// AND: los endpoints de escritura apilan <see cref="GestionDeCatalogo"/> sobre esta para
-    /// no relajar el ABM.</summary>
+    /// <summary>Vendedor, supervisor o admin — la puerta de la superficie de lectura del POS
+    /// (artículos, códigos de barra, clientes, listas de precio, parámetros, catálogos
+    /// fiscales/medios de pago, resolución de ofertas) y del checkout/anulación/lectura de
+    /// stock (etapa 5). Supervisor se suma por paridad con el legacy (decisión del
+    /// orquestador, registrada en el spec). Root queda afuera, mismo criterio que
+    /// <see cref="GestionDeCatalogo"/> ("root administra tenants, no opera ninguno" —
+    /// design.md decisión 6). ASP.NET Core compone políticas con AND: los endpoints de
+    /// escritura apilan <see cref="GestionDeCatalogo"/> sobre esta para no relajar el ABM.</summary>
     public const string OperacionDePos = "operacion_de_pos";
 
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
@@ -62,6 +63,7 @@ public static class Politicas
                         .RequireClaim(
                             ClaimsWays.RolId,
                             ((int)RolConocido.Vendedor).ToString(),
+                            ((int)RolConocido.Supervisor).ToString(),
                             ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -27,6 +27,15 @@ public static class Politicas
     /// distinto (organización, no cuentas).</summary>
     public const string GestionDeOrganizacion = "gestion_organizacion";
 
+    /// <summary>Vendedor o admin — la puerta de la superficie de lectura del POS (artículos,
+    /// códigos de barra, clientes, listas de precio, parámetros, catálogos fiscales/medios de
+    /// pago, resolución de ofertas) y del checkout/anulación/lectura de stock (etapa 5). Root
+    /// queda afuera, mismo criterio que <see cref="GestionDeCatalogo"/> ("root administra
+    /// tenants, no opera ninguno" — design.md decisión 6). ASP.NET Core compone políticas con
+    /// AND: los endpoints de escritura apilan <see cref="GestionDeCatalogo"/> sobre esta para
+    /// no relajar el ABM.</summary>
+    public const string OperacionDePos = "operacion_de_pos";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -47,6 +56,12 @@ public static class Politicas
                         .RequireClaim(
                             ClaimsWays.RolId,
                             ((int)RolConocido.Root).ToString(),
+                            ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(OperacionDePos, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(
+                            ClaimsWays.RolId,
+                            ((int)RolConocido.Vendedor).ToString(),
                             ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Domain/Clientes/Cliente.cs
+++ b/src/Ways.Domain/Clientes/Cliente.cs
@@ -12,9 +12,10 @@ namespace Ways.Domain.Clientes;
 /// input de usuario deduplicado por unicidad de nombre.
 ///
 /// <see cref="Numero"/> == 1 identifica siempre al Consumidor Final protegido de su tenant
-/// (<see cref="ReglaDeClientes"/>, <c>ck_clientes_cf_protegido</c>). No hay motor de cuenta
-/// corriente todavía (etapa 7): <see cref="Saldo"/> queda en su default fuera de la siembra
-/// del Consumidor Final.
+/// (<see cref="ReglaDeClientes"/>, <c>ck_clientes_cf_protegido</c>). <see cref="Saldo"/> deja
+/// de estar dormant en esta etapa (stage-5-pos-ventas, Slice 3): pasa a ser el caché
+/// mantenido del ledger de <c>movimientos_cuenta_corriente</c>, escrito dentro de la misma
+/// transacción de venta/anulación (Slice 4/5).
 /// </summary>
 public class Cliente : EntidadTenant
 {
@@ -56,9 +57,9 @@ public class Cliente : EntidadTenant
     public decimal LimiteCredito { get; set; }
     public bool CreditoIlimitado { get; set; }
 
-    /// <summary>Sin motor de movimientos de cuenta corriente todavía (etapa 7): se
-    /// mantiene en su valor de siembra/default, nunca lo mueve un caso de uso de esta
-    /// etapa.</summary>
+    /// <summary>Caché mantenido de <c>Σ movimientos_cuenta_corriente.importe</c> (stage-5-pos-ventas,
+    /// Slice 3 crea la tabla; Slice 4/5 son los únicos escritores, dentro de la transacción de
+    /// venta/anulación). Hasta entonces se mantiene en su valor de siembra/default.</summary>
     public decimal Saldo { get; set; }
 
     public bool Activo { get; set; } = true;

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -126,7 +126,7 @@ export function App() {
             <Route
               path="/catalogos-fiscales"
               element={
-                <RutaProtegida rolesPermitidos={[ROL.Root, ROL.Admin]}>
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
                   <CatalogosFiscales />
                 </RutaProtegida>
               }

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -83,15 +83,15 @@ export function Layout() {
                         Parámetros
                       </NavLink>
                     </li>
-                  </>
-                )}
-                {usuario && (usuario.rolId === ROL.Root || usuario.rolId === ROL.Admin) && (
-                  <>
                     <li className="nav-item">
                       <NavLink className="nav-link" to="/catalogos-fiscales">
                         Catálogos fiscales
                       </NavLink>
                     </li>
+                  </>
+                )}
+                {usuario && (usuario.rolId === ROL.Root || usuario.rolId === ROL.Admin) && (
+                  <>
                     <li className="nav-item">
                       <NavLink className="nav-link" to="/organizacion/empresas">
                         Empresas

--- a/tests/Ways.IntegrationTests/ArticulosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/ArticulosEndpointsTests.cs
@@ -741,23 +741,26 @@ public class ArticulosEndpointsTests(WaysApiFixture fixture) : IClassFixture<Way
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
-    /// <summary>Mismo criterio que <see cref="UnVendedorNoPuedeAgregarCodigosDeBarra"/>, para
-    /// el GET de listado: toda la ruta cuelga del mismo grupo con la policy
-    /// <c>GestionDeCatalogo</c> (admin-only).</summary>
+    /// <summary>INVERSIÓN INTENCIONAL (stage-5-pos-ventas, Slice 1, design: Authorization
+    /// Surface — "Two shipped tests invert"): el grupo de <c>ArticulosEndpoints</c> pasa de
+    /// <c>GestionDeCatalogo</c> a <c>Politicas.OperacionDePos</c> (decisión 6) — un Vendedor
+    /// necesita leer los códigos de barra para el escaneo del POS. La escritura (agregar/quitar)
+    /// sigue admin-only vía <see cref="UnVendedorNoPuedeAgregarCodigosDeBarra"/> (apila
+    /// <c>GestionDeCatalogo</c> sobre el grupo).</summary>
     [Fact]
-    public async Task UnVendedorNoPuedeListarCodigosDeBarra()
+    public async Task UnVendedorPuedeListarCodigosDeBarra()
     {
         var (idTenant, idArea, idAlicuotaIva, mailAdmin, passwordAdmin) =
-            await AprovisionarTenantAsync(nameof(UnVendedorNoPuedeListarCodigosDeBarra));
+            await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarCodigosDeBarra));
         using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
         var articulo = await CrearArticuloAsync(admin, idArea, idAlicuotaIva);
 
-        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorNoPuedeListarCodigosDeBarra));
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorPuedeListarCodigosDeBarra));
         using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
 
         var respuesta = await vendedor.GetAsync($"/api/articulos/{articulo.Id}/codigos-barra");
 
-        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
 
     /// <summary>Spec: articulos / Availability Model — un vendedor tampoco puede cambiar la

--- a/tests/Ways.IntegrationTests/ArticulosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/ArticulosEndpointsTests.cs
@@ -763,6 +763,22 @@ public class ArticulosEndpointsTests(WaysApiFixture fixture) : IClassFixture<Way
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
 
+    /// <summary>Confirmed issue (judgment-day, stage-5-pos-ventas Slice 1): Root-403 en una
+    /// superficie de lectura re-gateada — root no está en OperacionDePos (design decisión 6,
+    /// "root administra tenants, no opera ninguno"), mismo criterio que
+    /// <c>CatalogosTests.UnaSesionDeRootRecibe403EnUnCatalogoDeTenant</c>.</summary>
+    [Fact]
+    public async Task UnaSesionDeRootRecibe403AlListarArticulos()
+    {
+        using var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin("test@test.com", "root"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var respuesta = await cliente.GetAsync("/api/articulos");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
     /// <summary>Spec: articulos / Availability Model — un vendedor tampoco puede cambiar la
     /// disponibilidad de un artículo (la disponibilidad viaja en el PUT de edición, no en un
     /// endpoint propio).</summary>

--- a/tests/Ways.IntegrationTests/CatalogosTests.cs
+++ b/tests/Ways.IntegrationTests/CatalogosTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Npgsql;
+using Ways.Api.Seguridad;
 using Ways.Application.Catalogos;
 using Ways.Application.Usuarios;
 using Ways.Domain.Catalogos;
@@ -77,6 +78,30 @@ public class CatalogosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtu
         var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, Password));
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         return cliente;
+    }
+
+    private async Task<string> SembrarVendedorAsync(int idTenant, string nombre)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = "vendedor",
+            Mail = mail,
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(Password),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return mail;
     }
 
     [Fact]
@@ -341,5 +366,37 @@ public class CatalogosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtu
         var intentoDeEscritura = await cliente.PostAsJsonAsync(
             "/api/catalogos-fiscales/condiciones-fiscales", new { });
         Assert.Equal(HttpStatusCode.NotFound, intentoDeEscritura.StatusCode);
+    }
+
+    /// <summary>CRITICAL (judgment-day, stage-5-pos-ventas Slice 1): el grupo
+    /// <c>/api/catalogos-fiscales</c> no apilaba <see cref="Politicas.OperacionDePos"/> y caía
+    /// al fallback autenticado-only — un Vendedor igual podía leer (por accidente, no por
+    /// policy). Esta prueba fija el comportamiento POSITIVO ahora que la policy está explícita:
+    /// un Vendedor lee.</summary>
+    [Fact]
+    public async Task UnVendedorPuedeLeerCatalogosFiscales()
+    {
+        var (idTenant, _) = await SembrarTenantConAdminAsync(nameof(UnVendedorPuedeLeerCatalogosFiscales));
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorPuedeLeerCatalogosFiscales));
+        using var vendedor = await ClienteLogueadoAsync(mailVendedor);
+
+        var respuesta = await vendedor.GetAsync("/api/catalogos-fiscales/condiciones-fiscales");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>Companion del fix de arriba: mismo criterio que
+    /// <see cref="UnaSesionDeRootRecibe403EnUnCatalogoDeTenant"/> — root queda afuera de
+    /// <see cref="Politicas.OperacionDePos"/> ("root administra tenants, no opera ninguno").</summary>
+    [Fact]
+    public async Task UnaSesionDeRootRecibe403AlLeerCatalogosFiscales()
+    {
+        using var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin("test@test.com", "root"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var respuesta = await cliente.GetAsync("/api/catalogos-fiscales/condiciones-fiscales");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 }

--- a/tests/Ways.IntegrationTests/ClientesEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/ClientesEndpointsTests.cs
@@ -329,17 +329,22 @@ public class ClientesEndpointsTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(idListaPrecioGeneralA, listas![0].Id);
     }
 
+    /// <summary>INVERSIÓN INTENCIONAL (stage-5-pos-ventas, Slice 1, design: Authorization
+    /// Surface — "Two shipped tests invert"): <c>GET /api/listas-precio</c> pasa de
+    /// <c>GestionDeCatalogo</c> a <c>Politicas.OperacionDePos</c> (decisión 6) — el POS necesita
+    /// el selector de lista de precios del cliente. Sin ABM propio esta etapa (design decisión
+    /// 1), así que no hay contraparte de escritura que probar acá.</summary>
     [Fact]
-    public async Task UnVendedorNoPuedeListarListasDePrecio()
+    public async Task UnVendedorPuedeListarListasDePrecio()
     {
         var (idTenant, _, _, _, _) =
-            await AprovisionarTenantAsync(nameof(UnVendedorNoPuedeListarListasDePrecio));
-        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorNoPuedeListarListasDePrecio));
+            await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarListasDePrecio));
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorPuedeListarListasDePrecio));
         using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
 
         var respuesta = await vendedor.GetAsync("/api/listas-precio");
 
-        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
 
     /// <summary>Judgment-day ronda 1 (item 4): <see cref="Ways.Domain.Clientes.ReglaDeClientes.ValidarNoConsumidorFinal"/>

--- a/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Json;
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios; // SolicitudDeLogin
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Stage-5-pos-ventas, Slice 1 (task 1.9, design: Authorization Surface — decisión 6, spec:
+/// articulos/clientes/codigos-barra/parametros-operativos "Vendedor can …" scenarios): prueba
+/// positiva, punta a punta, de que un Vendedor lee todas las superficies re-gateadas a
+/// <c>Politicas.OperacionDePos</c> — el complemento de los <c>UnVendedorNoPuede…</c> existentes
+/// (que siguen en rojo para toda escritura, sin tocar). Cada resurso re-gateado se prueba una
+/// vez acá; los <c>*EndpointsTests</c> ya cubren la variante negativa (escritura) por resurso.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "una-contraseña-larga";
+
+    private async Task<(int IdTenant, int IdEmpresa)> AprovisionarTenantAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
+        Assert.NotNull(resultado);
+
+        return (resultado!.IdTenant, resultado.IdEmpresa);
+    }
+
+    private async Task<string> SembrarVendedorAsync(int idTenant, string nombre)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = "vendedor",
+            Mail = mail,
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return mail;
+    }
+
+    private async Task<HttpClient> VendedorLogueadoAsync(int idTenant, string nombre)
+    {
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nombre);
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeListarArticulos()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarArticulos));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarArticulos));
+
+        var respuesta = await vendedor.GetAsync("/api/articulos");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeListarClientes()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarClientes));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarClientes));
+
+        var respuesta = await vendedor.GetAsync("/api/clientes");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeListarUnCatalogoDeTenant()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarUnCatalogoDeTenant));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarUnCatalogoDeTenant));
+
+        var respuesta = await vendedor.GetAsync("/api/catalogos/areas");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeListarParametros()
+    {
+        var (idTenant, idEmpresa) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarParametros));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarParametros));
+
+        var respuesta = await vendedor.GetAsync($"/api/parametros?idEmpresa={idEmpresa}");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>Cierra el carryover de verify de la etapa 4 (spec: resolucion-de-ofertas /
+    /// OperacionDePos Authorization For POST /api/ofertas/resolver). Lote vacío: el servicio
+    /// responde <c>[]</c> sin tocar la base (batch 3.11 de la etapa 4), así que esta prueba
+    /// aísla la autorización sin depender de datos de catálogo.</summary>
+    [Fact]
+    public async Task UnVendedorPuedeResolverOfertas()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeResolverOfertas));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeResolverOfertas));
+
+        var respuesta = await vendedor.PostAsJsonAsync(
+            "/api/ofertas/resolver", new SolicitudDeResolucion(Lineas: []));
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using Ways.Api.Seguridad;
+using Ways.Application.Catalogos;
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios; // SolicitudDeLogin
@@ -23,6 +25,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
     private const string PasswordVendedor = "una-contraseña-larga";
+    private const string PasswordSupervisor = "una-contraseña-larga";
 
     private async Task<(int IdTenant, int IdEmpresa)> AprovisionarTenantAsync(string nombre)
     {
@@ -70,6 +73,39 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
         var mailVendedor = await SembrarVendedorAsync(idTenant, nombre);
         var cliente = fixture.CreateClient();
         var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<string> SembrarSupervisorAsync(int idTenant, string nombre)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombre.ToLowerInvariant()}-supervisor@ways.test";
+
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = "supervisor",
+            Mail = mail,
+            RolId = (int)RolConocido.Supervisor,
+            PasswordHash = hasheador.Hashear(PasswordSupervisor),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return mail;
+    }
+
+    private async Task<HttpClient> SupervisorLogueadoAsync(int idTenant, string nombre)
+    {
+        var mailSupervisor = await SembrarSupervisorAsync(idTenant, nombre);
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailSupervisor, PasswordSupervisor));
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         return cliente;
     }
@@ -132,5 +168,47 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
             "/api/ofertas/resolver", new SolicitudDeResolucion(Lineas: []));
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>Confirmed issue (judgment-day, stage-5-pos-ventas Slice 1): sin token, la
+    /// policy OperacionDePos exige <c>RequireAuthenticatedUser()</c> antes que nada — 401, no
+    /// 403 (la distinción importa: 403 implica una sesión ya autenticada sin el rol correcto).</summary>
+    [Fact]
+    public async Task ResolverOfertasSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/ofertas/resolver", new SolicitudDeResolucion(Lineas: []));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+
+    /// <summary>ORCHESTRATOR DECISION (recorded en el spec de main, paridad legacy): Supervisor
+    /// se suma al conjunto de roles de <see cref="Politicas.OperacionDePos"/> — mismo acceso de
+    /// lectura que Vendedor sobre las superficies re-gateadas.</summary>
+    [Fact]
+    public async Task UnSupervisorPuedeListarArticulos()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnSupervisorPuedeListarArticulos));
+        using var supervisor = await SupervisorLogueadoAsync(idTenant, nameof(UnSupervisorPuedeListarArticulos));
+
+        var respuesta = await supervisor.GetAsync("/api/articulos");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>Companion del test de arriba: sumar Supervisor a OperacionDePos no relaja el
+    /// ABM de catálogos, que sigue admin-only (<see cref="Politicas.GestionDeCatalogo"/>).</summary>
+    [Fact]
+    public async Task UnSupervisorNoPuedeCrearUnCatalogoDeTenant()
+    {
+        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnSupervisorNoPuedeCrearUnCatalogoDeTenant));
+        using var supervisor = await SupervisorLogueadoAsync(idTenant, nameof(UnSupervisorNoPuedeCrearUnCatalogoDeTenant));
+
+        var respuesta = await supervisor.PostAsJsonAsync(
+            "/api/catalogos/areas", new AreaAlta("Intrusa", IdEmpresa: null, Orden: 1));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 }

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -102,4 +102,78 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
             faltantes.Count == 0,
             $"Endpoint(s) de escritura sin GestionDeCatalogo y fuera del allowlist: {string.Join(", ", faltantes)}");
     }
+
+    /// <summary>
+    /// WARNING real (judgment-day, Judge A): el guard de arriba salta explícitamente todo
+    /// endpoint GET (<c>metodos.Contains("GET")</c>) — quedaba ciego a un grupo GET sin
+    /// <c>RequireAuthorization</c> (el caso real: <c>/api/catalogos-fiscales</c>, que caía al
+    /// fallback autenticado-only). Este segundo guard cubre justo ese punto ciego: camina el
+    /// mismo <see cref="EndpointDataSource"/> real y falla-cerrado sobre las superficies de
+    /// lectura que este slice re-gateó a <see cref="Politicas.OperacionDePos"/> — cualquier GET
+    /// nuevo bajo esos prefijos que no apile una policy al menos tan estricta como
+    /// <see cref="Politicas.OperacionDePos"/> (o quede en el fallback autenticado-only, sin
+    /// policy nombrada) rompe la build.
+    /// </summary>
+    private static readonly string[] PrefijosDeLecturaReGateados =
+    [
+        "/api/articulos",
+        "/api/clientes",
+        "/api/listas-precio",
+        "/api/catalogos/",
+        "/api/catalogos-fiscales",
+        "/api/parametros",
+        "/api/ofertas"
+    ];
+
+    // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —
+    // todas excluyen Vendedor, así que ninguna relaja la superficie que este guard vigila.
+    private static readonly HashSet<string> PoliticasAlMenosTanEstrictasComoOperacionDePos =
+    [
+        Politicas.OperacionDePos,
+        Politicas.GestionDeCatalogo,
+        Politicas.GestionDeUsuarios,
+        Politicas.GestionDeOrganizacion,
+        Politicas.SoloPlataforma
+    ];
+
+    [Fact]
+    public void TodoEndpointGetBajoLasSuperficiesReGateadasApilaOperacionDePos()
+    {
+        var fuente = fixture.Services.GetRequiredService<EndpointDataSource>();
+
+        var faltantes = new List<string>();
+
+        foreach (var endpoint in fuente.Endpoints)
+        {
+            if (endpoint is not RouteEndpoint ruta)
+            {
+                continue;
+            }
+
+            var metodos = ruta.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods;
+            if (metodos is null || !metodos.Contains("GET"))
+            {
+                continue;
+            }
+
+            var patron = ruta.RoutePattern.RawText ?? string.Empty;
+            if (!PrefijosDeLecturaReGateados.Any(prefijo => patron.StartsWith(prefijo, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            var tienePoliticaValida = ruta.Metadata
+                .GetOrderedMetadata<IAuthorizeData>()
+                .Any(dato => dato.Policy is not null && PoliticasAlMenosTanEstrictasComoOperacionDePos.Contains(dato.Policy));
+
+            if (!tienePoliticaValida)
+            {
+                faltantes.Add($"GET {patron}");
+            }
+        }
+
+        Assert.True(
+            faltantes.Count == 0,
+            $"Endpoint(s) GET sin OperacionDePos (o una policy más estricta) bajo las superficies re-gateadas: {string.Join(", ", faltantes)}");
+    }
 }

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Stage-5-pos-ventas, Slice 1 (task 1.7, design: Authorization Surface — omission guard,
+/// mandatory). ASP.NET Core compone metadata de autorización con AND (design decisión 6): un
+/// endpoint de escritura bajo un grupo relajado a <see cref="Politicas.OperacionDePos"/> queda
+/// abierto a Vendedor si alguien olvida apilar <see cref="Politicas.GestionDeCatalogo"/>. Esta
+/// prueba camina el <see cref="EndpointDataSource"/> real (no una lista mantenida a mano de
+/// rutas) y falla la build ante ese olvido, en vez de depender de la disciplina del siguiente
+/// PR.
+///
+/// El allowlist cubre dos familias, ambas explícitas y comentadas: (a) las cuatro rutas que el
+/// design nombra por su cuenta — el carryover de <c>/api/ofertas/resolver</c> (etapa 4) y el
+/// contrato de checkout/anulación que Slice 4/5 todavía no aterrizan (quedan acá ya, para que
+/// esta prueba no requiera edición cuando aparezcan); (b) los endpoints de escritura
+/// preexistentes que NUNCA estuvieron bajo <c>GestionDeCatalogo</c> porque viven en una
+/// superficie administrativa distinta y más estricta (usuarios, organización, aprovisionamiento
+/// de plataforma, login) — ninguno de esos grupos admite Vendedor, así que no son el riesgo que
+/// esta prueba vigila, pero tienen que declararse a propósito para que el chequeo sea honesto
+/// sobre TODO el <see cref="EndpointDataSource"/>, no solo sobre los cinco grupos que este slice
+/// re-gateó.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private static readonly HashSet<(string Metodo, string Ruta)> Allowlist =
+    [
+        // Los cuatro que el design nombra explícitamente.
+        ("POST", "/api/auth/login"),
+        ("POST", "/api/auth/logout"),
+        ("POST", "/api/ofertas/resolver"),
+        ("POST", "/api/ventas"),
+        ("POST", "/api/ventas/{id}/anulacion"),
+
+        // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
+        // admite Vendedor (Politicas.cs).
+        ("POST", "/api/plataforma/tenants/"),
+        ("PUT", "/api/plataforma/tenants/{id:int}"),
+        ("POST", "/api/plataforma/tenants/{id:int}/suspender"),
+        ("POST", "/api/plataforma/tenants/{id:int}/reactivar"),
+
+        // Organización (empresas/puntos de venta) — GestionDeOrganizacion (Root + Admin, sin
+        // Vendedor).
+        ("PUT", "/api/empresas/{id:int}"),
+        ("PUT", "/api/puntos-venta/{id:int}"),
+
+        // ABM de usuarios — GestionDeUsuarios (Root + Admin, sin Vendedor).
+        ("POST", "/api/usuarios/"),
+        ("PUT", "/api/usuarios/{id:int}"),
+        ("POST", "/api/usuarios/{id:int}/password"),
+        ("POST", "/api/usuarios/{id:int}/desbloquear"),
+        ("DELETE", "/api/usuarios/{id:int}")
+    ];
+
+    [Fact]
+    public void TodoEndpointNoGetFueraDelAllowlistApilaGestionDeCatalogo()
+    {
+        var fuente = fixture.Services.GetRequiredService<EndpointDataSource>();
+
+        var faltantes = new List<string>();
+
+        foreach (var endpoint in fuente.Endpoints)
+        {
+            if (endpoint is not RouteEndpoint ruta)
+            {
+                continue;
+            }
+
+            var metodos = ruta.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods;
+            if (metodos is null || metodos.Contains("GET"))
+            {
+                // Sin restricción de método (MapFallback, MapOpenApi) o GET: fuera del alcance
+                // del guard — la superficie de lectura es justamente lo que este slice abrió.
+                continue;
+            }
+
+            var patron = ruta.RoutePattern.RawText ?? string.Empty;
+            var metodo = metodos.Single();
+
+            if (Allowlist.Contains((metodo, patron)))
+            {
+                continue;
+            }
+
+            var apilaGestionDeCatalogo = ruta.Metadata
+                .GetOrderedMetadata<IAuthorizeData>()
+                .Any(dato => dato.Policy == Politicas.GestionDeCatalogo);
+
+            if (!apilaGestionDeCatalogo)
+            {
+                faltantes.Add($"{metodo} {patron}");
+            }
+        }
+
+        Assert.True(
+            faltantes.Count == 0,
+            $"Endpoint(s) de escritura sin GestionDeCatalogo y fuera del allowlist: {string.Join(", ", faltantes)}");
+    }
+}


### PR DESCRIPTION
Closes #37

## Summary

- Slice 1 of `stage-5-pos-ventas`: new `Politicas.OperacionDePos` (Vendedor + Supervisor + Admin; Root excluded — Supervisor added at judgment-day per legacy parity `tipoUser IN (2,3,4)`). The POS read surface (articulos incl. precios/barcodes, clientes + listas-precio selector, catalogos genéricos, catalogos-fiscales, parametros, ofertas incl. `/resolver`) re-gates to it; every catalog WRITE stacks `GestionDeCatalogo` via AND-composition, keeping writes byte-identical Admin-only. Closes the stage-4 carryover: the POS can now call `POST /api/ofertas/resolver`.
- Two fail-closed guards walk the real `EndpointDataSource`: non-GET endpoints must stack `GestionDeCatalogo` (allowlist), and every GET under the re-gated prefixes must carry `OperacionDePos` — the exact blind spot that let `/catalogos-fiscales` ship ungated in round 1.
- Judgment-day (2 rounds): R1 — 1 CRITICAL (fiscales group left on the authenticated-only fallback, contradicting the design table) + missing Root-403/401 tests + the Supervisor parity decision → fixed. R2 — 1 CRITICAL (shipped React front still routed Root into the now-403 fiscales page → permanent error screen) → front gates narrowed to Admin; design/spec amended.
- Two deliberate test inversions (Vendedor can now list listas-precio and codigos-barra) renamed with rationale.

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 162/162, Application 207/207, Integration 281/281 (+7: guards, fiscales Vendedor-200/Root-403, articulos Root-403, resolver 401-sin-token, Supervisor 200/403)
- [x] `npx vitest run` — 57/57; `tsc -b`/`oxlint`/`vite build` clean
- [x] judgment-day: APPROVED — R2's front fix orchestrator-verified inline (mechanical two-gate narrowing, trivial-iteration precedent)

## Notes

- No schema changes. Unblocks the escaneo endpoint of Slice 2 (group gate now OperacionDePos) — its interim Admin-only test gets inverted at Slice 2's rebase.