### PR TITLE
feat(caja): pantalla web de apertura, movimientos y resumen (etapa 6, slice 6)

### DIFF
--- a/openspec/changes/stage-6-turnos-caja/tasks.md
+++ b/openspec/changes/stage-6-turnos-caja/tasks.md
@@ -391,9 +391,9 @@ sequenced here after PR 5 for review load). **Finish**: apertura,
 movimientos, and live resumen parcial functional; `Caja.tsx` compiles and
 is tested. **Rollback**: new route only.
 
-- [ ] 6.1 Add pure `src/Ways.Web/src/api/caja.ts`: request/response mappers
+- [x] 6.1 Add pure `src/Ways.Web/src/api/caja.ts`: request/response mappers
   for apertura, movimiento, and resumen. *(design: Web Composition)*
-- [ ] 6.2 Add `src/Ways.Web/src/paginas/Caja.tsx`: turno status, apertura
+- [x] 6.2 Add `src/Ways.Web/src/paginas/Caja.tsx`: turno status, apertura
   form (fondo inicial + observaciones), movimientos form (retiro / refuerzo
   / apertura de cajón with motivo), resumen parcial (áreas, medios,
   tickets, egresos por categoría). `react-async-state` rules 1
@@ -402,9 +402,17 @@ is tested. **Rollback**: new route only.
   or gasto bumps the resumen generation before the write), 8
   (`key={idTurno ?? 'sin-turno'}` on the caja subtree). *(design: Web
   Composition; react-async-state obligations 2, 3, 8)*
-- [ ] 6.3 Wire `/caja` route + nav entry.
-- [ ] 6.4 [P] Unit: `caja.ts` mappers. *(web-descriptor-tests)*
-- [ ] 6.5 Component: apertura flow; registering a movimiento bumps and
+  — **Deviation**: the merged `GET …/resumen` contract
+  (`ServicioDeResumenDeTurno`/`ResumenDeTurno`, Slice 4) exposes only
+  `{ idTurnoCaja, idMedioAncla, medios: [{ idMedioPago, importeEsperado }] }`
+  — no tickets count, no gastos-por-categoría breakdown, no
+  retiros/refuerzos/fondo lines. The screen renders per-medio esperado
+  (medio ancla flagged) against the real contract; the "áreas, medios,
+  tickets, egresos" wording here and in design's Data Flow diagram is
+  aspirational and not backed by the backend response as merged.
+- [x] 6.3 Wire `/caja` route + nav entry.
+- [x] 6.4 [P] Unit: `caja.ts` mappers. *(web-descriptor-tests)*
+- [x] 6.5 Component: apertura flow; registering a movimiento bumps and
   refetches the resumen generation; opening a new turno does not inherit
   the previous turno's displayed state (`key` reset). RTL + `user-event`,
   `vi.mock('../api/cliente')`. *(design: Testing Strategy — Component

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './auth/AuthContext'
 import { RutaProtegida } from './auth/RutaProtegida'
 import { Layout } from './componentes/Layout'
 import { Articulos } from './paginas/Articulos'
+import { Caja } from './paginas/Caja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
 import { Clientes } from './paginas/Clientes'
@@ -47,6 +48,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <Pos />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-6-turnos-caja (Slice 6, design: Web Composition): turno de caja del punto
+                de venta — apertura, movimientos y resumen parcial. Misma política de rol que
+                /pos (Politicas.OperacionDePos): Vendedor + Supervisor + Admin. */}
+            <Route
+              path="/caja"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Caja />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/caja.test.ts
+++ b/src/Ways.Web/src/api/caja.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { aSolicitudDeMovimiento, importeValidoParaTipo, motivoValido } from './caja'
+
+describe('motivoValido', () => {
+  it('rechaza un motivo vacío', () => {
+    expect(motivoValido('')).toBe(false)
+  })
+
+  it('rechaza un motivo de menos de 5 caracteres tras recortar espacios', () => {
+    expect(motivoValido('  abc  ')).toBe(false)
+  })
+
+  it('acepta un motivo de exactamente 5 caracteres (el límite)', () => {
+    expect(motivoValido('abcde')).toBe(true)
+  })
+
+  it('acepta un motivo largo', () => {
+    expect(motivoValido('cambio de caja fuerte')).toBe(true)
+  })
+
+  it('recorta espacios antes de contar la longitud', () => {
+    expect(motivoValido('   ab   ')).toBe(false)
+    expect(motivoValido('   abcde   ')).toBe(true)
+  })
+})
+
+describe('importeValidoParaTipo', () => {
+  it('apertura_cajon solo acepta exactamente 0', () => {
+    expect(importeValidoParaTipo('AperturaCajon', 0)).toBe(true)
+    expect(importeValidoParaTipo('AperturaCajon', 50)).toBe(false)
+    expect(importeValidoParaTipo('AperturaCajon', -1)).toBe(false)
+  })
+
+  it('retiro exige un importe positivo', () => {
+    expect(importeValidoParaTipo('Retiro', 200)).toBe(true)
+    expect(importeValidoParaTipo('Retiro', 0)).toBe(false)
+    expect(importeValidoParaTipo('Retiro', -10)).toBe(false)
+  })
+
+  it('refuerzo exige un importe positivo', () => {
+    expect(importeValidoParaTipo('Refuerzo', 100)).toBe(true)
+    expect(importeValidoParaTipo('Refuerzo', 0)).toBe(false)
+  })
+
+  it('un importe no finito nunca es válido para retiro/refuerzo', () => {
+    expect(importeValidoParaTipo('Retiro', Number.NaN)).toBe(false)
+  })
+})
+
+describe('aSolicitudDeMovimiento', () => {
+  it('retiro conserva el importe tipeado y recorta el motivo', () => {
+    const resultado = aSolicitudDeMovimiento('Retiro', '200', '  cambio de caja fuerte  ')
+
+    expect(resultado).toEqual({ tipo: 'Retiro', importe: 200, motivo: 'cambio de caja fuerte' })
+  })
+
+  it('apertura_cajon fuerza importe 0 sin importar lo que traiga el campo', () => {
+    const resultado = aSolicitudDeMovimiento('AperturaCajon', '999', 'conteo inicial de turno')
+
+    expect(resultado).toEqual({ tipo: 'AperturaCajon', importe: 0, motivo: 'conteo inicial de turno' })
+  })
+
+  it('un importe con texto no numérico se convierte en NaN — la validación previa (importeValidoParaTipo) debe rechazarlo antes de llegar acá', () => {
+    const resultado = aSolicitudDeMovimiento('Refuerzo', 'abc', 'motivo válido')
+
+    expect(Number.isNaN(resultado.importe)).toBe(true)
+  })
+})

--- a/src/Ways.Web/src/api/caja.ts
+++ b/src/Ways.Web/src/api/caja.ts
@@ -1,0 +1,61 @@
+/**
+ * Cliente HTTP + reglas puras de caja (stage-6-turnos-caja, Slice 6): apertura de turno,
+ * movimientos físicos fuera de la venta (retiro/refuerzo/apertura de cajón) y resumen parcial.
+ * `motivoValido`/`importeValidoParaTipo` espejan `ReglaDeMovimientosDeCaja` (Ways.Domain.Caja)
+ * para dar feedback instantáneo en pantalla — nunca son autoritativos, el servidor vuelve a
+ * validar todo (mismo criterio que `pagos.ts`, stage-5).
+ */
+import { api } from './cliente'
+import type {
+  MovimientoRegistrado,
+  ResumenDeTurno,
+  SolicitudDeApertura,
+  SolicitudDeMovimiento,
+  TipoMovimientoCaja,
+  TurnoResumen,
+} from './tipos'
+
+export const clienteDeCaja = {
+  /** `POST /api/caja/turnos` (design: API Surface): 201 + turno, o `409 turno_ya_abierto` si el
+   * punto de venta ya tiene uno abierto. */
+  abrir: (solicitud: SolicitudDeApertura) => api.post<TurnoResumen>('/caja/turnos', solicitud),
+  /** `GET /api/caja/turnos/abierto?idPuntoVenta=` — fuente de verdad del estado del turno: 200
+   * con el turno abierto o 200 con `null`, nunca un error. */
+  obtenerAbierto: (idPuntoVenta: number) =>
+    api.get<TurnoResumen | null>(`/caja/turnos/abierto?idPuntoVenta=${idPuntoVenta}`),
+  /** `POST /api/caja/turnos/{id}/movimientos` — retiro / refuerzo / apertura de cajón contra el
+   * turno de la ruta (nunca contra un `idTurnoCaja` del cuerpo). */
+  registrarMovimiento: (idTurnoCaja: number, solicitud: SolicitudDeMovimiento) =>
+    api.post<MovimientoRegistrado>(`/caja/turnos/${idTurnoCaja}/movimientos`, solicitud),
+  /** `GET /api/caja/turnos/{id}/resumen` — resumen parcial, misma derivación que el cierre
+   * (spec: Resumen Parcial Uses The Same Derivation As Cierre), de solo lectura. */
+  obtenerResumen: (idTurnoCaja: number) => api.get<ResumenDeTurno>(`/caja/turnos/${idTurnoCaja}/resumen`),
+}
+
+/** Longitud mínima del motivo, uniforme para los 3 tipos de movimiento (design decisión 8;
+ * spec: movimientos-de-caja / Motivo Required For Retiro And Refuerzo, Apertura De Cajón Follows
+ * Legacy F12 Parity). */
+const MOTIVO_LONGITUD_MINIMA = 5
+
+/** Espejo de `ReglaDeMovimientosDeCaja.ExigirMotivoValido` — `motivo` es obligatorio y con al
+ * menos 5 caracteres (tras recortar espacios) para los 3 tipos de movimiento. */
+export function motivoValido(motivo: string): boolean {
+  return motivo.trim().length >= MOTIVO_LONGITUD_MINIMA
+}
+
+/** Espejo de `ReglaDeMovimientosDeCaja.ExigirImporteValido`: `apertura_cajon` es SIEMPRE `0`
+ * (paridad legacy F12), los demás tipos exigen un importe positivo. */
+export function importeValidoParaTipo(tipo: TipoMovimientoCaja, importe: number): boolean {
+  if (tipo === 'AperturaCajon') return importe === 0
+  return Number.isFinite(importe) && importe > 0
+}
+
+/** Arma el cuerpo de `POST …/movimientos`: fuerza `importe = 0` para `apertura_cajon` (el
+ * cajero nunca tipea uno, el campo queda deshabilitado en pantalla) y recorta el motivo. */
+export function aSolicitudDeMovimiento(tipo: TipoMovimientoCaja, importe: string, motivo: string): SolicitudDeMovimiento {
+  return {
+    tipo,
+    importe: tipo === 'AperturaCajon' ? 0 : Number(importe),
+    motivo: motivo.trim(),
+  }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -576,6 +576,61 @@ export type ResultadoDeResolucion = {
   aplicadas: OfertaAplicada[]
 }
 
+// --- Caja: turnos, movimientos y resumen (stage-6-turnos-caja, Slice 6) ---
+// Espejo de `Ways.Application.Caja.Contratos` — apertura, movimientos físicos fuera de la venta
+// (retiro/refuerzo/apertura de cajón) y el resumen parcial (misma derivación que va a usar el
+// cierre, Slice 7). El turno SIEMPRE se resuelve server-side (spec: turnos-de-caja / Turno Is
+// Always Server-Resolved) — ningún contrato de acá acepta un `idTurnoCaja` como campo de entrada.
+
+export type EstadoTurno = 'Abierto' | 'Cerrado'
+
+/** Cuerpo de `POST /api/caja/turnos` — sin campo de empleado, `id_empleado_apertura` siempre
+ * sale de la sesión del lado del servidor. */
+export type SolicitudDeApertura = { idPuntoVenta: number; fondoInicial: number; observaciones: string | null }
+
+/** Proyección de un turno — respuesta de apertura, `GET …/abierto` y `GET …/{id}`. */
+export type TurnoResumen = {
+  id: number
+  idPuntoVenta: number
+  idEmpleadoApertura: number
+  idEmpleadoCierre: number | null
+  fechaApertura: string
+  fechaCierre: string | null
+  fondoInicial: number
+  estado: EstadoTurno
+  observaciones: string | null
+}
+
+export type TipoMovimientoCaja = 'Retiro' | 'Refuerzo' | 'AperturaCajon'
+
+export const TIPOS_MOVIMIENTO_CAJA: { valor: TipoMovimientoCaja; etiqueta: string }[] = [
+  { valor: 'Retiro', etiqueta: 'Retiro' },
+  { valor: 'Refuerzo', etiqueta: 'Refuerzo' },
+  { valor: 'AperturaCajon', etiqueta: 'Apertura de cajón' },
+]
+
+/** Cuerpo de `POST /api/caja/turnos/{id}/movimientos` — el turno lo identifica la ruta, nunca
+ * este cuerpo. */
+export type SolicitudDeMovimiento = { tipo: TipoMovimientoCaja; importe: number; motivo: string | null }
+
+export type MovimientoRegistrado = {
+  id: number
+  idTurnoCaja: number
+  tipo: TipoMovimientoCaja
+  importe: number
+  motivo: string
+  idEmpleado: number
+  creadoEl: string
+}
+
+export type LineaDeResumen = { idMedioPago: number; importeEsperado: number }
+
+/** Respuesta de `GET /api/caja/turnos/{id}/resumen` (espejo de `ResumenDeTurno`, Slice 4) — el
+ * `importeEsperado` derivado por medio y el medio ancla (efectivo), la misma derivación que el
+ * cierre va a persistir. Sin desglose de tickets ni de gastos por categoría: la derivación real
+ * (`ServicioDeResumenDeTurno`) no expone ese detalle, solo el total esperado por medio. */
+export type ResumenDeTurno = { idTurnoCaja: number; idMedioAncla: number; medios: LineaDeResumen[] }
+
 // --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---
 // Espejo de `Ways.Application.Ventas.Contratos` (confirmado contra el DTO real de
 // `POST /api/ventas`, mergeado en Slice 4) — usado por `ventas.ts` (mappers) y `Pos.tsx`

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -39,6 +39,13 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {usuario && puedeOperarPos(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/caja">
+                      Caja
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -1,0 +1,373 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Caja } from './Caja'
+import { ErrorApi } from '../api/cliente'
+import type { MedioPagoListado, MovimientoRegistrado, PuntoVentaListado, ResumenDeTurno, TurnoResumen } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
+  return {
+    id: 1,
+    nombre: 'Efectivo',
+    activo: true,
+    idEmpresa: null,
+    orden: 1,
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    recargoPorcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function turnoFixture(sobrescribir: Partial<TurnoResumen> = {}): TurnoResumen {
+  return {
+    id: 501,
+    idPuntoVenta: 7,
+    idEmpleadoApertura: 3,
+    idEmpleadoCierre: null,
+    fechaApertura: '2026-08-04T12:00:00Z',
+    fechaCierre: null,
+    fondoInicial: 500,
+    estado: 'Abierto',
+    observaciones: null,
+    ...sobrescribir,
+  }
+}
+
+function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTurno {
+  return {
+    idTurnoCaja: 501,
+    idMedioAncla: 1,
+    medios: [{ idMedioPago: 1, importeEsperado: 640 }],
+    ...sobrescribir,
+  }
+}
+
+function movimientoFixture(sobrescribir: Partial<MovimientoRegistrado> = {}): MovimientoRegistrado {
+  return {
+    id: 90,
+    idTurnoCaja: 501,
+    tipo: 'Retiro',
+    importe: 100,
+    motivo: 'motivo de prueba',
+    idEmpleado: 3,
+    creadoEl: '2026-08-04T13:00:00Z',
+    ...sobrescribir,
+  }
+}
+
+const medioEfectivo = medioFixture()
+const puntoVentaCentro = puntoVentaFixture()
+
+/** Rutas comunes a toda la pantalla (puntos de venta + medios de pago) — cada test suma encima
+ * las rutas de caja que le hacen falta (`/caja/turnos/...`). */
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+    if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+})
+
+describe('Caja — apertura', () => {
+  it('sin turno abierto muestra el formulario de apertura; abrirlo lo reemplaza por el panel del turno y dispara el resumen', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(null)
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') return Promise.resolve<TurnoResumen>(turnoFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('No hay un turno abierto en este punto de venta.')
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.type(screen.getByLabelText('Observaciones'), 'apertura de prueba')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    await screen.findByText('Turno abierto')
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/caja/turnos')
+    expect(llamada?.[1]).toEqual({ idPuntoVenta: 7, fondoInicial: 500, observaciones: 'apertura de prueba' })
+
+    await waitFor(() => expect(screen.getByText('$640,00')).toBeInTheDocument())
+  })
+
+  it('un fondo inicial negativo se rechaza localmente, sin disparar el POST', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(null)
+      return undefined
+    })
+
+    render(<Caja />)
+    await screen.findByText('No hay un turno abierto en este punto de venta.')
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '-10')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    expect(await screen.findByText('El fondo inicial tiene que ser un número mayor o igual a 0.')).toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos')).toHaveLength(0)
+  })
+
+  it('doble click en "Abrir turno" dispara exactamente un POST', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(null)
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    let resolverApertura: (t: TurnoResumen) => void = () => {}
+    const aperturaPendiente = new Promise<TurnoResumen>((resolve) => {
+      resolverApertura = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') return aperturaPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('No hay un turno abierto en este punto de venta.')
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+
+    const boton = screen.getByRole('button', { name: 'Abrir turno' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Abriendo…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverApertura(turnoFixture())
+      await Promise.resolve()
+    })
+    await screen.findByText('Turno abierto')
+  })
+})
+
+describe('Caja — movimientos', () => {
+  it('registrar un movimiento bumpea la generación del resumen y descarta una respuesta tardía de la carga inicial', async () => {
+    let resolverResumenLento: (valor: ResumenDeTurno) => void = () => {}
+    const resumenLentoPromise = new Promise<ResumenDeTurno>((resolve) => {
+      resolverResumenLento = resolve
+    })
+    let llamadasResumen = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') {
+        llamadasResumen += 1
+        if (llamadasResumen === 1) return resumenLentoPromise
+        return Promise.resolve<ResumenDeTurno>(resumenFixture({ medios: [{ idMedioPago: 1, importeEsperado: 700 }] }))
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/movimientos') return Promise.resolve<MovimientoRegistrado>(movimientoFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+    expect(screen.getByText('Calculando…')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByLabelText('Importe'), '100')
+    await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+
+    await waitFor(() => expect(screen.getByText('$700,00')).toBeInTheDocument())
+
+    // La respuesta lenta de la carga inicial (generación anterior) llega recién ahora, con datos
+    // viejos (distintos del fondo inicial del turno, $500,00, para no confundir el assert con el
+    // encabezado) — no puede pisar los $700,00 ya mostrados por el refetch posterior al movimiento.
+    await act(async () => {
+      resolverResumenLento(resumenFixture({ medios: [{ idMedioPago: 1, importeEsperado: 640 }] }))
+      await Promise.resolve()
+    })
+    expect(screen.getByText('$700,00')).toBeInTheDocument()
+    expect(screen.queryByText('$640,00')).not.toBeInTheDocument()
+  })
+
+  it('un motivo de menos de 5 caracteres se rechaza localmente, sin disparar el POST', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+
+    await userEvent.type(screen.getByLabelText('Importe'), '100')
+    await userEvent.type(screen.getByLabelText('Motivo'), 'abc')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+
+    expect(await screen.findByText('El motivo tiene que tener al menos 5 caracteres.')).toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos/501/movimientos')).toHaveLength(0)
+  })
+
+  it('apertura de cajón fuerza el importe a 0 en el campo (deshabilitado) y en el cuerpo enviado', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/movimientos') {
+        return Promise.resolve<MovimientoRegistrado>(
+          movimientoFixture({ tipo: 'AperturaCajon', importe: 0, motivo: 'conteo inicial de turno' }),
+        )
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+
+    await userEvent.selectOptions(screen.getByLabelText('Tipo de movimiento'), 'Apertura de cajón')
+    expect(screen.getByLabelText('Importe')).toBeDisabled()
+    expect(screen.getByLabelText('Importe')).toHaveValue(0)
+
+    await userEvent.type(screen.getByLabelText('Motivo'), 'conteo inicial de turno')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+
+    await waitFor(() =>
+      expect(apiPostMock.mock.calls.some((c) => c[0] === '/caja/turnos/501/movimientos')).toBe(true),
+    )
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/caja/turnos/501/movimientos')
+    expect(llamada?.[1]).toEqual({ tipo: 'AperturaCajon', importe: 0, motivo: 'conteo inicial de turno' })
+  })
+
+  it('doble click en "Registrar movimiento" dispara exactamente un POST', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    let resolverMovimiento: (m: MovimientoRegistrado) => void = () => {}
+    const movimientoPendiente = new Promise<MovimientoRegistrado>((resolve) => {
+      resolverMovimiento = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/movimientos') return movimientoPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+    await userEvent.type(screen.getByLabelText('Importe'), '100')
+    await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
+
+    const boton = screen.getByRole('button', { name: 'Registrar movimiento' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos/501/movimientos')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Registrando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverMovimiento(movimientoFixture())
+      await Promise.resolve()
+    })
+  })
+})
+
+describe('Caja — turno nuevo no hereda el estado del anterior (react-async-state regla 8)', () => {
+  it('cambiar de punto de venta a uno con otro turno abierto resetea el formulario de movimiento y el resumen mostrado', async () => {
+    const puntoVentaNorte = puntoVentaFixture({ id: 8, nombre: 'Local Norte' })
+    const turnoNorte = turnoFixture({ id: 900, idPuntoVenta: 8, fondoInicial: 1000 })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro, puntoVentaNorte])
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=8') return Promise.resolve<TurnoResumen | null>(turnoNorte)
+      if (ruta === '/caja/turnos/501/resumen') {
+        return Promise.resolve<ResumenDeTurno>(resumenFixture({ idTurnoCaja: 501, medios: [{ idMedioPago: 1, importeEsperado: 640 }] }))
+      }
+      if (ruta === '/caja/turnos/900/resumen') {
+        return Promise.resolve<ResumenDeTurno>(resumenFixture({ idTurnoCaja: 900, medios: [{ idMedioPago: 1, importeEsperado: 999 }] }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+    await waitFor(() => expect(screen.getByText('$640,00')).toBeInTheDocument())
+
+    await userEvent.type(screen.getByLabelText('Motivo'), 'algo que no debería sobrevivir al cambio de turno')
+
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Norte')
+
+    await waitFor(() => expect(screen.getByText('$999,00')).toBeInTheDocument())
+    expect(screen.queryByText('$640,00')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Motivo')).toHaveValue('')
+  })
+})
+
+describe('Caja — errores', () => {
+  it('un turno abierto que falla al consultarse muestra el mensaje del servidor', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') {
+        return Promise.reject(new ErrorApi(500, 'error', 'No se pudo consultar el turno.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+
+    expect(await screen.findByText('No se pudo consultar el turno.')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -320,6 +320,115 @@ describe('Caja — movimientos', () => {
       await Promise.resolve()
     })
   })
+
+  it('un movimiento que falla igual dispara el refetch del resumen: "Calculando…" no queda colgado', async () => {
+    let resolverResumenInicial: (valor: ResumenDeTurno) => void = () => {}
+    const resumenInicialPromise = new Promise<ResumenDeTurno>((resolve) => {
+      resolverResumenInicial = resolve
+    })
+    let llamadasResumen = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') {
+        llamadasResumen += 1
+        if (llamadasResumen === 1) return resumenInicialPromise
+        return Promise.resolve<ResumenDeTurno>(resumenFixture({ medios: [{ idMedioPago: 1, importeEsperado: 850 }] }))
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/movimientos') {
+        return Promise.reject(new ErrorApi(400, 'error', 'No se pudo registrar el movimiento.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+    expect(screen.getByText('Calculando…')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByLabelText('Importe'), '100')
+    await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+
+    expect(await screen.findByText('No se pudo registrar el movimiento.')).toBeInTheDocument()
+
+    // regla 6: aunque la respuesta inicial del resumen (generación anterior al bump previo a la
+    // escritura) nunca llega, el refetch disparado tras la falla del movimiento cierra
+    // "Calculando…" por su cuenta y trae el dato vigente.
+    await waitFor(() => expect(screen.queryByText('Calculando…')).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('$850,00')).toBeInTheDocument())
+
+    // la respuesta huérfana de la carga inicial, si llega tarde, no debe pisar nada.
+    await act(async () => {
+      resolverResumenInicial(resumenFixture({ medios: [{ idMedioPago: 1, importeEsperado: 111 }] }))
+      await Promise.resolve()
+    })
+    expect(screen.getByText('$850,00')).toBeInTheDocument()
+    expect(screen.queryByText('$111,00')).not.toBeInTheDocument()
+  })
+})
+
+describe('Caja — selector de punto de venta bloqueado durante una escritura en vuelo (react-async-state regla 9)', () => {
+  it('queda deshabilitado mientras la apertura del turno está en vuelo', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(null)
+      return undefined
+    })
+
+    let resolverApertura: (t: TurnoResumen) => void = () => {}
+    const aperturaPendiente = new Promise<TurnoResumen>((resolve) => {
+      resolverApertura = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') return aperturaPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('No hay un turno abierto en este punto de venta.')
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
+
+    await act(async () => {
+      resolverApertura(turnoFixture())
+      await Promise.resolve()
+    })
+  })
+
+  it('queda deshabilitado mientras un movimiento de caja está en vuelo', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    let resolverMovimiento: (m: MovimientoRegistrado) => void = () => {}
+    const movimientoPendiente = new Promise<MovimientoRegistrado>((resolve) => {
+      resolverMovimiento = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/movimientos') return movimientoPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />)
+    await screen.findByText('Turno abierto')
+    await userEvent.type(screen.getByLabelText('Importe'), '100')
+    await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+
+    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
+
+    await act(async () => {
+      resolverMovimiento(movimientoFixture())
+      await Promise.resolve()
+    })
+  })
 })
 
 describe('Caja — turno nuevo no hereda el estado del anterior (react-async-state regla 8)', () => {

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -47,7 +47,6 @@ function formatearFechaHora(iso: string): string {
 
 type PropsFormularioApertura = {
   idPuntoVenta: number
-  disabled: boolean
   onAbierto: (turno: TurnoResumen) => void
   onEscribiendoCambio: (valor: boolean) => void
 }
@@ -55,7 +54,7 @@ type PropsFormularioApertura = {
 /** Apertura de turno (spec: turnos-de-caja / Apertura Creates An Open Turno With Its Fondo):
  * fondo inicial + observaciones opcionales, `idPuntoVenta` siempre lo trae la selección de
  * arriba, nunca un campo editable acá. */
-function FormularioApertura({ idPuntoVenta, disabled, onAbierto, onEscribiendoCambio }: PropsFormularioApertura) {
+function FormularioApertura({ idPuntoVenta, onAbierto, onEscribiendoCambio }: PropsFormularioApertura) {
   const [fondoInicial, setFondoInicial] = useState('')
   const [observaciones, setObservaciones] = useState('')
   const [abriendo, setAbriendo] = useState(false)
@@ -94,7 +93,7 @@ function FormularioApertura({ idPuntoVenta, disabled, onAbierto, onEscribiendoCa
     }
   }
 
-  const bloqueado = disabled || abriendo
+  const bloqueado = abriendo
 
   return (
     <div>
@@ -237,7 +236,6 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
       )
       setImporteMovimiento('')
       setMotivoMovimiento('')
-      cargarResumen()
     } catch (e) {
       setErrorMovimiento(e instanceof ErrorApi ? e.message : 'No se pudo registrar el movimiento.')
     } finally {
@@ -245,6 +243,12 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
       setRegistrando(false)
       onEscribiendoCambio(false)
     }
+
+    // regla 6: el refetch del resumen queda aislado del try/catch de la escritura — corre tanto en
+    // éxito como en falla, porque el bump de generación previo a la escritura deja huérfano
+    // cualquier resumen en vuelo y solo un nuevo pedido lo cierra (si no, "Calculando…" queda
+    // colgado para siempre). Un error acá no debe pisar `errorMovimiento`.
+    cargarResumen()
   }
 
   return (
@@ -541,7 +545,6 @@ export function Caja() {
                 {!cargandoTurno && turno === null && (
                   <FormularioApertura
                     idPuntoVenta={idPuntoVenta}
-                    disabled={cargandoTurno}
                     onAbierto={turnoAbierto}
                     onEscribiendoCambio={setEscribiendo}
                   />

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -1,0 +1,565 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { aSolicitudDeMovimiento, clienteDeCaja, importeValidoParaTipo, motivoValido } from '../api/caja'
+import { clienteDeCatalogo } from '../api/catalogos'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import {
+  TIPOS_MOVIMIENTO_CAJA,
+  type MedioPagoAlta,
+  type MedioPagoListado,
+  type PuntoVentaListado,
+  type ResumenDeTurno,
+  type TipoMovimientoCaja,
+  type TurnoResumen,
+} from '../api/tipos'
+import { Box } from '../componentes/Box'
+
+const CLAVE_PUNTO_VENTA = 'ways.caja.idPuntoVenta'
+
+const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+function leerPuntoVentaGuardado(): number | null {
+  try {
+    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
+    return crudo ? Number(crudo) : null
+  } catch {
+    return null
+  }
+}
+
+function guardarPuntoVentaSeleccionado(id: number) {
+  try {
+    localStorage.setItem(CLAVE_PUNTO_VENTA, String(id))
+  } catch {
+    // localStorage puede no estar disponible (modo privado del navegador) — la selección
+    // simplemente no persiste entre sesiones, el resto de la pantalla sigue funcionando.
+  }
+}
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+type PropsFormularioApertura = {
+  idPuntoVenta: number
+  disabled: boolean
+  onAbierto: (turno: TurnoResumen) => void
+  onEscribiendoCambio: (valor: boolean) => void
+}
+
+/** Apertura de turno (spec: turnos-de-caja / Apertura Creates An Open Turno With Its Fondo):
+ * fondo inicial + observaciones opcionales, `idPuntoVenta` siempre lo trae la selección de
+ * arriba, nunca un campo editable acá. */
+function FormularioApertura({ idPuntoVenta, disabled, onAbierto, onEscribiendoCambio }: PropsFormularioApertura) {
+  const [fondoInicial, setFondoInicial] = useState('')
+  const [observaciones, setObservaciones] = useState('')
+  const [abriendo, setAbriendo] = useState(false)
+  const abriendoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  async function abrir() {
+    // regla 9 (react-async-state): guard de reentrancia de primera línea — un doble click en el
+    // mismo tick le gana al re-render que deshabilita el botón.
+    if (abriendoRef.current) return
+
+    const fondo = Number(fondoInicial)
+    if (fondoInicial.trim() === '' || !Number.isFinite(fondo) || fondo < 0) {
+      setError('El fondo inicial tiene que ser un número mayor o igual a 0.')
+      return
+    }
+
+    abriendoRef.current = true
+    setAbriendo(true)
+    onEscribiendoCambio(true)
+    setError('')
+
+    try {
+      const turno = await clienteDeCaja.abrir({
+        idPuntoVenta,
+        fondoInicial: fondo,
+        observaciones: observaciones.trim() === '' ? null : observaciones.trim(),
+      })
+      onAbierto(turno)
+    } catch (e) {
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+    } finally {
+      abriendoRef.current = false
+      setAbriendo(false)
+      onEscribiendoCambio(false)
+    }
+  }
+
+  const bloqueado = disabled || abriendo
+
+  return (
+    <div>
+      <p className="text-muted">No hay un turno abierto en este punto de venta.</p>
+      {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+
+      <div className="row g-2 align-items-end" style={{ maxWidth: 640 }}>
+        <div className="col-md-4">
+          <label className="form-label" htmlFor="caja-fondo-inicial">
+            Fondo inicial
+          </label>
+          <input
+            id="caja-fondo-inicial"
+            type="number"
+            step="0.01"
+            min="0"
+            className="form-control rounded-0"
+            value={fondoInicial}
+            disabled={bloqueado}
+            onChange={(e) => setFondoInicial(e.target.value)}
+          />
+        </div>
+        <div className="col-md-5">
+          <label className="form-label" htmlFor="caja-observaciones-apertura">
+            Observaciones
+          </label>
+          <input
+            id="caja-observaciones-apertura"
+            type="text"
+            className="form-control rounded-0"
+            value={observaciones}
+            disabled={bloqueado}
+            onChange={(e) => setObservaciones(e.target.value)}
+          />
+        </div>
+        <div className="col-md-3">
+          <button type="button" className="btn btn-primary rounded-0 w-100" disabled={bloqueado} onClick={abrir}>
+            {abriendo ? 'Abriendo…' : 'Abrir turno'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type PropsPanelTurnoAbierto = {
+  turno: TurnoResumen
+  medios: MedioPagoListado[] | null
+  errorMedios: string
+  onEscribiendoCambio: (valor: boolean) => void
+}
+
+/** Turno abierto: movimientos (retiro/refuerzo/apertura de cajón) + resumen parcial — misma
+ * derivación que el cierre (spec: arqueo-de-cierre / Resumen Parcial Uses The Same Derivation As
+ * Cierre). El componente entero se remonta por `key={turno.id}` en el padre (regla 8): ningún
+ * estado de acá (formulario de movimiento, resumen, generación) sobrevive a un cambio de turno. */
+function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: PropsPanelTurnoAbierto) {
+  const [resumen, setResumen] = useState<ResumenDeTurno | null>(null)
+  const [cargandoResumen, setCargandoResumen] = useState(false)
+  const [errorResumen, setErrorResumen] = useState('')
+  // regla 2: gatea CADA respuesta de resumen (la carga inicial y cada refetch posterior a un
+  // movimiento) — una respuesta desactualizada nunca puede pisar la más reciente.
+  const generacionResumenRef = useRef(0)
+
+  const [tipoMovimiento, setTipoMovimiento] = useState<TipoMovimientoCaja>('Retiro')
+  const [importeMovimiento, setImporteMovimiento] = useState('')
+  const [motivoMovimiento, setMotivoMovimiento] = useState('')
+  const [registrando, setRegistrando] = useState(false)
+  const registrandoRef = useRef(false)
+  const [errorMovimiento, setErrorMovimiento] = useState('')
+
+  const medioPorId = useMemo(() => {
+    const indice: Record<number, MedioPagoListado> = {}
+    for (const m of medios ?? []) indice[m.id] = m
+    return indice
+  }, [medios])
+
+  function cargarResumen() {
+    const miGeneracion = (generacionResumenRef.current += 1)
+    setCargandoResumen(true)
+    setErrorResumen('')
+
+    clienteDeCaja
+      .obtenerResumen(turno.id)
+      .then((datos) => {
+        if (generacionResumenRef.current !== miGeneracion) return
+        setResumen(datos)
+      })
+      .catch((e) => {
+        if (generacionResumenRef.current !== miGeneracion) return
+        setResumen(null)
+        setErrorResumen(e instanceof ErrorApi ? e.message : 'No se pudo cargar el resumen del turno.')
+      })
+      .finally(() => {
+        if (generacionResumenRef.current !== miGeneracion) return
+        setCargandoResumen(false)
+      })
+  }
+
+  useEffect(() => {
+    cargarResumen()
+    // Corre una única vez por montaje: `turno.id` es estable durante toda la vida de esta
+    // instancia (el padre remonta el componente entero cuando cambia, regla 8).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [turno.id])
+
+  async function registrarMovimiento() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (registrandoRef.current) return
+
+    const importeCandidato = tipoMovimiento === 'AperturaCajon' ? 0 : Number(importeMovimiento)
+
+    if (!motivoValido(motivoMovimiento)) {
+      setErrorMovimiento('El motivo tiene que tener al menos 5 caracteres.')
+      return
+    }
+    if (!importeValidoParaTipo(tipoMovimiento, importeCandidato)) {
+      setErrorMovimiento(
+        tipoMovimiento === 'AperturaCajon'
+          ? 'La apertura de cajón no lleva importe: siempre viaja en 0.'
+          : 'El importe tiene que ser mayor a 0.',
+      )
+      return
+    }
+
+    registrandoRef.current = true
+    setRegistrando(true)
+    onEscribiendoCambio(true)
+    setErrorMovimiento('')
+
+    // regla 3: bumpear la generación del resumen ANTES de la escritura — cualquier resumen en
+    // vuelo desde antes de este movimiento queda obsoleto aunque su respuesta llegue después de
+    // que este movimiento se registre.
+    generacionResumenRef.current += 1
+
+    try {
+      await clienteDeCaja.registrarMovimiento(
+        turno.id,
+        aSolicitudDeMovimiento(tipoMovimiento, importeMovimiento, motivoMovimiento),
+      )
+      setImporteMovimiento('')
+      setMotivoMovimiento('')
+      cargarResumen()
+    } catch (e) {
+      setErrorMovimiento(e instanceof ErrorApi ? e.message : 'No se pudo registrar el movimiento.')
+    } finally {
+      registrandoRef.current = false
+      setRegistrando(false)
+      onEscribiendoCambio(false)
+    }
+  }
+
+  return (
+    <div>
+      <div className="row g-3 mb-3">
+        <div className="col-md-4">
+          <div className="small text-muted">Estado</div>
+          <div>
+            <span className="badge bg-success">Turno abierto</span>
+          </div>
+        </div>
+        <div className="col-md-4">
+          <div className="small text-muted">Apertura</div>
+          <div>{formatearFechaHora(turno.fechaApertura)}</div>
+        </div>
+        <div className="col-md-4">
+          <div className="small text-muted">Fondo inicial</div>
+          <div>{formatearMoneda(turno.fondoInicial)}</div>
+        </div>
+      </div>
+
+      {turno.observaciones && <p className="text-muted small">{turno.observaciones}</p>}
+
+      <div className="row g-3">
+        <div className="col-lg-6">
+          <h6>Movimiento de caja</h6>
+          {errorMovimiento && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorMovimiento}</div>}
+
+          <div className="mb-2">
+            <label className="form-label" htmlFor="caja-tipo-movimiento">
+              Tipo de movimiento
+            </label>
+            <select
+              id="caja-tipo-movimiento"
+              className="form-select rounded-0"
+              value={tipoMovimiento}
+              disabled={registrando}
+              onChange={(e) => {
+                setTipoMovimiento(e.target.value as TipoMovimientoCaja)
+                setErrorMovimiento('')
+              }}
+            >
+              {TIPOS_MOVIMIENTO_CAJA.map((t) => (
+                <option key={t.valor} value={t.valor}>
+                  {t.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="mb-2">
+            <label className="form-label" htmlFor="caja-importe-movimiento">
+              Importe
+            </label>
+            <input
+              id="caja-importe-movimiento"
+              type="number"
+              step="0.01"
+              min="0"
+              className="form-control rounded-0"
+              value={tipoMovimiento === 'AperturaCajon' ? '0' : importeMovimiento}
+              disabled={registrando || tipoMovimiento === 'AperturaCajon'}
+              onChange={(e) => setImporteMovimiento(e.target.value)}
+            />
+          </div>
+
+          <div className="mb-2">
+            <label className="form-label" htmlFor="caja-motivo-movimiento">
+              Motivo
+            </label>
+            <input
+              id="caja-motivo-movimiento"
+              type="text"
+              className="form-control rounded-0"
+              value={motivoMovimiento}
+              disabled={registrando}
+              onChange={(e) => setMotivoMovimiento(e.target.value)}
+            />
+            <div className="form-text">Mínimo 5 caracteres.</div>
+          </div>
+
+          <button
+            type="button"
+            className="btn btn-primary rounded-0"
+            disabled={registrando}
+            onClick={registrarMovimiento}
+          >
+            {registrando ? 'Registrando…' : 'Registrar movimiento'}
+          </button>
+        </div>
+
+        <div className="col-lg-6">
+          <h6>Resumen parcial</h6>
+          {errorMedios && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorMedios}</div>}
+          {errorResumen && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorResumen}</div>}
+          {cargandoResumen && <p className="text-muted">Calculando…</p>}
+
+          {!cargandoResumen && resumen && (
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Medio</th>
+                    <th className="text-end">Esperado</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resumen.medios.map((m) => (
+                    <tr key={m.idMedioPago}>
+                      <td>
+                        {medioPorId[m.idMedioPago]?.nombre ?? `Medio #${m.idMedioPago}`}
+                        {m.idMedioPago === resumen.idMedioAncla && (
+                          <span className="badge bg-secondary ms-1">efectivo</span>
+                        )}
+                      </td>
+                      <td className="text-end">{formatearMoneda(m.importeEsperado)}</td>
+                    </tr>
+                  ))}
+                  {resumen.medios.length === 0 && (
+                    <tr>
+                      <td colSpan={2} className="text-center text-muted">
+                        Todavía no hay actividad en este turno.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Pantalla de caja (stage-6-turnos-caja, Slice 6, design: Web Composition): estado del turno del
+ * punto de venta seleccionado, apertura cuando no hay uno abierto, movimientos físicos fuera de
+ * la venta y el resumen parcial en vivo — misma derivación que el cierre (Slice 7). Precedente de
+ * forma: `Pos.tsx`. El resumen que devuelve `GET …/resumen` (`ServicioDeResumenDeTurno`) expone
+ * solo el esperado derivado por medio — no hay desglose de tickets ni de gastos por categoría en
+ * el contrato real, así que esta pantalla no los muestra (ver el doc-comment de `ResumenDeTurno`
+ * en `api/tipos.ts`).
+ */
+export function Caja() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
+  const [errorMedios, setErrorMedios] = useState('')
+
+  const [turno, setTurno] = useState<TurnoResumen | null>(null)
+  const [cargandoTurno, setCargandoTurno] = useState(false)
+  const [errorTurno, setErrorTurno] = useState('')
+  const generacionTurnoRef = useRef(0)
+
+  // regla 9: mientras la apertura o un movimiento tienen una escritura en vuelo, el selector de
+  // punto de venta —el único recurso que ambos formularios podrían superponer, porque cambiarlo
+  // reemplaza el turno entero de abajo— queda inerte. Cada formulario sigue dueño de su propio
+  // flag de "en curso" (regla 5); esto es solo la señal combinada para ese selector puntual.
+  const [escribiendo, setEscribiendo] = useState(false)
+
+  // Carga inicial: puntos de venta (selector explícito, mismo criterio que Pos.tsx) y medios de
+  // pago (para etiquetar el resumen parcial) — cada uno con su propio try/catch.
+  useEffect(() => {
+    let vigente = true
+
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        const guardado = leerPuntoVentaGuardado()
+        const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
+        setIdPuntoVenta(porDefecto ? porDefecto.id : '')
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(
+          e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta. Seleccioná uno para operar.',
+        )
+      })
+
+    clienteMediosPago
+      .listar(false)
+      .then((lista) => {
+        if (!vigente) return
+        setMedios(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setMedios([])
+        setErrorMedios(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los medios de pago.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // regla 2: cada cambio de punto de venta dispara una nueva consulta del turno abierto — una
+  // respuesta desactualizada (de un punto de venta que el cajero ya dejó de mirar) nunca puede
+  // pisar la más reciente.
+  useEffect(() => {
+    if (idPuntoVenta === '') {
+      setTurno(null)
+      setErrorTurno('')
+      return
+    }
+
+    const miGeneracion = (generacionTurnoRef.current += 1)
+    let vigente = true
+    setCargandoTurno(true)
+    setErrorTurno('')
+
+    clienteDeCaja
+      .obtenerAbierto(idPuntoVenta)
+      .then((t) => {
+        if (!vigente || generacionTurnoRef.current !== miGeneracion) return
+        setTurno(t)
+      })
+      .catch((e) => {
+        if (!vigente || generacionTurnoRef.current !== miGeneracion) return
+        setTurno(null)
+        setErrorTurno(
+          e instanceof ErrorApi ? e.message : 'No se pudo consultar el turno abierto de este punto de venta.',
+        )
+      })
+      .finally(() => {
+        if (!vigente || generacionTurnoRef.current !== miGeneracion) return
+        setCargandoTurno(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idPuntoVenta])
+
+  function cambiarPuntoVenta(id: number) {
+    if (escribiendo) return
+    setIdPuntoVenta(id)
+    guardarPuntoVentaSeleccionado(id)
+  }
+
+  function turnoAbierto(nuevoTurno: TurnoResumen) {
+    // La apertura recién confirmada es la fuente más autoritativa posible: bumpear la
+    // generación invalida cualquier GET …/abierto que siguiera en vuelo desde antes.
+    generacionTurnoRef.current += 1
+    setErrorTurno('')
+    setTurno(nuevoTurno)
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row g-3">
+        <div className="col-12">
+          <Box titulo="Caja">
+            {errorPuntosVenta && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+            <div className="mb-3" style={{ maxWidth: 320 }}>
+              <label className="form-label" htmlFor="caja-punto-venta">
+                Punto de venta
+              </label>
+              <select
+                id="caja-punto-venta"
+                className="form-select rounded-0"
+                value={idPuntoVenta}
+                disabled={puntosVenta === null || escribiendo}
+                onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
+              >
+                {puntosVenta === null && <option value="">Cargando…</option>}
+                {puntosVenta !== null && puntosVenta.length === 0 && (
+                  <option value="">Sin puntos de venta disponibles</option>
+                )}
+                {puntosVenta?.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {errorTurno && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorTurno}</div>}
+
+            {idPuntoVenta !== '' && (
+              // regla 8: la clave por turno (o "sin-turno" mientras no hay ninguno) remonta todo
+              // el subárbol — un turno nuevo nunca hereda el formulario de movimiento ni el
+              // resumen del turno anterior.
+              <div key={turno?.id ?? 'sin-turno'}>
+                {cargandoTurno && <p className="text-muted">Consultando el turno…</p>}
+
+                {!cargandoTurno && turno === null && (
+                  <FormularioApertura
+                    idPuntoVenta={idPuntoVenta}
+                    disabled={cargandoTurno}
+                    onAbierto={turnoAbierto}
+                    onEscribiendoCambio={setEscribiendo}
+                  />
+                )}
+
+                {!cargandoTurno && turno !== null && (
+                  <PanelTurnoAbierto
+                    turno={turno}
+                    medios={medios}
+                    errorMedios={errorMedios}
+                    onEscribiendoCambio={setEscribiendo}
+                  />
+                )}
+              </div>
+            )}
+          </Box>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumen

Slice 6/7 de la etapa 6 (stage-6-turnos-caja): la pantalla de caja en Ways.Web — greenfield.

- `api/caja.ts`: cliente + espejos puros de `ReglaDeMovimientosDeCaja` (motivo ≥5 post-trim, importe 0 exacto para apertura de cajón) — ni más laxos ni más estrictos que el server.
- `Caja.tsx`: header de estado del turno, apertura (fondo + observaciones), movimientos (retiro/refuerzo/apertura de cajón), resumen parcial per-medio. `react-async-state` completo: generación gateando cada respuesta, bump pre-escritura, `key` por turno (un turno nuevo jamás hereda estado), flags de ocupado por acción con guards de reentrada, selector de PV bloqueado con escritura en vuelo.
- Fidelidad de contratos verificada contra `Contratos.cs` campo por campo, enums contra el `JsonStringEnumConverter` real.
- **Desviación documentada**: el resumen renderiza el contrato real del backend (per-medio esperado + ancla); el contenido D6 rico (áreas/tickets/egresos) es un gap del backend anotado para el verify.

## Verificación

- vitest 189/189 (165 base + 24 nuevos), `tsc -b`, `vite build` y `oxlint` limpios. Cero archivos backend tocados.
- Judgment-day: ronda 1 — 1 MAJOR confirmado y corregido (huérfano de generación: un movimiento fallido dejaba `cargandoResumen` colgado en "Calculando…" para siempre; refetch incondicional post-try/catch con evidencia de mutación) + prop muerto eliminado + tests del selector bloqueado. El self-heal del 409 de apertura quedó agendado como tarea del slice 7. Ronda 2 verificada limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)