### PR TITLE
feat(ventas): numeracion atomica de comprobantes y escaneo de codigos (etapa 5, slice 2)

### DIFF
--- a/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
@@ -25,11 +25,8 @@ public static class ArticulosEndpoints
         .WithSummary("Lista artículos con búsqueda, filtro de disponibilidad por empresa y paginado.");
 
         // stage-5-pos-ventas (Slice 2, task 2.9, design: API Surface): resolución de escaneo
-        // del POS — segmento literal, no colisiona con "/{id:int}" de abajo. Gateada acá con
-        // Politicas.GestionDeCatalogo (admin-only) por construcción del grupo: la Slice 1 en
-        // paralelo (auth policy) va a re-gatear TODO el grupo a Politicas.OperacionDePos
-        // (Vendedor + Admin, design decisión 6) — esta línea queda como deuda declarada hasta
-        // que esa slice se mergee, no como decisión final de autorización.
+        // del POS — segmento literal, no colisiona con "/{id:int}" de abajo. Hereda
+        // Politicas.OperacionDePos del grupo (Vendedor + Admin, design decisión 6).
         grupo.MapGet("/escaneo", (ServicioDeEscaneo servicio, string entrada, CancellationToken ct) =>
             servicio.ResolverAsync(entrada, ct))
         .WithSummary("Resuelve un código escaneado (codigo_interno o codigos_barra) a su artículo.");

--- a/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ArticulosEndpoints.cs
@@ -1,6 +1,7 @@
 using Ways.Api.Seguridad;
 using Ways.Application.Articulos;
 using Ways.Application.Precios;
+using Ways.Application.Ventas;
 
 namespace Ways.Api.Endpoints;
 
@@ -22,6 +23,16 @@ public static class ArticulosEndpoints
             CancellationToken ct) =>
             servicio.ListarAsync(busqueda, idEmpresa, incluirEliminados ?? false, pagina ?? 1, tamanio ?? 25, ct))
         .WithSummary("Lista artículos con búsqueda, filtro de disponibilidad por empresa y paginado.");
+
+        // stage-5-pos-ventas (Slice 2, task 2.9, design: API Surface): resolución de escaneo
+        // del POS — segmento literal, no colisiona con "/{id:int}" de abajo. Gateada acá con
+        // Politicas.GestionDeCatalogo (admin-only) por construcción del grupo: la Slice 1 en
+        // paralelo (auth policy) va a re-gatear TODO el grupo a Politicas.OperacionDePos
+        // (Vendedor + Admin, design decisión 6) — esta línea queda como deuda declarada hasta
+        // que esa slice se mergee, no como decisión final de autorización.
+        grupo.MapGet("/escaneo", (ServicioDeEscaneo servicio, string entrada, CancellationToken ct) =>
+            servicio.ResolverAsync(entrada, ct))
+        .WithSummary("Resuelve un código escaneado (codigo_interno o codigos_barra) a su artículo.");
 
         grupo.MapGet("/{id:int}", (ServicioDeArticulos servicio, int id, CancellationToken ct) =>
             servicio.ObtenerAsync(id, ct))

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -131,6 +131,19 @@ public class ManejadorDeErrores(
                 when string.Equals(pkOfertasListas, "pk_ofertas_listas", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "La lista de precios ya está en el subconjunto de targeting de la oferta.", "oferta_lista_duplicada"),
 
+            // stage-5-pos-ventas (Slice 2, task 2.6, db-error-backstops, design: Backstop Map):
+            // pk_numeraciones_comprobante — exención documentada de prueba de carrera. A
+            // diferencia de pk_ofertas_listas/PK_articulos_empresas (que SÍ tienen un camino de
+            // escritura normal que puede chocar), el único escritor de esta tabla
+            // (AsignadorDeNumeroComprobante) inserta con ON CONFLICT DO NOTHING — nunca puede
+            // disparar 23505 por construcción. Esta rama queda como defensa de esquema pura,
+            // alcanzable solo por un INSERT crudo/fuera de banda que bypasee el asignador
+            // (misma familia que pk_stock, Slice 3), probada con SQL directo, no con una
+            // carrera real.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string pkNumeracion } }
+                when string.Equals(pkNumeracion, "pk_numeraciones_comprobante", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe una numeración para ese punto de venta y tipo de comprobante.", "numeracion_duplicada"),
+
             // Defensa en profundidad genérica (judgment-day, item 2, stage-4-ofertas): EF
             // interpreta un UPDATE/DELETE que afecta 0 filas de las esperadas (en vez de la 1
             // esperada por su predicado de PK) como un conflicto de concurrencia y lanza

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Ways.Application.Parametros;
 using Ways.Application.Precios;
 using Ways.Application.Proveedores;
 using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
 
 namespace Ways.Application;
 
@@ -39,6 +40,11 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeArticulos>();
         services.AddScoped<ServicioDePrecios>();
         services.AddScoped<ServicioDeOfertas>();
+
+        // AsignadorDeNumeroComprobante (Ways.Application.Ventas) es estática, sin ciclo de
+        // vida de DI que registrar — mismo criterio que AsignadorDeNumeroCliente/
+        // AsignadorDeCodigoInternoArticulo.
+        services.AddScoped<ServicioDeEscaneo>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -41,9 +41,6 @@ public static class DependencyInjection
         services.AddScoped<ServicioDePrecios>();
         services.AddScoped<ServicioDeOfertas>();
 
-        // AsignadorDeNumeroComprobante (Ways.Application.Ventas) es estática, sin ciclo de
-        // vida de DI que registrar — mismo criterio que AsignadorDeNumeroCliente/
-        // AsignadorDeCodigoInternoArticulo.
         services.AddScoped<ServicioDeEscaneo>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();

--- a/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
+++ b/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
@@ -1,0 +1,94 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// Asigna <c>comprobantes_venta.numero</c> de forma atómica por punto de venta + tipo de
+/// comprobante (design decisiones 8 y 9, clon de
+/// <see cref="Clientes.AsignadorDeNumeroCliente"/>): <c>INSERT ... ON CONFLICT DO NOTHING</c>
+/// (creación perezosa de la fila, sin backfill) seguido de <c>UPDATE numeraciones_comprobante
+/// SET proximo_numero = proximo_numero + 1 ... RETURNING</c>, vía ADO.NET crudo sobre la
+/// conexión/transacción activa de <paramref name="db"/> — nunca <c>Database.SqlQuery&lt;T&gt;()</c>/
+/// <c>FromSqlRaw&lt;T&gt;()</c> (mismo hallazgo de stage-1-slice-2 que documentan
+/// <see cref="Clientes.AsignadorDeNumeroCliente"/>/<see cref="Articulos.AsignadorDeCodigoInternoArticulo"/>).
+///
+/// A diferencia de <see cref="Clientes.AsignadorDeNumeroCliente"/> (PK = <c>id_tenant</c> solo),
+/// acá la fila la identifica <c>(id_punto_venta, tipo_comprobante)</c> — <c>id_tenant</c> viaja
+/// aparte, solo para el INSERT inicial (RLS <c>WITH CHECK</c>) y la columna de diagnóstico; no
+/// participa del <c>WHERE</c> del UPDATE porque la PK ya es global (design decisión 8).
+///
+/// <c>proximo_numero</c> es <c>bigint</c> (doc 10): el contador se expone como <see cref="long"/>,
+/// nunca <see cref="int"/> — a diferencia de <c>clientes.numero</c>/<c>articulos.codigo_interno</c>.
+///
+/// Estática a propósito: sin estado propio, cada método recibe el <see cref="IWaysDbContext"/>
+/// del llamador de turno (mismo criterio que los dos asignadores hermanos). Su único llamador
+/// hoy es la suite de concurrencia de esta slice — <c>ServicioDeVentas.EmitirAsync</c> (Slice 4)
+/// es quien lo va a invocar dentro de la transacción de venta, paso 1 del statement order
+/// pineado (design: The Sale Transaction).
+/// </summary>
+public static class AsignadorDeNumeroComprobante
+{
+    public static async Task AsegurarContadorAsync(
+        IWaysDbContext db, int idTenant, int idPuntoVenta, string tipoComprobante, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "INSERT INTO numeraciones_comprobante (id_tenant, id_punto_venta, tipo_comprobante, proximo_numero) " +
+            "VALUES ($1, $2, $3, 1) " +
+            "ON CONFLICT (id_punto_venta, tipo_comprobante) DO NOTHING";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, tipoComprobante);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    public static async Task<long> AsignarSiguienteAsync(
+        IWaysDbContext db, int idPuntoVenta, string tipoComprobante, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "UPDATE numeraciones_comprobante SET proximo_numero = proximo_numero + 1 " +
+            "WHERE id_punto_venta = $1 AND tipo_comprobante = $2 RETURNING proximo_numero - 1";
+
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, tipoComprobante);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException(
+                $"No existe contador de numeraciones para el punto de venta {idPuntoVenta}, " +
+                $"tipo {tipoComprobante}: llamá a {nameof(AsegurarContadorAsync)} antes de asignar.");
+
+        return Convert.ToInt64(resultado);
+    }
+
+    private static async Task<DbConnection> ObtenerConexionAbiertaAsync(IWaysDbContext db, CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+}

--- a/src/Ways.Application/Ventas/ServicioDeEscaneo.cs
+++ b/src/Ways.Application/Ventas/ServicioDeEscaneo.cs
@@ -23,8 +23,9 @@ public record ArticuloEscaneado(
 /// distinto de <see cref="Articulos.ServicioDeArticulos"/> (ABM): acá no hay autorización de
 /// catálogo ni ciclo de vida de escritura, solo una lectura identity-only. Parsea con
 /// <see cref="ParserDeEscaneo"/> (pure) y corre UNA query contra <c>articulos</c>/
-/// <c>codigos_barra</c>, ambas ya filtradas por tenant (EF query filter) y por
-/// <c>activo = true</c> (spec: "Inactive articulo is not resolved").
+/// <c>codigos_barra</c>, ambas ya filtradas por tenant (EF query filter); el artículo además
+/// exige <c>activo = true</c> (spec: "Inactive articulo is not resolved") — el código de barra
+/// no tiene baja lógica propia, su ciclo de vida es el soft-delete global.
 /// </summary>
 public class ServicioDeEscaneo(IWaysDbContext db)
 {
@@ -41,7 +42,7 @@ public class ServicioDeEscaneo(IWaysDbContext db)
             ObjetivoDeEscaneo.CodigoBarra => await (
                 from a in db.Articulos
                 join c in db.CodigosBarra on a.Id equals c.IdArticulo
-                where a.Activo && c.Activo && c.Codigo == parseado.Codigo
+                where a.Activo && c.Codigo == parseado.Codigo
                 select a).FirstOrDefaultAsync(ct),
 
             _ => null

--- a/src/Ways.Application/Ventas/ServicioDeEscaneo.cs
+++ b/src/Ways.Application/Ventas/ServicioDeEscaneo.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>Respuesta de <c>GET /api/articulos/escaneo</c> (design: API Surface) — identidad y
+/// campos de snapshot únicamente, nunca precio ni oferta (design decisión 7: la resolución de
+/// precio queda en el único camino existente, <c>POST /api/ofertas/resolver</c>).
+/// <see cref="CodigoBarra"/> es <c>null</c> cuando la entrada resolvió por
+/// <c>codigo_interno</c> — el llamador (carrito del POS) usa <see cref="Cantidad"/> tal cual la
+/// devolvió <see cref="Ways.Domain.Ventas.ParserDeEscaneo"/>.</summary>
+public record ArticuloEscaneado(
+    int IdArticulo,
+    string CodigoInterno,
+    string Nombre,
+    string? CodigoBarra,
+    decimal Cantidad);
+
+/// <summary>
+/// Resolución de escaneo del POS (design decisiones 7 y 10) — servicio de Application dedicado,
+/// distinto de <see cref="Articulos.ServicioDeArticulos"/> (ABM): acá no hay autorización de
+/// catálogo ni ciclo de vida de escritura, solo una lectura identity-only. Parsea con
+/// <see cref="ParserDeEscaneo"/> (pure) y corre UNA query contra <c>articulos</c>/
+/// <c>codigos_barra</c>, ambas ya filtradas por tenant (EF query filter) y por
+/// <c>activo = true</c> (spec: "Inactive articulo is not resolved").
+/// </summary>
+public class ServicioDeEscaneo(IWaysDbContext db)
+{
+    public async Task<ArticuloEscaneado> ResolverAsync(string entrada, CancellationToken ct = default)
+    {
+        var parseado = ParserDeEscaneo.Parsear(entrada);
+
+        var articulo = parseado.Objetivo switch
+        {
+            ObjetivoDeEscaneo.CodigoInterno => await db.Articulos
+                .Where(a => a.Activo && a.CodigoInterno == parseado.Codigo)
+                .FirstOrDefaultAsync(ct),
+
+            ObjetivoDeEscaneo.CodigoBarra => await (
+                from a in db.Articulos
+                join c in db.CodigosBarra on a.Id equals c.IdArticulo
+                where a.Activo && c.Activo && c.Codigo == parseado.Codigo
+                select a).FirstOrDefaultAsync(ct),
+
+            _ => null
+        };
+
+        if (articulo is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No se encontró un artículo activo para el código {parseado.Codigo}.");
+        }
+
+        return new ArticuloEscaneado(
+            articulo.Id,
+            articulo.CodigoInterno,
+            articulo.Nombre,
+            parseado.Objetivo == ObjetivoDeEscaneo.CodigoBarra ? parseado.Codigo : null,
+            parseado.Cantidad);
+    }
+}

--- a/src/Ways.Domain/Ventas/NumeracionComprobante.cs
+++ b/src/Ways.Domain/Ventas/NumeracionComprobante.cs
@@ -1,0 +1,32 @@
+namespace Ways.Domain.Ventas;
+
+/// <summary>
+/// Contador atómico de <c>comprobantes_venta.numero</c> por punto de venta + tipo de
+/// comprobante (design decision 8, doc 09 <c>numeraciones_comprobante</c> family): la PK es
+/// <c>(IdPuntoVenta, TipoComprobante)</c> — <c>IdPuntoVenta</c> ya es una identidad global
+/// (doc 09), así que agregar <c>IdTenant</c> a la PK sería redundante (mismo criterio que
+/// <c>pk_ofertas_listas</c>: lo carga como columna no-key, solo para RLS/FKs).
+///
+/// PK-only, sin auditoría ni baja lógica — mismo criterio que <see cref="Articulos.ArticuloEmpresa"/>/
+/// <see cref="Ofertas.OfertaLista"/>: no hereda de <see cref="Common.EntidadBase"/>/
+/// <see cref="Common.EntidadTenant"/>, así que necesita filtro de tenant escrito a mano
+/// (<c>WaysDbContext.AplicarFiltroDeTenantEnNumeracionComprobante</c>).
+///
+/// <see cref="Application.Ventas.AsignadorDeNumeroComprobante"/> es el único punto de
+/// escritura legítimo: lo hace con SQL crudo, con creación perezosa de la fila dentro de la
+/// transacción del llamador (design decision 9) — nunca vía <c>SaveChangesAsync</c>.
+/// </summary>
+public class NumeracionComprobante
+{
+    public int IdPuntoVenta { get; set; }
+
+    /// <summary><c>tipos_comprobante.codigo</c> ("TX", "NCX", …) — <c>varchar(30)</c> en vez
+    /// de una FK: nunca es input de cliente (siempre viene de un <c>TipoComprobante</c> ya
+    /// cargado), y doc 09 numera en esta misma tabla conceptos que no son comprobante
+    /// (<c>retiro</c>, <c>cierre_caja</c> — stage 6).</summary>
+    public required string TipoComprobante { get; set; }
+
+    public int IdTenant { get; set; }
+
+    public long ProximoNumero { get; set; } = 1;
+}

--- a/src/Ways.Domain/Ventas/NumeroDeComprobante.cs
+++ b/src/Ways.Domain/Ventas/NumeroDeComprobante.cs
@@ -1,0 +1,14 @@
+namespace Ways.Domain.Ventas;
+
+/// <summary>
+/// Formatea el número visible de un comprobante (design: API Surface — <c>PPPP-NNNNNNNN</c>).
+/// <c>PPPP</c> es el <c>id_punto_venta</c> zero-padded — una identidad global, no un número de
+/// negocio por empresa (design's Open Questions: <c>puntos_venta</c> no tiene columna
+/// <c>numero</c> todavía; inofensivo mientras TX/NCX sean no fiscales). Sin bound superior: un
+/// id o un número que excedan 4/8 dígitos simplemente imprimen más dígitos, no se truncan.
+/// </summary>
+public static class NumeroDeComprobante
+{
+    public static string Formatear(int idPuntoVenta, long numero) =>
+        $"{idPuntoVenta:D4}-{numero:D8}";
+}

--- a/src/Ways.Domain/Ventas/ParserDeEscaneo.cs
+++ b/src/Ways.Domain/Ventas/ParserDeEscaneo.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Ventas;
+
+/// <summary>Contra qué columna resuelve un <see cref="EntradaDeEscaneo.Codigo"/> (spec:
+/// codigos-barra / Scan Resolution Rule).</summary>
+public enum ObjetivoDeEscaneo
+{
+    CodigoInterno,
+    CodigoBarra
+}
+
+/// <summary>Resultado puro de <see cref="ParserDeEscaneo.Parsear"/> — <see cref="Codigo"/> y
+/// <see cref="Objetivo"/> le dicen a <see cref="Application.Ventas.ServicioDeEscaneo"/> qué
+/// columna consultar, sin que este tipo sepa nada de persistencia.</summary>
+public readonly record struct EntradaDeEscaneo(decimal Cantidad, string Codigo, ObjetivoDeEscaneo Objetivo);
+
+/// <summary>
+/// Parsea la entrada cruda de un escaneo de POS (design decision 7, spec: codigos-barra / Scan
+/// Resolution Rule) — pura, sin acceso a base de datos: solo decide sintaxis y a qué columna
+/// apunta el código, nunca si ese código existe.
+/// </summary>
+public static class ParserDeEscaneo
+{
+    /// <summary>Regla I.2: menos de 7 dígitos ⇒ <c>codigo_interno</c>, 7 o más ⇒
+    /// <c>codigos_barra</c> — el mismo corte que <c>AsignadorDeCodigoInternoArticulo</c> ya
+    /// documenta como restricción heredada por esta etapa.</summary>
+    private const int LongitudMinimaCodigoBarra = 7;
+
+    public static EntradaDeEscaneo Parsear(string? entrada)
+    {
+        var texto = entrada?.Trim();
+
+        if (string.IsNullOrEmpty(texto))
+        {
+            throw new ErrorDominio("escaneo_invalido", "El código escaneado no puede estar vacío.", 400);
+        }
+
+        var (cantidad, codigo) = SepararCantidadYCodigo(texto);
+
+        if (string.IsNullOrEmpty(codigo))
+        {
+            throw new ErrorDominio("escaneo_invalido", "El código escaneado no puede estar vacío.", 400);
+        }
+
+        var objetivo = codigo.Length < LongitudMinimaCodigoBarra
+            ? ObjetivoDeEscaneo.CodigoInterno
+            : ObjetivoDeEscaneo.CodigoBarra;
+
+        return new EntradaDeEscaneo(cantidad, codigo, objetivo);
+    }
+
+    /// <summary>Sintaxis <c>&lt;cantidad&gt;*&lt;codigo&gt;</c> (p.ej. <c>"3*7790001"</c>).
+    /// Un prefijo ausente, vacío, <c>"0"</c>, negativo o no numérico NUNCA invalida el
+    /// escaneo — cae a cantidad 1 (spec: "defaults an empty or 0 cantidad to 1"; una entrada
+    /// "rara" antes del <c>*</c> se trata igual que una ausente, nunca como error de parseo —
+    /// el <c>*</c> es a lo sumo un separador opcional, no sintaxis obligatoria).</summary>
+    private static (decimal Cantidad, string Codigo) SepararCantidadYCodigo(string texto)
+    {
+        var indice = texto.IndexOf('*');
+
+        if (indice < 0)
+        {
+            return (1m, texto);
+        }
+
+        var prefijo = texto[..indice].Trim();
+        var codigo = texto[(indice + 1)..].Trim();
+
+        var cantidad = decimal.TryParse(prefijo, NumberStyles.Number, CultureInfo.InvariantCulture, out var parseada)
+            && parseada > 0
+                ? parseada
+                : 1m;
+
+        return (cantidad, codigo);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionComprobanteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionComprobanteConfiguration.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="NumeracionComprobante"/> (design: Table Shapes — write path A, decisión 8):
+/// PK compuesta <c>(id_punto_venta, tipo_comprobante)</c>, <c>id_tenant</c> columna no-key para
+/// RLS. Solo <c>AsignadorDeNumeroComprobante</c> escribe esta tabla, con SQL crudo (design
+/// decisión 9) — este mapeo existe para que el modelo de EF conozca la forma de la tabla (RLS,
+/// FK compuesta, lecturas de diagnóstico), no para que <c>SaveChangesAsync</c> la toque.
+/// </summary>
+public class NumeracionComprobanteConfiguration : IEntityTypeConfiguration<NumeracionComprobante>
+{
+    public void Configure(EntityTypeBuilder<NumeracionComprobante> builder)
+    {
+        builder.ToTable("numeraciones_comprobante");
+
+        builder.HasKey(n => new { n.IdPuntoVenta, n.TipoComprobante })
+            .HasName("pk_numeraciones_comprobante");
+
+        builder.Property(n => n.IdPuntoVenta)
+            .HasColumnName("id_punto_venta")
+            .ValueGeneratedNever();
+
+        builder.Property(n => n.TipoComprobante)
+            .HasColumnName("tipo_comprobante")
+            .HasMaxLength(30)
+            .ValueGeneratedNever();
+
+        builder.Property(n => n.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(n => n.ProximoNumero)
+            .HasColumnName("proximo_numero")
+            .HasDefaultValue(1L)
+            .IsRequired();
+
+        builder.HasIndex(n => n.IdTenant).HasDatabaseName("ix_numeraciones_comprobante_tenant");
+
+        // Nombre explícito en snake_case (mismo fix documentado en ArticuloEmpresaConfiguration):
+        // sin esto, EF nombra el índice de soporte de fk_numeraciones_comprobante_punto_venta
+        // con su convención propia (IX_numeraciones_comprobante_id_punto_venta_id_tenant,
+        // PascalCase) — el mismo trap de stage-3-articulos-y-precios.
+        builder.HasIndex(n => new { n.IdPuntoVenta, n.IdTenant })
+            .HasDatabaseName("ix_numeraciones_comprobante_punto_venta");
+
+        // FK compuesta (id_punto_venta, id_tenant) → puntos_venta (mismo criterio que
+        // PuntoVentaConfiguration.ak_puntos_venta_id_punto_venta_id_tenant): un tenant no
+        // puede tener un contador colgado del punto de venta de otro tenant ni por bug.
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(n => new { n.IdPuntoVenta, n.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_numeraciones_comprobante_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(n => n.IdTenant)
+            .HasConstraintName("fk_numeraciones_comprobante_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804131605_NumeracionDeComprobantesEtapa5.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804131605_NumeracionDeComprobantesEtapa5.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -16,9 +17,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804131605_NumeracionDeComprobantesEtapa5")]
+    partial class NumeracionDeComprobantesEtapa5
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804131605_NumeracionDeComprobantesEtapa5.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804131605_NumeracionDeComprobantesEtapa5.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class NumeracionDeComprobantesEtapa5 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "numeraciones_comprobante",
+                columns: table => new
+                {
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    tipo_comprobante = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    proximo_numero = table.Column<long>(type: "bigint", nullable: false, defaultValue: 1L)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_numeraciones_comprobante", x => new { x.id_punto_venta, x.tipo_comprobante });
+                    table.ForeignKey(
+                        name: "fk_numeraciones_comprobante_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_numeraciones_comprobante_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_numeraciones_comprobante_punto_venta",
+                table: "numeraciones_comprobante",
+                columns: new[] { "id_punto_venta", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_numeraciones_comprobante_tenant",
+                table: "numeraciones_comprobante",
+                column: "id_tenant");
+
+            // RLS (ADR-4/ADR-15, DB CHANGE GATE aprobado 2026-08-04): la tabla nueva activa su
+            // policy en la misma migración que la crea (design: Migration Sequencing).
+            migrationBuilder.HabilitarRlsDeTenant("numeraciones_comprobante");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "numeraciones_comprobante");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Application.Articulos;
 using Ways.Application.Clientes;
+using Ways.Application.Ventas;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
@@ -13,6 +14,7 @@ using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Proveedores;
 using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
 
 namespace Ways.Infrastructure.Persistencia;
 
@@ -67,6 +69,14 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<Oferta> Ofertas => Set<Oferta>();
     public DbSet<OfertaLista> OfertasListas => Set<OfertaLista>();
 
+    // stage-5-pos-ventas, Slice 2: NumeracionesComprobante NO se expone en IWaysDbContext —
+    // mismo criterio que NumeracionesArticulos (no NumeracionesClientes): su único escritor
+    // legítimo (AsignadorDeNumeroComprobante) recibe el WaysDbContext concreto por parámetro,
+    // y no hay backfill de InicializadorDeBaseDeDatos que necesite la interfaz acá (design
+    // decisión 9: creación perezosa dentro de la transacción de venta, sin seed al crear el
+    // punto de venta).
+    public DbSet<NumeracionComprobante> NumeracionesComprobante => Set<NumeracionComprobante>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>
@@ -102,6 +112,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenantEnNumeracionArticulo(modelBuilder);
         AplicarFiltroDeTenantEnArticuloEmpresa(modelBuilder);
         AplicarFiltroDeTenantEnOfertaLista(modelBuilder);
+        AplicarFiltroDeTenantEnNumeracionComprobante(modelBuilder);
     }
 
     /// <summary>
@@ -143,6 +154,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     {
         RechazarEscriturasDeNumeracionCliente();
         RechazarEscriturasDeNumeracionArticulo();
+        RechazarEscriturasDeNumeracionComprobante();
 
         foreach (var entrada in ChangeTracker.Entries<EntidadTenant>())
         {
@@ -227,6 +239,27 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
                 throw new InvalidOperationException(
                     "numeraciones_articulos solo se escribe con SQL crudo, vía " +
                     $"{nameof(AsignadorDeCodigoInternoArticulo)} — nunca por " +
+                    $"{nameof(SaveChanges)}/{nameof(SaveChangesAsync)}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// stage-5-pos-ventas (Slice 2, design decisión 9): mismo guard que
+    /// <see cref="RechazarEscriturasDeNumeracionArticulo"/>, acá para
+    /// <see cref="NumeracionComprobante"/> — <see cref="AsignadorDeNumeroComprobante"/> es su
+    /// único punto de escritura legítimo, con SQL crudo, con creación perezosa de la fila
+    /// dentro de la transacción del llamador.
+    /// </summary>
+    private void RechazarEscriturasDeNumeracionComprobante()
+    {
+        foreach (var entrada in ChangeTracker.Entries<NumeracionComprobante>())
+        {
+            if (entrada.State is EntityState.Added or EntityState.Modified)
+            {
+                throw new InvalidOperationException(
+                    "numeraciones_comprobante solo se escribe con SQL crudo, vía " +
+                    $"{nameof(AsignadorDeNumeroComprobante)} — nunca por " +
                     $"{nameof(SaveChanges)}/{nameof(SaveChangesAsync)}.");
             }
         }
@@ -414,6 +447,23 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
         var parametro = Expression.Parameter(typeof(OfertaLista), "e");
         var propiedadIdTenant = Expression.Property(parametro, nameof(OfertaLista.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// <see cref="NumeracionComprobante"/> no hereda de <see cref="EntidadTenant"/> (PK
+    /// compuesta <c>(IdPuntoVenta, TipoComprobante)</c>, mismo motivo que
+    /// <see cref="OfertaLista"/>/<see cref="ArticuloEmpresa"/>), así que necesita la misma
+    /// variante escrita a mano.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnNumeracionComprobante(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(NumeracionComprobante))!;
+
+        var parametro = Expression.Parameter(typeof(NumeracionComprobante), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(NumeracionComprobante.IdTenant));
         var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
 
         entidad.SetQueryFilter("Tenant", filtro);

--- a/tests/Ways.Domain.Tests/Ventas/NumeroDeComprobanteTests.cs
+++ b/tests/Ways.Domain.Tests/Ventas/NumeroDeComprobanteTests.cs
@@ -1,0 +1,60 @@
+using Ways.Domain.Ventas;
+
+namespace Ways.Domain.Tests.Ventas;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.10, design: API Surface — <c>PPPP-NNNNNNNN</c>).
+/// </summary>
+public class NumeroDeComprobanteTests
+{
+    [Fact]
+    public void RellenaConCerosLosDosSegmentos()
+    {
+        Assert.Equal("0001-00000001", NumeroDeComprobante.Formatear(1, 1));
+    }
+
+    [Fact]
+    public void UnPuntoDeVentaDeDosDigitosSeRellenaAcuatro()
+    {
+        Assert.Equal("0042-00000007", NumeroDeComprobante.Formatear(42, 7));
+    }
+
+    [Fact]
+    public void UnNumeroDeVariosDigitosSeRellenaAOcho()
+    {
+        Assert.Equal("0001-00012345", NumeroDeComprobante.Formatear(1, 12345));
+    }
+
+    [Fact]
+    public void ElLimiteExactoDeCuatroDigitosNoAgregaCeros()
+    {
+        Assert.Equal("9999-00000001", NumeroDeComprobante.Formatear(9999, 1));
+    }
+
+    [Fact]
+    public void ElLimiteExactoDeOchoDigitosNoAgregaCeros()
+    {
+        Assert.Equal("0001-99999999", NumeroDeComprobante.Formatear(1, 99999999L));
+    }
+
+    /// <summary>Design's Open Questions: sin bound superior — un id o número que excedan
+    /// 4/8 dígitos imprimen más dígitos en vez de truncarse (harmless mientras TX/NCX no
+    /// sean fiscales).</summary>
+    [Fact]
+    public void UnPuntoDeVentaDeMasDeCuatroDigitosNoSeTrunca()
+    {
+        Assert.Equal("10000-00000001", NumeroDeComprobante.Formatear(10000, 1));
+    }
+
+    [Fact]
+    public void UnNumeroDeMasDeOchoDigitosNoSeTrunca()
+    {
+        Assert.Equal("0001-100000000", NumeroDeComprobante.Formatear(1, 100000000L));
+    }
+
+    [Fact]
+    public void ElPuntoDeVentaCeroEsPosibleParaElInputAunqueElAsignadorNuncaLoUse()
+    {
+        Assert.Equal("0000-00000001", NumeroDeComprobante.Formatear(0, 1));
+    }
+}

--- a/tests/Ways.Domain.Tests/Ventas/ParserDeEscaneoTests.cs
+++ b/tests/Ways.Domain.Tests/Ventas/ParserDeEscaneoTests.cs
@@ -1,0 +1,174 @@
+using Ways.Domain.Common;
+using Ways.Domain.Ventas;
+
+namespace Ways.Domain.Tests.Ventas;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.11, design decisión 7, spec: codigos-barra / Scan
+/// Resolution Rule) — exhaustivo: boundary de 6/7/13 dígitos, sintaxis <c>N*codigo</c>,
+/// cantidad vacía/0, entrada basura. Pura, sin base de datos: <see cref="ParserDeEscaneo"/> no
+/// sabe si el código existe, solo a qué columna apunta.
+/// </summary>
+public class ParserDeEscaneoTests
+{
+    // ---- boundary de longitud (regla I.2: < 7 -> codigo_interno, >= 7 -> codigos_barra) ------
+
+    [Fact]
+    public void UnCodigoDeSeisDigitosResuelvePorCodigoInterno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("123456");
+
+        Assert.Equal(ObjetivoDeEscaneo.CodigoInterno, resultado.Objetivo);
+        Assert.Equal("123456", resultado.Codigo);
+    }
+
+    [Fact]
+    public void UnCodigoDeSieteDigitosResuelvePorCodigosBarra()
+    {
+        var resultado = ParserDeEscaneo.Parsear("1234567");
+
+        Assert.Equal(ObjetivoDeEscaneo.CodigoBarra, resultado.Objetivo);
+        Assert.Equal("1234567", resultado.Codigo);
+    }
+
+    [Fact]
+    public void UnCodigoDeTreceDigitosResuelvePorCodigosBarra()
+    {
+        var resultado = ParserDeEscaneo.Parsear("7790001234567");
+
+        Assert.Equal(ObjetivoDeEscaneo.CodigoBarra, resultado.Objetivo);
+        Assert.Equal("7790001234567", resultado.Codigo);
+    }
+
+    [Fact]
+    public void UnCodigoDeUnSoloDigitoResuelvePorCodigoInterno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("4");
+
+        Assert.Equal(ObjetivoDeEscaneo.CodigoInterno, resultado.Objetivo);
+    }
+
+    // ---- sintaxis N*codigo ---------------------------------------------------------------
+
+    [Fact]
+    public void UnPrefijoDeCantidadCargaLaCantidadIndicada()
+    {
+        var resultado = ParserDeEscaneo.Parsear("3*7790001234567");
+
+        Assert.Equal(3m, resultado.Cantidad);
+        Assert.Equal("7790001234567", resultado.Codigo);
+        Assert.Equal(ObjetivoDeEscaneo.CodigoBarra, resultado.Objetivo);
+    }
+
+    [Fact]
+    public void UnPrefijoDeCantidadConDecimalesSePreserva()
+    {
+        var resultado = ParserDeEscaneo.Parsear("1.5*42");
+
+        Assert.Equal(1.5m, resultado.Cantidad);
+        Assert.Equal("42", resultado.Codigo);
+    }
+
+    [Fact]
+    public void UnPrefijoDeCantidadAplicaTambienAUnCodigoInterno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("2*42");
+
+        Assert.Equal(2m, resultado.Cantidad);
+        Assert.Equal(ObjetivoDeEscaneo.CodigoInterno, resultado.Objetivo);
+    }
+
+    [Fact]
+    public void ConEspaciosAlrededorDelAsteriscoSeIgnoranAlTrimear()
+    {
+        var resultado = ParserDeEscaneo.Parsear(" 3 * 7790001234567 ");
+
+        Assert.Equal(3m, resultado.Cantidad);
+        Assert.Equal("7790001234567", resultado.Codigo);
+    }
+
+    // ---- cantidad vacía/0 default a 1 -----------------------------------------------------
+
+    [Fact]
+    public void SinAsteriscoLaCantidadEsUno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("42");
+
+        Assert.Equal(1m, resultado.Cantidad);
+    }
+
+    [Fact]
+    public void UnPrefijoVacioAntesDelAsteriscoDefaultAUno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("*7790001234567");
+
+        Assert.Equal(1m, resultado.Cantidad);
+        Assert.Equal("7790001234567", resultado.Codigo);
+    }
+
+    [Fact]
+    public void UnPrefijoCeroDefaultAUno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("0*7790001234567");
+
+        Assert.Equal(1m, resultado.Cantidad);
+    }
+
+    [Fact]
+    public void UnPrefijoNegativoDefaultAUno()
+    {
+        var resultado = ParserDeEscaneo.Parsear("-3*7790001234567");
+
+        Assert.Equal(1m, resultado.Cantidad);
+    }
+
+    // ---- entrada basura: nunca revienta, cae a un código plano ---------------------------
+
+    [Fact]
+    public void UnPrefijoNoNumericoDefaultAUnoYElCodigoEsElRestoDeLaEntrada()
+    {
+        var resultado = ParserDeEscaneo.Parsear("abc*123");
+
+        Assert.Equal(1m, resultado.Cantidad);
+        Assert.Equal("123", resultado.Codigo);
+        Assert.Equal(ObjetivoDeEscaneo.CodigoInterno, resultado.Objetivo);
+    }
+
+    [Fact]
+    public void UnaEntradaSinAsteriscoNiDigitosSeUsaTalCualComoCodigo()
+    {
+        var resultado = ParserDeEscaneo.Parsear("basura");
+
+        Assert.Equal(1m, resultado.Cantidad);
+        Assert.Equal("basura", resultado.Codigo);
+        Assert.Equal(ObjetivoDeEscaneo.CodigoInterno, resultado.Objetivo);
+    }
+
+    // ---- validación de entrada -------------------------------------------------------------
+
+    [Fact]
+    public void UnaEntradaVaciaLanzaErrorDeDominio()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ParserDeEscaneo.Parsear(""));
+        Assert.Equal("escaneo_invalido", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void UnaEntradaSoloDeEspaciosLanzaErrorDeDominio()
+    {
+        Assert.Throws<ErrorDominio>(() => ParserDeEscaneo.Parsear("   "));
+    }
+
+    [Fact]
+    public void UnaEntradaNulaLanzaErrorDeDominio()
+    {
+        Assert.Throws<ErrorDominio>(() => ParserDeEscaneo.Parsear(null));
+    }
+
+    [Fact]
+    public void UnAsteriscoSinCodigoDespuesLanzaErrorDeDominio()
+    {
+        Assert.Throws<ErrorDominio>(() => ParserDeEscaneo.Parsear("3*"));
+    }
+}

--- a/tests/Ways.IntegrationTests/AsignadorDeNumeroComprobanteConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/AsignadorDeNumeroComprobanteConcurrenciaTests.cs
@@ -1,0 +1,128 @@
+using Ways.Application.Ventas;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.13, design decisiones 1/2/8/9, spec: comprobantes-venta /
+/// Numeración Allocation Is Atomic, ambos escenarios): mismo patrón que
+/// <c>AsignadorDeNumeroClienteConcurrenciaTests</c> — el <c>UPDATE ... RETURNING</c>
+/// incondicional sobre la fila del contador serializa las dos transacciones sin ayuda externa
+/// (el propio row lock de Postgres alcanza, sin <c>InterceptorDeRendezVous</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AsignadorDeNumeroComprobanteConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const int CantidadDeRondas = 3;
+    private const string TipoComprobante = "TX";
+
+    private async Task<(int IdTenant, int IdPuntoVenta)> SembrarTenantConPuntoVentaAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Tenants.Add(tenant);
+        await siembra.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Empresas.Add(empresa);
+        await siembra.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        siembra.PuntosVenta.Add(puntoVenta);
+        await siembra.SaveChangesAsync();
+
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(siembra, tenant.Id, puntoVenta.Id, TipoComprobante);
+
+        return (tenant.Id, puntoVenta.Id);
+    }
+
+    /// <summary>Spec: "Concurrent sales at the same punto de venta get consecutive numbers" —
+    /// dos asignaciones simultáneas sobre el MISMO contador (mismo punto de venta y tipo) no
+    /// pueden repetir ni saltear un número.</summary>
+    [Fact]
+    public async Task DosAsignacionesConcurrentesDelMismoPuntoDeVentaYTipoDanNumerosDistintosYConsecutivos()
+    {
+        var (_, idPuntoVenta) = await SembrarTenantConPuntoVentaAsync(
+            nameof(DosAsignacionesConcurrentesDelMismoPuntoDeVentaYTipoDanNumerosDistintosYConsecutivos));
+
+        var todosLosNumeros = new List<long>();
+
+        for (var ronda = 0; ronda < CantidadDeRondas; ronda++)
+        {
+            var tareaA = AsignarUnoAsync(idPuntoVenta);
+            var tareaB = AsignarUnoAsync(idPuntoVenta);
+
+            var numeros = await Task.WhenAll(tareaA, tareaB);
+
+            Assert.NotEqual(numeros[0], numeros[1]);
+            todosLosNumeros.AddRange(numeros);
+        }
+
+        var minimo = todosLosNumeros.Min();
+        var esperados = Enumerable.Range(0, todosLosNumeros.Count).Select(i => minimo + i);
+
+        Assert.Equal(esperados, todosLosNumeros.OrderBy(n => n));
+        Assert.Equal(todosLosNumeros.Count, todosLosNumeros.Distinct().Count());
+    }
+
+    /// <summary>Hallazgo honesto sobre el mecanismo (contraparte del "a rolled-back sale
+    /// leaves an accepted gap" de la spec, que describe la SALE completa de la Slice 4, no el
+    /// asignador aislado): acá el UPDATE es transaccional de verdad — <c>ROLLBACK</c> deshace
+    /// el incremento como cualquier otra fila, así que un rollback ANTES de comitear NO deja
+    /// un hueco, REUSA el número. El "hueco aceptado" de la spec nace en la capa de la Sale
+    /// (Slice 4): un retry del <c>CreateExecutionStrategy</c> ante una falla transitoria con
+    /// estado de commit ambiguo puede reconsumir otro número sin que este asignador, por sí
+    /// solo, pueda saltear ninguno — la garantía que SÍ da este nivel es la que importa acá:
+    /// el contador nunca retrocede ante una operación EXITOSA (monótono no decreciente), que es
+    /// la base sobre la que la Slice 4 construye el resto.</summary>
+    [Fact]
+    public async Task UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco()
+    {
+        var (_, idPuntoVenta) = await SembrarTenantConPuntoVentaAsync(
+            nameof(UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco));
+
+        await using var dbRollback = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccionRollback = await dbRollback.Database.BeginTransactionAsync();
+        var numeroDescartado = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(
+            dbRollback, idPuntoVenta, TipoComprobante);
+        await transaccionRollback.RollbackAsync();
+
+        var numeroSiguiente = await AsignarUnoAsync(idPuntoVenta);
+
+        Assert.Equal(numeroDescartado, numeroSiguiente);
+    }
+
+    /// <summary>La otra cara del mismo hallazgo: una asignación que SÍ comitea nunca se
+    /// "devuelve" — el contador es monótono no decreciente, sin importar qué le pase después al
+    /// llamador con ese número (spec: "no gap, no duplicate" en su mitad "no duplicate").</summary>
+    [Fact]
+    public async Task UnaAsignacionYaComiteadaNuncaSeReusaEnUnaAsignacionPosterior()
+    {
+        var (_, idPuntoVenta) = await SembrarTenantConPuntoVentaAsync(
+            nameof(UnaAsignacionYaComiteadaNuncaSeReusaEnUnaAsignacionPosterior));
+
+        var primero = await AsignarUnoAsync(idPuntoVenta);
+        var segundo = await AsignarUnoAsync(idPuntoVenta);
+
+        Assert.Equal(primero + 1, segundo);
+    }
+
+    private async Task<long> AsignarUnoAsync(int idPuntoVenta)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccion = await db.Database.BeginTransactionAsync();
+
+        var numero = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(db, idPuntoVenta, TipoComprobante);
+
+        await transaccion.CommitAsync();
+        return numero;
+    }
+}

--- a/tests/Ways.IntegrationTests/EscaneoEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/EscaneoEndpointsTests.cs
@@ -1,0 +1,225 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.14, design decisión 7, spec: codigos-barra / Scan
+/// Resolution Rule) — <c>GET /api/articulos/escaneo</c> punta a punta contra Postgres real:
+/// código corto, código largo, prefijo <c>N*</c>, artículo inactivo, código desconocido.
+///
+/// Gateada hoy con <c>Politicas.GestionDeCatalogo</c> (admin-only) por construcción del grupo
+/// <c>ArticulosEndpoints</c> — deuda declarada hasta que la Slice 1 (en paralelo) re-gatee el
+/// grupo entero a <c>Politicas.OperacionDePos</c> (Vendedor + Admin, design decisión 6). Esta
+/// suite prueba el comportamiento ACTUAL (admin-only), no el final.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class EscaneoEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "una-contraseña-larga";
+
+    private async Task<(int IdTenant, int IdArea, int IdAlicuotaIva, string MailAdmin, string PasswordAdmin)>
+        AprovisionarTenantAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
+        Assert.NotNull(resultado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado!.IdTenant, Nombre = $"{nombre}-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        return (resultado.IdTenant, area.Id, idAlicuotaIva, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private async Task<HttpClient> ClienteLogueadoAsync(string mail, string password)
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, password));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<string> SembrarVendedorAsync(int idTenant, string nombre)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = "vendedor",
+            Mail = mail,
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return mail;
+    }
+
+    private async Task<Articulo> SembrarArticuloAsync(
+        int idTenant, int idArea, int idAlicuotaIva, string nombre,
+        string codigoInterno, bool activo = true, string? codigoBarra = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = idTenant,
+            CodigoInterno = codigoInterno,
+            Nombre = nombre,
+            IdArea = idArea,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            Activo = activo,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        if (codigoBarra is not null)
+        {
+            db.CodigosBarra.Add(new CodigoBarra
+            {
+                IdTenant = idTenant, IdArticulo = articulo.Id, Codigo = codigoBarra,
+                CreatedAt = ahora, UpdatedAt = ahora
+            });
+            await db.SaveChangesAsync();
+        }
+
+        return articulo;
+    }
+
+    [Fact]
+    public async Task UnCodigoCortoResuelvePorCodigoInterno()
+    {
+        var (idTenant, idArea, idAlicuotaIva, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnCodigoCortoResuelvePorCodigoInterno));
+        await SembrarArticuloAsync(idTenant, idArea, idAlicuotaIva, "Café", "42");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.GetFromJsonAsync<ArticuloEscaneado>("/api/articulos/escaneo?entrada=42");
+
+        Assert.NotNull(respuesta);
+        Assert.Equal("42", respuesta!.CodigoInterno);
+        Assert.Equal(1m, respuesta.Cantidad);
+        Assert.Null(respuesta.CodigoBarra);
+    }
+
+    [Fact]
+    public async Task UnCodigoLargoResuelvePorCodigosBarra()
+    {
+        var (idTenant, idArea, idAlicuotaIva, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnCodigoLargoResuelvePorCodigosBarra));
+        await SembrarArticuloAsync(
+            idTenant, idArea, idAlicuotaIva, "Gaseosa", "COD-1", codigoBarra: "7790001234567");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.GetFromJsonAsync<ArticuloEscaneado>(
+            "/api/articulos/escaneo?entrada=7790001234567");
+
+        Assert.NotNull(respuesta);
+        Assert.Equal("COD-1", respuesta!.CodigoInterno);
+        Assert.Equal("7790001234567", respuesta.CodigoBarra);
+    }
+
+    [Fact]
+    public async Task UnPrefijoDeCantidadSePropagaEnLaRespuesta()
+    {
+        var (idTenant, idArea, idAlicuotaIva, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnPrefijoDeCantidadSePropagaEnLaRespuesta));
+        await SembrarArticuloAsync(
+            idTenant, idArea, idAlicuotaIva, "Agua", "COD-2", codigoBarra: "7790007654321");
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.GetFromJsonAsync<ArticuloEscaneado>(
+            "/api/articulos/escaneo?entrada=3*7790007654321");
+
+        Assert.NotNull(respuesta);
+        Assert.Equal(3m, respuesta!.Cantidad);
+        Assert.Equal("COD-2", respuesta.CodigoInterno);
+    }
+
+    [Fact]
+    public async Task UnArticuloInactivoNoResuelve()
+    {
+        var (idTenant, idArea, idAlicuotaIva, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnArticuloInactivoNoResuelve));
+        await SembrarArticuloAsync(idTenant, idArea, idAlicuotaIva, "Descontinuado", "99", activo: false);
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.GetAsync("/api/articulos/escaneo?entrada=99");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnCodigoDesconocidoEsRechazado()
+    {
+        var (_, _, _, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(UnCodigoDesconocidoEsRechazado));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+
+        var respuesta = await admin.GetAsync("/api/articulos/escaneo?entrada=noexiste123456789");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("no_encontrado", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Deuda declarada (ver el comentario de clase): hoy el grupo entero de
+    /// <c>ArticulosEndpoints</c> exige <c>GestionDeCatalogo</c>, así que un Vendedor todavía no
+    /// puede escanear — la Slice 1 en paralelo (auth policy, design decisión 6) es quien
+    /// habilita esto bajo <c>OperacionDePos</c>.</summary>
+    [Fact]
+    public async Task UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo()
+    {
+        var (idTenant, _, _, _, _) = await AprovisionarTenantAsync(
+            nameof(UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo));
+        var mailVendedor = await SembrarVendedorAsync(
+            idTenant, nameof(UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo));
+        using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
+
+        var respuesta = await vendedor.GetAsync("/api/articulos/escaneo?entrada=42");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/EscaneoEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/EscaneoEndpointsTests.cs
@@ -18,10 +18,8 @@ namespace Ways.IntegrationTests;
 /// Resolution Rule) — <c>GET /api/articulos/escaneo</c> punta a punta contra Postgres real:
 /// código corto, código largo, prefijo <c>N*</c>, artículo inactivo, código desconocido.
 ///
-/// Gateada hoy con <c>Politicas.GestionDeCatalogo</c> (admin-only) por construcción del grupo
-/// <c>ArticulosEndpoints</c> — deuda declarada hasta que la Slice 1 (en paralelo) re-gatee el
-/// grupo entero a <c>Politicas.OperacionDePos</c> (Vendedor + Admin, design decisión 6). Esta
-/// suite prueba el comportamiento ACTUAL (admin-only), no el final.
+/// Gateada con <c>Politicas.OperacionDePos</c> (Vendedor + Admin, design decisión 6) por
+/// construcción del grupo <c>ArticulosEndpoints</c>, re-gateado por la Slice 1.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class EscaneoEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -205,21 +203,42 @@ public class EscaneoEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal("no_encontrado", problema.GetProperty("codigo").GetString());
     }
 
-    /// <summary>Deuda declarada (ver el comentario de clase): hoy el grupo entero de
-    /// <c>ArticulosEndpoints</c> exige <c>GestionDeCatalogo</c>, así que un Vendedor todavía no
-    /// puede escanear — la Slice 1 en paralelo (auth policy, design decisión 6) es quien
-    /// habilita esto bajo <c>OperacionDePos</c>.</summary>
+    /// <summary>Depende de la Slice 1 (auth policy, design decisión 6), que re-gateó el grupo
+    /// de <c>ArticulosEndpoints</c> a <c>OperacionDePos</c>: un Vendedor ya puede escanear.</summary>
     [Fact]
-    public async Task UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo()
+    public async Task UnVendedorPuedeEscanear()
     {
-        var (idTenant, _, _, _, _) = await AprovisionarTenantAsync(
-            nameof(UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo));
-        var mailVendedor = await SembrarVendedorAsync(
-            idTenant, nameof(UnVendedorTodaviaNoPuedeEscanearHastaQueLaSlice1ReGateeElGrupo));
+        var (idTenant, idArea, idAlicuotaIva, _, _) =
+            await AprovisionarTenantAsync(nameof(UnVendedorPuedeEscanear));
+        await SembrarArticuloAsync(idTenant, idArea, idAlicuotaIva, "Café", "42");
+        var mailVendedor = await SembrarVendedorAsync(idTenant, nameof(UnVendedorPuedeEscanear));
         using var vendedor = await ClienteLogueadoAsync(mailVendedor, PasswordVendedor);
 
-        var respuesta = await vendedor.GetAsync("/api/articulos/escaneo?entrada=42");
+        var respuesta = await vendedor.GetFromJsonAsync<ArticuloEscaneado>("/api/articulos/escaneo?entrada=42");
 
-        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+        Assert.NotNull(respuesta);
+        Assert.Equal("42", respuesta!.CodigoInterno);
+    }
+
+    /// <summary>ADR-8: mismo 404 uniforme cross-tenant que el resto de <c>ArticulosEndpoints</c>
+    /// — un artículo de otro tenant es indistinguible de uno inexistente, tanto por
+    /// <c>codigo_interno</c> como por <c>codigos_barra</c>.</summary>
+    [Fact]
+    public async Task UnArticuloDeOtroTenantNoResuelve()
+    {
+        var (idTenantA, idAreaA, idAlicuotaIvaA, _, _) =
+            await AprovisionarTenantAsync(nameof(UnArticuloDeOtroTenantNoResuelve) + "-A");
+        await SembrarArticuloAsync(
+            idTenantA, idAreaA, idAlicuotaIvaA, "Café", "77", codigoBarra: "7790009999999");
+
+        var (_, _, _, mailAdminB, passwordAdminB) =
+            await AprovisionarTenantAsync(nameof(UnArticuloDeOtroTenantNoResuelve) + "-B");
+        using var adminB = await ClienteLogueadoAsync(mailAdminB, passwordAdminB);
+
+        var respuestaCodigoInterno = await adminB.GetAsync("/api/articulos/escaneo?entrada=77");
+        var respuestaCodigoBarra = await adminB.GetAsync("/api/articulos/escaneo?entrada=7790009999999");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuestaCodigoInterno.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, respuestaCodigoBarra.StatusCode);
     }
 }

--- a/tests/Ways.IntegrationTests/NumeracionesComprobanteBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/NumeracionesComprobanteBackstopTests.cs
@@ -1,0 +1,69 @@
+using Npgsql;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.6, db-error-backstops skill, design: Backstop Map):
+/// <c>pk_numeraciones_comprobante</c> — exención documentada de prueba de carrera. El único
+/// escritor legítimo (<c>AsignadorDeNumeroComprobante</c>) inserta con <c>ON CONFLICT DO
+/// NOTHING</c>, así que nunca puede disparar 23505 por el camino normal; esto prueba solo la
+/// traducción de esquema con un INSERT crudo que bypasea el asignador — mismo patrón que
+/// <c>pk_ofertas_listas</c>/<c>PK_articulos_empresas</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class NumeracionesComprobanteBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    [Fact]
+    public async Task UnaFilaConLaMismaClaveInsertadaPorFueraDelAsignadorViolaLaPk()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant
+        {
+            Nombre = nameof(UnaFilaConLaMismaClaveInsertadaPorFueraDelAsignadorViolaLaPk),
+            Estado = EstadoTenant.Activo,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa
+        {
+            IdTenant = tenant.Id, RazonSocial = tenant.Nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = tenant.Nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenant.Id);
+
+        async Task InsertarAsync()
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO numeraciones_comprobante (id_tenant, id_punto_venta, tipo_comprobante, proximo_numero) " +
+                "VALUES ($1, $2, 'TX', 1)";
+            comando.Parameters.Add(new NpgsqlParameter { Value = tenant.Id });
+            comando.Parameters.Add(new NpgsqlParameter { Value = puntoVenta.Id });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await InsertarAsync();
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(InsertarAsync);
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("pk_numeraciones_comprobante", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/NumeracionesComprobanteRlsTests.cs
+++ b/tests/Ways.IntegrationTests/NumeracionesComprobanteRlsTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ventas;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 2 (task 2.12, design: Table Shapes — write path A, decisiones 8/9):
+/// mismo patrón que <c>ArticulosYPreciosRlsTests.NumeracionesArticulosEsInvisibleParaOtroTenant</c>/
+/// <c>UnInsertEnNumeracionesArticulosConIdTenantAjenoSeRechaza</c> — <c>numeraciones_comprobante</c>
+/// es PK-only (<c>id_punto_venta</c>, <c>tipo_comprobante</c>), sin columna <c>id</c> propia, así
+/// que no entra en la tabla parametrizada genérica de otras RLS suites y necesita su propio test.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class NumeracionesComprobanteRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string TipoComprobante = "TX";
+
+    private async Task<(int IdTenant, int IdPuntoVenta)> SembrarTenantConPuntoVentaAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return (tenant.Id, puntoVenta.Id);
+    }
+
+    [Fact]
+    public async Task NumeracionesComprobanteEsInvisibleParaOtroTenant()
+    {
+        var (idTenantA, idPuntoVentaA) = await SembrarTenantConPuntoVentaAsync(
+            nameof(NumeracionesComprobanteEsInvisibleParaOtroTenant) + "-A");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        // AsignadorDeNumeroComprobante.AsegurarContadorAsync (SQL crudo), no
+        // db.NumeracionesComprobante.Add: WaysDbContext.RechazarEscriturasDeNumeracionComprobante
+        // rechaza cualquier Added/Modified que llegue por el ChangeTracker.
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, idTenantA, idPuntoVentaA, TipoComprobante);
+
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(NumeracionesComprobanteEsInvisibleParaOtroTenant) + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM numeraciones_comprobante WHERE id_punto_venta = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnInsertConIdTenantAjenoSeRechaza()
+    {
+        var (idTenantA, idPuntoVentaA) = await SembrarTenantConPuntoVentaAsync(
+            nameof(UnInsertConIdTenantAjenoSeRechaza) + "-A");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnInsertConIdTenantAjenoSeRechaza) + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantA);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO numeraciones_comprobante (id_tenant, id_punto_venta, tipo_comprobante, proximo_numero) " +
+            "VALUES ($1, $2, 'TX', 1)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) -- se dispara antes de la
+        // FK compuesta a puntos_venta, mismo criterio que el resto de las RLS suites.
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila()
+    {
+        var (idTenantA, idPuntoVentaA) = await SembrarTenantConPuntoVentaAsync(
+            nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + "-A");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, idTenantA, idPuntoVentaA, TipoComprobante);
+
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "UPDATE numeraciones_comprobante SET proximo_numero = proximo_numero + 1 " +
+            "WHERE id_punto_venta = $1 AND tipo_comprobante = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = TipoComprobante });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ) de que el filtro de tenant manual también bloquea la
+    /// entidad que sí pasa por el ORM (no hereda <c>EntidadTenant</c>, ver
+    /// <c>WaysDbContext.AplicarFiltroDeTenantEnNumeracionComprobante</c>).</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant()
+    {
+        var (idTenantA, idPuntoVentaA) = await SembrarTenantConPuntoVentaAsync(
+            nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + "-A");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, idTenantA, idPuntoVentaA, TipoComprobante);
+
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
+        var visibles = await sesionB.NumeracionesComprobante
+            .Where(n => n.IdPuntoVenta == idPuntoVentaA).ToListAsync();
+
+        Assert.Empty(visibles);
+    }
+}


### PR DESCRIPTION
Closes #39

## Summary

- Slice 2 of `stage-5-pos-ventas`: `numeraciones_comprobante` (first of the two gate-approved migrations; PK `(id_punto_venta, tipo_comprobante)`, RLS, id_tenant non-key with manual filter + write-reject guard) + `AsignadorDeNumeroComprobante` (raw-ADO atomic INSERT ON CONFLICT + UPDATE RETURNING riding the caller's transaction) + `NumeroDeComprobante.Formatear` (NNNN-NNNNNNNN) + pure `ParserDeEscaneo` (<7 digits → codigo_interno, ≥7 → EAN, `cantidad*codigo` syntax) + `ServicioDeEscaneo` identity-only lookup at `GET /api/articulos/escaneo` (inherits `OperacionDePos`).
- Honest gap-semantics correction recorded for Slice 4: a clean allocator rollback REUSES the number (proven by test); 'accepted gaps' only arise from execution-strategy retry mechanics at the sale-transaction layer.
- Judgment-day: R1 zero CRITICALs / zero confirmed real code warnings (A's merge-order warning resolved by merging Slice 1 first — the interim Admin-gated test was inverted at rebase); suggestion-level items closed (comment placement, dead `c.Activo` dropped with rationale, cross-tenant scan test added).

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 188/188 (+26: parser exhaustive, formato), Application 207/207, Integration 296/296 (+15: allocator concurrency gapless, RLS proofs, raw-SQL PK backstop, escaneo both routes + cross-tenant + Vendedor-200)
- [x] `dotnet ef migrations has-pending-model-changes` — clean
- [x] judgment-day: APPROVED

## Notes

- `size:exception`: mostly EF boilerplate + exhaustive parser/concurrency tests.
- Unblocks Slice 3 (the 6-table schema gate) and the checkout chain.