### PR TITLE
feat(ventas): checkout decide-then-commit del POS (etapa 5, slice 4)

### DIFF
--- a/openspec/changes/stage-5-pos-ventas/tasks.md
+++ b/openspec/changes/stage-5-pos-ventas/tasks.md
@@ -315,7 +315,7 @@ slice — expect its own review round to run long.
 
 ### 4A. Application — the transaction
 
-- [ ] 4.1 Add `ServicioDeVentas.EmitirAsync` — decide-then-commit: resolve
+- [x] 4.1 Add `ServicioDeVentas.EmitirAsync` — decide-then-commit: resolve
   `momento`, `tipo`, `cliente`/`puntoVenta`, run `ServicioDeOfertas.
   ResolverAsync` (7 queries), snapshot articulos/codigos_barra/alicuotas (2
   queries), `CalculadorDeTotales.Materializar` (pure), resolve
@@ -323,58 +323,58 @@ slice — expect its own review round to run long.
   `ValidadorDePagos.Validar` (pure) — all **outside** the transaction,
   building an immutable `PlanDeVenta`. *(design: Technical Approach —
   "decide, then commit"; The Sale Transaction)*
-- [ ] 4.2 Add the transactional half inside `CreateExecutionStrategy`: steps
+- [x] 4.2 Add the transactional half inside `CreateExecutionStrategy`: steps
   1–6 in the pinned order (numeración → comprobante → items → pagos → stock
   loop ascending `id_articulo` → CC), every entity built fresh from the plan
   on each retry attempt, step 6 raw ADO. *(design: The Sale Transaction —
   binding statement order, Retry contract)*
-- [ ] 4.3 Add `LineaDeVenta`/`PagoDeVenta`/`SolicitudDeVenta` contracts — no
+- [x] 4.3 Add `LineaDeVenta`/`PagoDeVenta`/`SolicitudDeVenta` contracts — no
   money fields on the request. *(design decision 3; spec: operacion-de-pos /
   Checkout Orchestration Contract)*
-- [ ] 4.4 Wire `movimientos_stock` INSERT + `stock` upsert (`ON CONFLICT DO
+- [x] 4.4 Wire `movimientos_stock` INSERT + `stock` upsert (`ON CONFLICT DO
   UPDATE … RETURNING`) per line, ascending `id_articulo`. *(design decisions
   1, 2; spec: stock / Sale Decrement Inside The Checkout Transaction)*
-- [ ] 4.5 Wire `movimientos_cuenta_corriente` consumo + `Cliente.Saldo`
+- [x] 4.5 Wire `movimientos_cuenta_corriente` consumo + `Cliente.Saldo`
   `UPDATE … RETURNING` + post-check, only when a pago's medio is
   `CuentaCorriente`. *(spec: consumo-cuenta-corriente / Consumo Is Written
   Inside The Sale Transaction)*
 
 ### 4B. API
 
-- [ ] 4.6 Add `POST /api/ventas` — 201 + `Location`, body = comprobante
+- [x] 4.6 Add `POST /api/ventas` — 201 + `Location`, body = comprobante
   emitido with `numeroVisible`, `OperacionDePos`. *(spec: operacion-de-pos /
   Checkout Orchestration Contract)*
-- [ ] 4.7 [P] Add `GET /api/ventas/{id}` (reprint, reads the snapshot only)
+- [x] 4.7 [P] Add `GET /api/ventas/{id}` (reprint, reads the snapshot only)
   and `GET /api/ventas` (filtros + paginado), both `OperacionDePos`. *(spec:
   comprobantes-venta / Snapshot Immutability of Items)*
 
 ### 4C. Tests
 
-- [ ] 4.8 Integration (atomicity): force a failure at each of the six
+- [x] 4.8 Integration (atomicity): force a failure at each of the six
   statements, assert nothing persisted except the consumed número. *(spec:
   comprobantes-venta / A failure after stock decrement rolls back
   everything; design: Testing Strategy — Integration (atomicity))*
-- [ ] 4.9 Integration (concurrency): two concurrent sales of the same
+- [x] 4.9 Integration (concurrency): two concurrent sales of the same
   articulo/punto de venta → `stock.cantidad = Σ movimientos_stock`. *(spec:
   stock / Concurrent sales of the same articulo do not corrupt the cache)*
-- [ ] 4.10 Integration (concurrency): two concurrent CC sales near the limit
+- [x] 4.10 Integration (concurrency): two concurrent CC sales near the limit
   → limit never exceeded, `saldo = Σ movimientos_cc`. *(spec:
   consumo-cuenta-corriente / Credit-Limit Evaluation)*
-- [ ] 4.11 Integration (concurrency): two concurrent sales at the same
+- [x] 4.11 Integration (concurrency): two concurrent sales at the same
   punto de venta racing the counter → consecutive numbers.
-- [ ] 4.12 Integration (budget): checkout with 2/20/50 lines issues the same
+- [x] 4.12 Integration (budget): checkout with 2/20/50 lines issues the same
   command count (≤16 + writes), `DbCommand` interceptor. *(design: Testing
   Strategy — Integration (budget))*
-- [ ] 4.13 Integration (snapshot): sell, mutate the articulo's catalog
+- [x] 4.13 Integration (snapshot): sell, mutate the articulo's catalog
   fields, re-read the comprobante ⇒ byte-identical items. *(spec:
   comprobantes-venta / Reprint is unaffected by a later catalog change)*
-- [ ] 4.14 Integration (parity): legacy B6 rejection order end-to-end; grep
+- [x] 4.14 Integration (parity): legacy B6 rejection order end-to-end; grep
   assertion — no literal `10`/`20` in the checkout path. *(spec:
   parametros-operativos / No hardcoded tolerancia or vuelto value exists)*
-- [ ] 4.15 [P] Integration: devolución as standalone NCX and as NCX
+- [x] 4.15 [P] Integration: devolución as standalone NCX and as NCX
   referencing an original TX. *(spec: comprobantes-venta / Devoluciones As
   NCX Comprobantes, both scenarios)*
-- [ ] 4.16 Regression: Slices 1–3 suites unedited and green.
+- [x] 4.16 Regression: Slices 1–3 suites unedited and green.
 
 ---
 

--- a/src/Ways.Api/Endpoints/OrganizacionEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OrganizacionEndpoints.cs
@@ -59,20 +59,25 @@ public static class OrganizacionEndpoints
         .WithSummary("Actualiza los datos descriptivos de una empresa.");
 
         var puntosVenta = app.MapGroup("/api/puntos-venta")
-            .WithTags("Organización")
-            .RequireAuthorization(Politicas.GestionDeOrganizacion);
+            .WithTags("Organización");
 
+        // El listado es la única ruta con policy propia distinta de GestionDeOrganizacion: la
+        // usan tanto el ABM admin (PuntosVenta.tsx) como el selector de PV del POS (Vendedor/
+        // Supervisor). Ver Politicas.LecturaDePuntosVenta.
         puntosVenta.MapGet("/", (ServicioDeOrganizacion servicio, CancellationToken ct) =>
             servicio.ListarPuntosVentaAsync(ct))
+        .RequireAuthorization(Politicas.LecturaDePuntosVenta)
         .WithSummary("Lista puntos de venta: plataforma ve todos, un admin de tenant ve los propios.");
 
         puntosVenta.MapGet("/{id:int}", (ServicioDeOrganizacion servicio, int id, CancellationToken ct) =>
             servicio.ObtenerPuntoVentaAsync(id, ct))
+        .RequireAuthorization(Politicas.GestionDeOrganizacion)
         .WithSummary("Obtiene un punto de venta.");
 
         puntosVenta.MapPut("/{id:int}", (
             ServicioDeOrganizacion servicio, int id, PuntoVentaEdicion datos, CancellationToken ct) =>
             servicio.ActualizarPuntoVentaAsync(id, datos, ct))
+        .RequireAuthorization(Politicas.GestionDeOrganizacion)
         .WithSummary("Actualiza los datos descriptivos de un punto de venta.");
 
         return app;

--- a/src/Ways.Api/Endpoints/VentasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/VentasEndpoints.cs
@@ -1,0 +1,44 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Ventas;
+using Ways.Domain.Ventas;
+
+namespace Ways.Api.Endpoints;
+
+public static class VentasEndpoints
+{
+    public static IEndpointRouteBuilder MapearVentas(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/ventas")
+            .WithTags("Ventas")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        // stage-5-pos-ventas (Slice 4, task 4.6, design: API Surface): checkout — sin
+        // GestionDeCatalogo apilado (design: Authorization Surface, "/api/ventas... solo
+        // GestionDeCatalogo en POST /api/stock/ajustes"). Un Vendedor tiene que poder vender.
+        grupo.MapPost("/", async (ServicioDeVentas servicio, SolicitudDeVenta solicitud, CancellationToken ct) =>
+        {
+            var emitido = await servicio.EmitirAsync(solicitud, ct);
+            return Results.Created($"/api/ventas/{emitido.Id}", emitido);
+        })
+        .WithSummary("Emite un comprobante de venta (checkout). Todo el dinero se recalcula server-side.");
+
+        grupo.MapGet("/{id:int}", (ServicioDeVentas servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerAsync(id, ct))
+        .WithSummary("Reimpresión: lee el snapshot del comprobante, nunca re-joinea el catálogo.");
+
+        grupo.MapGet("/", (
+            ServicioDeVentas servicio,
+            int? idPuntoVenta,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? idCliente,
+            EstadoComprobante? estado,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, desde, hasta, idCliente, estado, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Lista comprobantes de venta con filtros y paginado.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -168,6 +168,7 @@ app.MapearClientes();
 app.MapearProveedores();
 app.MapearArticulos();
 app.MapearOfertas();
+app.MapearVentas();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -37,6 +37,16 @@ public static class Politicas
     /// escritura apilan <see cref="GestionDeCatalogo"/> sobre esta para no relajar el ABM.</summary>
     public const string OperacionDePos = "operacion_de_pos";
 
+    /// <summary>Cualquier rol autenticado (Root, admin, supervisor o vendedor) — la puerta del
+    /// <c>GET /api/puntos-venta</c> (listado). Es la única ruta de <c>OrganizacionEndpoints</c>
+    /// que necesitan tanto el ABM administrativo (<see cref="GestionDeOrganizacion"/>, root/admin,
+    /// <c>PuntosVenta.tsx</c>) como el selector de PV del POS (<see cref="OperacionDePos"/>,
+    /// vendedor/supervisor/admin) — un AND de esas dos policies excluiría a vendedor y supervisor
+    /// del admin, o a root del POS, así que en vez de apilarlas se usa esta policy combinada solo
+    /// para el listado; el resto de <c>OrganizacionEndpoints</c> (obtener por id, editar) sigue
+    /// exclusivamente bajo <see cref="GestionDeOrganizacion"/>.</summary>
+    public const string LecturaDePuntosVenta = "lectura_puntos_venta";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -64,6 +74,14 @@ public static class Politicas
                             ClaimsWays.RolId,
                             ((int)RolConocido.Vendedor).ToString(),
                             ((int)RolConocido.Supervisor).ToString(),
-                            ((int)RolConocido.Admin).ToString()));
+                            ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(LecturaDePuntosVenta, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(
+                            ClaimsWays.RolId,
+                            ((int)RolConocido.Root).ToString(),
+                            ((int)RolConocido.Admin).ToString(),
+                            ((int)RolConocido.Supervisor).ToString(),
+                            ((int)RolConocido.Vendedor).ToString()));
     }
 }

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -3,11 +3,14 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
 
 namespace Ways.Application.Abstracciones;
 
@@ -58,6 +61,18 @@ public interface IWaysDbContext
     // (list/create/edit/soft-delete + replace-set de ofertas_listas).
     DbSet<Oferta> Ofertas { get; }
     DbSet<OfertaLista> OfertasListas { get; }
+
+    // stage-5-pos-ventas, Slice 4: ServicioDeVentas es el primer consumidor de Application de
+    // estos 6 — Slice 3 solo adelantaba el modelo a la migración (design: Table Shapes A/B/C).
+    // NumeracionesComprobante sigue sin exponerse acá (ver el comentario de WaysDbContext):
+    // AsignadorDeNumeroComprobante recibe el IWaysDbContext por parámetro y opera con ADO.NET
+    // crudo, no un DbSet.
+    DbSet<ComprobanteVenta> ComprobantesVenta { get; }
+    DbSet<ItemComprobanteVenta> ItemsComprobanteVenta { get; }
+    DbSet<PagoComprobante> PagosComprobante { get; }
+    DbSet<Ways.Domain.Stock.Stock> Stock { get; }
+    DbSet<MovimientoStock> MovimientosStock { get; }
+    DbSet<MovimientoCuentaCorriente> MovimientosCuentaCorriente { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -42,6 +42,7 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeOfertas>();
 
         services.AddScoped<ServicioDeEscaneo>();
+        services.AddScoped<ServicioDeVentas>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
+++ b/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
@@ -25,10 +25,11 @@ namespace Ways.Application.Ventas;
 /// nunca <see cref="int"/> — a diferencia de <c>clientes.numero</c>/<c>articulos.codigo_interno</c>.
 ///
 /// Estática a propósito: sin estado propio, cada método recibe el <see cref="IWaysDbContext"/>
-/// del llamador de turno (mismo criterio que los dos asignadores hermanos). Su único llamador
-/// hoy es la suite de concurrencia de esta slice — <c>ServicioDeVentas.EmitirAsync</c> (Slice 4)
-/// es quien lo va a invocar dentro de la transacción de venta, paso 1 del statement order
-/// pineado (design: The Sale Transaction).
+/// del llamador de turno (mismo criterio que los dos asignadores hermanos). Llamado desde
+/// <c>ServicioDeVentas.AsignarNumeroComprometidoAsync</c>, en su PROPIA transacción chica,
+/// comprometida ANTES de la transacción que escribe el resto de la venta (design: Failure
+/// Semantics — corrección de esta slice para que "el número se consume aunque falle el resto"
+/// sea literal, ver el doc-comment de <c>ServicioDeVentas.EmitirAsync</c>), no dentro de ella.
 /// </summary>
 public static class AsignadorDeNumeroComprobante
 {

--- a/src/Ways.Application/Ventas/Contratos.cs
+++ b/src/Ways.Application/Ventas/Contratos.cs
@@ -1,0 +1,95 @@
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// Cuerpo de <c>POST /api/ventas</c> (design: Checkout Contract; design decisión 3): sin ningún
+/// campo de dinero — el total y el precio de cada línea se re-resuelven server-side vía
+/// <see cref="Ofertas.ServicioDeOfertas.ResolverAsync"/>, nunca se confía en lo que mostró el
+/// carrito. <see cref="IdCliente"/> es opcional: <c>null</c> ⇒ Consumidor Final del tenant (spec:
+/// operacion-de-pos / Checkout Orchestration Contract, "Omitted idCliente defaults to Consumidor
+/// Final"). Sin campo de empleado a propósito (design decisión 11, forward obligation de Slice
+/// 3): <c>id_empleado</c> siempre sale de <c>IContextoDeUsuario.UsuarioId</c>, nunca de este
+/// contrato.
+/// </summary>
+public sealed record SolicitudDeVenta(
+    int IdPuntoVenta,
+    int? IdCliente,
+    string CodigoTipoComprobante,
+    int? IdComprobanteAsociado,
+    IReadOnlyList<LineaDeVenta>? Lineas,
+    IReadOnlyList<PagoDeVenta>? Pagos,
+    string? DireccionEntrega,
+    string? Observaciones);
+
+/// <summary><see cref="Cantidad"/> siempre positiva, sin importar el tipo de comprobante — el
+/// signo lo deriva <see cref="ServicioDeVentas"/> a partir de <c>tipos_comprobante.signo</c>
+/// (design decisión 4): el operador del POS piensa en "cuántas unidades", nunca en el signo de
+/// contabilidad. Sin <c>precioUnitario</c>/<c>descuento</c>/<c>total</c> (design decisión 3).
+/// <see cref="CodigoBarra"/> es el que devolvió el escaneo — snapshot informativo en el item, no
+/// se re-valida contra <c>codigos_barra</c> en el checkout (ya se validó en
+/// <c>GET /api/articulos/escaneo</c>).</summary>
+public sealed record LineaDeVenta(int IdArticulo, decimal Cantidad, string? CodigoBarra);
+
+/// <summary>Un medio de pago del checkout (design: Checkout Contract). A diferencia de
+/// <see cref="LineaDeVenta"/>, SÍ lleva dinero: <see cref="Importe"/>/<see cref="Vuelto"/> son lo
+/// que el cajero tipeó en caja, no un valor derivado del catálogo — <see cref="ValidadorDePagos"/>
+/// los valida, no los calcula.</summary>
+public sealed record PagoDeVenta(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);
+
+/// <summary>Un item ya emitido — snapshot inmutable (spec: Snapshot Immutability of Items).</summary>
+public sealed record ItemEmitido(
+    int Orden,
+    int? IdArticulo,
+    string Descripcion,
+    string? CodigoBarra,
+    int IdArea,
+    int IdListaPrecio,
+    int? IdOferta,
+    int IdAlicuotaIva,
+    decimal PorcentajeIva,
+    decimal Cantidad,
+    decimal PrecioUnitario,
+    decimal Descuento,
+    decimal Total);
+
+/// <summary>Un pago ya emitido.</summary>
+public sealed record PagoEmitido(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);
+
+/// <summary>Respuesta de checkout/reprint (spec: operacion-de-pos / Checkout Orchestration
+/// Contract) — <see cref="NumeroVisible"/> es <c>NumeroDeComprobante.Formatear(IdPuntoVenta,
+/// Numero)</c>, ya formateado para no obligar al front a reimplementar el padding.</summary>
+public sealed record ComprobanteEmitido(
+    int Id,
+    long Numero,
+    string NumeroVisible,
+    EstadoComprobante Estado,
+    DateTimeOffset Fecha,
+    int IdPuntoVenta,
+    int IdCliente,
+    int? IdComprobanteAsociado,
+    decimal Subtotal,
+    decimal DescuentoTotal,
+    decimal Total,
+    string? DireccionEntrega,
+    string? Observaciones,
+    IReadOnlyList<ItemEmitido> Items,
+    IReadOnlyList<PagoEmitido> Pagos);
+
+/// <summary>Fila de <c>GET /api/ventas</c> (listado paginado) — sin items/pagos, mismo criterio
+/// que los demás <c>*Listado</c> del proyecto (evita el N+1 de traer el detalle completo de cada
+/// fila listada).</summary>
+public sealed record ComprobanteListado(
+    int Id,
+    long Numero,
+    string NumeroVisible,
+    EstadoComprobante Estado,
+    DateTimeOffset Fecha,
+    int IdPuntoVenta,
+    int IdCliente,
+    decimal Total);
+
+/// <summary>Página de resultados de <c>GET /api/ventas</c> — mismo shape que
+/// <c>Ways.Application.Usuarios.PaginaDe&lt;T&gt;</c>, redeclarado acá porque ese genérico vive en
+/// un namespace de un ABM no relacionado (evita un acoplamiento cruzado innecesario).</summary>
+public sealed record PaginaDeVentas(IReadOnlyList<ComprobanteListado> Items, int Total, int Pagina, int Tamanio);

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -304,8 +304,11 @@ public class ServicioDeVentas(
 
         // 5. Stock — ORDEN ASCENDENTE por id_articulo (design decisión 2, no negociable): el
         // upsert de abajo toma su propio row lock de forma implícita, así que dos ventas que
-        // comparten artículos en orden distinto se deadlockearían sin este orden total.
-        foreach (var item in plan.Items.OrderBy(i => i.IdArticulo))
+        // comparten artículos en orden distinto se deadlockearían sin este orden total. Un
+        // artículo con EsProducto = false es un servicio (doc 10 §3: "false = servicio: no toca
+        // stock") — se salta ENTERO, ni movimiento ni upsert, en vez de escribir un movimiento
+        // sin sentido para algo que nunca tuvo una fila en stock.
+        foreach (var item in plan.Items.Where(i => i.EsProducto).OrderBy(i => i.IdArticulo))
         {
             var delta = -item.Cantidad;
 
@@ -460,7 +463,8 @@ public class ServicioDeVentas(
             items.Add(new LineaDelPlan(
                 articulo.Id, articulo.Nombre, linea.CodigoBarra, articulo.IdArea, idListaPrecio, idOferta,
                 articulo.IdAlicuotaIva, porcentajePorAlicuota[articulo.IdAlicuotaIva],
-                calculado.Cantidad, calculado.PrecioUnitario, calculado.Descuento, calculado.Total));
+                calculado.Cantidad, calculado.PrecioUnitario, calculado.Descuento, calculado.Total,
+                articulo.EsProducto));
         }
 
         return (items, totales);
@@ -676,7 +680,7 @@ public class ServicioDeVentas(
     private readonly record struct LineaDelPlan(
         int IdArticulo, string Descripcion, string? CodigoBarra, int IdArea, int IdListaPrecio, int? IdOferta,
         int IdAlicuotaIva, decimal PorcentajeIva, decimal Cantidad, decimal PrecioUnitario, decimal Descuento,
-        decimal Total);
+        decimal Total, bool EsProducto);
 
     private readonly record struct PagoDelPlan(
         int IdMedioPago, ComportamientoMedioPago Comportamiento, decimal Importe, string? Referencia, decimal Vuelto);

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -596,6 +596,11 @@ public class ServicioDeVentas(
 
     // ---- Utilidades ---------------------------------------------------------------------------
 
+    /// <summary>Snapshot informativo, nunca clave de negocio (ver doc-comment de
+    /// <see cref="LineaDeVenta.CodigoBarra"/>) — el tope solo evita que un payload arbitrariamente
+    /// largo llegue a <c>items_comprobante_venta.codigo_barra</c>.</summary>
+    private const int LongitudMaximaCodigoBarra = 64;
+
     private static IReadOnlyList<LineaDeVenta> ExigirLineasValidas(IReadOnlyList<LineaDeVenta>? lineas)
     {
         if (lineas is null || lineas.Count == 0)
@@ -609,6 +614,22 @@ public class ServicioDeVentas(
             {
                 throw new ErrorDominio(
                     "cantidad_de_linea_invalida", "La cantidad de cada línea tiene que ser mayor a cero.", 400);
+            }
+
+            // Máximo 3 decimales (doc 10: cantidad soporta fracción para UnidadVenta.Peso, pero
+            // sin precisión ilimitada) — decimal.Round con MidpointRounding.AwayFromZero nunca
+            // altera un valor que ya tiene ≤ 3 decimales, así que la comparación detecta
+            // exactamente el exceso de precisión sin falsos positivos por redondeo bancario.
+            if (decimal.Round(linea.Cantidad, 3, MidpointRounding.AwayFromZero) != linea.Cantidad)
+            {
+                throw new ErrorDominio(
+                    "cantidad_invalida", "La cantidad de cada línea admite hasta 3 decimales.", 400);
+            }
+
+            if (linea.CodigoBarra is { Length: > LongitudMaximaCodigoBarra })
+            {
+                throw new ErrorDominio(
+                    "codigo_barra_invalido", $"El código de barra no puede superar los {LongitudMaximaCodigoBarra} caracteres.", 400);
             }
         }
 

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -1,0 +1,681 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// Checkout del POS — la transacción más crítica del proyecto (design: Technical Approach,
+/// "decide, then commit"). <see cref="EmitirAsync"/> tiene dos mitades bien separadas:
+///
+/// <list type="number">
+/// <item>TODO lo que decide algo (precios, ofertas, parámetros, validación de pagos) corre
+/// ANTES de abrir la transacción, como lecturas + reglas puras, y arma un
+/// <see cref="PlanDeVenta"/> inmutable. Si esta mitad corriera DENTRO de la lambda reintentable
+/// de <c>CreateExecutionStrategy</c>, un reintento podría recalcular un total DISTINTO del que
+/// la mezcla de pagos ya validó.</item>
+/// <item>La transacción recibe el plan ya congelado y solo lo escribe, en el orden pineado por
+/// design (numeración → comprobante → items → pagos → stock ascendente por <c>id_articulo</c> →
+/// cuenta corriente). Cada fila mutable se escribe con un único statement atómico que toma su
+/// propio row lock y devuelve el post-estado (<c>UPDATE ... RETURNING</c>/<c>INSERT ... ON
+/// CONFLICT DO UPDATE ... RETURNING</c>) — design decisión 1: sin advisory locks, el lock de fila
+/// del propio upsert alcanza.</item>
+/// </list>
+///
+/// Dedicado (design decisión 10), no una extensión de ningún ABM: autorización, transacción y
+/// forma de las consultas son todas propias de esta operación.
+/// </summary>
+public class ServicioDeVentas(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas)
+{
+    public async Task<ComprobanteEmitido> EmitirAsync(SolicitudDeVenta solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+
+        // design decisión 11 (forward obligation de Slice 3): id_empleado SIEMPRE sale del
+        // actor autenticado — SolicitudDeVenta no tiene ningún campo de empleado que pueda
+        // pisar esto.
+        var idEmpleado = contexto.UsuarioId;
+
+        var lineas = ExigirLineasValidas(solicitud.Lineas);
+        var pagos = solicitud.Pagos ?? [];
+
+        // Pineado UNA sola vez acá — nunca se vuelve a leer dentro de la lambda reintentable
+        // (design: The Sale Transaction, "momento := reloj.Ahora (pinned; never re-read on
+        // retry)").
+        var momento = reloj.Ahora;
+
+        var tipo = await ResolverTipoComprobanteAsync(solicitud.CodigoTipoComprobante, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
+
+        var asociado = solicitud.IdComprobanteAsociado is { } idAsociado
+            ? await db.ComprobantesVenta.FirstOrDefaultAsync(c => c.Id == idAsociado, ct)
+            : null;
+
+        ReglaDeComprobantes.ValidarComprobanteAsociado(
+            tipo.Signo, solicitud.IdComprobanteAsociado, asociado, puntoVenta.Id, cliente.Id);
+
+        // 7 consultas (ServicioDeOfertas.ResolverAsync, design: Technical Approach) — la
+        // autoridad de precio ÚNICA, nunca lo que mostró el carrito (design decisión 3).
+        var lineasDeResolucion = lineas
+            .Select(l => new LineaDeResolucion(l.IdArticulo, puntoVenta.IdEmpresa, cliente.IdListaPrecio, l.Cantidad))
+            .ToList();
+        var resolucion = await servicioDeOfertas.ResolverAsync(lineasDeResolucion, momento, ct);
+
+        // 2 consultas: snapshot de articulos + alicuotas (design: The Sale Transaction). Sin
+        // segunda validación de existencia de articulo — ResolverAsync ya la hizo (400
+        // referencia_invalida) antes de llegar acá; si un id no aparece en el diccionario es un
+        // bug de esta clase, no un caso de negocio alcanzable.
+        var idsArticulo = lineas.Select(l => l.IdArticulo).Distinct().ToList();
+        var articuloPorId = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, ct);
+
+        var idsAlicuota = articuloPorId.Values.Select(a => a.IdAlicuotaIva).Distinct().ToList();
+        var porcentajePorAlicuota = await db.AlicuotasIva
+            .Where(a => idsAlicuota.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, a => a.Porcentaje, ct);
+
+        var (items, totales) = MaterializarItems(tipo.Signo, lineas, resolucion, articuloPorId, porcentajePorAlicuota, cliente.IdListaPrecio);
+
+        // 2 consultas: tolerancia_pago + vuelto_maximo, resueltas directo (sin el pre-chequeo
+        // de pertenencia de ServicioDeParametros.ResolverAsync — puntoVenta ya se resolvió
+        // arriba, así que idEmpresa ya es de confianza) para mantener el presupuesto pineado
+        // por design (Technical Approach: "≤ 16 round trips").
+        var toleranciaPago = await ResolverParametroAsync(ParametroConocido.ToleranciaPago, puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+        var vueltoMaximo = await ResolverParametroAsync(ParametroConocido.VueltoMaximo, puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+
+        // 1 consulta: medios de pago pedidos.
+        var idsMedioPago = pagos.Select(p => p.IdMedioPago).Distinct().ToList();
+        var medioPorId = await db.MediosPago
+            .Where(m => idsMedioPago.Contains(m.Id))
+            .ToDictionaryAsync(m => m.Id, ct);
+
+        var idsMedioFaltantes = idsMedioPago.Except(medioPorId.Keys).ToList();
+        if (idsMedioFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el medio de pago {idsMedioFaltantes[0]}.", 400);
+        }
+
+        var pagosAValidar = pagos
+            .Select(p =>
+            {
+                var medio = medioPorId[p.IdMedioPago];
+                return new PagoAValidar(
+                    p.IdMedioPago, medio.Comportamiento, medio.AdmiteVuelto, medio.RequiereReferencia,
+                    p.Importe, p.Vuelto, p.Referencia);
+            })
+            .ToList();
+
+        ValidadorDePagos.Validar(
+            totales.Total, pagosAValidar, toleranciaPago, vueltoMaximo,
+            cliente.EsConsumidorFinal, cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado);
+
+        var pagosDelPlan = pagos
+            .Select(p => new PagoDelPlan(
+                p.IdMedioPago, medioPorId[p.IdMedioPago].Comportamiento, p.Importe, p.Referencia, p.Vuelto))
+            .ToList();
+
+        var plan = new PlanDeVenta(
+            idTenant, idEmpleado, tipo.Id, tipo.Codigo, momento, puntoVenta.Id, cliente.Id,
+            solicitud.IdComprobanteAsociado, items, totales.Subtotal, totales.DescuentoTotal, totales.Total,
+            pagosDelPlan, cliente.LimiteCredito, cliente.CreditoIlimitado,
+            NormalizarOpcional(solicitud.DireccionEntrega), NormalizarOpcional(solicitud.Observaciones));
+
+        // ADR-16 (mismo trámite que ServicioDeAprovisionamiento/ServicioDeOfertas): la
+        // transacción se abre ACÁ ADENTRO — EnableRetryOnFailure exige que la apertura viva
+        // dentro de ExecuteAsync. El plan de arriba es el ÚNICO dato de negocio que cruza hacia
+        // la lambda: cada entidad de EF se construye de cero en cada intento (retry contract).
+        var estrategia = db.Database.CreateExecutionStrategy();
+
+        return await estrategia.ExecuteAsync(async () => await EjecutarTransaccionAsync(plan, ct));
+    }
+
+    public async Task<ComprobanteEmitido> ObtenerAsync(int id, CancellationToken ct = default)
+    {
+        var comprobante = await BuscarComprobanteAsync(id, ct);
+
+        var items = await db.ItemsComprobanteVenta
+            .Where(i => i.IdComprobanteVenta == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        var pagos = await db.PagosComprobante
+            .Where(p => p.IdComprobanteVenta == id)
+            .ToListAsync(ct);
+
+        return Proyectar(comprobante, items, pagos);
+    }
+
+    public async Task<PaginaDeVentas> ListarAsync(
+        int? idPuntoVenta = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int? idCliente = null,
+        EstadoComprobante? estado = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = db.ComprobantesVenta.AsQueryable();
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(c => c.IdPuntoVenta == pv);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(c => c.Fecha >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(c => c.Fecha <= h);
+        }
+
+        if (idCliente is { } ic)
+        {
+            query = query.Where(c => c.IdCliente == ic);
+        }
+
+        if (estado is { } e)
+        {
+            query = query.Where(c => c.Estado == e);
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var crudos = await query
+            .OrderByDescending(c => c.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(c => new { c.Id, c.Numero, c.Estado, c.Fecha, c.IdPuntoVenta, c.IdCliente, c.Total })
+            .ToListAsync(ct);
+
+        // NumeroDeComprobante.Formatear no traduce a SQL: se arma en memoria, después de traer
+        // la página ya paginada/filtrada (nunca antes — evita materializar todo el listado).
+        var items = crudos
+            .Select(c => new ComprobanteListado(
+                c.Id, c.Numero, NumeroDeComprobante.Formatear(c.IdPuntoVenta, c.Numero), c.Estado, c.Fecha,
+                c.IdPuntoVenta, c.IdCliente, c.Total))
+            .ToList();
+
+        return new PaginaDeVentas(items, total, pagina, tamanio);
+    }
+
+    // ---- La transacción (design: The Sale Transaction, orden de statements pineado) ----------
+
+    private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(PlanDeVenta plan, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        // 1. Numeración — lazy, misma fila que el resto de la venta serializa por completo
+        // (design decisión 2: numeración PRIMERO, aunque acorte el throughput, para que "el
+        // primer statement de toda venta es el asignador" sea un invariante auditable de un
+        // vistazo).
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, plan.IdTenant, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
+        var numero = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(db, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
+
+        // 2. Comprobante.
+        var comprobante = new ComprobanteVenta
+        {
+            IdTipoComprobante = plan.IdTipoComprobante,
+            Numero = numero,
+            Fecha = plan.Momento,
+            IdPuntoVenta = plan.IdPuntoVenta,
+            IdTurnoCaja = null,
+            IdEmpleado = plan.IdEmpleado,
+            IdCliente = plan.IdCliente,
+            IdComprobanteAsociado = plan.IdComprobanteAsociado,
+            Subtotal = plan.Subtotal,
+            DescuentoTotal = plan.DescuentoTotal,
+            Total = plan.Total,
+            DireccionEntrega = plan.DireccionEntrega,
+            Observaciones = plan.Observaciones,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = plan.Momento,
+            UpdatedAt = plan.Momento
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync(ct);
+
+        // 3 + 4. Items y pagos, en un único SaveChanges (sin FK entre ellos, así que el orden
+        // relativo entre las dos tablas no importa acá — solo necesitaban el Id del
+        // comprobante, ya generado arriba).
+        var orden = 1;
+        var itemsEntidad = plan.Items
+            .Select(i => new ItemComprobanteVenta
+            {
+                IdComprobanteVenta = comprobante.Id,
+                Orden = orden++,
+                IdArticulo = i.IdArticulo,
+                Descripcion = i.Descripcion,
+                CodigoBarra = i.CodigoBarra,
+                IdArea = i.IdArea,
+                IdListaPrecio = i.IdListaPrecio,
+                IdOferta = i.IdOferta,
+                IdAlicuotaIva = i.IdAlicuotaIva,
+                PorcentajeIva = i.PorcentajeIva,
+                Cantidad = i.Cantidad,
+                PrecioUnitario = i.PrecioUnitario,
+                Descuento = i.Descuento,
+                Total = i.Total,
+                CreatedAt = plan.Momento,
+                UpdatedAt = plan.Momento
+            })
+            .ToList();
+        db.ItemsComprobanteVenta.AddRange(itemsEntidad);
+
+        var pagosEntidad = plan.Pagos
+            .Select(p => new PagoComprobante
+            {
+                IdComprobanteVenta = comprobante.Id,
+                IdMedioPago = p.IdMedioPago,
+                Importe = p.Importe,
+                Referencia = p.Referencia,
+                Vuelto = p.Vuelto,
+                CreatedAt = plan.Momento,
+                UpdatedAt = plan.Momento
+            })
+            .ToList();
+        db.PagosComprobante.AddRange(pagosEntidad);
+
+        await db.SaveChangesAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 5. Stock — ORDEN ASCENDENTE por id_articulo (design decisión 2, no negociable): el
+        // upsert de abajo toma su propio row lock de forma implícita, así que dos ventas que
+        // comparten artículos en orden distinto se deadlockearían sin este orden total.
+        foreach (var item in plan.Items.OrderBy(i => i.IdArticulo))
+        {
+            var delta = -item.Cantidad;
+
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, plan.IdTenant, item.IdArticulo, plan.IdPuntoVenta, delta,
+                MotivoStock.Venta, comprobante.Id, plan.IdEmpleado, plan.Momento, ct);
+
+            await UpsertStockAsync(conexion, transaccionCruda, plan.IdTenant, item.IdArticulo, plan.IdPuntoVenta, delta, ct);
+        }
+
+        // 6. Cuenta corriente — un pago por vez, en el orden pedido (raw ADO: un
+        // `cliente.Saldo += x` trackeado por EF duplicaría el incremento en un reintento, ver
+        // el Retry contract de design).
+        for (var i = 0; i < plan.Pagos.Count; i++)
+        {
+            var pago = plan.Pagos[i];
+            if (pago.Comportamiento != ComportamientoMedioPago.CuentaCorriente)
+            {
+                continue;
+            }
+
+            var nuevoSaldo = await ActualizarSaldoClienteAsync(
+                conexion, transaccionCruda, plan.IdTenant, plan.IdCliente, pago.Importe, ct);
+
+            if (!plan.ClienteCreditoIlimitado && nuevoSaldo > plan.ClienteLimiteCredito)
+            {
+                // Backstop de concurrencia (spec: Credit-Limit Evaluation) — el pre-chequeo de
+                // ValidadorDePagos ya corrió AFUERA de esta transacción contra el saldo de ese
+                // momento; esto atrapa una venta concurrente del MISMO cliente que subió el
+                // saldo entre el pre-chequeo y este commit (test 4.10).
+                throw new ErrorDominio("limite_credito_excedido", "El pago supera el límite de crédito del cliente.", 400);
+            }
+
+            await InsertarMovimientoCcAsync(
+                conexion, transaccionCruda, plan.IdTenant, plan.IdCliente, plan.Momento, plan.IdPuntoVenta,
+                plan.IdEmpleado, TipoMovimientoCc.Consumo, comprobante.Id, pagosEntidad[i].Id, pago.Importe, nuevoSaldo, ct);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return Proyectar(comprobante, itemsEntidad, pagosEntidad);
+    }
+
+    // ---- Resolución de datos, fuera de la transacción ----------------------------------------
+
+    private async Task<TipoComprobante> ResolverTipoComprobanteAsync(string codigo, CancellationToken ct)
+    {
+        var tipo = await db.TiposComprobante.FirstOrDefaultAsync(t => t.Codigo == codigo, ct);
+
+        // El POS solo emite tipos de venta no fiscales (TX/NCX, design: "neither of which is
+        // fiscal") — un código de factura/nota real (fiscal) queda afuera de este camino a
+        // propósito, no solo por no existir el flujo de facturación electrónica todavía.
+        if (tipo is null || !tipo.Activo || tipo.Clase != ClaseComprobante.Venta || tipo.EsFiscal)
+        {
+            throw new ErrorDominio(
+                "tipo_comprobante_invalido", $"'{codigo}' no es un tipo de comprobante válido para el POS.", 400);
+        }
+
+        return tipo;
+    }
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            // El filtro de EF (+ RLS) ya deja invisible un punto de venta de otro tenant — ADR-8:
+            // mismo 404 para "no existe" y "es de otro tenant".
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<Cliente> ResolverClienteAsync(int? idCliente, CancellationToken ct)
+    {
+        if (idCliente is { } id)
+        {
+            return await db.Clientes.FirstOrDefaultAsync(c => c.Id == id, ct)
+                ?? throw ErrorDominio.NoEncontrado($"No existe el cliente {id}.");
+        }
+
+        // Spec: "Omitted idCliente defaults to Consumidor Final".
+        return await db.Clientes.FirstOrDefaultAsync(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal, ct)
+            // Backfilleado para todo tenant desde InicializadorDeBaseDeDatos — su ausencia es un
+            // bug de aprovisionamiento, no un caso de negocio alcanzable.
+            ?? throw new InvalidOperationException("El tenant actual no tiene un Consumidor Final sembrado.");
+    }
+
+    private async Task<decimal> ResolverParametroAsync(
+        ParametroConocido conocido, int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == conocido.Clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var valorJson = ResolucionDeParametros.Resolver(conocido.Clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<decimal>(valorJson);
+    }
+
+    /// <summary>Corre <see cref="CalculadorDeTotales"/> (pura) sobre las líneas ya resueltas y
+    /// arma el resto del snapshot de cada item — design decisión 3: <see cref="LineaDeVenta"/>
+    /// siempre manda <see cref="LineaDeVenta.Cantidad"/> POSITIVA (el operador piensa en
+    /// unidades, no en signo contable); el signo lo aplica esta clase a partir de
+    /// <c>tipos_comprobante.signo</c> ANTES de calcular — así <c>CalculadorDeTotales</c> hace la
+    /// misma aritmética para TX y NCX, sin rama especial (design: decisión 4, "aritmética
+    /// uniforme para ambos signos").</summary>
+    private static (IReadOnlyList<LineaDelPlan> Items, TotalesCalculados Totales) MaterializarItems(
+        short signoTipoComprobante,
+        IReadOnlyList<LineaDeVenta> lineas,
+        IReadOnlyList<ResultadoDeResolucion> resolucion,
+        IReadOnlyDictionary<int, Articulo> articuloPorId,
+        IReadOnlyDictionary<int, decimal> porcentajePorAlicuota,
+        int idListaPrecio)
+    {
+        var lineasParaCalcular = new List<LineaParaCalcular>(lineas.Count);
+
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var resultado = resolucion[i];
+
+            if (resultado.PrecioOriginal is null)
+            {
+                throw new ErrorDominio(
+                    "articulo_sin_precio_vigente",
+                    $"El artículo {lineas[i].IdArticulo} no tiene un precio vigente en la lista del cliente.",
+                    400);
+            }
+
+            var cantidadConSigno = signoTipoComprobante > 0 ? lineas[i].Cantidad : -lineas[i].Cantidad;
+
+            lineasParaCalcular.Add(new LineaParaCalcular(
+                cantidadConSigno, resultado.PrecioOriginal.Value, resultado.DescuentoUnitario));
+        }
+
+        var totales = CalculadorDeTotales.Calcular(lineasParaCalcular);
+
+        // Defensa en profundidad (design: Domain rules first) — con el signo ya aplicado arriba,
+        // esta llamada siempre debería pasar; si no pasa, es un bug de esta clase, no un caso de
+        // negocio alcanzable.
+        ReglaDeComprobantes.ValidarSignoDeLineas(signoTipoComprobante, totales.Items.Select(it => it.Cantidad).ToList());
+
+        var items = new List<LineaDelPlan>(lineas.Count);
+
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var linea = lineas[i];
+            var resultado = resolucion[i];
+            var calculado = totales.Items[i];
+            var articulo = articuloPorId[linea.IdArticulo];
+
+            // Solo UNA columna id_oferta por item (esquema): cuando se acumulan varias ofertas
+            // en la misma línea, se snapshotea la de mayor prioridad (la primera de la lista que
+            // arma ResolvedorDeOfertas) — el descuento total sigue siendo la suma de todas, ese
+            // no se pierde.
+            var idOferta = resultado.Aplicadas.Count > 0 ? resultado.Aplicadas[0].IdOferta : (int?)null;
+
+            items.Add(new LineaDelPlan(
+                articulo.Id, articulo.Nombre, linea.CodigoBarra, articulo.IdArea, idListaPrecio, idOferta,
+                articulo.IdAlicuotaIva, porcentajePorAlicuota[articulo.IdAlicuotaIva],
+                calculado.Cantidad, calculado.PrecioUnitario, calculado.Descuento, calculado.Total));
+        }
+
+        return (items, totales);
+    }
+
+    // ---- Statements crudos de la transacción (ADO.NET, misma convención que
+    // AsignadorDeNumeroComprobante) --------------------------------------------------------------
+
+    /// <summary>Design: The Sale Transaction, paso 5 — INSERT simple, sin upsert: usa
+    /// <c>ExecuteNonQueryAsync</c> (nunca dispara <c>ReaderExecuting</c>/<c>ScalarExecuting</c>),
+    /// así que el guard de presupuesto de consultas (task 4.12) que solo cuenta lecturas EF de
+    /// la mitad de "decidir" nunca lo ve — es escritura, escala con la cantidad de líneas por
+    /// diseño, no un N+1 a corregir.</summary>
+    private static async Task InsertarMovimientoStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal cantidad, MotivoStock motivo, int idComprobanteVenta, int idEmpleado, DateTimeOffset creadoEl,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_stock " +
+            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_venta, id_empleado, creado_el) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, cantidad);
+        AgregarParametro(comando, motivo);
+        AgregarParametro(comando, idComprobanteVenta);
+        AgregarParametro(comando, idEmpleado);
+        AgregarParametro(comando, creadoEl);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>Design decisión 1: el único statement que toca <c>stock</c> — su propio row lock
+    /// (implícito en el <c>INSERT ... ON CONFLICT</c>) es lo que reemplaza al advisory lock.
+    /// <c>RETURNING</c> vía <c>ExecuteScalarAsync</c> (no <c>ExecuteReaderAsync</c>): mismo
+    /// motivo que <see cref="InsertarMovimientoStockAsync"/>, invisible al guard de presupuesto.</summary>
+    private static async Task UpsertStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock (id_articulo, id_punto_venta, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4) " +
+            "ON CONFLICT (id_articulo, id_punto_venta) DO UPDATE " +
+            "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, delta);
+
+        await comando.ExecuteScalarAsync(ct);
+    }
+
+    /// <summary>Design: The Sale Transaction, paso 6 — <c>UPDATE ... RETURNING</c> crudo:
+    /// nunca vía una entidad <see cref="Cliente"/> trackeada (un <c>cliente.Saldo += x</c> por
+    /// <c>SaveChangesAsync</c> duplicaría el incremento en un reintento de
+    /// <c>CreateExecutionStrategy</c>, ver el Retry contract de design). <c>id_tenant</c> en el
+    /// <c>WHERE</c> además de <c>id</c>: RLS ya aísla por tenant, esto es una segunda capa
+    /// barata (mismo criterio que el resto del proyecto), no la única defensa.</summary>
+    private static async Task<decimal> ActualizarSaldoClienteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, decimal importe,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE clientes SET saldo = saldo + $1 WHERE id_cliente = $2 AND id_tenant = $3 RETURNING saldo";
+
+        AgregarParametro(comando, importe);
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException($"No se pudo actualizar el saldo del cliente {idCliente}.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    private static async Task InsertarMovimientoCcAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, DateTimeOffset fecha,
+        int idPuntoVenta, int idEmpleado, TipoMovimientoCc tipo, int idComprobanteVenta, int idPagoComprobante,
+        decimal importe, decimal saldoResultante, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_cuenta_corriente " +
+            "(id_tenant, id_cliente, fecha, id_punto_venta, id_empleado, tipo, id_comprobante_venta, " +
+            " id_pago_comprobante, importe, saldo_resultante) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, fecha);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idEmpleado);
+        AgregarParametro(comando, tipo);
+        AgregarParametro(comando, idComprobanteVenta);
+        AgregarParametro(comando, idPagoComprobante);
+        AgregarParametro(comando, importe);
+        AgregarParametro(comando, saldoResultante);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    // ---- Utilidades ---------------------------------------------------------------------------
+
+    private static IReadOnlyList<LineaDeVenta> ExigirLineasValidas(IReadOnlyList<LineaDeVenta>? lineas)
+    {
+        if (lineas is null || lineas.Count == 0)
+        {
+            throw new ErrorDominio("lineas_requeridas", "El carrito tiene que tener al menos una línea.", 400);
+        }
+
+        foreach (var linea in lineas)
+        {
+            if (linea.Cantidad <= 0)
+            {
+                throw new ErrorDominio(
+                    "cantidad_de_linea_invalida", "La cantidad de cada línea tiene que ser mayor a cero.", 400);
+            }
+        }
+
+        return lineas;
+    }
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private async Task<ComprobanteVenta> BuscarComprobanteAsync(int id, CancellationToken ct) =>
+        await db.ComprobantesVenta.FirstOrDefaultAsync(c => c.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el comprobante {id}.");
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            // OperacionDePos (capa de API) ya exige un actor de tenant (Vendedor/Supervisor/
+            // Admin) — un actor de plataforma nunca llega hasta acá. Defensa en profundidad, no
+            // un camino alcanzable en operación normal.
+            ?? throw new InvalidOperationException(
+                "ServicioDeVentas requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    private static ComprobanteEmitido Proyectar(
+        ComprobanteVenta comprobante, IReadOnlyList<ItemComprobanteVenta> items, IReadOnlyList<PagoComprobante> pagos) => new(
+        comprobante.Id, comprobante.Numero,
+        NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
+        comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
+        comprobante.IdComprobanteAsociado, comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.Total,
+        comprobante.DireccionEntrega, comprobante.Observaciones,
+        items
+            .OrderBy(i => i.Orden)
+            .Select(i => new ItemEmitido(
+                i.Orden, i.IdArticulo, i.Descripcion, i.CodigoBarra, i.IdArea, i.IdListaPrecio, i.IdOferta,
+                i.IdAlicuotaIva, i.PorcentajeIva, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total))
+            .ToList(),
+        pagos
+            .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
+            .ToList());
+
+    // ---- El plan inmutable (design: "PlanDeVenta(immutable)") --------------------------------
+
+    private readonly record struct LineaDelPlan(
+        int IdArticulo, string Descripcion, string? CodigoBarra, int IdArea, int IdListaPrecio, int? IdOferta,
+        int IdAlicuotaIva, decimal PorcentajeIva, decimal Cantidad, decimal PrecioUnitario, decimal Descuento,
+        decimal Total);
+
+    private readonly record struct PagoDelPlan(
+        int IdMedioPago, ComportamientoMedioPago Comportamiento, decimal Importe, string? Referencia, decimal Vuelto);
+
+    private sealed record PlanDeVenta(
+        int IdTenant,
+        int IdEmpleado,
+        int IdTipoComprobante,
+        string CodigoTipoComprobante,
+        DateTimeOffset Momento,
+        int IdPuntoVenta,
+        int IdCliente,
+        int? IdComprobanteAsociado,
+        IReadOnlyList<LineaDelPlan> Items,
+        decimal Subtotal,
+        decimal DescuentoTotal,
+        decimal Total,
+        IReadOnlyList<PagoDelPlan> Pagos,
+        decimal ClienteLimiteCredito,
+        bool ClienteCreditoIlimitado,
+        string? DireccionEntrega,
+        string? Observaciones);
+}

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -26,12 +26,14 @@ namespace Ways.Application.Ventas;
 /// <see cref="PlanDeVenta"/> inmutable. Si esta mitad corriera DENTRO de la lambda reintentable
 /// de <c>CreateExecutionStrategy</c>, un reintento podría recalcular un total DISTINTO del que
 /// la mezcla de pagos ya validó.</item>
-/// <item>La transacción recibe el plan ya congelado y solo lo escribe, en el orden pineado por
-/// design (numeración → comprobante → items → pagos → stock ascendente por <c>id_articulo</c> →
-/// cuenta corriente). Cada fila mutable se escribe con un único statement atómico que toma su
-/// propio row lock y devuelve el post-estado (<c>UPDATE ... RETURNING</c>/<c>INSERT ... ON
-/// CONFLICT DO UPDATE ... RETURNING</c>) — design decisión 1: sin advisory locks, el lock de fila
-/// del propio upsert alcanza.</item>
+/// <item>La numeración se reserva y comitea en su PROPIA transacción, ANTES de la que escribe el
+/// resto (corrección de esta slice: el número queda consumido aunque lo de abajo falle, ver el
+/// comentario de <see cref="EmitirAsync"/>). Esa segunda transacción recibe el plan ya congelado
+/// más el número ya comprometido, y solo escribe, en el orden pineado por design (comprobante →
+/// items → pagos → stock ascendente por <c>id_articulo</c> → cuenta corriente). Cada fila mutable
+/// se escribe con un único statement atómico que toma su propio row lock y devuelve el
+/// post-estado (<c>UPDATE ... RETURNING</c>/<c>INSERT ... ON CONFLICT DO UPDATE ... RETURNING</c>)
+/// — design decisión 1: sin advisory locks, el lock de fila del propio upsert alcanza.</item>
 /// </list>
 ///
 /// Dedicado (design decisión 10), no una extensión de ningún ABM: autorización, transacción y
@@ -135,13 +137,78 @@ public class ServicioDeVentas(
             pagosDelPlan, cliente.LimiteCredito, cliente.CreditoIlimitado,
             NormalizarOpcional(solicitud.DireccionEntrega), NormalizarOpcional(solicitud.Observaciones));
 
+        // Corrección de esta slice al decisión 2 original (ver el doc-comment de
+        // VentasAtomicidadYConcurrenciaTests): la numeración se reserva y COMITEA en su PROPIA
+        // transacción, separada de la que escribe el resto de la venta — así "el número se
+        // consume aunque falle el resto" (design: Failure Semantics) es literal, no una
+        // aproximación que un ROLLBACK conjunto desmentía. Un commit ambiguo sobre ESTA
+        // transacción es inofensivo: si en verdad comiteó, el contador ya avanzó; si el cliente
+        // reintenta (execution strategy), reservar de nuevo solo vuelve a avanzarlo — nunca
+        // duplica una fila (design decisión 2: "gaps are accepted", nunca duplicados).
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () => await AsignarNumeroComprometidoAsync(plan, ct));
+
         // ADR-16 (mismo trámite que ServicioDeAprovisionamiento/ServicioDeOfertas): la
         // transacción se abre ACÁ ADENTRO — EnableRetryOnFailure exige que la apertura viva
         // dentro de ExecuteAsync. El plan de arriba es el ÚNICO dato de negocio que cruza hacia
         // la lambda: cada entidad de EF se construye de cero en cada intento (retry contract).
+        //
+        // El número YA está comprometido cuando esta lambda arranca — un commit ambiguo acá (el
+        // servidor comitea pero la conexión se corta antes del ACK al cliente) hace que
+        // CreateExecutionStrategy reintente la lambda completa; sin la guarda de abajo, ese
+        // reintento volvería a INSERTAR el mismo comprobante bajo el mismo número, violando
+        // ux_comprobantes_venta_numero (o, peor, duplicando la venta si esa unicidad no
+        // existiera). BuscarPorNumeroComprometidoAsync corre PRIMERO en cada intento: si el
+        // commit anterior sí llegó a puerto, el comprobante ya existe y se devuelve tal cual en
+        // vez de reinsertarse.
         var estrategia = db.Database.CreateExecutionStrategy();
 
-        return await estrategia.ExecuteAsync(async () => await EjecutarTransaccionAsync(plan, ct));
+        return await estrategia.ExecuteAsync(async () =>
+            await BuscarPorNumeroComprometidoAsync(plan.IdPuntoVenta, plan.IdTipoComprobante, numero, ct)
+            ?? await EjecutarTransaccionAsync(plan, numero, ct));
+    }
+
+    /// <summary>Transacción chica y propia (ADR-16), comprometida ANTES de que exista ningún
+    /// otro dato de la venta — ver el comentario de <see cref="EmitirAsync"/>.</summary>
+    private async Task<long> AsignarNumeroComprometidoAsync(PlanDeVenta plan, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, plan.IdTenant, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
+        var numero = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(db, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
+
+        await transaccion.CommitAsync(ct);
+        return numero;
+    }
+
+    /// <summary>Detección de idempotencia (ver el comentario de <see cref="EmitirAsync"/> sobre
+    /// el commit ambiguo): <c>null</c> ⇒ el número todavía no tiene comprobante, esta es la
+    /// primera vez que se corre la mitad transaccional para él. Firma en primitivos (no recibe
+    /// <see cref="PlanDeVenta"/> entero) a propósito: es la pieza que
+    /// <c>VentasAtomicidadYConcurrenciaTests</c> ejercita por reflexión para probar la detección
+    /// en aislamiento, sin tener que construir un <see cref="PlanDeVenta"/> completo (privado,
+    /// sin constructor público) desde el test.</summary>
+    private async Task<ComprobanteEmitido?> BuscarPorNumeroComprometidoAsync(
+        int idPuntoVenta, int idTipoComprobante, long numero, CancellationToken ct)
+    {
+        var comprobante = await db.ComprobantesVenta.FirstOrDefaultAsync(
+            c => c.IdPuntoVenta == idPuntoVenta && c.IdTipoComprobante == idTipoComprobante && c.Numero == numero, ct);
+
+        if (comprobante is null)
+        {
+            return null;
+        }
+
+        var items = await db.ItemsComprobanteVenta
+            .Where(i => i.IdComprobanteVenta == comprobante.Id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        var pagos = await db.PagosComprobante
+            .Where(p => p.IdComprobanteVenta == comprobante.Id)
+            .ToListAsync(ct);
+
+        return Proyectar(comprobante, items, pagos);
     }
 
     public async Task<ComprobanteEmitido> ObtenerAsync(int id, CancellationToken ct = default)
@@ -222,17 +289,15 @@ public class ServicioDeVentas(
 
     // ---- La transacción (design: The Sale Transaction, orden de statements pineado) ----------
 
-    private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(PlanDeVenta plan, CancellationToken ct)
+    private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(PlanDeVenta plan, long numero, CancellationToken ct)
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
-        // 1. Numeración — lazy, misma fila que el resto de la venta serializa por completo
-        // (design decisión 2: numeración PRIMERO, aunque acorte el throughput, para que "el
-        // primer statement de toda venta es el asignador" sea un invariante auditable de un
-        // vistazo).
-        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, plan.IdTenant, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
-        var numero = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(db, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
-
+        // 1. Numeración — YA reservada y comprometida por AsignarNumeroComprometidoAsync, en su
+        // propia transacción (ver el comentario de EmitirAsync). Esta transacción arranca
+        // directo en el paso 2: el número que recibe como parámetro es un dato de solo lectura
+        // acá, nunca se vuelve a pedir.
+        //
         // 2. Comprobante.
         var comprobante = new ComprobanteVenta
         {

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -540,9 +540,14 @@ public class ServicioDeVentas(
 
     /// <summary>Design: The Sale Transaction, paso 5 — INSERT simple, sin upsert: usa
     /// <c>ExecuteNonQueryAsync</c> (nunca dispara <c>ReaderExecuting</c>/<c>ScalarExecuting</c>),
-    /// así que el guard de presupuesto de consultas (task 4.12) que solo cuenta lecturas EF de
-    /// la mitad de "decidir" nunca lo ve — es escritura, escala con la cantidad de líneas por
-    /// diseño, no un N+1 a corregir.</summary>
+    /// así que el guard de presupuesto de consultas (task 4.12) no lo ve. Ojo con la simplificación
+    /// fácil acá: el guard SÍ ve los dos <c>SaveChangesAsync</c> de la mitad transaccional
+    /// (comprobante e items/pagos, <see cref="EjecutarTransaccionAsync"/>) — Npgsql dispara
+    /// <c>ReaderExecuting</c> también en un <c>INSERT ... RETURNING</c> para leer la clave
+    /// generada, no solo en un <c>SELECT</c>. El presupuesto sigue dando un número constante
+    /// porque esos dos <c>SaveChangesAsync</c> no escalan con la cantidad de líneas/pagos; esta
+    /// escritura sí escala (una por línea) y por quedar fuera de <c>ReaderExecuting</c> no aporta
+    /// al conteo — no es un N+1 a corregir, es auténticamente invisible al guard.</summary>
     private static async Task InsertarMovimientoStockAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
         decimal cantidad, MotivoStock motivo, int idComprobanteVenta, int idEmpleado, DateTimeOffset creadoEl,

--- a/src/Ways.Domain/Ventas/ValidadorDePagos.cs
+++ b/src/Ways.Domain/Ventas/ValidadorDePagos.cs
@@ -51,6 +51,21 @@ public static class ValidadorDePagos
         decimal limiteCredito,
         bool creditoIlimitado)
     {
+        // 0 (nuevo, sin numeración legacy — corta ANTES que cualquier otra regla): un
+        // Importe negativo permite manipular Σ importe sin que ninguna regla de abajo lo note
+        // (p. ej. {Efectivo, 150}, {CuentaCorriente, -50} sobre un total de 100 pasa la regla 2
+        // porque Σ importe da 100, y nunca dispara las reglas 5/6 porque
+        // <c>consumoCuentaCorriente > 0m</c> es falso con un consumo negativo) — un Importe
+        // negativo no tiene significado de negocio para un pago, se rechaza de plano.
+        foreach (var pago in pagos)
+        {
+            if (pago.Importe < 0m)
+            {
+                throw new ErrorDominio(
+                    "pago_importe_negativo", "El importe de un pago no puede ser negativo.", 400);
+            }
+        }
+
         var sumaImportes = pagos.Sum(p => p.Importe);
         var sumaVueltos = pagos.Sum(p => p.Vuelto);
 
@@ -84,6 +99,10 @@ public static class ValidadorDePagos
             }
         }
 
+        // La regla 0 ya garantizó Importe >= 0 en cada pago, así que "> 0m" abajo distingue sin
+        // ambigüedad "hubo consumo de cuenta corriente" de "no lo hubo" — sin la regla 0, un
+        // Importe negativo en un pago de CuentaCorriente podía compensar uno positivo y esconder
+        // el consumo real detrás de las reglas 5/6.
         var consumoCuentaCorriente = pagos
             .Where(p => p.Comportamiento == ComportamientoMedioPago.CuentaCorriente)
             .Sum(p => p.Importe);

--- a/src/Ways.Domain/Ventas/ValidadorDePagos.cs
+++ b/src/Ways.Domain/Ventas/ValidadorDePagos.cs
@@ -71,6 +71,18 @@ public static class ValidadorDePagos
             }
         }
 
+        // 0b (mismo criterio que la regla 0, mismo lugar en el orden — corta ANTES que
+        // cualquier otra regla): un Vuelto negativo, igual que un Importe negativo, no tiene
+        // significado de negocio y podría manipular Σ vuelto sin que las reglas 3/8 lo noten.
+        foreach (var pago in pagos)
+        {
+            if (pago.Vuelto < 0m)
+            {
+                throw new ErrorDominio(
+                    "vuelto_negativo", "El vuelto de un pago no puede ser negativo.", 400);
+            }
+        }
+
         var sumaImportes = pagos.Sum(p => p.Importe);
         var sumaVueltos = pagos.Sum(p => p.Vuelto);
 

--- a/src/Ways.Domain/Ventas/ValidadorDePagos.cs
+++ b/src/Ways.Domain/Ventas/ValidadorDePagos.cs
@@ -57,6 +57,11 @@ public static class ValidadorDePagos
         // porque Σ importe da 100, y nunca dispara las reglas 5/6 porque
         // <c>consumoCuentaCorriente > 0m</c> es falso con un consumo negativo) — un Importe
         // negativo no tiene significado de negocio para un pago, se rechaza de plano.
+        //
+        // TODO: este gate de dominio es la defensa de aplicación; falta el backstop de esquema
+        // (CHECK ck_pagos_comprobante_importe_no_negativo sobre pagos_comprobante.importe >= 0,
+        // mismo criterio que ck_comprobantes_venta_numero_positivo) — pendiente del micro-gate de
+        // cambio de base de datos con el usuario, se agrega en un follow-up.
         foreach (var pago in pagos)
         {
             if (pago.Importe < 0m)

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -81,8 +81,8 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
     // stage-5-pos-ventas, Slice 3 (schema/domain foundation, DB CHANGE GATE aprobado
     // 2026-08-04): modelo adelantado a la migración, mismo trámite que Articulo/CodigoBarra/
-    // Precio en stage-3 Slice 1 — sin DbSet en IWaysDbContext todavía, ServicioDeVentas
-    // (Slice 4) es el primer consumidor de Application.
+    // Precio en stage-3 Slice 1. Slice 4 expone los 6 en IWaysDbContext: ServicioDeVentas es
+    // el primer consumidor de Application.
     public DbSet<ComprobanteVenta> ComprobantesVenta => Set<ComprobanteVenta>();
     public DbSet<ItemComprobanteVenta> ItemsComprobanteVenta => Set<ItemComprobanteVenta>();
     public DbSet<PagoComprobante> PagosComprobante => Set<PagoComprobante>();

--- a/tests/Ways.Domain.Tests/Ventas/ValidadorDePagosTests.cs
+++ b/tests/Ways.Domain.Tests/Ventas/ValidadorDePagosTests.cs
@@ -32,6 +32,37 @@ public class ValidadorDePagosTests
         bool creditoIlimitado = false) =>
         ValidadorDePagos.Validar(total, pagos, tolerancia, vueltoMaximo, esConsumidorFinal, saldo, limiteCredito, creditoIlimitado);
 
+    // ---- 0: pago_importe_negativo -----------------------------------------------------------
+
+    [Fact]
+    public void UnPagoDeCuentaCorrienteNegativoQueCompensaOtroPagoSeRechaza()
+    {
+        // El exploit: {Efectivo, 150}, {CuentaCorriente, -50} sobre un total de 100 -> Σ importe
+        // da 100 (pasaría la regla 2) y consumoCuentaCorriente da -50 (nunca dispara las reglas
+        // 5/6, que exigen "> 0m"). Sin la regla 0 esto se aceptaba.
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            Validar(100m, [Efectivo(150m), CuentaCorriente(-50m)], esConsumidorFinal: true));
+        Assert.Equal("pago_importe_negativo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnSoloPagoEnEfectivoNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => Validar(100m, [Efectivo(-50m)]));
+        Assert.Equal("pago_importe_negativo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnPagoConImporteExactamenteCeroNoDisparaLaRegla0()
+    {
+        // Boundary: 0 no es negativo, así que la regla 0 lo deja pasar — no tiene significado
+        // propio de negocio (ni resta ni suma), así que queda como no-op frente al resto de las
+        // reglas (mismo comportamiento que si no se hubiera incluido en la lista); no se lo
+        // rechaza de forma explícita para no reñir con la regla 1 (que sí lo cubre cuando es el
+        // ÚNICO pago) ni con la 5/6 (que ya lo tratan como "sin consumo" al no ser > 0m).
+        Validar(100m, [Efectivo(100m), CuentaCorriente(0m)], esConsumidorFinal: true);
+    }
+
     // ---- 1: pago_no_ingresado -------------------------------------------------------------
 
     [Fact]

--- a/tests/Ways.Domain.Tests/Ventas/ValidadorDePagosTests.cs
+++ b/tests/Ways.Domain.Tests/Ventas/ValidadorDePagosTests.cs
@@ -63,6 +63,23 @@ public class ValidadorDePagosTests
         Validar(100m, [Efectivo(100m), CuentaCorriente(0m)], esConsumidorFinal: true);
     }
 
+    // ---- 0b: vuelto_negativo ----------------------------------------------------------------
+
+    [Fact]
+    public void UnPagoConVueltoNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            Validar(100m, [Efectivo(100m, vuelto: -1m)], vueltoMaximo: 50m));
+        Assert.Equal("vuelto_negativo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnPagoConVueltoExactamenteCeroNoDisparaLaRegla0b()
+    {
+        // Boundary: 0 no es negativo, así que la regla 0b lo deja pasar.
+        Validar(100m, [Efectivo(100m, vuelto: 0m)]);
+    }
+
     // ---- 1: pago_no_ingresado -------------------------------------------------------------
 
     [Fact]

--- a/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OperacionDePosLecturaTests.cs
@@ -27,7 +27,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     private const string PasswordVendedor = "una-contraseña-larga";
     private const string PasswordSupervisor = "una-contraseña-larga";
 
-    private async Task<(int IdTenant, int IdEmpresa)> AprovisionarTenantAsync(string nombre)
+    private async Task<(int IdTenant, int IdEmpresa, int IdPuntoVenta)> AprovisionarTenantAsync(string nombre)
     {
         using var root = fixture.CreateClient();
         var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
@@ -41,7 +41,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
         var resultado = await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>();
         Assert.NotNull(resultado);
 
-        return (resultado!.IdTenant, resultado.IdEmpresa);
+        return (resultado!.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta);
     }
 
     private async Task<string> SembrarVendedorAsync(int idTenant, string nombre)
@@ -113,7 +113,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnVendedorPuedeListarArticulos()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarArticulos));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarArticulos));
         using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarArticulos));
 
         var respuesta = await vendedor.GetAsync("/api/articulos");
@@ -124,7 +124,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnVendedorPuedeListarClientes()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarClientes));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarClientes));
         using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarClientes));
 
         var respuesta = await vendedor.GetAsync("/api/clientes");
@@ -135,7 +135,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnVendedorPuedeListarUnCatalogoDeTenant()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarUnCatalogoDeTenant));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarUnCatalogoDeTenant));
         using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarUnCatalogoDeTenant));
 
         var respuesta = await vendedor.GetAsync("/api/catalogos/areas");
@@ -146,7 +146,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnVendedorPuedeListarParametros()
     {
-        var (idTenant, idEmpresa) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarParametros));
+        var (idTenant, idEmpresa, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarParametros));
         using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarParametros));
 
         var respuesta = await vendedor.GetAsync($"/api/parametros?idEmpresa={idEmpresa}");
@@ -161,7 +161,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnVendedorPuedeResolverOfertas()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeResolverOfertas));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeResolverOfertas));
         using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeResolverOfertas));
 
         var respuesta = await vendedor.PostAsJsonAsync(
@@ -190,7 +190,7 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnSupervisorPuedeListarArticulos()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnSupervisorPuedeListarArticulos));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnSupervisorPuedeListarArticulos));
         using var supervisor = await SupervisorLogueadoAsync(idTenant, nameof(UnSupervisorPuedeListarArticulos));
 
         var respuesta = await supervisor.GetAsync("/api/articulos");
@@ -203,12 +203,59 @@ public class OperacionDePosLecturaTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnSupervisorNoPuedeCrearUnCatalogoDeTenant()
     {
-        var (idTenant, _) = await AprovisionarTenantAsync(nameof(UnSupervisorNoPuedeCrearUnCatalogoDeTenant));
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnSupervisorNoPuedeCrearUnCatalogoDeTenant));
         using var supervisor = await SupervisorLogueadoAsync(idTenant, nameof(UnSupervisorNoPuedeCrearUnCatalogoDeTenant));
 
         var respuesta = await supervisor.PostAsJsonAsync(
             "/api/catalogos/areas", new AreaAlta("Intrusa", IdEmpresa: null, Orden: 1));
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    /// <summary>Judgment-day slice-6 CRITICAL: <c>GET /api/puntos-venta</c> (listado) quedaba
+    /// bajo <see cref="Politicas.GestionDeOrganizacion"/> (Root/Admin), lo que le bloqueaba al
+    /// selector de PV del POS el acceso de Vendedor/Supervisor. Se re-gateó solo esta ruta a
+    /// <see cref="Politicas.LecturaDePuntosVenta"/>; el resto de <c>OrganizacionEndpoints</c>
+    /// (obtener por id, editar) sigue exclusivamente bajo GestionDeOrganizacion.</summary>
+    [Fact]
+    public async Task UnVendedorPuedeListarPuntosDeVenta()
+    {
+        var (idTenant, _, _) = await AprovisionarTenantAsync(nameof(UnVendedorPuedeListarPuntosDeVenta));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorPuedeListarPuntosDeVenta));
+
+        var respuesta = await vendedor.GetAsync("/api/puntos-venta");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>Companion del test de arriba: el listado se relaja, pero la edición de un punto
+    /// de venta sigue exclusivamente admin/root (<see cref="Politicas.GestionDeOrganizacion"/>).</summary>
+    [Fact]
+    public async Task UnVendedorNoPuedeEditarUnPuntoDeVenta()
+    {
+        var (idTenant, _, idPuntoVenta) = await AprovisionarTenantAsync(nameof(UnVendedorNoPuedeEditarUnPuntoDeVenta));
+        using var vendedor = await VendedorLogueadoAsync(idTenant, nameof(UnVendedorNoPuedeEditarUnPuntoDeVenta));
+
+        var respuesta = await vendedor.PutAsJsonAsync(
+            $"/api/puntos-venta/{idPuntoVenta}",
+            new PuntoVentaEdicion("Intento vendedor", null, null, null, null, null, null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    /// <summary>El re-gateo del listado a LecturaDePuntosVenta no le rompe a Root el acceso que
+    /// ya tenía vía GestionDeOrganizacion — <c>PuntosVenta.tsx</c> (admin) sigue funcionando.</summary>
+    [Fact]
+    public async Task RootPuedeListarPuntosDeVenta()
+    {
+        await AprovisionarTenantAsync(nameof(RootPuedeListarPuntosDeVenta));
+
+        using var root = fixture.CreateClient();
+        var login = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var respuesta = await root.GetAsync("/api/puntos-venta");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
 }

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -35,7 +35,11 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         ("POST", "/api/auth/login"),
         ("POST", "/api/auth/logout"),
         ("POST", "/api/ofertas/resolver"),
-        ("POST", "/api/ventas"),
+        // Slice 4 (task 4.6): MapGroup("/api/ventas").MapPost("/", ...) — el RoutePattern.RawText
+        // real lleva la barra final (mismo shape que "/api/plataforma/tenants/"/"/api/usuarios/"
+        // más abajo), a diferencia del literal sin barra que este allowlist traía adelantado
+        // desde Slice 1.
+        ("POST", "/api/ventas/"),
         ("POST", "/api/ventas/{id}/anulacion"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -126,18 +126,26 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         "/api/catalogos/",
         "/api/catalogos-fiscales",
         "/api/parametros",
-        "/api/ofertas"
+        "/api/ofertas",
+        // GET /api/puntos-venta (listado) — re-gateado a Politicas.LecturaDePuntosVenta para
+        // habilitar el selector de PV del POS (Vendedor/Supervisor) sin sacarle el acceso a
+        // Root/Admin (PuntosVenta.tsx). GET /{id:int} sigue bajo GestionDeOrganizacion, ya
+        // cubierto por el allowlist de policies de abajo.
+        "/api/puntos-venta"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —
-    // todas excluyen Vendedor, así que ninguna relaja la superficie que este guard vigila.
+    // ninguna relaja la superficie que este guard vigila a "autenticado sin rol". La única
+    // excepción documentada es LecturaDePuntosVenta, que sí agrega Root frente a OperacionDePos
+    // pero sigue exigiendo un rol conocido (nunca cae al fallback autenticado-only).
     private static readonly HashSet<string> PoliticasAlMenosTanEstrictasComoOperacionDePos =
     [
         Politicas.OperacionDePos,
         Politicas.GestionDeCatalogo,
         Politicas.GestionDeUsuarios,
         Politicas.GestionDeOrganizacion,
-        Politicas.SoloPlataforma
+        Politicas.SoloPlataforma,
+        Politicas.LecturaDePuntosVenta
     ];
 
     [Fact]

--- a/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
@@ -1,0 +1,450 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 4 (task 4.8, "force a failure at each of the six statements"; tasks
+/// 4.9-4.11, las tres superficies racy de esta slice). Las fallas de la mitad transaccional se
+/// fuerzan REVOCANDO el privilegio de Postgres de la tabla puntual (con <c>ways_owner</c>, nunca
+/// con <c>ways_app</c>) durante el único checkout de la prueba — funciona igual para los pasos
+/// escritos vía EF (comprobante/items/pagos, <c>SaveChangesAsync</c>) y los escritos con ADO.NET
+/// crudo (numeración/stock/cuenta corriente), a diferencia de un <c>DbCommandInterceptor</c> de
+/// EF Core, que NUNCA ve un <c>DbCommand</c> creado a mano sobre
+/// <c>db.Database.GetDbConnection()</c>.
+///
+/// Gap semantics (honesto, no el resumen simplificado de design.md): un ROLLBACK LIMPIO —
+/// exactamente lo que fuerza esta prueba— deshace TAMBIÉN el <c>UPDATE numeraciones_comprobante</c>
+/// del paso 1 (misma transacción), así que el próximo checkout exitoso en el mismo punto de
+/// venta/tipo REUSA el número — no lo saltea. Confirmado por
+/// <c>AsignadorDeNumeroComprobanteConcurrenciaTests.UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco</c>
+/// (Slice 2). El "hueco aceptado" de la spec nace únicamente de un reintento de
+/// <c>CreateExecutionStrategy</c> ante un fallo transitorio de commit ambiguo — un mecanismo
+/// distinto, no reproducible con una revocación de privilegio determinística, y por eso NO es lo
+/// que estas pruebas afirman.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    // Mismo motivo que VentasCheckoutTests.OpcionesJson/ArticulosEndpointsTests.OpcionesJson.
+    private static readonly System.Text.Json.JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva,
+        int IdListaPrecio, int IdMedioEfectivo, int IdMedioCuentaCorriente);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Ventas-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista de Prueba", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, idMedioEfectivo, medioCc.Id);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(
+        Contexto ctx, string nombre, decimal limiteCredito = 0, bool creditoIlimitado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = limiteCredito,
+            CreditoIlimitado = creditoIlimitado, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    /// <summary>Semilla directa por SQL crudo — nunca vía <c>ServicioDeVentas</c> (esta slice no
+    /// tiene un endpoint de ajuste todavía, eso es Slice 5). Inserta TAMBIÉN el
+    /// <c>movimientos_stock</c> correspondiente (<c>motivo = ajuste</c>) para no romper el
+    /// invariante <c>stock.cantidad = Σ movimientos_stock.cantidad</c> que las pruebas de
+    /// concurrencia verifican (spec: stock / Cantidad Is Always The Sum Of Its Movimientos) —
+    /// si solo se sembrara la fila de <c>stock</c>, la suma de movimientos quedaría corta por
+    /// esta cantidad inicial.</summary>
+    private async Task SembrarStockInicialAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Stock.Add(new Ways.Domain.Stock.Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        db.MovimientosStock.Add(new Ways.Domain.Stock.MovimientoStock
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, Cantidad = cantidad,
+            Motivo = Ways.Domain.Stock.MotivoStock.Ajuste, IdEmpleado = idEmpleado, CreadoEl = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeVenta SolicitudSimple(
+        Contexto ctx, int idCliente, int idArticulo, decimal precio, decimal cantidad = 1m, int? idMedio = null) =>
+        new(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null)],
+            [new PagoDeVenta(idMedio ?? ctx.IdMedioEfectivo, precio * cantidad, null, 0m)],
+            null, null);
+
+    // ---- privilegios (fault injection determinística, ver el doc-comment de la clase) --------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task<HttpResponseMessage> IntentarConPrivilegioRevocadoAsync(
+        Contexto ctx, SolicitudDeVenta solicitud, string tabla, string privilegios)
+    {
+        await RevocarAsync(tabla, privilegios);
+        try
+        {
+            return await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        }
+        finally
+        {
+            await RestaurarAsync(tabla, privilegios);
+        }
+    }
+
+    private async Task VerificarNadaPersistidoAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(0, await db.ItemsComprobanteVenta.CountAsync());
+        Assert.Equal(0, await db.PagosComprobante.CountAsync());
+        Assert.Equal(0, await db.MovimientosStock.CountAsync());
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
+    }
+
+    /// <summary>Prueba central del "gap honesto": el próximo checkout LIMPIO en el mismo punto
+    /// de venta/tipo recibe <c>numero = 1</c> — si el intento fallido hubiera dejado un hueco,
+    /// este sería <c>2</c>.</summary>
+    private static async Task VerificarElProximoNumeroEsUnoAsync(Contexto ctx, int idCliente, int idArticulo, decimal precio)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idCliente, idArticulo, precio));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(1L, emitido.Numero);
+    }
+
+    // ---- task 4.8: atomicidad, un punto de falla por prueba -----------------------------------
+
+    [Fact]
+    public async Task UnaFallaEnLaNumeracionNoPersisteNadaYElProximoIntentoReusaElNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLaNumeracionNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-1", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 1");
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "numeraciones_comprobante", "INSERT, UPDATE");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElComprobanteNoPersisteNadaYElProximoIntentoReusaElNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElComprobanteNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-2", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 2");
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "comprobantes_venta", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnLosItemsNoPersisteNadaYElProximoIntentoReusaElNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLosItemsNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-3", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 3");
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "items_comprobante_venta", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnLosPagosNoPersisteNadaYElProximoIntentoReusaElNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLosPagosNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-4", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 4");
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "pagos_comprobante", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElStockNoPersisteNadaYElProximoIntentoReusaElNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElStockNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-5", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 5");
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "movimientos_stock", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(0, await db.Stock.CountAsync());
+        }
+
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnCuentaCorrienteNoPersisteNadaYElSaldoQuedaSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnCuentaCorrienteNoPersisteNadaYElSaldoQuedaSinCambios));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-6", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 6", limiteCredito: 1000m);
+
+        var solicitud = SolicitudSimple(ctx, idCliente, idArticulo, 100m, idMedio: ctx.IdMedioCuentaCorriente);
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(ctx, solicitud, "clientes", "UPDATE");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            Assert.Equal(0m, saldo);
+        }
+
+        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    // ---- task 4.9: dos ventas concurrentes del mismo artículo ---------------------------------
+
+    [Fact]
+    public async Task DosVentasConcurrentesDelMismoArticuloNoCorrompenElCacheDeStock()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(DosVentasConcurrentesDelMismoArticuloNoCorrompenElCacheDeStock)}-{ronda}");
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-concurrencia-stock", 10m);
+            var idClienteA = await SembrarClienteAsync(ctx, "Concurrencia Stock A");
+            var idClienteB = await SembrarClienteAsync(ctx, "Concurrencia Stock B");
+            await SembrarStockInicialAsync(ctx, idArticulo, 10m);
+
+            var tareaA = ctx.Admin.PostAsJsonAsync(
+                "/api/ventas", SolicitudSimple(ctx, idClienteA, idArticulo, 10m, cantidad: 3m));
+            var tareaB = ctx.Admin.PostAsJsonAsync(
+                "/api/ventas", SolicitudSimple(ctx, idClienteB, idArticulo, 10m, cantidad: 3m));
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+            Assert.All(respuestas, r => Assert.Equal(HttpStatusCode.Created, r.StatusCode));
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var cantidad = await db.Stock
+                .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+                .Select(s => s.Cantidad).FirstAsync();
+            var sumaDeMovimientos = await db.MovimientosStock
+                .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == ctx.IdPuntoVenta)
+                .SumAsync(m => m.Cantidad);
+
+            Assert.Equal(4m, cantidad);
+            Assert.Equal(cantidad, sumaDeMovimientos);
+        }
+    }
+
+    // ---- task 4.10: dos ventas de cuenta corriente cerca del límite ---------------------------
+
+    [Fact]
+    public async Task DosVentasConcurrentesDeCuentaCorrienteNuncaSuperanElLimite()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(DosVentasConcurrentesDeCuentaCorrienteNuncaSuperanElLimite)}-{ronda}");
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-concurrencia-cc", 600m);
+            var idCliente = await SembrarClienteAsync(ctx, "Concurrencia CC", limiteCredito: 1000m);
+
+            var solicitud = SolicitudSimple(ctx, idCliente, idArticulo, 600m, idMedio: ctx.IdMedioCuentaCorriente);
+
+            var tareaA = ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+            var tareaB = ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+            var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+            Assert.Contains(HttpStatusCode.Created, estados);
+            Assert.Contains(HttpStatusCode.BadRequest, estados);
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            var sumaDeMovimientos = await db.MovimientosCuentaCorriente
+                .Where(m => m.IdCliente == idCliente).SumAsync(m => m.Importe);
+
+            Assert.Equal(600m, saldo);
+            Assert.Equal(saldo, sumaDeMovimientos);
+            Assert.True(saldo <= 1000m, $"El saldo ({saldo}) no puede superar el límite de crédito (1000).");
+        }
+    }
+
+    // ---- task 4.11: dos ventas concurrentes del mismo punto de venta ---------------------------
+
+    [Fact]
+    public async Task DosVentasConcurrentesDelMismoPuntoDeVentaGetNumerosDistintosYConsecutivos()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(DosVentasConcurrentesDelMismoPuntoDeVentaGetNumerosDistintosYConsecutivos)}-{ronda}");
+            var idArticuloA = await SembrarArticuloConPrecioAsync(ctx, "art-concurrencia-numero-a", 10m);
+            var idArticuloB = await SembrarArticuloConPrecioAsync(ctx, "art-concurrencia-numero-b", 10m);
+            var idClienteA = await SembrarClienteAsync(ctx, "Concurrencia Numero A");
+            var idClienteB = await SembrarClienteAsync(ctx, "Concurrencia Numero B");
+
+            var tareaA = ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idClienteA, idArticuloA, 10m));
+            var tareaB = ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idClienteB, idArticuloB, 10m));
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+            Assert.All(respuestas, r => Assert.Equal(HttpStatusCode.Created, r.StatusCode));
+
+            var numeros = new List<long>();
+            foreach (var r in respuestas)
+            {
+                var emitido = (await r.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+                numeros.Add(emitido.Numero);
+            }
+
+            Assert.NotEqual(numeros[0], numeros[1]);
+            Assert.Equal([1L, 2L], numeros.OrderBy(n => n));
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
@@ -11,6 +11,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
 using Ways.Domain.Ventas;
 using Ways.Infrastructure.Multitenancy;
 
@@ -22,19 +23,25 @@ namespace Ways.IntegrationTests;
 /// fuerzan REVOCANDO el privilegio de Postgres de la tabla puntual (con <c>ways_owner</c>, nunca
 /// con <c>ways_app</c>) durante el único checkout de la prueba — funciona igual para los pasos
 /// escritos vía EF (comprobante/items/pagos, <c>SaveChangesAsync</c>) y los escritos con ADO.NET
-/// crudo (numeración/stock/cuenta corriente), a diferencia de un <c>DbCommandInterceptor</c> de
-/// EF Core, que NUNCA ve un <c>DbCommand</c> creado a mano sobre
-/// <c>db.Database.GetDbConnection()</c>.
+/// crudo (stock/cuenta corriente), a diferencia de un <c>DbCommandInterceptor</c> de EF Core, que
+/// NUNCA ve un <c>DbCommand</c> creado a mano sobre <c>db.Database.GetDbConnection()</c>.
 ///
-/// Gap semantics (honesto, no el resumen simplificado de design.md): un ROLLBACK LIMPIO —
-/// exactamente lo que fuerza esta prueba— deshace TAMBIÉN el <c>UPDATE numeraciones_comprobante</c>
-/// del paso 1 (misma transacción), así que el próximo checkout exitoso en el mismo punto de
-/// venta/tipo REUSA el número — no lo saltea. Confirmado por
+/// Gap semantics (ahora literal, no el resumen simplificado de una corrección previa de esta
+/// clase): <c>ServicioDeVentas.EmitirAsync</c> reserva y COMITEA el número en su PROPIA
+/// transacción, ANTES de abrir la que escribe el resto de la venta (ver el doc-comment de
+/// <c>EmitirAsync</c>). Un ROLLBACK de la transacción principal —exactamente lo que fuerzan las
+/// pruebas de este archivo, salvo <see cref="UnaFallaEnLaNumeracionDejaElContadorSinAvanzar"/>—
+/// nunca alcanza esa primera transacción: el número queda consumido pase lo que pase después.
+/// El próximo checkout exitoso en el mismo punto de venta/tipo SALTEA el número fallido — el
+/// "hueco aceptado" de la spec/design.md (Failure Semantics) es ahora el comportamiento real, no
+/// solo el de un reintento de <c>CreateExecutionStrategy</c> ante un commit ambiguo.
+///
+/// La única excepción es una falla DENTRO de la transacción de numeración
+/// (<see cref="UnaFallaEnLaNumeracionDejaElContadorSinAvanzar"/>): ahí no hay nada que comprometer
+/// todavía, así que esa transacción también hace ROLLBACK limpio y el contador no avanza — el
+/// próximo checkout exitoso REUSA el número, no lo saltea. Confirmado por
 /// <c>AsignadorDeNumeroComprobanteConcurrenciaTests.UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco</c>
-/// (Slice 2). El "hueco aceptado" de la spec nace únicamente de un reintento de
-/// <c>CreateExecutionStrategy</c> ante un fallo transitorio de commit ambiguo — un mecanismo
-/// distinto, no reproducible con una revocación de privilegio determinística, y por eso NO es lo
-/// que estas pruebas afirman.
+/// (Slice 2), que prueba exactamente esa transacción chica en aislamiento.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -229,9 +236,10 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
         Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
     }
 
-    /// <summary>Prueba central del "gap honesto": el próximo checkout LIMPIO en el mismo punto
-    /// de venta/tipo recibe <c>numero = 1</c> — si el intento fallido hubiera dejado un hueco,
-    /// este sería <c>2</c>.</summary>
+    /// <summary>Solo para <see cref="UnaFallaEnLaNumeracionDejaElContadorSinAvanzar"/>: ahí la
+    /// falla ocurre DENTRO de la transacción de numeración, así que no hay número comprometido
+    /// que consumir — el próximo checkout LIMPIO en el mismo punto de venta/tipo reusa
+    /// <c>numero = 1</c>.</summary>
     private static async Task VerificarElProximoNumeroEsUnoAsync(Contexto ctx, int idCliente, int idArticulo, decimal precio)
     {
         var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idCliente, idArticulo, precio));
@@ -241,12 +249,25 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
         Assert.Equal(1L, emitido.Numero);
     }
 
+    /// <summary>Prueba central del gap ahora literal (ver el doc-comment de la clase): una falla
+    /// DESPUÉS de que la numeración ya comitió en su propia transacción deja el número 1
+    /// consumido sin comprobante — el próximo checkout LIMPIO en el mismo punto de venta/tipo
+    /// saltea directo a <c>numero = 2</c>.</summary>
+    private static async Task VerificarElProximoNumeroEsDosAsync(Contexto ctx, int idCliente, int idArticulo, decimal precio)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idCliente, idArticulo, precio));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(2L, emitido.Numero);
+    }
+
     // ---- task 4.8: atomicidad, un punto de falla por prueba -----------------------------------
 
     [Fact]
-    public async Task UnaFallaEnLaNumeracionNoPersisteNadaYElProximoIntentoReusaElNumero()
+    public async Task UnaFallaEnLaNumeracionDejaElContadorSinAvanzar()
     {
-        var ctx = await PrepararAsync(nameof(UnaFallaEnLaNumeracionNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLaNumeracionDejaElContadorSinAvanzar));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-1", 100m);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 1");
 
@@ -259,9 +280,9 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
     }
 
     [Fact]
-    public async Task UnaFallaEnElComprobanteNoPersisteNadaYElProximoIntentoReusaElNumero()
+    public async Task UnaFallaEnElComprobanteNoPersisteNadaYElNumeroQuedaConsumido()
     {
-        var ctx = await PrepararAsync(nameof(UnaFallaEnElComprobanteNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElComprobanteNoPersisteNadaYElNumeroQuedaConsumido));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-2", 100m);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 2");
 
@@ -270,13 +291,13 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
 
         Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
         await VerificarNadaPersistidoAsync(ctx);
-        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
     }
 
     [Fact]
-    public async Task UnaFallaEnLosItemsNoPersisteNadaYElProximoIntentoReusaElNumero()
+    public async Task UnaFallaEnLosItemsNoPersisteNadaYElNumeroQuedaConsumido()
     {
-        var ctx = await PrepararAsync(nameof(UnaFallaEnLosItemsNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLosItemsNoPersisteNadaYElNumeroQuedaConsumido));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-3", 100m);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 3");
 
@@ -285,13 +306,13 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
 
         Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
         await VerificarNadaPersistidoAsync(ctx);
-        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
     }
 
     [Fact]
-    public async Task UnaFallaEnLosPagosNoPersisteNadaYElProximoIntentoReusaElNumero()
+    public async Task UnaFallaEnLosPagosNoPersisteNadaYElNumeroQuedaConsumido()
     {
-        var ctx = await PrepararAsync(nameof(UnaFallaEnLosPagosNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var ctx = await PrepararAsync(nameof(UnaFallaEnLosPagosNoPersisteNadaYElNumeroQuedaConsumido));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-4", 100m);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 4");
 
@@ -300,13 +321,13 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
 
         Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
         await VerificarNadaPersistidoAsync(ctx);
-        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
     }
 
     [Fact]
-    public async Task UnaFallaEnElStockNoPersisteNadaYElProximoIntentoReusaElNumero()
+    public async Task UnaFallaEnElStockNoPersisteNadaYElNumeroQuedaConsumido()
     {
-        var ctx = await PrepararAsync(nameof(UnaFallaEnElStockNoPersisteNadaYElProximoIntentoReusaElNumero));
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElStockNoPersisteNadaYElNumeroQuedaConsumido));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-5", 100m);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 5");
 
@@ -321,7 +342,49 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
             Assert.Equal(0, await db.Stock.CountAsync());
         }
 
-        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElUpsertDeStockNoPersisteNadaYElStockQuedaSinCambios()
+    {
+        // El movimiento (paso 5a) YA se insertó cuando el upsert (paso 5b) falla — el upsert es
+        // un INSERT ... ON CONFLICT DO UPDATE, y SembrarStockInicialAsync ya deja la fila de
+        // stock sembrada, así que la venta siempre pisa la rama UPDATE (privilegio revocado).
+        // Prueba que el rollback deshace TAMBIÉN un statement anterior de la MISMA transacción,
+        // no solo el que efectivamente tiró la excepción.
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElUpsertDeStockNoPersisteNadaYElStockQuedaSinCambios));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-7", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 7");
+        await SembrarStockInicialAsync(ctx, idArticulo, 10m);
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(
+            ctx, SolicitudSimple(ctx, idCliente, idArticulo, 100m), "stock", "UPDATE");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+            Assert.Equal(0, await db.ItemsComprobanteVenta.CountAsync());
+            Assert.Equal(0, await db.PagosComprobante.CountAsync());
+            Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
+
+            // Único movimiento esperado: el de motivo = ajuste que sembró
+            // SembrarStockInicialAsync ANTES de la venta — el rollback deshizo el de motivo =
+            // venta (paso 5a) junto con el upsert que falló (paso 5b).
+            Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo));
+            Assert.Equal(
+                Ways.Domain.Stock.MotivoStock.Ajuste,
+                await db.MovimientosStock.Where(m => m.IdArticulo == idArticulo).Select(m => m.Motivo).SingleAsync());
+
+            var cantidad = await db.Stock
+                .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+                .Select(s => s.Cantidad).FirstAsync();
+            Assert.Equal(10m, cantidad);
+        }
+
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
     }
 
     [Fact]
@@ -344,7 +407,34 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
             Assert.Equal(0m, saldo);
         }
 
-        await VerificarElProximoNumeroEsUnoAsync(ctx, idCliente, idArticulo, 100m);
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElInsertDeCuentaCorrienteNoPersisteNadaYElSaldoQuedaSinCambios()
+    {
+        // El UPDATE de saldo (primer statement de paso 6) YA corrió cuando el INSERT del
+        // movimiento (segundo statement) falla — REVOKE INSERT sobre
+        // movimientos_cuenta_corriente prueba que el rollback deshace ese UPDATE previo también,
+        // no solo el INSERT que tiró la excepción.
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElInsertDeCuentaCorrienteNoPersisteNadaYElSaldoQuedaSinCambios));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-atom-8", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Atomicidad 8", limiteCredito: 1000m);
+
+        var solicitud = SolicitudSimple(ctx, idCliente, idArticulo, 100m, idMedio: ctx.IdMedioCuentaCorriente);
+
+        var respuesta = await IntentarConPrivilegioRevocadoAsync(ctx, solicitud, "movimientos_cuenta_corriente", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarNadaPersistidoAsync(ctx);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            Assert.Equal(0m, saldo);
+        }
+
+        await VerificarElProximoNumeroEsDosAsync(ctx, idCliente, idArticulo, 100m);
     }
 
     // ---- task 4.9: dos ventas concurrentes del mismo artículo ---------------------------------
@@ -446,5 +536,70 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
             Assert.NotEqual(numeros[0], numeros[1]);
             Assert.Equal([1L, 2L], numeros.OrderBy(n => n));
         }
+    }
+
+    // ---- task 4.8b: detección de commit ambiguo ------------------------------------------------
+
+    /// <summary>Un commit ambiguo genuino (el servidor comitea, la conexión se corta antes del
+    /// ACK) no es reproducible de forma determinística con una revocación de privilegio — por
+    /// eso esta prueba ejercita <c>ServicioDeVentas.BuscarPorNumeroComprometidoAsync</c>
+    /// DIRECTAMENTE por reflexión (es privado — la firma en primitivos, no en
+    /// <c>PlanDeVenta</c>, es justamente para que esto sea posible sin reconstruir el plan
+    /// completo) en sus dos ramas: número con comprobante ya comprometido (lo que un reintento
+    /// vería tras un commit que sí llegó a puerto) y número sin comprobante (lo que vería tras un
+    /// rollback limpio).</summary>
+    [Fact]
+    public async Task LaDeteccionDeCommitAmbiguoEncuentraLoYaEmitidoYNoInventaLoQueNuncaSeEscribio()
+    {
+        var ctx = await PrepararAsync(nameof(LaDeteccionDeCommitAmbiguoEncuentraLoYaEmitidoYNoInventaLoQueNuncaSeEscribio));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "art-deteccion-ambiguo", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Deteccion Ambiguo");
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudSimple(ctx, idCliente, idArticulo, 100m));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idTipoComprobante = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        var reloj = new RelojDetector(DateTimeOffset.UtcNow);
+        var contexto = new ContextoDetector(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas);
+
+        var metodo = typeof(ServicioDeVentas).GetMethod(
+            "BuscarPorNumeroComprometidoAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        // Rama "el commit anterior sí llegó a puerto": el número de la venta que ya se emitió.
+        var tareaEncontrado = (Task<ComprobanteEmitido?>)metodo.Invoke(
+            servicioDeVentas, [ctx.IdPuntoVenta, idTipoComprobante, emitido.Numero, CancellationToken.None])!;
+        var encontrado = await tareaEncontrado;
+
+        Assert.NotNull(encontrado);
+        Assert.Equal(emitido.Id, encontrado!.Id);
+        Assert.Equal(emitido.Numero, encontrado.Numero);
+
+        // Rama "rollback limpio, nunca hubo comprobante": un número que jamás se comprometió
+        // para este punto de venta/tipo.
+        var tareaInexistente = (Task<ComprobanteEmitido?>)metodo.Invoke(
+            servicioDeVentas, [ctx.IdPuntoVenta, idTipoComprobante, emitido.Numero + 999, CancellationToken.None])!;
+        var inexistente = await tareaInexistente;
+
+        Assert.Null(inexistente);
+    }
+
+    private sealed class RelojDetector(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoDetector(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
     }
 }

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -266,6 +266,13 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
 
+        // El servicio (30, sin stock) tiene que entrar en el total igual que el producto
+        // (2 × 50 = 100) — el guard de stock de abajo no puede confundirse con un descuento
+        // silencioso del precio de la línea de servicio.
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+        Assert.Equal(130m, emitido.Subtotal);
+        Assert.Equal(130m, emitido.Total);
+
         var (cantidadProducto, _) = await LeerStockYSaldoAsync(ctx, idProducto, idCliente);
         Assert.Equal(-2m, cantidadProducto);
 
@@ -367,6 +374,25 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("codigo_barra_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnCodigoBarraEnLaLongitudMaximaEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnCodigoBarraEnLaLongitudMaximaEsAceptado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-codigo-barra-maximo", 10m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Código Barra Máximo");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, new string('9', 64))],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 10m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
     }
 
     [Fact]
@@ -564,6 +590,39 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("pago_importe_negativo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnPagoConVueltoNegativoEsRechazadoYNoConsumeNumero()
+    {
+        var ctx = await PrepararAsync(nameof(UnPagoConVueltoNegativoEsRechazadoYNoConsumeNumero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-vuelto-negativo", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Vuelto Negativo");
+
+        var solicitudRechazada = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, -1m)],
+            null, null);
+
+        var respuestaRechazada = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudRechazada);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuestaRechazada.StatusCode);
+        var problema = await respuestaRechazada.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("vuelto_negativo", problema.GetProperty("codigo").GetString());
+
+        // El rechazo corre ANTES de la reserva de número (design: Failure Semantics) — un
+        // checkout válido inmediato después tiene que arrancar en el número 1, sin gap.
+        var solicitudValida = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var respuestaValida = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudValida);
+        Assert.Equal(HttpStatusCode.Created, respuestaValida.StatusCode);
+        var emitido = (await respuestaValida.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(1, emitido.Numero);
     }
 
     [Fact]
@@ -833,11 +892,15 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
 
         var consultasConPocasLineas = await EmitirYContarConsultasAsync(ctx, idCliente, cantidadDeLineas: 2);
         var consultasConMuchasLineas = await EmitirYContarConsultasAsync(ctx, idCliente, cantidadDeLineas: 20);
+        var consultasConMuchisimasLineas = await EmitirYContarConsultasAsync(ctx, idCliente, cantidadDeLineas: 50);
 
         Assert.Equal(consultasConPocasLineas, consultasConMuchasLineas);
-        Assert.True(
-            consultasConPocasLineas <= 16,
-            $"Se esperaban a lo sumo 16 consultas (design: Technical Approach), se emitieron {consultasConPocasLineas}.");
+        Assert.Equal(consultasConPocasLineas, consultasConMuchisimasLineas);
+
+        // El techo en sí está bajo prueba (design: Technical Approach, "≤ 16 round trips"): una
+        // baja tiene que notarse acá y actualizar la constante a propósito, nunca colarse muda
+        // detrás de un "<=".
+        Assert.Equal(16, consultasConPocasLineas);
     }
 
     private async Task<int> EmitirYContarConsultasAsync(Contexto ctx, int idCliente, int cantidadDeLineas)

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -258,6 +258,64 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     }
 
     [Fact]
+    public async Task UnaCantidadConMasDeTresDecimalesEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCantidadConMasDeTresDecimalesEsRechazada));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cantidad-precision", 10m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Cantidad Precisión");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1.2345m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 12.345m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("cantidad_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaCantidadConHastaTresDecimalesEsAceptada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCantidadConHastaTresDecimalesEsAceptada));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cantidad-precision-ok", 10m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Cantidad Precisión Ok");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1.234m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 12.34m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    [Fact]
+    public async Task UnCodigoBarraQueSuperaLaLongitudMaximaEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnCodigoBarraQueSuperaLaLongitudMaximaEsRechazado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-codigo-barra-largo", 10m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Código Barra Largo");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, new string('9', 65))],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 10m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("codigo_barra_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
     public async Task UnVendedorPuedeEmitirUnaVenta()
     {
         var ctx = await PrepararAsync(nameof(UnVendedorPuedeEmitirUnaVenta));

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -1,0 +1,710 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Ways.Application.Abstracciones;
+using Ways.Application.Articulos;
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-5-pos-ventas, Slice 4 (tasks 4.8-4.15 salvo atomicidad/concurrencia, que viven en
+/// <see cref="VentasAtomicidadYConcurrenciaTests"/>): <c>POST /api/ventas</c> punta a punta
+/// contra Postgres real — TX multi-línea/multi-pago/vuelto, NCX standalone y con asociado, la
+/// mezcla de rechazos B6, cuenta corriente, el snapshot inmutable, y el guard de presupuesto de
+/// consultas (design: Testing Strategy).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Mismo motivo que ArticulosEndpointsTests.OpcionesJson: el server registra
+    // JsonStringEnumConverter (Program.cs) pero ReadFromJsonAsync<T>()/GetFromJsonAsync<T>() sin
+    // opciones usa las opciones DEFAULT del lado cliente, que no lo traen —
+    // ComprobanteEmitido.Estado revienta la deserialización sin esto.
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant,
+        int IdEmpresa,
+        int IdPuntoVenta,
+        HttpClient Admin,
+        int IdArea,
+        int IdAlicuotaIva,
+        int IdListaPrecio,
+        int IdMedioEfectivo,
+        int IdMedioTransferencia,
+        int IdMedioCuentaCorriente,
+        int IdClienteConsumidorFinal,
+        int IdListaPrecioConsumidorFinal);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Ventas-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista de Prueba", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+        var idMedioTransferencia = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Electronico)
+            .Select(m => m.Id).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        var cf = await db.Clientes.FirstAsync(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, idMedioEfectivo, idMedioTransferencia, medioCc.Id, cf.Id, cf.IdListaPrecio);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(
+        Contexto ctx, string nombre, decimal precio, int? idListaPrecio = null, bool esProducto = true)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = esProducto, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = idListaPrecio ?? ctx.IdListaPrecio,
+            Monto = precio, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<(int Id, decimal LimiteCredito)> SembrarClienteAsync(
+        Contexto ctx, string nombre, decimal limiteCredito = 0, bool creditoIlimitado = false, int? idListaPrecio = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = idListaPrecio ?? ctx.IdListaPrecio,
+            LimiteCredito = limiteCredito, CreditoIlimitado = creditoIlimitado, Activo = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return (cliente.Id, limiteCredito);
+    }
+
+    private async Task<(decimal Cantidad, decimal Saldo)> LeerStockYSaldoAsync(
+        Contexto ctx, int idArticulo, int idCliente)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad)
+            .FirstOrDefaultAsync();
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        return (cantidad, saldo);
+    }
+
+    // ---- task 4.8 (parcial, happy path): TX multi-línea/multi-pago/vuelto ---------------------
+
+    [Fact]
+    public async Task CheckoutTxMultiLineaMultiPagoConVueltoCommiteaTodoJunto()
+    {
+        var ctx = await PrepararAsync(nameof(CheckoutTxMultiLineaMultiPagoConVueltoCommiteaTodoJunto));
+        var idArticuloA = await SembrarArticuloConPrecioAsync(ctx, "articulo-a", 100m);
+        var idArticuloB = await SembrarArticuloConPrecioAsync(ctx, "articulo-b", 50m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Juan Comprador", limiteCredito: 1000m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticuloA, 2m, null), new LineaDeVenta(idArticuloB, 3m, null)],
+            [
+                new PagoDeVenta(ctx.IdMedioEfectivo, 210m, null, 10m),
+                new PagoDeVenta(ctx.IdMedioTransferencia, 150m, "OP-1", 0m)
+            ],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(EstadoComprobante.Emitido, emitido.Estado);
+        Assert.Equal(350m, emitido.Subtotal);
+        Assert.Equal(0m, emitido.DescuentoTotal);
+        Assert.Equal(350m, emitido.Total);
+        Assert.Equal(2, emitido.Items.Count);
+        Assert.Equal(2, emitido.Pagos.Count);
+        Assert.StartsWith($"{ctx.IdPuntoVenta:D4}-", emitido.NumeroVisible);
+
+        var (cantidadA, _) = await LeerStockYSaldoAsync(ctx, idArticuloA, idCliente);
+        var (cantidadB, _) = await LeerStockYSaldoAsync(ctx, idArticuloB, idCliente);
+        Assert.Equal(-2m, cantidadA);
+        Assert.Equal(-3m, cantidadB);
+
+        // GET /api/ventas/{id} — reprint del mismo comprobante.
+        var reimpreso = await ctx.Admin.GetFromJsonAsync<ComprobanteEmitido>($"/api/ventas/{emitido.Id}", OpcionesJson);
+        Assert.Equal(emitido.Total, reimpreso!.Total);
+        Assert.Equal(emitido.Items.Count, reimpreso.Items.Count);
+    }
+
+    [Fact]
+    public async Task CheckoutOmitiendoIdClienteQuedaAtribuidoAlConsumidorFinal()
+    {
+        var ctx = await PrepararAsync(nameof(CheckoutOmitiendoIdClienteQuedaAtribuidoAlConsumidorFinal));
+        var idArticulo = await SembrarArticuloConPrecioAsync(
+            ctx, "articulo-cf", 100m, idListaPrecio: ctx.IdListaPrecioConsumidorFinal);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, null, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(ctx.IdClienteConsumidorFinal, emitido.IdCliente);
+    }
+
+    [Fact]
+    public async Task CheckoutSinIdPuntoVentaEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(CheckoutSinIdPuntoVentaEsRechazado));
+
+        using var contenido = new StringContent(
+            "{\"idCliente\":null,\"codigoTipoComprobante\":\"TX\",\"idComprobanteAsociado\":null," +
+            "\"lineas\":[],\"pagos\":[]}",
+            System.Text.Encoding.UTF8, "application/json");
+
+        var respuesta = await ctx.Admin.PostAsync("/api/ventas", contenido);
+
+        Assert.True(
+            respuesta.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.NotFound,
+            $"Se esperaba un 4xx, se obtuvo {respuesta.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeEmitirUnaVenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorPuedeEmitirUnaVenta));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-vendedor", 50m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente del Vendedor");
+
+        var mailVendedor = $"vendedor-{Guid.NewGuid():N}@ways.test";
+        var altaVendedor = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor1", mailVendedor, (int)RolConocido.Vendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
+
+        using var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailVendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 50m, null, 0m)],
+            null, null);
+
+        var respuesta = await vendedor.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    // ---- task 4.15: devoluciones como NCX -------------------------------------------------------
+
+    [Fact]
+    public async Task DevolucionStandaloneSePersisteComoNcxSinAsociado()
+    {
+        var ctx = await PrepararAsync(nameof(DevolucionStandaloneSePersisteComoNcxSinAsociado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-ncx", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente NCX");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "NCX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Null(emitido.IdComprobanteAsociado);
+        Assert.Equal(-100m, emitido.Total);
+        Assert.Equal(-1m, emitido.Items[0].Cantidad);
+
+        var (cantidad, _) = await LeerStockYSaldoAsync(ctx, idArticulo, idCliente);
+        Assert.Equal(1m, cantidad);
+    }
+
+    [Fact]
+    public async Task DevolucionReferenciandoUnOriginalPropagaElIdComprobanteAsociado()
+    {
+        var ctx = await PrepararAsync(nameof(DevolucionReferenciandoUnOriginalPropagaElIdComprobanteAsociado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-ncx-asoc", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente NCX Asociado");
+
+        var original = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+        var respuestaOriginal = await ctx.Admin.PostAsJsonAsync("/api/ventas", original);
+        Assert.Equal(HttpStatusCode.Created, respuestaOriginal.StatusCode);
+        var emitidoOriginal = (await respuestaOriginal.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var devolucion = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "NCX", emitidoOriginal.Id,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [],
+            null, null);
+        var respuestaDevolucion = await ctx.Admin.PostAsJsonAsync("/api/ventas", devolucion);
+        Assert.Equal(HttpStatusCode.Created, respuestaDevolucion.StatusCode);
+
+        var emitidoDevolucion = (await respuestaDevolucion.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(emitidoOriginal.Id, emitidoDevolucion.IdComprobanteAsociado);
+    }
+
+    [Fact]
+    public async Task UnaTxNoPuedeAsociarseAOtroComprobante()
+    {
+        var ctx = await PrepararAsync(nameof(UnaTxNoPuedeAsociarseAOtroComprobante));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-tx-asoc-invalido", 50m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente TX asociado inválido");
+
+        var original = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 50m, null, 0m)],
+            null, null);
+        var respuestaOriginal = await ctx.Admin.PostAsJsonAsync("/api/ventas", original);
+        var emitidoOriginal = (await respuestaOriginal.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var otraTx = original with { IdComprobanteAsociado = emitidoOriginal.Id };
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", otraTx);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("comprobante_asociado_no_permitido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 4.14: paridad de rechazo B6 + guard de literales -------------------------------
+
+    [Fact]
+    public async Task UnPagoQueViolaToleranciaYVueltoALaVezReportaToleranciaPrimero()
+    {
+        var ctx = await PrepararAsync(nameof(UnPagoQueViolaToleranciaYVueltoALaVezReportaToleranciaPrimero));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-rechazo", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Rechazo");
+
+        // total = 100; tolerancia default = 10 ⇒ 100 - 10 = 90 es el piso aceptado sin vuelto.
+        // Con importe = 50 se viola la regla 2 (tolerancia) de entrada — un vuelto de 60 también
+        // violaría la regla 3 (vuelto_excedido, máximo default 20) si se llegara a evaluar, pero
+        // la regla 2 corta antes.
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 50m, null, 60m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("tolerancia_de_pago_superada", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task ElToleranciaYVueltoMaximoResuelvenPorPuntoDeVentaAntesQuePorDefault()
+    {
+        var ctx = await PrepararAsync(nameof(ElToleranciaYVueltoMaximoResuelvenPorPuntoDeVentaAntesQuePorDefault));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-parametro-pv", 50m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente parametro PV");
+
+        var altaParametro = await ctx.Admin.PutAsJsonAsync(
+            $"/api/parametros?idEmpresa={ctx.IdEmpresa}",
+            new ParametroAlta("vuelto_maximo", "30", ctx.IdPuntoVenta));
+        Assert.Equal(HttpStatusCode.OK, altaParametro.StatusCode);
+
+        // vuelto = 25 > default (20) pero <= el override de punto de venta (30).
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 75m, null, 25m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public void NingunLiteralDeToleranciaOVueltoHardcodeadoEnElCaminoDeCheckout()
+    {
+        // Spec: parametros-operativos / "No hardcoded tolerancia or vuelto value exists" — grep
+        // sobre el código fuente del camino de checkout (ValidadorDePagos, ya cubierto en
+        // Ways.Domain.Tests, más ServicioDeVentas, que agrega esta slice): ningún literal `10`/
+        // `20` fuera de comentarios/doc-comments.
+        var raiz = ResolverRaizDelRepositorio();
+        var archivos = new[]
+        {
+            Path.Combine(raiz, "src", "Ways.Domain", "Ventas", "ValidadorDePagos.cs"),
+            Path.Combine(raiz, "src", "Ways.Application", "Ventas", "ServicioDeVentas.cs")
+        };
+
+        foreach (var archivo in archivos)
+        {
+            Assert.True(File.Exists(archivo), $"No se encontró {archivo}.");
+
+            var codigo = File.ReadAllLines(archivo)
+                .Where(linea => !linea.TrimStart().StartsWith("//", StringComparison.Ordinal)
+                    && !linea.TrimStart().StartsWith("///", StringComparison.Ordinal)
+                    && !linea.TrimStart().StartsWith("*", StringComparison.Ordinal))
+                .ToList();
+
+            foreach (var linea in codigo)
+            {
+                Assert.False(
+                    System.Text.RegularExpressions.Regex.IsMatch(linea, @"(?<![\w.$])(10|20)(?![\w.])"),
+                    $"Literal de tolerancia/vuelto sospechoso en {Path.GetFileName(archivo)}: '{linea.Trim()}'.");
+            }
+        }
+    }
+
+    private static string ResolverRaizDelRepositorio()
+    {
+        var directorio = AppContext.BaseDirectory;
+
+        while (directorio is not null && !File.Exists(Path.Combine(directorio, "Ways.slnx")))
+        {
+            directorio = Path.GetDirectoryName(directorio.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        return directorio ?? throw new InvalidOperationException("No se encontró la raíz del repositorio (Ways.slnx).");
+    }
+
+    // ---- cuenta corriente -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ConsumidorFinalNoPuedePagarConCuentaCorriente()
+    {
+        var ctx = await PrepararAsync(nameof(ConsumidorFinalNoPuedePagarConCuentaCorriente));
+        var idArticulo = await SembrarArticuloConPrecioAsync(
+            ctx, "articulo-cf-cc", 100m, idListaPrecio: ctx.IdListaPrecioConsumidorFinal);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdClienteConsumidorFinal, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 100m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("cuenta_corriente_no_permitida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnConsumoDeCuentaCorrienteEnElLimiteExactoEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConsumoDeCuentaCorrienteEnElLimiteExactoEsAceptado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cc-limite", 300m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente CC límite", limiteCredito: 1000m);
+
+        // saldo arranca en 0: 0 + 300*? — armamos saldo previo de 700 con una primera venta CC,
+        // y una segunda de 300 que cae justo en el límite (700 + 300 = 1000).
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var cliente = await db.Clientes.FirstAsync(c => c.Id == idCliente);
+            cliente.Saldo = 700m;
+            await db.SaveChangesAsync();
+        }
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 300m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var (_, saldo) = await LeerStockYSaldoAsync(ctx, idArticulo, idCliente);
+        Assert.Equal(1000m, saldo);
+    }
+
+    [Fact]
+    public async Task UnPesoSobreElLimiteDeCreditoEsRechazadoSinEscribirNada()
+    {
+        var ctx = await PrepararAsync(nameof(UnPesoSobreElLimiteDeCreditoEsRechazadoSinEscribirNada));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cc-sobre-limite", 300.01m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente CC sobre límite", limiteCredito: 1000m);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var cliente = await db.Clientes.FirstAsync(c => c.Id == idCliente);
+            cliente.Saldo = 700m;
+            await db.SaveChangesAsync();
+        }
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 300.01m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("limite_credito_excedido", problema.GetProperty("codigo").GetString());
+
+        var (_, saldo) = await LeerStockYSaldoAsync(ctx, idArticulo, idCliente);
+        Assert.Equal(700m, saldo);
+    }
+
+    [Fact]
+    public async Task CreditoIlimitadoOmiteElLimite()
+    {
+        var ctx = await PrepararAsync(nameof(CreditoIlimitadoOmiteElLimite));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cc-ilimitado", 2000m);
+        var (idCliente, _) = await SembrarClienteAsync(
+            ctx, "Cliente CC ilimitado", limiteCredito: 1000m, creditoIlimitado: true);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var cliente = await db.Clientes.FirstAsync(c => c.Id == idCliente);
+            cliente.Saldo = 5000m;
+            await db.SaveChangesAsync();
+        }
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 2000m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    // ---- task 4.13: snapshot inmutable -----------------------------------------------------------
+
+    [Fact]
+    public async Task ReimprimirDespuesDeUnCambioDeCatalogoDevuelveElItemSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(ReimprimirDespuesDeUnCambioDeCatalogoDevuelveElItemSinCambios));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "nombre-original", 150m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Snapshot");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 150m, null, 0m)],
+            null, null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        Assert.Equal("nombre-original", emitido.Items[0].Descripcion);
+        Assert.Equal(150m, emitido.Items[0].PrecioUnitario);
+
+        // Cambiar el nombre y el precio vigente del artículo DESPUÉS de emitido.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var articulo = await db.Articulos.FirstAsync(a => a.Id == idArticulo);
+            articulo.Nombre = "nombre-cambiado";
+            await db.SaveChangesAsync();
+
+            var precio = await db.Precios.FirstAsync(p => p.IdArticulo == idArticulo);
+            precio.Monto = 999m;
+            await db.SaveChangesAsync();
+        }
+
+        var reimpreso = await ctx.Admin.GetFromJsonAsync<ComprobanteEmitido>($"/api/ventas/{emitido.Id}", OpcionesJson);
+
+        Assert.Equal("nombre-original", reimpreso!.Items[0].Descripcion);
+        Assert.Equal(150m, reimpreso.Items[0].PrecioUnitario);
+    }
+
+    // ---- task 4.12: guard de presupuesto de consultas --------------------------------------------
+
+    /// <summary>Cuenta cada <c>SELECT</c> que EF Core emite a través de su propio pipeline —
+    /// misma técnica que <c>OfertasResolucionTests.ContadorDeComandos</c>. Los statements crudos
+    /// de la mitad transaccional (numeración/stock/cuenta corriente) usan
+    /// <c>ExecuteNonQueryAsync</c>/<c>ExecuteScalarAsync</c>, nunca <c>ExecuteReaderAsync</c>, así
+    /// que este contador aísla exactamente la mitad "decidir" que design acota a ≤ 16 lecturas.</summary>
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    [Fact]
+    public async Task ElCheckoutEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeLineas()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeLineas));
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Presupuesto", limiteCredito: 1_000_000m);
+
+        var consultasConPocasLineas = await EmitirYContarConsultasAsync(ctx, idCliente, cantidadDeLineas: 2);
+        var consultasConMuchasLineas = await EmitirYContarConsultasAsync(ctx, idCliente, cantidadDeLineas: 20);
+
+        Assert.Equal(consultasConPocasLineas, consultasConMuchasLineas);
+        Assert.True(
+            consultasConPocasLineas <= 16,
+            $"Se esperaban a lo sumo 16 consultas (design: Technical Approach), se emitieron {consultasConPocasLineas}.");
+    }
+
+    private async Task<int> EmitirYContarConsultasAsync(Contexto ctx, int idCliente, int cantidadDeLineas)
+    {
+        var lineas = new List<LineaDeVenta>();
+        var totalEsperado = 0m;
+
+        for (var i = 0; i < cantidadDeLineas; i++)
+        {
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, $"presupuesto-{Guid.NewGuid():N}", 10m);
+            lineas.Add(new LineaDeVenta(idArticulo, 1m, null));
+            totalEsperado += 10m;
+        }
+
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null, lineas,
+            [new PagoDeVenta(ctx.IdMedioEfectivo, totalEsperado, null, 0m)],
+            null, null);
+
+        await servicioDeVentas.EmitirAsync(solicitud);
+
+        return contador.Consultas;
+    }
+}

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -390,6 +390,28 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     }
 
     [Fact]
+    public async Task UnPagoDeCuentaCorrienteNegativoQueDisfrazaElConsumoRealEsRechazado()
+    {
+        // Mismo exploit que ValidadorDePagosTests.UnPagoDeCuentaCorrienteNegativoQueCompensaOtroPagoSeRechaza,
+        // punta a punta: {Efectivo, 150}, {CuentaCorriente, -50} sobre un total de 100.
+        var ctx = await PrepararAsync(nameof(UnPagoDeCuentaCorrienteNegativoQueDisfrazaElConsumoRealEsRechazado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cc-negativo", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente CC negativo", limiteCredito: 1000m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 150m, null, 0m), new PagoDeVenta(ctx.IdMedioCuentaCorriente, -50m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("pago_importe_negativo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
     public async Task ElToleranciaYVueltoMaximoResuelvenPorPuntoDeVentaAntesQuePorDefault()
     {
         var ctx = await PrepararAsync(nameof(ElToleranciaYVueltoMaximoResuelvenPorPuntoDeVentaAntesQuePorDefault));

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -453,6 +453,49 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     }
 
     [Fact]
+    public async Task UnaDevolucionReResuelveElPrecioVigenteEnVezDePinearElDeLaVentaOriginal()
+    {
+        // Paridad legacy (alsina): una devolución NO es un "deshacer" contable de la venta
+        // original — vuelve a pasar por el mismo camino de resolución de precios que cualquier
+        // línea nueva, así que si el precio cambió entre la venta y la devolución, la devolución
+        // usa el vigente AL MOMENTO DE LA DEVOLUCIÓN, nunca el snapshoteado en la venta original
+        // (a diferencia del reimpreso de la MISMA venta, que sí es un snapshot inmutable —
+        // ReimprimirDespuesDeUnCambioDeCatalogoDevuelveElItemSinCambios).
+        var ctx = await PrepararAsync(nameof(UnaDevolucionReResuelveElPrecioVigenteEnVezDePinearElDeLaVentaOriginal));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-ncx-precio-vigente", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente NCX Precio Vigente");
+
+        var original = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+        var respuestaOriginal = await ctx.Admin.PostAsJsonAsync("/api/ventas", original);
+        Assert.Equal(HttpStatusCode.Created, respuestaOriginal.StatusCode);
+        var emitidoOriginal = (await respuestaOriginal.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(100m, emitidoOriginal.Items[0].PrecioUnitario);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var precio = await db.Precios.FirstAsync(p => p.IdArticulo == idArticulo);
+            precio.Monto = 150m;
+            await db.SaveChangesAsync();
+        }
+
+        var devolucion = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "NCX", emitidoOriginal.Id,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [],
+            null, null);
+        var respuestaDevolucion = await ctx.Admin.PostAsJsonAsync("/api/ventas", devolucion);
+        Assert.Equal(HttpStatusCode.Created, respuestaDevolucion.StatusCode);
+
+        var emitidoDevolucion = (await respuestaDevolucion.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(150m, emitidoDevolucion.Items[0].PrecioUnitario);
+        Assert.Equal(-150m, emitidoDevolucion.Total);
+    }
+
+    [Fact]
     public async Task UnaTxNoPuedeAsociarseAOtroComprobante()
     {
         var ctx = await PrepararAsync(nameof(UnaTxNoPuedeAsociarseAOtroComprobante));

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -738,11 +738,16 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
 
     // ---- task 4.12: guard de presupuesto de consultas --------------------------------------------
 
-    /// <summary>Cuenta cada <c>SELECT</c> que EF Core emite a través de su propio pipeline —
-    /// misma técnica que <c>OfertasResolucionTests.ContadorDeComandos</c>. Los statements crudos
-    /// de la mitad transaccional (numeración/stock/cuenta corriente) usan
-    /// <c>ExecuteNonQueryAsync</c>/<c>ExecuteScalarAsync</c>, nunca <c>ExecuteReaderAsync</c>, así
-    /// que este contador aísla exactamente la mitad "decidir" que design acota a ≤ 16 lecturas.</summary>
+    /// <summary>Cuenta cada comando que dispara <c>ReaderExecuting</c> — misma técnica que
+    /// <c>OfertasResolucionTests.ContadorDeComandos</c>, pero acá NO es literalmente "cada
+    /// <c>SELECT</c>": los dos <c>SaveChangesAsync</c> de la mitad transaccional (comprobante e
+    /// items/pagos) también entran, porque Npgsql dispara <c>ReaderExecuting</c> en un
+    /// <c>INSERT ... RETURNING</c> igual que en un <c>SELECT</c>, para leer la clave generada.
+    /// Eso no rompe el guard (design: Technical Approach, "≤ 16 round trips") porque esos dos
+    /// <c>SaveChangesAsync</c> son de cantidad constante, no escalan con la cantidad de
+    /// líneas/pagos. Los statements crudos de numeración/stock/cuenta corriente sí quedan afuera
+    /// del conteo: usan <c>ExecuteNonQueryAsync</c>/<c>ExecuteScalarAsync</c>, nunca
+    /// <c>ExecuteReaderAsync</c>.</summary>
     private sealed class ContadorDeComandos : DbCommandInterceptor
     {
         public int Consultas { get; private set; }

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -220,6 +220,60 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(emitido.Items.Count, reimpreso.Items.Count);
     }
 
+    // ---- doc 10 §3: EsProducto = false (servicio) no toca stock -------------------------------
+
+    [Fact]
+    public async Task UnaVentaDeUnServicioNoGeneraMovimientoNiFilaDeStock()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaDeUnServicioNoGeneraMovimientoNiFilaDeStock));
+        var idServicio = await SembrarArticuloConPrecioAsync(ctx, "servicio-mano-de-obra", 100m, esProducto: false);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Servicio", limiteCredito: 1000m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idServicio, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Single(emitido.Items);
+        Assert.Single(emitido.Pagos);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idServicio));
+        Assert.False(await db.Stock.AnyAsync(s => s.IdArticulo == idServicio));
+    }
+
+    [Fact]
+    public async Task UnCarritoMixtoDeProductoYServicioSoloMueveElStockDelProducto()
+    {
+        var ctx = await PrepararAsync(nameof(UnCarritoMixtoDeProductoYServicioSoloMueveElStockDelProducto));
+        var idProducto = await SembrarArticuloConPrecioAsync(ctx, "producto-mixto", 50m);
+        var idServicio = await SembrarArticuloConPrecioAsync(ctx, "servicio-mixto", 30m, esProducto: false);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Carrito Mixto", limiteCredito: 1000m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idProducto, 2m, null), new LineaDeVenta(idServicio, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 130m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var (cantidadProducto, _) = await LeerStockYSaldoAsync(ctx, idProducto, idCliente);
+        Assert.Equal(-2m, cantidadProducto);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idServicio));
+        Assert.False(await db.Stock.AnyAsync(s => s.IdArticulo == idServicio));
+    }
+
     [Fact]
     public async Task CheckoutOmitiendoIdClienteQuedaAtribuidoAlConsumidorFinal()
     {


### PR DESCRIPTION
Closes #43

## Summary

- Slice 4 of `stage-5-pos-ventas`: `ServicioDeVentas.EmitirAsync` — the project's most critical transaction. Decide-then-commit: ALL pricing re-resolved server-side (`LineaDeVenta` carries no money and no employee field), frozen `PlanDeVenta`, número allocated and COMMITTED in its own transaction (real gap semantics — a failed sale leaves a gap, never reuses), main transaction with pinned statement order (stock upserts ascending by id, atomic `UPDATE...RETURNING` for saldo with O(1) credit-limit enforcement) and ambiguous-commit idempotency (`BuscarPorNumeroComprometidoAsync` on the unique `(PV, tipo, numero)` — provably no false positives). `EsProducto=false` lines are charged but never touch stock (doc 10). NCX devoluciones re-resolve at current prices (legacy parity, pinned by test).
- Judgment-day (2 rounds, maximally adversarial on the money path): R1 — 2 CRITICALs confirmed (negative `Importe` fabricating CC credit past the limit gates → rule 0 + exploit tests; `EnableRetryOnFailure` ambiguous-commit could duplicate the whole sale → the pre-committed-número + idempotency-lookup restructure) + EsProducto, 2 vacuous fault points, cantidad precision. R2 — zero CRITICALs; symmetric `Vuelto` rule 0b + budget/test contract closures by exact prescription.
- Auth addendum from slice 6's judgment: `LecturaDePuntosVenta` (combined OR policy, all four roles) on `GET /api/puntos-venta` list only — Root's admin pages and the POS selector both work; writes untouched.
- 8 REVOKE-based atomicity fault points (gap-not-reuse asserted), 3 concurrency races serialized (stock, CC near-limit, numbering), query budget pinned at exactly 16 (`Assert.Equal`) constant across 2/20/50 lines.

## Test Plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — Domain 271/271, Application 207/207, Integration 370/370 (real Postgres; atomicity/concurrency suites rerun 3× isolated)
- [x] judgment-day: APPROVED

## Notes

- `size:exception`: the checkout transaction + its torture suite.
- Gate-pending follow-up: `ck_pagos_comprobante_importe_no_negativo` (DB defense-in-depth; domain rules 0/0b already close the reachable paths; TODO recorded in code awaiting the user's micro-gate).
- Unblocks Slices 5 (anulación) and 7 (web payment).