### PR TITLE
feat(ventas): CHECK de importe no negativo en pagos_comprobante

### DIFF
--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -426,15 +426,21 @@ public class ManejadorDeErrores(
         };
 
     /// <summary>stage-5-pos-ventas (Slice 3, task 3.12, tasks.md "Orchestrator Decisions
-    /// Recorded This Phase" #2, design: Backstop Map): switch por nombre EXACTO de las tres
-    /// CHECKs nuevas de <c>comprobantes_venta</c>/<c>pagos_comprobante</c>/
-    /// <c>movimientos_stock</c> — sin prefijo compartido entre las tres tablas (a diferencia de
-    /// <c>ClasificarCheckDeOfertas</c>, que sí puede filtrar por <c>"ck_ofertas_"</c> antes de
-    /// llamar), así que el caso del switch de arriba llama directo a esta función.
+    /// Recorded This Phase" #2, design: Backstop Map; ampliado en un follow-up con
+    /// <c>ck_pagos_comprobante_importe_no_negativo</c>, gate de DB aprobado 2026-08-04): switch
+    /// por nombre EXACTO de las cuatro CHECKs nuevas de <c>comprobantes_venta</c>/
+    /// <c>pagos_comprobante</c>/<c>movimientos_stock</c> — sin prefijo compartido entre las tres
+    /// tablas (a diferencia de <c>ClasificarCheckDeOfertas</c>, que sí puede filtrar por
+    /// <c>"ck_ofertas_"</c> antes de llamar), así que el caso del switch de arriba llama directo
+    /// a esta función.
     /// <c>vuelto_de_pago_negativo</c> se pinea DISTINTO del código de dominio
     /// <c>vuelto_invalido</c> de <c>ValidadorDePagos</c> (regla <c>Σ vuelto &gt; max(0, Σ
     /// importe − total)</c>): son dos familias de rechazo distintas — reusar el mismo texto de
-    /// código las confundiría en un log o en el cliente.</summary>
+    /// código las confundiría en un log o en el cliente.
+    /// <c>pago_importe_negativo</c>, en cambio, REUSA el código de dominio de la regla 0 de
+    /// <c>ValidadorDePagos</c> a propósito: es la MISMA regla de negocio (un importe negativo no
+    /// tiene significado), esta CHECK es solo su backstop de esquema — un cliente nunca debería
+    /// distinguir si el rechazo vino de la validación de aplicación o de la CHECK.</summary>
     private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeVentas(string nombreDeCheck) =>
         nombreDeCheck switch
         {
@@ -447,6 +453,11 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status400BadRequest,
                     "El vuelto de un pago no puede ser negativo.",
                     "vuelto_de_pago_negativo"),
+
+            "ck_pagos_comprobante_importe_no_negativo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El importe de un pago no puede ser negativo.",
+                    "pago_importe_negativo"),
 
             "ck_movimientos_stock_cantidad_no_cero" =>
                 (StatusCodes.Status400BadRequest,

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -132,13 +132,13 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status409Conflict, "Ya existe stock cargado para ese artículo en ese punto de venta.", "stock_duplicado"),
 
             // stage-5-pos-ventas (Slice 3, task 3.12, db-error-backstops, design: Backstop Map):
-            // las tres CHECKs nuevas de comprobantes_venta/pagos_comprobante/movimientos_stock
+            // las cuatro CHECKs de comprobantes_venta/pagos_comprobante/movimientos_stock
             // no comparten un prefijo común (a diferencia de "ck_ofertas_"), así que el guard
             // de esta rama llama directo a ClasificarCheckDeVentas (switch por nombre EXACTO,
             // nunca Contains) en vez de filtrar por StartsWith primero. ValidadorDePagos/
             // ReglaDeComprobantes/el camino de escritura de movimientos_stock (Slice 4/5) ya
-            // validan los tres invariantes en el servicio — bajo operación normal ninguna de
-            // las tres ramas es alcanzable, quedan como backstop de una escritura cruda/fuera
+            // validan los cuatro invariantes en el servicio — bajo operación normal ninguna de
+            // las cuatro ramas es alcanzable, quedan como backstop de una escritura cruda/fuera
             // de banda (misma familia que ClasificarCheckDeOfertas).
             DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckVenta } }
                 when ClasificarCheckDeVentas(ckVenta) is { } checkVenta =>

--- a/src/Ways.Domain/Ventas/ValidadorDePagos.cs
+++ b/src/Ways.Domain/Ventas/ValidadorDePagos.cs
@@ -58,10 +58,9 @@ public static class ValidadorDePagos
         // <c>consumoCuentaCorriente > 0m</c> es falso con un consumo negativo) — un Importe
         // negativo no tiene significado de negocio para un pago, se rechaza de plano.
         //
-        // TODO: este gate de dominio es la defensa de aplicación; falta el backstop de esquema
-        // (CHECK ck_pagos_comprobante_importe_no_negativo sobre pagos_comprobante.importe >= 0,
-        // mismo criterio que ck_comprobantes_venta_numero_positivo) — pendiente del micro-gate de
-        // cambio de base de datos con el usuario, se agrega en un follow-up.
+        // Backstop de esquema: CHECK ck_pagos_comprobante_importe_no_negativo sobre
+        // pagos_comprobante.importe >= 0 (mismo criterio que ck_comprobantes_venta_numero_positivo),
+        // traducida al mismo código "pago_importe_negativo" en ManejadorDeErrores.ClasificarCheckDeVentas.
         foreach (var pago in pagos)
         {
             if (pago.Importe < 0m)

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/PagoComprobanteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/PagoComprobanteConfiguration.cs
@@ -7,10 +7,11 @@ using Ways.Domain.Ventas;
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
 
 /// <summary>
-/// Mapea <see cref="PagoComprobante"/> (design: Table Shapes — write path A). La CHECK
-/// <c>ck_pagos_comprobante_vuelto_no_negativo</c> es defensa en profundidad —
-/// <c>ValidadorDePagos</c> ya rechaza cualquier vuelto negativo aritméticamente antes de llegar
-/// acá (misma familia que <c>ck_comprobantes_venta_numero_positivo</c>).
+/// Mapea <see cref="PagoComprobante"/> (design: Table Shapes — write path A). Las CHECKs
+/// <c>ck_pagos_comprobante_vuelto_no_negativo</c> e <c>ck_pagos_comprobante_importe_no_negativo</c>
+/// son defensa en profundidad — <c>ValidadorDePagos</c> ya rechaza cualquier vuelto o importe
+/// negativo aritméticamente antes de llegar acá (misma familia que
+/// <c>ck_comprobantes_venta_numero_positivo</c>).
 /// </summary>
 public class PagoComprobanteConfiguration : IEntityTypeConfiguration<PagoComprobante>
 {
@@ -19,6 +20,7 @@ public class PagoComprobanteConfiguration : IEntityTypeConfiguration<PagoComprob
         builder.ToTable("pagos_comprobante", t =>
         {
             t.HasCheckConstraint("ck_pagos_comprobante_vuelto_no_negativo", "vuelto >= 0");
+            t.HasCheckConstraint("ck_pagos_comprobante_importe_no_negativo", "importe >= 0");
         });
 
         builder.HasKey(p => p.Id).HasName("pk_pagos_comprobante");

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804210341_CheckImporteNoNegativoEtapa5.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804210341_CheckImporteNoNegativoEtapa5.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -19,9 +20,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804210341_CheckImporteNoNegativoEtapa5")]
+    partial class CheckImporteNoNegativoEtapa5
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804210341_CheckImporteNoNegativoEtapa5.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804210341_CheckImporteNoNegativoEtapa5.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class CheckImporteNoNegativoEtapa5 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_pagos_comprobante_importe_no_negativo",
+                table: "pagos_comprobante",
+                sql: "importe >= 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_pagos_comprobante_importe_no_negativo",
+                table: "pagos_comprobante");
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresVentasTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresVentasTests.cs
@@ -130,4 +130,17 @@ public class ManejadorDeErroresVentasTests
         Assert.Equal(StatusCodes.Status400BadRequest, estado);
         Assert.Equal("movimiento_de_stock_sin_cantidad", codigo);
     }
+
+    [Fact]
+    public async Task CkPagosComprobanteImporteNoNegativoSeTraduceA400PagoImporteNegativo()
+    {
+        var postgres = CrearExcepcion("23514", "ck_pagos_comprobante_importe_no_negativo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("pago_importe_negativo", codigo);
+        // A diferencia de ck_pagos_comprobante_vuelto_no_negativo, este código SÍ coincide con el
+        // de la regla 0 de ValidadorDePagos a propósito (misma regla de negocio, backstop de
+        // esquema de la misma validación).
+    }
 }

--- a/tests/Ways.IntegrationTests/VentasStockBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/VentasStockBackstopTests.cs
@@ -11,14 +11,15 @@ using Ways.Infrastructure.Multitenancy;
 namespace Ways.IntegrationTests;
 
 /// <summary>
-/// stage-5-pos-ventas, Slice 3 (task 3.19, db-error-backstops, design: Backstop Map): raw-SQL
-/// INSERTs que bypasean por completo <c>ValidadorDePagos</c>/<c>ReglaDeComprobantes</c> (no hay
-/// <c>ServicioDeVentas</c> todavía, Slice 4) para probar las tres CHECKs de esquema nuevas, la
-/// unicidad de <c>ux_comprobantes_venta_numero</c> (SQLSTATE 23505 — la traducción exacta al
-/// código de dominio, incluido el "ordering trap", vive en
-/// <c>ManejadorDeErroresVentasTests</c>, que no depende de Postgres real) y la exención
-/// documentada de <c>pk_stock</c> — mismo patrón que <c>OfertasCheckBackstopTests</c>/
-/// <c>NumeracionesComprobanteBackstopTests</c>.
+/// stage-5-pos-ventas, Slice 3 (task 3.19, db-error-backstops, design: Backstop Map; ampliado en
+/// un follow-up con <c>ck_pagos_comprobante_importe_no_negativo</c>, gate de DB aprobado
+/// 2026-08-04): raw-SQL INSERTs que bypasean por completo
+/// <c>ValidadorDePagos</c>/<c>ReglaDeComprobantes</c> (no hay <c>ServicioDeVentas</c> todavía,
+/// Slice 4) para probar las cuatro CHECKs de esquema nuevas, la unicidad de
+/// <c>ux_comprobantes_venta_numero</c> (SQLSTATE 23505 — la traducción exacta al código de
+/// dominio, incluido el "ordering trap", vive en <c>ManejadorDeErroresVentasTests</c>, que no
+/// depende de Postgres real) y la exención documentada de <c>pk_stock</c> — mismo patrón que
+/// <c>OfertasCheckBackstopTests</c>/<c>NumeracionesComprobanteBackstopTests</c>.
 ///
 /// Honesto sobre alcanzabilidad (design: Backstop Map): bajo operación normal (Slice 4 en
 /// adelante) ninguna de estas ramas es alcanzable por un cliente HTTP — prueban la traducción de
@@ -189,6 +190,61 @@ public class VentasStockBackstopTests(WaysApiFixture fixture) : IClassFixture<Wa
         var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
         Assert.Equal("23514", excepcion.SqlState);
         Assert.Equal("ck_pagos_comprobante_vuelto_no_negativo", excepcion.ConstraintName);
+    }
+
+    // ---- ck_pagos_comprobante_importe_no_negativo (follow-up, gate de DB aprobado 2026-08-04)
+    // -------------------------------------------------------------------------------------------
+    // Honesto sobre alcanzabilidad: bajo operación normal esta rama es inalcanzable por un
+    // cliente vía servicio — la regla 0 de ValidadorDePagos ya rechaza cualquier Importe
+    // negativo antes de que la fila llegue a INSERT (misma razón que documenta la clase sobre
+    // las otras CHECKs de esta tabla).
+
+    [Fact]
+    public async Task UnPagoConImporteNegativoViolaLaCheckDeImporteNoNegativo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnPagoConImporteNegativoViolaLaCheckDeImporteNoNegativo));
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = p.IdTenant,
+            IdTipoComprobante = p.IdTipoComprobanteTx,
+            Numero = 1,
+            Fecha = ahora,
+            IdPuntoVenta = p.IdPuntoVenta,
+            IdEmpleado = p.IdEmpleado,
+            IdCliente = p.IdCliente,
+            Subtotal = 100m,
+            DescuentoTotal = 0m,
+            Total = 100m,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        var medioPago = new MedioPago
+        {
+            IdTenant = p.IdTenant, Nombre = "efectivo", Orden = 1, Comportamiento = ComportamientoMedioPago.Efectivo,
+            AdmiteVuelto = true, RequiereReferencia = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioPago);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO pagos_comprobante (id_tenant, id_comprobante_venta, id_medio_pago, importe, vuelto, " +
+            "created_at, updated_at) VALUES ($1, $2, $3, -100, 0, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = comprobante.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = medioPago.Id });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_pagos_comprobante_importe_no_negativo", excepcion.ConstraintName);
     }
 
     // ---- ck_movimientos_stock_cantidad_no_cero ---------------------------------------------


### PR DESCRIPTION
## Resumen

Follow-up de la etapa 5 (micro-gate aprobado): agrega la constraint de defensa en profundidad `ck_pagos_comprobante_importe_no_negativo` (`importe >= 0`) sobre `pagos_comprobante`.

- Migración `CheckImporteNoNegativoEtapa5` con solo el par Add/Drop de la constraint.
- `ClasificarCheckDeVentas` mapea el 23514 a 400 `pago_importe_negativo` (reusa el código de la regla 0 de dominio: es el mismo invariante de negocio; la CHECK de vuelto mantiene código distinto porque es una regla derivada diferente).
- Se remueve el TODO cumplido en `ValidadorDePagos`.
- Tests: backstop raw-SQL (SQLSTATE 23514 + ConstraintName exacto) + test de traducción en `ManejadorDeErrores`.

## Verificación

- Build 0 warnings / 0 errores.
- Suites: Domain 271/271, Application 209/209, Integration 393/393 (391 base + 2 nuevos), contra Postgres real.
- Judgment-day: juez B CLEAN; juez A un MINOR (conteo desactualizado en un comentario del dispatch), corregido en `6442575`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)