### PR TITLE
feat(ventas): cablear el turno abierto en el checkout (etapa 6, slice 5)

### DIFF
--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
 using Ways.Application.Ofertas;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
@@ -40,7 +41,8 @@ namespace Ways.Application.Ventas;
 /// forma de las consultas son todas propias de esta operación.
 /// </summary>
 public class ServicioDeVentas(
-    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas)
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas,
+    ServicioDeTurnos servicioDeTurnos)
 {
     public async Task<ComprobanteEmitido> EmitirAsync(SolicitudDeVenta solicitud, CancellationToken ct = default)
     {
@@ -61,6 +63,14 @@ public class ServicioDeVentas(
 
         var tipo = await ResolverTipoComprobanteAsync(solicitud.CodigoTipoComprobante, ct);
         var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        // design decisión 11 (Slice 5): turno SIEMPRE resuelto server-side, inmediatamente
+        // después del punto de venta — un punto de venta apócrifo ya dio el 404 de ADR-8 arriba,
+        // así que esto es lo primero que puede rechazar con 409 turno_no_abierto, ANTES de
+        // cualquier consulta de precio/oferta (spec: Selling with no open turno fails before any
+        // pricing work).
+        var turno = await servicioDeTurnos.ResolverTurnoAbiertoAsync(puntoVenta.Id, ct);
+
         var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
 
         var asociado = solicitud.IdComprobanteAsociado is { } idAsociado
@@ -132,7 +142,7 @@ public class ServicioDeVentas(
             .ToList();
 
         var plan = new PlanDeVenta(
-            idTenant, idEmpleado, tipo.Id, tipo.Codigo, momento, puntoVenta.Id, cliente.Id,
+            idTenant, idEmpleado, tipo.Id, tipo.Codigo, momento, puntoVenta.Id, turno.Id, cliente.Id,
             solicitud.IdComprobanteAsociado, items, totales.Subtotal, totales.DescuentoTotal, totales.Total,
             pagosDelPlan, cliente.LimiteCredito, cliente.CreditoIlimitado,
             NormalizarOpcional(solicitud.DireccionEntrega), NormalizarOpcional(solicitud.Observaciones));
@@ -340,6 +350,13 @@ public class ServicioDeVentas(
         var conexion = await ObtenerConexionAbiertaAsync(ct);
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
+        // 0. Guard del turno (design decisión 4; Slice 5 task 5.3): SELECT ... FOR SHARE OF t
+        // ANTES del UPDATE atómico del paso 1 — un EXISTS embebido en el WHERE de ese UPDATE
+        // leería el turno SIN lock, dejando pasar una anulación concurrente a un cierre que ya
+        // derivó el arqueo. 0 filas (el comprobante tiene id_turno_caja NULL, era stage-5) deja
+        // pasar sin lanzar (spec: Stage-5 NULL-turno comprobante stays anulable).
+        await ExigirTurnoNoCerradoAsync(conexion, transaccionCruda, idTenant, id, ct);
+
         // 1. Transición atómica emitido → anulado — un único UPDATE ... WHERE estado = 'emitido'
         // RETURNING (forward obligation, ADR-8: el segundo layer id_tenant en el WHERE es la
         // misma defensa barata que ActualizarSaldoClienteAsync, RLS ya aísla por tenant). Dos
@@ -416,6 +433,34 @@ public class ServicioDeVentas(
         return await ObtenerAsync(id, ct);
     }
 
+    /// <summary>Guard de turno (design decisión 4; Slice 5 task 5.3) — <c>FOR SHARE OF t</c>
+    /// contra el turno del comprobante, ANTES del UPDATE atómico de <see cref="MarcarAnuladoAsync"/>:
+    /// mismo criterio que <c>ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync</c>, un
+    /// <c>FOR SHARE</c> propio en vez de un <c>EXISTS</c> sin lock embebido en el WHERE del
+    /// UPDATE. 0 filas (el join no matchea — comprobante con <c>id_turno_caja NULL</c>) deja
+    /// pasar sin lanzar; <c>'cerrado'</c> lanza <c>409 turno_cerrado</c>; <c>'abierto'</c> deja
+    /// pasar.</summary>
+    private static async Task ExigirTurnoNoCerradoAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idComprobanteVenta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT t.estado::text FROM turnos_caja t " +
+            "JOIN comprobantes_venta c ON c.id_turno_caja = t.id_turno_caja AND c.id_tenant = t.id_tenant " +
+            "WHERE c.id_comprobante_venta = $1 AND c.id_tenant = $2 " +
+            "FOR SHARE OF t";
+
+        AgregarParametro(comando, idComprobanteVenta);
+        AgregarParametro(comando, idTenant);
+
+        var estado = (string?)await comando.ExecuteScalarAsync(ct);
+        if (estado == "cerrado")
+        {
+            throw new ErrorDominio("turno_cerrado", "El turno de este comprobante está cerrado.", 409);
+        }
+    }
+
     /// <summary>Único UPDATE atómico de la transición de estado — ver el doc-comment de
     /// <see cref="EjecutarAnulacionAsync"/> sobre por qué esto alcanza para serializar dos
     /// anulaciones concurrentes sin ningún lock explícito.</summary>
@@ -444,6 +489,15 @@ public class ServicioDeVentas(
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
+        // 0. Turno — re-chequeo bajo FOR SHARE, PRIMER statement (design decisiones 1 y 11;
+        // Slice 5 task 5.2): el turno ya vino resuelto como abierto arriba, ANTES de esta
+        // transacción — sin este re-chequeo, una venta concurrente a un cierre podría comitear
+        // dentro de un turno cuyo arqueo YA se derivó. Reusa
+        // ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync tal cual (mismo criterio que
+        // ServicioDeGastos.InsertarGastoAsync) — el IWaysDbContext es el mismo por scope de DI,
+        // así que ve esta misma transacción recién abierta.
+        await servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(plan.IdTurnoCaja, ct);
+
         // 1. Numeración — YA reservada y comprometida por AsignarNumeroComprometidoAsync, en su
         // propia transacción (ver el comentario de EmitirAsync). Esta transacción arranca
         // directo en el paso 2: el número que recibe como parámetro es un dato de solo lectura
@@ -456,7 +510,7 @@ public class ServicioDeVentas(
             Numero = numero,
             Fecha = plan.Momento,
             IdPuntoVenta = plan.IdPuntoVenta,
-            IdTurnoCaja = null,
+            IdTurnoCaja = plan.IdTurnoCaja,
             IdEmpleado = plan.IdEmpleado,
             IdCliente = plan.IdCliente,
             IdComprobanteAsociado = plan.IdComprobanteAsociado,
@@ -913,6 +967,7 @@ public class ServicioDeVentas(
         string CodigoTipoComprobante,
         DateTimeOffset Momento,
         int IdPuntoVenta,
+        int IdTurnoCaja,
         int IdCliente,
         int? IdComprobanteAsociado,
         IReadOnlyList<LineaDelPlan> Items,

--- a/src/Ways.Domain/Ventas/ComprobanteVenta.cs
+++ b/src/Ways.Domain/Ventas/ComprobanteVenta.cs
@@ -31,8 +31,10 @@ public class ComprobanteVenta : EntidadTenant
 
     public int IdPuntoVenta { get; set; }
 
-    /// <summary>Siempre <c>NULL</c> en esta etapa (proposal decisión 1, design: Migration
-    /// Sequencing) — no hay <c>turnos_caja</c> todavía.</summary>
+    /// <summary>Resuelto server-side desde el turno abierto del punto de venta (stage 6,
+    /// <c>ServicioDeVentas.EmitirAsync</c>) — la promesa de esta etapa ya se cumple: toda venta
+    /// nueva lo lleva poblado. <c>NULL</c> permanece solo en los comprobantes emitidos en stage 5,
+    /// antes de que <c>turnos_caja</c> existiera (decisión 8: sin backfill).</summary>
     public int? IdTurnoCaja { get; set; }
 
     /// <summary><c>IContextoDeUsuario.UsuarioId</c> (design decisión 11) — quien opera la venta

--- a/tests/Ways.IntegrationTests/AjusteDeStockTests.cs
+++ b/tests/Ways.IntegrationTests/AjusteDeStockTests.cs
@@ -81,6 +81,17 @@ public class AjusteDeStockTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
             .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
             .Select(m => m.Id).FirstAsync();
 
+        // stage-6-turnos-caja, Slice 5 (task 5.9): checkout ahora exige un turno abierto (409
+        // turno_no_abierto) — sembrado directo por EF, mismo criterio que el resto de este
+        // método, en vez de un round-trip HTTP extra por cada PrepararAsync.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
         return new Contexto(
             resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
             lista.Id, idMedioEfectivo);

--- a/tests/Ways.IntegrationTests/AnulacionTests.cs
+++ b/tests/Ways.IntegrationTests/AnulacionTests.cs
@@ -92,6 +92,17 @@ public class AnulacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtu
         db.MediosPago.Add(medioCc);
         await db.SaveChangesAsync();
 
+        // stage-6-turnos-caja, Slice 5 (task 5.9): checkout ahora exige un turno abierto (409
+        // turno_no_abierto) — sembrado directo por EF, mismo criterio que el resto de este
+        // método, en vez de un round-trip HTTP extra por cada PrepararAsync.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
         return new Contexto(
             resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
             lista.Id, idMedioEfectivo, medioCc.Id);

--- a/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
@@ -111,6 +111,17 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
         db.MediosPago.Add(medioCc);
         await db.SaveChangesAsync();
 
+        // stage-6-turnos-caja, Slice 5 (task 5.9): checkout ahora exige un turno abierto (409
+        // turno_no_abierto) — sembrado directo por EF, mismo criterio que el resto de este
+        // método, en vez de un round-trip HTTP extra por cada PrepararAsync.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
         return new Contexto(
             resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
             lista.Id, idMedioEfectivo, medioCc.Id);
@@ -566,7 +577,9 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
         var contexto = new ContextoDetector(ctx.IdTenant, usuarioId: 1);
         var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
         var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
 
         var metodo = typeof(ServicioDeVentas).GetMethod(
             "BuscarPorNumeroComprometidoAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -114,6 +114,17 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         db.MediosPago.Add(medioCc);
         await db.SaveChangesAsync();
 
+        // stage-6-turnos-caja, Slice 5 (task 5.9): checkout ahora exige un turno abierto (409
+        // turno_no_abierto) — sembrado directo por EF, mismo criterio que el resto de este
+        // método, en vez de un round-trip HTTP extra por cada PrepararAsync.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
         var cf = await db.Clientes.FirstAsync(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal);
 
         return new Contexto(
@@ -897,10 +908,14 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(consultasConPocasLineas, consultasConMuchasLineas);
         Assert.Equal(consultasConPocasLineas, consultasConMuchisimasLineas);
 
-        // El techo en sí está bajo prueba (design: Technical Approach, "≤ 16 round trips"): una
-        // baja tiene que notarse acá y actualizar la constante a propósito, nunca colarse muda
-        // detrás de un "<=".
-        Assert.Equal(16, consultasConPocasLineas);
+        // El techo en sí está bajo prueba (design: Technical Approach, "≤ 16 round trips", ahora
+        // "≤ 17" — stage-6-turnos-caja design decisión 11): una baja tiene que notarse acá y
+        // actualizar la constante a propósito, nunca colarse muda detrás de un "<=". El +1 sobre
+        // el techo de stage 5 es ResolverTurnoAbiertoAsync (EF, sí dispara ReaderExecuting) — el
+        // FOR SHARE de EjecutarTransaccionAsync es un DbCommand crudo sobre la conexión
+        // subyacente, invisible a este interceptor (misma familia que UpsertStockAsync), así que
+        // no suma un segundo punto.
+        Assert.Equal(17, consultasConPocasLineas);
     }
 
     private async Task<int> EmitirYContarConsultasAsync(Contexto ctx, int idCliente, int cantidadDeLineas)
@@ -931,6 +946,7 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
                 npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;
@@ -941,7 +957,9 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
         var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
         var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
 
         var solicitud = new SolicitudDeVenta(
             ctx.IdPuntoVenta, idCliente, "TX", null, lineas,

--- a/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
+++ b/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
@@ -1,0 +1,438 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-6-turnos-caja, Slice 5 (tasks 5.5-5.7): cobertura NUEVA del cableado quirúrgico de
+/// checkout/anulación contra <c>turnos_caja</c> — no modifica ningún archivo de stage 5 (esos
+/// solo ganan la siembra de un turno abierto en su <c>PrepararAsync</c>, ver
+/// <see cref="VentasCheckoutTests"/>/<see cref="VentasAtomicidadYConcurrenciaTests"/>/
+/// <see cref="AnulacionTests"/>). A diferencia de esos archivos, <see cref="PrepararAsync"/> acá
+/// NUNCA abre un turno por defecto — cada prueba lo abre (o no) explícitamente, porque el punto
+/// de varias de ellas es precisamente el estado del turno.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VentasTurnoWiringTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdMedioEfectivo,
+        int IdListaPrecio, int IdArea, int IdAlicuotaIva, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Turno-wiring-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Turno Wiring", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, idTipoComprobanteTx,
+            idMedioEfectivo, lista.Id, area.Id, idAlicuotaIva, admin);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre, decimal limiteCredito = 0)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = limiteCredito,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, fondoInicial, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private long _numeroSecuencial = 1;
+
+    /// <summary>Pago sembrado directo (bypass <c>EmitirAsync</c>) — mismo helper que
+    /// <c>CajaCierreAtomicidadYConcurrenciaTests.SembrarPagoAsync</c>: deja el medio arqueable
+    /// ANTES de una carrera, así el set de conteos declarados en el cierre queda fijo sin
+    /// importar el resultado de la carrera (solo el SET de medios tiene que matchear lo
+    /// arqueable, no el valor declarado).</summary>
+    private async Task SembrarPagoAsync(Contexto ctx, int idTurno, int idMedioPago, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = await db.Clientes.Select(c => c.Id).FirstAsync(),
+            Subtotal = importe,
+            DescuentoTotal = 0m,
+            Total = importe,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            IdMedioPago = idMedioPago,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    // ---- task 5.5: el turno resuelto server-side queda persistido, siempre --------------------
+
+    [Fact]
+    public async Task UnaVentaEmitidaPersisteElTurnoAbiertoResueltoServerSide()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaEmitidaPersisteElTurnoAbiertoResueltoServerSide));
+        var turno = await AbrirTurnoAsync(ctx);
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-turno-wiring", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Turno Wiring");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idTurnoPersistido = await db.ComprobantesVenta
+            .Where(c => c.Id == emitido.Id).Select(c => c.IdTurnoCaja).SingleAsync();
+
+        Assert.Equal(turno.Id, idTurnoPersistido);
+    }
+
+    // ---- task 5.5: sin turno abierto, rechaza ANTES de cualquier consulta de precio/oferta ----
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Mismo criterio de aislamiento que <c>VentasCheckoutTests.EmitirYContarConsultasAsync</c>:
+    /// <c>ServicioDeVentas</c> se construye DIRECTO (sin HTTP) para que el conteo de consultas no
+    /// se contamine con las de autenticación/sesión — acá el punto es contar SOLO lo que
+    /// <c>EmitirAsync</c> dispara antes de lanzar.</summary>
+    [Fact]
+    public async Task VenderSinTurnoAbiertoRechazaAntesDeCualquierConsultaDePrecioUOferta()
+    {
+        var ctx = await PrepararAsync(nameof(VenderSinTurnoAbiertoRechazaAntesDeCualquierConsultaDePrecioUOferta));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-sin-turno", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Sin Turno");
+        // Turno NUNCA se abre para este punto de venta acá — a diferencia de las otras pruebas
+        // de este archivo.
+
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: ctx.IdEmpleadoAdmin);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var lector = new LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new ServicioDeTurnos(db, reloj, contexto, lector);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var excepcion = await Assert.ThrowsAsync<ErrorDominio>(() => servicioDeVentas.EmitirAsync(solicitud));
+
+        Assert.Equal("turno_no_abierto", excepcion.Codigo);
+        Assert.Equal(409, excepcion.EstadoHttp);
+
+        // ResolverTipoComprobanteAsync + ResolverPuntoVentaAsync + ResolverTurnoAbiertoAsync: 3
+        // consultas EF antes del rechazo — ServicioDeOfertas.ResolverAsync (pricing/ofertas) SOLA
+        // ya dispara 7 por sí misma (doc-comment de EmitirAsync), así que 3 confirma que ninguna
+        // de esas corrió.
+        Assert.Equal(3, contador.Consultas);
+    }
+
+    // ---- task 5.6: 3ra superficie racy — una venta compitiendo con un cierre -------------------
+
+    [Fact]
+    public async Task UnaVentaQueCompiteConUnCierreQuedaContadaEnElArqueoORechazadaNuncaSinContar()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(UnaVentaQueCompiteConUnCierreQuedaContadaEnElArqueoORechazadaNuncaSinContar)}-{ronda}");
+            var turno = await AbrirTurnoAsync(ctx);
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-race-cierre", 100m);
+            var idCliente = await SembrarClienteAsync(ctx, "Cliente Race Cierre");
+
+            // El ancla (efectivo) ya queda arqueable ANTES de la carrera — el conteo declarado
+            // de abajo tiene que ser un SET fijo sin importar si la venta gana o pierde.
+            await SembrarPagoAsync(ctx, turno.Id, ctx.IdMedioEfectivo, 500m);
+
+            var solicitudDeVenta = new SolicitudDeVenta(
+                ctx.IdPuntoVenta, idCliente, "TX", null,
+                [new LineaDeVenta(idArticulo, 1m, null)],
+                [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+                null, null);
+            var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 0m)], null);
+
+            var tareaVenta = ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudDeVenta);
+            var tareaCierre = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+
+            var respuestaVenta = await tareaVenta;
+            var respuestaCierre = await tareaCierre;
+
+            Assert.Contains(respuestaVenta.StatusCode, new[] { HttpStatusCode.Created, HttpStatusCode.Conflict });
+            if (respuestaVenta.StatusCode == HttpStatusCode.Conflict)
+            {
+                var problema = await respuestaVenta.Content.ReadFromJsonAsync<JsonElement>();
+                Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+            }
+
+            // El cierre es el único que compite por cerrar — siempre tiene que ganar en algún
+            // momento (ya cerró antes de que la venta lo viera, o se cierra después de que la
+            // venta comiteó).
+            Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var importeEsperado = await db.ArqueosTurno
+                .Where(a => a.IdTurnoCaja == turno.Id && a.IdMedioPago == ctx.IdMedioEfectivo)
+                .Select(a => a.ImporteEsperado).SingleAsync();
+
+            var esperado = respuestaVenta.StatusCode == HttpStatusCode.Created ? 600m : 500m;
+            Assert.Equal(esperado, importeEsperado);
+        }
+    }
+
+    // ---- task 5.7: anulación respeta el gate de turno cerrado ----------------------------------
+
+    [Fact]
+    public async Task AnulacionEsRechazadaCon409TurnoCerradoCuandoElTurnoDelComprobanteYaCerro()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionEsRechazadaCon409TurnoCerradoCuandoElTurnoDelComprobanteYaCerro));
+        var turno = await AbrirTurnoAsync(ctx);
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-anulacion-turno-cerrado", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Anulación Turno Cerrado");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+        var respuestaVenta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuestaVenta.StatusCode);
+        var emitido = (await respuestaVenta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)], null);
+        var respuestaCierre = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+        Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+        var respuestaAnulacion = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        var cuerpo = await respuestaAnulacion.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuestaAnulacion.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("turno_cerrado", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnComprobanteConTurnoNuloDeStage5SigueSiendoAnulable()
+    {
+        var ctx = await PrepararAsync(nameof(UnComprobanteConTurnoNuloDeStage5SigueSiendoAnulable));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Turno Nulo");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = 1,
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = null, // era stage-5 — nunca se resiembra (decisión 8, sin backfill).
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = idCliente,
+            Subtotal = 50m,
+            DescuentoTotal = 0m,
+            Total = 50m,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{comprobante.Id}/anulacion", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var anulado = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoComprobante.Anulado, anulado.Estado);
+    }
+}


### PR DESCRIPTION
## Resumen

Slice 5/7 de la etapa 6 (stage-6-turnos-caja) — el quirúrgico: el turno entra a `ServicioDeVentas`, la transacción más custodiada del proyecto. Diff de producción: **58 inserciones / 3 borrados**.

- `EmitirAsync` resuelve el turno abierto inmediatamente después del PV (404 antes que 409 `turno_no_abierto`, ANTES de cualquier trabajo de precios — probado con conteo de queries pinneado en 3).
- `PlanDeVenta` congela `IdTurnoCaja`; el hardcode `null` de la etapa 5 muere.
- Primer statement de la transacción de escritura: `FOR SHARE` sobre ESE turno específico (helper compartido del slice 4) — el TOCTOU entre resolución temprana y commit queda cerrado; si un cierre ganó, 409 y número gapeado por diseño.
- `AnularAsync` gana el guard de turno cerrado (`FOR SHARE OF t` en la misma transacción): 409 `turno_cerrado`; los comprobantes NULL-turno de la etapa 5 siguen anulables bit a bit.
- El camino de recuperación de commit ambiguo NO re-guarda una venta ya commiteada (correcto: la venta existe).

## Verificación

- Build 0 warnings; sin migración; `has-pending-model-changes` limpio.
- Suites: Domain 306/306, Application 209/209, Integration 481/481 (+5), contra Postgres real. Fixtures de 4 archivos de stage 5 actualizados solo con siembra de turno (verificado hunk por hunk por ambos jueces); presupuesto de lecturas 16→17 con contabilidad honesta (el FOR SHARE crudo es invisible al interceptor, precedente documentado).
- Judgment-day (ronda dedicada, rigor máximo): **ambos jueces CLEAN en ronda 1** — carrera de commit ambiguo trazada (gap + 409, jamás duplicado), análisis de orden de locks sin ciclo posible, diff verificado byte a byte fuera de los 5 toques mandatados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)