### PR TITLE
feat(caja): captura de gastos contra el turno abierto (etapa 6, slice 3)

### DIFF
--- a/src/Ways.Api/Endpoints/GastosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/GastosEndpoints.cs
@@ -1,0 +1,38 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Gastos;
+
+namespace Ways.Api.Endpoints;
+
+public static class GastosEndpoints
+{
+    public static IEndpointRouteBuilder MapearGastos(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/gastos")
+            .WithTags("Gastos")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        // stage-6-turnos-caja (Slice 3, task 3.2, design: API Surface): captura de gasto contra
+        // el turno abierto — sin GestionDeCatalogo apilado (spec: Gasto Authorization, un
+        // Vendedor tiene que poder registrar un gasto), mismo criterio que
+        // "/api/caja/turnos/{id}/movimientos".
+        grupo.MapPost("/", async (ServicioDeGastos servicio, SolicitudDeGasto solicitud, CancellationToken ct) =>
+        {
+            var gasto = await servicio.RegistrarAsync(solicitud, ct);
+            return Results.Created($"/api/gastos/{gasto.Id}", gasto);
+        })
+        .WithSummary("Registra un gasto contra el turno abierto del punto de venta.");
+
+        grupo.MapGet("/", (
+            ServicioDeGastos servicio,
+            int? idPuntoVenta,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Historial de gastos, paginado.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -171,6 +171,7 @@ app.MapearOfertas();
 app.MapearVentas();
 app.MapearStock();
 app.MapearCaja();
+app.MapearGastos();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -5,6 +5,7 @@ using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
@@ -77,10 +78,14 @@ public interface IWaysDbContext
 
     // stage-6-turnos-caja, Slice 2: ServicioDeTurnos es el primer consumidor de Application de
     // estos 2 — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes A/B).
-    // ArqueosTurno/MovimientosTesoreria/Gastos siguen sin exponerse acá: sus primeros
-    // consumidores (ServicioDeTurnos.CerrarAsync/ServicioDeGastos) llegan en Slice 3/4.
+    // ArqueosTurno/MovimientosTesoreria siguen sin exponerse acá: su primer consumidor
+    // (ServicioDeTurnos.CerrarAsync) llega en Slice 4.
     DbSet<TurnoCaja> TurnosCaja { get; }
     DbSet<MovimientoCaja> MovimientosCaja { get; }
+
+    // stage-6-turnos-caja, Slice 3: ServicioDeGastos es el primer consumidor de Application de
+    // este DbSet — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes C).
+    DbSet<Gasto> Gastos { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Ways.Application.Articulos;
 using Ways.Application.Caja;
 using Ways.Application.Catalogos;
 using Ways.Application.Clientes;
+using Ways.Application.Gastos;
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
 using Ways.Application.Parametros;
@@ -47,6 +48,7 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeVentas>();
         services.AddScoped<ServicioDeStock>();
         services.AddScoped<ServicioDeTurnos>();
+        services.AddScoped<ServicioDeGastos>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Application/Gastos/Contratos.cs
+++ b/src/Ways.Application/Gastos/Contratos.cs
@@ -1,0 +1,49 @@
+using Ways.Domain.Gastos;
+
+namespace Ways.Application.Gastos;
+
+/// <summary>Cuerpo de <c>POST /api/gastos</c> (design: API Surface) — sin <c>idTurnoCaja</c> a
+/// propósito, mismo criterio que <c>Ways.Application.Caja.SolicitudDeApertura</c>: el turno
+/// siempre lo resuelve el servidor desde <see cref="IdPuntoVenta"/> (spec: Gasto Requires An
+/// Open Turno, Gasto succeeds with an open turno), nunca este contrato.</summary>
+public sealed record SolicitudDeGasto(
+    int IdPuntoVenta,
+    CategoriaGasto Categoria,
+    int? IdProveedor,
+    int? IdArea,
+    string Concepto,
+    string? Detalle,
+    int IdMedioPago,
+    string? NumeroFactura,
+    decimal Importe);
+
+/// <summary>Proyección de <see cref="Gasto"/> ya persistido — respuesta de <c>POST
+/// /api/gastos</c>.</summary>
+public sealed record GastoRegistrado(
+    int Id,
+    int IdTurnoCaja,
+    int IdPuntoVenta,
+    DateTimeOffset Fecha,
+    CategoriaGasto Categoria,
+    int? IdProveedor,
+    int? IdArea,
+    string Concepto,
+    string? Detalle,
+    int IdMedioPago,
+    string? NumeroFactura,
+    decimal Importe,
+    int IdEmpleado);
+
+/// <summary>Fila de <c>GET /api/gastos</c> (historial paginado) — mismo criterio de shape
+/// reducido que <c>Ways.Application.Caja.TurnoListado</c>.</summary>
+public sealed record GastoListado(
+    int Id,
+    int IdPuntoVenta,
+    DateTimeOffset Fecha,
+    CategoriaGasto Categoria,
+    int IdMedioPago,
+    decimal Importe);
+
+/// <summary>Página de resultados de <c>GET /api/gastos</c> — mismo shape que
+/// <c>Ways.Application.Caja.PaginaDeTurnos</c>.</summary>
+public sealed record PaginaDeGastos(IReadOnlyList<GastoListado> Items, int Total, int Pagina, int Tamanio);

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -1,0 +1,161 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Domain.Common;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Application.Gastos;
+
+/// <summary>
+/// Captura de gastos contra un turno abierto (design: Table Shapes — write path C; tasks.md
+/// Slice 3). Reutiliza <see cref="ServicioDeTurnos.ResolverTurnoAbiertoAsync"/> (tasks.md,
+/// Orchestrator Decision 3) en vez de escribir su propia consulta de turno abierto — mismo
+/// criterio que <c>ServicioDeVentas.EmitirAsync</c> (Slice 5).
+/// </summary>
+public class ServicioDeGastos(
+    IWaysDbContext db, ServicioDeTurnos servicioDeTurnos, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+{
+    /// <summary>Resuelve el punto de venta (404 ADR-8) antes que el turno abierto (spec: Gasto
+    /// Requires An Open Turno) — mismo orden que <c>ServicioDeVentas.EmitirAsync</c> (design
+    /// decisión 11): un punto de venta apócrifo tiene que dar 404, nunca el 409 de "sin turno
+    /// abierto" de un punto de venta que ni siquiera existe.</summary>
+    public async Task<GastoRegistrado> RegistrarAsync(SolicitudDeGasto solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        ExigirImporteValido(solicitud.Importe);
+
+        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var turno = await servicioDeTurnos.ResolverTurnoAbiertoAsync(solicitud.IdPuntoVenta, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        var gasto = await estrategia.ExecuteAsync(async () =>
+            await InsertarGastoAsync(idTenant, turno.Id, solicitud, idEmpleado, momento, ct));
+
+        return Proyectar(gasto);
+    }
+
+    /// <summary>Historial paginado (design: API Surface, <c>GET /api/gastos</c>) — mismo criterio
+    /// de paginado que <c>ServicioDeTurnos.ListarAsync</c>.</summary>
+    public async Task<PaginaDeGastos> ListarAsync(
+        int? idPuntoVenta = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = db.Gastos.AsQueryable();
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(g => g.IdPuntoVenta == pv);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(g => g.Fecha >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(g => g.Fecha <= h);
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(g => g.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(g => new GastoListado(g.Id, g.IdPuntoVenta, g.Fecha, g.Categoria, g.IdMedioPago, g.Importe))
+            .ToListAsync(ct);
+
+        return new PaginaDeGastos(items, total, pagina, tamanio);
+    }
+
+    // ---- validación de dominio -------------------------------------------------------------
+
+    /// <summary>Mismo código que la CHECK de esquema <c>ck_gastos_importe_positivo</c> (design:
+    /// Backstop Map, Slice 1 task 1.7): esta validación de servicio es la UX rápida, la CHECK es
+    /// el contrato real (db-error-backstops — nunca tratar el pre-check como la protección).
+    /// (spec: Importe Must Be Positive).</summary>
+    private static void ExigirImporteValido(decimal importe)
+    {
+        if (importe <= 0m)
+        {
+            throw new ErrorDominio("gasto_importe_invalido", "El importe del gasto tiene que ser positivo.", 400);
+        }
+    }
+
+    // ---- persistencia -------------------------------------------------------------------------
+
+    private async Task<Gasto> InsertarGastoAsync(
+        int idTenant, int idTurnoCaja, SolicitudDeGasto solicitud, int idEmpleado, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        var gasto = new Gasto
+        {
+            IdTenant = idTenant,
+            Fecha = momento,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdTurnoCaja = idTurnoCaja,
+            IdEmpleado = idEmpleado,
+            Categoria = solicitud.Categoria,
+            IdProveedor = solicitud.IdProveedor,
+            IdArea = solicitud.IdArea,
+            Concepto = solicitud.Concepto,
+            Detalle = solicitud.Detalle,
+            IdMedioPago = solicitud.IdMedioPago,
+            NumeroFactura = solicitud.NumeroFactura,
+            Importe = solicitud.Importe,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+
+        db.Gastos.Add(gasto);
+        await db.SaveChangesAsync(ct);
+
+        return gasto;
+    }
+
+    // ---- resolución interna ---------------------------------------------------------------
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" — mismo criterio que
+            // ServicioDeTurnos.ResolverPuntoVentaAsync/ServicioDeStock.ResolverPuntoVentaAsync/
+            // ServicioDeVentas.ResolverPuntoVentaAsync.
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            // OperacionDePos (capa de API) ya exige un actor de tenant — un actor de plataforma
+            // (root) nunca llega hasta acá. Defensa en profundidad, mismo criterio que
+            // ServicioDeTurnos.ExigirTenantDeLaSesion.
+            ?? throw new InvalidOperationException(
+                "ServicioDeGastos requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    // ---- proyecciones -----------------------------------------------------------------------
+
+    private static GastoRegistrado Proyectar(Gasto gasto) => new(
+        gasto.Id,
+        gasto.IdTurnoCaja,
+        gasto.IdPuntoVenta,
+        gasto.Fecha,
+        gasto.Categoria,
+        gasto.IdProveedor,
+        gasto.IdArea,
+        gasto.Concepto,
+        gasto.Detalle,
+        gasto.IdMedioPago,
+        gasto.NumeroFactura,
+        gasto.Importe,
+        gasto.IdEmpleado);
+}

--- a/tests/Ways.Domain.Tests/Gastos/CategoriaGastoTests.cs
+++ b/tests/Ways.Domain.Tests/Gastos/CategoriaGastoTests.cs
@@ -1,0 +1,20 @@
+using Ways.Domain.Gastos;
+
+namespace Ways.Domain.Tests.Gastos;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 3 (task 3.4, spec: gastos / No Magic Tipo Encodes A Retiro As A
+/// Gasto): prueba de reflexión — el legacy's <c>tipo = 95</c> (retiro de efectivo disfrazado de
+/// gasto) no tiene representación posible en <see cref="CategoriaGasto"/>. Un retiro SIEMPRE se
+/// escribe en <c>movimientos_caja</c> (<c>TipoMovimientoCaja.Retiro</c>), nunca acá.
+/// </summary>
+public class CategoriaGastoTests
+{
+    [Fact]
+    public void NingunValorDeCategoriaGastoRepresentaUnRetiro()
+    {
+        var nombres = Enum.GetNames<CategoriaGasto>();
+
+        Assert.All(nombres, nombre => Assert.DoesNotContain("retiro", nombre, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Ways.Domain.Tests/Gastos/CategoriaGastoTests.cs
+++ b/tests/Ways.Domain.Tests/Gastos/CategoriaGastoTests.cs
@@ -11,10 +11,22 @@ namespace Ways.Domain.Tests.Gastos;
 public class CategoriaGastoTests
 {
     [Fact]
-    public void NingunValorDeCategoriaGastoRepresentaUnRetiro()
+    public void CategoriaGastoSoloContieneLosValoresDelWhitelistYNingunoRepresentaUnRetiro()
     {
+        // Whitelist exacta (no blacklist de "retiro"): pinea el conjunto completo de miembros
+        // para que un valor nuevo agregado al enum deba pasar explícitamente por este test.
+        var nombresEsperados = new[]
+        {
+            nameof(CategoriaGasto.Proveedor),
+            nameof(CategoriaGasto.Sueldos),
+            nameof(CategoriaGasto.Viaticos),
+            nameof(CategoriaGasto.Impuestos),
+            nameof(CategoriaGasto.Servicios),
+            nameof(CategoriaGasto.Otros)
+        };
+
         var nombres = Enum.GetNames<CategoriaGasto>();
 
-        Assert.All(nombres, nombre => Assert.DoesNotContain("retiro", nombre, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(nombresEsperados.OrderBy(n => n), nombres.OrderBy(n => n));
     }
 }

--- a/tests/Ways.IntegrationTests/GastosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/GastosEndpointsTests.cs
@@ -159,6 +159,42 @@ public class GastosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         Assert.Equal("gasto_importe_invalido", problema.GetProperty("codigo").GetString());
     }
 
+    // ---- pre-checks de FK: referencias inválidas nunca llegan como 500 --------------------------
+
+    [Fact]
+    public async Task UnGastoConMedioDePagoInexistenteEsRechazadoCon400()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoConMedioDePagoInexistenteEsRechazadoCon400));
+        await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Medio de pago apócrifo", null,
+                999999, null, 100m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnGastoConProveedorInexistenteEsRechazadoCon400()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoConProveedorInexistenteEsRechazadoCon400));
+        await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, 999999, null, "Proveedor apócrifo", null,
+                ctx.IdMedioPago, null, 100m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
     // ---- task 3.5: autorización -------------------------------------------------------------------
 
     [Fact]
@@ -175,6 +211,26 @@ public class GastosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                 ctx.IdMedioPago, null, 150m));
 
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRolFueraDeOperacionDePosEsRechazadoDeGastos()
+    {
+        var ctx = await PrepararAsync(nameof(UnRolFueraDeOperacionDePosEsRechazadoDeGastos));
+        await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin("test@test.com", "root"));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var respuesta = await root.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Intento de root", null,
+                ctx.IdMedioPago, null, 100m));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
     // ---- historial paginado (GET /api/gastos) ------------------------------------------------------

--- a/tests/Ways.IntegrationTests/GastosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/GastosEndpointsTests.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 3 (tasks 3.2, 3.3, 3.5): <c>POST /api/gastos</c>, <c>GET
+/// /api/gastos</c> punta a punta — captura contra el turno abierto resuelto server-side
+/// (<c>ServicioDeTurnos.ResolverTurnoAbiertoAsync</c> compartido), importe positivo y
+/// autorización <c>OperacionDePos</c> (spec: gastos).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class GastosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordVendedor = "una-contraseña-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdMedioPago, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin("test@test.com", "root"));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(
+            new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idMedioPago = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id)
+            .FirstAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, idMedioPago, admin);
+    }
+
+    private async Task<HttpClient> CrearVendedorAsync(Contexto ctx, string nombre)
+    {
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-gastos", mailVendedor, (int)RolConocido.Vendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return vendedor;
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(HttpClient cliente, int idPuntoVenta)
+    {
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(idPuntoVenta, 500m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 3.3: happy path + resolución server-side del turno --------------------------------
+
+    [Fact]
+    public async Task UnGastoPersisteConSuCategoriaYSuMedio()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoPersisteConSuCategoriaYSuMedio));
+        var turno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Servicios, null, null, "Internet del local", null,
+                ctx.IdMedioPago, null, 300m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(CategoriaGasto.Servicios, gasto.Categoria);
+        Assert.Equal(ctx.IdMedioPago, gasto.IdMedioPago);
+        Assert.Equal(300m, gasto.Importe);
+        // spec: Gasto succeeds with an open turno — id_turno_caja resuelto server-side, nunca
+        // client-supplied (SolicitudDeGasto no tiene ese campo).
+        Assert.Equal(turno.Id, gasto.IdTurnoCaja);
+    }
+
+    [Fact]
+    public async Task UnGastoSinTurnoAbiertoSeRechaza()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoSinTurnoAbiertoSeRechaza));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Gasto sin turno", null,
+                ctx.IdMedioPago, null, 100m));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnGastoContraUnPuntoDeVentaInexistenteDevuelve404()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoContraUnPuntoDeVentaInexistenteDevuelve404));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                999999, CategoriaGasto.Otros, null, null, "Gasto contra PV apócrifo", null,
+                ctx.IdMedioPago, null, 100m));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- task 3.3: importe positivo -------------------------------------------------------------
+
+    [Fact]
+    public async Task UnGastoConImporteCeroSeRechazaAntesDeLlegarALaBaseDeDatos()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoConImporteCeroSeRechazaAntesDeLlegarALaBaseDeDatos));
+        await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Gasto en cero", null,
+                ctx.IdMedioPago, null, 0m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("gasto_importe_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 3.5: autorización -------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorRegistraUnGasto()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorRegistraUnGasto));
+        using var vendedor = await CrearVendedorAsync(ctx, nameof(UnVendedorRegistraUnGasto));
+        await AbrirTurnoAsync(vendedor, ctx.IdPuntoVenta);
+
+        var respuesta = await vendedor.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Viaticos, null, null, "Viáticos de reparto", null,
+                ctx.IdMedioPago, null, 150m));
+
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    // ---- historial paginado (GET /api/gastos) ------------------------------------------------------
+
+    [Fact]
+    public async Task ElHistorialPaginaYFiltraPorPuntoDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(ElHistorialPaginaYFiltraPorPuntoDeVenta));
+        await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        foreach (var importe in new[] { 100m, 200m })
+        {
+            var respuesta = await ctx.Admin.PostAsJsonAsync(
+                "/api/gastos",
+                new SolicitudDeGasto(
+                    ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Gasto de historial", null,
+                    ctx.IdMedioPago, null, importe));
+            Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        }
+
+        var pagina = await ctx.Admin.GetFromJsonAsync<PaginaDeGastos>(
+            $"/api/gastos?idPuntoVenta={ctx.IdPuntoVenta}", OpcionesJson);
+        Assert.NotNull(pagina);
+        Assert.Equal(2, pagina!.Total);
+        Assert.All(pagina.Items, item => Assert.Equal(ctx.IdPuntoVenta, item.IdPuntoVenta));
+        Assert.Equal(1, pagina.Pagina);
+        Assert.Equal(25, pagina.Tamanio);
+    }
+
+    // ---- judgment-day precedent (Slice 2): guard de autenticación / cross-tenant ------------------
+
+    [Fact]
+    public async Task ListarGastosSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.GetAsync("/api/gastos?idPuntoVenta=1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -49,9 +49,13 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // stage-6-turnos-caja (Slice 2, task 2.6): apertura de turno y movimientos de caja — sin
         // GestionDeCatalogo apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que
         // poder abrir su turno y registrar un retiro/refuerzo). Task 4.8 suma acá el cierre
-        // (POST …/{id}/cierre) y los gastos (POST /api/gastos) cuando Slices 3/4 los aterricen.
+        // (POST …/{id}/cierre) cuando Slice 4 lo aterrice.
         ("POST", "/api/caja/turnos/"),
         ("POST", "/api/caja/turnos/{id:int}/movimientos"),
+        // stage-6-turnos-caja (Slice 3, task 3.2): captura de gasto — sin GestionDeCatalogo
+        // apilado, mismo criterio que los dos de arriba (spec: gastos / Gasto Authorization, un
+        // Vendedor tiene que poder registrar un gasto).
+        ("POST", "/api/gastos/"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).
@@ -149,7 +153,10 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // stage-6-turnos-caja (Slice 2, task 2.10): GET /api/caja/turnos/abierto,
         // GET /api/caja/turnos/{id} y GET /api/caja/turnos (historial) — mismo criterio que
         // "/api/stock", las tres rutas de lectura de CajaEndpoints quedan bajo OperacionDePos.
-        "/api/caja/turnos"
+        "/api/caja/turnos",
+        // stage-6-turnos-caja (Slice 3, task 3.5): GET /api/gastos (historial) — mismo criterio
+        // que "/api/caja/turnos".
+        "/api/gastos"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —


### PR DESCRIPTION
## Resumen

Slice 3/7 de la etapa 6 (stage-6-turnos-caja): el write path de gastos.

- `ServicioDeGastos.RegistrarAsync`: PV → 404 (ADR-8), turno abierto vía el resolver compartido del slice 2 → 409 `turno_no_abierto`, importe ≤ 0 → 400 `gasto_importe_invalido` (mismo código que el backstop de `ck_gastos_importe_positivo`), INSERT bajo `EstrategiaSinReintento`. `id_turno_caja`, `fecha` e `id_empleado` siempre server-side — el DTO no puede transportarlos.
- `GastosEndpoints`: `POST /api/gastos` + `GET /api/gastos` paginado, bajo `OperacionDePos`.
- El tipo=95 del legacy es irrepresentable: test de whitelist exacto sobre `categoria_gasto`.
- Allowlist doble de autorización actualizada de entrada (lección del slice 2).

## Verificación

- Build 0 warnings; sin migración nueva; `has-pending-model-changes` limpio.
- Suites: Domain 292/292 (+1), Application 209/209, Integration 450/450 (+10), contra Postgres real.
- Judgment-day: ronda 1 sin majors — 3 MINORs de tests confirmados y corregidos (whitelist del enum, backstops de FK `referencia_invalida` para medio/proveedor inexistentes, 403 negativo espejo del precedente del slice 2). Ronda 2 limpia (iteración test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)