### PR TITLE
feat(caja): apertura de turno y movimientos de caja (etapa 6, slice 2)

### DIFF
--- a/src/Ways.Api/Endpoints/CajaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CajaEndpoints.cs
@@ -25,7 +25,11 @@ public static class CajaEndpoints
         grupo.MapGet("/abierto", async (ServicioDeTurnos servicio, int idPuntoVenta, CancellationToken ct) =>
         {
             var turno = await servicio.ObtenerAbiertoAsync(idPuntoVenta, ct);
-            return Results.Ok(turno);
+            // Con turno null hay que emitir el literal JSON "null" a mano: tanto Ok(null) como
+            // Json(null) producen body vacío, y eso rompe el response.json() del cliente.
+            return turno is null
+                ? Results.Content("null", "application/json; charset=utf-8")
+                : Results.Json(turno);
         })
         .WithSummary("Fuente de verdad del gate seam de Pos.tsx: 200 con el turno abierto o 200 con null.");
 

--- a/src/Ways.Api/Endpoints/CajaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CajaEndpoints.cs
@@ -1,0 +1,59 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Caja;
+
+namespace Ways.Api.Endpoints;
+
+public static class CajaEndpoints
+{
+    public static IEndpointRouteBuilder MapearCaja(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/caja/turnos")
+            .WithTags("Caja")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        // stage-6-turnos-caja (Slice 2, task 2.6, design: API Surface): apertura — INSERT llano
+        // detrás de ux_turnos_caja_abierto, 409 turno_ya_abierto si el punto de venta ya tiene
+        // uno abierto. Sin GestionDeCatalogo apilado (spec: Apertura And Cierre Authorization —
+        // un Vendedor tiene que poder abrir turno).
+        grupo.MapPost("/", async (ServicioDeTurnos servicio, SolicitudDeApertura solicitud, CancellationToken ct) =>
+        {
+            var turno = await servicio.AbrirAsync(solicitud, ct);
+            return Results.Created($"/api/caja/turnos/{turno.Id}", turno);
+        })
+        .WithSummary("Apertura de turno de caja.");
+
+        grupo.MapGet("/abierto", async (ServicioDeTurnos servicio, int idPuntoVenta, CancellationToken ct) =>
+        {
+            var turno = await servicio.ObtenerAbiertoAsync(idPuntoVenta, ct);
+            return Results.Ok(turno);
+        })
+        .WithSummary("Fuente de verdad del gate seam de Pos.tsx: 200 con el turno abierto o 200 con null.");
+
+        grupo.MapGet("/{id:int}", async (ServicioDeTurnos servicio, int id, CancellationToken ct) =>
+            Results.Ok(await servicio.ObtenerAsync(id, ct)))
+        .WithSummary("Turno por id (payload del Z-report).");
+
+        grupo.MapGet("/", (
+            ServicioDeTurnos servicio,
+            int? idPuntoVenta,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Historial de turnos, paginado.");
+
+        // task 2.6, design: API Surface — retiro / refuerzo / apertura de cajón contra el turno
+        // que identifica la ruta (nunca contra un idTurnoCaja del cuerpo).
+        grupo.MapPost("/{id:int}/movimientos", async (
+            ServicioDeTurnos servicio, int id, SolicitudDeMovimiento solicitud, CancellationToken ct) =>
+        {
+            var movimiento = await servicio.RegistrarMovimientoAsync(id, solicitud, ct);
+            return Results.Created($"/api/caja/turnos/{id}/movimientos/{movimiento.Id}", movimiento);
+        })
+        .WithSummary("Retiro / refuerzo / apertura de cajón contra el turno abierto.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -170,6 +170,7 @@ app.MapearArticulos();
 app.MapearOfertas();
 app.MapearVentas();
 app.MapearStock();
+app.MapearCaja();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
@@ -73,6 +74,13 @@ public interface IWaysDbContext
     DbSet<Ways.Domain.Stock.Stock> Stock { get; }
     DbSet<MovimientoStock> MovimientosStock { get; }
     DbSet<MovimientoCuentaCorriente> MovimientosCuentaCorriente { get; }
+
+    // stage-6-turnos-caja, Slice 2: ServicioDeTurnos es el primer consumidor de Application de
+    // estos 2 — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes A/B).
+    // ArqueosTurno/MovimientosTesoreria/Gastos siguen sin exponerse acá: sus primeros
+    // consumidores (ServicioDeTurnos.CerrarAsync/ServicioDeGastos) llegan en Slice 3/4.
+    DbSet<TurnoCaja> TurnosCaja { get; }
+    DbSet<MovimientoCaja> MovimientosCaja { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -1,0 +1,41 @@
+using Ways.Domain.Caja;
+
+namespace Ways.Application.Caja;
+
+/// <summary>Cuerpo de <c>POST /api/caja/turnos</c> (design: API Surface) — sin campo de
+/// empleado a propósito, mismo criterio que <c>Ways.Application.Ventas.SolicitudDeVenta</c>
+/// (design decisión 11): <c>id_empleado_apertura</c> siempre sale de
+/// <c>IContextoDeUsuario.UsuarioId</c>, nunca de este contrato.</summary>
+public sealed record SolicitudDeApertura(int IdPuntoVenta, decimal FondoInicial, string? Observaciones);
+
+/// <summary>Cuerpo de <c>POST /api/caja/turnos/{id}/movimientos</c> (design: API Surface) — el
+/// turno lo identifica la ruta, nunca este cuerpo (spec: idTurnoCaja is not an accepted request
+/// field, sobre los campos del contrato).</summary>
+public sealed record SolicitudDeMovimiento(TipoMovimientoCaja Tipo, decimal Importe, string? Motivo);
+
+/// <summary>Proyección de <see cref="TurnoCaja"/> — respuesta de apertura, <c>GET …/abierto</c>
+/// y <c>GET …/{id}</c> (Slice 4 le agrega <c>Arqueos</c> cuando el cierre exista).</summary>
+public sealed record TurnoResumen(
+    int Id,
+    int IdPuntoVenta,
+    int IdEmpleadoApertura,
+    int? IdEmpleadoCierre,
+    DateTimeOffset FechaApertura,
+    DateTimeOffset? FechaCierre,
+    decimal FondoInicial,
+    EstadoTurno Estado,
+    string? Observaciones);
+
+/// <summary>Fila de <c>GET /api/caja/turnos</c> (historial paginado) — sin
+/// observaciones/empleados, mismo criterio que <c>Ways.Application.Ventas.ComprobanteListado</c>.
+/// </summary>
+public sealed record TurnoListado(
+    int Id, int IdPuntoVenta, DateTimeOffset FechaApertura, DateTimeOffset? FechaCierre, EstadoTurno Estado);
+
+/// <summary>Página de resultados de <c>GET /api/caja/turnos</c> — mismo shape que
+/// <c>Ways.Application.Ventas.PaginaDeVentas</c>.</summary>
+public sealed record PaginaDeTurnos(IReadOnlyList<TurnoListado> Items, int Total, int Pagina, int Tamanio);
+
+/// <summary>Proyección de <see cref="MovimientoCaja"/> ya persistido.</summary>
+public sealed record MovimientoRegistrado(
+    int Id, int IdTurnoCaja, TipoMovimientoCaja Tipo, decimal Importe, string Motivo, int IdEmpleado, DateTimeOffset CreadoEl);

--- a/src/Ways.Application/Caja/ServicioDeTurnos.cs
+++ b/src/Ways.Application/Caja/ServicioDeTurnos.cs
@@ -1,0 +1,241 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Caja;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// Turno de caja: apertura, movimientos físicos fuera de la venta (retiro/refuerzo/apertura de
+/// cajón) y lectura (design: API Surface). El cierre (design: The Cierre Transaction) llega en
+/// Slice 4 — <see cref="ResolverTurnoAbiertoAsync"/> es el resolver compartido que Slice 3
+/// (gastos) y Slice 5 (checkout) reutilizan (tasks.md, Orchestrator Decision 3), evitando tres
+/// copias del mismo <c>409 turno_no_abierto</c>.
+/// </summary>
+public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+{
+    /// <summary>Apertura (design decisión 7): INSERT llano detrás de <c>ux_turnos_caja_abierto
+    /// (id_punto_venta) WHERE estado = 'abierto'</c> — sin lectura previa, sin advisory lock. La
+    /// carrera se resuelve en el <c>23505</c> del <c>SaveChangesAsync</c>
+    /// (<c>ManejadorDeErrores.ClasificarUnicidad</c> ya traduce ese índice a <c>409
+    /// turno_ya_abierto</c>, groundwork de Slice 1). <see
+    /// cref="FabricaDeEstrategiaSinReintento"/>: operación manual y rara, sin clave de
+    /// idempotencia — mismo criterio que <c>ServicioDeStock.AjustarAsync</c>.</summary>
+    public async Task<TurnoResumen> AbrirAsync(SolicitudDeApertura solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        var turno = await estrategia.ExecuteAsync(async () =>
+            await InsertarTurnoAsync(idTenant, solicitud, idEmpleado, momento, ct));
+
+        return Proyectar(turno);
+    }
+
+    private async Task<TurnoCaja> InsertarTurnoAsync(
+        int idTenant, SolicitudDeApertura solicitud, int idEmpleado, DateTimeOffset momento, CancellationToken ct)
+    {
+        var turno = new TurnoCaja
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdEmpleadoApertura = idEmpleado,
+            FechaApertura = momento,
+            FondoInicial = solicitud.FondoInicial,
+            Estado = EstadoTurno.Abierto,
+            Observaciones = solicitud.Observaciones,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync(ct);
+
+        return turno;
+    }
+
+    /// <summary>Resolver compartido (spec: Turno Is Always Server-Resolved, Never
+    /// Client-Supplied): el turno abierto de un punto de venta se resuelve SIEMPRE desde
+    /// <paramref name="idPuntoVenta"/>, nunca desde un id de turno que mande el cliente.
+    /// Reutilizado por <c>ServicioDeGastos.RegistrarAsync</c> (Slice 3) y
+    /// <c>ServicioDeVentas.EmitirAsync</c> (Slice 5, design decisión 11).</summary>
+    public async Task<TurnoCaja> ResolverTurnoAbiertoAsync(int idPuntoVenta, CancellationToken ct = default) =>
+        await db.TurnosCaja
+            .Where(t => t.IdPuntoVenta == idPuntoVenta && t.Estado == EstadoTurno.Abierto)
+            .FirstOrDefaultAsync(ct)
+        ?? throw new ErrorDominio("turno_no_abierto", "No hay un turno abierto en este punto de venta.", 409);
+
+    /// <summary>Movimiento físico de caja fuera de la venta — retiro, refuerzo o apertura de
+    /// cajón (design decisión 8). A diferencia de <see cref="ResolverTurnoAbiertoAsync"/>, acá el
+    /// turno lo identifica la ruta (<c>POST /api/caja/turnos/{id}/movimientos</c>, design: API
+    /// Surface — mismo patrón que <c>GET …/{id}</c> y <c>POST …/{id}/cierre</c>, que también
+    /// direccionan un turno puntual por id): el servidor igual decide con autoridad, nunca
+    /// confiando en que el turno de esa url siga abierto — <see
+    /// cref="ResolverTurnoPorIdAbiertoAsync"/> lo revalida contra el estado persistido y devuelve
+    /// el mismo <c>409 turno_no_abierto</c> si no lo está.</summary>
+    public async Task<MovimientoRegistrado> RegistrarMovimientoAsync(
+        int idTurnoCaja, SolicitudDeMovimiento solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        ReglaDeMovimientosDeCaja.ExigirImporteValido(solicitud.Tipo, solicitud.Importe);
+        ReglaDeMovimientosDeCaja.ExigirMotivoValido(solicitud.Tipo, solicitud.Motivo);
+
+        var turno = await ResolverTurnoPorIdAbiertoAsync(idTurnoCaja, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        var movimiento = await estrategia.ExecuteAsync(async () =>
+            await InsertarMovimientoAsync(idTenant, turno.Id, solicitud, idEmpleado, momento, ct));
+
+        return Proyectar(movimiento);
+    }
+
+    private async Task<MovimientoCaja> InsertarMovimientoAsync(
+        int idTenant, int idTurnoCaja, SolicitudDeMovimiento solicitud, int idEmpleado, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        var movimiento = new MovimientoCaja
+        {
+            IdTenant = idTenant,
+            IdTurnoCaja = idTurnoCaja,
+            Tipo = solicitud.Tipo,
+            Importe = solicitud.Importe,
+            // ReglaDeMovimientosDeCaja.ExigirMotivoValido ya garantizó no-nulo/no-vacío arriba.
+            Motivo = solicitud.Motivo!.Trim(),
+            IdEmpleado = idEmpleado,
+            CreadoEl = momento
+        };
+
+        db.MovimientosCaja.Add(movimiento);
+        await db.SaveChangesAsync(ct);
+
+        return movimiento;
+    }
+
+    /// <summary>Fuente de verdad del gate seam de <c>Pos.tsx</c> (design: API Surface, <c>GET
+    /// /api/caja/turnos/abierto</c>): a diferencia de <see cref="ResolverTurnoAbiertoAsync"/>,
+    /// nunca lanza — <c>null</c> es una respuesta válida (200), no un error.</summary>
+    public async Task<TurnoResumen?> ObtenerAbiertoAsync(int idPuntoVenta, CancellationToken ct = default)
+    {
+        var turno = await db.TurnosCaja
+            .Where(t => t.IdPuntoVenta == idPuntoVenta && t.Estado == EstadoTurno.Abierto)
+            .FirstOrDefaultAsync(ct);
+
+        return turno is null ? null : Proyectar(turno);
+    }
+
+    /// <summary>Turno por id (design: API Surface, <c>GET /api/caja/turnos/{id}</c> — el payload
+    /// del Z-report; Slice 4 le agrega los <c>arqueos_turno</c> cuando el cierre exista).</summary>
+    public async Task<TurnoResumen> ObtenerAsync(int id, CancellationToken ct = default)
+    {
+        var turno = await db.TurnosCaja.FirstOrDefaultAsync(t => t.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el turno {id}.");
+
+        return Proyectar(turno);
+    }
+
+    /// <summary>Historial paginado (design: API Surface, <c>GET /api/caja/turnos</c>) — mismo
+    /// criterio de paginado que <c>ServicioDeVentas.ListarAsync</c>.</summary>
+    public async Task<PaginaDeTurnos> ListarAsync(
+        int? idPuntoVenta = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = db.TurnosCaja.AsQueryable();
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(t => t.IdPuntoVenta == pv);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(t => t.FechaApertura >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(t => t.FechaApertura <= h);
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(t => t.FechaApertura)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(t => new TurnoListado(t.Id, t.IdPuntoVenta, t.FechaApertura, t.FechaCierre, t.Estado))
+            .ToListAsync(ct);
+
+        return new PaginaDeTurnos(items, total, pagina, tamanio);
+    }
+
+    // ---- resolución interna ---------------------------------------------------------------
+
+    /// <summary>Ver el doc-comment de <see cref="RegistrarMovimientoAsync"/> — resuelve por id de
+    /// turno (el que trae la ruta), pero SIGUE decidiendo con autoridad server-side: <c>404</c>
+    /// (ADR-8, no existe/es de otro tenant — el filtro de EF/RLS ya lo deja invisible) o <c>409
+    /// turno_no_abierto</c> si existe pero no está <see cref="EstadoTurno.Abierto"/>.</summary>
+    private async Task<TurnoCaja> ResolverTurnoPorIdAbiertoAsync(int idTurnoCaja, CancellationToken ct)
+    {
+        var turno = await db.TurnosCaja.FirstOrDefaultAsync(t => t.Id == idTurnoCaja, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el turno {idTurnoCaja}.");
+
+        if (turno.Estado != EstadoTurno.Abierto)
+        {
+            throw new ErrorDominio("turno_no_abierto", "El turno no está abierto.", 409);
+        }
+
+        return turno;
+    }
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (filtro de EF + RLS ya
+            // deja invisible un punto de venta ajeno) — mismo criterio que
+            // ServicioDeStock.ResolverPuntoVentaAsync/ServicioDeVentas.ResolverPuntoVentaAsync.
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            // OperacionDePos (capa de API) ya exige un actor de tenant — un actor de plataforma
+            // (root) nunca llega hasta acá. Defensa en profundidad, mismo criterio que
+            // ServicioDeStock.ExigirTenantDeLaSesion.
+            ?? throw new InvalidOperationException(
+                "ServicioDeTurnos requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    // ---- proyecciones -----------------------------------------------------------------------
+
+    private static TurnoResumen Proyectar(TurnoCaja turno) => new(
+        turno.Id,
+        turno.IdPuntoVenta,
+        turno.IdEmpleadoApertura,
+        turno.IdEmpleadoCierre,
+        turno.FechaApertura,
+        turno.FechaCierre,
+        turno.FondoInicial,
+        turno.Estado,
+        turno.Observaciones);
+
+    private static MovimientoRegistrado Proyectar(MovimientoCaja movimiento) => new(
+        movimiento.Id,
+        movimiento.IdTurnoCaja,
+        movimiento.Tipo,
+        movimiento.Importe,
+        movimiento.Motivo,
+        movimiento.IdEmpleado,
+        movimiento.CreadoEl);
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Articulos;
+using Ways.Application.Caja;
 using Ways.Application.Catalogos;
 using Ways.Application.Clientes;
 using Ways.Application.Ofertas;
@@ -45,6 +46,7 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeEscaneo>();
         services.AddScoped<ServicioDeVentas>();
         services.AddScoped<ServicioDeStock>();
+        services.AddScoped<ServicioDeTurnos>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Domain/Caja/ReglaDeMovimientosDeCaja.cs
+++ b/src/Ways.Domain/Caja/ReglaDeMovimientosDeCaja.cs
@@ -1,0 +1,70 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Reglas de negocio puras de <see cref="MovimientoCaja"/> (design decisión 8), sin
+/// dependencias — mismo criterio que <see cref="ReglaDeTurnos"/>. <c>ServicioDeTurnos.
+/// RegistrarMovimientoAsync</c> (Slice 2) pasa por acá antes de tocar la fila.
+/// </summary>
+public static class ReglaDeMovimientosDeCaja
+{
+    /// <summary>Longitud mínima de <see cref="MovimientoCaja.Motivo"/>, uniforme para los tres
+    /// <see cref="TipoMovimientoCaja"/> (design decisión 8: "una regla, sin rama por tipo") —
+    /// paridad con el F12 del legacy (doc-01:157), llevada a los otros dos tipos en vez de
+    /// inventar una regla distinta para cada uno.</summary>
+    private const int LongitudMinimaDeMotivo = 5;
+
+    /// <summary><see cref="TipoMovimientoCaja.AperturaCajon"/> exige <c>importe = 0</c> exacto
+    /// (es un rastro de auditoría, nunca dinero); los otros dos tipos exigen <c>importe &gt;
+    /// 0</c> — mover dinero físico en cero o en negativo no tiene significado de negocio (design
+    /// decisión 8, <c>ck_movimientos_caja_importe</c>).</summary>
+    public static void ExigirImporteValido(TipoMovimientoCaja tipo, decimal importe)
+    {
+        if (tipo == TipoMovimientoCaja.AperturaCajon)
+        {
+            if (importe != 0m)
+            {
+                throw new ErrorDominio(
+                    "movimiento_de_caja_importe_invalido",
+                    "El importe de una apertura de cajón tiene que ser exactamente 0.", 400);
+            }
+
+            return;
+        }
+
+        if (importe <= 0m)
+        {
+            throw new ErrorDominio(
+                "movimiento_de_caja_importe_invalido", "El importe tiene que ser mayor a 0.", 400);
+        }
+    }
+
+    /// <summary>Un único chequeo de longitud (<see cref="LongitudMinimaDeMotivo"/>) para los tres
+    /// tipos (design decisión 8) — el código de error sí distingue por tipo, para que la UX
+    /// nombre la causa real: <c>apertura_cajon</c> usa <c>motivo_de_apertura_cajon_invalido</c>
+    /// (spec: Apertura De Cajón Follows Legacy F12 Parity), <c>retiro</c>/<c>refuerzo</c> usan
+    /// <c>movimiento_de_caja_sin_motivo</c> (spec: Motivo Required For Retiro And Refuerzo) tanto
+    /// para un motivo ausente como para uno más corto que el mínimo — ambos son la misma falla de
+    /// negocio ("no diste una razón válida").</summary>
+    public static void ExigirMotivoValido(TipoMovimientoCaja tipo, string? motivo)
+    {
+        var limpio = motivo?.Trim();
+        var esValido = !string.IsNullOrEmpty(limpio) && limpio.Length >= LongitudMinimaDeMotivo;
+
+        if (esValido)
+        {
+            return;
+        }
+
+        if (tipo == TipoMovimientoCaja.AperturaCajon)
+        {
+            throw new ErrorDominio(
+                "motivo_de_apertura_cajon_invalido",
+                $"El motivo de una apertura de cajón requiere al menos {LongitudMinimaDeMotivo} caracteres.", 400);
+        }
+
+        throw new ErrorDominio(
+            "movimiento_de_caja_sin_motivo", "Este movimiento requiere un motivo.", 400);
+    }
+}

--- a/src/Ways.Domain/Caja/ReglaDeTurnos.cs
+++ b/src/Ways.Domain/Caja/ReglaDeTurnos.cs
@@ -1,0 +1,33 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Reglas de negocio puras de <see cref="TurnoCaja"/> (design decisión 10), sin dependencias —
+/// mismo criterio que <see cref="Ventas.ReglaDeComprobantes"/>. <c>ServicioDeTurnos.CerrarAsync</c>
+/// (Slice 4, cierre — la única transición real de este stage) pasa por acá antes de tocar la fila.
+/// </summary>
+public static class ReglaDeTurnos
+{
+    /// <summary>Única transición válida: <see cref="EstadoTurno.Abierto"/> → <see
+    /// cref="EstadoTurno.Cerrado"/> (design decisión 10) — nunca al revés, no hay reapertura.
+    /// Un turno ya cerrado que intenta cerrarse de nuevo es <c>409 turno_ya_cerrado</c> (design:
+    /// The Cierre Transaction, statement 1 — el mismo código que produce el <c>UPDATE … WHERE
+    /// estado = 'abierto'</c> de 0 filas cuando el turno existe pero ya está cerrado, para que el
+    /// resultado sea idéntico sin importar si la doble transición se detecta acá o en la carrera
+    /// de la base).</summary>
+    public static void ValidarTransicionAEstado(EstadoTurno actual, EstadoTurno nuevo)
+    {
+        if (actual == EstadoTurno.Cerrado)
+        {
+            throw new ErrorDominio("turno_ya_cerrado", "El turno ya está cerrado.", 409);
+        }
+
+        if (actual == EstadoTurno.Abierto && nuevo == EstadoTurno.Cerrado)
+        {
+            return;
+        }
+
+        throw new ErrorDominio("transicion_de_estado_invalida", "Esa transición de estado no es válida.", 400);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/TurnoCajaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/TurnoCajaConfiguration.cs
@@ -7,9 +7,10 @@ using Ways.Domain.Usuarios;
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
 
 /// <summary>
-/// Mapea <see cref="TurnoCaja"/> (design: Table Shapes — write path A). Las dos CHECKs son
-/// defensa en profundidad — <c>ReglaDeTurnos</c> (Slice 2)/<c>ServicioDeTurnos.CerrarAsync</c>
-/// (Slice 4) garantizan los mismos invariantes en el camino de servicio.
+/// Mapea <see cref="TurnoCaja"/> (design: Table Shapes — write path A). <c>ck_turnos_caja_cierre_consistente</c>
+/// es defensa en profundidad de <c>ServicioDeTurnos.CerrarAsync</c> (Slice 4), que garantiza el
+/// mismo invariante en el camino de servicio. <c>ck_turnos_caja_fondo_inicial_no_negativo</c> no
+/// tiene gemelo de dominio: <c>ServicioDeTurnos.AbrirAsync</c> confía solo en esta CHECK.
 /// </summary>
 public class TurnoCajaConfiguration : IEntityTypeConfiguration<TurnoCaja>
 {

--- a/tests/Ways.Domain.Tests/Caja/ReglaDeMovimientosDeCajaTests.cs
+++ b/tests/Ways.Domain.Tests/Caja/ReglaDeMovimientosDeCajaTests.cs
@@ -1,0 +1,126 @@
+using Ways.Domain.Caja;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Tests.Caja;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 2 (task 2.2, task 2.7, design decisión 8) — pura, sin base de
+/// datos. Exhaustivo sobre importe/motivo por tipo, incluido el borde de 5 caracteres.
+/// </summary>
+public class ReglaDeMovimientosDeCajaTests
+{
+    // ---- ExigirImporteValido -----------------------------------------------------------------
+
+    [Fact]
+    public void RetiroConImportePositivoEsValido() =>
+        ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.Retiro, 200m);
+
+    [Fact]
+    public void RefuerzoConImportePositivoEsValido() =>
+        ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.Refuerzo, 1m);
+
+    [Fact]
+    public void RetiroConImporteCeroSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.Retiro, 0m));
+        Assert.Equal("movimiento_de_caja_importe_invalido", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void RefuerzoConImporteNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.Refuerzo, -1m));
+        Assert.Equal("movimiento_de_caja_importe_invalido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void AperturaDeCajonConImporteCeroEsValida() =>
+        ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.AperturaCajon, 0m);
+
+    [Fact]
+    public void AperturaDeCajonConImportePositivoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.AperturaCajon, 50m));
+        Assert.Equal("movimiento_de_caja_importe_invalido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void AperturaDeCajonConImporteNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirImporteValido(TipoMovimientoCaja.AperturaCajon, -1m));
+        Assert.Equal("movimiento_de_caja_importe_invalido", excepcion.Codigo);
+    }
+
+    // ---- ExigirMotivoValido -------------------------------------------------------------------
+
+    [Fact]
+    public void RetiroConMotivoVacioSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.Retiro, ""));
+        Assert.Equal("movimiento_de_caja_sin_motivo", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void RetiroConMotivoNuloSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.Retiro, null));
+        Assert.Equal("movimiento_de_caja_sin_motivo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void RefuerzoConMotivoMasCortoQueElMinimoSeRechaza()
+    {
+        // design decisión 8: la longitud mínima (5) aplica uniforme a los 3 tipos, no solo a
+        // apertura_cajon — "abc" (3 caracteres) también falla acá.
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.Refuerzo, "abc"));
+        Assert.Equal("movimiento_de_caja_sin_motivo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void RetiroConMotivoValidoEsAceptado() =>
+        ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.Retiro, "pago a proveedor en efectivo");
+
+    [Fact]
+    public void AperturaDeCajonConMotivoCortoSeRechazaConCodigoPropio()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.AperturaCajon, "abc"));
+        Assert.Equal("motivo_de_apertura_cajon_invalido", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void AperturaDeCajonEnElBordeDeCincoCaracteresEsValida() =>
+        ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.AperturaCajon, "abcde");
+
+    [Fact]
+    public void AperturaDeCajonConCuatroCaracteresSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.AperturaCajon, "abcd"));
+        Assert.Equal("motivo_de_apertura_cajon_invalido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnMotivoConEspaciosAlrededorSeRecortaAntesDeMedir()
+    {
+        // "  ab  ".Trim() = "ab" (2 caracteres) — no alcanza el mínimo aunque el string crudo
+        // tenga 6 caracteres de largo.
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.Retiro, "  ab  "));
+        Assert.Equal("movimiento_de_caja_sin_motivo", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void AperturaDeCajonConMotivoValidoEsAceptada() =>
+        ReglaDeMovimientosDeCaja.ExigirMotivoValido(TipoMovimientoCaja.AperturaCajon, "conteo inicial de turno");
+}

--- a/tests/Ways.Domain.Tests/Caja/ReglaDeTurnosTests.cs
+++ b/tests/Ways.Domain.Tests/Caja/ReglaDeTurnosTests.cs
@@ -1,0 +1,41 @@
+using Ways.Domain.Caja;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Tests.Caja;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 2 (task 2.1, task 2.7, design decisión 10) — pura, sin base de
+/// datos. Única transición válida: Abierto → Cerrado.
+/// </summary>
+public class ReglaDeTurnosTests
+{
+    [Fact]
+    public void AbiertoACerradoEsUnaTransicionValida() =>
+        ReglaDeTurnos.ValidarTransicionAEstado(EstadoTurno.Abierto, EstadoTurno.Cerrado);
+
+    [Fact]
+    public void CerradoNoPuedeVolverAAbrirse()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeTurnos.ValidarTransicionAEstado(EstadoTurno.Cerrado, EstadoTurno.Abierto));
+        Assert.Equal("turno_ya_cerrado", excepcion.Codigo);
+        Assert.Equal(409, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void CerradoNoPuedeVolverACerrarse()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeTurnos.ValidarTransicionAEstado(EstadoTurno.Cerrado, EstadoTurno.Cerrado));
+        Assert.Equal("turno_ya_cerrado", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void AbiertoNoPuedeQuedarseEnAbiertoComoTransicion()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ReglaDeTurnos.ValidarTransicionAEstado(EstadoTurno.Abierto, EstadoTurno.Abierto));
+        Assert.Equal("transicion_de_estado_invalida", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+}

--- a/tests/Ways.IntegrationTests/CajaTurnosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/CajaTurnosEndpointsTests.cs
@@ -418,6 +418,102 @@ public class CajaTurnosEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         Assert.Equal(HttpStatusCode.Forbidden, movimiento.StatusCode);
     }
 
+    // ---- judgment-day (Slice 2, ronda 2): auth guard blind spot ------------------------------------
+
+    /// <summary>Confirmed issue (judgment-day, Slice 2 ronda 2, MAJOR): companion directa del
+    /// guard de <see cref="SuperficieDeAutorizacionTests.TodoEndpointGetBajoLasSuperficiesReGateadasApilaOperacionDePos"/>
+    /// — mismo criterio que <c>OperacionDePosLecturaTests.ResolverOfertasSinTokenDevuelve401</c>:
+    /// sin token, <c>OperacionDePos</c> exige <c>RequireAuthenticatedUser()</c> antes que nada.</summary>
+    [Fact]
+    public async Task ObtenerTurnoAbiertoSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.GetAsync("/api/caja/turnos/abierto?idPuntoVenta=1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+
+    // ---- judgment-day (Slice 2, ronda 2): regresión cross-tenant ------------------------------------
+
+    /// <summary>Confirmed issue (judgment-day, Slice 2 ronda 2, MAJOR): mismo criterio ADR-8 que
+    /// <c>ArticulosEndpointsTests.AgregarCodigoBarraAUnArticuloDeOtroTenantDevuelve404</c> — pin
+    /// contra una regresión futura de <c>IgnoreQueryFilters</c> sobre <c>ObtenerAsync</c>.</summary>
+    [Fact]
+    public async Task ObtenerUnTurnoDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(ObtenerUnTurnoDeOtroTenantDevuelve404) + "-A");
+        var turnoDeA = await AbrirTurnoAsync(ctxA);
+
+        var ctxB = await PrepararAsync(nameof(ObtenerUnTurnoDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxB.Admin.GetAsync($"/api/caja/turnos/{turnoDeA.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    /// <summary>Confirmed issue (judgment-day, Slice 2 ronda 2, MAJOR): mismo criterio que
+    /// <see cref="ObtenerUnTurnoDeOtroTenantDevuelve404"/>, pin contra
+    /// <c>ResolverTurnoPorIdAbiertoAsync</c> sobre el turno ABIERTO de otro tenant.</summary>
+    [Fact]
+    public async Task RegistrarMovimientoContraElTurnoAbiertoDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(RegistrarMovimientoContraElTurnoAbiertoDeOtroTenantDevuelve404) + "-A");
+        var turnoDeA = await AbrirTurnoAsync(ctxA);
+
+        var ctxB = await PrepararAsync(nameof(RegistrarMovimientoContraElTurnoAbiertoDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxB.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turnoDeA.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 100m, "intento cross-tenant"));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- judgment-day (Slice 2, ronda 2): cobertura del historial y del 404 puntual ------------------
+
+    /// <summary>Confirmed issue (judgment-day, Slice 2 ronda 2, MINOR): <c>ServicioDeTurnos.ListarAsync</c>
+    /// sin cobertura punta a punta — pagina (Total/Pagina/Tamanio) y el filtro <c>idPuntoVenta</c>.</summary>
+    [Fact]
+    public async Task ElHistorialPaginaYFiltraPorPuntoDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(ElHistorialPaginaYFiltraPorPuntoDeVenta));
+        var idOtroPuntoVenta = await SembrarSegundoPuntoDeVentaAsync(ctx);
+
+        await SembrarTurnoCerradoAsync(ctx);
+        await AbrirTurnoAsync(ctx);
+
+        var enOtroPunto = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(idOtroPuntoVenta, 100m, "Local 2"));
+        Assert.Equal(HttpStatusCode.Created, enOtroPunto.StatusCode);
+
+        var completo = await ctx.Admin.GetFromJsonAsync<PaginaDeTurnos>("/api/caja/turnos", OpcionesJson);
+        Assert.NotNull(completo);
+        Assert.Equal(3, completo!.Total);
+        Assert.Equal(3, completo.Items.Count);
+        Assert.Equal(1, completo.Pagina);
+        Assert.Equal(25, completo.Tamanio);
+
+        var filtrado = await ctx.Admin.GetFromJsonAsync<PaginaDeTurnos>(
+            $"/api/caja/turnos?idPuntoVenta={ctx.IdPuntoVenta}", OpcionesJson);
+        Assert.NotNull(filtrado);
+        Assert.Equal(2, filtrado!.Total);
+        Assert.All(filtrado.Items, item => Assert.Equal(ctx.IdPuntoVenta, item.IdPuntoVenta));
+    }
+
+    /// <summary>Confirmed issue (judgment-day, Slice 2 ronda 2, MINOR): <c>GET …/{id}</c> con un id
+    /// que no existe (a diferencia de <see cref="ObtenerUnTurnoDeOtroTenantDevuelve404"/>, que
+    /// existe pero es de otro tenant) también cae en el mismo <c>404</c> ADR-8.</summary>
+    [Fact]
+    public async Task ObtenerUnTurnoInexistenteDevuelve404()
+    {
+        var ctx = await PrepararAsync(nameof(ObtenerUnTurnoInexistenteDevuelve404));
+
+        var respuesta = await ctx.Admin.GetAsync("/api/caja/turnos/999999");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
     // ---- helper compartido ----------------------------------------------------------------------
 
     private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx)

--- a/tests/Ways.IntegrationTests/CajaTurnosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/CajaTurnosEndpointsTests.cs
@@ -1,0 +1,432 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 2 (tasks 2.6, 2.8, 2.9, 2.10): <c>POST /api/caja/turnos</c>,
+/// <c>GET …/abierto</c>, <c>POST …/{id}/movimientos</c> punta a punta — apertura detrás de
+/// <c>ux_turnos_caja_abierto</c> con su carrera genuina, motivo/importe de movimientos, y
+/// autorización <c>OperacionDePos</c> (spec: turnos-de-caja, movimientos-de-caja).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CajaTurnosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "una-contraseña-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, string MailAdmin, string PasswordAdmin, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, mailAdmin, resultado.PasswordTemporal, admin);
+    }
+
+    private async Task<HttpClient> CrearVendedorAsync(Contexto ctx, string nombre)
+    {
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-caja", mailVendedor, (int)RolConocido.Vendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return vendedor;
+    }
+
+    private async Task<int> SembrarSegundoPuntoDeVentaAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idEmpresa = await db.PuntosVenta.Where(p => p.Id == ctx.IdPuntoVenta).Select(p => p.IdEmpresa).FirstAsync();
+
+        var otro = new PuntoVenta
+        {
+            IdTenant = ctx.IdTenant, IdEmpresa = idEmpresa, Nombre = "Local 2", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(otro);
+        await db.SaveChangesAsync();
+
+        return otro.Id;
+    }
+
+    /// <summary>Seed directo (sin pasar por la API — el cierre real es Slice 4): un turno YA
+    /// cerrado, para probar <c>409 turno_no_abierto</c> sobre un movimiento sin turno abierto
+    /// (spec: Movimiento Requires An Open Turno).</summary>
+    private async Task<int> SembrarTurnoCerradoAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = ctx.IdTenant,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleadoApertura = ctx.IdEmpleadoAdmin,
+            IdEmpleadoCierre = ctx.IdEmpleadoAdmin,
+            FechaApertura = ahora.AddHours(-2),
+            FechaCierre = ahora.AddHours(-1),
+            FondoInicial = 100m,
+            Estado = EstadoTurno.Cerrado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        return turno.Id;
+    }
+
+    // ---- task 2.6: apertura --------------------------------------------------------------------
+
+    [Fact]
+    public async Task LaAperturaCreaUnTurnoAbiertoConSuFondo()
+    {
+        var ctx = await PrepararAsync(nameof(LaAperturaCreaUnTurnoAbiertoConSuFondo));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 500m, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var turno = JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoTurno.Abierto, turno.Estado);
+        Assert.Equal(500m, turno.FondoInicial);
+        Assert.Null(turno.FechaCierre);
+
+        var abierto = await ctx.Admin.GetFromJsonAsync<TurnoResumen>(
+            $"/api/caja/turnos/abierto?idPuntoVenta={ctx.IdPuntoVenta}", OpcionesJson);
+        Assert.NotNull(abierto);
+        Assert.Equal(turno.Id, abierto!.Id);
+
+        var porId = await ctx.Admin.GetFromJsonAsync<TurnoResumen>($"/api/caja/turnos/{turno.Id}", OpcionesJson);
+        Assert.Equal(turno.Id, porId!.Id);
+    }
+
+    [Fact]
+    public async Task SinTurnoAbiertoElGateSeamDevuelveNull()
+    {
+        var ctx = await PrepararAsync(nameof(SinTurnoAbiertoElGateSeamDevuelveNull));
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/caja/turnos/abierto?idPuntoVenta={ctx.IdPuntoVenta}");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.Equal("null", cuerpo);
+    }
+
+    [Fact]
+    public async Task UnaSegundaAperturaEnElMismoPuntoDeVentaSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnaSegundaAperturaEnElMismoPuntoDeVentaSeRechaza));
+
+        var primera = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 100m, "Primera apertura"));
+        Assert.Equal(HttpStatusCode.Created, primera.StatusCode);
+
+        var segunda = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 200m, "Segunda apertura"));
+        Assert.Equal(HttpStatusCode.Conflict, segunda.StatusCode);
+
+        var problema = await segunda.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_ya_abierto", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task AperturasEnDistintosPuntosDeVentaSonIndependientes()
+    {
+        var ctx = await PrepararAsync(nameof(AperturasEnDistintosPuntosDeVentaSonIndependientes));
+        var idOtroPuntoVenta = await SembrarSegundoPuntoDeVentaAsync(ctx);
+
+        var primera = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 100m, "Local 1"));
+        Assert.Equal(HttpStatusCode.Created, primera.StatusCode);
+
+        var segunda = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(idOtroPuntoVenta, 100m, "Local 2"));
+        Assert.Equal(HttpStatusCode.Created, segunda.StatusCode);
+    }
+
+    // ---- task 2.8: la carrera genuina -----------------------------------------------------------
+
+    [Fact]
+    public async Task DosAperturasConcurrentesEnElMismoPuntoDeVentaProducenExactamenteUnGanador()
+    {
+        var ctx = await PrepararAsync(nameof(DosAperturasConcurrentesEnElMismoPuntoDeVentaProducenExactamenteUnGanador));
+
+        using var gate = new CountdownEvent(2);
+        var interceptor = new InterceptorDeRendezVousDeTurnos(gate);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) =>
+                    options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaA = cliente.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 100m, "Apertura A"));
+        var tareaB = cliente.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 200m, "Apertura B"));
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+        Assert.True(interceptor.Participantes >= 2, $"participantes={interceptor.Participantes}");
+        Assert.Contains(HttpStatusCode.Created, estados);
+        Assert.Contains(HttpStatusCode.Conflict, estados);
+
+        var respuestaConflicto = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await respuestaConflicto.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_ya_abierto", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Retiene las dos primeras <c>INSERT INTO turnos_caja</c> hasta que ambas
+    /// llegaron — apertura es un INSERT llano sin lectura previa (design decisión 7), así que a
+    /// diferencia de <c>ParametrosTests.InterceptorDeRendezVous</c> (que intercepta el SELECT
+    /// "existente" de un upsert) acá se intercepta directamente el INSERT: es el único statement
+    /// que la apertura ejecuta, y forzar su simultaneidad es lo único que hace la carrera
+    /// genuina en vez de depender del timing real del pool de conexiones.</summary>
+    private sealed class InterceptorDeRendezVousDeTurnos(CountdownEvent gate) : DbCommandInterceptor
+    {
+        private int _participantes;
+
+        public int Participantes => _participantes;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            EsperarSiCorresponde(command);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            EsperarSiCorresponde(command);
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        private void EsperarSiCorresponde(DbCommand command)
+        {
+            if (!command.CommandText.Contains("INSERT INTO turnos_caja", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _participantes) > 2)
+            {
+                return;
+            }
+
+            gate.Signal();
+
+            var senializo = gate.Wait(TimeSpan.FromSeconds(10));
+            Assert.True(senializo, "El rendezvous de InterceptorDeRendezVousDeTurnos no llegó a los 2 participantes a tiempo.");
+        }
+    }
+
+    // ---- task 2.9: movimientos_caja --------------------------------------------------------------
+
+    [Fact]
+    public async Task UnRetiroSinMotivoSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnRetiroSinMotivoSeRechaza));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 200m, ""));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("movimiento_de_caja_sin_motivo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnRefuerzoSinMotivoSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnRefuerzoSinMotivoSeRechaza));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Refuerzo, 200m, null));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("movimiento_de_caja_sin_motivo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnRetiroConMotivoEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnRetiroConMotivoEsAceptado));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 200m, "pago a proveedor en efectivo"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var movimiento = JsonSerializer.Deserialize<MovimientoRegistrado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(TipoMovimientoCaja.Retiro, movimiento.Tipo);
+        Assert.Equal(200m, movimiento.Importe);
+        Assert.Equal(turno.Id, movimiento.IdTurnoCaja);
+    }
+
+    [Fact]
+    public async Task UnaAperturaDeCajonConImporteNoCeroSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnaAperturaDeCajonConImporteNoCeroSeRechaza));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.AperturaCajon, 50m, "conteo inicial de turno"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("movimiento_de_caja_importe_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaAperturaDeCajonConMotivoCortoSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnaAperturaDeCajonConMotivoCortoSeRechaza));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.AperturaCajon, 0m, "abc"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("motivo_de_apertura_cajon_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaAperturaDeCajonValidaEsAceptada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaAperturaDeCajonValidaEsAceptada));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.AperturaCajon, 0m, "conteo inicial de turno"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var movimiento = JsonSerializer.Deserialize<MovimientoRegistrado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(0m, movimiento.Importe);
+    }
+
+    [Fact]
+    public async Task UnMovimientoSinTurnoAbiertoSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnMovimientoSinTurnoAbiertoSeRechaza));
+        var idTurnoCerrado = await SembrarTurnoCerradoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{idTurnoCerrado}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 100m, "retiro contra turno cerrado"));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.10: autorización ------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorAbreUnTurnoYRegistraUnMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorAbreUnTurnoYRegistraUnMovimiento));
+        using var vendedor = await CrearVendedorAsync(ctx, nameof(UnVendedorAbreUnTurnoYRegistraUnMovimiento));
+
+        var apertura = await vendedor.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 300m, "Apertura de vendedor"));
+        var cuerpoApertura = await apertura.Content.ReadAsStringAsync();
+        Assert.True(apertura.StatusCode == HttpStatusCode.Created, cuerpoApertura);
+        var turno = JsonSerializer.Deserialize<TurnoResumen>(cuerpoApertura, OpcionesJson)!;
+
+        var movimiento = await vendedor.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Refuerzo, 50m, "refuerzo de vendedor"));
+        Assert.Equal(HttpStatusCode.Created, movimiento.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRolFueraDeOperacionDePosEsRechazadoDeAperturaYDeMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnRolFueraDeOperacionDePosEsRechazadoDeAperturaYDeMovimientos));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var apertura = await root.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 100m, "Intento de root"));
+        Assert.Equal(HttpStatusCode.Forbidden, apertura.StatusCode);
+
+        var movimiento = await root.PostAsJsonAsync(
+            $"/api/caja/turnos/{turno.Id}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 100m, "intento de root"));
+        Assert.Equal(HttpStatusCode.Forbidden, movimiento.StatusCode);
+    }
+
+    // ---- helper compartido ----------------------------------------------------------------------
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 500m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+}

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -145,7 +145,11 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         "/api/puntos-venta",
         // stage-5-pos-ventas (Slice 5, task 5.4): GET /api/stock — balance del badge del POS,
         // spec: stock / Stock Read Access Under OperacionDePos.
-        "/api/stock"
+        "/api/stock",
+        // stage-6-turnos-caja (Slice 2, task 2.10): GET /api/caja/turnos/abierto,
+        // GET /api/caja/turnos/{id} y GET /api/caja/turnos (historial) — mismo criterio que
+        // "/api/stock", las tres rutas de lectura de CajaEndpoints quedan bajo OperacionDePos.
+        "/api/caja/turnos"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -46,6 +46,13 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // restricción que este allowlist traía adelantado desde Slice 1.
         ("POST", "/api/ventas/{id:int}/anulacion"),
 
+        // stage-6-turnos-caja (Slice 2, task 2.6): apertura de turno y movimientos de caja — sin
+        // GestionDeCatalogo apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que
+        // poder abrir su turno y registrar un retiro/refuerzo). Task 4.8 suma acá el cierre
+        // (POST …/{id}/cierre) y los gastos (POST /api/gastos) cuando Slices 3/4 los aterricen.
+        ("POST", "/api/caja/turnos/"),
+        ("POST", "/api/caja/turnos/{id:int}/movimientos"),
+
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).
         ("POST", "/api/plataforma/tenants/"),


### PR DESCRIPTION
## Resumen

Slice 2/7 de la etapa 6 (stage-6-turnos-caja): el ciclo de vida del turno.

- `ReglaDeTurnos` y `ReglaDeMovimientosDeCaja` (dominio puro, sin DB): transiciones abierto→cerrado, regla de importe (apertura de cajón = 0, resto > 0), motivo ≥5 caracteres uniforme en los tres tipos.
- `ServicioDeTurnos`: `AbrirAsync` como INSERT llano detrás de `ux_turnos_caja_abierto` (la carrera la arbitra la DB: 23505 → 409 `turno_ya_abierto`), `ResolverTurnoAbiertoAsync` (resolver compartido que reutilizan gastos y checkout), `RegistrarMovimientoAsync`, lecturas con historial paginado.
- `CajaEndpoints`: 5 rutas bajo `OperacionDePos` (un Vendedor opera la caja, sin `GestionDeCatalogo` apilado).
- Gate seam del POS: `GET /api/caja/turnos/abierto` devuelve 200 con el turno o **el literal JSON `null`** (fix real detectado por el test: `Ok(null)`/`Json(null)` de Minimal APIs producen body vacío y rompen el `response.json()` del cliente).

## Verificación

- Build 0 warnings; `has-pending-model-changes` limpio; migración y tests del slice 1 intactos.
- Suites: Domain 291/291 (+20), Application 209/209, Integration 440/440 (+19), contra Postgres real. Test de carrera genuino (rendezvous con interceptor sobre el INSERT: exactamente un 201 y un 409).
- Judgment-day: ronda 1 con hallazgos confirmados y corregidos — punto ciego del guard de autorización de lecturas (cerrado con verificación por mutación), tests cross-tenant de las rutas por id, cobertura de historial y 404. El hallazgo de plan (guard `FOR SHARE` para movimientos/gastos) quedó agendado en las tareas 4.17/4.18. Ronda 2 limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)