### PR TITLE
feat(caja): esquema de turnos, arqueos, tesoreria y gastos (etapa 6, slice 1)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -416,6 +416,16 @@ gastos (                      -- [operativa]
 Los retiros de efectivo **dejan de ser gastos** (`tipo=95` era otro número mágico):
 van a `movimientos_caja` (§7).
 
+> **Estado (Etapa 6, Slice 1):** `gastos` se crea en esta etapa, pero **sin**
+> `id_comprobante_compra`: `comprobantes_compra` no existe todavía (etapa 8), así que un
+> `int NULL` sin FK sería una referencia sin garantía — mismo criterio que
+> `movimientos_stock.id_comprobante_compra` (§6). La etapa 8 agrega la columna y su FK
+> juntas, en la misma migración que crea `comprobantes_compra` (design de
+> stage-6-turnos-caja: Table Shapes — write path C). `id_turno_caja` sí se crea **NOT NULL**
+> desde esta etapa (a diferencia de la ambigüedad de la tabla de arriba, que lo muestra
+> nullable): todo gasto se registra contra un turno abierto, resuelto server-side, nunca
+> input de cliente.
+
 ## 6. Stock
 
 ```sql

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -117,6 +117,15 @@ public class ManejadorDeErrores(
             // movimientos_cuenta_corriente: tenant/cliente/punto_venta/empleado/
             // comprobante_venta/pago_comprobante) — todas siguen la convención fk_* del resto
             // del esquema.
+            //
+            // stage-6-turnos-caja (Slice 1, task 1.7): confirmado sin cambio de código — el
+            // mismo match por prefijo "fk_" ya cubre las FKs nuevas de las cinco tablas de esta
+            // slice (turnos_caja: tenant/punto_venta/empleado_apertura/empleado_cierre;
+            // movimientos_caja: tenant/turno/empleado; arqueos_turno: tenant/turno/medio_pago;
+            // movimientos_tesoreria: tenant/punto_venta/turno/empleado; gastos: tenant/
+            // punto_venta/turno/empleado/proveedor/area/medio_pago) y también
+            // fk_comprobantes_venta_turno — todas siguen la convención fk_* del resto del
+            // esquema.
             DbUpdateException { InnerException: PostgresException { SqlState: "23503", ConstraintName: string fk } }
                 when fk.StartsWith("fk_", StringComparison.Ordinal) =>
                 LogYClasificarReferenciaInvalida(fk, log),
@@ -143,6 +152,18 @@ public class ManejadorDeErrores(
             DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckVenta } }
                 when ClasificarCheckDeVentas(ckVenta) is { } checkVenta =>
                 (checkVenta.EstadoHttp, checkVenta.Titulo, checkVenta.Codigo),
+
+            // stage-6-turnos-caja (Slice 1, task 1.7, db-error-backstops, design: Backstop Map):
+            // switch por nombre EXACTO de las seis CHECKs nuevas de turnos_caja/movimientos_caja/
+            // gastos/movimientos_tesoreria — sin prefijo compartido entre las cuatro tablas
+            // (mismo motivo que ClasificarCheckDeVentas). ReglaDeTurnos/ReglaDeMovimientosDeCaja
+            // (Slice 2), ServicioDeGastos (Slice 3) y ServicioDeTurnos.CerrarAsync (Slice 4) ya
+            // validan estos invariantes en el camino de servicio — bajo operación normal ninguna
+            // de las seis ramas es alcanzable, quedan como backstop de una escritura cruda/fuera
+            // de banda.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckCaja } }
+                when ClasificarCheckDeCaja(ckCaja) is { } checkCaja =>
+                (checkCaja.EstadoHttp, checkCaja.Titulo, checkCaja.Codigo),
 
             // Backstop genérico (db-error-backstops, judgment-day slice 3 ronda 1): cualquier
             // valor numérico que desborda la precisión/escala de su columna (p.ej. un margen o
@@ -259,6 +280,27 @@ public class ManejadorDeErrores(
         if (nombreDeIndice is "ux_parametros_empresa" or "ux_parametros_punto_venta")
         {
             return ("parametro_duplicado", "Ya existe un parámetro con esa clave en este alcance.");
+        }
+
+        // stage-6-turnos-caja (Slice 1, task 1.7, db-error-backstops, design: Backstop Map):
+        // ux_turnos_caja_abierto — backstop de "One Open Turno Per Punto De Venta" (spec:
+        // turnos-de-caja). Sin trampa de ordering: el nombre no contiene ninguna de las
+        // substrings que matchean más abajo (_cuit/_numero/_nombre/_codigo/_vigente/_default),
+        // así que su posición acá no importa — se deja arriba, junto al otro literal exacto,
+        // por prolijidad. La prueba de carrera real vive en Slice 2 (task 2.8); acá solo el
+        // proof raw-SQL 23505 (task 1.9).
+        if (nombreDeIndice == "ux_turnos_caja_abierto")
+        {
+            return ("turno_ya_abierto", "Ya existe un turno abierto en este punto de venta.");
+        }
+
+        // stage-6-turnos-caja (Slice 1, task 1.7, db-error-backstops, design: Backstop Map):
+        // ux_arqueos_turno_medio — exención documentada de prueba de carrera: el cierre deriva
+        // el set de filas dentro de su propio lock exclusivo (Slice 4), así que el camino normal
+        // nunca puede chocar acá. Mismo motivo de "sin trampa de ordering" que el caso de arriba.
+        if (nombreDeIndice == "ux_arqueos_turno_medio")
+        {
+            return ("arqueo_duplicado", "Ya existe un arqueo para ese medio de pago en este turno.");
         }
 
         // stage-2-clientes-proveedores (task 1.12, backstop map): ux_proveedores_cuit —
@@ -463,6 +505,55 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status400BadRequest,
                     "El movimiento de stock tiene que tener una cantidad distinta de cero.",
                     "movimiento_de_stock_sin_cantidad"),
+
+            _ => null
+        };
+
+    /// <summary>stage-6-turnos-caja (Slice 1, task 1.7, tasks.md "Orchestrator Decisions
+    /// Recorded This Phase" — design decisión 8): switch por nombre EXACTO de las seis CHECKs
+    /// nuevas de <c>turnos_caja</c>/<c>movimientos_caja</c>/<c>gastos</c>/
+    /// <c>movimientos_tesoreria</c>. <c>ck_movimientos_caja_motivo_minimo</c> y
+    /// <c>ck_movimientos_caja_importe</c> cubren, cada una, una sola regla UNIFORME sobre los
+    /// tres <c>tipo_movimiento_caja</c> (design decisión 8: sin rama por tipo) — la CHECK en sí
+    /// no puede distinguir qué tipo la disparó, así que su código de backstop es genérico y
+    /// DISTINTO de los dos códigos de dominio que sí distinguen por tipo
+    /// (<c>movimiento_de_caja_sin_motivo</c> para retiro/refuerzo,
+    /// <c>motivo_de_apertura_cajon_invalido</c> para apertura_cajon — ambos de
+    /// <c>ReglaDeMovimientosDeCaja</c>, Slice 2): mismo criterio que
+    /// <c>ck_pagos_comprobante_vuelto_no_negativo</c>, que tampoco reusa el código de una regla
+    /// de dominio distinta.</summary>
+    private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeCaja(string nombreDeCheck) =>
+        nombreDeCheck switch
+        {
+            "ck_turnos_caja_fondo_inicial_no_negativo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El fondo inicial no puede ser negativo.",
+                    "fondo_inicial_negativo"),
+
+            "ck_turnos_caja_cierre_consistente" =>
+                (StatusCodes.Status400BadRequest,
+                    "El turno quedó en un estado de cierre inconsistente.",
+                    "turno_cierre_inconsistente"),
+
+            "ck_movimientos_caja_importe" =>
+                (StatusCodes.Status400BadRequest,
+                    "El importe del movimiento de caja no es válido para ese tipo.",
+                    "movimiento_de_caja_importe_invalido"),
+
+            "ck_movimientos_caja_motivo_minimo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El motivo del movimiento de caja tiene que tener al menos 5 caracteres.",
+                    "movimiento_de_caja_motivo_invalido"),
+
+            "ck_gastos_importe_positivo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El importe del gasto tiene que ser positivo.",
+                    "gasto_importe_invalido"),
+
+            "ck_movimientos_tesoreria_cadena" =>
+                (StatusCodes.Status400BadRequest,
+                    "La cadena de tesorería es inconsistente (final tiene que ser inicio + ingreso − egreso).",
+                    "tesoreria_cadena_invalida"),
 
             _ => null
         };

--- a/src/Ways.Domain/Caja/ArqueoTurno.cs
+++ b/src/Ways.Domain/Caja/ArqueoTurno.cs
@@ -1,0 +1,33 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Una fila por medio de pago con actividad en el turno, escrita una sola vez al cierre (doc 10
+/// §7, design: Table Shapes — write path A; The Cierre Transaction). Append-only e irreversible
+/// por diseño — ningún endpoint edita ni elimina una fila; no tiene columna de fecha propia
+/// porque su momento ES <see cref="TurnoCaja.FechaCierre"/>.
+///
+/// A propósito NO hereda de <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/>
+/// — mismo criterio que <see cref="Ways.Domain.Stock.MovimientoStock"/>, con filtro de tenant
+/// escrito a mano en <c>WaysDbContext.AplicarFiltroDeTenantEnArqueoTurno</c>.
+/// </summary>
+public class ArqueoTurno
+{
+    public int Id { get; set; }
+    public int IdTenant { get; set; }
+
+    public int IdTurnoCaja { get; set; }
+    public int IdMedioPago { get; set; }
+
+    /// <summary>Derivado server-side por <c>CalculadorDeArqueo</c> (Slice 4) — nunca input de
+    /// cliente (spec: Cierre Payload Carries Only Declared Counts).</summary>
+    public decimal ImporteEsperado { get; set; }
+
+    /// <summary>Lo que el cajero contó — el único dato que el cliente envía.</summary>
+    public decimal ImporteDeclarado { get; set; }
+
+    /// <summary><c>importe_esperado − importe_declarado</c> (positivo = faltante). Columna
+    /// <c>GENERATED ALWAYS ... STORED</c> (design decisión 6): no puede desviarse de sus
+    /// operandos ni por una escritura fuera de banda — ver <c>ArqueoTurnoConfiguration</c>, EF
+    /// nunca la incluye en el INSERT.</summary>
+    public decimal Diferencia { get; set; }
+}

--- a/src/Ways.Domain/Caja/EstadoTurno.cs
+++ b/src/Ways.Domain/Caja/EstadoTurno.cs
@@ -1,0 +1,12 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Estado de un <see cref="TurnoCaja"/> (doc 10 §7). Enum nativo de Postgres
+/// (<c>estado_turno</c>). Única transición válida: <see cref="Abierto"/> → <see cref="Cerrado"/>
+/// (design decisión 10) — nunca al revés, no hay reapertura.
+/// </summary>
+public enum EstadoTurno
+{
+    Abierto,
+    Cerrado
+}

--- a/src/Ways.Domain/Caja/MovimientoCaja.cs
+++ b/src/Ways.Domain/Caja/MovimientoCaja.cs
@@ -1,0 +1,35 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Ledger de movimientos físicos de caja fuera de la venta (doc 10 §7, design: Table Shapes —
+/// write path B): retiros, refuerzos y apertura de cajón (F12 del legacy). Append-only por
+/// contrato — ningún endpoint actualiza ni elimina una fila.
+///
+/// A propósito NO hereda de <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/>
+/// — mismo criterio que <see cref="Ways.Domain.Stock.MovimientoStock"/>: un ledger append-only
+/// no tiene <c>updated_at</c>/<c>deleted_at</c> con sentido, así que su única columna de fecha
+/// es <c>creado_el</c>, con filtro de tenant escrito a mano en
+/// <c>WaysDbContext.AplicarFiltroDeTenantEnMovimientoCaja</c>.
+/// </summary>
+public class MovimientoCaja
+{
+    public int Id { get; set; }
+    public int IdTenant { get; set; }
+
+    public int IdTurnoCaja { get; set; }
+
+    public TipoMovimientoCaja Tipo { get; set; }
+
+    /// <summary>Siempre <c>0</c> para <see cref="TipoMovimientoCaja.AperturaCajon"/>, siempre
+    /// <c>&gt; 0</c> para los demás (design decisión 8, <c>ck_movimientos_caja_importe</c>).</summary>
+    public decimal Importe { get; set; }
+
+    /// <summary>Obligatorio y con longitud mínima uniformada para los tres tipos por igual
+    /// (design decisión 8, <c>ck_movimientos_caja_motivo_minimo</c>): mover dinero físico o
+    /// abrir el cajón merecen una razón registrada.</summary>
+    public required string Motivo { get; set; }
+
+    public int IdEmpleado { get; set; }
+
+    public DateTimeOffset CreadoEl { get; set; }
+}

--- a/src/Ways.Domain/Caja/MovimientoTesoreria.cs
+++ b/src/Ways.Domain/Caja/MovimientoTesoreria.cs
@@ -1,0 +1,41 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Ledger encadenado de tesorería (doc 10 §7, design: Table Shapes — write path D; ex
+/// <c>cajaz</c> del legacy): el cierre escribe automáticamente una fila
+/// <see cref="TipoMovimientoTesoreria.RetiroCaja"/> por turno (design: The Cierre Transaction),
+/// encadenando <see cref="Inicio"/> desde el <see cref="Final"/> de la última fila del mismo
+/// punto de venta.
+///
+/// A propósito NO hereda de <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/>
+/// — mismo criterio que <see cref="Ways.Domain.Stock.MovimientoStock"/>, con filtro de tenant
+/// escrito a mano en <c>WaysDbContext.AplicarFiltroDeTenantEnMovimientoTesoreria</c>.
+/// </summary>
+public class MovimientoTesoreria
+{
+    public int Id { get; set; }
+    public int IdTenant { get; set; }
+
+    public int IdPuntoVenta { get; set; }
+    public DateTimeOffset Fecha { get; set; }
+    public TipoMovimientoTesoreria Tipo { get; set; }
+
+    /// <summary>Turno que originó la fila — único escritor de esta etapa es el cierre, siempre
+    /// la puebla. Nullable en el esquema para admitir tesorería sin turno (futuras entradas
+    /// manuales, decisión 4, fuera de alcance hoy).</summary>
+    public int? IdTurnoCaja { get; set; }
+
+    public required string Concepto { get; set; }
+
+    public decimal Inicio { get; set; }
+    public decimal Ingreso { get; set; }
+    public decimal Egreso { get; set; }
+
+    /// <summary><c>inicio + ingreso − egreso</c> (design decisión 6, backstop de esquema
+    /// <c>ck_movimientos_tesoreria_cadena</c>) — a diferencia de
+    /// <see cref="ArqueoTurno.Diferencia"/>, se calcula en C# y se inserta: la CHECK es defensa
+    /// en profundidad, no la fuente de verdad.</summary>
+    public decimal Final { get; set; }
+
+    public int IdEmpleado { get; set; }
+}

--- a/src/Ways.Domain/Caja/TipoMovimientoCaja.cs
+++ b/src/Ways.Domain/Caja/TipoMovimientoCaja.cs
@@ -1,0 +1,13 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Tipo de un <see cref="MovimientoCaja"/> (doc 10 §7). Enum nativo de Postgres
+/// (<c>tipo_movimiento_caja</c>). <see cref="AperturaCajon"/> es la paridad del F12 del
+/// legacy — la fila es el rastro de auditoría, nunca dinero (siempre <c>importe = 0</c>).
+/// </summary>
+public enum TipoMovimientoCaja
+{
+    Retiro,
+    Refuerzo,
+    AperturaCajon
+}

--- a/src/Ways.Domain/Caja/TipoMovimientoTesoreria.cs
+++ b/src/Ways.Domain/Caja/TipoMovimientoTesoreria.cs
@@ -1,0 +1,17 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Tipo de un <see cref="MovimientoTesoreria"/> (doc 10 §7, ex <c>cajaz</c> del legacy). Enum
+/// nativo de Postgres (<c>tipo_movimiento_tesoreria</c>). Esta etapa solo abre camino de
+/// escritura para <see cref="RetiroCaja"/> (el cierre lo encadena automáticamente,
+/// design: The Cierre Transaction) — <see cref="Deposito"/>, <see cref="Gasto"/> y
+/// <see cref="Ajuste"/> son valores reservados sin escritor todavía (decisión 4: entradas
+/// manuales de tesorería fuera de alcance).
+/// </summary>
+public enum TipoMovimientoTesoreria
+{
+    RetiroCaja,
+    Deposito,
+    Gasto,
+    Ajuste
+}

--- a/src/Ways.Domain/Caja/TurnoCaja.cs
+++ b/src/Ways.Domain/Caja/TurnoCaja.cs
@@ -1,0 +1,38 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Turno de caja (doc 10 §7, design: Table Shapes — write path A): serializa cada camino que
+/// toca la caja física de un punto de venta (venta, anulación, gasto, movimiento de caja) — el
+/// turno abierto es el lock de primer orden de toda la etapa (design: lock-order invariant, The
+/// Cierre Transaction). Se abre con <see cref="FondoInicial"/> y se cierra una sola vez (nunca
+/// hay reapertura, design decisión 10): <see cref="Estado"/> solo transiciona abierto → cerrado.
+///
+/// Mutable (hereda <see cref="EntidadTenant"/>, a diferencia de los ledgers append-only de esta
+/// misma etapa): la fila se abre y después se cierra —dos escrituras sobre la misma fila—, así
+/// que <c>updated_at</c> tiene sentido acá, a diferencia de <see cref="ArqueoTurno"/>/
+/// <see cref="MovimientoCaja"/>/<see cref="MovimientoTesoreria"/>.
+/// </summary>
+public class TurnoCaja : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdPuntoVenta { get; set; }
+
+    public int IdEmpleadoApertura { get; set; }
+
+    /// <summary>Poblado solo al cerrar (<c>ck_turnos_caja_cierre_consistente</c>).</summary>
+    public int? IdEmpleadoCierre { get; set; }
+
+    public DateTimeOffset FechaApertura { get; set; }
+
+    /// <summary>Poblado solo al cerrar (<c>ck_turnos_caja_cierre_consistente</c>).</summary>
+    public DateTimeOffset? FechaCierre { get; set; }
+
+    public decimal FondoInicial { get; set; }
+
+    public EstadoTurno Estado { get; set; } = EstadoTurno.Abierto;
+
+    public string? Observaciones { get; set; }
+}

--- a/src/Ways.Domain/Gastos/CategoriaGasto.cs
+++ b/src/Ways.Domain/Gastos/CategoriaGasto.cs
@@ -1,0 +1,17 @@
+namespace Ways.Domain.Gastos;
+
+/// <summary>
+/// Categoría de un <see cref="Gasto"/> (doc 10 §5/§7). Enum nativo de Postgres
+/// (<c>categoria_gasto</c>). Ninguno de estos valores representa un retiro de efectivo (spec:
+/// No Magic Tipo Encodes A Retiro As A Gasto) — el legacy <c>tipo = 95</c> murió con esta etapa,
+/// un retiro se registra en <c>movimientos_caja</c>.
+/// </summary>
+public enum CategoriaGasto
+{
+    Proveedor,
+    Sueldos,
+    Viaticos,
+    Impuestos,
+    Servicios,
+    Otros
+}

--- a/src/Ways.Domain/Gastos/Gasto.cs
+++ b/src/Ways.Domain/Gastos/Gasto.cs
@@ -1,0 +1,45 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Gastos;
+
+/// <summary>
+/// Gasto operativo capturado contra un turno abierto (doc 10 §5/§7, design: Table Shapes —
+/// write path C). Entidad de tenant (documento de autoría de usuario, no un ledger derivado) —
+/// gana <c>updated_at</c>/baja lógica igual que <c>Cliente</c>/<c>Proveedor</c>, a diferencia de
+/// los ledgers append-only de esta misma etapa.
+///
+/// <c>id_comprobante_compra</c> NO existe todavía (proposal decisión 1, design: Table Shapes —
+/// write path C): <c>comprobantes_compra</c> no existe, así que la columna se difiere a la
+/// etapa 8 (que la crea junto con su FK, mismo patrón que
+/// <see cref="Ways.Domain.Stock.MovimientoStock"/> con su propio FK diferido de compra) en vez
+/// de dejar un <c>int?</c> sin constraint.
+/// </summary>
+public class Gasto : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public DateTimeOffset Fecha { get; set; }
+
+    public int IdPuntoVenta { get; set; }
+
+    /// <summary>Resuelto server-side del turno abierto — nunca input de cliente (spec: Gasto
+    /// Requires An Open Turno).</summary>
+    public int IdTurnoCaja { get; set; }
+
+    public int IdEmpleado { get; set; }
+
+    public CategoriaGasto Categoria { get; set; }
+
+    public int? IdProveedor { get; set; }
+    public int? IdArea { get; set; }
+
+    public required string Concepto { get; set; }
+    public string? Detalle { get; set; }
+
+    public int IdMedioPago { get; set; }
+
+    public string? NumeroFactura { get; set; }
+
+    /// <summary>Siempre <c>&gt; 0</c> (spec: Importe Must Be Positive, <c>ck_gastos_importe_positivo</c>).</summary>
+    public decimal Importe { get; set; }
+}

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -4,9 +4,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
@@ -97,6 +99,10 @@ public static class DependencyInjection
             npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
             npgsql.MapEnum<MotivoStock>("motivo_stock");
             npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+            npgsql.MapEnum<EstadoTurno>("estado_turno");
+            npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+            npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+            npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
             npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
         });
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ArqueoTurnoConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ArqueoTurnoConfiguration.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="ArqueoTurno"/> (design: Table Shapes — write path A; The Cierre
+/// Transaction). <see cref="ArqueoTurno.Diferencia"/> es una columna
+/// <c>GENERATED ALWAYS ... STORED</c> (design decisión 6) — EF nunca la incluye en el INSERT.
+/// </summary>
+public class ArqueoTurnoConfiguration : IEntityTypeConfiguration<ArqueoTurno>
+{
+    public void Configure(EntityTypeBuilder<ArqueoTurno> builder)
+    {
+        builder.ToTable("arqueos_turno");
+
+        builder.HasKey(a => a.Id).HasName("pk_arqueos_turno");
+
+        builder.Property(a => a.Id)
+            .HasColumnName("id_arqueo")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(a => a.IdTenant).HasColumnName("id_tenant").IsRequired();
+        builder.Property(a => a.IdTurnoCaja).HasColumnName("id_turno_caja").IsRequired();
+        builder.Property(a => a.IdMedioPago).HasColumnName("id_medio_pago").IsRequired();
+
+        builder.Property(a => a.ImporteEsperado)
+            .HasColumnName("importe_esperado")
+            .HasColumnType("numeric(14,2)")
+            .IsRequired();
+
+        builder.Property(a => a.ImporteDeclarado)
+            .HasColumnName("importe_declarado")
+            .HasColumnType("numeric(14,2)")
+            .IsRequired();
+
+        builder.Property(a => a.Diferencia)
+            .HasColumnName("diferencia")
+            .HasColumnType("numeric(14,2)")
+            .HasComputedColumnSql("(importe_esperado - importe_declarado)", stored: true);
+
+        // design decisión 6: una fila por (turno, medio) — backstop 23505 -> 409
+        // arqueo_duplicado (ManejadorDeErrores); exención documentada de prueba de carrera
+        // (design: Backstop Map): el cierre deriva el set de filas bajo su propio lock
+        // exclusivo, así que el camino normal nunca puede chocar acá.
+        builder.HasIndex(a => new { a.IdTurnoCaja, a.IdMedioPago })
+            .HasDatabaseName("ux_arqueos_turno_medio")
+            .IsUnique();
+
+        builder.HasIndex(a => a.IdTenant).HasDatabaseName("ix_arqueos_turno_tenant");
+        builder.HasIndex(a => new { a.IdTurnoCaja, a.IdTenant }).HasDatabaseName("ix_arqueos_turno_turno");
+
+        // Índice de soporte de la FK compuesta a medios_pago (evita el índice implícito
+        // PascalCase de EF).
+        builder.HasIndex(a => new { a.IdMedioPago, a.IdTenant }).HasDatabaseName("ix_arqueos_turno_medio_pago");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(a => a.IdTenant)
+            .HasConstraintName("fk_arqueos_turno_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<TurnoCaja>()
+            .WithMany()
+            .HasForeignKey(a => new { a.IdTurnoCaja, a.IdTenant })
+            .HasPrincipalKey(t => new { t.Id, t.IdTenant })
+            .HasConstraintName("fk_arqueos_turno_turno")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<MedioPago>()
+            .WithMany()
+            .HasForeignKey(a => new { a.IdMedioPago, a.IdTenant })
+            .HasPrincipalKey(m => new { m.Id, m.IdTenant })
+            .HasConstraintName("fk_arqueos_turno_medio_pago")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteVentaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteVentaConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
@@ -44,7 +45,10 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
         builder.Property(c => c.Fecha).HasColumnName("fecha").IsRequired();
         builder.Property(c => c.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
 
-        // Siempre NULL en esta etapa (proposal decisión 1) — sin turnos_caja todavía.
+        // stage-6-turnos-caja, Slice 1 (design: Table Shapes — write path E): la columna ya
+        // existía NULL desde la migración de stage 5; acá se agrega la FK/índice. Slice 5 es
+        // quien empieza a poblarla en cada venta nueva — las filas de stage 5 quedan NULL para
+        // siempre (proposal decisión 8, sin backfill).
         builder.Property(c => c.IdTurnoCaja).HasColumnName("id_turno_caja");
 
         builder.Property(c => c.IdEmpleado).HasColumnName("id_empleado").IsRequired();
@@ -94,6 +98,11 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
         builder.HasIndex(c => new { c.IdComprobanteAsociado, c.IdTenant }).HasDatabaseName("ix_comprobantes_venta_asociado");
         builder.HasIndex(c => c.IdEmpleado).HasDatabaseName("ix_comprobantes_venta_empleado");
         builder.HasIndex(c => c.IdTipoComprobante).HasDatabaseName("ix_comprobantes_venta_tipo_comprobante");
+
+        // stage-6-turnos-caja, Slice 1 (design: Table Shapes — write path E): índice de
+        // soporte de fk_comprobantes_venta_turno, además el acceso de la derivación
+        // (LectorDeMovimientosDelTurno, Slice 4) para "pagos/vueltos de este turno".
+        builder.HasIndex(c => new { c.IdTurnoCaja, c.IdTenant }).HasDatabaseName("ix_comprobantes_venta_turno");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -145,6 +154,16 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
             .HasForeignKey(c => new { c.IdComprobanteAsociado, c.IdTenant })
             .HasPrincipalKey(c => new { c.Id, c.IdTenant })
             .HasConstraintName("fk_comprobantes_venta_comprobante_asociado")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // stage-6-turnos-caja, Slice 1 (design: Table Shapes — write path E): la columna es
+        // nullable para siempre (stage-5 rows nunca se backfillean) — FK compuesta igual que el
+        // resto, sin marcar la relación requerida.
+        builder.HasOne<TurnoCaja>()
+            .WithMany()
+            .HasForeignKey(c => new { c.IdTurnoCaja, c.IdTenant })
+            .HasPrincipalKey(t => new { t.Id, t.IdTenant })
+            .HasConstraintName("fk_comprobantes_venta_turno")
             .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/GastoConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/GastoConfiguration.cs
@@ -1,0 +1,120 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Gasto"/> (design: Table Shapes — write path C). La CHECK es defensa en
+/// profundidad — <c>ServicioDeGastos.RegistrarAsync</c> (Slice 3) ya rechaza un importe
+/// <c>&lt;= 0</c> en el camino de servicio.
+/// </summary>
+public class GastoConfiguration : IEntityTypeConfiguration<Gasto>
+{
+    public void Configure(EntityTypeBuilder<Gasto> builder)
+    {
+        builder.ToTable("gastos", t =>
+        {
+            t.HasCheckConstraint("ck_gastos_importe_positivo", "importe > 0");
+        });
+
+        builder.HasKey(g => g.Id).HasName("pk_gastos");
+
+        builder.Property(g => g.Id)
+            .HasColumnName("id_gasto")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(g => g.IdTenant).HasColumnName("id_tenant").IsRequired();
+
+        builder.Property(g => g.Fecha).HasColumnName("fecha").IsRequired();
+        builder.Property(g => g.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
+        builder.Property(g => g.IdTurnoCaja).HasColumnName("id_turno_caja").IsRequired();
+        builder.Property(g => g.IdEmpleado).HasColumnName("id_empleado").IsRequired();
+
+        builder.Property(g => g.Categoria)
+            .HasColumnName("categoria")
+            .HasColumnType("categoria_gasto")
+            .IsRequired();
+
+        builder.Property(g => g.IdProveedor).HasColumnName("id_proveedor");
+        builder.Property(g => g.IdArea).HasColumnName("id_area");
+
+        builder.Property(g => g.Concepto).HasColumnName("concepto").HasColumnType("text").IsRequired();
+        builder.Property(g => g.Detalle).HasColumnName("detalle").HasColumnType("text");
+
+        builder.Property(g => g.IdMedioPago).HasColumnName("id_medio_pago").IsRequired();
+        builder.Property(g => g.NumeroFactura).HasColumnName("numero_factura").HasColumnType("text");
+
+        builder.Property(g => g.Importe).HasColumnName("importe").HasColumnType("numeric(14,2)").IsRequired();
+
+        builder.Property(g => g.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(g => g.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(g => g.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(g => g.EstaEliminada);
+
+        builder.HasIndex(g => g.IdTenant).HasDatabaseName("ix_gastos_tenant");
+        builder.HasIndex(g => new { g.IdTurnoCaja, g.IdTenant }).HasDatabaseName("ix_gastos_turno");
+        builder.HasIndex(g => new { g.IdPuntoVenta, g.IdTenant, g.Fecha }).HasDatabaseName("ix_gastos_punto_venta_fecha");
+        builder.HasIndex(g => new { g.IdProveedor, g.IdTenant }).HasDatabaseName("ix_gastos_proveedor");
+
+        // Índices de soporte de FK (evitan el índice implícito PascalCase de EF, misma trampa
+        // que documenta ComprobanteVentaConfiguration).
+        builder.HasIndex(g => g.IdEmpleado).HasDatabaseName("ix_gastos_empleado");
+        builder.HasIndex(g => new { g.IdArea, g.IdTenant }).HasDatabaseName("ix_gastos_area");
+        builder.HasIndex(g => new { g.IdMedioPago, g.IdTenant }).HasDatabaseName("ix_gastos_medio_pago");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(g => g.IdTenant)
+            .HasConstraintName("fk_gastos_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdPuntoVenta, g.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_gastos_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<TurnoCaja>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdTurnoCaja, g.IdTenant })
+            .HasPrincipalKey(t => new { t.Id, t.IdTenant })
+            .HasConstraintName("fk_gastos_turno")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // id_empleado: FK simple, mismo motivo que TurnoCajaConfiguration.fk_turnos_caja_empleado_apertura.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(g => g.IdEmpleado)
+            .HasConstraintName("fk_gastos_empleado")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Proveedor>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdProveedor, g.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_gastos_proveedor")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Area>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdArea, g.IdTenant })
+            .HasPrincipalKey(a => new { a.Id, a.IdTenant })
+            .HasConstraintName("fk_gastos_area")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<MedioPago>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdMedioPago, g.IdTenant })
+            .HasPrincipalKey(m => new { m.Id, m.IdTenant })
+            .HasConstraintName("fk_gastos_medio_pago")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoCajaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoCajaConfiguration.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="MovimientoCaja"/> (design: Table Shapes — write path B). Las dos CHECKs son
+/// defensa en profundidad — <c>ReglaDeMovimientosDeCaja</c> (Slice 2) ya garantiza los mismos
+/// invariantes en el camino de servicio.
+/// </summary>
+public class MovimientoCajaConfiguration : IEntityTypeConfiguration<MovimientoCaja>
+{
+    public void Configure(EntityTypeBuilder<MovimientoCaja> builder)
+    {
+        builder.ToTable("movimientos_caja", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_movimientos_caja_importe",
+                "(tipo = 'apertura_cajon' AND importe = 0) OR (tipo <> 'apertura_cajon' AND importe > 0)");
+            t.HasCheckConstraint("ck_movimientos_caja_motivo_minimo", "length(btrim(motivo)) >= 5");
+        });
+
+        builder.HasKey(m => m.Id).HasName("pk_movimientos_caja");
+
+        builder.Property(m => m.Id)
+            .HasColumnName("id_movimiento")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(m => m.IdTenant).HasColumnName("id_tenant").IsRequired();
+        builder.Property(m => m.IdTurnoCaja).HasColumnName("id_turno_caja").IsRequired();
+
+        builder.Property(m => m.Tipo)
+            .HasColumnName("tipo")
+            .HasColumnType("tipo_movimiento_caja")
+            .IsRequired();
+
+        builder.Property(m => m.Importe).HasColumnName("importe").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(m => m.Motivo).HasColumnName("motivo").HasColumnType("text").IsRequired();
+        builder.Property(m => m.IdEmpleado).HasColumnName("id_empleado").IsRequired();
+        builder.Property(m => m.CreadoEl).HasColumnName("creado_el").IsRequired();
+
+        builder.HasIndex(m => m.IdTenant).HasDatabaseName("ix_movimientos_caja_tenant");
+        builder.HasIndex(m => new { m.IdTurnoCaja, m.IdTenant }).HasDatabaseName("ix_movimientos_caja_turno");
+
+        // Índice de soporte de FK simple (evita el índice implícito PascalCase de EF).
+        builder.HasIndex(m => m.IdEmpleado).HasDatabaseName("ix_movimientos_caja_empleado");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(m => m.IdTenant)
+            .HasConstraintName("fk_movimientos_caja_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<TurnoCaja>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdTurnoCaja, m.IdTenant })
+            .HasPrincipalKey(t => new { t.Id, t.IdTenant })
+            .HasConstraintName("fk_movimientos_caja_turno")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // id_empleado: FK simple, mismo motivo que TurnoCajaConfiguration.fk_turnos_caja_empleado_apertura.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(m => m.IdEmpleado)
+            .HasConstraintName("fk_movimientos_caja_empleado")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoTesoreriaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoTesoreriaConfiguration.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="MovimientoTesoreria"/> (design: Table Shapes — write path D).
+/// <c>ck_movimientos_tesoreria_cadena</c> es defensa en profundidad — el único escritor de esta
+/// etapa (<c>ServicioDeTurnos.CerrarAsync</c>, Slice 4) ya calcula <c>Final</c> como
+/// <c>Inicio + Ingreso − Egreso</c> antes de insertar.
+/// </summary>
+public class MovimientoTesoreriaConfiguration : IEntityTypeConfiguration<MovimientoTesoreria>
+{
+    public void Configure(EntityTypeBuilder<MovimientoTesoreria> builder)
+    {
+        builder.ToTable("movimientos_tesoreria", t =>
+        {
+            t.HasCheckConstraint("ck_movimientos_tesoreria_cadena", "final = inicio + ingreso - egreso");
+        });
+
+        builder.HasKey(m => m.Id).HasName("pk_movimientos_tesoreria");
+
+        builder.Property(m => m.Id)
+            .HasColumnName("id_movimiento")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(m => m.IdTenant).HasColumnName("id_tenant").IsRequired();
+        builder.Property(m => m.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
+        builder.Property(m => m.Fecha).HasColumnName("fecha").IsRequired();
+
+        builder.Property(m => m.Tipo)
+            .HasColumnName("tipo")
+            .HasColumnType("tipo_movimiento_tesoreria")
+            .IsRequired();
+
+        builder.Property(m => m.IdTurnoCaja).HasColumnName("id_turno_caja");
+        builder.Property(m => m.Concepto).HasColumnName("concepto").HasColumnType("text").IsRequired();
+
+        builder.Property(m => m.Inicio).HasColumnName("inicio").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(m => m.Ingreso).HasColumnName("ingreso").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(m => m.Egreso).HasColumnName("egreso").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(m => m.Final).HasColumnName("final").HasColumnType("numeric(14,2)").IsRequired();
+
+        builder.Property(m => m.IdEmpleado).HasColumnName("id_empleado").IsRequired();
+
+        builder.HasIndex(m => m.IdTenant).HasDatabaseName("ix_movimientos_tesoreria_tenant");
+
+        // Soporta la lectura encadenada "ORDER BY id DESC LIMIT 1 por punto de venta" (design:
+        // The Cierre Transaction, paso 6).
+        builder.HasIndex(m => new { m.IdPuntoVenta, m.IdTenant, m.Id })
+            .HasDatabaseName("ix_movimientos_tesoreria_punto_venta_id");
+
+        // Índices de soporte de FK (evitan el índice implícito PascalCase de EF).
+        builder.HasIndex(m => m.IdEmpleado).HasDatabaseName("ix_movimientos_tesoreria_empleado");
+        builder.HasIndex(m => new { m.IdTurnoCaja, m.IdTenant }).HasDatabaseName("ix_movimientos_tesoreria_turno");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(m => m.IdTenant)
+            .HasConstraintName("fk_movimientos_tesoreria_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdPuntoVenta, m.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_movimientos_tesoreria_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<TurnoCaja>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdTurnoCaja, m.IdTenant })
+            .HasPrincipalKey(t => new { t.Id, t.IdTenant })
+            .HasConstraintName("fk_movimientos_tesoreria_turno")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // id_empleado: FK simple, mismo motivo que TurnoCajaConfiguration.fk_turnos_caja_empleado_apertura.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(m => m.IdEmpleado)
+            .HasConstraintName("fk_movimientos_tesoreria_empleado")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/TurnoCajaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/TurnoCajaConfiguration.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Caja;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="TurnoCaja"/> (design: Table Shapes — write path A). Las dos CHECKs son
+/// defensa en profundidad — <c>ReglaDeTurnos</c> (Slice 2)/<c>ServicioDeTurnos.CerrarAsync</c>
+/// (Slice 4) garantizan los mismos invariantes en el camino de servicio.
+/// </summary>
+public class TurnoCajaConfiguration : IEntityTypeConfiguration<TurnoCaja>
+{
+    public void Configure(EntityTypeBuilder<TurnoCaja> builder)
+    {
+        builder.ToTable("turnos_caja", t =>
+        {
+            t.HasCheckConstraint("ck_turnos_caja_fondo_inicial_no_negativo", "fondo_inicial >= 0");
+            t.HasCheckConstraint(
+                "ck_turnos_caja_cierre_consistente",
+                "(estado = 'abierto' AND fecha_cierre IS NULL AND id_empleado_cierre IS NULL) " +
+                "OR (estado = 'cerrado' AND fecha_cierre IS NOT NULL AND id_empleado_cierre IS NOT NULL)");
+        });
+
+        builder.HasKey(t => t.Id).HasName("pk_turnos_caja");
+
+        builder.Property(t => t.Id)
+            .HasColumnName("id_turno_caja")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(t => t.IdTenant).HasColumnName("id_tenant").IsRequired();
+
+        // Habilita las FKs compuestas de movimientos_caja/arqueos_turno/movimientos_tesoreria/
+        // gastos/comprobantes_venta — mismo patrón que ComprobanteVenta/Oferta/Cliente.
+        builder.HasAlternateKey(t => new { t.Id, t.IdTenant })
+            .HasName("ak_turnos_caja_id_turno_caja_id_tenant");
+
+        builder.Property(t => t.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
+        builder.Property(t => t.IdEmpleadoApertura).HasColumnName("id_empleado_apertura").IsRequired();
+        builder.Property(t => t.IdEmpleadoCierre).HasColumnName("id_empleado_cierre");
+
+        builder.Property(t => t.FechaApertura).HasColumnName("fecha_apertura").IsRequired();
+        builder.Property(t => t.FechaCierre).HasColumnName("fecha_cierre");
+
+        builder.Property(t => t.FondoInicial)
+            .HasColumnName("fondo_inicial")
+            .HasColumnType("numeric(14,2)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(t => t.Estado)
+            .HasColumnName("estado")
+            .HasColumnType("estado_turno")
+            .IsRequired();
+
+        builder.Property(t => t.Observaciones).HasColumnName("observaciones").HasColumnType("text");
+
+        builder.Property(t => t.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(t => t.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(t => t.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(t => t.EstaEliminada);
+
+        // design: One Open Turno Per Punto De Venta — 23505 -> 409 turno_ya_abierto
+        // (ManejadorDeErrores.ClasificarUnicidad).
+        builder.HasIndex(t => t.IdPuntoVenta)
+            .HasDatabaseName("ux_turnos_caja_abierto")
+            .HasFilter("estado = 'abierto'")
+            .IsUnique();
+
+        builder.HasIndex(t => t.IdTenant).HasDatabaseName("ix_turnos_caja_tenant");
+        builder.HasIndex(t => new { t.IdPuntoVenta, t.IdTenant, t.FechaApertura })
+            .HasDatabaseName("ix_turnos_caja_punto_venta_fecha");
+
+        // Índices de soporte de FK simple (evitan el índice implícito PascalCase de EF, misma
+        // trampa que documenta ComprobanteVentaConfiguration).
+        builder.HasIndex(t => t.IdEmpleadoApertura).HasDatabaseName("ix_turnos_caja_empleado_apertura");
+        builder.HasIndex(t => t.IdEmpleadoCierre).HasDatabaseName("ix_turnos_caja_empleado_cierre");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(t => t.IdTenant)
+            .HasConstraintName("fk_turnos_caja_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(t => new { t.IdPuntoVenta, t.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_turnos_caja_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // FKs simples (no compuestas) — mismo patrón/motivo que
+        // ComprobanteVentaConfiguration.fk_comprobantes_venta_empleado: usuarios.IdTenant es
+        // nullable a propósito (sentinel de plataforma), una clave alterna (Id, IdTenant)
+        // forzaría esa columna a NOT NULL por convención de EF.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(t => t.IdEmpleadoApertura)
+            .HasConstraintName("fk_turnos_caja_empleado_apertura")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(t => t.IdEmpleadoCierre)
+            .HasConstraintName("fk_turnos_caja_empleado_cierre")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804222255_TurnosCajaYGastosEtapa6.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804222255_TurnosCajaYGastosEtapa6.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -21,9 +22,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804222255_TurnosCajaYGastosEtapa6")]
+    partial class TurnosCajaYGastosEtapa6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260804222255_TurnosCajaYGastosEtapa6.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260804222255_TurnosCajaYGastosEtapa6.cs
@@ -1,0 +1,486 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Domain.Caja;
+using Ways.Domain.Gastos;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class TurnosCajaYGastosEtapa6 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "turnos_caja",
+                columns: table => new
+                {
+                    id_turno_caja = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    id_empleado_apertura = table.Column<int>(type: "integer", nullable: false),
+                    id_empleado_cierre = table.Column<int>(type: "integer", nullable: true),
+                    fecha_apertura = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    fecha_cierre = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    fondo_inicial = table.Column<decimal>(type: "numeric(14,2)", nullable: false, defaultValue: 0m),
+                    estado = table.Column<EstadoTurno>(type: "estado_turno", nullable: false),
+                    observaciones = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_turnos_caja", x => x.id_turno_caja);
+                    table.UniqueConstraint("ak_turnos_caja_id_turno_caja_id_tenant", x => new { x.id_turno_caja, x.id_tenant });
+                    table.CheckConstraint("ck_turnos_caja_cierre_consistente", "(estado = 'abierto' AND fecha_cierre IS NULL AND id_empleado_cierre IS NULL) OR (estado = 'cerrado' AND fecha_cierre IS NOT NULL AND id_empleado_cierre IS NOT NULL)");
+                    table.CheckConstraint("ck_turnos_caja_fondo_inicial_no_negativo", "fondo_inicial >= 0");
+                    table.ForeignKey(
+                        name: "fk_turnos_caja_empleado_apertura",
+                        column: x => x.id_empleado_apertura,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_turnos_caja_empleado_cierre",
+                        column: x => x.id_empleado_cierre,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_turnos_caja_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_turnos_caja_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "arqueos_turno",
+                columns: table => new
+                {
+                    id_arqueo = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    id_turno_caja = table.Column<int>(type: "integer", nullable: false),
+                    id_medio_pago = table.Column<int>(type: "integer", nullable: false),
+                    importe_esperado = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    importe_declarado = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    diferencia = table.Column<decimal>(type: "numeric(14,2)", nullable: false, computedColumnSql: "(importe_esperado - importe_declarado)", stored: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_arqueos_turno", x => x.id_arqueo);
+                    table.ForeignKey(
+                        name: "fk_arqueos_turno_medio_pago",
+                        columns: x => new { x.id_medio_pago, x.id_tenant },
+                        principalTable: "medios_pago",
+                        principalColumns: new[] { "id_medio_pago", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_arqueos_turno_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_arqueos_turno_turno",
+                        columns: x => new { x.id_turno_caja, x.id_tenant },
+                        principalTable: "turnos_caja",
+                        principalColumns: new[] { "id_turno_caja", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "gastos",
+                columns: table => new
+                {
+                    id_gasto = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    fecha = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    id_turno_caja = table.Column<int>(type: "integer", nullable: false),
+                    id_empleado = table.Column<int>(type: "integer", nullable: false),
+                    categoria = table.Column<CategoriaGasto>(type: "categoria_gasto", nullable: false),
+                    id_proveedor = table.Column<int>(type: "integer", nullable: true),
+                    id_area = table.Column<int>(type: "integer", nullable: true),
+                    concepto = table.Column<string>(type: "text", nullable: false),
+                    detalle = table.Column<string>(type: "text", nullable: true),
+                    id_medio_pago = table.Column<int>(type: "integer", nullable: false),
+                    numero_factura = table.Column<string>(type: "text", nullable: true),
+                    importe = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_gastos", x => x.id_gasto);
+                    table.CheckConstraint("ck_gastos_importe_positivo", "importe > 0");
+                    table.ForeignKey(
+                        name: "fk_gastos_area",
+                        columns: x => new { x.id_area, x.id_tenant },
+                        principalTable: "areas",
+                        principalColumns: new[] { "id_area", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_empleado",
+                        column: x => x.id_empleado,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_medio_pago",
+                        columns: x => new { x.id_medio_pago, x.id_tenant },
+                        principalTable: "medios_pago",
+                        principalColumns: new[] { "id_medio_pago", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_proveedor",
+                        columns: x => new { x.id_proveedor, x.id_tenant },
+                        principalTable: "proveedores",
+                        principalColumns: new[] { "id_proveedor", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_gastos_turno",
+                        columns: x => new { x.id_turno_caja, x.id_tenant },
+                        principalTable: "turnos_caja",
+                        principalColumns: new[] { "id_turno_caja", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "movimientos_caja",
+                columns: table => new
+                {
+                    id_movimiento = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    id_turno_caja = table.Column<int>(type: "integer", nullable: false),
+                    tipo = table.Column<TipoMovimientoCaja>(type: "tipo_movimiento_caja", nullable: false),
+                    importe = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    motivo = table.Column<string>(type: "text", nullable: false),
+                    id_empleado = table.Column<int>(type: "integer", nullable: false),
+                    creado_el = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_movimientos_caja", x => x.id_movimiento);
+                    table.CheckConstraint("ck_movimientos_caja_importe", "(tipo = 'apertura_cajon' AND importe = 0) OR (tipo <> 'apertura_cajon' AND importe > 0)");
+                    table.CheckConstraint("ck_movimientos_caja_motivo_minimo", "length(btrim(motivo)) >= 5");
+                    table.ForeignKey(
+                        name: "fk_movimientos_caja_empleado",
+                        column: x => x.id_empleado,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_movimientos_caja_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_movimientos_caja_turno",
+                        columns: x => new { x.id_turno_caja, x.id_tenant },
+                        principalTable: "turnos_caja",
+                        principalColumns: new[] { "id_turno_caja", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "movimientos_tesoreria",
+                columns: table => new
+                {
+                    id_movimiento = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    fecha = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    tipo = table.Column<TipoMovimientoTesoreria>(type: "tipo_movimiento_tesoreria", nullable: false),
+                    id_turno_caja = table.Column<int>(type: "integer", nullable: true),
+                    concepto = table.Column<string>(type: "text", nullable: false),
+                    inicio = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    ingreso = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    egreso = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    final = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    id_empleado = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_movimientos_tesoreria", x => x.id_movimiento);
+                    table.CheckConstraint("ck_movimientos_tesoreria_cadena", "final = inicio + ingreso - egreso");
+                    table.ForeignKey(
+                        name: "fk_movimientos_tesoreria_empleado",
+                        column: x => x.id_empleado,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_movimientos_tesoreria_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_movimientos_tesoreria_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_movimientos_tesoreria_turno",
+                        columns: x => new { x.id_turno_caja, x.id_tenant },
+                        principalTable: "turnos_caja",
+                        principalColumns: new[] { "id_turno_caja", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_venta_turno",
+                table: "comprobantes_venta",
+                columns: new[] { "id_turno_caja", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_arqueos_turno_medio_pago",
+                table: "arqueos_turno",
+                columns: new[] { "id_medio_pago", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_arqueos_turno_tenant",
+                table: "arqueos_turno",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_arqueos_turno_turno",
+                table: "arqueos_turno",
+                columns: new[] { "id_turno_caja", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_arqueos_turno_medio",
+                table: "arqueos_turno",
+                columns: new[] { "id_turno_caja", "id_medio_pago" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_area",
+                table: "gastos",
+                columns: new[] { "id_area", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_empleado",
+                table: "gastos",
+                column: "id_empleado");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_medio_pago",
+                table: "gastos",
+                columns: new[] { "id_medio_pago", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_proveedor",
+                table: "gastos",
+                columns: new[] { "id_proveedor", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_punto_venta_fecha",
+                table: "gastos",
+                columns: new[] { "id_punto_venta", "id_tenant", "fecha" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_tenant",
+                table: "gastos",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_turno",
+                table: "gastos",
+                columns: new[] { "id_turno_caja", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_caja_empleado",
+                table: "movimientos_caja",
+                column: "id_empleado");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_caja_tenant",
+                table: "movimientos_caja",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_caja_turno",
+                table: "movimientos_caja",
+                columns: new[] { "id_turno_caja", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_tesoreria_empleado",
+                table: "movimientos_tesoreria",
+                column: "id_empleado");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_tesoreria_punto_venta_id",
+                table: "movimientos_tesoreria",
+                columns: new[] { "id_punto_venta", "id_tenant", "id_movimiento" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_tesoreria_tenant",
+                table: "movimientos_tesoreria",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_tesoreria_turno",
+                table: "movimientos_tesoreria",
+                columns: new[] { "id_turno_caja", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_turnos_caja_empleado_apertura",
+                table: "turnos_caja",
+                column: "id_empleado_apertura");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_turnos_caja_empleado_cierre",
+                table: "turnos_caja",
+                column: "id_empleado_cierre");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_turnos_caja_punto_venta_fecha",
+                table: "turnos_caja",
+                columns: new[] { "id_punto_venta", "id_tenant", "fecha_apertura" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_turnos_caja_tenant",
+                table: "turnos_caja",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_turnos_caja_abierto",
+                table: "turnos_caja",
+                column: "id_punto_venta",
+                unique: true,
+                filter: "estado = 'abierto'");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_comprobantes_venta_turno",
+                table: "comprobantes_venta",
+                columns: new[] { "id_turno_caja", "id_tenant" },
+                principalTable: "turnos_caja",
+                principalColumns: new[] { "id_turno_caja", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            // RLS (ADR-4/ADR-15, DB CHANGE GATE aprobado 2026-08-04): cada tabla nueva activa
+            // su policy en la misma migración que la crea (design: Migration/Rollout).
+            migrationBuilder.HabilitarRlsDeTenant("turnos_caja");
+            migrationBuilder.HabilitarRlsDeTenant("movimientos_caja");
+            migrationBuilder.HabilitarRlsDeTenant("arqueos_turno");
+            migrationBuilder.HabilitarRlsDeTenant("movimientos_tesoreria");
+            migrationBuilder.HabilitarRlsDeTenant("gastos");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_comprobantes_venta_turno",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropTable(
+                name: "arqueos_turno");
+
+            migrationBuilder.DropTable(
+                name: "gastos");
+
+            migrationBuilder.DropTable(
+                name: "movimientos_caja");
+
+            migrationBuilder.DropTable(
+                name: "movimientos_tesoreria");
+
+            migrationBuilder.DropTable(
+                name: "turnos_caja");
+
+            migrationBuilder.DropIndex(
+                name: "ix_comprobantes_venta_turno",
+                table: "comprobantes_venta");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -6,9 +6,11 @@ using Ways.Application.Articulos;
 using Ways.Application.Clientes;
 using Ways.Application.Ventas;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
+using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
 using Ways.Domain.CuentaCorriente;
@@ -90,6 +92,16 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<MovimientoStock> MovimientosStock => Set<MovimientoStock>();
     public DbSet<MovimientoCuentaCorriente> MovimientosCuentaCorriente => Set<MovimientoCuentaCorriente>();
 
+    // stage-6-turnos-caja, Slice 1 (schema/domain foundation, DB CHANGE GATE aprobado
+    // 2026-08-04): modelo adelantado a la migración, mismo trámite que ComprobanteVenta/Stock/
+    // MovimientoStock en stage-5 Slice 3 — sin exponer en IWaysDbContext todavía, ningún
+    // consumidor de Application en este lote (Slice 2/3/4 son los primeros escritores reales).
+    public DbSet<TurnoCaja> TurnosCaja => Set<TurnoCaja>();
+    public DbSet<MovimientoCaja> MovimientosCaja => Set<MovimientoCaja>();
+    public DbSet<ArqueoTurno> ArqueosTurno => Set<ArqueoTurno>();
+    public DbSet<MovimientoTesoreria> MovimientosTesoreria => Set<MovimientoTesoreria>();
+    public DbSet<Gasto> Gastos => Set<Gasto>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>
@@ -129,6 +141,9 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenantEnStock(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoStock(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoCuentaCorriente(modelBuilder);
+        AplicarFiltroDeTenantEnMovimientoCaja(modelBuilder);
+        AplicarFiltroDeTenantEnArqueoTurno(modelBuilder);
+        AplicarFiltroDeTenantEnMovimientoTesoreria(modelBuilder);
     }
 
     /// <summary>
@@ -533,6 +548,55 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
         var parametro = Expression.Parameter(typeof(MovimientoCuentaCorriente), "e");
         var propiedadIdTenant = Expression.Property(parametro, nameof(MovimientoCuentaCorriente.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// stage-6-turnos-caja (Slice 1, design: Table Shapes — write path B): <see cref="MovimientoCaja"/>
+    /// es un ledger append-only, no hereda <see cref="EntidadTenant"/> (ver el comentario de la
+    /// clase) — necesita la variante escrita a mano, mismo criterio que
+    /// <see cref="AplicarFiltroDeTenantEnMovimientoStock"/>.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnMovimientoCaja(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(MovimientoCaja))!;
+
+        var parametro = Expression.Parameter(typeof(MovimientoCaja), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(MovimientoCaja.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// stage-6-turnos-caja (Slice 1, design: Table Shapes — write path A): <see cref="ArqueoTurno"/>
+    /// es append-only, escrito una sola vez al cierre — misma variante escrita a mano que
+    /// <see cref="AplicarFiltroDeTenantEnMovimientoCaja"/>.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnArqueoTurno(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(ArqueoTurno))!;
+
+        var parametro = Expression.Parameter(typeof(ArqueoTurno), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(ArqueoTurno.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// stage-6-turnos-caja (Slice 1, design: Table Shapes — write path D): <see cref="MovimientoTesoreria"/>
+    /// es el mismo shape de ledger append-only que <see cref="MovimientoCaja"/> — necesita la
+    /// variante escrita a mano.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnMovimientoTesoreria(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(MovimientoTesoreria))!;
+
+        var parametro = Expression.Parameter(typeof(MovimientoTesoreria), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(MovimientoTesoreria.IdTenant));
         var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
 
         entidad.SetQueryFilter("Tenant", filtro);

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
@@ -1,9 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
@@ -37,6 +39,10 @@ public class WaysDbContextFactory : IDesignTimeDbContextFactory<WaysDbContext>
                 npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
             })
             .Options;
 

--- a/tests/Ways.IntegrationTests/TurnosCajaYGastosBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/TurnosCajaYGastosBackstopTests.cs
@@ -1,0 +1,301 @@
+using Npgsql;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 1 (task 1.9, db-error-backstops, design: Backstop Map):
+/// raw-SQL INSERTs que bypasean por completo <c>ReglaDeTurnos</c>/<c>ReglaDeMovimientosDeCaja</c>
+/// (Slice 2)/<c>ServicioDeGastos</c> (Slice 3)/<c>ServicioDeTurnos.CerrarAsync</c> (Slice 4) — no
+/// existen todavía — para probar las seis CHECKs de esquema nuevas y los dos índices únicos,
+/// mismo patrón que <c>VentasStockBackstopTests</c>/<c>OfertasCheckBackstopTests</c>.
+///
+/// Honesto sobre alcanzabilidad (design: Backstop Map): bajo operación normal (Slice 2 en
+/// adelante) ninguna de estas ramas es alcanzable por un cliente HTTP — prueban la traducción de
+/// esquema, no un camino de cliente real. <c>ux_arqueos_turno_medio</c> queda exenta de prueba de
+/// carrera de forma permanente (el cierre deriva el set de filas dentro de su propio lock
+/// exclusivo, Slice 4); <c>ux_turnos_caja_abierto</c> solo queda exenta EN ESTA SLICE — la prueba
+/// de carrera real (rendezvous, dos aperturas concurrentes) es tarea de Slice 2 (task 2.8), una
+/// vez que exista <c>ServicioDeTurnos.AbrirAsync</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class TurnosCajaYGastosBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private sealed record Prerequisitos(int IdTenant, int IdPuntoVenta, int IdEmpleado, int IdMedioPago);
+
+    private async Task<Prerequisitos> SembrarPrerequisitosAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var medioPago = new MedioPago
+        {
+            IdTenant = tenant.Id,
+            Nombre = nombre + "-efectivo",
+            Orden = 1,
+            Comportamiento = ComportamientoMedioPago.Efectivo,
+            AdmiteVuelto = true,
+            RequiereReferencia = false,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioPago);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        return new Prerequisitos(tenant.Id, puntoVenta.Id, usuario.Id, medioPago.Id);
+    }
+
+    /// <summary>Abre un turno vía EF (sesión de plataforma, sin pasar por el backstop bajo
+    /// prueba) — sirve de FK target para los tests de <c>movimientos_caja</c>/
+    /// <c>arqueos_turno</c>/<c>movimientos_tesoreria</c>/<c>gastos</c>.</summary>
+    private async Task<int> AbrirTurnoAsync(Prerequisitos p)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = p.IdTenant,
+            IdPuntoVenta = p.IdPuntoVenta,
+            IdEmpleadoApertura = p.IdEmpleado,
+            FechaApertura = ahora,
+            FondoInicial = 500m,
+            Estado = EstadoTurno.Abierto,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        return turno.Id;
+    }
+
+    // ---- ck_turnos_caja_fondo_inicial_no_negativo -------------------------------------------
+
+    [Fact]
+    public async Task UnTurnoConFondoInicialNegativoViolaLaCheckDeFondoNoNegativo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnTurnoConFondoInicialNegativoViolaLaCheckDeFondoNoNegativo));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO turnos_caja (id_tenant, id_punto_venta, id_empleado_apertura, fecha_apertura, " +
+            "fondo_inicial, estado, created_at, updated_at) VALUES ($1, $2, $3, now(), -100, 'abierto', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_turnos_caja_fondo_inicial_no_negativo", excepcion.ConstraintName);
+    }
+
+    // ---- ck_turnos_caja_cierre_consistente ---------------------------------------------------
+
+    [Fact]
+    public async Task UnTurnoAbiertoConFechaDeCierreViolaLaCheckDeCierreConsistente()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnTurnoAbiertoConFechaDeCierreViolaLaCheckDeCierreConsistente));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO turnos_caja (id_tenant, id_punto_venta, id_empleado_apertura, fecha_apertura, " +
+            "fecha_cierre, fondo_inicial, estado, created_at, updated_at) " +
+            "VALUES ($1, $2, $3, now(), now(), 0, 'abierto', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_turnos_caja_cierre_consistente", excepcion.ConstraintName);
+    }
+
+    // ---- ck_movimientos_caja_importe ---------------------------------------------------------
+
+    [Fact]
+    public async Task UnRetiroConImporteCeroViolaLaCheckDeImporte()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnRetiroConImporteCeroViolaLaCheckDeImporte));
+        var idTurno = await AbrirTurnoAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_caja (id_tenant, id_turno_caja, tipo, importe, motivo, id_empleado, creado_el) " +
+            "VALUES ($1, $2, 'retiro', 0, 'motivo válido de prueba', $3, now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTurno });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_movimientos_caja_importe", excepcion.ConstraintName);
+    }
+
+    // ---- ck_movimientos_caja_motivo_minimo -----------------------------------------------
+
+    [Fact]
+    public async Task UnRetiroConMotivoCortoViolaLaCheckDeMotivoMinimo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnRetiroConMotivoCortoViolaLaCheckDeMotivoMinimo));
+        var idTurno = await AbrirTurnoAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_caja (id_tenant, id_turno_caja, tipo, importe, motivo, id_empleado, creado_el) " +
+            "VALUES ($1, $2, 'retiro', 50, 'ab', $3, now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTurno });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_movimientos_caja_motivo_minimo", excepcion.ConstraintName);
+    }
+
+    // ---- ck_gastos_importe_positivo ----------------------------------------------------------
+
+    [Fact]
+    public async Task UnGastoConImporteCeroViolaLaCheckDeImportePositivo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnGastoConImporteCeroViolaLaCheckDeImportePositivo));
+        var idTurno = await AbrirTurnoAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO gastos (id_tenant, fecha, id_punto_venta, id_turno_caja, id_empleado, categoria, " +
+            "concepto, id_medio_pago, importe, created_at, updated_at) " +
+            "VALUES ($1, now(), $2, $3, $4, 'otros', 'gasto de prueba', $5, 0, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTurno });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdMedioPago });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_gastos_importe_positivo", excepcion.ConstraintName);
+    }
+
+    // ---- ck_movimientos_tesoreria_cadena -----------------------------------------------------
+
+    [Fact]
+    public async Task UnMovimientoDeTesoreriaConCadenaInconsistenteViolaLaCheckDeCadena()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnMovimientoDeTesoreriaConCadenaInconsistenteViolaLaCheckDeCadena));
+        var idTurno = await AbrirTurnoAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_tesoreria (id_tenant, id_punto_venta, fecha, tipo, id_turno_caja, " +
+            "concepto, inicio, ingreso, egreso, final, id_empleado) " +
+            "VALUES ($1, $2, now(), 'retiro_caja', $3, 'cadena inconsistente', 0, 10, 0, 999, $4)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTurno });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_movimientos_tesoreria_cadena", excepcion.ConstraintName);
+    }
+
+    // ---- ux_turnos_caja_abierto (proof 23505 -- la carrera real es Slice 2, task 2.8) --------
+
+    [Fact]
+    public async Task DosTurnosAbiertosEnElMismoPuntoDeVentaViolanLaUnicidad()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosTurnosAbiertosEnElMismoPuntoDeVentaViolanLaUnicidad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        async Task InsertarAsync()
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO turnos_caja (id_tenant, id_punto_venta, id_empleado_apertura, fecha_apertura, " +
+                "fondo_inicial, estado, created_at, updated_at) VALUES ($1, $2, $3, now(), 0, 'abierto', now(), now())";
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await InsertarAsync();
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(InsertarAsync);
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_turnos_caja_abierto", excepcion.ConstraintName);
+    }
+
+    // ---- ux_arqueos_turno_medio (exención documentada de prueba de carrera) -----------------
+
+    [Fact]
+    public async Task DosArqueosDelMismoTurnoYMedioViolanLaUnicidad()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosArqueosDelMismoTurnoYMedioViolanLaUnicidad));
+        var idTurno = await AbrirTurnoAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        async Task InsertarAsync()
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO arqueos_turno (id_tenant, id_turno_caja, id_medio_pago, importe_esperado, " +
+                "importe_declarado) VALUES ($1, $2, $3, 100, 100)";
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+            comando.Parameters.Add(new NpgsqlParameter { Value = idTurno });
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdMedioPago });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await InsertarAsync();
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(InsertarAsync);
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_arqueos_turno_medio", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/TurnosCajaYGastosRlsTests.cs
+++ b/tests/Ways.IntegrationTests/TurnosCajaYGastosRlsTests.cs
@@ -1,0 +1,401 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 1 (task 1.8, spec: turnos-de-caja/movimientos-de-caja/
+/// arqueo-de-cierre/tesoreria/gastos — aislamiento de tenant implícito): mismo patrón que
+/// <c>VentasStockYCuentaCorrienteRlsTests</c> — SQL crudo, independiente de EF, 0 filas para
+/// SELECT/UPDATE cross-tenant, 42501 para el INSERT que viola <c>WITH CHECK</c>, más un proof a
+/// nivel EF (LINQ) por tabla. Cubre las cinco tablas nuevas de esta etapa.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class TurnosCajaYGastosRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    public static TheoryData<string, string> TablasDeTenant => new()
+    {
+        { "turnos_caja", "id_turno_caja" },
+        { "movimientos_caja", "id_movimiento" },
+        { "arqueos_turno", "id_arqueo" },
+        { "movimientos_tesoreria", "id_movimiento" },
+        { "gastos", "id_gasto" }
+    };
+
+    private sealed record Escenario(
+        int IdTenant, int IdPuntoVenta, int IdEmpleado, int IdMedioPago, int IdMedioPagoAlterno,
+        int IdTurnoCaja, int IdMovimientoCaja, int IdArqueoTurno, int IdMovimientoTesoreria, int IdGasto);
+
+    /// <summary>Arma la cadena completa de prerequisitos y una fila en cada una de las cinco
+    /// tablas nuevas, todas del mismo tenant A — comparte el escenario entero para no repetir
+    /// cinco tablas de seed por test. <see cref="Escenario.IdMedioPagoAlterno"/> existe solo
+    /// para que el INSERT ajeno de <c>arqueos_turno</c> no choque con
+    /// <c>ux_arqueos_turno_medio</c> contra la fila ya sembrada.</summary>
+    private async Task<Escenario> SembrarEscenarioAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var medioPago = new MedioPago
+        {
+            IdTenant = tenant.Id,
+            Nombre = nombre + "-efectivo",
+            Orden = 1,
+            Comportamiento = ComportamientoMedioPago.Efectivo,
+            AdmiteVuelto = true,
+            RequiereReferencia = false,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioPago);
+        await db.SaveChangesAsync();
+
+        var medioPagoAlterno = new MedioPago
+        {
+            IdTenant = tenant.Id,
+            Nombre = nombre + "-tarjeta",
+            Orden = 2,
+            Comportamiento = ComportamientoMedioPago.Electronico,
+            AdmiteVuelto = false,
+            RequiereReferencia = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioPagoAlterno);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = tenant.Id,
+            IdPuntoVenta = puntoVenta.Id,
+            IdEmpleadoApertura = usuario.Id,
+            FechaApertura = ahora,
+            FondoInicial = 500m,
+            Estado = EstadoTurno.Abierto,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        var movimientoCaja = new MovimientoCaja
+        {
+            IdTenant = tenant.Id,
+            IdTurnoCaja = turno.Id,
+            Tipo = TipoMovimientoCaja.Retiro,
+            Importe = 100m,
+            Motivo = "retiro de prueba de RLS",
+            IdEmpleado = usuario.Id,
+            CreadoEl = ahora
+        };
+        db.MovimientosCaja.Add(movimientoCaja);
+        await db.SaveChangesAsync();
+
+        var arqueoTurno = new ArqueoTurno
+        {
+            IdTenant = tenant.Id,
+            IdTurnoCaja = turno.Id,
+            IdMedioPago = medioPago.Id,
+            ImporteEsperado = 400m,
+            ImporteDeclarado = 400m
+        };
+        db.ArqueosTurno.Add(arqueoTurno);
+        await db.SaveChangesAsync();
+
+        var movimientoTesoreria = new MovimientoTesoreria
+        {
+            IdTenant = tenant.Id,
+            IdPuntoVenta = puntoVenta.Id,
+            Fecha = ahora,
+            Tipo = TipoMovimientoTesoreria.RetiroCaja,
+            IdTurnoCaja = turno.Id,
+            Concepto = "cierre de prueba",
+            Inicio = 0m,
+            Ingreso = 100m,
+            Egreso = 0m,
+            Final = 100m,
+            IdEmpleado = usuario.Id
+        };
+        db.MovimientosTesoreria.Add(movimientoTesoreria);
+        await db.SaveChangesAsync();
+
+        var gasto = new Gasto
+        {
+            IdTenant = tenant.Id,
+            Fecha = ahora,
+            IdPuntoVenta = puntoVenta.Id,
+            IdTurnoCaja = turno.Id,
+            IdEmpleado = usuario.Id,
+            Categoria = CategoriaGasto.Otros,
+            Concepto = "gasto de prueba de RLS",
+            IdMedioPago = medioPago.Id,
+            Importe = 50m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Gastos.Add(gasto);
+        await db.SaveChangesAsync();
+
+        return new Escenario(
+            tenant.Id, puntoVenta.Id, usuario.Id, medioPago.Id, medioPagoAlterno.Id,
+            turno.Id, movimientoCaja.Id, arqueoTurno.Id, movimientoTesoreria.Id, gasto.Id);
+    }
+
+    private static int IdDeFila(Escenario escenario, string tabla) => tabla switch
+    {
+        "turnos_caja" => escenario.IdTurnoCaja,
+        "movimientos_caja" => escenario.IdMovimientoCaja,
+        "arqueos_turno" => escenario.IdArqueoTurno,
+        "movimientos_tesoreria" => escenario.IdMovimientoTesoreria,
+        "gastos" => escenario.IdGasto,
+        _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+    };
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoVeLaFilaPorSelect(string tabla, string columnaId)
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla);
+        var idFila = IdDeFila(escenario, tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"SELECT count(*) FROM {tabla} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila(string tabla, string columnaId)
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla);
+        var idFila = IdDeFila(escenario, tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        // turnos_caja/gastos tienen updated_at (EntidadTenant); los tres ledgers append-only no
+        // — da lo mismo qué columna se toque, lo que se prueba es que USING oculta la fila antes
+        // de que el UPDATE la alcance.
+        var (columna, valor) = tabla switch
+        {
+            "turnos_caja" => ("updated_at", "now()"),
+            "movimientos_caja" => ("motivo", "'motivo actualizado por prueba'"),
+            "arqueos_turno" => ("importe_declarado", "999"),
+            "movimientos_tesoreria" => ("concepto", "'concepto actualizado'"),
+            "gastos" => ("updated_at", "now()"),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"UPDATE {tabla} SET {columna} = {valor} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ) de que el filtro de tenant también bloquea a las
+    /// entidades que pasan por el ORM — <c>movimientos_caja</c>/<c>arqueos_turno</c>/
+    /// <c>movimientos_tesoreria</c> quedan cubiertas acá también aunque usen el filtro manual
+    /// (no heredan <c>EntidadTenant</c>, ver los comentarios de
+    /// <c>WaysDbContext.AplicarFiltroDeTenantEnMovimientoCaja</c>/<c>...EnArqueoTurno</c>/
+    /// <c>...EnMovimientoTesoreria</c>).</summary>
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant(string tabla, string columnaId)
+    {
+        _ = columnaId;
+        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
+
+        var visible = tabla switch
+        {
+            "turnos_caja" => await sesionB.TurnosCaja.AnyAsync(t => t.Id == escenario.IdTurnoCaja),
+            "movimientos_caja" => await sesionB.MovimientosCaja.AnyAsync(m => m.Id == escenario.IdMovimientoCaja),
+            "arqueos_turno" => await sesionB.ArqueosTurno.AnyAsync(a => a.Id == escenario.IdArqueoTurno),
+            "movimientos_tesoreria" => await sesionB.MovimientosTesoreria.AnyAsync(m => m.Id == escenario.IdMovimientoTesoreria),
+            "gastos" => await sesionB.Gastos.AnyAsync(g => g.Id == escenario.IdGasto),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        Assert.False(visible);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnInsertConIdTenantAjenoSeRechaza(string tabla, string columnaId)
+    {
+        _ = columnaId;
+        var escenario = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoSeRechaza) + tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnInsertConIdTenantAjenoSeRechaza) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        // Sesión del tenant A intentando insertar una fila con id_tenant del tenant B (ajeno) —
+        // WITH CHECK tiene que rechazarla antes de que cualquier FK/CHECK se evalúe.
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", escenario.IdTenant);
+
+        var ahora = DateTimeOffset.UtcNow;
+
+        (string Sql, Action<NpgsqlCommand> Bind) insert = tabla switch
+        {
+            // estado='cerrado' a propósito (no 'abierto'): esquiva ux_turnos_caja_abierto —
+            // ya existe un turno abierto para este punto de venta en el escenario sembrado, y
+            // lo que se prueba acá es el 42501 de WITH CHECK, no la unicidad.
+            "turnos_caja" => (
+                "INSERT INTO turnos_caja (id_tenant, id_punto_venta, id_empleado_apertura, " +
+                "id_empleado_cierre, fecha_apertura, fecha_cierre, fondo_inicial, estado, " +
+                "created_at, updated_at) VALUES ($1, $2, $3, $3, $4, $4, 0, 'cerrado', $4, $4)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdEmpleado });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                }),
+            "movimientos_caja" => (
+                "INSERT INTO movimientos_caja (id_tenant, id_turno_caja, tipo, importe, motivo, " +
+                "id_empleado, creado_el) VALUES ($1, $2, 'retiro', 10, 'motivo de intruso válido', $3, $4)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdTurnoCaja });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdEmpleado });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                }),
+            // id_medio_pago ALTERNO a propósito: esquiva ux_arqueos_turno_medio contra la fila
+            // ya sembrada con el medio principal — lo que se prueba acá es el 42501.
+            "arqueos_turno" => (
+                "INSERT INTO arqueos_turno (id_tenant, id_turno_caja, id_medio_pago, " +
+                "importe_esperado, importe_declarado) VALUES ($1, $2, $3, 10, 10)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdTurnoCaja });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdMedioPagoAlterno });
+                }),
+            "movimientos_tesoreria" => (
+                "INSERT INTO movimientos_tesoreria (id_tenant, id_punto_venta, fecha, tipo, " +
+                "id_turno_caja, concepto, inicio, ingreso, egreso, final, id_empleado) " +
+                "VALUES ($1, $2, $3, 'retiro_caja', $4, 'intruso', 0, 10, 0, 10, $5)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdTurnoCaja });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdEmpleado });
+                }),
+            "gastos" => (
+                "INSERT INTO gastos (id_tenant, fecha, id_punto_venta, id_turno_caja, id_empleado, " +
+                "categoria, concepto, id_medio_pago, importe, created_at, updated_at) " +
+                "VALUES ($1, $2, $3, $4, $5, 'otros', 'gasto intruso', $6, 10, $2, $2)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdTurnoCaja });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdEmpleado });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdMedioPago });
+                }),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = insert.Sql;
+        insert.Bind(comando);
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) -- se dispara antes de
+        // cualquier FK/CHECK, sin importar que el resto de columnas referencien filas válidas
+        // del tenant A (la sesión sigue siendo la del tenant A, así que solo id_tenant desentona).
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+}

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -10,9 +10,11 @@ using Npgsql;
 using Testcontainers.PostgreSql;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
@@ -206,6 +208,10 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                 npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
             })
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
@@ -235,6 +241,10 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;


### PR DESCRIPTION
## Resumen

Slice 1/7 de la etapa 6 (stage-6-turnos-caja), gate de DB aprobado: el esquema completo de caja.

- Migración `TurnosCajaYGastosEtapa6`: `turnos_caja`, `movimientos_caja`, `arqueos_turno`, `movimientos_tesoreria`, `gastos` + 4 enums nativos + RLS en las 5 tablas en la misma migración.
- `ux_turnos_caja_abierto (id_punto_venta) WHERE estado='abierto'` — un solo turno abierto por PV, arbitrado por la DB.
- `arqueos_turno.diferencia` como `GENERATED ALWAYS ... STORED`.
- FK + índice sobre la columna preexistente `comprobantes_venta.id_turno_caja` (queda nullable; sin backfill).
- 6 CHECKs con sus backstops: 2 ramas nuevas en `ClasificarUnicidad` (match exacto, sin trampa de ordering) + `ClasificarCheckDeCaja` (switch por nombre exacto).
- Entidades skeleton (`Ways.Domain/Caja`, `Ways.Domain/Gastos`); `turnos_caja`/`gastos` como `EntidadTenant`, los 3 ledgers append-only con filtro manual de tenant (patrón `MovimientoStock`).
- Nota de FK diferida de `gastos.id_comprobante_compra` en doc 10 (columna y FK llegan juntas en la etapa 8).

`size:exception` pre-aprobado en el forecast: ~4.7k de las líneas son Designer/snapshot de EF; el código a mano es ~1.6k.

## Verificación

- Build 0 warnings; `has-pending-model-changes` limpio.
- Suites: Domain 271/271, Application 209/209, Integration 421/421 (393 base + 20 RLS + 8 backstops), contra Postgres real.
- Judgment-day: ronda 1 limpia — ambos jueces CLEAN (verificación independiente del DDL contra el contrato del gate y de los 28 tests nuevos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)