### PR TITLE
feat(caja): derivacion del arqueo y cierre transaccional (etapa 6, slice 4)

### DIFF
--- a/src/Ways.Api/Endpoints/CajaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CajaEndpoints.cs
@@ -58,6 +58,23 @@ public static class CajaEndpoints
         })
         .WithSummary("Retiro / refuerzo / apertura de cajón contra el turno abierto.");
 
+        // stage-6-turnos-caja (Slice 4, task 4.7, design: API Surface): resumen parcial — misma
+        // derivación que el cierre (spec: Resumen Parcial Uses The Same Derivation As Cierre),
+        // de solo lectura.
+        grupo.MapGet("/{id:int}/resumen", async (
+            ServicioDeResumenDeTurno servicio, int id, CancellationToken ct) =>
+            Results.Ok(await servicio.ObtenerAsync(id, ct)))
+        .WithSummary("Resumen parcial del turno — misma derivación que el cierre.");
+
+        // stage-6-turnos-caja (Slice 4, task 4.7, design: The Cierre Transaction): cierre —
+        // irreversible, una sola transacción atómica. El cuerpo SOLO trae los conteos declarados
+        // (spec: Cierre Payload Carries Only Declared Counts) — el importe esperado siempre lo
+        // deriva el servidor.
+        grupo.MapPost("/{id:int}/cierre", async (
+            ServicioDeTurnos servicio, int id, SolicitudDeCierre solicitud, CancellationToken ct) =>
+            Results.Ok(await servicio.CerrarAsync(id, solicitud, ct)))
+        .WithSummary("Cierre de turno: deriva el arqueo, lo persiste y encadena la tesorería — irreversible.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -78,10 +78,16 @@ public interface IWaysDbContext
 
     // stage-6-turnos-caja, Slice 2: ServicioDeTurnos es el primer consumidor de Application de
     // estos 2 — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes A/B).
-    // ArqueosTurno/MovimientosTesoreria siguen sin exponerse acá: su primer consumidor
-    // (ServicioDeTurnos.CerrarAsync) llega en Slice 4.
     DbSet<TurnoCaja> TurnosCaja { get; }
     DbSet<MovimientoCaja> MovimientosCaja { get; }
+
+    // stage-6-turnos-caja, Slice 4: ServicioDeTurnos.CerrarAsync es el primer consumidor de
+    // Application de estos 2 — Slice 1 solo adelantaba el modelo a la migración (design: Table
+    // Shapes A/D). ArqueosTurno es append-only (una fila por medio arqueable, escrita una sola
+    // vez al cierre); MovimientosTesoreria encadena su Inicio desde el Final de la última fila
+    // del mismo punto de venta.
+    DbSet<ArqueoTurno> ArqueosTurno { get; }
+    DbSet<MovimientoTesoreria> MovimientosTesoreria { get; }
 
     // stage-6-turnos-caja, Slice 3: ServicioDeGastos es el primer consumidor de Application de
     // este DbSet — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes C).

--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -39,3 +39,46 @@ public sealed record PaginaDeTurnos(IReadOnlyList<TurnoListado> Items, int Total
 /// <summary>Proyección de <see cref="MovimientoCaja"/> ya persistido.</summary>
 public sealed record MovimientoRegistrado(
     int Id, int IdTurnoCaja, TipoMovimientoCaja Tipo, decimal Importe, string Motivo, int IdEmpleado, DateTimeOffset CreadoEl);
+
+// ---- Slice 4: derivación, resumen y cierre (design: The Cierre Transaction; Interfaces/Contracts) ----
+
+/// <summary>Un conteo declarado por el cajero — <c>(id_medio_pago, importe_declarado)</c>, el
+/// ÚNICO dato que el cliente envía (spec: Cierre Payload Carries Only Declared Counts).</summary>
+public readonly record struct ConteoDeclarado(int IdMedioPago, decimal ImporteDeclarado);
+
+/// <summary>Cuerpo de <c>POST /api/caja/turnos/{id}/cierre</c> (design: API Surface;
+/// Interfaces/Contracts) — sin ningún campo de total, subtotal o esperado (spec: No Request
+/// Shape Accepts A Total): <c>ImporteEsperado</c> SIEMPRE lo deriva el servidor.</summary>
+public sealed record SolicitudDeCierre(IReadOnlyList<ConteoDeclarado> Conteos, string? Observaciones);
+
+/// <summary>Una línea de <see cref="ResumenDeTurno"/> — proyección de
+/// <see cref="Ways.Domain.Caja.LineaDeArqueo"/>, la misma derivación que el cierre va a
+/// persistir (spec: Resumen Parcial Uses The Same Derivation As Cierre).</summary>
+public sealed record LineaDeResumen(int IdMedioPago, decimal ImporteEsperado);
+
+/// <summary>Respuesta de <c>GET /api/caja/turnos/{id}/resumen</c> (D6 parity, design: API
+/// Surface) — de solo lectura, nunca escribe nada.</summary>
+public sealed record ResumenDeTurno(int IdTurnoCaja, int IdMedioAncla, IReadOnlyList<LineaDeResumen> Medios);
+
+/// <summary>Una fila ya persistida de <see cref="ArqueoTurno"/> — con <c>Diferencia</c> incluida
+/// (columna <c>GENERATED ALWAYS</c>, design decisión 6).</summary>
+public sealed record LineaDeArqueoResumen(
+    int IdMedioPago, decimal ImporteEsperado, decimal ImporteDeclarado, decimal Diferencia);
+
+/// <summary>Respuesta de <c>POST /api/caja/turnos/{id}/cierre</c> y de
+/// <c>GET /api/caja/turnos/{id}</c> (design: API Surface — "Turno + its arqueos_turno, the
+/// Z-report payload"): mismos campos planos que <see cref="TurnoResumen"/> más
+/// <see cref="Arqueos"/> — la deserialización de <see cref="TurnoResumen"/> sobre este mismo JSON
+/// sigue funcionando (System.Text.Json ignora propiedades no mapeadas), así que las pruebas de
+/// Slice 2 contra <c>GET …/{id}</c> quedan intactas.</summary>
+public sealed record TurnoConArqueos(
+    int Id,
+    int IdPuntoVenta,
+    int IdEmpleadoApertura,
+    int? IdEmpleadoCierre,
+    DateTimeOffset FechaApertura,
+    DateTimeOffset? FechaCierre,
+    decimal FondoInicial,
+    EstadoTurno Estado,
+    string? Observaciones,
+    IReadOnlyList<LineaDeArqueoResumen> Arqueos);

--- a/src/Ways.Application/Caja/LectorDeMovimientosDelTurno.cs
+++ b/src/Ways.Application/Caja/LectorDeMovimientosDelTurno.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Caja;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// El único lector de los insumos de la derivación (design decisión 5; The Cierre Transaction,
+/// paso 2) — 7 consultas agrupadas de cantidad FIJA, nunca una por fila (Testing Strategy:
+/// Integration (budget), tasks 4.3/4.14): pagos por medio, vueltos por medio, gastos por medio,
+/// refuerzos, retiros, fondo inicial y el catálogo completo de medios. Compartido tal cual por
+/// <c>ServicioDeTurnos.CerrarAsync</c> y <c>ServicioDeResumenDeTurno</c> — la única fuente de
+/// <see cref="InsumosDeArqueo"/> que existe en el sistema (spec: Resumen Parcial Uses The Same
+/// Derivation As Cierre).
+/// </summary>
+public class LectorDeMovimientosDelTurno(IWaysDbContext db)
+{
+    public async Task<InsumosDeArqueo> LeerAsync(int idTurnoCaja, CancellationToken ct = default)
+    {
+        // PagoComprobante no tiene navigation property a ComprobanteVenta (convención del
+        // proyecto: FKs sin propiedad de navegación, ver PagoComprobanteConfiguration) — join
+        // explícito por id_comprobante_venta en vez de una propiedad de navegación inexistente.
+        var pagosDelTurno = db.PagosComprobante
+            .Join(
+                db.ComprobantesVenta,
+                p => p.IdComprobanteVenta,
+                c => c.Id,
+                (p, c) => new { p.IdMedioPago, p.Importe, p.Vuelto, c.IdTurnoCaja, c.Estado })
+            .Where(x => x.IdTurnoCaja == idTurnoCaja && x.Estado == EstadoComprobante.Emitido);
+
+        // 1. pagos por medio — solo comprobantes emitido (spec: Anulados Are Excluded From The
+        // Derivation); un NCX aporta un importe negativo sin rama especial (stage-5 decisión 4).
+        var pagosPorMedio = await pagosDelTurno
+            .GroupBy(x => x.IdMedioPago)
+            .Select(g => new { IdMedioPago = g.Key, Total = g.Sum(x => x.Importe) })
+            .ToDictionaryAsync(x => x.IdMedioPago, x => x.Total, ct);
+
+        // 2. vueltos por medio — mismo filtro; CalculadorDeArqueo suma esto sobre TODOS los
+        // medios para restarlo únicamente en la línea del ancla (design decisión 2).
+        var vueltosPorMedio = await pagosDelTurno
+            .GroupBy(x => x.IdMedioPago)
+            .Select(g => new { IdMedioPago = g.Key, Total = g.Sum(x => x.Vuelto) })
+            .ToDictionaryAsync(x => x.IdMedioPago, x => x.Total, ct);
+
+        // 3. gastos por medio — el gasto resta según SU PROPIO id_medio_pago, nunca todo al ancla.
+        var gastosPorMedio = await db.Gastos
+            .Where(g => g.IdTurnoCaja == idTurnoCaja)
+            .GroupBy(g => g.IdMedioPago)
+            .Select(g => new { IdMedioPago = g.Key, Total = g.Sum(x => x.Importe) })
+            .ToDictionaryAsync(x => x.IdMedioPago, x => x.Total, ct);
+
+        // 4. refuerzos — solo del ancla (aplicado en CalculadorDeArqueo).
+        var refuerzos = await db.MovimientosCaja
+            .Where(m => m.IdTurnoCaja == idTurnoCaja && m.Tipo == TipoMovimientoCaja.Refuerzo)
+            .SumAsync(m => m.Importe, ct);
+
+        // 5. retiros — ídem.
+        var retiros = await db.MovimientosCaja
+            .Where(m => m.IdTurnoCaja == idTurnoCaja && m.Tipo == TipoMovimientoCaja.Retiro)
+            .SumAsync(m => m.Importe, ct);
+
+        // 6. fondo inicial del turno — lectura propia (no depende del RETURNING de la UPDATE
+        // atómica del cierre): el resumen parcial necesita este mismo dato sobre un turno
+        // TODAVÍA abierto, así que el lector siempre lo pide de nuevo.
+        var fondoInicial = await db.TurnosCaja
+            .Where(t => t.Id == idTurnoCaja)
+            .Select(t => t.FondoInicial)
+            .FirstAsync(ct);
+
+        // 7. catálogo completo de medios — TODAS las filas, sin filtrar Activo (design decisión
+        // 3: un medio desactivado a mitad de turno puede seguir teniendo pagos). Universo
+        // completo de ActividadDeMedio: todo medio del catálogo aparece acá, tenga o no
+        // actividad — CalculadorDeArqueo decide qué queda.
+        var medios = await db.MediosPago
+            .Select(m => new { m.Id, m.Comportamiento })
+            .ToListAsync(ct);
+
+        var actividad = medios
+            .Select(m => new ActividadDeMedio(
+                m.Id,
+                m.Comportamiento,
+                pagosPorMedio.GetValueOrDefault(m.Id),
+                vueltosPorMedio.GetValueOrDefault(m.Id),
+                gastosPorMedio.GetValueOrDefault(m.Id),
+                pagosPorMedio.ContainsKey(m.Id) || gastosPorMedio.ContainsKey(m.Id)))
+            .ToList();
+
+        return new InsumosDeArqueo(fondoInicial, refuerzos, retiros, actividad);
+    }
+}

--- a/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
+++ b/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Caja;
+using Ways.Domain.Common;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// Resumen parcial (design: API Surface, <c>GET /api/caja/turnos/{id}/resumen</c>; spec: Resumen
+/// Parcial Uses The Same Derivation As Cierre) — llama al MISMO par
+/// <see cref="LectorDeMovimientosDelTurno"/> + <see cref="CalculadorDeArqueo"/> que
+/// <c>ServicioDeTurnos.CerrarAsync</c>, de solo lectura, sin ninguna escritura: es la única
+/// garantía estructural de que el número que el cajero ve a mitad de turno es el que el cierre va
+/// a comparar (task 4.13, "byte-identical").
+/// </summary>
+public class ServicioDeResumenDeTurno(IWaysDbContext db, LectorDeMovimientosDelTurno lector)
+{
+    public async Task<ResumenDeTurno> ObtenerAsync(int idTurnoCaja, CancellationToken ct = default)
+    {
+        await ExigirTurnoExisteAsync(idTurnoCaja, ct);
+
+        var insumos = await lector.LeerAsync(idTurnoCaja, ct);
+        var idAncla = ResolvedorDeMedioDeCajaFisica.Resolver(insumos.Actividad);
+        var lineas = CalculadorDeArqueo.Calcular(insumos, idAncla);
+
+        return new ResumenDeTurno(
+            idTurnoCaja, idAncla,
+            lineas.Select(l => new LineaDeResumen(l.IdMedioPago, l.ImporteEsperado)).ToList());
+    }
+
+    private async Task ExigirTurnoExisteAsync(int idTurnoCaja, CancellationToken ct)
+    {
+        var existe = await db.TurnosCaja.AnyAsync(t => t.Id == idTurnoCaja, ct);
+        if (!existe)
+        {
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" — el filtro de EF/RLS ya
+            // deja invisible un turno ajeno, mismo criterio que ServicioDeTurnos.ObtenerAsync.
+            throw ErrorDominio.NoEncontrado($"No existe el turno {idTurnoCaja}.");
+        }
+    }
+}

--- a/src/Ways.Application/Caja/ServicioDeTurnos.cs
+++ b/src/Ways.Application/Caja/ServicioDeTurnos.cs
@@ -1,4 +1,7 @@
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Caja;
 using Ways.Domain.Common;
@@ -8,12 +11,15 @@ namespace Ways.Application.Caja;
 
 /// <summary>
 /// Turno de caja: apertura, movimientos físicos fuera de la venta (retiro/refuerzo/apertura de
-/// cajón) y lectura (design: API Surface). El cierre (design: The Cierre Transaction) llega en
-/// Slice 4 — <see cref="ResolverTurnoAbiertoAsync"/> es el resolver compartido que Slice 3
-/// (gastos) y Slice 5 (checkout) reutilizan (tasks.md, Orchestrator Decision 3), evitando tres
-/// copias del mismo <c>409 turno_no_abierto</c>.
+/// cajón), cierre (design: The Cierre Transaction) y lectura (design: API Surface). <see
+/// cref="ResolverTurnoAbiertoAsync"/> es el resolver compartido que Slice 3 (gastos) y Slice 5
+/// (checkout) reutilizan (tasks.md, Orchestrator Decision 3), evitando tres copias del mismo
+/// <c>409 turno_no_abierto</c>; <see cref="ExigirTurnoAbiertoBajoLockAsync"/> (Slice 4, task
+/// 4.17) es el mismo tipo de pieza compartida para el guard <c>FOR SHARE</c> — reusado por
+/// <c>ServicioDeGastos.RegistrarAsync</c>.
 /// </summary>
-public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+public class ServicioDeTurnos(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, LectorDeMovimientosDelTurno lector)
 {
     /// <summary>Apertura (design decisión 7): INSERT llano detrás de <c>ux_turnos_caja_abierto
     /// (id_punto_venta) WHERE estado = 'abierto'</c> — sin lectura previa, sin advisory lock. La
@@ -88,19 +94,34 @@ public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContex
         ReglaDeMovimientosDeCaja.ExigirImporteValido(solicitud.Tipo, solicitud.Importe);
         ReglaDeMovimientosDeCaja.ExigirMotivoValido(solicitud.Tipo, solicitud.Motivo);
 
-        var turno = await ResolverTurnoPorIdAbiertoAsync(idTurnoCaja, ct);
+        // Pre-chequeo barato, FUERA de la transacción de escritura (404 ADR-8 / 409 rápido) —
+        // ver el doc-comment de EjecutarRegistroDeMovimientoAsync sobre por qué esto no alcanza
+        // por sí solo como protección de la carrera contra un cierre concurrente.
+        await ResolverTurnoPorIdAbiertoAsync(idTurnoCaja, ct);
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
         var movimiento = await estrategia.ExecuteAsync(async () =>
-            await InsertarMovimientoAsync(idTenant, turno.Id, solicitud, idEmpleado, momento, ct));
+            await EjecutarRegistroDeMovimientoAsync(idTenant, idTurnoCaja, solicitud, idEmpleado, momento, ct));
 
         return Proyectar(movimiento);
     }
 
-    private async Task<MovimientoCaja> InsertarMovimientoAsync(
+    /// <summary>task 4.17 (judgment-day, hallazgo de Slice 2, juez B): <see
+    /// cref="ExigirTurnoAbiertoBajoLockAsync"/> como PRIMER statement de la transacción de
+    /// escritura — el pre-chequeo de <see cref="ResolverTurnoPorIdAbiertoAsync"/> (arriba, sin
+    /// lock) es solo UX rápida; sin este re-chequeo bajo <c>FOR SHARE</c>, una vez que existe
+    /// <see cref="CerrarAsync"/> un retiro/refuerzo concurrente podría comitear dentro de un
+    /// turno cuyo arqueo YA se derivó — exactamente la clase de defecto que design decisión 1
+    /// mata. El lock EXCLUSIVO del cierre (su propio primer statement) y este <c>FOR SHARE</c>
+    /// se excluyen mutuamente: quien pierde la carrera re-lee el estado ya comiteado.</summary>
+    private async Task<MovimientoCaja> EjecutarRegistroDeMovimientoAsync(
         int idTenant, int idTurnoCaja, SolicitudDeMovimiento solicitud, int idEmpleado, DateTimeOffset momento,
         CancellationToken ct)
     {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        await ExigirTurnoAbiertoBajoLockAsync(idTurnoCaja, ct);
+
         var movimiento = new MovimientoCaja
         {
             IdTenant = idTenant,
@@ -116,7 +137,34 @@ public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContex
         db.MovimientosCaja.Add(movimiento);
         await db.SaveChangesAsync(ct);
 
+        await transaccion.CommitAsync(ct);
+
         return movimiento;
+    }
+
+    /// <summary>Guard compartido (task 4.17) — reusado tal cual por
+    /// <c>ServicioDeGastos.RegistrarAsync</c> (mismo criterio de reuso que <see
+    /// cref="ResolverTurnoAbiertoAsync"/>, tasks.md Orchestrator Decision 3). DEBE llamarse como
+    /// el PRIMER statement de una transacción YA abierta por el llamador — no abre ninguna
+    /// transacción propia. <c>estado::text</c> en vez de leer el enum nativo directo: evita
+    /// depender de que Npgsql resuelva el tipo mapeado sobre un <c>ExecuteScalarAsync</c> crudo,
+    /// misma cautela que el resto de los statements ADO.NET de este proyecto (comparación
+    /// literal, nunca <c>Contains</c>).</summary>
+    public async Task ExigirTurnoAbiertoBajoLockAsync(int idTurnoCaja, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccionCruda;
+        comando.CommandText = "SELECT estado::text FROM turnos_caja WHERE id_turno_caja = $1 FOR SHARE";
+        AgregarParametro(comando, idTurnoCaja);
+
+        var estado = (string?)await comando.ExecuteScalarAsync(ct);
+        if (estado != "abierto")
+        {
+            throw new ErrorDominio("turno_no_abierto", "El turno no está abierto.", 409);
+        }
     }
 
     /// <summary>Fuente de verdad del gate seam de <c>Pos.tsx</c> (design: API Surface, <c>GET
@@ -132,13 +180,152 @@ public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContex
     }
 
     /// <summary>Turno por id (design: API Surface, <c>GET /api/caja/turnos/{id}</c> — el payload
-    /// del Z-report; Slice 4 le agrega los <c>arqueos_turno</c> cuando el cierre exista).</summary>
-    public async Task<TurnoResumen> ObtenerAsync(int id, CancellationToken ct = default)
+    /// del Z-report): incluye sus <c>arqueos_turno</c>, vacío mientras el turno sigue abierto.
+    /// <see cref="TurnoConArqueos"/> repite los mismos campos planos que <see cref="TurnoResumen"/>
+    /// más <c>Arqueos</c> — la deserialización de Slice 2 contra este mismo endpoint sigue
+    /// funcionando tal cual (System.Text.Json ignora la propiedad nueva).</summary>
+    public async Task<TurnoConArqueos> ObtenerAsync(int id, CancellationToken ct = default)
     {
         var turno = await db.TurnosCaja.FirstOrDefaultAsync(t => t.Id == id, ct)
             ?? throw ErrorDominio.NoEncontrado($"No existe el turno {id}.");
 
-        return Proyectar(turno);
+        var arqueos = await db.ArqueosTurno
+            .Where(a => a.IdTurnoCaja == id)
+            .OrderBy(a => a.IdMedioPago)
+            .ToListAsync(ct);
+
+        return ProyectarConArqueos(turno, arqueos);
+    }
+
+    /// <summary>Cierre (design: The Cierre Transaction — orden de statements pineado; decisión 1
+    /// declarada: el UPDATE guardado va PRIMERO, no derive-then-close). Irreversible: no existe
+    /// reapertura ni edición de arqueo (spec: Cierre Is One Atomic, Irreversible Transaction).
+    /// <see cref="FabricaDeEstrategiaSinReintento"/>: manual, raro, sin clave de idempotencia —
+    /// un commit ambiguo tiene que llegar al operador como una falla que re-chequea, nunca como
+    /// un reintento automático que reporte <c>409 turno_ya_cerrado</c> sobre un cierre que en
+    /// verdad tuvo éxito (design: Failure Semantics).</summary>
+    public async Task<TurnoConArqueos> CerrarAsync(
+        int idTurnoCaja, SolicitudDeCierre solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        // Pineado ACÁ, nunca releído dentro de la lambda reintentable (design: The Cierre
+        // Transaction, "momento := reloj.Ahora, pinned, never re-read").
+        var momento = reloj.Ahora;
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarCierreAsync(idTurnoCaja, idTenant, idEmpleado, momento, solicitud, ct));
+    }
+
+    private async Task<TurnoConArqueos> EjecutarCierreAsync(
+        int idTurnoCaja, int idTenant, int idEmpleado, DateTimeOffset momento, SolicitudDeCierre solicitud,
+        CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        // 1. UPDATE ... WHERE estado = 'abierto' RETURNING id_punto_venta — lock EXCLUSIVO de
+        // fila, PRIMER statement (design decisión 1), sostenido hasta el COMMIT. 0 filas: ¿existe
+        // el turno? no -> 404; sí -> 409 turno_ya_cerrado (Orchestrator Decision 2, tasks.md —
+        // distinto de turno_no_abierto: el turno EXISTE, solo que ya no está abierto).
+        var idPuntoVenta = await MarcarCerradoAsync(idTenant, idTurnoCaja, idEmpleado, momento, ct);
+        if (idPuntoVenta is null)
+        {
+            var existe = await db.TurnosCaja.AnyAsync(t => t.Id == idTurnoCaja, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el turno {idTurnoCaja}.");
+            }
+
+            throw new ErrorDominio("turno_ya_cerrado", "El turno ya está cerrado.", 409);
+        }
+
+        // 2. Insumos de la derivación (7 consultas agrupadas, cantidad fija) — bajo el lock.
+        var insumos = await lector.LeerAsync(idTurnoCaja, ct);
+
+        // 3. Ancla — puro, 409 caja_sin_medio_efectivo_unico si no es único.
+        var idAncla = ResolvedorDeMedioDeCajaFisica.Resolver(insumos.Actividad);
+
+        // 4. Cálculo (PURO, la única fórmula) + validación de los conteos declarados.
+        var lineas = CalculadorDeArqueo.Calcular(insumos, idAncla);
+        ValidadorDeConteos.Validar(lineas, insumos.Actividad, solicitud.Conteos);
+
+        // 5. INSERT arqueos_turno — una fila por medio arqueable; Diferencia la calcula la
+        // columna GENERATED (design decisión 6), nunca se asigna acá.
+        var declaradoPorMedio = solicitud.Conteos.ToDictionary(c => c.IdMedioPago, c => c.ImporteDeclarado);
+        var arqueos = lineas
+            .Select(l => new ArqueoTurno
+            {
+                IdTenant = idTenant,
+                IdTurnoCaja = idTurnoCaja,
+                IdMedioPago = l.IdMedioPago,
+                ImporteEsperado = l.ImporteEsperado,
+                ImporteDeclarado = declaradoPorMedio[l.IdMedioPago]
+            })
+            .ToList();
+        db.ArqueosTurno.AddRange(arqueos);
+        await db.SaveChangesAsync(ct);
+
+        // 6. Tesorería encadenada — UN único movimiento (tipo retiro_caja), inicio = final de la
+        // última fila del mismo punto de venta (0 si no hay), egreso = Σ gastos sobre TODOS los
+        // medios (design decisión 9, paridad legacy).
+        var totalGastos = insumos.Actividad.Sum(a => a.Gastos);
+        var inicio = await db.MovimientosTesoreria
+            .Where(m => m.IdPuntoVenta == idPuntoVenta.Value)
+            .OrderByDescending(m => m.Id)
+            .Select(m => m.Final)
+            .FirstOrDefaultAsync(ct);
+        var final = inicio + insumos.Retiros - totalGastos;
+
+        db.MovimientosTesoreria.Add(new MovimientoTesoreria
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = idPuntoVenta.Value,
+            Fecha = momento,
+            Tipo = TipoMovimientoTesoreria.RetiroCaja,
+            IdTurnoCaja = idTurnoCaja,
+            Concepto = "Cierre de turno",
+            Inicio = inicio,
+            Ingreso = insumos.Retiros,
+            Egreso = totalGastos,
+            Final = final,
+            IdEmpleado = idEmpleado
+        });
+        await db.SaveChangesAsync(ct);
+
+        await transaccion.CommitAsync(ct);
+
+        var turno = await db.TurnosCaja.AsNoTracking().FirstAsync(t => t.Id == idTurnoCaja, ct);
+        return ProyectarConArqueos(turno, arqueos);
+    }
+
+    /// <summary>Design: The Cierre Transaction, statement 1 — único punto de transición de
+    /// <c>estado</c> (mismo criterio que <c>MarcarAnuladoAsync</c> de <c>ServicioDeVentas</c>):
+    /// <c>RETURNING id_punto_venta</c>, no <c>fondo_inicial</c> — <see
+    /// cref="LectorDeMovimientosDelTurno"/> lo vuelve a leer por su cuenta (lo necesita también
+    /// para el resumen parcial sobre un turno TODAVÍA abierto, sin este RETURNING disponible).</summary>
+    private async Task<int?> MarcarCerradoAsync(
+        int idTenant, int idTurnoCaja, int idEmpleadoCierre, DateTimeOffset momento, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccionCruda;
+        comando.CommandText =
+            "UPDATE turnos_caja SET estado = $1, fecha_cierre = $2, id_empleado_cierre = $3 " +
+            "WHERE id_turno_caja = $4 AND id_tenant = $5 AND estado = $6 " +
+            "RETURNING id_punto_venta";
+
+        AgregarParametro(comando, EstadoTurno.Cerrado);
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, idEmpleadoCierre);
+        AgregarParametro(comando, idTurnoCaja);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, EstadoTurno.Abierto);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is null ? null : Convert.ToInt32(resultado);
     }
 
     /// <summary>Historial paginado (design: API Surface, <c>GET /api/caja/turnos</c>) — mismo
@@ -217,6 +404,27 @@ public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContex
             ?? throw new InvalidOperationException(
                 "ServicioDeTurnos requiere un actor de tenant; OperacionDePos no admite plataforma.");
 
+    // ---- statements crudos (ADO.NET, misma convención que ServicioDeVentas) -------------------
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
     // ---- proyecciones -----------------------------------------------------------------------
 
     private static TurnoResumen Proyectar(TurnoCaja turno) => new(
@@ -238,4 +446,18 @@ public class ServicioDeTurnos(IWaysDbContext db, IRelojDelSistema reloj, IContex
         movimiento.Motivo,
         movimiento.IdEmpleado,
         movimiento.CreadoEl);
+
+    private static TurnoConArqueos ProyectarConArqueos(TurnoCaja turno, IReadOnlyList<ArqueoTurno> arqueos) => new(
+        turno.Id,
+        turno.IdPuntoVenta,
+        turno.IdEmpleadoApertura,
+        turno.IdEmpleadoCierre,
+        turno.FechaApertura,
+        turno.FechaCierre,
+        turno.FondoInicial,
+        turno.Estado,
+        turno.Observaciones,
+        arqueos
+            .Select(a => new LineaDeArqueoResumen(a.IdMedioPago, a.ImporteEsperado, a.ImporteDeclarado, a.Diferencia))
+            .ToList());
 }

--- a/src/Ways.Application/Caja/ServicioDeTurnos.cs
+++ b/src/Ways.Application/Caja/ServicioDeTurnos.cs
@@ -227,8 +227,13 @@ public class ServicioDeTurnos(
         // 1. UPDATE ... WHERE estado = 'abierto' RETURNING id_punto_venta — lock EXCLUSIVO de
         // fila, PRIMER statement (design decisión 1), sostenido hasta el COMMIT. 0 filas: ¿existe
         // el turno? no -> 404; sí -> 409 turno_ya_cerrado (Orchestrator Decision 2, tasks.md —
-        // distinto de turno_no_abierto: el turno EXISTE, solo que ya no está abierto).
-        var idPuntoVenta = await MarcarCerradoAsync(idTenant, idTurnoCaja, idEmpleado, momento, ct);
+        // distinto de turno_no_abierto: el turno EXISTE, solo que ya no está abierto). El mismo
+        // UPDATE también acumula solicitud.Observaciones a continuación de las de la apertura,
+        // separadas por un salto de línea, sin pisar el texto existente.
+        var observacionesCierre = string.IsNullOrWhiteSpace(solicitud.Observaciones)
+            ? null
+            : solicitud.Observaciones.Trim();
+        var idPuntoVenta = await MarcarCerradoAsync(idTenant, idTurnoCaja, idEmpleado, momento, observacionesCierre, ct);
         if (idPuntoVenta is null)
         {
             var existe = await db.TurnosCaja.AnyAsync(t => t.Id == idTurnoCaja, ct);
@@ -303,9 +308,13 @@ public class ServicioDeTurnos(
     /// <c>estado</c> (mismo criterio que <c>MarcarAnuladoAsync</c> de <c>ServicioDeVentas</c>):
     /// <c>RETURNING id_punto_venta</c>, no <c>fondo_inicial</c> — <see
     /// cref="LectorDeMovimientosDelTurno"/> lo vuelve a leer por su cuenta (lo necesita también
-    /// para el resumen parcial sobre un turno TODAVÍA abierto, sin este RETURNING disponible).</summary>
+    /// para el resumen parcial sobre un turno TODAVÍA abierto, sin este RETURNING disponible).
+    /// Cuando <paramref name="observacionesCierre"/> no es nulo, el mismo UPDATE lo agrega a
+    /// continuación de las observaciones de la apertura (separadas por un salto de línea) sin
+    /// pisarlas; si es nulo, la columna queda intacta.</summary>
     private async Task<int?> MarcarCerradoAsync(
-        int idTenant, int idTurnoCaja, int idEmpleadoCierre, DateTimeOffset momento, CancellationToken ct)
+        int idTenant, int idTurnoCaja, int idEmpleadoCierre, DateTimeOffset momento, string? observacionesCierre,
+        CancellationToken ct)
     {
         var conexion = await ObtenerConexionAbiertaAsync(ct);
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
@@ -313,7 +322,9 @@ public class ServicioDeTurnos(
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccionCruda;
         comando.CommandText =
-            "UPDATE turnos_caja SET estado = $1, fecha_cierre = $2, id_empleado_cierre = $3 " +
+            "UPDATE turnos_caja SET estado = $1, fecha_cierre = $2, id_empleado_cierre = $3, " +
+            "observaciones = CASE WHEN $7::text IS NULL THEN observaciones " +
+            "ELSE COALESCE(observaciones || E'\n', '') || $7::text END " +
             "WHERE id_turno_caja = $4 AND id_tenant = $5 AND estado = $6 " +
             "RETURNING id_punto_venta";
 
@@ -323,6 +334,7 @@ public class ServicioDeTurnos(
         AgregarParametro(comando, idTurnoCaja);
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, EstadoTurno.Abierto);
+        AgregarParametro(comando, (object?)observacionesCierre ?? DBNull.Value);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is null ? null : Convert.ToInt32(resultado);

--- a/src/Ways.Application/Caja/ValidadorDeConteos.cs
+++ b/src/Ways.Application/Caja/ValidadorDeConteos.cs
@@ -1,0 +1,50 @@
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// Compara los conteos declarados por el cajero contra los medios arqueables que el SERVIDOR
+/// calculó (design: The Derivation — "Which medios get a row"; The Cierre Transaction, paso 4).
+/// Contar cero es un acto deliberado del cajero, nunca un default que el servidor asuma: falta
+/// un medio arqueable ⇒ <c>400 arqueo_incompleto</c>; sobra uno sin actividad ⇒ <c>400
+/// medio_sin_actividad_en_el_turno</c>; sobra uno de cuenta corriente ⇒ <c>400
+/// medio_no_arqueable</c>.
+/// </summary>
+public static class ValidadorDeConteos
+{
+    public static void Validar(
+        IReadOnlyList<LineaDeArqueo> arqueables, IReadOnlyList<ActividadDeMedio> actividad,
+        IReadOnlyList<ConteoDeclarado> declarados)
+    {
+        var idsArqueables = arqueables.Select(a => a.IdMedioPago).ToHashSet();
+        var idsDeclarados = declarados.Select(d => d.IdMedioPago).ToHashSet();
+
+        if (idsArqueables.Any(id => !idsDeclarados.Contains(id)))
+        {
+            throw new ErrorDominio(
+                "arqueo_incompleto",
+                "Falta declarar el conteo de al menos un medio con actividad en este turno.",
+                400);
+        }
+
+        foreach (var idDeclarado in idsDeclarados)
+        {
+            if (idsArqueables.Contains(idDeclarado))
+            {
+                continue;
+            }
+
+            var esCuentaCorriente = actividad.Any(
+                a => a.IdMedioPago == idDeclarado && a.Comportamiento == ComportamientoMedioPago.CuentaCorriente);
+
+            throw esCuentaCorriente
+                ? new ErrorDominio("medio_no_arqueable", "La cuenta corriente no es un medio arqueable.", 400)
+                : new ErrorDominio(
+                    "medio_sin_actividad_en_el_turno",
+                    "Declaraste un conteo para un medio sin actividad en este turno.",
+                    400);
+        }
+    }
+}

--- a/src/Ways.Application/Caja/ValidadorDeConteos.cs
+++ b/src/Ways.Application/Caja/ValidadorDeConteos.cs
@@ -18,6 +18,28 @@ public static class ValidadorDeConteos
         IReadOnlyList<LineaDeArqueo> arqueables, IReadOnlyList<ActividadDeMedio> actividad,
         IReadOnlyList<ConteoDeclarado> declarados)
     {
+        // Chequeos de forma del payload, ANTES de comparar contra los arqueables del servidor: un
+        // idMedioPago duplicado reventaría con un ArgumentException genérico (500) al armar el
+        // diccionario en ServicioDeTurnos.EjecutarCierreAsync si llegara hasta ahí sin control.
+        var duplicado = declarados
+            .GroupBy(d => d.IdMedioPago)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (duplicado is not null)
+        {
+            throw new ErrorDominio(
+                "conteo_duplicado",
+                "Declaraste el conteo de un mismo medio más de una vez.",
+                400);
+        }
+
+        if (declarados.Any(d => d.ImporteDeclarado < 0))
+        {
+            throw new ErrorDominio(
+                "conteo_invalido",
+                "El conteo declarado no puede ser negativo.",
+                400);
+        }
+
         var idsArqueables = arqueables.Select(a => a.IdMedioPago).ToHashSet();
         var idsDeclarados = declarados.Select(d => d.IdMedioPago).ToHashSet();
 

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -47,7 +47,13 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeEscaneo>();
         services.AddScoped<ServicioDeVentas>();
         services.AddScoped<ServicioDeStock>();
+
+        // stage-6-turnos-caja, Slice 4: LectorDeMovimientosDelTurno es el único lector de la
+        // derivación (design decisión 5), compartido por ServicioDeTurnos.CerrarAsync y
+        // ServicioDeResumenDeTurno.
+        services.AddScoped<LectorDeMovimientosDelTurno>();
         services.AddScoped<ServicioDeTurnos>();
+        services.AddScoped<ServicioDeResumenDeTurno>();
         services.AddScoped<ServicioDeGastos>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -96,10 +96,20 @@ public class ServicioDeGastos(
 
     // ---- persistencia -------------------------------------------------------------------------
 
+    /// <summary>task 4.17 (mismo guard que <c>ServicioDeTurnos.RegistrarMovimientoAsync</c>, reusado
+    /// vía <see cref="ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync"/> como PRIMER statement
+    /// de esta transacción de escritura): el turno ya vino resuelto como abierto (<see
+    /// cref="ServicioDeTurnos.ResolverTurnoAbiertoAsync"/>, arriba, ANTES de abrir esta
+    /// transacción) — sin este re-chequeo bajo <c>FOR SHARE</c>, un gasto concurrente a un
+    /// cierre podría comitear dentro de un turno cuyo arqueo YA se derivó (design decisión 1).</summary>
     private async Task<Gasto> InsertarGastoAsync(
         int idTenant, int idTurnoCaja, SolicitudDeGasto solicitud, int idEmpleado, DateTimeOffset momento,
         CancellationToken ct)
     {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        await servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(idTurnoCaja, ct);
+
         var gasto = new Gasto
         {
             IdTenant = idTenant,
@@ -121,6 +131,8 @@ public class ServicioDeGastos(
 
         db.Gastos.Add(gasto);
         await db.SaveChangesAsync(ct);
+
+        await transaccion.CommitAsync(ct);
 
         return gasto;
     }

--- a/src/Ways.Domain/Caja/ActividadDeMedio.cs
+++ b/src/Ways.Domain/Caja/ActividadDeMedio.cs
@@ -1,0 +1,23 @@
+using Ways.Domain.Catalogos;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Actividad de un medio de pago dentro de un turno (design: The Derivation; Interfaces/
+/// Contracts) — una fila por medio del catálogo del tenant, sin importar si tuvo actividad o no
+/// (<see cref="TuvoFilas"/> es lo que distingue "medio con actividad" de "medio sin actividad",
+/// nunca el valor de <see cref="Pagos"/>/<see cref="Gastos"/>: un medio puede netear exactamente
+/// 0 y seguir debiendo una declaración — spec: Arqueo Rows Only For Medios With Activity).
+///
+/// <see cref="Vueltos"/> es SIEMPRE por medio del pago original (nunca reasignado al ancla acá):
+/// es <see cref="CalculadorDeArqueo"/> quien suma <c>vueltosTotales</c> sobre TODOS los medios y
+/// lo resta únicamente en la línea del ancla (design decisión 2) — este record solo transporta el
+/// dato crudo.
+/// </summary>
+public readonly record struct ActividadDeMedio(
+    int IdMedioPago,
+    ComportamientoMedioPago Comportamiento,
+    decimal Pagos,
+    decimal Vueltos,
+    decimal Gastos,
+    bool TuvoFilas);

--- a/src/Ways.Domain/Caja/CalculadorDeArqueo.cs
+++ b/src/Ways.Domain/Caja/CalculadorDeArqueo.cs
@@ -1,0 +1,65 @@
+using Ways.Domain.Catalogos;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// La derivación (design: The Derivation — binding, una sola fórmula, sin segunda copia): pura,
+/// sin base de datos, mismo criterio que <see cref="Ventas.ValidadorDePagos"/>. Tanto
+/// <c>ServicioDeResumenDeTurno</c> como <c>ServicioDeTurnos.CerrarAsync</c> (Slice 4) llaman a
+/// esta misma clase con los mismos insumos — es la única garantía estructural de que el número
+/// que el cajero vio a las 19:00 es el que el cierre compara a las 20:00 (spec: Resumen Parcial
+/// Uses The Same Derivation As Cierre).
+/// </summary>
+public static class CalculadorDeArqueo
+{
+    /// <summary>Por medio con <c>Comportamiento ≠ CuentaCorriente</c>: <c>importe_esperado(m) =
+    /// pagos(m) − gastos(m) + [m = ancla] × (fondo + refuerzos − retiros − vueltosTotales)</c>
+    /// (design decisiones 2 y 9). <c>vueltosTotales</c> se deriva acá sumando
+    /// <see cref="ActividadDeMedio.Vueltos"/> de TODOS los medios — el cambio sale físicamente
+    /// del cajón sin importar con qué medio pagó el cliente, así que solo la línea del ancla lo
+    /// absorbe (design decisión 2: no por medio).
+    ///
+    /// Arqueable por EXISTENCIA de fila, nunca por valor (<paramref name="insumos"/>.Actividad ya
+    /// trae <see cref="ActividadDeMedio.TuvoFilas"/> resuelto): un medio puede netear exactamente
+    /// 0 y seguir debiendo una declaración. El ancla entra igual sin <c>TuvoFilas</c> propio
+    /// cuando el turno tuvo fondo/retiro/refuerzo/vuelto físico — el dinero se movió aunque nadie
+    /// pagó con ese medio puntual. Cuenta corriente queda afuera siempre (proposal decisión 6):
+    /// nada físico que contar.
+    ///
+    /// Devuelve SOLO los medios arqueables, en orden estable por <c>id_medio_pago</c> (Interfaces/
+    /// Contracts).</summary>
+    public static IReadOnlyList<LineaDeArqueo> Calcular(InsumosDeArqueo insumos, int idMedioAncla)
+    {
+        var vueltosTotales = insumos.Actividad.Sum(a => a.Vueltos);
+        var hayMovimientoFisicoDelAncla =
+            insumos.FondoInicial != 0m || insumos.Refuerzos != 0m || insumos.Retiros != 0m || vueltosTotales != 0m;
+
+        var lineas = new List<LineaDeArqueo>();
+
+        foreach (var actividad in insumos.Actividad.OrderBy(a => a.IdMedioPago))
+        {
+            if (actividad.Comportamiento == ComportamientoMedioPago.CuentaCorriente)
+            {
+                continue;
+            }
+
+            var esAncla = actividad.IdMedioPago == idMedioAncla;
+            var esArqueable = actividad.TuvoFilas || (esAncla && hayMovimientoFisicoDelAncla);
+
+            if (!esArqueable)
+            {
+                continue;
+            }
+
+            var importeEsperado = actividad.Pagos - actividad.Gastos;
+            if (esAncla)
+            {
+                importeEsperado += insumos.FondoInicial + insumos.Refuerzos - insumos.Retiros - vueltosTotales;
+            }
+
+            lineas.Add(new LineaDeArqueo(actividad.IdMedioPago, importeEsperado));
+        }
+
+        return lineas;
+    }
+}

--- a/src/Ways.Domain/Caja/InsumosDeArqueo.cs
+++ b/src/Ways.Domain/Caja/InsumosDeArqueo.cs
@@ -1,0 +1,19 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Entrada de <see cref="CalculadorDeArqueo"/> (design: The Derivation; Interfaces/Contracts) —
+/// armada por <c>Ways.Application.Caja.LectorDeMovimientosDelTurno</c>, la única fuente de estos
+/// datos tanto para el cierre como para el resumen parcial (spec: Resumen Parcial Uses The Same
+/// Derivation As Cierre).
+///
+/// <see cref="FondoInicial"/>/<see cref="Refuerzos"/>/<see cref="Retiros"/> son montos del turno
+/// completo (nunca por medio): solo aplican a la línea del ancla, decisión que
+/// <see cref="CalculadorDeArqueo"/> toma internamente. <c>vueltosTotales</c> NO viaja acá como
+/// campo propio — se deriva sumando <see cref="ActividadDeMedio.Vueltos"/> de
+/// <see cref="Actividad"/>, así que solo existe una fuente para ese número.
+/// </summary>
+public sealed record InsumosDeArqueo(
+    decimal FondoInicial,
+    decimal Refuerzos,
+    decimal Retiros,
+    IReadOnlyList<ActividadDeMedio> Actividad);

--- a/src/Ways.Domain/Caja/LineaDeArqueo.cs
+++ b/src/Ways.Domain/Caja/LineaDeArqueo.cs
@@ -1,0 +1,9 @@
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Una línea del resultado de <see cref="CalculadorDeArqueo"/> — un medio arqueable con su
+/// <c>importe_esperado</c> ya derivado (design: The Derivation; Interfaces/Contracts). El cierre
+/// la combina con el <c>importe_declarado</c> del cajero para armar cada fila de
+/// <see cref="ArqueoTurno"/>; el resumen parcial la expone tal cual, sin declarado (D6 parity).
+/// </summary>
+public sealed record LineaDeArqueo(int IdMedioPago, decimal ImporteEsperado);

--- a/src/Ways.Domain/Caja/ResolvedorDeMedioDeCajaFisica.cs
+++ b/src/Ways.Domain/Caja/ResolvedorDeMedioDeCajaFisica.cs
@@ -1,0 +1,34 @@
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Caja;
+
+/// <summary>
+/// Resuelve el ancla de la derivación (design decisión 3): el único medio del tenant con
+/// <c>Comportamiento = Efectivo</c>, sobre TODAS las filas del catálogo sin importar
+/// <c>Activo</c> (un medio desactivado a mitad de turno puede seguir teniendo pagos). Cero o dos
+/// o más filas ⇒ freno duro <c>409 caja_sin_medio_efectivo_unico</c>, la misma excepción tanto
+/// para el resumen como para el cierre (design: The Derivation — "so the misconfiguration
+/// surfaces during the shift, not at the close").
+///
+/// Pura, sin base de datos — recibe la actividad ya leída por
+/// <c>Ways.Application.Caja.LectorDeMovimientosDelTurno</c> (el catálogo completo de medios ya
+/// viaja ahí, así que no hace falta una consulta aparte).
+/// </summary>
+public static class ResolvedorDeMedioDeCajaFisica
+{
+    public static int Resolver(IReadOnlyList<ActividadDeMedio> medios)
+    {
+        var efectivos = medios.Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).ToList();
+
+        if (efectivos.Count != 1)
+        {
+            throw new ErrorDominio(
+                "caja_sin_medio_efectivo_unico",
+                "El tenant tiene que tener exactamente un medio de pago con comportamiento efectivo.",
+                409);
+        }
+
+        return efectivos[0].IdMedioPago;
+    }
+}

--- a/tests/Ways.Domain.Tests/Caja/CalculadorDeArqueoTests.cs
+++ b/tests/Ways.Domain.Tests/Caja/CalculadorDeArqueoTests.cs
@@ -1,0 +1,205 @@
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+
+namespace Ways.Domain.Tests.Caja;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 4 (tasks 4.1, 4.9, design: The Derivation — binding, una sola
+/// fórmula). Pura, sin base de datos: la exclusión de anulados NO se prueba acá porque ya pasó
+/// antes de llegar a este nivel (es <c>LectorDeMovimientosDelTurno</c>, Application, quien filtra
+/// <c>estado = emitido</c> al armar <see cref="ActividadDeMedio.Pagos"/>/<see
+/// cref="ActividadDeMedio.Vueltos"/>) — la cubre el escenario de integración (spec: Anulados Are
+/// Excluded From The Derivation).
+///
+/// IDs sintéticos usados en todo el archivo: 1 = efectivo (ancla en la mayoría de los casos),
+/// 2 = tarjeta (electrónico), 3 = cuenta corriente.
+/// </summary>
+public class CalculadorDeArqueoTests
+{
+    private const int IdEfectivo = 1;
+    private const int IdTarjeta = 2;
+    private const int IdCuentaCorriente = 3;
+
+    private static ActividadDeMedio Actividad(
+        int id, ComportamientoMedioPago comportamiento, decimal pagos = 0m, decimal vueltos = 0m,
+        decimal gastos = 0m, bool tuvoFilas = true) =>
+        new(id, comportamiento, pagos, vueltos, gastos, tuvoFilas);
+
+    /// <summary>spec: Efectivo expected includes fondo, pagos, vuelto, gastos, and movimientos —
+    /// también la prueba de colapso (design decisión 2): con vuelto SOLO en el ancla, la fórmula
+    /// da exactamente lo mismo que la literal de doc 10 (<c>fondo + pagos − vueltos − gastos −
+    /// retiros + refuerzos</c>).</summary>
+    [Fact]
+    public void ElEfectivoIncluyeFondoPagosVueltoGastosYMovimientosYColapsaConDoc10()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 500m, Refuerzos: 100m, Retiros: 200m,
+            Actividad: [Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 3000m, vueltos: 120m, gastos: 400m)]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        var linea = Assert.Single(resultado);
+        Assert.Equal(IdEfectivo, linea.IdMedioPago);
+        Assert.Equal(2880m, linea.ImporteEsperado);
+    }
+
+    /// <summary>spec: Electrónico expected is pagos net of its own gastos only — sin fondo,
+    /// vuelto, retiro ni refuerzo (esos son conceptos solo del ancla).</summary>
+    [Fact]
+    public void ElElectronicoEsPagosNetoDeSusPropiosGastosSinTerminosDeCajaFisica()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 500m, Refuerzos: 100m, Retiros: 200m,
+            Actividad:
+            [
+                Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 1000m),
+                Actividad(IdTarjeta, ComportamientoMedioPago.Electronico, pagos: 1500m, gastos: 200m)
+            ]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        var tarjeta = resultado.Single(l => l.IdMedioPago == IdTarjeta);
+        Assert.Equal(1300m, tarjeta.ImporteEsperado);
+    }
+
+    /// <summary>design decisión 2: el vuelto de un medio electrónico también sale físicamente del
+    /// cajón — lo absorbe la línea del ANCLA (vueltosTotales), nunca el propio medio electrónico
+    /// que lo generó.</summary>
+    [Fact]
+    public void UnVueltoEnUnMedioElectronicoLoAbsorbeElAnclaNoElPropioMedio()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            Actividad:
+            [
+                Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 1000m, vueltos: 50m),
+                Actividad(IdTarjeta, ComportamientoMedioPago.Electronico, pagos: 500m, vueltos: 30m)
+            ]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        var ancla = resultado.Single(l => l.IdMedioPago == IdEfectivo);
+        var tarjeta = resultado.Single(l => l.IdMedioPago == IdTarjeta);
+
+        // vueltosTotales = 50 + 30 = 80, restado SOLO en el ancla.
+        Assert.Equal(1000m - 80m, ancla.ImporteEsperado);
+        // La tarjeta no resta ni su propio vuelto ni el ajeno.
+        Assert.Equal(500m, tarjeta.ImporteEsperado);
+    }
+
+    /// <summary>Una NCX aporta un pago con importe negativo (stage-5 decisión 4: aritmética con
+    /// signo, sin rama especial) — el neteo ya viene resuelto en <see
+    /// cref="ActividadDeMedio.Pagos"/> (Application ya sumó todas las filas).</summary>
+    [Fact]
+    public void UnaNcxAportaPagoNegativoYSeNeteaSinRamaEspecial()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            // 1000 de un TX menos 300 de una NCX asociada = 700 netos.
+            Actividad: [Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 700m)]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        Assert.Equal(700m, Assert.Single(resultado).ImporteEsperado);
+    }
+
+    /// <summary>Retiros/refuerzos/fondo son SOLO del ancla — un medio no-ancla con actividad
+    /// nunca los recibe (ya cubierto en parte por el test de electrónico; acá se aísla el caso
+    /// de un no-ancla SIN actividad propia, que además no debería aparecer en el resultado).</summary>
+    [Fact]
+    public void UnMedioNoAnclaSinActividadPropiaNoApareceAunConFondoYMovimientosDelTurno()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 500m, Refuerzos: 100m, Retiros: 50m,
+            Actividad:
+            [
+                Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 100m),
+                Actividad(IdTarjeta, ComportamientoMedioPago.Electronico, tuvoFilas: false)
+            ]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        Assert.DoesNotContain(resultado, l => l.IdMedioPago == IdTarjeta);
+    }
+
+    /// <summary>spec: Arqueo Rows Only For Medios With Activity — un medio que netea exactamente
+    /// 0 (dos pagos que se cancelan) sigue debiendo una fila, porque la inclusión es por
+    /// EXISTENCIA de fila, nunca por valor.</summary>
+    [Fact]
+    public void UnMedioQueNeteaExactamenteCeroConActividadSigueTeniendoFila()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            Actividad: [Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 0m, tuvoFilas: true)]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        var linea = Assert.Single(resultado);
+        Assert.Equal(0m, linea.ImporteEsperado);
+    }
+
+    /// <summary>proposal decisión 6 / spec: Cuenta corriente never produces a row — excluida
+    /// siempre, incluso con actividad y aunque coincidiera (por error de configuración) con el
+    /// id del ancla resuelto.</summary>
+    [Fact]
+    public void CuentaCorrienteNuncaProduceUnaFilaAunqueTengaActividad()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            Actividad:
+            [
+                Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 100m),
+                Actividad(IdCuentaCorriente, ComportamientoMedioPago.CuentaCorriente, pagos: 500m, tuvoFilas: true)
+            ]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        Assert.DoesNotContain(resultado, l => l.IdMedioPago == IdCuentaCorriente);
+    }
+
+    /// <summary>El ancla entra sin <c>TuvoFilas</c> propio cuando el turno tuvo movimiento físico
+    /// (fondo/retiro/refuerzo/vuelto) — el dinero se movió aunque nadie pagó con ese medio en
+    /// este turno puntual.</summary>
+    [Fact]
+    public void ElAnclaApareceSinPagosPropiosCuandoHuboFondoORetiroORefuerzoOVuelto()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 500m, Refuerzos: 0m, Retiros: 0m,
+            Actividad: [Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, tuvoFilas: false)]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        var linea = Assert.Single(resultado);
+        Assert.Equal(500m, linea.ImporteEsperado);
+    }
+
+    /// <summary>Sin ningún movimiento físico ni pago, el ancla tampoco aparece — mismo criterio
+    /// "por existencia" que cualquier otro medio (spec: A medio with no activity gets no row).</summary>
+    [Fact]
+    public void ElAnclaNoApareceSiNoHuboNingunMovimientoFisicoNiPagoPropio()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            Actividad: [Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, tuvoFilas: false)]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        Assert.Empty(resultado);
+    }
+
+    [Fact]
+    public void ElResultadoQuedaOrdenadoEnFormaEstablePorIdMedioPago()
+    {
+        var insumos = new InsumosDeArqueo(
+            FondoInicial: 0m, Refuerzos: 0m, Retiros: 0m,
+            Actividad:
+            [
+                Actividad(IdTarjeta, ComportamientoMedioPago.Electronico, pagos: 10m),
+                Actividad(IdEfectivo, ComportamientoMedioPago.Efectivo, pagos: 10m)
+            ]);
+
+        var resultado = CalculadorDeArqueo.Calcular(insumos, IdEfectivo);
+
+        Assert.Equal([IdEfectivo, IdTarjeta], resultado.Select(l => l.IdMedioPago));
+    }
+}

--- a/tests/Ways.Domain.Tests/Caja/CalculadorDeArqueoTests.cs
+++ b/tests/Ways.Domain.Tests/Caja/CalculadorDeArqueoTests.cs
@@ -8,8 +8,9 @@ namespace Ways.Domain.Tests.Caja;
 /// fórmula). Pura, sin base de datos: la exclusión de anulados NO se prueba acá porque ya pasó
 /// antes de llegar a este nivel (es <c>LectorDeMovimientosDelTurno</c>, Application, quien filtra
 /// <c>estado = emitido</c> al armar <see cref="ActividadDeMedio.Pagos"/>/<see
-/// cref="ActividadDeMedio.Vueltos"/>) — la cubre el escenario de integración (spec: Anulados Are
-/// Excluded From The Derivation).
+/// cref="ActividadDeMedio.Vueltos"/>) — la cubre
+/// <c>CajaCierreEndpointsTests.LosPagosYVueltosDeUnComprobanteAnuladoQuedanExcluidosDeLaDerivacion</c>
+/// (spec: Anulados Are Excluded From The Derivation).
 ///
 /// IDs sintéticos usados en todo el archivo: 1 = efectivo (ancla en la mayoría de los casos),
 /// 2 = tarjeta (electrónico), 3 = cuenta corriente.

--- a/tests/Ways.Domain.Tests/Caja/ResolvedorDeMedioDeCajaFisicaTests.cs
+++ b/tests/Ways.Domain.Tests/Caja/ResolvedorDeMedioDeCajaFisicaTests.cs
@@ -1,0 +1,62 @@
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Tests.Caja;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 4 (tasks 4.2, 4.10, design decisión 3). Pura, sin base de datos —
+/// 0 / 1 / 2 medios efectivo.
+/// </summary>
+public class ResolvedorDeMedioDeCajaFisicaTests
+{
+    private static ActividadDeMedio Medio(int id, ComportamientoMedioPago comportamiento) =>
+        new(id, comportamiento, Pagos: 0m, Vueltos: 0m, Gastos: 0m, TuvoFilas: false);
+
+    [Fact]
+    public void UnUnicoMedioEfectivoSeResuelveSinError()
+    {
+        var medios = new[]
+        {
+            Medio(1, ComportamientoMedioPago.Efectivo),
+            Medio(2, ComportamientoMedioPago.Electronico)
+        };
+
+        var idAncla = ResolvedorDeMedioDeCajaFisica.Resolver(medios);
+
+        Assert.Equal(1, idAncla);
+    }
+
+    [Fact]
+    public void SinNingunMedioEfectivoTira409()
+    {
+        var medios = new[] { Medio(2, ComportamientoMedioPago.Electronico) };
+
+        var excepcion = Assert.Throws<ErrorDominio>(() => ResolvedorDeMedioDeCajaFisica.Resolver(medios));
+
+        Assert.Equal("caja_sin_medio_efectivo_unico", excepcion.Codigo);
+        Assert.Equal(409, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void ConDosMediosEfectivoTambienTira409()
+    {
+        var medios = new[]
+        {
+            Medio(1, ComportamientoMedioPago.Efectivo),
+            Medio(2, ComportamientoMedioPago.Efectivo)
+        };
+
+        var excepcion = Assert.Throws<ErrorDominio>(() => ResolvedorDeMedioDeCajaFisica.Resolver(medios));
+
+        Assert.Equal("caja_sin_medio_efectivo_unico", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void SinNingunMedioEnAbsolutoTambienTira409()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ResolvedorDeMedioDeCajaFisica.Resolver([]));
+
+        Assert.Equal("caja_sin_medio_efectivo_unico", excepcion.Codigo);
+    }
+}

--- a/tests/Ways.IntegrationTests/CajaCierreAtomicidadYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/CajaCierreAtomicidadYConcurrenciaTests.cs
@@ -1,0 +1,406 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 4 (tasks 4.11, 4.12, 4.14, 4.17, 4.18): las tres superficies
+/// racy/atómicas del cierre — fallas forzadas en cada punto de escritura real de la transacción
+/// (statements 1/5/6; los pasos 2-4 son puros/de solo lectura, sin punto de falla propio),
+/// dos cierres concurrentes del mismo turno, el presupuesto de consultas del resumen, y las dos
+/// carreras <c>FOR SHARE</c> (movimiento/gasto vs. cierre) que el hallazgo de judgment-day de la
+/// task 4.17 cierra.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CajaCierreAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdCliente, int IdTipoComprobanteTx,
+        int IdMedioEfectivo, string MailAdmin, string PasswordAdmin, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+        var idCliente = await db.Clientes.Select(c => c.Id).FirstAsync();
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, idCliente, idTipoComprobanteTx,
+            idMedioEfectivo, mailAdmin, resultado.PasswordTemporal, admin);
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, fondoInicial, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private long _numeroSecuencial = 1;
+
+    private async Task SembrarPagoAsync(Contexto ctx, int idTurno, int idMedioPago, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = importe,
+            DescuentoTotal = 0m,
+            Total = importe,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            IdMedioPago = idMedioPago,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    // ---- task 4.11: un punto de falla por prueba, en cada statement de escritura real ------------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task<HttpResponseMessage> IntentarCierreConPrivilegioRevocadoAsync(
+        Contexto ctx, int idTurno, SolicitudDeCierre solicitud, string tabla, string privilegios)
+    {
+        await RevocarAsync(tabla, privilegios);
+        try
+        {
+            return await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{idTurno}/cierre", solicitud);
+        }
+        finally
+        {
+            await RestaurarAsync(tabla, privilegios);
+        }
+    }
+
+    private async Task VerificarTurnoSigueAbiertoSinArqueosNiTesoreriaAsync(Contexto ctx, int idTurno)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var estado = await db.TurnosCaja.Where(t => t.Id == idTurno).Select(t => t.Estado).SingleAsync();
+        Assert.Equal(EstadoTurno.Abierto, estado);
+        Assert.Equal(0, await db.ArqueosTurno.CountAsync(a => a.IdTurnoCaja == idTurno));
+        Assert.Equal(0, await db.MovimientosTesoreria.CountAsync(m => m.IdTurnoCaja == idTurno));
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElUpdateDeTurnosCajaNoPersisteNadaYElTurnoSigueAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElUpdateDeTurnosCajaNoPersisteNadaYElTurnoSigueAbierto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+        var respuesta = await IntentarCierreConPrivilegioRevocadoAsync(
+            ctx, turno.Id, new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null),
+            "turnos_caja", "UPDATE");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        await VerificarTurnoSigueAbiertoSinArqueosNiTesoreriaAsync(ctx, turno.Id);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElInsertDeArqueosTurnoNoPersisteNadaYElTurnoSigueAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElInsertDeArqueosTurnoNoPersisteNadaYElTurnoSigueAbierto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+        var respuesta = await IntentarCierreConPrivilegioRevocadoAsync(
+            ctx, turno.Id, new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null),
+            "arqueos_turno", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        // El UPDATE guardado (statement 1) YA corrió cuando el INSERT de arqueos (statement 5)
+        // falla — prueba que el rollback deshace TAMBIÉN un statement anterior de la MISMA
+        // transacción, no solo el que tiró la excepción.
+        await VerificarTurnoSigueAbiertoSinArqueosNiTesoreriaAsync(ctx, turno.Id);
+    }
+
+    [Fact]
+    public async Task UnaFallaEnElInsertDeMovimientosTesoreriaNoPersisteNadaYElTurnoSigueAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaEnElInsertDeMovimientosTesoreriaNoPersisteNadaYElTurnoSigueAbierto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+        var respuesta = await IntentarCierreConPrivilegioRevocadoAsync(
+            ctx, turno.Id, new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null),
+            "movimientos_tesoreria", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        // El INSERT de arqueos_turno (statement 5) YA corrió — prueba que el rollback también lo
+        // deshace, no solo el statement 6 que tiró la excepción (spec: A failed cierre leaves the
+        // turno open with no side effects; tesoreria / A failed cierre leaves no tesorería row).
+        await VerificarTurnoSigueAbiertoSinArqueosNiTesoreriaAsync(ctx, turno.Id);
+    }
+
+    // ---- task 4.12: dos cierres concurrentes del mismo turno --------------------------------------
+
+    [Fact]
+    public async Task DosCierresConcurrentesDelMismoTurnoProducenExactamenteUnGanador()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync($"{nameof(DosCierresConcurrentesDelMismoTurnoProducenExactamenteUnGanador)}-{ronda}");
+            var turno = await AbrirTurnoAsync(ctx);
+            await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+            var solicitud = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null);
+
+            var tareaA = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+            var tareaB = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+            var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+            Assert.Contains(HttpStatusCode.OK, estados);
+            Assert.Contains(HttpStatusCode.Conflict, estados);
+
+            var perdedora = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+            var problema = await perdedora.Content.ReadFromJsonAsync<JsonElement>();
+            Assert.Equal("turno_ya_cerrado", problema.GetProperty("codigo").GetString());
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            Assert.Equal(1, await db.ArqueosTurno.CountAsync(a => a.IdTurnoCaja == turno.Id));
+            Assert.Equal(1, await db.MovimientosTesoreria.CountAsync(m => m.IdTurnoCaja == turno.Id));
+        }
+    }
+
+    // ---- task 4.17/4.18: las carreras FOR SHARE ----------------------------------------------------
+
+    /// <summary>Invariante robusto a la interleaving real (no depende de forzar el rendezvous):
+    /// si el movimiento ganó (201), su importe queda contado en <c>Ingreso</c> de la tesorería;
+    /// si perdió (409 turno_no_abierto), nunca se insertó — <c>Σ movimientos_caja(retiro) =
+    /// Ingreso</c> es verdad en los dos casos, nunca "201 pero no contado".</summary>
+    [Fact]
+    public async Task UnMovimientoQueCompiteConUnCierreQuedaContadoORechazadoNuncaSinContar()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync($"{nameof(UnMovimientoQueCompiteConUnCierreQuedaContadoORechazadoNuncaSinContar)}-{ronda}");
+            var turno = await AbrirTurnoAsync(ctx);
+            // El pago ya deja el ancla arqueable independientemente de si el retiro gana o
+            // pierde la carrera — el set de conteos declarados no cambia según el resultado.
+            await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 500m);
+
+            var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 500m)], null);
+
+            var tareaMovimiento = ctx.Admin.PostAsJsonAsync(
+                $"/api/caja/turnos/{turno.Id}/movimientos",
+                new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, 50m, "retiro en carrera con cierre"));
+            var tareaCierre = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+
+            var respuestaMovimiento = await tareaMovimiento;
+            var respuestaCierre = await tareaCierre;
+
+            Assert.Contains(respuestaMovimiento.StatusCode, new[] { HttpStatusCode.Created, HttpStatusCode.Conflict });
+            if (respuestaMovimiento.StatusCode == HttpStatusCode.Conflict)
+            {
+                var problema = await respuestaMovimiento.Content.ReadFromJsonAsync<JsonElement>();
+                Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+            }
+
+            // El cierre SIEMPRE tiene que ganar en algún momento (es el único que compite por
+            // cerrar) — o ya se cerró antes del movimiento, o se cierra después de que el
+            // movimiento comitea. Nunca puede fallar por la carrera en sí.
+            Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var sumaDeRetiros = await db.MovimientosCaja
+                .Where(m => m.IdTurnoCaja == turno.Id && m.Tipo == TipoMovimientoCaja.Retiro)
+                .SumAsync(m => m.Importe);
+            var ingresoDeTesoreria = await db.MovimientosTesoreria
+                .Where(m => m.IdTurnoCaja == turno.Id).Select(m => m.Ingreso).SingleAsync();
+
+            Assert.Equal(sumaDeRetiros, ingresoDeTesoreria);
+        }
+    }
+
+    /// <summary>Mismo invariante que el movimiento, para gastos: <c>Σ gastos = Egreso</c> sin
+    /// importar si el gasto ganó o perdió la carrera contra el cierre.</summary>
+    [Fact]
+    public async Task UnGastoQueCompiteConUnCierreQuedaContadoORechazadoNuncaSinContar()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync($"{nameof(UnGastoQueCompiteConUnCierreQuedaContadoORechazadoNuncaSinContar)}-{ronda}");
+            var turno = await AbrirTurnoAsync(ctx);
+            await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 500m);
+
+            var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 500m)], null);
+
+            var tareaGasto = ctx.Admin.PostAsJsonAsync(
+                "/api/gastos",
+                new SolicitudDeGasto(
+                    ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "gasto en carrera con cierre", null,
+                    ctx.IdMedioEfectivo, null, 30m));
+            var tareaCierre = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+
+            var respuestaGasto = await tareaGasto;
+            var respuestaCierre = await tareaCierre;
+
+            Assert.Contains(respuestaGasto.StatusCode, new[] { HttpStatusCode.Created, HttpStatusCode.Conflict });
+            if (respuestaGasto.StatusCode == HttpStatusCode.Conflict)
+            {
+                var problema = await respuestaGasto.Content.ReadFromJsonAsync<JsonElement>();
+                Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+            }
+
+            Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var sumaDeGastos = await db.Gastos.Where(g => g.IdTurnoCaja == turno.Id).SumAsync(g => g.Importe);
+            var egresoDeTesoreria = await db.MovimientosTesoreria
+                .Where(m => m.IdTurnoCaja == turno.Id).Select(m => m.Egreso).SingleAsync();
+
+            Assert.Equal(sumaDeGastos, egresoDeTesoreria);
+        }
+    }
+
+    // ---- task 4.14: presupuesto de consultas del resumen -------------------------------------------
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task ElResumenEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeTickets()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeTickets));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var interceptor = new ContadorDeComandos();
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var consultasCon2 = await SembrarYMedirAsync(ctx, cliente, turno.Id, interceptor, cantidadNueva: 2);
+        var consultasCon50 = await SembrarYMedirAsync(ctx, cliente, turno.Id, interceptor, cantidadNueva: 48);
+        var consultasCon200 = await SembrarYMedirAsync(ctx, cliente, turno.Id, interceptor, cantidadNueva: 150);
+
+        Assert.Equal(consultasCon2, consultasCon50);
+        Assert.Equal(consultasCon2, consultasCon200);
+    }
+
+    private async Task<int> SembrarYMedirAsync(
+        Contexto ctx, HttpClient cliente, int idTurno, ContadorDeComandos interceptor, int cantidadNueva)
+    {
+        for (var i = 0; i < cantidadNueva; i++)
+        {
+            await SembrarPagoAsync(ctx, idTurno, ctx.IdMedioEfectivo, 10m);
+        }
+
+        var antes = interceptor.Consultas;
+        var respuesta = await cliente.GetAsync($"/api/caja/turnos/{idTurno}/resumen");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        return interceptor.Consultas - antes;
+    }
+}

--- a/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
@@ -20,7 +20,7 @@ namespace Ways.IntegrationTests;
 /// <summary>
 /// stage-6-turnos-caja, Slice 4 (tasks 4.7, 4.8, 4.13, 4.15, 4.16): <c>GET
 /// /api/caja/turnos/{id}/resumen</c> y <c>POST /api/caja/turnos/{id}/cierre</c> punta a punta —
-/// la derivación, los tres rechazos de <c>ValidadorDeConteos</c>, el ancla no-única, una fila de
+/// la derivación, los cinco rechazos de <c>ValidadorDeConteos</c>, el ancla no-única, una fila de
 /// arqueo por medio con actividad, la cadena de tesorería, y autorización/ADR-8 (spec:
 /// arqueo-de-cierre, tesoreria).
 ///
@@ -291,7 +291,7 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         Assert.Equal(0m, arqueoEfectivo.Diferencia);
     }
 
-    // ---- ValidadorDeConteos: los tres rechazos ---------------------------------------------------
+    // ---- ValidadorDeConteos: los rechazos ---------------------------------------------------
 
     [Fact]
     public async Task FaltarUnMedioArqueableEnLosConteosDaArqueoIncompleto()
@@ -528,6 +528,14 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
             $"/api/caja/turnos/{primerTurno.Id}/cierre",
             new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 0m)], null));
         Assert.Equal(HttpStatusCode.OK, primerCierre.StatusCode);
+
+        // El esperado derivado negativo (faltante real) fluye sin clamping hasta el arqueo y la
+        // columna generada diferencia: -140 = 0 pagos - 40 gastos + (0 fondo - 100 retiro).
+        var cuerpoPrimerCierre = await primerCierre.Content.ReadAsStringAsync();
+        var arqueosPrimerCierre = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpoPrimerCierre, OpcionesJson)!;
+        var arqueoEfectivo = arqueosPrimerCierre.Arqueos.Single(a => a.IdMedioPago == ctx.IdMedioEfectivo);
+        Assert.Equal(-140m, arqueoEfectivo.ImporteEsperado);
+        Assert.Equal(-140m, arqueoEfectivo.Diferencia);
 
         await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
         {

--- a/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
@@ -1,0 +1,493 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 4 (tasks 4.7, 4.8, 4.13, 4.15, 4.16): <c>GET
+/// /api/caja/turnos/{id}/resumen</c> y <c>POST /api/caja/turnos/{id}/cierre</c> punta a punta —
+/// la derivación, los tres rechazos de <c>ValidadorDeConteos</c>, el ancla no-única, una fila de
+/// arqueo por medio con actividad, la cadena de tesorería, y autorización/ADR-8 (spec:
+/// arqueo-de-cierre, tesoreria).
+///
+/// Los pagos/gastos/movimientos de cada turno se siembran DIRECTO por EF (sin pasar por el
+/// checkout completo, que no es parte de esta slice — Slice 5 lo conecta) — mismo criterio que
+/// <c>VentasStockYCuentaCorrienteRlsTests</c>: la derivación solo lee <c>pagos_comprobante</c> +
+/// <c>comprobantes_venta.{id_turno_caja,estado}</c> + <c>gastos</c> + <c>movimientos_caja</c>,
+/// nunca <c>items_comprobante_venta</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdCliente, int IdTipoComprobanteTx,
+        int IdMedioEfectivo, int IdMedioTarjeta, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+        var idMedioTarjeta = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Electronico)
+            .Select(m => m.Id).FirstAsync();
+        var idCliente = await db.Clientes.Select(c => c.Id).FirstAsync();
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, idCliente, idTipoComprobanteTx,
+            idMedioEfectivo, idMedioTarjeta, admin);
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, fondoInicial, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private long _numeroSecuencial = 1;
+
+    /// <summary>Siembra directo un comprobante emitido (o anulado) con UN pago — la derivación
+    /// nunca toca <c>items_comprobante_venta</c>, así que esta prueba no los siembra.</summary>
+    private async Task SembrarPagoAsync(
+        Contexto ctx, int idTurno, int idMedioPago, decimal importe, decimal vuelto = 0m,
+        EstadoComprobante estado = EstadoComprobante.Emitido)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = importe,
+            DescuentoTotal = 0m,
+            Total = importe,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            IdMedioPago = idMedioPago,
+            Importe = importe,
+            Vuelto = vuelto,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> SembrarMedioAsync(Contexto ctx, string nombre, ComportamientoMedioPago comportamiento)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var medio = new MedioPago
+        {
+            IdTenant = ctx.IdTenant, Nombre = nombre, Orden = 9, Comportamiento = comportamiento,
+            AdmiteVuelto = false, RequiereReferencia = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medio);
+        await db.SaveChangesAsync();
+
+        return medio.Id;
+    }
+
+    private static async Task RegistrarMovimientoAsync(Contexto ctx, int idTurno, TipoMovimientoCaja tipo, decimal importe, string motivo)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{idTurno}/movimientos", new SolicitudDeMovimiento(tipo, importe, motivo));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    private static async Task RegistrarGastoAsync(Contexto ctx, int idMedioPago, decimal importe)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Otros, null, null, "Gasto de prueba", null, idMedioPago, null, importe));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    // ---- task 4.13/derivación: resumen y feliz camino de cierre ---------------------------------
+
+    [Fact]
+    public async Task ElResumenParcialDerivaFondoPagosVueltoGastosRetiroYRefuerzo()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenParcialDerivaFondoPagosVueltoGastosRetiroYRefuerzo));
+        var turno = await AbrirTurnoAsync(ctx, fondoInicial: 500m);
+
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 1000m, vuelto: 50m);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioTarjeta, importe: 300m);
+        await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Retiro, 100m, "retiro de prueba");
+        await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Refuerzo, 50m, "refuerzo de prueba");
+        await RegistrarGastoAsync(ctx, ctx.IdMedioEfectivo, 80m);
+        await RegistrarGastoAsync(ctx, ctx.IdMedioTarjeta, 20m);
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+        Assert.Equal(ctx.IdMedioEfectivo, resumen!.IdMedioAncla);
+
+        var efectivo = resumen.Medios.Single(m => m.IdMedioPago == ctx.IdMedioEfectivo);
+        var tarjeta = resumen.Medios.Single(m => m.IdMedioPago == ctx.IdMedioTarjeta);
+
+        // efectivo = 1000 - 80 + (500 + 50 - 100 - 50) = 1320 ; tarjeta = 300 - 20 = 280.
+        Assert.Equal(1320m, efectivo.ImporteEsperado);
+        Assert.Equal(280m, tarjeta.ImporteEsperado);
+    }
+
+    [Fact]
+    public async Task ElCierreConLosConteosCorrectosEsAceptadoYPersisteLosArqueos()
+    {
+        var ctx = await PrepararAsync(nameof(ElCierreConLosConteosCorrectosEsAceptadoYPersisteLosArqueos));
+        var turno = await AbrirTurnoAsync(ctx, fondoInicial: 500m);
+
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 1000m);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioTarjeta, importe: 300m);
+
+        var solicitud = new SolicitudDeCierre(
+            [new ConteoDeclarado(ctx.IdMedioEfectivo, 1500m), new ConteoDeclarado(ctx.IdMedioTarjeta, 300m)], null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoTurno.Cerrado, resultado.Estado);
+        Assert.Equal(2, resultado.Arqueos.Count);
+
+        var efectivo = resultado.Arqueos.Single(a => a.IdMedioPago == ctx.IdMedioEfectivo);
+        Assert.Equal(1500m, efectivo.ImporteEsperado);
+        Assert.Equal(1500m, efectivo.ImporteDeclarado);
+        Assert.Equal(0m, efectivo.Diferencia);
+
+        // La respuesta de GET .../{id} también expone los mismos arqueos (design: API Surface —
+        // "Turno + its arqueos_turno, the Z-report payload").
+        var porId = await ctx.Admin.GetFromJsonAsync<TurnoConArqueos>($"/api/caja/turnos/{turno.Id}", OpcionesJson);
+        Assert.Equal(2, porId!.Arqueos.Count);
+    }
+
+    // ---- task 4.16: una fila por medio con actividad, ninguna para CC ni sin actividad ----------
+
+    [Fact]
+    public async Task ElCierreEscribeUnaFilaPorMedioConActividadNingunaParaCcNiParaMedioSinActividad()
+    {
+        var ctx = await PrepararAsync(nameof(ElCierreEscribeUnaFilaPorMedioConActividadNingunaParaCcNiParaMedioSinActividad));
+        var idMedioSinActividad = await SembrarMedioAsync(ctx, "QR", ComportamientoMedioPago.Electronico);
+        var idMedioCc = await SembrarMedioAsync(ctx, "Cuenta corriente", ComportamientoMedioPago.CuentaCorriente);
+
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 200m);
+        await SembrarPagoAsync(ctx, turno.Id, idMedioCc, importe: 400m);
+
+        var solicitud = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 200m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpo, OpcionesJson)!;
+        Assert.Single(resultado.Arqueos);
+        Assert.Equal(ctx.IdMedioEfectivo, resultado.Arqueos[0].IdMedioPago);
+        Assert.DoesNotContain(resultado.Arqueos, a => a.IdMedioPago == idMedioSinActividad);
+        Assert.DoesNotContain(resultado.Arqueos, a => a.IdMedioPago == idMedioCc);
+    }
+
+    // ---- ValidadorDeConteos: los tres rechazos ---------------------------------------------------
+
+    [Fact]
+    public async Task FaltarUnMedioArqueableEnLosConteosDaArqueoIncompleto()
+    {
+        var ctx = await PrepararAsync(nameof(FaltarUnMedioArqueableEnLosConteosDaArqueoIncompleto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 100m);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioTarjeta, importe: 50m);
+
+        var solicitud = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("arqueo_incompleto", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task DeclararUnMedioSinActividadDaMedioSinActividadEnElTurno()
+    {
+        var ctx = await PrepararAsync(nameof(DeclararUnMedioSinActividadDaMedioSinActividadEnElTurno));
+        var idMedioSinActividad = await SembrarMedioAsync(ctx, "QR", ComportamientoMedioPago.Electronico);
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 100m);
+
+        var solicitud = new SolicitudDeCierre(
+            [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m), new ConteoDeclarado(idMedioSinActividad, 0m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("medio_sin_actividad_en_el_turno", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task DeclararUnaCuentaCorrienteDaMedioNoArqueable()
+    {
+        var ctx = await PrepararAsync(nameof(DeclararUnaCuentaCorrienteDaMedioNoArqueable));
+        var idMedioCc = await SembrarMedioAsync(ctx, "Cuenta corriente", ComportamientoMedioPago.CuentaCorriente);
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 100m);
+        await SembrarPagoAsync(ctx, turno.Id, idMedioCc, importe: 500m);
+
+        var solicitud = new SolicitudDeCierre(
+            [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m), new ConteoDeclarado(idMedioCc, 500m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("medio_no_arqueable", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- 404 / 409 turno_ya_cerrado / ancla no única ---------------------------------------------
+
+    [Fact]
+    public async Task CerrarUnTurnoInexistenteDevuelve404()
+    {
+        var ctx = await PrepararAsync(nameof(CerrarUnTurnoInexistenteDevuelve404));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos/999999/cierre", new SolicitudDeCierre([], null));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task CerrarUnTurnoDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(CerrarUnTurnoDeOtroTenantDevuelve404) + "-A");
+        var turnoDeA = await AbrirTurnoAsync(ctxA);
+
+        var ctxB = await PrepararAsync(nameof(CerrarUnTurnoDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxB.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{turnoDeA.Id}/cierre", new SolicitudDeCierre([], null));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSegundoCierreDelMismoTurnoDaTurnoYaCerrado()
+    {
+        var ctx = await PrepararAsync(nameof(UnSegundoCierreDelMismoTurnoDaTurnoYaCerrado));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var primero = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre([], null));
+        Assert.Equal(HttpStatusCode.OK, primero.StatusCode);
+
+        var segundo = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre([], null));
+        Assert.Equal(HttpStatusCode.Conflict, segundo.StatusCode);
+
+        var problema = await segundo.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_ya_cerrado", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task SinNingunaActividadElCierreConConteosVaciosEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(SinNingunaActividadElCierreConConteosVaciosEsAceptado));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre([], null));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpo, OpcionesJson)!;
+        Assert.Empty(resultado.Arqueos);
+    }
+
+    [Fact]
+    public async Task DosMediosEfectivoHacenQueElResumenYElCierreDevuelvan409()
+    {
+        var ctx = await PrepararAsync(nameof(DosMediosEfectivoHacenQueElResumenYElCierreDevuelvan409));
+        await SembrarMedioAsync(ctx, "Efectivo caja chica", ComportamientoMedioPago.Efectivo);
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var resumen = await ctx.Admin.GetAsync($"/api/caja/turnos/{turno.Id}/resumen");
+        Assert.Equal(HttpStatusCode.Conflict, resumen.StatusCode);
+        var problemaResumen = await resumen.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("caja_sin_medio_efectivo_unico", problemaResumen.GetProperty("codigo").GetString());
+
+        var cierre = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre([], null));
+        Assert.Equal(HttpStatusCode.Conflict, cierre.StatusCode);
+        var problemaCierre = await cierre.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("caja_sin_medio_efectivo_unico", problemaCierre.GetProperty("codigo").GetString());
+
+        // El UPDATE guardado (statement 1) ya corrió antes de que el ancla no-única tirara —
+        // el rollback de la transacción tiene que deshacer TAMBIÉN esa transición de estado
+        // (design: The Cierre Transaction, "any failure between 1 and 6 rolls everything back").
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var estado = await db.TurnosCaja.Where(t => t.Id == turno.Id).Select(t => t.Estado).SingleAsync();
+        Assert.Equal(EstadoTurno.Abierto, estado);
+        Assert.Equal(0, await db.ArqueosTurno.CountAsync(a => a.IdTurnoCaja == turno.Id));
+    }
+
+    // ---- task 4.13: identidad byte-a-byte entre resumen y cierre ---------------------------------
+
+    [Fact]
+    public async Task ElResumenInmediatamenteAntesDelCierreCoincideByteABiteConLoQuePersisteElCierre()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenInmediatamenteAntesDelCierreCoincideByteABiteConLoQuePersisteElCierre));
+        var turno = await AbrirTurnoAsync(ctx, fondoInicial: 300m);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 750.33m, vuelto: 12.11m);
+        await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Refuerzo, 44.50m, "refuerzo de prueba");
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        var conteos = resumen!.Medios.Select(m => new ConteoDeclarado(m.IdMedioPago, m.ImporteEsperado)).ToList();
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre(conteos, null));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpo, OpcionesJson)!;
+        foreach (var linea in resumen.Medios)
+        {
+            var arqueo = resultado.Arqueos.Single(a => a.IdMedioPago == linea.IdMedioPago);
+            Assert.Equal(linea.ImporteEsperado, arqueo.ImporteEsperado);
+            Assert.Equal(0m, arqueo.Diferencia);
+        }
+    }
+
+    // ---- tesorería: primera y segunda cadena ------------------------------------------------------
+
+    [Fact]
+    public async Task LaTesoreriaEncadenaDesdeElFinalDeLaUltimaFilaDelMismoPuntoDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(LaTesoreriaEncadenaDesdeElFinalDeLaUltimaFilaDelMismoPuntoDeVenta));
+
+        var primerTurno = await AbrirTurnoAsync(ctx);
+        await RegistrarMovimientoAsync(ctx, primerTurno.Id, TipoMovimientoCaja.Retiro, 100m, "retiro de prueba");
+        await RegistrarGastoAsync(ctx, ctx.IdMedioEfectivo, 40m);
+        var primerCierre = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{primerTurno.Id}/cierre",
+            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, -140m)], null));
+        Assert.Equal(HttpStatusCode.OK, primerCierre.StatusCode);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.MovimientosTesoreria.Where(m => m.IdTurnoCaja == primerTurno.Id).SingleAsync();
+            Assert.Equal(0m, fila.Inicio);
+            Assert.Equal(100m, fila.Ingreso);
+            Assert.Equal(40m, fila.Egreso);
+            Assert.Equal(60m, fila.Final);
+        }
+
+        var segundoTurno = await AbrirTurnoAsync(ctx);
+        await RegistrarMovimientoAsync(ctx, segundoTurno.Id, TipoMovimientoCaja.Retiro, 50m, "segundo retiro de prueba");
+        var segundoCierre = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{segundoTurno.Id}/cierre",
+            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, -50m)], null));
+        Assert.Equal(HttpStatusCode.OK, segundoCierre.StatusCode);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.MovimientosTesoreria.Where(m => m.IdTurnoCaja == segundoTurno.Id).SingleAsync();
+            Assert.Equal(60m, fila.Inicio);
+            Assert.Equal(50m, fila.Ingreso);
+            Assert.Equal(0m, fila.Egreso);
+            Assert.Equal(110m, fila.Final);
+
+            Assert.Equal(2, await db.MovimientosTesoreria.CountAsync(m => m.IdPuntoVenta == ctx.IdPuntoVenta));
+        }
+    }
+
+    // ---- autorización -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnRolFueraDeOperacionDePosEsRechazadoDelCierreYDelResumen()
+    {
+        var ctx = await PrepararAsync(nameof(UnRolFueraDeOperacionDePosEsRechazadoDelCierreYDelResumen));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var resumen = await root.GetAsync($"/api/caja/turnos/{turno.Id}/resumen");
+        Assert.Equal(HttpStatusCode.Forbidden, resumen.StatusCode);
+
+        var cierre = await root.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", new SolicitudDeCierre([], null));
+        Assert.Equal(HttpStatusCode.Forbidden, cierre.StatusCode);
+    }
+
+    // ---- task 4.15: el contrato de cierre nunca acepta un total -----------------------------------
+
+    [Fact]
+    public void NingunCampoDeSolicitudDeCierreOConteoDeclaradoNombraUnTotalOUnEsperado()
+    {
+        var prohibidos = new[] { "total", "esperado", "importeesperado", "subtotal" };
+
+        foreach (var tipo in new[] { typeof(SolicitudDeCierre), typeof(ConteoDeclarado) })
+        {
+            foreach (var propiedad in tipo.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var nombre = propiedad.Name.ToLowerInvariant();
+                Assert.DoesNotContain(prohibidos, p => nombre.Contains(p, StringComparison.Ordinal));
+            }
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/CajaCierreEndpointsTests.cs
@@ -203,7 +203,8 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioTarjeta, importe: 300m);
 
         var solicitud = new SolicitudDeCierre(
-            [new ConteoDeclarado(ctx.IdMedioEfectivo, 1500m), new ConteoDeclarado(ctx.IdMedioTarjeta, 300m)], null);
+            [new ConteoDeclarado(ctx.IdMedioEfectivo, 1500m), new ConteoDeclarado(ctx.IdMedioTarjeta, 300m)],
+            "Cierre de prueba");
 
         var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
@@ -218,10 +219,15 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         Assert.Equal(1500m, efectivo.ImporteDeclarado);
         Assert.Equal(0m, efectivo.Diferencia);
 
+        // El UPDATE guardado del cierre agrega las observaciones a continuación de las de la
+        // apertura ("Apertura de prueba", sembrada por AbrirTurnoAsync), sin pisarlas.
+        Assert.Equal("Apertura de prueba\nCierre de prueba", resultado.Observaciones);
+
         // La respuesta de GET .../{id} también expone los mismos arqueos (design: API Surface —
         // "Turno + its arqueos_turno, the Z-report payload").
         var porId = await ctx.Admin.GetFromJsonAsync<TurnoConArqueos>($"/api/caja/turnos/{turno.Id}", OpcionesJson);
         Assert.Equal(2, porId!.Arqueos.Count);
+        Assert.Equal("Apertura de prueba\nCierre de prueba", porId.Observaciones);
     }
 
     // ---- task 4.16: una fila por medio con actividad, ninguna para CC ni sin actividad ----------
@@ -247,6 +253,42 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         Assert.Equal(ctx.IdMedioEfectivo, resultado.Arqueos[0].IdMedioPago);
         Assert.DoesNotContain(resultado.Arqueos, a => a.IdMedioPago == idMedioSinActividad);
         Assert.DoesNotContain(resultado.Arqueos, a => a.IdMedioPago == idMedioCc);
+    }
+
+    // ---- task 4.3/4.14: los anulados quedan fuera de la derivación --------------------------------
+
+    /// <summary>spec: Anulados Are Excluded From The Derivation — <see
+    /// cref="LectorDeMovimientosDelTurno"/> filtra <c>estado = emitido</c> al armar pagos y
+    /// vueltos por medio (ver su comentario en el paso 1); acá se prueba punta a punta que un
+    /// comprobante anulado no aporta NI su pago NI su vuelto al <c>importe_esperado</c>, ni en el
+    /// resumen parcial ni en el cierre persistido.</summary>
+    [Fact]
+    public async Task LosPagosYVueltosDeUnComprobanteAnuladoQuedanExcluidosDeLaDerivacion()
+    {
+        var ctx = await PrepararAsync(nameof(LosPagosYVueltosDeUnComprobanteAnuladoQuedanExcluidosDeLaDerivacion));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 500m, vuelto: 20m);
+        await SembrarPagoAsync(
+            ctx, turno.Id, ctx.IdMedioEfectivo, importe: 300m, vuelto: 10m, estado: EstadoComprobante.Anulado);
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+        var efectivo = resumen!.Medios.Single(m => m.IdMedioPago == ctx.IdMedioEfectivo);
+
+        // Solo el comprobante emitido aporta: 500 - 20 = 480; el anulado (300, vuelto 10) no suma
+        // ni resta nada.
+        Assert.Equal(480m, efectivo.ImporteEsperado);
+
+        var solicitud = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 480m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<TurnoConArqueos>(cuerpo, OpcionesJson)!;
+        var arqueoEfectivo = resultado.Arqueos.Single(a => a.IdMedioPago == ctx.IdMedioEfectivo);
+        Assert.Equal(480m, arqueoEfectivo.ImporteEsperado);
+        Assert.Equal(0m, arqueoEfectivo.Diferencia);
     }
 
     // ---- ValidadorDeConteos: los tres rechazos ---------------------------------------------------
@@ -302,6 +344,50 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         Assert.Equal("medio_no_arqueable", problema.GetProperty("codigo").GetString());
     }
 
+    /// <summary>Fix judgment-day (juzgados A y B, Slice 4): antes de este fix, <c>declarados
+    /// .ToHashSet()</c> deduplicaba en silencio y el <c>ToDictionary</c> de
+    /// <c>ServicioDeTurnos.EjecutarCierreAsync</c> reventaba con un <c>ArgumentException</c> sin
+    /// controlar (500 genérico) ante un mismo <c>idMedioPago</c> declarado dos veces.</summary>
+    [Fact]
+    public async Task DeclararElMismoMedioDosVecesDaConteoDuplicadoYElTurnoSigueAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(DeclararElMismoMedioDosVecesDaConteoDuplicadoYElTurnoSigueAbierto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 100m);
+
+        var solicitud = new SolicitudDeCierre(
+            [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m), new ConteoDeclarado(ctx.IdMedioEfectivo, 90m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_duplicado", problema.GetProperty("codigo").GetString());
+
+        var porId = await ctx.Admin.GetFromJsonAsync<TurnoConArqueos>($"/api/caja/turnos/{turno.Id}", OpcionesJson);
+        Assert.Equal(EstadoTurno.Abierto, porId!.Estado);
+    }
+
+    /// <summary>Fix judgment-day (juez A, Slice 4): un conteo físico nunca puede ser negativo —
+    /// <c>ValidadorDeConteos.Validar</c> ahora lo rechaza antes de comparar contra los
+    /// arqueables.</summary>
+    [Fact]
+    public async Task DeclararUnConteoNegativoDaConteoInvalidoYElTurnoSigueAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(DeclararUnConteoNegativoDaConteoInvalidoYElTurnoSigueAbierto));
+        var turno = await AbrirTurnoAsync(ctx);
+        await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, importe: 100m);
+
+        var solicitud = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, -1m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_invalido", problema.GetProperty("codigo").GetString());
+
+        var porId = await ctx.Admin.GetFromJsonAsync<TurnoConArqueos>($"/api/caja/turnos/{turno.Id}", OpcionesJson);
+        Assert.Equal(EstadoTurno.Abierto, porId!.Estado);
+    }
+
     // ---- 404 / 409 turno_ya_cerrado / ancla no única ---------------------------------------------
 
     [Fact]
@@ -325,6 +411,19 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
 
         var respuesta = await ctxB.Admin.PostAsJsonAsync(
             $"/api/caja/turnos/{turnoDeA.Id}/cierre", new SolicitudDeCierre([], null));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task ElResumenDeUnTurnoDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(ElResumenDeUnTurnoDeOtroTenantDevuelve404) + "-A");
+        var turnoDeA = await AbrirTurnoAsync(ctxA);
+
+        var ctxB = await PrepararAsync(nameof(ElResumenDeUnTurnoDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxB.Admin.GetAsync($"/api/caja/turnos/{turnoDeA.Id}/resumen");
 
         Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
     }
@@ -422,9 +521,12 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         var primerTurno = await AbrirTurnoAsync(ctx);
         await RegistrarMovimientoAsync(ctx, primerTurno.Id, TipoMovimientoCaja.Retiro, 100m, "retiro de prueba");
         await RegistrarGastoAsync(ctx, ctx.IdMedioEfectivo, 40m);
+        // El importe esperado derivado da negativo (fondo 0 + retiro > pagos), pero un conteo
+        // FÍSICO nunca puede serlo (fix judgment-day, conteo_invalido) — se declara 0m, que no
+        // afecta la cadena de tesorería (ésta depende de insumos.Retiros/gastos, no del conteo).
         var primerCierre = await ctx.Admin.PostAsJsonAsync(
             $"/api/caja/turnos/{primerTurno.Id}/cierre",
-            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, -140m)], null));
+            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 0m)], null));
         Assert.Equal(HttpStatusCode.OK, primerCierre.StatusCode);
 
         await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
@@ -440,7 +542,7 @@ public class CajaCierreEndpointsTests(WaysApiFixture fixture) : IClassFixture<Wa
         await RegistrarMovimientoAsync(ctx, segundoTurno.Id, TipoMovimientoCaja.Retiro, 50m, "segundo retiro de prueba");
         var segundoCierre = await ctx.Admin.PostAsJsonAsync(
             $"/api/caja/turnos/{segundoTurno.Id}/cierre",
-            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, -50m)], null));
+            new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 0m)], null));
         Assert.Equal(HttpStatusCode.OK, segundoCierre.StatusCode);
 
         await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -48,10 +48,13 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
 
         // stage-6-turnos-caja (Slice 2, task 2.6): apertura de turno y movimientos de caja — sin
         // GestionDeCatalogo apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que
-        // poder abrir su turno y registrar un retiro/refuerzo). Task 4.8 suma acá el cierre
-        // (POST …/{id}/cierre) cuando Slice 4 lo aterrice.
+        // poder abrir su turno y registrar un retiro/refuerzo).
         ("POST", "/api/caja/turnos/"),
         ("POST", "/api/caja/turnos/{id:int}/movimientos"),
+        // stage-6-turnos-caja (Slice 4, task 4.8): cierre de turno — mismo criterio que las dos
+        // rutas de arriba (proposal decisión 2 ofrece tightening a Supervisor+Admin, flagged en
+        // el gate; sigue OperacionDePos por ahora, sin decisión tomada).
+        ("POST", "/api/caja/turnos/{id:int}/cierre"),
         // stage-6-turnos-caja (Slice 3, task 3.2): captura de gasto — sin GestionDeCatalogo
         // apilado, mismo criterio que los dos de arriba (spec: gastos / Gasto Authorization, un
         // Vendedor tiene que poder registrar un gasto).


### PR DESCRIPTION
## Resumen

Slice 4/7 de la etapa 6 (stage-6-turnos-caja) — el centerpiece: la derivación per-medio del arqueo y el cierre atómico. El bug D7 del legacy (totales por POST manipulable) muere acá: el cliente solo manda conteos declarados, el esperado se deriva SIEMPRE del ledger.

- `CalculadorDeArqueo` + `ResolvedorDeMedioDeCajaFisica` (dominio puro): `esperado(m) = pagos(m) − gastos(m) + [m=ancla]×(fondo + refuerzos − retiros − vueltosTotales)`; ancla = único medio efectivo del tenant (0 o 2+ → 409); NCX netea con aritmética con signo, sin rama especial; CC excluida del arqueo.
- Cierre en UNA transacción con orden fijado: UPDATE exclusivo del turno PRIMERO (0 filas → 404 o 409 `turno_ya_cerrado`), 7 queries agrupadas de costo constante, validación de conteos, INSERT de arqueos (diferencia GENERATED), y una fila de tesorería encadenada `inicio→final`.
- Guards `FOR SHARE` en movimientos y gastos (hallazgo de la ronda del slice 2): ningún ledger puede commitear en un turno cuyo arqueo ya se derivó.
- Resumen parcial (D6) usa LA MISMA derivación — identidad probada byte a byte.
- `Observaciones` del cierre se persiste (append a la nota de apertura).

## Verificación

- Build 0 warnings; sin migración; `has-pending-model-changes` limpio.
- Suites: Domain 306/306 (+14), Application 209/209, Integration 476/476 (+26), contra Postgres real. Atomicidad por inyección de fallas en los 3 statements de escritura (el turno queda abierto, cero arqueos, cero tesorería); carreras de cierre concurrente y movimiento/gasto-vs-cierre; presupuesto de queries invariante en 2/50/200 tickets.
- Judgment-day (rigor completo): ronda 1 — ambos jueces re-derivaron la fórmula de forma independiente y coincidió; 2 MAJORs corregidos (conteo duplicado → 400 `conteo_duplicado` en vez de 500; el escenario de anulados excluidos no tenía test y el comentario decía que sí — test agregado con verificación por mutación) + 3 MINORs (observaciones persistidas, conteo negativo → 400 `conteo_invalido`, cross-tenant del resumen). Ronda 2 — juez A CLEAN, juez B un MINOR (el pin del esperado negativo se había perdido al corregir los conteos) restaurado con assertion sobre el arqueo (-140 esperado, -140 diferencia). Ronda cerrada limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)