### PR TITLE
feat(caja): cierre de turno en pantalla y gate de turno en el POS (etapa 6, slice 7)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -4,6 +4,7 @@ import { RutaProtegida } from './auth/RutaProtegida'
 import { Layout } from './componentes/Layout'
 import { Articulos } from './paginas/Articulos'
 import { Caja } from './paginas/Caja'
+import { CierreDeCaja } from './paginas/CierreDeCaja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
 import { Clientes } from './paginas/Clientes'
@@ -59,6 +60,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <Caja />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-6-turnos-caja (Slice 7, design: Web Composition): cierre de turno — el
+                turno lo trae la URL (`?idTurno=`), se navega acá desde el panel del turno
+                abierto en /caja. Misma política de rol. */}
+            <Route
+              path="/caja/cierre"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <CierreDeCaja />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/arqueo.test.ts
+++ b/src/Ways.Web/src/api/arqueo.test.ts
@@ -44,8 +44,8 @@ describe('conteosCompletos', () => {
     { idMedioPago: 2, importeEsperado: 300 },
   ]
 
-  it('false sin ningún medio arqueable (todavía no hay resumen cargado)', () => {
-    expect(conteosCompletos([], {})).toBe(false)
+  it('true sin ningún medio arqueable (turno sin actividad: legítimo, el servidor acepta conteos: []; "todavía no cargó el resumen" lo distingue el caller con resumen !== null, no esta función)', () => {
+    expect(conteosCompletos([], {})).toBe(true)
   })
 
   it('false si falta el conteo de un medio', () => {

--- a/src/Ways.Web/src/api/arqueo.test.ts
+++ b/src/Ways.Web/src/api/arqueo.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { aSolicitudDeCierre, conteoValido, conteosCompletos, diferenciaPrevia } from './arqueo'
+import type { LineaDeResumen } from './tipos'
+
+describe('diferenciaPrevia', () => {
+  it('positivo cuando lo declarado es menor a lo esperado (faltante)', () => {
+    expect(diferenciaPrevia(1000, 900)).toBe(100)
+  })
+
+  it('negativo cuando lo declarado supera lo esperado (sobrante)', () => {
+    expect(diferenciaPrevia(1000, 1100)).toBe(-100)
+  })
+
+  it('cero cuando coinciden exactamente', () => {
+    expect(diferenciaPrevia(500, 500)).toBe(0)
+  })
+})
+
+describe('conteoValido', () => {
+  it('rechaza un valor vacío', () => {
+    expect(conteoValido('')).toBe(false)
+  })
+
+  it('rechaza un valor no numérico', () => {
+    expect(conteoValido('abc')).toBe(false)
+  })
+
+  it('rechaza un número negativo', () => {
+    expect(conteoValido('-1')).toBe(false)
+  })
+
+  it('acepta 0 (declarar nada es un acto deliberado, no un default)', () => {
+    expect(conteoValido('0')).toBe(true)
+  })
+
+  it('acepta un número positivo', () => {
+    expect(conteoValido('640')).toBe(true)
+  })
+})
+
+describe('conteosCompletos', () => {
+  const medios: LineaDeResumen[] = [
+    { idMedioPago: 1, importeEsperado: 640 },
+    { idMedioPago: 2, importeEsperado: 300 },
+  ]
+
+  it('false sin ningún medio arqueable (todavía no hay resumen cargado)', () => {
+    expect(conteosCompletos([], {})).toBe(false)
+  })
+
+  it('false si falta el conteo de un medio', () => {
+    expect(conteosCompletos(medios, { 1: '640' })).toBe(false)
+  })
+
+  it('false si el conteo de un medio es inválido', () => {
+    expect(conteosCompletos(medios, { 1: '640', 2: 'abc' })).toBe(false)
+  })
+
+  it('true cuando todos los medios arqueables tienen un conteo válido', () => {
+    expect(conteosCompletos(medios, { 1: '640', 2: '0' })).toBe(true)
+  })
+})
+
+describe('aSolicitudDeCierre', () => {
+  const medios: LineaDeResumen[] = [
+    { idMedioPago: 1, importeEsperado: 640 },
+    { idMedioPago: 2, importeEsperado: 300 },
+  ]
+
+  it('arma exactamente un conteo por medio arqueable, en el mismo orden', () => {
+    const solicitud = aSolicitudDeCierre(medios, { 1: '635', 2: '300' }, '')
+
+    expect(solicitud.conteos).toEqual([
+      { idMedioPago: 1, importeDeclarado: 635 },
+      { idMedioPago: 2, importeDeclarado: 300 },
+    ])
+  })
+
+  it('recorta observaciones y las convierte a null si quedan vacías', () => {
+    expect(aSolicitudDeCierre(medios, { 1: '0', 2: '0' }, '   ').observaciones).toBeNull()
+    expect(aSolicitudDeCierre(medios, { 1: '0', 2: '0' }, '  turno tranquilo  ').observaciones).toBe(
+      'turno tranquilo',
+    )
+  })
+})

--- a/src/Ways.Web/src/api/arqueo.ts
+++ b/src/Ways.Web/src/api/arqueo.ts
@@ -21,9 +21,13 @@ export function conteoValido(valor: string): boolean {
 }
 
 /** Todos los medios arqueables (`resumen.medios`, la fuente de verdad del servidor sobre qué
- * declarar) tienen que tener un conteo válido antes de habilitar "Finalizar cierre". */
+ * declarar) tienen que tener un conteo válido antes de habilitar "Finalizar cierre". Un turno sin
+ * actividad tiene `medios` vacío y eso es legítimo (el servidor acepta `conteos: []`) — acá
+ * `every` sobre un array vacío es vacuously true, así que esta función NO distingue "todavía no
+ * cargó el resumen" de "cargó y no hay nada que arquear": esa distinción la hace el caller con
+ * `resumen !== null`. */
 export function conteosCompletos(medios: LineaDeResumen[], valores: Record<number, string>): boolean {
-  return medios.length > 0 && medios.every((m) => conteoValido(valores[m.idMedioPago] ?? ''))
+  return medios.every((m) => conteoValido(valores[m.idMedioPago] ?? ''))
 }
 
 /** Arma `SolicitudDeCierre.conteos` — exactamente un conteo por medio arqueable, en el mismo

--- a/src/Ways.Web/src/api/arqueo.ts
+++ b/src/Ways.Web/src/api/arqueo.ts
@@ -1,0 +1,42 @@
+/**
+ * Reglas puras del arqueo de cierre (stage-6-turnos-caja, Slice 7): vista previa de `diferencia`
+ * y armado del cuerpo de `POST …/cierre` a partir de los conteos tipeados en pantalla. Mismo
+ * criterio que `caja.ts`/`pagos.ts` (stage 5/6): estas funciones son solo feedback instantáneo,
+ * nunca autoritativas — el servidor vuelve a derivar todo (`arqueos_turno.diferencia` es una
+ * columna `GENERATED ALWAYS`, design decisión 6).
+ */
+import type { ConteoDeclarado, LineaDeResumen, SolicitudDeCierre } from './tipos'
+
+/** Espejo de `diferencia = importe_esperado − importe_declarado` (doc 10; design: The
+ * Derivation). Positivo = faltante, negativo = sobrante. */
+export function diferenciaPrevia(importeEsperado: number, importeDeclarado: number): number {
+  return importeEsperado - importeDeclarado
+}
+
+/** Un conteo declarado es válido si es un número finito mayor o igual a 0 — declarar "nada" es
+ * un acto deliberado del cajero (tipear 0), nunca un default silencioso. */
+export function conteoValido(valor: string): boolean {
+  const numero = Number(valor)
+  return valor.trim() !== '' && Number.isFinite(numero) && numero >= 0
+}
+
+/** Todos los medios arqueables (`resumen.medios`, la fuente de verdad del servidor sobre qué
+ * declarar) tienen que tener un conteo válido antes de habilitar "Finalizar cierre". */
+export function conteosCompletos(medios: LineaDeResumen[], valores: Record<number, string>): boolean {
+  return medios.length > 0 && medios.every((m) => conteoValido(valores[m.idMedioPago] ?? ''))
+}
+
+/** Arma `SolicitudDeCierre.conteos` — exactamente un conteo por medio arqueable, en el mismo
+ * orden que `resumen.medios` (el servidor exige el set exacto: ni de más ni de menos, spec:
+ * arqueo-de-cierre / Arqueo Incompleto, Medio Sin Actividad En El Turno). */
+export function aSolicitudDeCierre(
+  medios: LineaDeResumen[],
+  valores: Record<number, string>,
+  observaciones: string,
+): SolicitudDeCierre {
+  const conteos: ConteoDeclarado[] = medios.map((m) => ({
+    idMedioPago: m.idMedioPago,
+    importeDeclarado: Number(valores[m.idMedioPago] ?? '0'),
+  }))
+  return { conteos, observaciones: observaciones.trim() === '' ? null : observaciones.trim() }
+}

--- a/src/Ways.Web/src/api/caja.ts
+++ b/src/Ways.Web/src/api/caja.ts
@@ -38,10 +38,6 @@ export const clienteDeCaja = {
    * Declared Counts). */
   cerrar: (idTurnoCaja: number, solicitud: SolicitudDeCierre) =>
     api.post<TurnoConArqueos>(`/caja/turnos/${idTurnoCaja}/cierre`, solicitud),
-  /** `GET /api/caja/turnos/{id}` — turno + arqueos (el payload del comprobante Z). Se usa
-   * después de un cierre exitoso para volver a traer el comprobante en un fetch aislado del POST
-   * de cierre (react-async-state regla 6: un cierre 2xx nunca se reporta como falla). */
-  obtenerConArqueos: (idTurnoCaja: number) => api.get<TurnoConArqueos>(`/caja/turnos/${idTurnoCaja}`),
 }
 
 /** Longitud mínima del motivo, uniforme para los 3 tipos de movimiento (design decisión 8;

--- a/src/Ways.Web/src/api/caja.ts
+++ b/src/Ways.Web/src/api/caja.ts
@@ -10,8 +10,10 @@ import type {
   MovimientoRegistrado,
   ResumenDeTurno,
   SolicitudDeApertura,
+  SolicitudDeCierre,
   SolicitudDeMovimiento,
   TipoMovimientoCaja,
+  TurnoConArqueos,
   TurnoResumen,
 } from './tipos'
 
@@ -30,6 +32,16 @@ export const clienteDeCaja = {
   /** `GET /api/caja/turnos/{id}/resumen` — resumen parcial, misma derivación que el cierre
    * (spec: Resumen Parcial Uses The Same Derivation As Cierre), de solo lectura. */
   obtenerResumen: (idTurnoCaja: number) => api.get<ResumenDeTurno>(`/caja/turnos/${idTurnoCaja}/resumen`),
+  /** `POST /api/caja/turnos/{id}/cierre` (Slice 7, design: The Cierre Transaction) —
+   * irreversible: deriva el arqueo, lo persiste y encadena la tesorería en una única transacción
+   * atómica. El cuerpo SOLO trae los conteos declarados (spec: Cierre Payload Carries Only
+   * Declared Counts). */
+  cerrar: (idTurnoCaja: number, solicitud: SolicitudDeCierre) =>
+    api.post<TurnoConArqueos>(`/caja/turnos/${idTurnoCaja}/cierre`, solicitud),
+  /** `GET /api/caja/turnos/{id}` — turno + arqueos (el payload del comprobante Z). Se usa
+   * después de un cierre exitoso para volver a traer el comprobante en un fetch aislado del POST
+   * de cierre (react-async-state regla 6: un cierre 2xx nunca se reporta como falla). */
+  obtenerConArqueos: (idTurnoCaja: number) => api.get<TurnoConArqueos>(`/caja/turnos/${idTurnoCaja}`),
 }
 
 /** Longitud mínima del motivo, uniforme para los 3 tipos de movimiento (design decisión 8;

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -631,6 +631,31 @@ export type LineaDeResumen = { idMedioPago: number; importeEsperado: number }
  * (`ServicioDeResumenDeTurno`) no expone ese detalle, solo el total esperado por medio. */
 export type ResumenDeTurno = { idTurnoCaja: number; idMedioAncla: number; medios: LineaDeResumen[] }
 
+// --- Caja: cierre y comprobante Z (stage-6-turnos-caja, Slice 7) ---
+// Espejo de `Ways.Application.Caja.Contratos` (Slice 4/7) — el cierre y el detalle con arqueos.
+
+/** Un conteo declarado por el cajero — el ÚNICO dato que viaja en `SolicitudDeCierre.conteos`
+ * (spec: Cierre Payload Carries Only Declared Counts). `importeEsperado` NUNCA es un campo de
+ * entrada acá, lo deriva siempre el servidor. */
+export type ConteoDeclarado = { idMedioPago: number; importeDeclarado: number }
+
+/** Cuerpo de `POST /api/caja/turnos/{id}/cierre` — sin ningún campo de total, subtotal o
+ * esperado (spec: No Request Shape Accepts A Total). */
+export type SolicitudDeCierre = { conteos: ConteoDeclarado[]; observaciones: string | null }
+
+/** Una fila ya persistida de `arqueos_turno` — `diferencia` la calcula la columna `GENERATED
+ * ALWAYS` del servidor (design decisión 6); positivo = faltante. */
+export type LineaDeArqueoResumen = {
+  idMedioPago: number
+  importeEsperado: number
+  importeDeclarado: number
+  diferencia: number
+}
+
+/** Respuesta de `POST /api/caja/turnos/{id}/cierre` y de `GET /api/caja/turnos/{id}` (el
+ * payload del comprobante Z) — mismos campos planos que `TurnoResumen` más `arqueos`. */
+export type TurnoConArqueos = TurnoResumen & { arqueos: LineaDeArqueoResumen[] }
+
 // --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---
 // Espejo de `Ways.Application.Ventas.Contratos` (confirmado contra el DTO real de
 // `POST /api/ventas`, mergeado en Slice 4) — usado por `ventas.ts` (mappers) y `Pos.tsx`

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Caja } from './Caja'
 import { ErrorApi } from '../api/cliente'
@@ -126,7 +127,7 @@ describe('Caja — apertura', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('No hay un turno abierto en este punto de venta.')
 
     await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
@@ -147,7 +148,7 @@ describe('Caja — apertura', () => {
       return undefined
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('No hay un turno abierto en este punto de venta.')
 
     await userEvent.type(screen.getByLabelText('Fondo inicial'), '-10')
@@ -173,7 +174,7 @@ describe('Caja — apertura', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('No hay un turno abierto en este punto de venta.')
     await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
 
@@ -190,6 +191,36 @@ describe('Caja — apertura', () => {
       await Promise.resolve()
     })
     await screen.findByText('Turno abierto')
+  })
+
+  it('autocuración del 409 turno_ya_abierto (task 7.8, judgment-day slice-6 finding): en vez de un error + formulario obsoleto, refetchea y muestra el turno que ganó la carrera', async () => {
+    let llamadasAbierto = 0
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') {
+        llamadasAbierto += 1
+        // La primera consulta (montaje) no encuentra turno — por eso se muestra el formulario.
+        // La segunda (autocuración, tras el 409) sí lo encuentra: otra pestaña lo abrió primero.
+        return llamadasAbierto === 1
+          ? Promise.resolve<TurnoResumen | null>(null)
+          : Promise.resolve<TurnoResumen | null>(turnoFixture())
+      }
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') return Promise.reject(new ErrorApi(409, 'turno_ya_abierto', 'Ya hay un turno abierto en este punto de venta.'))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    render(<Caja />, { wrapper: MemoryRouter })
+    await screen.findByText('No hay un turno abierto en este punto de venta.')
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    await screen.findByText('Turno abierto')
+    expect(screen.queryByText('Ya hay un turno abierto en este punto de venta.')).not.toBeInTheDocument()
+    expect(llamadasAbierto).toBe(2)
   })
 })
 
@@ -215,7 +246,7 @@ describe('Caja — movimientos', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     expect(screen.getByText('Calculando…')).toBeInTheDocument()
 
@@ -243,7 +274,7 @@ describe('Caja — movimientos', () => {
       return undefined
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
 
     await userEvent.type(screen.getByLabelText('Importe'), '100')
@@ -269,7 +300,7 @@ describe('Caja — movimientos', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
 
     await userEvent.selectOptions(screen.getByLabelText('Tipo de movimiento'), 'Apertura de cajón')
@@ -302,7 +333,7 @@ describe('Caja — movimientos', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     await userEvent.type(screen.getByLabelText('Importe'), '100')
     await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
@@ -344,7 +375,7 @@ describe('Caja — movimientos', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     expect(screen.getByText('Calculando…')).toBeInTheDocument()
 
@@ -386,7 +417,7 @@ describe('Caja — selector de punto de venta bloqueado durante una escritura en
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('No hay un turno abierto en este punto de venta.')
 
     await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
@@ -416,7 +447,7 @@ describe('Caja — selector de punto de venta bloqueado durante una escritura en
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     await userEvent.type(screen.getByLabelText('Importe'), '100')
     await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
@@ -450,7 +481,7 @@ describe('Caja — turno nuevo no hereda el estado del anterior (react-async-sta
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     await waitFor(() => expect(screen.getByText('$640,00')).toBeInTheDocument())
 
@@ -475,8 +506,23 @@ describe('Caja — errores', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />)
+    render(<Caja />, { wrapper: MemoryRouter })
 
     expect(await screen.findByText('No se pudo consultar el turno.')).toBeInTheDocument()
+  })
+})
+
+describe('Caja — navegación a cierre (Slice 7)', () => {
+  it('el panel del turno abierto ofrece "Cerrar turno" con el id del turno en la URL', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    render(<Caja />, { wrapper: MemoryRouter })
+    await screen.findByText('Turno abierto')
+
+    expect(screen.getByRole('link', { name: 'Cerrar turno' })).toHaveAttribute('href', '/caja/cierre?idTurno=501')
   })
 })

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router'
 import { aSolicitudDeMovimiento, clienteDeCaja, importeValidoParaTipo, motivoValido } from '../api/caja'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
@@ -85,7 +86,24 @@ function FormularioApertura({ idPuntoVenta, onAbierto, onEscribiendoCambio }: Pr
       })
       onAbierto(turno)
     } catch (e) {
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+      if (e instanceof ErrorApi && e.codigo === 'turno_ya_abierto') {
+        // Autocuración (judgment-day slice-6, judge B): otra pestaña/cajero ganó la carrera de
+        // apertura entre que esta pestaña cargó el formulario y el click. En vez de dejar un
+        // error + formulario obsoleto (el turno YA está abierto, reintentar solo repetiría el
+        // mismo 409), se vuelve a consultar el turno abierto real y se muestra ese panel.
+        try {
+          const turnoReal = await clienteDeCaja.obtenerAbierto(idPuntoVenta)
+          if (turnoReal) {
+            onAbierto(turnoReal)
+          } else {
+            setError('El turno ya está abierto, pero no se pudo confirmar cuál — actualizá la página.')
+          }
+        } catch {
+          setError('El turno ya está abierto, pero no se pudo confirmar cuál — actualizá la página.')
+        }
+      } else {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+      }
     } finally {
       abriendoRef.current = false
       setAbriendo(false)
@@ -253,20 +271,34 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
 
   return (
     <div>
-      <div className="row g-3 mb-3">
-        <div className="col-md-4">
+      <div className="row g-3 mb-3 align-items-end">
+        <div className="col-md-3">
           <div className="small text-muted">Estado</div>
           <div>
             <span className="badge bg-success">Turno abierto</span>
           </div>
         </div>
-        <div className="col-md-4">
+        <div className="col-md-3">
           <div className="small text-muted">Apertura</div>
           <div>{formatearFechaHora(turno.fechaApertura)}</div>
         </div>
-        <div className="col-md-4">
+        <div className="col-md-3">
           <div className="small text-muted">Fondo inicial</div>
           <div>{formatearMoneda(turno.fondoInicial)}</div>
+        </div>
+        <div className="col-md-3 text-md-end">
+          {/* stage-6-turnos-caja (Slice 7, design: Web Composition): entrada a la pantalla de
+              cierre — el turno lo identifica la URL, nunca un selector propio de esa pantalla. */}
+          <Link
+            className={`btn btn-outline-danger btn-sm rounded-0${registrando ? ' disabled' : ''}`}
+            aria-disabled={registrando}
+            to={`/caja/cierre?idTurno=${turno.id}`}
+            onClick={(e) => {
+              if (registrando) e.preventDefault()
+            }}
+          >
+            Cerrar turno
+          </Link>
         </div>
       </div>
 

--- a/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
@@ -1,0 +1,250 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CierreDeCaja } from './CierreDeCaja'
+import { ErrorApi } from '../api/cliente'
+import type { MedioPagoListado, ResumenDeTurno, TurnoConArqueos } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
+  return {
+    id: 1,
+    nombre: 'Efectivo',
+    activo: true,
+    idEmpresa: null,
+    orden: 1,
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    recargoPorcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTurno {
+  return {
+    idTurnoCaja: 501,
+    idMedioAncla: 1,
+    medios: [{ idMedioPago: 1, importeEsperado: 640 }],
+    ...sobrescribir,
+  }
+}
+
+function turnoConArqueosFixture(sobrescribir: Partial<TurnoConArqueos> = {}): TurnoConArqueos {
+  return {
+    id: 501,
+    idPuntoVenta: 7,
+    idEmpleadoApertura: 3,
+    idEmpleadoCierre: 3,
+    fechaApertura: '2026-08-04T12:00:00Z',
+    fechaCierre: '2026-08-04T20:00:00Z',
+    fondoInicial: 500,
+    estado: 'Cerrado',
+    observaciones: null,
+    arqueos: [{ idMedioPago: 1, importeEsperado: 640, importeDeclarado: 635, diferencia: 5 }],
+    ...sobrescribir,
+  }
+}
+
+const medioEfectivo = medioFixture()
+
+function renderCierre(idTurno: string | null = '501') {
+  const ruta = idTurno === null ? '/caja/cierre' : `/caja/cierre?idTurno=${idTurno}`
+  return render(<CierreDeCaja />, { wrapper: ({ children }) => <MemoryRouter initialEntries={[ruta]}>{children}</MemoryRouter> })
+}
+
+/** Rutas comunes a toda la pantalla (medios de pago + resumen del turno 501) — cada test suma
+ * encima las rutas de cierre que le hacen falta. */
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+    if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+})
+
+describe('CierreDeCaja — turno inválido', () => {
+  it('sin idTurno en la URL muestra un aviso y no dispara ningún fetch', async () => {
+    renderCierre(null)
+
+    expect(await screen.findByText('No se especificó el turno a cerrar.')).toBeInTheDocument()
+    expect(apiGetMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('CierreDeCaja — flujo feliz', () => {
+  it('completar los conteos, confirmar y finalizar cierra el turno y muestra el comprobante Z con las diferencias', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/cierre') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      if (ruta === '/caja/turnos/501') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+    await screen.findByText('Efectivo')
+
+    await userEvent.type(screen.getByLabelText('Declarado de Efectivo'), '635')
+    expect(screen.getByText('$5,00')).toBeInTheDocument() // vista previa de diferencia (rule: preview, nunca autoritativa)
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeEnabled())
+    await userEvent.click(screen.getByRole('button', { name: 'Finalizar cierre' }))
+
+    await screen.findByText('Turno #501 cerrado')
+    const fila = screen.getByText('Efectivo').closest('tr') as HTMLElement
+    expect(fila.textContent).toContain('$640,00')
+    expect(fila.textContent).toContain('$635,00')
+    expect(fila.textContent).toContain('$5,00')
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/caja/turnos/501/cierre')
+    expect(llamada?.[1]).toEqual({ conteos: [{ idMedioPago: 1, importeDeclarado: 635 }], observaciones: null })
+  })
+
+  it('sin completar todos los conteos, "Finalizar cierre" queda deshabilitado', async () => {
+    mockearRutasBase()
+    renderCierre()
+    await screen.findByText('Efectivo')
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeDisabled()
+  })
+
+  it('sin marcar la confirmación de irreversibilidad, "Finalizar cierre" queda deshabilitado aunque los conteos estén completos', async () => {
+    mockearRutasBase()
+    renderCierre()
+    await screen.findByText('Efectivo')
+
+    await userEvent.type(screen.getByLabelText('Declarado de Efectivo'), '640')
+    expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeDisabled()
+  })
+})
+
+describe('CierreDeCaja — reentrancia (react-async-state regla 9)', () => {
+  it('doble click en "Finalizar cierre" dispara exactamente un POST', async () => {
+    mockearRutasBase()
+    let resolverCierre: (t: TurnoConArqueos) => void = () => {}
+    const cierrePendiente = new Promise<TurnoConArqueos>((resolve) => {
+      resolverCierre = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/cierre') return cierrePendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+    await screen.findByText('Efectivo')
+    await userEvent.type(screen.getByLabelText('Declarado de Efectivo'), '640')
+    await userEvent.click(screen.getByRole('checkbox'))
+
+    const boton = screen.getByRole('button', { name: 'Finalizar cierre' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos/501/cierre')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Cerrando…' })).toBeDisabled()
+    expect(screen.getByLabelText('Declarado de Efectivo')).toBeDisabled()
+
+    await act(async () => {
+      resolverCierre(turnoConArqueosFixture())
+      await Promise.resolve()
+    })
+  })
+})
+
+describe('CierreDeCaja — un cierre 2xx nunca se reporta como falla (react-async-state regla 6)', () => {
+  it('si el POST de cierre tiene éxito pero el fetch posterior del comprobante Z falla, se muestra el turno cerrado con un aviso propio, nunca un error de cierre', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/cierre') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      if (ruta === '/caja/turnos/501') return Promise.reject(new ErrorApi(500, 'error', 'boom'))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+    await screen.findByText('Efectivo')
+    await userEvent.type(screen.getByLabelText('Declarado de Efectivo'), '640')
+    await userEvent.click(screen.getByRole('checkbox'))
+    await userEvent.click(screen.getByRole('button', { name: 'Finalizar cierre' }))
+
+    await screen.findByText('Turno #501 cerrado')
+    expect(
+      await screen.findByText('El turno se cerró, pero no se pudo abrir el comprobante Z.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No se pudo cerrar el turno.')).not.toBeInTheDocument()
+    expect(screen.queryByText('boom')).not.toBeInTheDocument()
+  })
+})
+
+describe('CierreDeCaja — falla de carga (react-async-state regla 7)', () => {
+  it('si el resumen no se puede cargar, se muestra un aviso y "Finalizar cierre" queda visible pero realmente deshabilitado', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/501/resumen') {
+        return Promise.reject(new ErrorApi(500, 'error', 'No se pudo cargar el resumen del turno.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+
+    expect(await screen.findByText('No se pudo cargar el resumen del turno.')).toBeInTheDocument()
+    const boton = screen.getByRole('button', { name: 'Finalizar cierre' })
+    expect(boton).toBeInTheDocument()
+    expect(boton).toBeDisabled()
+  })
+
+  it('si los medios de pago no se pueden cargar, se muestra un aviso y "Finalizar cierre" queda deshabilitado aunque el resumen sí haya cargado', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.reject(new ErrorApi(500, 'error', 'No se pudieron cargar los medios de pago.'))
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+
+    expect(await screen.findByText('No se pudieron cargar los medios de pago.')).toBeInTheDocument()
+    await userEvent.type(await screen.findByLabelText('Declarado de Medio #1'), '640')
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeDisabled()
+  })
+})

--- a/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
@@ -107,12 +107,6 @@ describe('CierreDeCaja — flujo feliz', () => {
       if (ruta === '/caja/turnos/501/cierre') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
-    apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
-      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
-      if (ruta === '/caja/turnos/501') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
-      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
-    })
 
     renderCierre()
     await screen.findByText('Efectivo')
@@ -186,17 +180,11 @@ describe('CierreDeCaja — reentrancia (react-async-state regla 9)', () => {
   })
 })
 
-describe('CierreDeCaja — un cierre 2xx nunca se reporta como falla (react-async-state regla 6)', () => {
-  it('si el POST de cierre tiene éxito pero el fetch posterior del comprobante Z falla, se muestra el turno cerrado con un aviso propio, nunca un error de cierre', async () => {
+describe('CierreDeCaja — un cierre 2xx nunca se reporta como falla, ni se muestra sin datos (react-async-state regla 6)', () => {
+  it('un POST de cierre exitoso muestra el turno cerrado CON los datos del arqueo, sin depender de ningún fetch posterior', async () => {
     mockearRutasBase()
     apiPostMock.mockImplementation((ruta: string) => {
       if (ruta === '/caja/turnos/501/cierre') return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture())
-      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
-    })
-    apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
-      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
-      if (ruta === '/caja/turnos/501') return Promise.reject(new ErrorApi(500, 'error', 'boom'))
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
@@ -207,11 +195,88 @@ describe('CierreDeCaja — un cierre 2xx nunca se reporta como falla (react-asyn
     await userEvent.click(screen.getByRole('button', { name: 'Finalizar cierre' }))
 
     await screen.findByText('Turno #501 cerrado')
-    expect(
-      await screen.findByText('El turno se cerró, pero no se pudo abrir el comprobante Z.'),
-    ).toBeInTheDocument()
+    const fila = screen.getByText('Efectivo').closest('tr') as HTMLElement
+    expect(fila.textContent).toContain('$640,00')
+    expect(fila.textContent).toContain('$635,00')
+    expect(fila.textContent).toContain('$5,00')
     expect(screen.queryByText('No se pudo cerrar el turno.')).not.toBeInTheDocument()
-    expect(screen.queryByText('boom')).not.toBeInTheDocument()
+
+    // El payload del comprobante Z sale íntegro del POST — no hay ningún GET adicional a
+    // `/caja/turnos/501` después del cierre.
+    expect(apiGetMock.mock.calls.some((c) => c[0] === '/caja/turnos/501')).toBe(false)
+  })
+})
+
+describe('CierreDeCaja — turno sin actividad (Fix: conteosCompletos ya no exige medios.length > 0)', () => {
+  it('un turno sin actividad (resumen.medios vacío) se cierra con conteos: [] y muestra el comprobante Z vacío', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture({ medios: [] }))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/cierre') {
+        return Promise.resolve<TurnoConArqueos>(turnoConArqueosFixture({ arqueos: [] }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+    await screen.findByText('Este turno no tuvo actividad: no hay ningún medio para arquear.')
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeEnabled())
+    await userEvent.click(screen.getByRole('button', { name: 'Finalizar cierre' }))
+
+    await screen.findByText('Turno #501 cerrado')
+    expect(screen.getByText('Este turno no tuvo actividad: no hay ningún medio arqueado.')).toBeInTheDocument()
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/caja/turnos/501/cierre')
+    expect(llamada?.[1]).toEqual({ conteos: [], observaciones: null })
+  })
+})
+
+describe('CierreDeCaja — checklist desactualizado tras un rechazo del servidor (Fix: refetch del resumen)', () => {
+  it('arqueo_incompleto refresca el resumen, agrega el medio que apareció en el servidor, preserva los conteos ya tipeados y vuelve a habilitar "Finalizar cierre" una vez completado', async () => {
+    const medioTarjeta = medioFixture({ id: 2, nombre: 'Tarjeta' })
+    let resumenActual = resumenFixture()
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo, medioTarjeta])
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenActual)
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/501/cierre') {
+        return Promise.reject(new ErrorApi(409, 'arqueo_incompleto', 'Faltan medios por declarar.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderCierre()
+    await screen.findByText('Efectivo')
+    await userEvent.type(screen.getByLabelText('Declarado de Efectivo'), '640')
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeEnabled())
+
+    // Entre que se cargó este resumen y el click, el servidor ganó una carrera: apareció
+    // actividad en un medio nuevo — el próximo GET /resumen ya lo refleja.
+    resumenActual = resumenFixture({
+      medios: [
+        { idMedioPago: 1, importeEsperado: 640 },
+        { idMedioPago: 2, importeEsperado: 300 },
+      ],
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Finalizar cierre' }))
+
+    expect(await screen.findByText('Faltan medios por declarar.')).toBeInTheDocument()
+    expect(await screen.findByLabelText('Declarado de Tarjeta')).toBeInTheDocument()
+    expect(screen.getByLabelText('Declarado de Efectivo')).toHaveValue(640)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeDisabled())
+
+    await userEvent.type(screen.getByLabelText('Declarado de Tarjeta'), '300')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Finalizar cierre' })).toBeEnabled())
   })
 })
 

--- a/src/Ways.Web/src/paginas/CierreDeCaja.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.tsx
@@ -52,11 +52,12 @@ export function CierreDeCaja() {
   const generacionCierreRef = useRef(0)
   const [errorCierre, setErrorCierre] = useState('')
 
-  // A partir de acá el cierre en el servidor YA ocurrió — nada de lo que siga (el fetch del
-  // comprobante Z) puede volver a marcar el cierre como fallido (regla 6).
-  const [turnoCerrado, setTurnoCerrado] = useState(false)
+  // El comprobante Z viene en la propia respuesta 2xx del POST de cierre (design: The Cierre
+  // Transaction) — `zReporte !== null` ES la señal de "el turno ya cerró", no hace falta un
+  // booleano aparte ni un GET aislado después (react-async-state regla 6: un cierre 2xx que
+  // dependiera de un fetch posterior para mostrar sus propios datos podría reportarse sin datos
+  // por una falla ajena al cierre en sí).
   const [zReporte, setZReporte] = useState<TurnoConArqueos | null>(null)
-  const [errorZ, setErrorZ] = useState('')
 
   const medioPorId = useMemo(() => {
     const indice: Record<number, MedioPagoListado> = {}
@@ -126,36 +127,46 @@ export function CierreDeCaja() {
     const solicitud = aSolicitudDeCierre(resumen.medios, conteos, observaciones)
 
     try {
-      await clienteDeCaja.cerrar(idTurno, solicitud)
-    } catch (e) {
-      // regla 4: el `finally` que libera `cerrando` está gateado por generación — acá el catch
-      // hace las veces de finally porque esta rama SÍ es una falla real del cierre.
+      const conArqueos = await clienteDeCaja.cerrar(idTurno, solicitud)
+      // regla 4/6: el `finally` que libera `cerrando` está gateado por generación. El POST ya
+      // devolvió 2xx con el comprobante Z completo — se usa directo, sin un GET aislado después
+      // que podría fallar y dejar el cierre exitoso sin datos que el servidor ya mandó.
       if (generacionCierreRef.current !== miGeneracion) return
+      setZReporte(conArqueos)
+      cerrandoRef.current = false
+      setCerrando(false)
+    } catch (e) {
+      if (generacionCierreRef.current !== miGeneracion) return
+
+      if (e instanceof ErrorApi && (e.codigo === 'arqueo_incompleto' || e.codigo === 'medio_sin_actividad_en_el_turno')) {
+        // El checklist en pantalla quedó desactualizado contra el servidor (otro movimiento entró
+        // al turno entre que se cargó el resumen y este intento) — se refresca el resumen para
+        // volver a mostrar el set real de medios arqueables. Los conteos ya tipeados sobreviven
+        // tal cual están (siguen indexados por `idMedioPago`, ningún reset acá) para los medios
+        // que siguen presentes.
+        setErrorCierre(e.message)
+        clienteDeCaja
+          .obtenerResumen(idTurno)
+          .then((datos) => {
+            if (generacionCierreRef.current !== miGeneracion) return
+            setResumen(datos)
+            setErrorResumen('')
+          })
+          .catch(() => {
+            if (generacionCierreRef.current !== miGeneracion) return
+            setErrorResumen('No se pudo actualizar el resumen del turno con los datos más recientes. Actualizá la página.')
+          })
+          .finally(() => {
+            if (generacionCierreRef.current !== miGeneracion) return
+            cerrandoRef.current = false
+            setCerrando(false)
+          })
+        return
+      }
+
       setErrorCierre(e instanceof ErrorApi ? e.message : 'No se pudo cerrar el turno.')
       cerrandoRef.current = false
       setCerrando(false)
-      return
-    }
-
-    if (generacionCierreRef.current === miGeneracion) {
-      setTurnoCerrado(true)
-    }
-
-    // regla 6: el POST ya devolvió 2xx — el cierre YA pasó. El fetch del comprobante Z queda
-    // aislado en su propio try/catch: si falla, se avisa con una copia distinta ("se cerró, pero
-    // no se pudo abrir el Z"), nunca se reporta como una falla del cierre en sí.
-    try {
-      const conArqueos = await clienteDeCaja.obtenerConArqueos(idTurno)
-      if (generacionCierreRef.current !== miGeneracion) return
-      setZReporte(conArqueos)
-    } catch {
-      if (generacionCierreRef.current !== miGeneracion) return
-      setErrorZ('El turno se cerró, pero no se pudo abrir el comprobante Z.')
-    } finally {
-      if (generacionCierreRef.current === miGeneracion) {
-        cerrandoRef.current = false
-        setCerrando(false)
-      }
     }
   }
 
@@ -176,56 +187,56 @@ export function CierreDeCaja() {
     )
   }
 
-  if (turnoCerrado) {
+  if (zReporte) {
     return (
       <div className="container-fluid py-4">
         <div className="row g-3">
           <div className="col-12">
             <Box titulo={`Turno #${idTurno} cerrado`} variante="success">
-              {!zReporte && !errorZ && <p className="text-muted">Generando el comprobante Z…</p>}
-              {errorZ && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorZ}</div>}
+              <div className="row g-3 mb-3">
+                <div className="col-md-4">
+                  <div className="small text-muted">Apertura</div>
+                  <div>{formatearFechaHora(zReporte.fechaApertura)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Cierre</div>
+                  <div>{zReporte.fechaCierre ? formatearFechaHora(zReporte.fechaCierre) : '—'}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Fondo inicial</div>
+                  <div>{formatearMoneda(zReporte.fondoInicial)}</div>
+                </div>
+              </div>
 
-              {zReporte && (
-                <>
-                  <div className="row g-3 mb-3">
-                    <div className="col-md-4">
-                      <div className="small text-muted">Apertura</div>
-                      <div>{formatearFechaHora(zReporte.fechaApertura)}</div>
-                    </div>
-                    <div className="col-md-4">
-                      <div className="small text-muted">Cierre</div>
-                      <div>{zReporte.fechaCierre ? formatearFechaHora(zReporte.fechaCierre) : '—'}</div>
-                    </div>
-                    <div className="col-md-4">
-                      <div className="small text-muted">Fondo inicial</div>
-                      <div>{formatearMoneda(zReporte.fondoInicial)}</div>
-                    </div>
-                  </div>
-
-                  <div className="table-responsive">
-                    <table className="table table-sm table-striped table-bordered align-middle">
-                      <thead>
-                        <tr>
-                          <th>Medio</th>
-                          <th className="text-end">Esperado</th>
-                          <th className="text-end">Declarado</th>
-                          <th className="text-end">Diferencia</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {zReporte.arqueos.map((a) => (
-                          <tr key={a.idMedioPago}>
-                            <td>{medioPorId[a.idMedioPago]?.nombre ?? `Medio #${a.idMedioPago}`}</td>
-                            <td className="text-end">{formatearMoneda(a.importeEsperado)}</td>
-                            <td className="text-end">{formatearMoneda(a.importeDeclarado)}</td>
-                            <td className="text-end">{formatearMoneda(a.diferencia)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </>
-              )}
+              <div className="table-responsive">
+                <table className="table table-sm table-striped table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Medio</th>
+                      <th className="text-end">Esperado</th>
+                      <th className="text-end">Declarado</th>
+                      <th className="text-end">Diferencia</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {zReporte.arqueos.map((a) => (
+                      <tr key={a.idMedioPago}>
+                        <td>{medioPorId[a.idMedioPago]?.nombre ?? `Medio #${a.idMedioPago}`}</td>
+                        <td className="text-end">{formatearMoneda(a.importeEsperado)}</td>
+                        <td className="text-end">{formatearMoneda(a.importeDeclarado)}</td>
+                        <td className="text-end">{formatearMoneda(a.diferencia)}</td>
+                      </tr>
+                    ))}
+                    {zReporte.arqueos.length === 0 && (
+                      <tr>
+                        <td colSpan={4} className="text-center text-muted">
+                          Este turno no tuvo actividad: no hay ningún medio arqueado.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
 
               <Link className="btn btn-outline-secondary rounded-0" to="/caja">
                 Volver a caja

--- a/src/Ways.Web/src/paginas/CierreDeCaja.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router'
+import { aSolicitudDeCierre, conteosCompletos, conteoValido, diferenciaPrevia } from '../api/arqueo'
+import { clienteDeCaja } from '../api/caja'
+import { clienteDeCatalogo } from '../api/catalogos'
+import { ErrorApi } from '../api/cliente'
+import type { MedioPagoAlta, MedioPagoListado, ResumenDeTurno, TurnoConArqueos } from '../api/tipos'
+import { Box } from '../componentes/Box'
+
+const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+/**
+ * Pantalla de cierre de turno (stage-6-turnos-caja, Slice 7, design: Web Composition —
+ * `CierreDeCaja.tsx`): resumen del turno a cerrar, un conteo declarado por medio arqueable,
+ * confirmación de irreversibilidad y el comprobante Z al terminar. El turno lo trae la ruta
+ * (`?idTurno=`), nunca un selector propio — se navega acá desde el panel del turno abierto en
+ * `Caja.tsx`.
+ *
+ * Es la pantalla con más obligaciones de `react-async-state` de toda la etapa (reglas 1, 4, 5, 6,
+ * 7, 9): un cierre es irreversible, así que un doble submit es el peor defecto que puede tener.
+ */
+export function CierreDeCaja() {
+  const [searchParams] = useSearchParams()
+  const crudo = searchParams.get('idTurno')
+  const idTurno = crudo !== null && crudo.trim() !== '' ? Number(crudo) : Number.NaN
+  const idTurnoValido = Number.isFinite(idTurno)
+
+  const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
+  const [errorMedios, setErrorMedios] = useState('')
+
+  const [resumen, setResumen] = useState<ResumenDeTurno | null>(null)
+  const [cargandoResumen, setCargandoResumen] = useState(true)
+  const [errorResumen, setErrorResumen] = useState('')
+
+  // regla 1: un único record mutado SIEMPRE por updater funcional — ningún helper de acá lee el
+  // estado del componente para armar el próximo valor.
+  const [conteos, setConteos] = useState<Record<number, string>>({})
+  const [observaciones, setObservaciones] = useState('')
+  const [confirmado, setConfirmado] = useState(false)
+
+  const [cerrando, setCerrando] = useState(false)
+  const cerrandoRef = useRef(false)
+  const generacionCierreRef = useRef(0)
+  const [errorCierre, setErrorCierre] = useState('')
+
+  // A partir de acá el cierre en el servidor YA ocurrió — nada de lo que siga (el fetch del
+  // comprobante Z) puede volver a marcar el cierre como fallido (regla 6).
+  const [turnoCerrado, setTurnoCerrado] = useState(false)
+  const [zReporte, setZReporte] = useState<TurnoConArqueos | null>(null)
+  const [errorZ, setErrorZ] = useState('')
+
+  const medioPorId = useMemo(() => {
+    const indice: Record<number, MedioPagoListado> = {}
+    for (const m of medios ?? []) indice[m.id] = m
+    return indice
+  }, [medios])
+
+  useEffect(() => {
+    if (!idTurnoValido) return
+    let vigente = true
+
+    clienteMediosPago
+      .listar(false)
+      .then((lista) => {
+        if (!vigente) return
+        setMedios(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setMedios([])
+        setErrorMedios(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los medios de pago.')
+      })
+
+    clienteDeCaja
+      .obtenerResumen(idTurno)
+      .then((datos) => {
+        if (!vigente) return
+        setResumen(datos)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setResumen(null)
+        setErrorResumen(e instanceof ErrorApi ? e.message : 'No se pudo cargar el resumen del turno.')
+      })
+      .finally(() => {
+        if (!vigente) return
+        setCargandoResumen(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idTurnoValido])
+
+  function cambiarConteo(idMedioPago: number, valor: string) {
+    if (cerrandoRef.current) return
+    setConteos((prev) => ({ ...prev, [idMedioPago]: valor }))
+  }
+
+  const errorCarga = errorMedios || errorResumen
+  const cargaLista = !cargandoResumen && resumen !== null && medios !== null
+  const puedeFinalizar =
+    cargaLista && errorCarga === '' && confirmado && conteosCompletos(resumen?.medios ?? [], conteos) && !cerrando
+
+  async function finalizarCierre() {
+    // regla 9: guard de reentrancia de primera línea — un doble click en el mismo tick le gana
+    // al re-render que deshabilita el botón.
+    if (cerrandoRef.current) return
+    if (!resumen || !puedeFinalizar) return
+
+    const miGeneracion = (generacionCierreRef.current += 1)
+    cerrandoRef.current = true
+    setCerrando(true)
+    setErrorCierre('')
+
+    const solicitud = aSolicitudDeCierre(resumen.medios, conteos, observaciones)
+
+    try {
+      await clienteDeCaja.cerrar(idTurno, solicitud)
+    } catch (e) {
+      // regla 4: el `finally` que libera `cerrando` está gateado por generación — acá el catch
+      // hace las veces de finally porque esta rama SÍ es una falla real del cierre.
+      if (generacionCierreRef.current !== miGeneracion) return
+      setErrorCierre(e instanceof ErrorApi ? e.message : 'No se pudo cerrar el turno.')
+      cerrandoRef.current = false
+      setCerrando(false)
+      return
+    }
+
+    if (generacionCierreRef.current === miGeneracion) {
+      setTurnoCerrado(true)
+    }
+
+    // regla 6: el POST ya devolvió 2xx — el cierre YA pasó. El fetch del comprobante Z queda
+    // aislado en su propio try/catch: si falla, se avisa con una copia distinta ("se cerró, pero
+    // no se pudo abrir el Z"), nunca se reporta como una falla del cierre en sí.
+    try {
+      const conArqueos = await clienteDeCaja.obtenerConArqueos(idTurno)
+      if (generacionCierreRef.current !== miGeneracion) return
+      setZReporte(conArqueos)
+    } catch {
+      if (generacionCierreRef.current !== miGeneracion) return
+      setErrorZ('El turno se cerró, pero no se pudo abrir el comprobante Z.')
+    } finally {
+      if (generacionCierreRef.current === miGeneracion) {
+        cerrandoRef.current = false
+        setCerrando(false)
+      }
+    }
+  }
+
+  if (!idTurnoValido) {
+    return (
+      <div className="container-fluid py-4">
+        <div className="row g-3">
+          <div className="col-12">
+            <Box titulo="Cierre de turno" variante="warning">
+              <p className="text-muted">No se especificó el turno a cerrar.</p>
+              <Link className="btn btn-outline-secondary rounded-0" to="/caja">
+                Volver a caja
+              </Link>
+            </Box>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (turnoCerrado) {
+    return (
+      <div className="container-fluid py-4">
+        <div className="row g-3">
+          <div className="col-12">
+            <Box titulo={`Turno #${idTurno} cerrado`} variante="success">
+              {!zReporte && !errorZ && <p className="text-muted">Generando el comprobante Z…</p>}
+              {errorZ && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorZ}</div>}
+
+              {zReporte && (
+                <>
+                  <div className="row g-3 mb-3">
+                    <div className="col-md-4">
+                      <div className="small text-muted">Apertura</div>
+                      <div>{formatearFechaHora(zReporte.fechaApertura)}</div>
+                    </div>
+                    <div className="col-md-4">
+                      <div className="small text-muted">Cierre</div>
+                      <div>{zReporte.fechaCierre ? formatearFechaHora(zReporte.fechaCierre) : '—'}</div>
+                    </div>
+                    <div className="col-md-4">
+                      <div className="small text-muted">Fondo inicial</div>
+                      <div>{formatearMoneda(zReporte.fondoInicial)}</div>
+                    </div>
+                  </div>
+
+                  <div className="table-responsive">
+                    <table className="table table-sm table-striped table-bordered align-middle">
+                      <thead>
+                        <tr>
+                          <th>Medio</th>
+                          <th className="text-end">Esperado</th>
+                          <th className="text-end">Declarado</th>
+                          <th className="text-end">Diferencia</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {zReporte.arqueos.map((a) => (
+                          <tr key={a.idMedioPago}>
+                            <td>{medioPorId[a.idMedioPago]?.nombre ?? `Medio #${a.idMedioPago}`}</td>
+                            <td className="text-end">{formatearMoneda(a.importeEsperado)}</td>
+                            <td className="text-end">{formatearMoneda(a.importeDeclarado)}</td>
+                            <td className="text-end">{formatearMoneda(a.diferencia)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              )}
+
+              <Link className="btn btn-outline-secondary rounded-0" to="/caja">
+                Volver a caja
+              </Link>
+            </Box>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row g-3">
+        <div className="col-12">
+          <Box titulo={`Cierre de turno #${idTurno}`}>
+            {errorCarga && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorCarga}</div>}
+            {errorCierre && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorCierre}</div>}
+
+            {cargandoResumen && <p className="text-muted">Cargando el resumen del turno…</p>}
+
+            {/* regla 7: la falla de medios/resumen deja el botón VISIBLE pero realmente
+                deshabilitado (`puedeFinalizar` exige `errorCarga === ''`) — nunca lo esconde,
+                para que el aviso de arriba tenga un enforcement real detrás. */}
+            {!cargandoResumen && (
+              <>
+                {resumen && (
+                  <div className="table-responsive">
+                    <table className="table table-sm table-striped table-bordered align-middle">
+                      <thead>
+                        <tr>
+                          <th>Medio</th>
+                          <th className="text-end">Esperado</th>
+                          <th style={{ width: 160 }}>Declarado</th>
+                          <th className="text-end">Diferencia</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {resumen.medios.map((m) => {
+                          const valor = conteos[m.idMedioPago] ?? ''
+                          const nombreMedio = medioPorId[m.idMedioPago]?.nombre ?? `Medio #${m.idMedioPago}`
+                          return (
+                            <tr key={m.idMedioPago}>
+                              <td>
+                                {nombreMedio}
+                                {m.idMedioPago === resumen.idMedioAncla && (
+                                  <span className="badge bg-secondary ms-1">efectivo</span>
+                                )}
+                              </td>
+                              <td className="text-end">{formatearMoneda(m.importeEsperado)}</td>
+                              <td>
+                                <input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  className="form-control form-control-sm rounded-0"
+                                  aria-label={`Declarado de ${nombreMedio}`}
+                                  value={valor}
+                                  disabled={cerrando}
+                                  onChange={(e) => cambiarConteo(m.idMedioPago, e.target.value)}
+                                />
+                              </td>
+                              <td className="text-end">
+                                {conteoValido(valor)
+                                  ? formatearMoneda(diferenciaPrevia(m.importeEsperado, Number(valor)))
+                                  : '—'}
+                              </td>
+                            </tr>
+                          )
+                        })}
+                        {resumen.medios.length === 0 && (
+                          <tr>
+                            <td colSpan={4} className="text-center text-muted">
+                              Este turno no tuvo actividad: no hay ningún medio para arquear.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+
+                <div className="mb-3">
+                  <label className="form-label" htmlFor="cierre-observaciones">
+                    Observaciones
+                  </label>
+                  <input
+                    id="cierre-observaciones"
+                    type="text"
+                    className="form-control rounded-0"
+                    value={observaciones}
+                    disabled={cerrando || !resumen}
+                    onChange={(e) => setObservaciones(e.target.value)}
+                  />
+                </div>
+
+                <div className="form-check mb-3">
+                  <input
+                    id="cierre-confirmacion"
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={confirmado}
+                    disabled={cerrando || !resumen}
+                    onChange={(e) => setConfirmado(e.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="cierre-confirmacion">
+                    Confirmo que estoy cerrando este turno de forma definitiva. El cierre es irreversible: no se puede
+                    reabrir ni corregir después.
+                  </label>
+                </div>
+
+                <div className="d-flex gap-2">
+                  <button
+                    type="button"
+                    className="btn btn-danger rounded-0"
+                    disabled={!puedeFinalizar}
+                    onClick={finalizarCierre}
+                  >
+                    {cerrando ? 'Cerrando…' : 'Finalizar cierre'}
+                  </button>
+                  {!cerrando && (
+                    <Link className="btn btn-outline-secondary rounded-0" to="/caja">
+                      Cancelar
+                    </Link>
+                  )}
+                </div>
+              </>
+            )}
+          </Box>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -855,6 +855,85 @@ describe('Pos — checkout', () => {
   })
 })
 
+describe('Pos — gate seam de turno de caja (stage-6-turnos-caja, Slice 7)', () => {
+  it('un 409 turno_no_abierto reemplaza el panel de cobro por la oferta de abrir turno, y tras abrirlo la venta NO se reintenta sola', async () => {
+    await armarVentaLista()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') {
+        return Promise.reject(new ErrorApi(409, 'turno_no_abierto', 'No hay un turno abierto en este punto de venta.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+
+    expect(await screen.findByText('No hay un turno abierto')).toBeInTheDocument()
+    expect(screen.queryByText('No hay un turno abierto en este punto de venta.')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Cobrar/ })).not.toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ventas')).toHaveLength(1)
+
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') {
+        return Promise.resolve({
+          id: 900,
+          idPuntoVenta: 7,
+          idEmpleadoApertura: 3,
+          idEmpleadoCierre: null,
+          fechaApertura: '2026-08-04T12:00:00Z',
+          fechaCierre: null,
+          fondoInicial: 500,
+          estado: 'Abierto',
+          observaciones: null,
+        })
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    // El carrito y el panel de pagos quedan tal cual: el cajero vuelve a apretar "Cobrar" a
+    // mano, ningún checkout NUEVO se dispara automáticamente al volver (sigue habiendo un único
+    // POST /ventas acumulado, el del intento original que rebotó con el 409).
+    await screen.findByRole('button', { name: /Cobrar/ })
+    expect(screen.getByText('Coca Cola 1L')).toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ventas')).toHaveLength(1)
+  })
+
+  it('un fondo inicial negativo en el panel del gate se rechaza localmente, sin disparar el POST de apertura', async () => {
+    await armarVentaLista()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') {
+        return Promise.reject(new ErrorApi(409, 'turno_no_abierto', 'No hay un turno abierto en este punto de venta.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+    await screen.findByText('No hay un turno abierto')
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '-10')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    expect(await screen.findByText('El fondo inicial tiene que ser un número mayor o igual a 0.')).toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/caja/turnos')).toHaveLength(0)
+  })
+
+  it('un 409 con otro código sigue mostrando el error normal, sin activar el gate', async () => {
+    await armarVentaLista()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') {
+        return Promise.reject(new ErrorApi(409, 'stock_insuficiente', 'No hay stock suficiente.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+
+    expect(await screen.findByText('No hay stock suficiente.')).toBeInTheDocument()
+    expect(screen.queryByText('No hay un turno abierto')).not.toBeInTheDocument()
+  })
+})
+
 describe('Pos — checkout: split de pago con el mismo medio', () => {
   it('dos filas de Efectivo (split de pago) no colapsan: cada una envía su propio importe y vuelto', async () => {
     render(<Pos />)

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -932,6 +932,37 @@ describe('Pos — gate seam de turno de caja (stage-6-turnos-caja, Slice 7)', ()
     expect(await screen.findByText('No hay stock suficiente.')).toBeInTheDocument()
     expect(screen.queryByText('No hay un turno abierto')).not.toBeInTheDocument()
   })
+
+  it('el panel del gate se autocura si la apertura rechaza con turno_ya_abierto (otra pestaña/cajero ganó la carrera): el gate se cierra, el carrito queda intacto y "Cobrar" no se reintenta solo', async () => {
+    await armarVentaLista()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') {
+        return Promise.reject(new ErrorApi(409, 'turno_no_abierto', 'No hay un turno abierto en este punto de venta.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+    await screen.findByText('No hay un turno abierto')
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ventas')).toHaveLength(1)
+
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos') {
+        return Promise.reject(new ErrorApi(409, 'turno_ya_abierto', 'Ya hay un turno abierto en este punto de venta.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    // El gate se cierra igual que en el camino feliz (mismo `onAbierto`): el carrito sigue
+    // intacto y NINGÚN checkout nuevo se dispara solo — sigue habiendo un único POST /ventas
+    // acumulado, el del intento original que rebotó con el 409.
+    await screen.findByRole('button', { name: /Cobrar/ })
+    expect(screen.getByText('Coca Cola 1L')).toBeInTheDocument()
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ventas')).toHaveLength(1)
+  })
 })
 
 describe('Pos — checkout: split de pago con el mismo medio', () => {

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -129,7 +129,16 @@ function PanelGateTurno({ idPuntoVenta, onAbierto }: PropsPanelGateTurno) {
       })
       onAbierto()
     } catch (e) {
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+      if (e instanceof ErrorApi && e.codigo === 'turno_ya_abierto') {
+        // Autocuración (mismo criterio que `FormularioApertura` en Caja.tsx): otra
+        // pestaña/cajero ganó la carrera de apertura entre que se abrió este gate y el click. El
+        // turno YA está abierto, así que la continuación de éxito es la correcta — reintentar
+        // solo repetiría el mismo 409. El carrito y los pagos siguen intactos, el cajero vuelve a
+        // apretar "Cobrar" a mano (react-async-state regla 9: ningún reintento automático).
+        onAbierto()
+      } else {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+      }
     } finally {
       abriendoRef.current = false
       setAbriendo(false)

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clienteDeArticulos } from '../api/articulos'
+import { clienteDeCaja } from '../api/caja'
 import { reducirCarrito, type AccionCarrito, type LineaCarrito } from '../api/carrito'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { api, ErrorApi } from '../api/cliente'
@@ -86,6 +87,108 @@ function etiquetaDeCampoFila(prefijo: string, medioDeFila: MedioPagoListado | nu
   return `${prefijo} de ${medioDeFila?.nombre ?? 'medio de pago'} (fila ${idFila})`
 }
 
+type PropsPanelGateTurno = {
+  idPuntoVenta: number
+  onAbierto: () => void
+}
+
+/**
+ * Gate seam de checkout (stage-6-turnos-caja, Slice 7, design: Web Composition — "Pos.tsx gate
+ * seam"): un `409 turno_no_abierto` de `POST /api/ventas` reemplaza el panel de cobro por esto
+ * en vez de mostrar el error crudo — ofrece abrir el turno ahí mismo. Tras la apertura la venta
+ * NUNCA se reintenta sola (react-async-state regla 9: un reintento automático de un checkout es
+ * exactamente el defecto de doble venta que esa regla existe para evitar) — el cajero vuelve a
+ * apretar "Cobrar" a mano, con el carrito y el panel de pagos intactos.
+ */
+function PanelGateTurno({ idPuntoVenta, onAbierto }: PropsPanelGateTurno) {
+  const [fondoInicial, setFondoInicial] = useState('')
+  const [observaciones, setObservaciones] = useState('')
+  const [abriendo, setAbriendo] = useState(false)
+  const abriendoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  async function abrir() {
+    // regla 9 (react-async-state): guard de reentrancia de primera línea.
+    if (abriendoRef.current) return
+
+    const fondo = Number(fondoInicial)
+    if (fondoInicial.trim() === '' || !Number.isFinite(fondo) || fondo < 0) {
+      setError('El fondo inicial tiene que ser un número mayor o igual a 0.')
+      return
+    }
+
+    abriendoRef.current = true
+    setAbriendo(true)
+    setError('')
+
+    try {
+      await clienteDeCaja.abrir({
+        idPuntoVenta,
+        fondoInicial: fondo,
+        observaciones: observaciones.trim() === '' ? null : observaciones.trim(),
+      })
+      onAbierto()
+    } catch (e) {
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+    } finally {
+      abriendoRef.current = false
+      setAbriendo(false)
+    }
+  }
+
+  return (
+    <div className="container-fluid py-4" key="gate-turno">
+      <div className="row g-3">
+        <div className="col-12">
+          <Box titulo="No hay un turno abierto" variante="warning">
+            <p className="text-muted">
+              Para cobrar hace falta abrir un turno de caja en este punto de venta. El carrito y los pagos que ya
+              cargaste quedan como están — al abrir el turno volvés a esta pantalla para apretar «Cobrar» de nuevo.
+            </p>
+            {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+
+            <div className="row g-2 align-items-end" style={{ maxWidth: 640 }}>
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="pos-gate-fondo-inicial">
+                  Fondo inicial
+                </label>
+                <input
+                  id="pos-gate-fondo-inicial"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  className="form-control rounded-0"
+                  value={fondoInicial}
+                  disabled={abriendo}
+                  onChange={(e) => setFondoInicial(e.target.value)}
+                />
+              </div>
+              <div className="col-md-5">
+                <label className="form-label" htmlFor="pos-gate-observaciones">
+                  Observaciones
+                </label>
+                <input
+                  id="pos-gate-observaciones"
+                  type="text"
+                  className="form-control rounded-0"
+                  value={observaciones}
+                  disabled={abriendo}
+                  onChange={(e) => setObservaciones(e.target.value)}
+                />
+              </div>
+              <div className="col-md-3">
+                <button type="button" className="btn btn-primary rounded-0 w-100" disabled={abriendo} onClick={abrir}>
+                  {abriendo ? 'Abriendo…' : 'Abrir turno'}
+                </button>
+              </div>
+            </div>
+          </Box>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 /**
  * Pantalla del POS (stage-5-pos-ventas, Slice 7, design: POS Screen Composition) — escaneo +
  * carrito + selección de punto de venta/cliente (Slice 6) + panel de pagos, checkout (`POST
@@ -137,6 +240,11 @@ export function Pos() {
   const cobrandoRef = useRef(false)
   const generacionCobroRef = useRef(0)
   const [errorCobro, setErrorCobro] = useState('')
+
+  // stage-6-turnos-caja (Slice 7): gate seam del checkout — un 409 turno_no_abierto reemplaza el
+  // panel de cobro por la oferta de abrir turno en vez de un error crudo (design: Web
+  // Composition — "Pos.tsx gate seam").
+  const [gateTurno, setGateTurno] = useState(false)
 
   const [ventaEmitida, setVentaEmitida] = useState<{ comprobante: ComprobanteEmitido; cliente: ClienteListado } | null>(null)
 
@@ -578,13 +686,31 @@ export function Pos() {
       setTerminoCliente('')
     } catch (e) {
       if (generacionCobroRef.current !== miGeneracion) return
-      setErrorCobro(e instanceof ErrorApi ? e.message : 'No se pudo registrar la venta.')
+      // stage-6-turnos-caja (Slice 7): el gate seam reemplaza el panel entero, no un aviso más
+      // — reintentar el checkout sin turno abierto solo repetiría el mismo 409.
+      if (e instanceof ErrorApi && e.codigo === 'turno_no_abierto') {
+        setGateTurno(true)
+      } else {
+        setErrorCobro(e instanceof ErrorApi ? e.message : 'No se pudo registrar la venta.')
+      }
     } finally {
       if (generacionCobroRef.current === miGeneracion) {
         cobrandoRef.current = false
         setCobrando(false)
       }
     }
+  }
+
+  if (gateTurno && puntoVentaSeleccionada) {
+    return (
+      <PanelGateTurno
+        idPuntoVenta={puntoVentaSeleccionada.id}
+        onAbierto={() => {
+          setGateTurno(false)
+          setErrorCobro('')
+        }}
+      />
+    )
   }
 
   if (ventaEmitida) {


### PR DESCRIPTION
## Resumen

Slice 7/7 de la etapa 6 (stage-6-turnos-caja) — el cierre llega a la pantalla y el POS aprende a pedir un turno.

- `CierreDeCaja.tsx`: checklist de conteos per-medio (un solo record con functional updaters), confirmación de irreversibilidad, y el comprobante Z renderizado directo del response del POST (el GET redundante se eliminó — un 2xx SIEMPRE termina en la vista de éxito con datos).
- `arqueo.ts`: preview de diferencia puro (positivo = faltante, espejo de la columna GENERATED), helpers de completitud.
- **Gate seam de `Pos.tsx`** (127/1, quirúrgico): el 409 `turno_no_abierto` del cobro renderiza el panel "Abrir turno"; el carrito sobrevive intacto y el cobro JAMÁS se auto-reenvía. Self-heal en la carrera `turno_ya_abierto` (el turno ya está abierto: el panel se cierra y el cajero re-aprieta Cobrar).
- Self-heal de apertura en `Caja.tsx` (tarea 7.8, hallazgo del slice 6).
- Un turno sin actividad cierra con `conteos: []` (el server siempre lo aceptó; la UI lo bloqueaba — sin este fix el PV quedaba trabado para siempre).
- Rechazos por checklist desactualizado (`arqueo_incompleto`/`medio_sin_actividad_en_el_turno`) refetchean el resumen preservando los conteos tipeados; las claves huérfanas se excluyen del payload (sin loop posible).

## Verificación

- vitest 219/219 (165 base de etapa → +54 en los slices 6-7), `tsc -b`, `oxlint` y `vite build` limpios. Cero archivos backend.
- Judgment-day: ronda 1 — 4 MAJORs confirmados entre ambos jueces (Z descartado del POST, dead-end de checklist, turno sin actividad imposible de cerrar, panel sin self-heal) y corregidos con evidencia de mutación; ronda 2 — ambos jueces CLEAN, con el riesgo de loop verificado como estructuralmente cerrado. Un flake pre-existente de suite completa (test del slice 6 en main) quedó anotado para follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)