### PR TITLE
test(caja): hacer determinista la prueba del refetch tras un movimiento fallido

### DIFF
--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -377,7 +377,11 @@ describe('Caja — movimientos', () => {
 
     render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
-    expect(screen.getByText('Calculando…')).toBeInTheDocument()
+    // El badge "Turno abierto" se monta en el mismo commit que dispara el efecto de carga del
+    // resumen, pero ese efecto todavía no corrió: hay que esperar a "Calculando…" (no asumir que
+    // ya está), si no la aserción es una carrera contra el flush del efecto y flakea bajo carga
+    // (suite completa).
+    await screen.findByText('Calculando…')
 
     await userEvent.type(screen.getByLabelText('Importe'), '100')
     await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')


### PR DESCRIPTION
## Resumen

Fix del flake de suite completa detectado por el juez A en la ronda del slice 7: `Caja.test.tsx:380` asumía que "Calculando…" ya estaba renderizado inmediatamente después del badge "Turno abierto", pero ese estado lo prende un efecto pasivo en un commit de React separado — bajo la contención de los workers de la suite completa, el `getByText` síncrono a veces corría antes del flush del efecto.

- `getByText` → `await findByText`: espera el estado de carga en vez de asumirlo.
- El test sigue pinneando el bug original (movimiento fallido → refetch → "Calculando…" se resuelve).

## Verificación

- Reproducido pre-fix (218/219, falla exacta en la línea 380).
- Post-fix: **5 corridas completas consecutivas**, 219/219 cada una. `tsc -b` y `oxlint` limpios.
- Test-only, una línea; verificación del orquestador (precedente de iteraciones triviales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)