### PR TITLE
feat(web): pantalla POS de carrito y escaneo (etapa 5, slice 6)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -13,6 +13,7 @@ import { NuevoTenant } from './paginas/NuevoTenant'
 import { Ofertas } from './paginas/Ofertas'
 import { PaginaCatalogo } from './paginas/PaginaCatalogo'
 import { Parametros } from './paginas/Parametros'
+import { Pos } from './paginas/Pos'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
@@ -37,6 +38,18 @@ export function App() {
             }
           >
             <Route path="/" element={<Inicio />} />
+
+            {/* stage-5-pos-ventas (Slice 6, design: POS Screen Composition): pantalla dedicada,
+                admite Vendedor + Supervisor + Admin (Politicas.OperacionDePos) — no solo Admin
+                como el resto del ABM. Ruta propia, no la máquina genérica de catálogos. */}
+            <Route
+              path="/pos"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Pos />
+                </RutaProtegida>
+              }
+            />
             <Route
               path="/usuarios"
               element={

--- a/src/Ways.Web/src/api/articulos.ts
+++ b/src/Ways.Web/src/api/articulos.ts
@@ -7,6 +7,7 @@ import { api } from './cliente'
 import type {
   AltaArticulo,
   AltaCodigoBarra,
+  ArticuloEscaneado,
   ArticuloListado,
   CodigoBarraListado,
   EdicionArticulo,
@@ -36,4 +37,8 @@ export const clienteDeArticulos = {
   /** Solo lectura: propone, nunca persiste un precio por sí sola (spec: Margin-Based Price
    * Suggestion, "Suggestion requires explicit apply"). */
   sugerenciaDePrecio: (id: number) => api.get<SugerenciaDePrecio>(`/articulos/${id}/sugerencia-precio`),
+  /** Resolución de escaneo del POS (stage-5-pos-ventas, Slice 2/6): identidad únicamente, nunca
+   * precio (design decisión 7). `entrada` viaja tal cual la tipeó/leyó el lector — el parseo de
+   * `N*codigo` es responsabilidad del servidor (`ParserDeEscaneo`). */
+  escanear: (entrada: string) => api.get<ArticuloEscaneado>(`/articulos/escaneo?entrada=${encodeURIComponent(entrada)}`),
 }

--- a/src/Ways.Web/src/api/carrito.test.ts
+++ b/src/Ways.Web/src/api/carrito.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { reducirCarrito } from './carrito'
+import type { LineaCarrito } from './carrito'
+
+function lineaFixture(sobrescribir: Partial<LineaCarrito> = {}): LineaCarrito {
+  return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 1, ...sobrescribir }
+}
+
+describe('reducirCarrito — escanear', () => {
+  it('agrega una línea nueva cuando el artículo no está en el carrito', () => {
+    const resultado = reducirCarrito([], {
+      tipo: 'escanear',
+      linea: { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567' },
+      cantidad: 1,
+    })
+
+    expect(resultado).toEqual([lineaFixture()])
+  })
+
+  it('re-escanear el mismo artículo suma la cantidad en la línea existente, no duplica', () => {
+    const carritoConDos = [lineaFixture({ cantidad: 2 })]
+
+    const resultado = reducirCarrito(carritoConDos, {
+      tipo: 'escanear',
+      linea: { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567' },
+      cantidad: 1,
+    })
+
+    expect(resultado).toHaveLength(1)
+    expect(resultado[0].cantidad).toBe(3)
+  })
+
+  it('escanear el prefijo N*codigo pasa la cantidad indicada tal cual, sin transformarla', () => {
+    const resultado = reducirCarrito([], {
+      tipo: 'escanear',
+      linea: { idArticulo: 2, codigoInterno: 'A0002', nombre: 'Agua 500ml', codigoBarra: '7790009876543' },
+      cantidad: 3,
+    })
+
+    expect(resultado[0].cantidad).toBe(3)
+  })
+
+  it('escanear un segundo artículo agrega una línea nueva sin tocar la primera', () => {
+    const carritoConUno = [lineaFixture()]
+
+    const resultado = reducirCarrito(carritoConUno, {
+      tipo: 'escanear',
+      linea: { idArticulo: 2, codigoInterno: 'A0002', nombre: 'Agua 500ml', codigoBarra: '7790009876543' },
+      cantidad: 1,
+    })
+
+    expect(resultado).toHaveLength(2)
+    expect(resultado[0]).toEqual(lineaFixture())
+    expect(resultado[1].idArticulo).toBe(2)
+  })
+})
+
+describe('reducirCarrito — editarCantidad', () => {
+  it('actualiza la cantidad de la línea indicada sin tocar el resto', () => {
+    const carrito = [lineaFixture({ idArticulo: 1, cantidad: 1 }), lineaFixture({ idArticulo: 2, cantidad: 5 })]
+
+    const resultado = reducirCarrito(carrito, { tipo: 'editarCantidad', idArticulo: 1, cantidad: 7 })
+
+    expect(resultado.find((l) => l.idArticulo === 1)?.cantidad).toBe(7)
+    expect(resultado.find((l) => l.idArticulo === 2)?.cantidad).toBe(5)
+  })
+
+  it('permite cantidad negativa — convención de signo para líneas NCX (design decisión 4)', () => {
+    const carrito = [lineaFixture({ cantidad: 2 })]
+
+    const resultado = reducirCarrito(carrito, { tipo: 'editarCantidad', idArticulo: 1, cantidad: -2 })
+
+    expect(resultado[0].cantidad).toBe(-2)
+  })
+
+  it('editar la cantidad de un idArticulo inexistente no agrega ni modifica ninguna línea', () => {
+    const carrito = [lineaFixture()]
+
+    const resultado = reducirCarrito(carrito, { tipo: 'editarCantidad', idArticulo: 999, cantidad: 5 })
+
+    expect(resultado).toEqual(carrito)
+  })
+})
+
+describe('reducirCarrito — quitarLinea', () => {
+  it('remueve solo la línea indicada', () => {
+    const carrito = [lineaFixture({ idArticulo: 1 }), lineaFixture({ idArticulo: 2 })]
+
+    const resultado = reducirCarrito(carrito, { tipo: 'quitarLinea', idArticulo: 1 })
+
+    expect(resultado).toEqual([lineaFixture({ idArticulo: 2 })])
+  })
+
+  it('quitar un idArticulo inexistente deja el carrito sin cambios', () => {
+    const carrito = [lineaFixture()]
+
+    const resultado = reducirCarrito(carrito, { tipo: 'quitarLinea', idArticulo: 999 })
+
+    expect(resultado).toEqual(carrito)
+  })
+})
+
+describe('reducirCarrito — vaciar', () => {
+  it('deja el carrito vacío sin importar cuántas líneas tenía', () => {
+    const carrito = [lineaFixture({ idArticulo: 1 }), lineaFixture({ idArticulo: 2 })]
+
+    expect(reducirCarrito(carrito, { tipo: 'vaciar' })).toEqual([])
+  })
+
+  it('vaciar un carrito ya vacío sigue devolviendo un arreglo vacío', () => {
+    expect(reducirCarrito([], { tipo: 'vaciar' })).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/api/carrito.ts
+++ b/src/Ways.Web/src/api/carrito.ts
@@ -1,0 +1,53 @@
+/**
+ * Reducer puro del carrito del POS (stage-5-pos-ventas, Slice 6, design decisión 12): sin
+ * `useState` mutando líneas a mano dentro de `Pos.tsx` — toda mutación pasa por
+ * `reducirCarrito`, invocado desde un actualizador funcional (`react-async-state` regla 1). No
+ * conoce HTTP ni `ArticuloEscaneado`: `ventas.ts` es quien traduce la respuesta del escaneo a la
+ * forma que esta acción espera (`escanear`), manteniendo este módulo testeable sin red ni DOM.
+ */
+
+export type LineaCarrito = {
+  idArticulo: number
+  codigoInterno: string
+  nombre: string
+  codigoBarra: string | null
+  /** Con signo: positivo en una venta normal (TX); negativo cuando la línea es de una
+   * devolución (NCX, design decisión 4) — el reducer no impone el signo, solo lo preserva; la
+   * pantalla que arma el carrito de una NCX (Slice 7) es quien decide sumar con signo negativo. */
+  cantidad: number
+}
+
+export type AccionCarrito =
+  | { tipo: 'escanear'; linea: Omit<LineaCarrito, 'cantidad'>; cantidad: number }
+  | { tipo: 'editarCantidad'; idArticulo: number; cantidad: number }
+  | { tipo: 'quitarLinea'; idArticulo: number }
+  | { tipo: 'vaciar' }
+
+/**
+ * Único punto de mutación del carrito. `escanear` sobre un `idArticulo` ya presente SUMA la
+ * cantidad a la línea existente en vez de duplicarla (spec: codigos-barra / "Re-scanning sums
+ * quantity instead of duplicating the line") — el resto de las acciones no tiene ese caso
+ * especial, cada `idArticulo` es a lo sumo una línea.
+ */
+export function reducirCarrito(lineas: LineaCarrito[], accion: AccionCarrito): LineaCarrito[] {
+  switch (accion.tipo) {
+    case 'escanear': {
+      const existente = lineas.find((l) => l.idArticulo === accion.linea.idArticulo)
+      if (existente) {
+        return lineas.map((l) =>
+          l.idArticulo === accion.linea.idArticulo ? { ...l, cantidad: l.cantidad + accion.cantidad } : l,
+        )
+      }
+      return [...lineas, { ...accion.linea, cantidad: accion.cantidad }]
+    }
+
+    case 'editarCantidad':
+      return lineas.map((l) => (l.idArticulo === accion.idArticulo ? { ...l, cantidad: accion.cantidad } : l))
+
+    case 'quitarLinea':
+      return lineas.filter((l) => l.idArticulo !== accion.idArticulo)
+
+    case 'vaciar':
+      return []
+  }
+}

--- a/src/Ways.Web/src/api/ofertas.ts
+++ b/src/Ways.Web/src/api/ofertas.ts
@@ -7,7 +7,7 @@
  * descriptor literal).
  */
 import { api } from './cliente'
-import type { AltaOferta, EdicionOferta, ListaPrecioListado, OfertaListado } from './tipos'
+import type { AltaOferta, EdicionOferta, LineaDeResolucion, ListaPrecioListado, OfertaListado, ResultadoDeResolucion } from './tipos'
 
 export const clienteDeOfertas = {
   listar: (incluirEliminados: boolean) =>
@@ -18,6 +18,10 @@ export const clienteDeOfertas = {
   crear: (datos: AltaOferta) => api.post<OfertaListado>('/ofertas', datos),
   actualizar: (id: number, datos: EdicionOferta) => api.put<OfertaListado>(`/ofertas/${id}`, datos),
   eliminar: (id: number) => api.delete(`/ofertas/${id}`),
+  /** `POST /api/ofertas/resolver` (stage-4, re-gateado a `OperacionDePos` en stage-5): único
+   * camino de precio del carrito del POS (spec: operacion-de-pos / "Cart Pricing Has Exactly
+   * One Path") — no muta nada, solo reporta precio final y ofertas aplicadas por línea. */
+  resolver: (lineas: LineaDeResolucion[]) => api.post<ResultadoDeResolucion[]>('/ofertas/resolver', { lineas }),
 }
 
 export type AlcanceOferta = 'Articulo' | 'Grupo' | 'Categoria'

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -78,6 +78,13 @@ export function puedeAprovisionarTenants(rolId: number) {
   return rolId === ROL.Root
 }
 
+/** Espejo de `Politicas.OperacionDePos` (stage-5-pos-ventas, design decisión 6): vendedor,
+ * supervisor o admin pueden operar el POS — root queda afuera, mismo criterio que
+ * `puedeGestionarCatalogos` ("root administra tenants, no opera ninguno"). */
+export function puedeOperarPos(rolId: number) {
+  return rolId === ROL.Vendedor || rolId === ROL.Supervisor || rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -536,4 +543,79 @@ export type ResultadoAprovisionamiento = {
   idPuntoVenta: number
   idUsuarioAdmin: number
   passwordTemporal: string
+}
+
+// --- POS: escaneo y resolución de precios (stage-5-pos-ventas, Slice 6) ---
+// Espejo de Ways.Application.Ventas.ArticuloEscaneado y Ways.Application.Ofertas.Contratos —
+// identidad de escaneo y resolución de precios, nunca el checkout en sí (design decisión 7/10).
+
+/** Respuesta de `GET /api/articulos/escaneo` — identidad y snapshot únicamente, nunca precio ni
+ * oferta (design decisión 7: la resolución de precio queda en `POST /api/ofertas/resolver`).
+ * `codigoBarra` es `null` cuando la entrada resolvió por `codigoInterno`. */
+export type ArticuloEscaneado = {
+  idArticulo: number
+  codigoInterno: string
+  nombre: string
+  codigoBarra: string | null
+  cantidad: number
+}
+
+/** Línea de entrada de `POST /api/ofertas/resolver` (espejo de `LineaDeResolucion`, stage-4). */
+export type LineaDeResolucion = { idArticulo: number; idEmpresa: number | null; idListaPrecio: number; cantidad: number }
+
+export type OfertaAplicada = { idOferta: number; nombre: string; descuentoUnitario: number }
+
+/** `precioOriginal`/`precioFinal` son `null` cuando no hay precio vigente para el par (artículo,
+ * lista) — sin nada que descontar, `aplicadas` queda vacía (espejo de `ResultadoDeResolucion`). */
+export type ResultadoDeResolucion = {
+  idArticulo: number
+  idListaPrecio: number
+  precioOriginal: number | null
+  precioFinal: number | null
+  descuentoUnitario: number
+  aplicadas: OfertaAplicada[]
+}
+
+// --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---
+// Espejo pinneado por design.md (Checkout Contract) del futuro `SolicitudDeVenta`/comprobante
+// emitido de `POST /api/ventas` — ese endpoint vive en la Slice 4 (todavía en review, no
+// mergeada a main). Estos tipos solo sostienen los mappers puros de `ventas.ts`; ningún fetch
+// de esta slice los usa. Slice 7 debe confirmar el shape contra el DTO real antes de invocar el
+// endpoint — ver el comentario de `ComprobanteVenta`.
+
+export type LineaDeVenta = { idArticulo: number; cantidad: number; codigoBarra: string | null }
+export type PagoDeVenta = { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }
+
+export type SolicitudDeVenta = {
+  idPuntoVenta: number
+  idCliente: number
+  codigoTipoComprobante: 'TX' | 'NCX'
+  idComprobanteAsociado: number | null
+  lineas: LineaDeVenta[]
+  pagos: PagoDeVenta[]
+  direccionEntrega: string | null
+  observaciones: string | null
+}
+
+export type ItemComprobanteVenta = {
+  idArticulo: number | null
+  descripcion: string
+  codigoBarra: string | null
+  cantidad: number
+  precioUnitario: number
+  descuento: number
+  total: number
+}
+
+/** TODO(slice-7): shape inferido del Checkout Orchestration Contract + Table Shapes A de
+ * design.md — no existe todavía un DTO real de `POST /api/ventas` en main (Slice 4 en review).
+ * Confirmar/ajustar contra ese contrato definitivo antes de wirear el fetch. */
+export type ComprobanteVenta = {
+  id: number
+  numeroVisible: string
+  estado: 'emitido' | 'anulado'
+  subtotal: number
+  descuentoTotal: number
+  total: number
+  items: ItemComprobanteVenta[]
 }

--- a/src/Ways.Web/src/api/ventas.test.ts
+++ b/src/Ways.Web/src/api/ventas.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { LineaCarrito } from './carrito'
+import {
+  aLineaDeCarritoDesdeEscaneo,
+  aLineasDeResolucion,
+  aSolicitudDeVenta,
+  calcularSubtotalPrevia,
+  indexarResolucionPorArticulo,
+  previaDeLinea,
+} from './ventas'
+import type { ArticuloEscaneado, PagoDeVenta, ResultadoDeResolucion } from './tipos'
+
+function articuloEscaneadoFixture(sobrescribir: Partial<ArticuloEscaneado> = {}): ArticuloEscaneado {
+  return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 1, ...sobrescribir }
+}
+
+function lineaFixture(sobrescribir: Partial<LineaCarrito> = {}): LineaCarrito {
+  return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 2, ...sobrescribir }
+}
+
+function resultadoFixture(sobrescribir: Partial<ResultadoDeResolucion> = {}): ResultadoDeResolucion {
+  return { idArticulo: 1, idListaPrecio: 3, precioOriginal: 100, precioFinal: 90, descuentoUnitario: 10, aplicadas: [], ...sobrescribir }
+}
+
+describe('aLineaDeCarritoDesdeEscaneo', () => {
+  it('separa la cantidad parseada del resto de los datos de identidad', () => {
+    const resultado = aLineaDeCarritoDesdeEscaneo(articuloEscaneadoFixture({ cantidad: 3 }))
+
+    expect(resultado).toEqual({
+      linea: { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567' },
+      cantidad: 3,
+    })
+  })
+
+  it('preserva codigoBarra null cuando el escaneo resolvió por codigo_interno', () => {
+    const resultado = aLineaDeCarritoDesdeEscaneo(articuloEscaneadoFixture({ codigoBarra: null }))
+
+    expect(resultado.linea.codigoBarra).toBeNull()
+  })
+})
+
+describe('aLineasDeResolucion', () => {
+  it('proyecta cada línea del carrito con el idListaPrecio/idEmpresa del lote', () => {
+    const lineas = [lineaFixture({ idArticulo: 1, cantidad: 2 }), lineaFixture({ idArticulo: 2, cantidad: 5 })]
+
+    const resultado = aLineasDeResolucion(lineas, 3, 7)
+
+    expect(resultado).toEqual([
+      { idArticulo: 1, idEmpresa: 7, idListaPrecio: 3, cantidad: 2 },
+      { idArticulo: 2, idEmpresa: 7, idListaPrecio: 3, cantidad: 5 },
+    ])
+  })
+
+  it('idEmpresa null viaja tal cual (artículo disponible para todas las empresas)', () => {
+    const resultado = aLineasDeResolucion([lineaFixture()], 3, null)
+
+    expect(resultado[0].idEmpresa).toBeNull()
+  })
+
+  it('un carrito vacío produce un lote vacío', () => {
+    expect(aLineasDeResolucion([], 3, 7)).toEqual([])
+  })
+})
+
+describe('indexarResolucionPorArticulo', () => {
+  it('indexa por idArticulo para lookup O(1)', () => {
+    const resultados = [resultadoFixture({ idArticulo: 1 }), resultadoFixture({ idArticulo: 2, precioFinal: 50 })]
+
+    const indice = indexarResolucionPorArticulo(resultados)
+
+    expect(indice[1]).toEqual(resultados[0])
+    expect(indice[2].precioFinal).toBe(50)
+  })
+
+  it('un lote vacío produce un índice vacío', () => {
+    expect(indexarResolucionPorArticulo([])).toEqual({})
+  })
+})
+
+describe('previaDeLinea', () => {
+  it('sin resultado (todavía no resolvió) devuelve todo null/0', () => {
+    expect(previaDeLinea(lineaFixture(), undefined)).toEqual({ precioUnitario: null, descuentoUnitario: 0, total: null })
+  })
+
+  it('con precioFinal null (sin precio vigente) devuelve todo null/0', () => {
+    const resultado = resultadoFixture({ precioOriginal: null, precioFinal: null, descuentoUnitario: 0 })
+
+    expect(previaDeLinea(lineaFixture(), resultado)).toEqual({ precioUnitario: null, descuentoUnitario: 0, total: null })
+  })
+
+  it('el total de línea es cantidad × precioFinal (ya neto de descuento por unidad)', () => {
+    const linea = lineaFixture({ cantidad: 3 })
+    const resultado = resultadoFixture({ precioFinal: 90, descuentoUnitario: 10 })
+
+    expect(previaDeLinea(linea, resultado)).toEqual({ precioUnitario: 90, descuentoUnitario: 10, total: 270 })
+  })
+})
+
+describe('calcularSubtotalPrevia', () => {
+  it('null mientras no hay ningún precio resuelto (primera carga)', () => {
+    expect(calcularSubtotalPrevia([lineaFixture()], {})).toBeNull()
+  })
+
+  it('suma el total previsualizado de cada línea resuelta', () => {
+    const lineas = [lineaFixture({ idArticulo: 1, cantidad: 2 }), lineaFixture({ idArticulo: 2, cantidad: 1 })]
+    const precios = {
+      1: resultadoFixture({ idArticulo: 1, precioFinal: 90 }),
+      2: resultadoFixture({ idArticulo: 2, precioFinal: 50 }),
+    }
+
+    expect(calcularSubtotalPrevia(lineas, precios)).toBe(230)
+  })
+
+  it('una línea sin precio propio dentro de un lote parcial contribuye 0, no rompe la suma', () => {
+    const lineas = [lineaFixture({ idArticulo: 1, cantidad: 2 }), lineaFixture({ idArticulo: 2, cantidad: 1 })]
+    const precios = { 1: resultadoFixture({ idArticulo: 1, precioFinal: 90 }) }
+
+    expect(calcularSubtotalPrevia(lineas, precios)).toBe(180)
+  })
+})
+
+describe('aSolicitudDeVenta', () => {
+  it('mapea el carrito confirmado sin ningún campo de dinero por línea (design decisión 3)', () => {
+    const lineas = [lineaFixture({ idArticulo: 1, cantidad: 2, codigoBarra: '7790001234567' })]
+    const pagos: PagoDeVenta[] = [{ idMedioPago: 1, importe: 180, referencia: null, vuelto: 0 }]
+
+    const resultado = aSolicitudDeVenta({
+      idPuntoVenta: 7,
+      idCliente: 1,
+      codigoTipoComprobante: 'TX',
+      idComprobanteAsociado: null,
+      lineas,
+      pagos,
+      direccionEntrega: null,
+      observaciones: null,
+    })
+
+    expect(resultado).toEqual({
+      idPuntoVenta: 7,
+      idCliente: 1,
+      codigoTipoComprobante: 'TX',
+      idComprobanteAsociado: null,
+      lineas: [{ idArticulo: 1, cantidad: 2, codigoBarra: '7790001234567' }],
+      pagos,
+      direccionEntrega: null,
+      observaciones: null,
+    })
+    expect(resultado.lineas[0]).not.toHaveProperty('precioUnitario')
+  })
+
+  it('NCX lleva idComprobanteAsociado cuando referencia un TX original', () => {
+    const resultado = aSolicitudDeVenta({
+      idPuntoVenta: 7,
+      idCliente: 1,
+      codigoTipoComprobante: 'NCX',
+      idComprobanteAsociado: 42,
+      lineas: [lineaFixture({ cantidad: -2 })],
+      pagos: [],
+      direccionEntrega: null,
+      observaciones: null,
+    })
+
+    expect(resultado.codigoTipoComprobante).toBe('NCX')
+    expect(resultado.idComprobanteAsociado).toBe(42)
+    expect(resultado.lineas[0].cantidad).toBe(-2)
+  })
+})

--- a/src/Ways.Web/src/api/ventas.ts
+++ b/src/Ways.Web/src/api/ventas.ts
@@ -1,0 +1,115 @@
+/**
+ * Mappers puros del POS (stage-5-pos-ventas, Slice 6, task 6.2): traducen entre la forma HTTP
+ * (`ArticuloEscaneado`, `ResultadoDeResolucion`) y la forma del carrito (`LineaCarrito`), sin
+ * que `carrito.ts` ni `Pos.tsx` necesiten conocer el shape crudo de cada respuesta. Los mappers
+ * de checkout (`aSolicitudDeVenta`) son forward-looking: el `POST /api/ventas` real lo wirea la
+ * Slice 7 (Slice 4 — el endpoint — sigue en review), acá solo vive la forma pura y testeada.
+ */
+import type { LineaCarrito } from './carrito'
+import type {
+  ArticuloEscaneado,
+  LineaDeResolucion,
+  LineaDeVenta,
+  PagoDeVenta,
+  ResultadoDeResolucion,
+  SolicitudDeVenta,
+} from './tipos'
+
+/** Respuesta de `GET /api/articulos/escaneo` → acción `escanear` de `carrito.ts` (spec:
+ * codigos-barra / Scan Resolution Rule) — separa la cantidad parseada por el servidor
+ * (`N*codigo`) de los datos de identidad de la línea, tal como espera `AccionCarrito`. */
+export function aLineaDeCarritoDesdeEscaneo(
+  articulo: ArticuloEscaneado,
+): { linea: Omit<LineaCarrito, 'cantidad'>; cantidad: number } {
+  return {
+    linea: {
+      idArticulo: articulo.idArticulo,
+      codigoInterno: articulo.codigoInterno,
+      nombre: articulo.nombre,
+      codigoBarra: articulo.codigoBarra,
+    },
+    cantidad: articulo.cantidad,
+  }
+}
+
+/** Carrito → lote de `POST /api/ofertas/resolver` (spec: operacion-de-pos / "Cart Pricing Has
+ * Exactly One Path"): un `idEmpresa`/`idListaPrecio` fijo para todo el lote — la resolución de
+ * precio no varía línea a línea por esos dos campos, solo por `idArticulo`/`cantidad`. */
+export function aLineasDeResolucion(
+  lineas: LineaCarrito[],
+  idListaPrecio: number,
+  idEmpresa: number | null,
+): LineaDeResolucion[] {
+  return lineas.map((l) => ({ idArticulo: l.idArticulo, idEmpresa, idListaPrecio, cantidad: l.cantidad }))
+}
+
+/** Indexa el resultado del lote por `idArticulo` para lookup O(1) por línea al renderizar la
+ * tabla del carrito — el servidor no garantiza el mismo orden que el request. */
+export function indexarResolucionPorArticulo(resultados: ResultadoDeResolucion[]): Record<number, ResultadoDeResolucion> {
+  const indice: Record<number, ResultadoDeResolucion> = {}
+  for (const r of resultados) indice[r.idArticulo] = r
+  return indice
+}
+
+/** Previsualización de una línea: `precioFinal` ya viene neto de descuento por unidad
+ * (`ServicioDeOfertas.ResolverAsync`), así que el total de línea es `cantidad × precioFinal` —
+ * nunca autoritativo (design decisión 3: el servidor vuelve a resolver en el checkout). */
+export function previaDeLinea(
+  linea: LineaCarrito,
+  resultado: ResultadoDeResolucion | undefined,
+): { precioUnitario: number | null; descuentoUnitario: number; total: number | null } {
+  if (!resultado || resultado.precioFinal === null) {
+    return { precioUnitario: null, descuentoUnitario: 0, total: null }
+  }
+  return {
+    precioUnitario: resultado.precioFinal,
+    descuentoUnitario: resultado.descuentoUnitario,
+    total: linea.cantidad * resultado.precioFinal,
+  }
+}
+
+/** Subtotal previsualizado del carrito completo — `null` mientras no haya ningún precio
+ * resuelto todavía (primera carga, o el lote de `/resolver` falló); una línea sin precio propio
+ * dentro de un carrito parcialmente resuelto contribuye 0 y no rompe la suma. */
+export function calcularSubtotalPrevia(lineas: LineaCarrito[], precios: Record<number, ResultadoDeResolucion>): number | null {
+  if (Object.keys(precios).length === 0) return null
+  return lineas.reduce((acumulado, l) => {
+    const previa = previaDeLinea(l, precios[l.idArticulo])
+    return acumulado + (previa.total ?? 0)
+  }, 0)
+}
+
+/**
+ * Carrito confirmado → `SolicitudDeVenta` (design: Checkout Contract) — TODO(slice-7): ningún
+ * fetch de esta slice invoca este mapper todavía (`POST /api/ventas` es Slice 4, en review); se
+ * agrega ahora, probado, para que Slice 7 solo tenga que confirmar el contrato real y wirear el
+ * `fetch`, no diseñar el mapping desde cero. Sin precios en `LineaDeVenta` a propósito (design
+ * decisión 3: "no precioUnitario, no descuento, no total en el request").
+ */
+export function aSolicitudDeVenta(params: {
+  idPuntoVenta: number
+  idCliente: number
+  codigoTipoComprobante: 'TX' | 'NCX'
+  idComprobanteAsociado: number | null
+  lineas: LineaCarrito[]
+  pagos: PagoDeVenta[]
+  direccionEntrega: string | null
+  observaciones: string | null
+}): SolicitudDeVenta {
+  const lineasDeVenta: LineaDeVenta[] = params.lineas.map((l) => ({
+    idArticulo: l.idArticulo,
+    cantidad: l.cantidad,
+    codigoBarra: l.codigoBarra,
+  }))
+
+  return {
+    idPuntoVenta: params.idPuntoVenta,
+    idCliente: params.idCliente,
+    codigoTipoComprobante: params.codigoTipoComprobante,
+    idComprobanteAsociado: params.idComprobanteAsociado,
+    lineas: lineasDeVenta,
+    pagos: params.pagos,
+    direccionEntrega: params.direccionEntrega,
+    observaciones: params.observaciones,
+  }
+}

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Outlet, useNavigate } from 'react-router'
 import { useAuth } from '../auth/useAuth'
 import { DESCRIPTORES_DE_CATALOGO } from '../api/catalogos'
-import { ROL, puedeAprovisionarTenants, puedeGestionarCatalogos, puedeGestionarUsuarios } from '../api/tipos'
+import { ROL, puedeAprovisionarTenants, puedeGestionarCatalogos, puedeGestionarUsuarios, puedeOperarPos } from '../api/tipos'
 
 export function Layout() {
   const { usuario, cerrarSesion } = useAuth()
@@ -32,6 +32,13 @@ export function Layout() {
                     Inicio
                   </NavLink>
                 </li>
+                {usuario && puedeOperarPos(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/pos">
+                      POS
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Pos } from './Pos'
@@ -71,6 +71,20 @@ function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteList
 
 function articuloEscaneadoFixture(sobrescribir: Partial<ArticuloEscaneado> = {}): ArticuloEscaneado {
   return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 1, ...sobrescribir }
+}
+
+/**
+ * jsdom sanea el `value` de un `<input type="number">` a `""` apenas se le asigna un número
+ * incompleto (ej. "1."), a diferencia de un navegador real que preserva el texto tipeado
+ * mientras el usuario sigue escribiendo. Este helper sobrescribe la propiedad `value` de la
+ * instancia (que blindea al getter del prototipo) antes de disparar el evento, para poder
+ * reproducir en el test el mismo estado intermedio que ve un navegador real.
+ */
+function escribirValorCrudo(input: HTMLInputElement, valor: string) {
+  Object.defineProperty(input, 'value', { value: valor, configurable: true })
+  act(() => {
+    input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+  })
 }
 
 const consumidorFinal = clienteFixture()
@@ -350,5 +364,213 @@ describe('Pos — checkout stubbed', () => {
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     expect(screen.getByRole('button', { name: /Cobrar/ })).toBeDisabled()
+  })
+})
+
+describe('Pos — badge de ofertas apiladas', () => {
+  it('con dos ofertas aplicadas muestra el primer nombre y un contador de las restantes', async () => {
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ofertas/resolver') {
+        const resultados: ResultadoDeResolucion[] = [
+          {
+            idArticulo: 1,
+            idListaPrecio: 1,
+            precioOriginal: 150,
+            precioFinal: 100,
+            descuentoUnitario: 50,
+            aplicadas: [
+              { idOferta: 9, nombre: '2x1 Gaseosas', descuentoUnitario: 30 },
+              { idOferta: 10, nombre: 'Descuento Efectivo', descuentoUnitario: 20 },
+            ],
+          },
+        ]
+        return Promise.resolve(resultados)
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+
+    const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
+    const badge = await within(fila).findByText('2x1 Gaseosas +1')
+    expect(badge).toHaveAttribute('title', '2x1 Gaseosas, Descuento Efectivo')
+  })
+})
+
+describe('Pos — edición de cantidad', () => {
+  async function agregarLineaCocaCola() {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+    return screen.getByLabelText('Cantidad de Coca Cola 1L') as HTMLInputElement
+  }
+
+  it('tipear "1." conserva el punto decimal visible y no dispara ninguna mutación de cantidad', async () => {
+    const input = await agregarLineaCocaCola()
+    const llamadasPrevias = apiPostMock.mock.calls.length
+
+    escribirValorCrudo(input, '1.')
+
+    expect(input.value).toBe('1.')
+    expect(apiPostMock.mock.calls.length).toBe(llamadasPrevias)
+  })
+
+  it('poner la cantidad en "0" y perder el foco hace que el input vuelva a mostrar la cantidad confirmada', async () => {
+    const input = await agregarLineaCocaCola()
+
+    fireEvent.change(input, { target: { value: '0' } })
+    expect(input.value).toBe('0')
+
+    fireEvent.blur(input)
+
+    expect(input.value).toBe('1')
+  })
+
+  it('el guard de cantidad mínima rechaza valores por debajo de 0.001, el mismo piso declarado en min/step', async () => {
+    const input = await agregarLineaCocaCola()
+    expect(input).toHaveAttribute('min', '0.001')
+    expect(input).toHaveAttribute('step', '0.001')
+
+    fireEvent.change(input, { target: { value: '0.0001' } })
+    expect(input.value).toBe('0.0001')
+
+    fireEvent.blur(input)
+
+    expect(input.value).toBe('1')
+  })
+})
+
+describe('Pos — debounce de la resolución de precios', () => {
+  it('una edición debounce ~250ms y una segunda edición dentro de la ventana reemplaza a la primera; un escaneo resuelve sin demora', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(1))
+
+    vi.useFakeTimers()
+    try {
+      const input = screen.getByLabelText('Cantidad de Coca Cola 1L')
+
+      fireEvent.change(input, { target: { value: '2' } })
+      await vi.advanceTimersByTimeAsync(100)
+      expect(apiPostMock).toHaveBeenCalledTimes(1)
+
+      fireEvent.change(input, { target: { value: '3' } })
+      await vi.advanceTimersByTimeAsync(200)
+      expect(apiPostMock).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(100)
+      expect(apiPostMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('un cambio de cliente inmediatamente después de una edición de cantidad no hereda la demora de esa edición', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(1))
+
+    await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+    await screen.findByRole('option', { name: /Juan Pérez/ })
+
+    vi.useFakeTimers()
+    try {
+      const input = screen.getByLabelText('Cantidad de Coca Cola 1L')
+      fireEvent.change(input, { target: { value: '2' } })
+
+      fireEvent.change(screen.getByLabelText('Cliente'), { target: { value: String(otroCliente.id) } })
+      await vi.advanceTimersByTimeAsync(50)
+
+      expect(apiPostMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('Pos — limpieza de ediciones en curso', () => {
+  it('quitar una línea con una edición pendiente no deja un override fantasma para un artículo agregado de nuevo', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    const input = screen.getByLabelText('Cantidad de Coca Cola 1L') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '0.0001' } })
+    expect(input.value).toBe('0.0001')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quitar' }))
+    expect(screen.getByText('Escaneá o tipeá un código para empezar la venta.')).toBeInTheDocument()
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(1)
+  })
+
+  it('vaciar el carrito con una edición pendiente no deja overrides fantasma para las líneas siguientes', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    const input = screen.getByLabelText('Cantidad de Coca Cola 1L') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '0.0001' } })
+    expect(input.value).toBe('0.0001')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Vaciar carrito' }))
+    expect(screen.getByText('Escaneá o tipeá un código para empezar la venta.')).toBeInTheDocument()
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(1)
+  })
+
+  it('un escaneo que suma sobre una línea existente descarta el override de edición pendiente de esa fila', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    const input = screen.getByLabelText('Cantidad de Coca Cola 1L') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '0.0001' } })
+    expect(input.value).toBe('0.0001')
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+
+    await waitFor(() => expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(2))
   })
 })

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Pos } from './Pos'
@@ -198,6 +198,149 @@ describe('Pos — selector de cliente', () => {
     await userEvent.selectOptions(screen.getByLabelText('Cliente'), opcionJuan)
 
     expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id))
+  })
+})
+
+describe('Pos — regresión: carga inicial de clientes vs. selección del usuario', () => {
+  it('una respuesta tardía del fetch de montaje no pisa una selección hecha durante una búsqueda posterior', async () => {
+    let resolverMontaje: (pagina: PaginaDe<ClienteListado>) => void = () => {}
+    const montajePendiente = new Promise<PaginaDe<ClienteListado>>((resolve) => {
+      resolverMontaje = resolve
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta === '/clientes') return montajePendiente
+      if (ruta.startsWith('/clientes?busqueda=')) {
+        const pagina: PaginaDe<ClienteListado> = { items: [otroCliente], total: 1, pagina: 1, tamanio: 25 }
+        return Promise.resolve(pagina)
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+
+    await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    const opcionJuan = await screen.findByRole('option', { name: /Juan Pérez/ })
+    await userEvent.selectOptions(screen.getByLabelText('Cliente'), opcionJuan)
+    expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id))
+
+    await act(async () => {
+      resolverMontaje({ items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id))
+  })
+})
+
+describe('Pos — vista previa de precios', () => {
+  it('una resolución exitosa muestra el precio unitario, el original tachado, el total de línea y el subtotal previo', async () => {
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ofertas/resolver') {
+        const resultados: ResultadoDeResolucion[] = [
+          {
+            idArticulo: 1,
+            idListaPrecio: 1,
+            precioOriginal: 120,
+            precioFinal: 100,
+            descuentoUnitario: 20,
+            aplicadas: [{ idOferta: 9, nombre: '2x1 Gaseosas', descuentoUnitario: 20 }],
+          },
+        ]
+        return Promise.resolve(resultados)
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await waitFor(() => expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(2))
+
+    const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
+    await waitFor(() => expect(within(fila).getByText('$120,00')).toBeInTheDocument())
+    expect(within(fila).getByText('$100,00')).toBeInTheDocument()
+    expect(within(fila).getByText('$200,00')).toBeInTheDocument()
+    expect(within(fila).getByText('2x1 Gaseosas')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getByText('$200,00', { selector: 'strong' })).toBeInTheDocument())
+  })
+
+  it('una resolución rechazada muestra el aviso no bloqueante y el carrito sigue usable', async () => {
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ofertas/resolver') return Promise.reject(new Error('falló la resolución'))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+
+    expect(
+      await screen.findByText('No se pudo calcular la vista previa de precios. El total se confirma recién al cobrar.'),
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quitar' }))
+    expect(screen.getByText('Escaneá o tipeá un código para empezar la venta.')).toBeInTheDocument()
+  })
+
+  it('regresión: una respuesta desactualizada del resolver no pisa una más reciente (fuera de orden)', async () => {
+    let resolverPrimera: (resultados: ResultadoDeResolucion[]) => void = () => {}
+    const primeraPendiente = new Promise<ResultadoDeResolucion[]>((resolve) => {
+      resolverPrimera = resolve
+    })
+
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/ofertas/resolver') return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+      if (apiPostMock.mock.calls.filter((llamada) => llamada[0] === '/ofertas/resolver').length === 1) {
+        return primeraPendiente
+      }
+      const resultados: ResultadoDeResolucion[] = [
+        { idArticulo: 1, idListaPrecio: 1, precioOriginal: 90, precioFinal: 90, descuentoUnitario: 0, aplicadas: [] },
+      ]
+      return Promise.resolve(resultados)
+    })
+
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(1))
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await waitFor(() => expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(2))
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(2))
+
+    const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
+    await waitFor(() => expect(within(fila).getByText('$90,00')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverPrimera([{ idArticulo: 1, idListaPrecio: 1, precioOriginal: 100, precioFinal: 100, descuentoUnitario: 0, aplicadas: [] }])
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(within(fila).getByText('$90,00')).toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Pos } from './Pos'
+import { ErrorApi } from '../api/cliente'
+import type { ArticuloEscaneado, ClienteListado, PaginaDe, PuntoVentaListado, ResultadoDeResolucion } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 1,
+    numero: 1,
+    nombre: 'Consumidor Final',
+    apellido: null,
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: true,
+    ...sobrescribir,
+  }
+}
+
+function articuloEscaneadoFixture(sobrescribir: Partial<ArticuloEscaneado> = {}): ArticuloEscaneado {
+  return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 1, ...sobrescribir }
+}
+
+const consumidorFinal = clienteFixture()
+const otroCliente = clienteFixture({ id: 2, numero: 2, nombre: 'Juan', apellido: 'Pérez', esConsumidorFinal: false })
+const puntoVentaCentro = puntoVentaFixture()
+
+function mockearApiGet() {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+    if (ruta === '/clientes') {
+      const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
+      return Promise.resolve(pagina)
+    }
+    if (ruta.startsWith('/clientes?busqueda=')) {
+      const pagina: PaginaDe<ClienteListado> = { items: [otroCliente], total: 1, pagina: 1, tamanio: 25 }
+      return Promise.resolve(pagina)
+    }
+    if (ruta.startsWith('/articulos/escaneo?entrada=')) {
+      return Promise.resolve(articuloEscaneadoFixture())
+    }
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  mockearApiGet()
+  apiPostMock.mockImplementation((ruta: string) => {
+    if (ruta === '/ofertas/resolver') {
+      const resultados: ResultadoDeResolucion[] = [
+        { idArticulo: 1, idListaPrecio: 1, precioOriginal: 100, precioFinal: 100, descuentoUnitario: 0, aplicadas: [] },
+      ]
+      return Promise.resolve(resultados)
+    }
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+})
+
+describe('Pos — carga inicial', () => {
+  it('selecciona el Consumidor Final por defecto y el único punto de venta disponible', async () => {
+    render(<Pos />)
+
+    expect(await screen.findByRole('option', { name: /Consumidor Final/ })).toBeInTheDocument()
+    expect(screen.getByLabelText('Cliente')).toHaveValue(String(consumidorFinal.id))
+    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(puntoVentaCentro.id)))
+  })
+})
+
+describe('Pos — escaneo', () => {
+  it('escanear un código agrega una línea al carrito', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    expect(await screen.findByText('Coca Cola 1L')).toBeInTheDocument()
+    expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(1)
+  })
+
+  it('re-escanear el mismo código suma la cantidad en la misma línea, no duplica', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    const boton = screen.getByRole('button', { name: 'Agregar' })
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+    await screen.findByText('Coca Cola 1L')
+
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(boton)
+
+    await waitFor(() => expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(2))
+    expect(screen.getAllByText('Coca Cola 1L')).toHaveLength(1)
+  })
+
+  it('el input de escaneo se limpia después de un escaneo exitoso', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    await screen.findByText('Coca Cola 1L')
+    expect(entrada).toHaveValue('')
+  })
+
+  it('un código no encontrado muestra un error y no agrega ninguna línea', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta === '/clientes') {
+        const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
+        return Promise.resolve(pagina)
+      }
+      if (ruta.startsWith('/articulos/escaneo?entrada=')) {
+        return Promise.reject(new ErrorApi(404, 'no_encontrado', 'No se encontró un artículo activo para el código 999.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '999')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    expect(await screen.findByText('No se encontró un artículo activo para el código 999.')).toBeInTheDocument()
+    expect(screen.getByText('Escaneá o tipeá un código para empezar la venta.')).toBeInTheDocument()
+  })
+})
+
+describe('Pos — selector de cliente', () => {
+  it('buscar y elegir otro cliente lo deja seleccionado', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
+    await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    const opcionJuan = await screen.findByRole('option', { name: /Juan Pérez/ })
+    await userEvent.selectOptions(screen.getByLabelText('Cliente'), opcionJuan)
+
+    expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id))
+  })
+})
+
+describe('Pos — checkout stubbed', () => {
+  it('el botón Cobrar está deshabilitado (checkout se completa en la próxima entrega)', async () => {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    expect(screen.getByRole('button', { name: /Cobrar/ })).toBeDisabled()
+  })
+})

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -411,14 +411,24 @@ describe('Pos — edición de cantidad', () => {
     return screen.getByLabelText('Cantidad de Coca Cola 1L') as HTMLInputElement
   }
 
-  it('tipear "1." conserva el punto decimal visible y no dispara ninguna mutación de cantidad', async () => {
+  it('tipear "1." sobre una línea con cantidad 1 conserva el punto decimal visible y no dispara una resolución redundante (mismo valor comprometido), pero completar a "1.5" sí dispara una resolución', async () => {
     const input = await agregarLineaCocaCola()
-    const llamadasPrevias = apiPostMock.mock.calls.length
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(1))
 
-    escribirValorCrudo(input, '1.')
+    vi.useFakeTimers()
+    try {
+      escribirValorCrudo(input, '1.')
+      expect(input.value).toBe('1.')
+      await vi.advanceTimersByTimeAsync(300)
+      expect(apiPostMock).toHaveBeenCalledTimes(1)
+      expect(input.value).toBe('1.')
 
-    expect(input.value).toBe('1.')
-    expect(apiPostMock.mock.calls.length).toBe(llamadasPrevias)
+      escribirValorCrudo(input, '1.5')
+      await vi.advanceTimersByTimeAsync(300)
+      expect(apiPostMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('poner la cantidad en "0" y perder el foco hace que el input vuelva a mostrar la cantidad confirmada', async () => {
@@ -499,6 +509,46 @@ describe('Pos — debounce de la resolución de precios', () => {
       await vi.advanceTimersByTimeAsync(50)
 
       expect(apiPostMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('una edición hecha mientras el cliente todavía carga no queda pendiente: cuando el cliente carga, la corrida no relacionada resuelve sin heredar la demora de esa edición', async () => {
+    let resolverClientes: (pagina: PaginaDe<ClienteListado>) => void = () => {}
+    const clientesPendientes = new Promise<PaginaDe<ClienteListado>>((resolve) => {
+      resolverClientes = resolve
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta === '/clientes') return clientesPendientes
+      if (ruta.startsWith('/articulos/escaneo?entrada=')) return Promise.resolve(articuloEscaneadoFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Pos />)
+
+    const entrada = screen.getByLabelText('Código escaneado')
+    await userEvent.type(entrada, '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+    expect(apiPostMock).not.toHaveBeenCalled()
+
+    vi.useFakeTimers()
+    try {
+      const input = screen.getByLabelText('Cantidad de Coca Cola 1L')
+      fireEvent.change(input, { target: { value: '2' } })
+      expect(apiPostMock).not.toHaveBeenCalled()
+
+      await act(async () => {
+        resolverClientes({ items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 })
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await vi.advanceTimersByTimeAsync(50)
+      expect(apiPostMock).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -11,6 +11,11 @@ import { Box } from '../componentes/Box'
 
 const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
 
+/** Piso de cantidad por línea, compartido entre el guard de edición y los atributos
+ * `min`/`step` del input — evita que ambos se desincronicen (ej. el guard aceptando
+ * cantidades que el input ya no permite tipear). */
+const CANTIDAD_MINIMA = 0.001
+
 function leerPuntoVentaGuardado(): number | null {
   try {
     const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
@@ -139,8 +144,11 @@ export function Pos() {
     setAvisoPrecios('')
 
     // Una edición de cantidad se debounce (el usuario suele seguir tipeando); un escaneo
-    // dispara la resolución de inmediato, es una única mutación discreta.
+    // dispara la resolución de inmediato, es una única mutación discreta. La bandera se
+    // consume acá mismo: un cambio de cliente/punto de venta disparado justo después de una
+    // edición no debe heredar la demora de esa edición anterior.
     const demora = ultimaAccionEsEdicionRef.current ? 250 : 0
+    ultimaAccionEsEdicionRef.current = false
     const idTimeout = setTimeout(() => {
       clienteDeOfertas
         .resolver(aLineasDeResolucion(lineas, clienteSeleccionado.idListaPrecio, puntoVentaSeleccionada.idEmpresa))
@@ -167,6 +175,29 @@ export function Pos() {
   const mutarCarrito = useCallback((accion: AccionCarrito) => {
     ultimaAccionEsEdicionRef.current = accion.tipo === 'editarCantidad'
     setLineas((prev) => reducirCarrito(prev, accion))
+
+    // El mapa de ediciones en curso es un override por fila: si la fila desaparece (quitar,
+    // vaciar) o su cantidad se recalcula por fuera de la edición manual (un escaneo que suma
+    // sobre la línea existente), el override queda desactualizado y debe limpiarse acá mismo
+    // — no puede depender de que el blur del input dispare antes que la próxima mutación.
+    const limpiarFila = (idArticulo: number) =>
+      setCantidadesEnEdicion((prev) => {
+        if (!(idArticulo in prev)) return prev
+        const { [idArticulo]: _omitido, ...resto } = prev
+        return resto
+      })
+
+    switch (accion.tipo) {
+      case 'quitarLinea':
+        limpiarFila(accion.idArticulo)
+        break
+      case 'escanear':
+        limpiarFila(accion.linea.idArticulo)
+        break
+      case 'vaciar':
+        setCantidadesEnEdicion({})
+        break
+    }
   }, [])
 
   /** Texto crudo del input de cantidad de una línea: mientras el usuario está editando (input
@@ -180,7 +211,7 @@ export function Pos() {
   function cambiarCantidad(idArticulo: number, texto: string) {
     setCantidadesEnEdicion((prev) => ({ ...prev, [idArticulo]: texto }))
     const cantidad = Number(texto)
-    if (texto.trim() !== '' && Number.isFinite(cantidad) && cantidad > 0) {
+    if (texto.trim() !== '' && Number.isFinite(cantidad) && cantidad >= CANTIDAD_MINIMA) {
       mutarCarrito({ tipo: 'editarCantidad', idArticulo, cantidad })
     }
   }
@@ -288,8 +319,8 @@ export function Pos() {
                         <td>
                           <input
                             type="number"
-                            step="0.001"
-                            min="0.001"
+                            step={CANTIDAD_MINIMA}
+                            min={CANTIDAD_MINIMA}
                             className="form-control form-control-sm rounded-0"
                             aria-label={`Cantidad de ${l.nombre}`}
                             value={textoCantidad(l)}
@@ -314,7 +345,9 @@ export function Pos() {
                                     className="badge bg-success ms-1"
                                     title={resultado.aplicadas.map((a) => a.nombre).join(', ')}
                                   >
-                                    {resultado.aplicadas[0].nombre}
+                                    {resultado.aplicadas.length === 1
+                                      ? resultado.aplicadas[0].nombre
+                                      : `${resultado.aplicadas[0].nombre} +${resultado.aplicadas.length - 1}`}
                                   </span>
                                 )}
                               </div>

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -133,6 +133,15 @@ export function Pos() {
   useEffect(() => {
     const generacion = (generacionResolucionRef.current += 1)
 
+    // Una edición de cantidad se debounce (el usuario suele seguir tipeando); un escaneo
+    // dispara la resolución de inmediato, es una única mutación discreta. La bandera se
+    // consume acá mismo, ANTES del guard de precondiciones, para que se resetee en cada
+    // corrida del efecto sin importar si esta corrida llega a resolver o no — así una edición
+    // hecha mientras cliente/punto de venta todavía cargan no queda pendiente y termina
+    // heredada por una corrida posterior no relacionada.
+    const demora = ultimaAccionEsEdicionRef.current ? 250 : 0
+    ultimaAccionEsEdicionRef.current = false
+
     if (lineas.length === 0 || !clienteSeleccionado || !puntoVentaSeleccionada) {
       setPrecios({})
       setAvisoPrecios('')
@@ -143,12 +152,6 @@ export function Pos() {
     setResolviendo(true)
     setAvisoPrecios('')
 
-    // Una edición de cantidad se debounce (el usuario suele seguir tipeando); un escaneo
-    // dispara la resolución de inmediato, es una única mutación discreta. La bandera se
-    // consume acá mismo: un cambio de cliente/punto de venta disparado justo después de una
-    // edición no debe heredar la demora de esa edición anterior.
-    const demora = ultimaAccionEsEdicionRef.current ? 250 : 0
-    ultimaAccionEsEdicionRef.current = false
     const idTimeout = setTimeout(() => {
       clienteDeOfertas
         .resolver(aLineasDeResolucion(lineas, clienteSeleccionado.idListaPrecio, puntoVentaSeleccionada.idEmpresa))
@@ -197,6 +200,12 @@ export function Pos() {
       case 'vaciar':
         setCantidadesEnEdicion({})
         break
+      case 'editarCantidad':
+        break
+      default: {
+        const _exhaustivo: never = accion
+        void _exhaustivo
+      }
     }
   }, [])
 
@@ -211,9 +220,16 @@ export function Pos() {
   function cambiarCantidad(idArticulo: number, texto: string) {
     setCantidadesEnEdicion((prev) => ({ ...prev, [idArticulo]: texto }))
     const cantidad = Number(texto)
-    if (texto.trim() !== '' && Number.isFinite(cantidad) && cantidad >= CANTIDAD_MINIMA) {
-      mutarCarrito({ tipo: 'editarCantidad', idArticulo, cantidad })
-    }
+    if (texto.trim() === '' || !Number.isFinite(cantidad) || cantidad < CANTIDAD_MINIMA) return
+
+    // Un estado intermedio del input (ej. "1." tipeando hacia "1.5") puede parsear al mismo
+    // valor ya comprometido en la línea (Number("1.") === 1) — despachar en ese caso dispara
+    // una resolución de precios redundante. Solo se despacha cuando el valor parseado difiere
+    // de la cantidad comprometida.
+    const lineaActual = lineas.find((l) => l.idArticulo === idArticulo)
+    if (lineaActual && lineaActual.cantidad === cantidad) return
+
+    mutarCarrito({ tipo: 'editarCantidad', idArticulo, cantidad })
   }
 
   function confirmarCantidad(idArticulo: number) {

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -67,6 +67,8 @@ export function Pos() {
   const [resolviendo, setResolviendo] = useState(false)
   const [avisoPrecios, setAvisoPrecios] = useState('')
   const generacionResolucionRef = useRef(0)
+  const ultimaAccionEsEdicionRef = useRef(false)
+  const [cantidadesEnEdicion, setCantidadesEnEdicion] = useState<Record<number, string>>({})
 
   const [entradaEscaneo, setEntradaEscaneo] = useState('')
   const [escaneando, setEscaneando] = useState(false)
@@ -99,16 +101,18 @@ export function Pos() {
         )
       })
 
+    const generacionClientes = (generacionClientesRef.current += 1)
+
     clienteDeClientes
       .listar('', false)
       .then((pagina) => {
-        if (!vigente) return
+        if (!vigente || generacionClientesRef.current !== generacionClientes) return
         setOpcionesClientes(pagina.items)
         const consumidorFinal = pagina.items.find((c) => c.esConsumidorFinal) ?? null
         setClienteSeleccionado(consumidorFinal)
       })
       .catch((e) => {
-        if (!vigente) return
+        if (!vigente || generacionClientesRef.current !== generacionClientes) return
         setErrorClientes(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.')
       })
 
@@ -134,29 +138,59 @@ export function Pos() {
     setResolviendo(true)
     setAvisoPrecios('')
 
-    clienteDeOfertas
-      .resolver(aLineasDeResolucion(lineas, clienteSeleccionado.idListaPrecio, puntoVentaSeleccionada.idEmpresa))
-      .then((resultados) => {
-        if (!vigente || generacionResolucionRef.current !== generacion) return
-        setPrecios(indexarResolucionPorArticulo(resultados))
-      })
-      .catch(() => {
-        if (!vigente || generacionResolucionRef.current !== generacion) return
-        setAvisoPrecios('No se pudo calcular la vista previa de precios. El total se confirma recién al cobrar.')
-      })
-      .finally(() => {
-        if (!vigente || generacionResolucionRef.current !== generacion) return
-        setResolviendo(false)
-      })
+    // Una edición de cantidad se debounce (el usuario suele seguir tipeando); un escaneo
+    // dispara la resolución de inmediato, es una única mutación discreta.
+    const demora = ultimaAccionEsEdicionRef.current ? 250 : 0
+    const idTimeout = setTimeout(() => {
+      clienteDeOfertas
+        .resolver(aLineasDeResolucion(lineas, clienteSeleccionado.idListaPrecio, puntoVentaSeleccionada.idEmpresa))
+        .then((resultados) => {
+          if (!vigente || generacionResolucionRef.current !== generacion) return
+          setPrecios(indexarResolucionPorArticulo(resultados))
+        })
+        .catch(() => {
+          if (!vigente || generacionResolucionRef.current !== generacion) return
+          setAvisoPrecios('No se pudo calcular la vista previa de precios. El total se confirma recién al cobrar.')
+        })
+        .finally(() => {
+          if (!vigente || generacionResolucionRef.current !== generacion) return
+          setResolviendo(false)
+        })
+    }, demora)
 
     return () => {
       vigente = false
+      clearTimeout(idTimeout)
     }
   }, [lineas, clienteSeleccionado, puntoVentaSeleccionada])
 
   const mutarCarrito = useCallback((accion: AccionCarrito) => {
+    ultimaAccionEsEdicionRef.current = accion.tipo === 'editarCantidad'
     setLineas((prev) => reducirCarrito(prev, accion))
   }, [])
+
+  /** Texto crudo del input de cantidad de una línea: mientras el usuario está editando (input
+   * en `cantidadesEnEdicion`) se muestra tal cual se tipeó, incluso si todavía no es un número
+   * completo (ej. "1." antes del dígito decimal) — spec: no perder el punto decimal a mitad de
+   * tipeo. */
+  function textoCantidad(l: LineaCarrito): string {
+    return cantidadesEnEdicion[l.idArticulo] ?? String(l.cantidad)
+  }
+
+  function cambiarCantidad(idArticulo: number, texto: string) {
+    setCantidadesEnEdicion((prev) => ({ ...prev, [idArticulo]: texto }))
+    const cantidad = Number(texto)
+    if (texto.trim() !== '' && Number.isFinite(cantidad) && cantidad > 0) {
+      mutarCarrito({ tipo: 'editarCantidad', idArticulo, cantidad })
+    }
+  }
+
+  function confirmarCantidad(idArticulo: number) {
+    setCantidadesEnEdicion((prev) => {
+      const { [idArticulo]: _omitido, ...resto } = prev
+      return resto
+    })
+  }
 
   async function escanear() {
     if (escaneando) return
@@ -244,7 +278,9 @@ export function Pos() {
                 </thead>
                 <tbody>
                   {lineas.map((l) => {
-                    const previa = previaDeLinea(l, precios[l.idArticulo])
+                    const resultado = precios[l.idArticulo]
+                    const previa = previaDeLinea(l, resultado)
+                    const tieneDescuento = previa.descuentoUnitario > 0 && resultado?.precioOriginal != null
                     return (
                       <tr key={l.idArticulo}>
                         <td>{l.codigoBarra ?? l.codigoInterno}</td>
@@ -253,15 +289,38 @@ export function Pos() {
                           <input
                             type="number"
                             step="0.001"
+                            min="0.001"
                             className="form-control form-control-sm rounded-0"
                             aria-label={`Cantidad de ${l.nombre}`}
-                            value={l.cantidad}
-                            onChange={(e) =>
-                              mutarCarrito({ tipo: 'editarCantidad', idArticulo: l.idArticulo, cantidad: Number(e.target.value) })
-                            }
+                            value={textoCantidad(l)}
+                            onChange={(e) => cambiarCantidad(l.idArticulo, e.target.value)}
+                            onBlur={() => confirmarCantidad(l.idArticulo)}
                           />
                         </td>
-                        <td className="text-end">{previa.precioUnitario === null ? '—' : `$${formatearMoneda(previa.precioUnitario)}`}</td>
+                        <td className="text-end">
+                          {previa.precioUnitario === null ? (
+                            '—'
+                          ) : (
+                            <>
+                              {tieneDescuento && (
+                                <div className="text-decoration-line-through text-muted small">
+                                  ${formatearMoneda(resultado.precioOriginal as number)}
+                                </div>
+                              )}
+                              <div>
+                                ${formatearMoneda(previa.precioUnitario)}
+                                {tieneDescuento && resultado.aplicadas.length > 0 && (
+                                  <span
+                                    className="badge bg-success ms-1"
+                                    title={resultado.aplicadas.map((a) => a.nombre).join(', ')}
+                                  >
+                                    {resultado.aplicadas[0].nombre}
+                                  </span>
+                                )}
+                              </div>
+                            </>
+                          )}
+                        </td>
                         <td className="text-end">{previa.total === null ? '—' : `$${formatearMoneda(previa.total)}`}</td>
                         <td className="text-end">
                           <button

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { clienteDeArticulos } from '../api/articulos'
+import { reducirCarrito, type AccionCarrito, type LineaCarrito } from '../api/carrito'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
+import { clienteDeOfertas } from '../api/ofertas'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import type { ClienteListado, PuntoVentaListado, ResultadoDeResolucion } from '../api/tipos'
+import { aLineaDeCarritoDesdeEscaneo, aLineasDeResolucion, calcularSubtotalPrevia, indexarResolucionPorArticulo, previaDeLinea } from '../api/ventas'
+import { Box } from '../componentes/Box'
+
+const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
+
+function leerPuntoVentaGuardado(): number | null {
+  try {
+    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
+    return crudo ? Number(crudo) : null
+  } catch {
+    return null
+  }
+}
+
+function guardarPuntoVentaSeleccionado(id: number) {
+  try {
+    localStorage.setItem(CLAVE_PUNTO_VENTA, String(id))
+  } catch {
+    // localStorage puede no estar disponible (modo privado del navegador) — la selección
+    // simplemente no persiste entre sesiones, el resto de la pantalla sigue funcionando.
+  }
+}
+
+function fusionarOpcionesCliente(opciones: ClienteListado[], seleccionado: ClienteListado | null): ClienteListado[] {
+  if (!seleccionado) return opciones
+  return opciones.some((c) => c.id === seleccionado.id) ? opciones : [seleccionado, ...opciones]
+}
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+function formatearMoneda(valor: number): string {
+  return valor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+/**
+ * Pantalla del POS (stage-5-pos-ventas, Slice 6, design: POS Screen Composition) — escaneo +
+ * carrito + selección de punto de venta/cliente. El checkout (pago, ticket, `POST
+ * /api/ventas`) queda deshabilitado/stubbed a propósito: esa parte la wirea la Slice 7 sobre
+ * este mismo archivo (Slice 4, el endpoint real, sigue en review). Precedente de forma:
+ * `Articulos.tsx`/`Ofertas.tsx` tras sus rondas de judgment-day.
+ */
+export function Pos() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [opcionesClientes, setOpcionesClientes] = useState<ClienteListado[]>([])
+  const [clienteSeleccionado, setClienteSeleccionado] = useState<ClienteListado | null>(null)
+  const [terminoCliente, setTerminoCliente] = useState('')
+  const [buscandoClientes, setBuscandoClientes] = useState(false)
+  const [errorClientes, setErrorClientes] = useState('')
+  const generacionClientesRef = useRef(0)
+
+  const [lineas, setLineas] = useState<LineaCarrito[]>([])
+  const [precios, setPrecios] = useState<Record<number, ResultadoDeResolucion>>({})
+  const [resolviendo, setResolviendo] = useState(false)
+  const [avisoPrecios, setAvisoPrecios] = useState('')
+  const generacionResolucionRef = useRef(0)
+
+  const [entradaEscaneo, setEntradaEscaneo] = useState('')
+  const [escaneando, setEscaneando] = useState(false)
+  const [errorEscaneo, setErrorEscaneo] = useState('')
+  const tokenEscaneoRef = useRef(0)
+
+  const puntoVentaSeleccionada = puntosVenta?.find((p) => p.id === idPuntoVenta) ?? null
+
+  // Carga inicial: puntos de venta (para el selector explícito de la operación, proposal
+  // decisión 3 — sin sesión de "punto de venta actual" en el servidor) y clientes (para
+  // encontrar el Consumidor Final por defecto, spec: "Omitted idCliente defaults to Consumidor
+  // Final"). Cada uno con su propio try/catch: que uno falle no bloquea al otro.
+  useEffect(() => {
+    let vigente = true
+
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        const guardado = leerPuntoVentaGuardado()
+        const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
+        setIdPuntoVenta(porDefecto ? porDefecto.id : '')
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(
+          e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta. Seleccioná uno para operar.',
+        )
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((pagina) => {
+        if (!vigente) return
+        setOpcionesClientes(pagina.items)
+        const consumidorFinal = pagina.items.find((c) => c.esConsumidorFinal) ?? null
+        setClienteSeleccionado(consumidorFinal)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setErrorClientes(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // react-async-state regla 2/3/4: cada mutación del carrito (o un cambio de cliente/punto de
+  // venta, de los que depende el lote) dispara una nueva resolución de precios; una respuesta
+  // de una resolución anterior nunca puede pisar la de la más reciente (design: POS Screen
+  // Composition, regla 2 — "generacionResolucionRef gates every /resolver response").
+  useEffect(() => {
+    const generacion = (generacionResolucionRef.current += 1)
+
+    if (lineas.length === 0 || !clienteSeleccionado || !puntoVentaSeleccionada) {
+      setPrecios({})
+      setAvisoPrecios('')
+      return
+    }
+
+    let vigente = true
+    setResolviendo(true)
+    setAvisoPrecios('')
+
+    clienteDeOfertas
+      .resolver(aLineasDeResolucion(lineas, clienteSeleccionado.idListaPrecio, puntoVentaSeleccionada.idEmpresa))
+      .then((resultados) => {
+        if (!vigente || generacionResolucionRef.current !== generacion) return
+        setPrecios(indexarResolucionPorArticulo(resultados))
+      })
+      .catch(() => {
+        if (!vigente || generacionResolucionRef.current !== generacion) return
+        setAvisoPrecios('No se pudo calcular la vista previa de precios. El total se confirma recién al cobrar.')
+      })
+      .finally(() => {
+        if (!vigente || generacionResolucionRef.current !== generacion) return
+        setResolviendo(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [lineas, clienteSeleccionado, puntoVentaSeleccionada])
+
+  const mutarCarrito = useCallback((accion: AccionCarrito) => {
+    setLineas((prev) => reducirCarrito(prev, accion))
+  }, [])
+
+  async function escanear() {
+    if (escaneando) return
+    const entrada = entradaEscaneo.trim()
+    if (!entrada) return
+
+    const token = (tokenEscaneoRef.current += 1)
+    setEscaneando(true)
+    setErrorEscaneo('')
+    try {
+      const articulo = await clienteDeArticulos.escanear(entrada)
+      if (tokenEscaneoRef.current !== token) return
+      const { linea, cantidad } = aLineaDeCarritoDesdeEscaneo(articulo)
+      mutarCarrito({ tipo: 'escanear', linea, cantidad })
+      setEntradaEscaneo('')
+    } catch (e) {
+      if (tokenEscaneoRef.current !== token) return
+      setErrorEscaneo(e instanceof ErrorApi ? e.message : 'No se pudo resolver el código escaneado.')
+    } finally {
+      if (tokenEscaneoRef.current === token) setEscaneando(false)
+    }
+  }
+
+  async function buscarClientes() {
+    if (buscandoClientes) return
+    const generacion = (generacionClientesRef.current += 1)
+    setBuscandoClientes(true)
+    setErrorClientes('')
+    try {
+      const pagina = await clienteDeClientes.listar(terminoCliente, false)
+      if (generacionClientesRef.current !== generacion) return
+      setOpcionesClientes(pagina.items)
+    } catch (e) {
+      if (generacionClientesRef.current === generacion) {
+        setErrorClientes(e instanceof ErrorApi ? e.message : 'No se pudieron buscar clientes.')
+      }
+    } finally {
+      if (generacionClientesRef.current === generacion) setBuscandoClientes(false)
+    }
+  }
+
+  function cambiarPuntoVenta(id: number) {
+    setIdPuntoVenta(id)
+    guardarPuntoVentaSeleccionado(id)
+  }
+
+  const subtotalPrevia = calcularSubtotalPrevia(lineas, precios)
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row g-3">
+        <div className="col-lg-8">
+          <Box titulo="Carrito">
+            {errorEscaneo && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEscaneo}</div>}
+            {avisoPrecios && <div className="alert alert-warning rounded-0 py-1 px-2 small">{avisoPrecios}</div>}
+
+            <div className="input-group mb-3">
+              <input
+                type="text"
+                className="form-control rounded-0"
+                placeholder="Escanear o tipear un código (ej. 3*7790001234567)"
+                aria-label="Código escaneado"
+                value={entradaEscaneo}
+                disabled={escaneando}
+                onChange={(e) => setEntradaEscaneo(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), escanear())}
+                autoFocus
+              />
+              <button type="button" className="btn btn-primary rounded-0" disabled={escaneando} onClick={escanear}>
+                {escaneando ? 'Buscando…' : 'Agregar'}
+              </button>
+            </div>
+
+            <div className="table-responsive">
+              <table className="table table-striped table-hover table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Código</th>
+                    <th>Artículo</th>
+                    <th style={{ width: 110 }}>Cantidad</th>
+                    <th className="text-end">Precio unit.</th>
+                    <th className="text-end">Total</th>
+                    <th className="text-end">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lineas.map((l) => {
+                    const previa = previaDeLinea(l, precios[l.idArticulo])
+                    return (
+                      <tr key={l.idArticulo}>
+                        <td>{l.codigoBarra ?? l.codigoInterno}</td>
+                        <td>{l.nombre}</td>
+                        <td>
+                          <input
+                            type="number"
+                            step="0.001"
+                            className="form-control form-control-sm rounded-0"
+                            aria-label={`Cantidad de ${l.nombre}`}
+                            value={l.cantidad}
+                            onChange={(e) =>
+                              mutarCarrito({ tipo: 'editarCantidad', idArticulo: l.idArticulo, cantidad: Number(e.target.value) })
+                            }
+                          />
+                        </td>
+                        <td className="text-end">{previa.precioUnitario === null ? '—' : `$${formatearMoneda(previa.precioUnitario)}`}</td>
+                        <td className="text-end">{previa.total === null ? '—' : `$${formatearMoneda(previa.total)}`}</td>
+                        <td className="text-end">
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-danger rounded-0"
+                            onClick={() => mutarCarrito({ tipo: 'quitarLinea', idArticulo: l.idArticulo })}
+                          >
+                            Quitar
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                  {lineas.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="text-center text-muted py-4">
+                        Escaneá o tipeá un código para empezar la venta.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {lineas.length > 0 && (
+              <button type="button" className="btn btn-outline-secondary btn-sm rounded-0" onClick={() => mutarCarrito({ tipo: 'vaciar' })}>
+                Vaciar carrito
+              </button>
+            )}
+          </Box>
+        </div>
+
+        <div className="col-lg-4">
+          <Box titulo="Datos de la venta">
+            {errorPuntosVenta && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+            <div className="mb-3">
+              <label className="form-label" htmlFor="pos-punto-venta">
+                Punto de venta
+              </label>
+              <select
+                id="pos-punto-venta"
+                className="form-select rounded-0"
+                value={idPuntoVenta}
+                disabled={puntosVenta === null}
+                onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
+              >
+                {puntosVenta === null && <option value="">Cargando…</option>}
+                {puntosVenta !== null && puntosVenta.length === 0 && <option value="">Sin puntos de venta disponibles</option>}
+                {puntosVenta?.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {errorClientes && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorClientes}</div>}
+
+            <div className="mb-2">
+              <label className="form-label" htmlFor="pos-cliente">
+                Cliente
+              </label>
+              <select
+                id="pos-cliente"
+                className="form-select rounded-0"
+                value={clienteSeleccionado?.id ?? ''}
+                onChange={(e) => {
+                  const encontrado = fusionarOpcionesCliente(opcionesClientes, clienteSeleccionado).find(
+                    (c) => c.id === Number(e.target.value),
+                  )
+                  setClienteSeleccionado(encontrado ?? null)
+                }}
+              >
+                {fusionarOpcionesCliente(opcionesClientes, clienteSeleccionado).map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {etiquetaDeCliente(c)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="input-group input-group-sm mb-3">
+              <input
+                type="search"
+                className="form-control rounded-0"
+                placeholder="Buscar otro cliente…"
+                aria-label="Buscar cliente"
+                value={terminoCliente}
+                disabled={buscandoClientes}
+                onChange={(e) => setTerminoCliente(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), buscarClientes())}
+              />
+              <button type="button" className="btn btn-outline-primary rounded-0" disabled={buscandoClientes} onClick={buscarClientes}>
+                {buscandoClientes ? 'Buscando…' : 'Buscar'}
+              </button>
+            </div>
+
+            <hr />
+
+            <div className="d-flex justify-content-between mb-3">
+              <strong>Total previo</strong>
+              <strong>
+                {resolviendo ? 'Calculando…' : subtotalPrevia === null ? '—' : `$${formatearMoneda(subtotalPrevia)}`}
+              </strong>
+            </div>
+
+            <button type="button" className="btn btn-success w-100 rounded-0" disabled>
+              Cobrar (disponible en la próxima entrega)
+            </button>
+          </Box>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #45

## Summary

- Slice 6 of `stage-5-pos-ventas`: `Pos.tsx` — scan input (server-parsed `cantidad*codigo`, re-scan sums), pure `carrito.ts` reducer, PV selector (localStorage-persisted, backed by the new `LecturaDePuntosVenta` policy from PR #44), cliente selector defaulting to Consumidor Final, batched price preview via `POST /api/ofertas/resolver` (debounced for edits, immediate for scans, generation-gated), stacked-ofertas badge with struck-through original price. Cobrar deliberately stubbed — Slice 7 wires checkout.
- Judgment-day (3 rounds): R1 — 2 CRITICALs (the PV-listing 403 for Vendedor/Supervisor → fixed backend-side in PR #44; ungated mount-fetch silently reverting the selected customer to Consumidor Final → generation-gated) + decimal-typing and bounds fixes. R2/R3 — progressively narrower (floor constant unification, explicit edit-override cleanup instead of blur-order luck, debounce-flag consumed structurally, dispatch-only-on-change, exhaustiveness never-check), every fix mutation-verified (revert → test fails → restore).

## Test Plan

- [x] `npx tsc -b` / `npx oxlint` / `npx vite build` — clean
- [x] `npx vitest run` — 104/104 (21 POS component tests incl. fake-timer debounce, out-of-order resolver regression, stuck-flag regression, cleanup paths)
- [x] judgment-day: APPROVED — R3 items closed by exact prescription with mutation evidence

## Notes

- `size:exception`: the heaviest POS screen half + exhaustive test suite.
- Requires PR #44 (merged) for the PV selector to work for Vendedor/Supervisor.
- Slice 7 (payment+ticket) builds on the clean seam: `aSolicitudDeVenta` mapper + stubbed Cobrar; negative-currency formatting recorded as its INFO.