### PR TITLE
feat(caja): contenido D6 completo en el resumen parcial (follow-up etapa 6)

### DIFF
--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -1,4 +1,5 @@
 using Ways.Domain.Caja;
+using Ways.Domain.Gastos;
 
 namespace Ways.Application.Caja;
 
@@ -56,9 +57,45 @@ public sealed record SolicitudDeCierre(IReadOnlyList<ConteoDeclarado> Conteos, s
 /// persistir (spec: Resumen Parcial Uses The Same Derivation As Cierre).</summary>
 public sealed record LineaDeResumen(int IdMedioPago, decimal ImporteEsperado);
 
+/// <summary>Un ticket límite del turno (legacy D6: "primer y último ticket") — número visible y
+/// fecha de emisión del <see cref="Ways.Domain.Ventas.ComprobanteVenta"/> correspondiente.
+/// Nunca aparece para un comprobante anulado (spec: Anulados Are Excluded From The
+/// Derivation, mismo criterio aplicado acá).</summary>
+public sealed record TicketLimite(long Numero, DateTimeOffset Fecha);
+
+/// <summary>Ingresos de un área dentro del turno (legacy D6, primer bloque: "por área") —
+/// agrupa <see cref="Ways.Domain.Ventas.ItemComprobanteVenta.Total"/> por
+/// <see cref="Ways.Domain.Ventas.ItemComprobanteVenta.IdArea"/>, el snapshot inmutable del
+/// ítem (nunca re-derivado de <c>articulos</c>, doc 10 principio 6) — mismo criterio de
+/// snapshot que ya rige <c>ItemEmitido</c>.</summary>
+public sealed record IngresoPorArea(int IdArea, string NombreArea, decimal Total);
+
+/// <summary>Egresos de una categoría de gasto dentro del turno (legacy D6, segundo bloque: "por
+/// tipo").</summary>
+public sealed record EgresoPorCategoria(CategoriaGasto Categoria, decimal Total);
+
+/// <summary>Egresos del turno (legacy D6, segundo bloque) — gastos agrupados por categoría más
+/// el total de retiros físicos (<c>movimientos_caja</c> tipo <see
+/// cref="TipoMovimientoCaja.Retiro"/>); nunca incluye <see cref="TipoMovimientoCaja.Refuerzo"/>
+/// ni <see cref="TipoMovimientoCaja.AperturaCajon"/>, que no son egresos.</summary>
+public sealed record EgresosDeTurno(IReadOnlyList<EgresoPorCategoria> PorCategoria, decimal Retiros);
+
 /// <summary>Respuesta de <c>GET /api/caja/turnos/{id}/resumen</c> (D6 parity, design: API
-/// Surface) — de solo lectura, nunca escribe nada.</summary>
-public sealed record ResumenDeTurno(int IdTurnoCaja, int IdMedioAncla, IReadOnlyList<LineaDeResumen> Medios);
+/// Surface) — de solo lectura, nunca escribe nada. <see cref="Medios"/> es la MISMA derivación
+/// que el cierre va a persistir (spec: Resumen Parcial Uses The Same Derivation As Cierre,
+/// invariante intacto); <see cref="CantidadTickets"/>/<see cref="PrimerTicket"/>/<see
+/// cref="UltimoTicket"/>/<see cref="IngresosPorArea"/>/<see cref="Egresos"/> son contenido de
+/// reporte agregado ADITIVO (follow-up de la etapa 6, "Resumen parcial D6-content enrichment")
+/// — nunca alimentan <c>CalculadorDeArqueo</c> ni ninguna escritura.</summary>
+public sealed record ResumenDeTurno(
+    int IdTurnoCaja,
+    int IdMedioAncla,
+    IReadOnlyList<LineaDeResumen> Medios,
+    int CantidadTickets,
+    TicketLimite? PrimerTicket,
+    TicketLimite? UltimoTicket,
+    IReadOnlyList<IngresoPorArea> IngresosPorArea,
+    EgresosDeTurno Egresos);
 
 /// <summary>Una fila ya persistida de <see cref="ArqueoTurno"/> — con <c>Diferencia</c> incluida
 /// (columna <c>GENERATED ALWAYS</c>, design decisión 6).</summary>

--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -74,11 +74,21 @@ public sealed record IngresoPorArea(int IdArea, string NombreArea, decimal Total
 /// tipo").</summary>
 public sealed record EgresoPorCategoria(CategoriaGasto Categoria, decimal Total);
 
-/// <summary>Egresos del turno (legacy D6, segundo bloque) — gastos agrupados por categoría más
-/// el total de retiros físicos (<c>movimientos_caja</c> tipo <see
-/// cref="TipoMovimientoCaja.Retiro"/>); nunca incluye <see cref="TipoMovimientoCaja.Refuerzo"/>
-/// ni <see cref="TipoMovimientoCaja.AperturaCajon"/>, que no son egresos.</summary>
-public sealed record EgresosDeTurno(IReadOnlyList<EgresoPorCategoria> PorCategoria, decimal Retiros);
+/// <summary>Egresos de un área dentro del turno (legacy D6, segundo bloque: "por área") — agrupa
+/// <see cref="Ways.Domain.Gastos.Gasto.Importe"/> por <see cref="Ways.Domain.Gastos.Gasto.IdArea"/>,
+/// que a diferencia de <see cref="Ways.Domain.Ventas.ItemComprobanteVenta.IdArea"/> es NULLABLE:
+/// <see cref="IdArea"/> null representa el bucket "Sin área" (gastos sin área declarada), nunca
+/// descartados.</summary>
+public sealed record EgresoPorArea(int? IdArea, string NombreArea, decimal Total);
+
+/// <summary>Egresos del turno (legacy D6, segundo bloque: "por área y por tipo") — gastos
+/// agrupados por categoría y por área más el total de retiros físicos (<c>movimientos_caja</c>
+/// tipo <see cref="TipoMovimientoCaja.Retiro"/>); nunca incluye <see
+/// cref="TipoMovimientoCaja.Refuerzo"/> ni <see cref="TipoMovimientoCaja.AperturaCajon"/>, que no
+/// son egresos. Con este bloque, D6 queda completo salvo "saldo" (uno de los medios de pago del
+/// primer bloque de D6, Ingresos), que depende de la etapa 7 y todavía no existe.</summary>
+public sealed record EgresosDeTurno(
+    IReadOnlyList<EgresoPorCategoria> PorCategoria, IReadOnlyList<EgresoPorArea> PorArea, decimal Retiros);
 
 /// <summary>Respuesta de <c>GET /api/caja/turnos/{id}/resumen</c> (D6 parity, design: API
 /// Surface) — de solo lectura, nunca escribe nada. <see cref="Medios"/> es la MISMA derivación

--- a/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
+++ b/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Caja;
+using Ways.Domain.Gastos;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// Contenido de reporte del resumen parcial (follow-up de la etapa 6, "Resumen parcial
+/// D6-content enrichment" — legacy doc 01 D6: tickets, ingresos por área, egresos por
+/// categoría). Deliberadamente SEPARADO de <see cref="LectorDeMovimientosDelTurno"/>: ese lector
+/// alimenta la ÚNICA fórmula que comparte el resumen con el cierre
+/// (<see cref="CalculadorDeArqueo"/>) y su recuento de consultas está protegido por un test de
+/// presupuesto — este lector solo arma contenido de lectura adicional, nunca toca esa fórmula
+/// ni su set de insumos.
+///
+/// 6 consultas agrupadas de cantidad FIJA (nunca una por fila, mismo criterio que el lector
+/// hermano): cantidad de tickets, primer ticket, último ticket, ingresos por área, catálogo de
+/// áreas y egresos por categoría — el turno-con-más-tickets test (task 4.14 original) sigue
+/// pasando porque cada una de estas consultas es una agregación, no una lectura por ticket.
+/// </summary>
+public class LectorDeContenidoDeResumen(IWaysDbContext db)
+{
+    public async Task<ContenidoDeResumen> LeerAsync(int idTurnoCaja, CancellationToken ct = default)
+    {
+        var comprobantesDelTurno = db.ComprobantesVenta
+            .Where(c => c.IdTurnoCaja == idTurnoCaja && c.Estado == EstadoComprobante.Emitido);
+
+        // 1. cantidad de tickets — solo comprobantes emitido (mismo filtro que la derivación:
+        // spec Anulados Are Excluded From The Derivation).
+        var cantidadTickets = await comprobantesDelTurno.CountAsync(ct);
+
+        // 2. primer ticket — orden por fecha, desempate estable por id.
+        var primerTicket = await comprobantesDelTurno
+            .OrderBy(c => c.Fecha).ThenBy(c => c.Id)
+            .Select(c => new TicketLimite(c.Numero, c.Fecha))
+            .FirstOrDefaultAsync(ct);
+
+        // 3. último ticket — ídem, orden inverso.
+        var ultimoTicket = await comprobantesDelTurno
+            .OrderByDescending(c => c.Fecha).ThenByDescending(c => c.Id)
+            .Select(c => new TicketLimite(c.Numero, c.Fecha))
+            .FirstOrDefaultAsync(ct);
+
+        // 4. ingresos por área — snapshot inmutable de ItemComprobanteVenta.IdArea (doc 10
+        // principio 6), nunca re-derivado de articulos.
+        var totalesPorArea = await db.ItemsComprobanteVenta
+            .Join(
+                db.ComprobantesVenta,
+                i => i.IdComprobanteVenta,
+                c => c.Id,
+                (i, c) => new { i.IdArea, i.Total, c.IdTurnoCaja, c.Estado })
+            .Where(x => x.IdTurnoCaja == idTurnoCaja && x.Estado == EstadoComprobante.Emitido)
+            .GroupBy(x => x.IdArea)
+            .Select(g => new { IdArea = g.Key, Total = g.Sum(x => x.Total) })
+            .ToDictionaryAsync(x => x.IdArea, x => x.Total, ct);
+
+        // 5. catálogo completo de áreas — universo fijo (chico, propio del tenant), mismo
+        // criterio que el catálogo de medios del lector hermano (paso 7 de LectorDeMovimientosDelTurno).
+        var areas = await db.Areas
+            .Select(a => new { a.Id, a.Nombre })
+            .ToListAsync(ct);
+
+        var ingresosPorArea = totalesPorArea
+            .Select(kv => new IngresoPorArea(
+                kv.Key, areas.FirstOrDefault(a => a.Id == kv.Key)?.Nombre ?? $"Área #{kv.Key}", kv.Value))
+            .OrderBy(i => i.IdArea)
+            .ToList();
+
+        // 6. egresos por categoría — gastos del turno agrupados; los retiros NO son un gasto
+        // (spec: No Magic Tipo Encodes A Retiro As A Gasto) y llegan de afuera (insumos.Retiros,
+        // ya leído por LectorDeMovimientosDelTurno para la misma llamada — nunca se re-consulta).
+        var egresosPorCategoria = await db.Gastos
+            .Where(g => g.IdTurnoCaja == idTurnoCaja)
+            .GroupBy(g => g.Categoria)
+            .OrderBy(g => g.Key)
+            .Select(g => new EgresoPorCategoria(g.Key, g.Sum(x => x.Importe)))
+            .ToListAsync(ct);
+
+        return new ContenidoDeResumen(cantidadTickets, primerTicket, ultimoTicket, ingresosPorArea, egresosPorCategoria);
+    }
+}
+
+/// <summary>Salida de <see cref="LectorDeContenidoDeResumen"/> — todavía sin <c>Retiros</c>: ese
+/// dato ya lo trae <see cref="InsumosDeArqueo"/> (el mismo insumo que <see
+/// cref="CalculadorDeArqueo"/> usa), así que <see cref="ServicioDeResumenDeTurno"/> lo combina
+/// desde ahí en vez de volver a consultarlo.</summary>
+public sealed record ContenidoDeResumen(
+    int CantidadTickets,
+    TicketLimite? PrimerTicket,
+    TicketLimite? UltimoTicket,
+    IReadOnlyList<IngresoPorArea> IngresosPorArea,
+    IReadOnlyList<EgresoPorCategoria> EgresosPorCategoria);

--- a/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
+++ b/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
@@ -15,10 +15,11 @@ namespace Ways.Application.Caja;
 /// presupuesto — este lector solo arma contenido de lectura adicional, nunca toca esa fórmula
 /// ni su set de insumos.
 ///
-/// 6 consultas agrupadas de cantidad FIJA (nunca una por fila, mismo criterio que el lector
+/// 7 consultas agrupadas de cantidad FIJA (nunca una por fila, mismo criterio que el lector
 /// hermano): cantidad de tickets, primer ticket, último ticket, ingresos por área, catálogo de
-/// áreas y egresos por categoría — el turno-con-más-tickets test (task 4.14 original) sigue
-/// pasando porque cada una de estas consultas es una agregación, no una lectura por ticket.
+/// áreas, egresos por categoría y egresos por área — el turno-con-más-tickets test (task 4.14
+/// original) sigue pasando porque cada una de estas consultas es una agregación, no una lectura
+/// por ticket.
 /// </summary>
 public class LectorDeContenidoDeResumen(IWaysDbContext db)
 {
@@ -78,7 +79,28 @@ public class LectorDeContenidoDeResumen(IWaysDbContext db)
             .Select(g => new EgresoPorCategoria(g.Key, g.Sum(x => x.Importe)))
             .ToListAsync(ct);
 
-        return new ContenidoDeResumen(cantidadTickets, primerTicket, ultimoTicket, ingresosPorArea, egresosPorCategoria);
+        // 7. egresos por área — mismo criterio que ingresos por área (catálogo ya cargado en el
+        // paso 5), pero Gasto.IdArea es NULLABLE (a diferencia del snapshot inmutable del ítem de
+        // venta): los gastos sin área declarada se agrupan bajo un bucket "Sin área" con IdArea
+        // null, en vez de descartarlos.
+        var totalesEgresoPorArea = await db.Gastos
+            .Where(g => g.IdTurnoCaja == idTurnoCaja)
+            .GroupBy(g => g.IdArea)
+            .Select(g => new { IdArea = g.Key, Total = g.Sum(x => x.Importe) })
+            .ToListAsync(ct);
+
+        var egresosPorArea = totalesEgresoPorArea
+            .Select(x => new EgresoPorArea(
+                x.IdArea,
+                x.IdArea.HasValue
+                    ? areas.FirstOrDefault(a => a.Id == x.IdArea)?.Nombre ?? $"Área #{x.IdArea}"
+                    : "Sin área",
+                x.Total))
+            .OrderBy(e => e.IdArea)
+            .ToList();
+
+        return new ContenidoDeResumen(
+            cantidadTickets, primerTicket, ultimoTicket, ingresosPorArea, egresosPorCategoria, egresosPorArea);
     }
 }
 
@@ -91,4 +113,5 @@ public sealed record ContenidoDeResumen(
     TicketLimite? PrimerTicket,
     TicketLimite? UltimoTicket,
     IReadOnlyList<IngresoPorArea> IngresosPorArea,
-    IReadOnlyList<EgresoPorCategoria> EgresosPorCategoria);
+    IReadOnlyList<EgresoPorCategoria> EgresosPorCategoria,
+    IReadOnlyList<EgresoPorArea> EgresosPorArea);

--- a/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
+++ b/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
@@ -33,7 +33,7 @@ public class ServicioDeResumenDeTurno(
             idTurnoCaja, idAncla,
             lineas.Select(l => new LineaDeResumen(l.IdMedioPago, l.ImporteEsperado)).ToList(),
             contenido.CantidadTickets, contenido.PrimerTicket, contenido.UltimoTicket, contenido.IngresosPorArea,
-            new EgresosDeTurno(contenido.EgresosPorCategoria, insumos.Retiros));
+            new EgresosDeTurno(contenido.EgresosPorCategoria, contenido.EgresosPorArea, insumos.Retiros));
     }
 
     private async Task ExigirTurnoExisteAsync(int idTurnoCaja, CancellationToken ct)

--- a/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
+++ b/src/Ways.Application/Caja/ServicioDeResumenDeTurno.cs
@@ -11,9 +11,13 @@ namespace Ways.Application.Caja;
 /// <see cref="LectorDeMovimientosDelTurno"/> + <see cref="CalculadorDeArqueo"/> que
 /// <c>ServicioDeTurnos.CerrarAsync</c>, de solo lectura, sin ninguna escritura: es la única
 /// garantía estructural de que el número que el cajero ve a mitad de turno es el que el cierre va
-/// a comparar (task 4.13, "byte-identical").
+/// a comparar (task 4.13, "byte-identical"). El contenido D6 (tickets, áreas, egresos) lo trae
+/// <see cref="LectorDeContenidoDeResumen"/>, un lector HERMANO deliberadamente separado (follow-up
+/// "Resumen parcial D6-content enrichment") — nunca toca <see cref="InsumosDeArqueo"/> ni
+/// <see cref="CalculadorDeArqueo"/>, así que la derivación del arqueo queda intacta.
 /// </summary>
-public class ServicioDeResumenDeTurno(IWaysDbContext db, LectorDeMovimientosDelTurno lector)
+public class ServicioDeResumenDeTurno(
+    IWaysDbContext db, LectorDeMovimientosDelTurno lector, LectorDeContenidoDeResumen lectorDeContenido)
 {
     public async Task<ResumenDeTurno> ObtenerAsync(int idTurnoCaja, CancellationToken ct = default)
     {
@@ -23,9 +27,13 @@ public class ServicioDeResumenDeTurno(IWaysDbContext db, LectorDeMovimientosDelT
         var idAncla = ResolvedorDeMedioDeCajaFisica.Resolver(insumos.Actividad);
         var lineas = CalculadorDeArqueo.Calcular(insumos, idAncla);
 
+        var contenido = await lectorDeContenido.LeerAsync(idTurnoCaja, ct);
+
         return new ResumenDeTurno(
             idTurnoCaja, idAncla,
-            lineas.Select(l => new LineaDeResumen(l.IdMedioPago, l.ImporteEsperado)).ToList());
+            lineas.Select(l => new LineaDeResumen(l.IdMedioPago, l.ImporteEsperado)).ToList(),
+            contenido.CantidadTickets, contenido.PrimerTicket, contenido.UltimoTicket, contenido.IngresosPorArea,
+            new EgresosDeTurno(contenido.EgresosPorCategoria, insumos.Retiros));
     }
 
     private async Task ExigirTurnoExisteAsync(int idTurnoCaja, CancellationToken ct)

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -50,8 +50,10 @@ public static class DependencyInjection
 
         // stage-6-turnos-caja, Slice 4: LectorDeMovimientosDelTurno es el único lector de la
         // derivación (design decisión 5), compartido por ServicioDeTurnos.CerrarAsync y
-        // ServicioDeResumenDeTurno.
+        // ServicioDeResumenDeTurno. LectorDeContenidoDeResumen (follow-up D6-content
+        // enrichment) es un lector HERMANO, solo consumido por ServicioDeResumenDeTurno.
         services.AddScoped<LectorDeMovimientosDelTurno>();
+        services.AddScoped<LectorDeContenidoDeResumen>();
         services.AddScoped<ServicioDeTurnos>();
         services.AddScoped<ServicioDeResumenDeTurno>();
         services.AddScoped<ServicioDeGastos>();

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -625,11 +625,49 @@ export type MovimientoRegistrado = {
 
 export type LineaDeResumen = { idMedioPago: number; importeEsperado: number }
 
-/** Respuesta de `GET /api/caja/turnos/{id}/resumen` (espejo de `ResumenDeTurno`, Slice 4) — el
- * `importeEsperado` derivado por medio y el medio ancla (efectivo), la misma derivación que el
- * cierre va a persistir. Sin desglose de tickets ni de gastos por categoría: la derivación real
- * (`ServicioDeResumenDeTurno`) no expone ese detalle, solo el total esperado por medio. */
-export type ResumenDeTurno = { idTurnoCaja: number; idMedioAncla: number; medios: LineaDeResumen[] }
+/** Un ticket límite del turno (legacy doc 01 D6: "primer y último ticket") — espejo de
+ * `Ways.Application.Caja.TicketLimite`. */
+export type TicketLimite = { numero: number; fecha: string }
+
+/** Ingresos de un área dentro del turno (legacy D6, primer bloque: "por área") — espejo de
+ * `IngresoPorArea`. */
+export type IngresoPorArea = { idArea: number; nombreArea: string; total: number }
+
+export type CategoriaGasto = 'Proveedor' | 'Sueldos' | 'Viaticos' | 'Impuestos' | 'Servicios' | 'Otros'
+
+export const CATEGORIAS_GASTO: { valor: CategoriaGasto; etiqueta: string }[] = [
+  { valor: 'Proveedor', etiqueta: 'Proveedores' },
+  { valor: 'Sueldos', etiqueta: 'Sueldos' },
+  { valor: 'Viaticos', etiqueta: 'Viáticos' },
+  { valor: 'Impuestos', etiqueta: 'Impuestos' },
+  { valor: 'Servicios', etiqueta: 'Servicios' },
+  { valor: 'Otros', etiqueta: 'Otros' },
+]
+
+/** Egresos de una categoría de gasto dentro del turno (legacy D6, segundo bloque: "por tipo") —
+ * espejo de `EgresoPorCategoria`. */
+export type EgresoPorCategoria = { categoria: CategoriaGasto; total: number }
+
+/** Egresos del turno — gastos por categoría más el total de retiros físicos; nunca incluye
+ * refuerzos ni la apertura de cajón, que no son egresos — espejo de `EgresosDeTurno`. */
+export type EgresosDeTurno = { porCategoria: EgresoPorCategoria[]; retiros: number }
+
+/** Respuesta de `GET /api/caja/turnos/{id}/resumen` (espejo de `ResumenDeTurno`, Slice 4 +
+ * follow-up "Resumen parcial D6-content enrichment") — `medios` es el `importeEsperado`
+ * derivado por medio y el medio ancla (efectivo), la misma derivación que el cierre va a
+ * persistir (invariante intacto). `cantidadTickets`/`primerTicket`/`ultimoTicket`/
+ * `ingresosPorArea`/`egresos` son contenido de reporte aditivo (legacy D6 parity) — nunca
+ * alimentan la derivación del arqueo. */
+export type ResumenDeTurno = {
+  idTurnoCaja: number
+  idMedioAncla: number
+  medios: LineaDeResumen[]
+  cantidadTickets: number
+  primerTicket: TicketLimite | null
+  ultimoTicket: TicketLimite | null
+  ingresosPorArea: IngresoPorArea[]
+  egresos: EgresosDeTurno
+}
 
 // --- Caja: cierre y comprobante Z (stage-6-turnos-caja, Slice 7) ---
 // Espejo de `Ways.Application.Caja.Contratos` (Slice 4/7) — el cierre y el detalle con arqueos.

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -648,9 +648,13 @@ export const CATEGORIAS_GASTO: { valor: CategoriaGasto; etiqueta: string }[] = [
  * espejo de `EgresoPorCategoria`. */
 export type EgresoPorCategoria = { categoria: CategoriaGasto; total: number }
 
-/** Egresos del turno — gastos por categoría más el total de retiros físicos; nunca incluye
- * refuerzos ni la apertura de cajón, que no son egresos — espejo de `EgresosDeTurno`. */
-export type EgresosDeTurno = { porCategoria: EgresoPorCategoria[]; retiros: number }
+/** Egresos de un área dentro del turno (legacy D6, segundo bloque: "por área") — `idArea` es
+ * `null` para el bucket "Sin área" (gastos sin área declarada) — espejo de `EgresoPorArea`. */
+export type EgresoPorArea = { idArea: number | null; nombreArea: string; total: number }
+
+/** Egresos del turno — gastos por categoría y por área más el total de retiros físicos; nunca
+ * incluye refuerzos ni la apertura de cajón, que no son egresos — espejo de `EgresosDeTurno`. */
+export type EgresosDeTurno = { porCategoria: EgresoPorCategoria[]; porArea: EgresoPorArea[]; retiros: number }
 
 /** Respuesta de `GET /api/caja/turnos/{id}/resumen` (espejo de `ResumenDeTurno`, Slice 4 +
  * follow-up "Resumen parcial D6-content enrichment") — `medios` es el `importeEsperado`

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -78,6 +78,11 @@ function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTu
     idTurnoCaja: 501,
     idMedioAncla: 1,
     medios: [{ idMedioPago: 1, importeEsperado: 640 }],
+    cantidadTickets: 0,
+    primerTicket: null,
+    ultimoTicket: null,
+    ingresosPorArea: [],
+    egresos: { porCategoria: [], retiros: 0 },
     ...sobrescribir,
   }
 }
@@ -248,7 +253,10 @@ describe('Caja — movimientos', () => {
 
     render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
-    expect(screen.getByText('Calculando…')).toBeInTheDocument()
+    // El badge se monta en el mismo commit que dispara el efecto de carga del resumen, pero ese
+    // efecto todavía no corrió bajo carga de la suite completa (mismo flake que PR #59 fijó más
+    // abajo en este archivo) — hay que esperar a "Calculando…", no asumir que ya está.
+    await screen.findByText('Calculando…')
 
     await userEvent.type(screen.getByLabelText('Importe'), '100')
     await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
@@ -528,5 +536,65 @@ describe('Caja — navegación a cierre (Slice 7)', () => {
     await screen.findByText('Turno abierto')
 
     expect(screen.getByRole('link', { name: 'Cerrar turno' })).toHaveAttribute('href', '/caja/cierre?idTurno=501')
+  })
+})
+
+describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment")', () => {
+  it('muestra cantidad de tickets, primer/último ticket, ingresos por área y egresos por categoría + retiros', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') {
+        return Promise.resolve<ResumenDeTurno>(
+          resumenFixture({
+            cantidadTickets: 3,
+            primerTicket: { numero: 1001, fecha: '2026-08-04T12:00:00Z' },
+            ultimoTicket: { numero: 1003, fecha: '2026-08-04T14:00:00Z' },
+            ingresosPorArea: [
+              { idArea: 1, nombreArea: 'Almacén', total: 150 },
+              { idArea: 2, nombreArea: 'Verdulería', total: 200 },
+            ],
+            egresos: { porCategoria: [{ categoria: 'Proveedor', total: 30 }], retiros: 40 },
+          }),
+        )
+      }
+      return undefined
+    })
+
+    render(<Caja />, { wrapper: MemoryRouter })
+    await screen.findByText('Turno abierto')
+    await waitFor(() => expect(screen.getByText('Tickets')).toBeInTheDocument())
+
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('#1001 · ' + new Date('2026-08-04T12:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
+    expect(screen.getByText('#1003 · ' + new Date('2026-08-04T14:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
+
+    expect(screen.getByText('Almacén')).toBeInTheDocument()
+    expect(screen.getByText('$150,00')).toBeInTheDocument()
+    expect(screen.getByText('Verdulería')).toBeInTheDocument()
+    expect(screen.getByText('$200,00')).toBeInTheDocument()
+
+    expect(screen.getByText('Proveedores')).toBeInTheDocument()
+    expect(screen.getByText('$30,00')).toBeInTheDocument()
+    expect(screen.getByText('Retiros')).toBeInTheDocument()
+    expect(screen.getByText('$40,00')).toBeInTheDocument()
+  })
+
+  it('un turno sin actividad muestra ceros, guiones y los avisos de "todavía no hay" en las tres secciones', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
+      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
+      return undefined
+    })
+
+    render(<Caja />, { wrapper: MemoryRouter })
+    await screen.findByText('Turno abierto')
+    await waitFor(() => expect(screen.getByText('Tickets')).toBeInTheDocument())
+
+    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(screen.getAllByText('—')).toHaveLength(2) // primer y último ticket, ambos null
+    expect(screen.getByText('Todavía no hay ingresos en este turno.')).toBeInTheDocument()
+    expect(screen.getByText('Todavía no hay egresos en este turno.')).toBeInTheDocument()
+    // sin actividad, no debería renderizarse una fila de "Retiros" suelta.
+    expect(screen.queryByText('Retiros')).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -82,7 +82,7 @@ function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTu
     primerTicket: null,
     ultimoTicket: null,
     ingresosPorArea: [],
-    egresos: { porCategoria: [], retiros: 0 },
+    egresos: { porCategoria: [], porArea: [], retiros: 0 },
     ...sobrescribir,
   }
 }
@@ -553,7 +553,14 @@ describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment"
               { idArea: 1, nombreArea: 'Almacén', total: 150 },
               { idArea: 2, nombreArea: 'Verdulería', total: 200 },
             ],
-            egresos: { porCategoria: [{ categoria: 'Proveedor', total: 30 }], retiros: 40 },
+            egresos: {
+              porCategoria: [{ categoria: 'Proveedor', total: 30 }],
+              porArea: [
+                { idArea: 3, nombreArea: 'Cigarrillos', total: 25 },
+                { idArea: null, nombreArea: 'Sin área', total: 15 },
+              ],
+              retiros: 40,
+            },
           }),
         )
       }
@@ -577,9 +584,16 @@ describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment"
     expect(screen.getByText('$30,00')).toBeInTheDocument()
     expect(screen.getByText('Retiros')).toBeInTheDocument()
     expect(screen.getByText('$40,00')).toBeInTheDocument()
+
+    // egresos por área — bloque nuevo, incluye el bucket "Sin área".
+    expect(screen.getByText('Por área')).toBeInTheDocument()
+    expect(screen.getByText('Cigarrillos')).toBeInTheDocument()
+    expect(screen.getByText('$25,00')).toBeInTheDocument()
+    expect(screen.getByText('Sin área')).toBeInTheDocument()
+    expect(screen.getByText('$15,00')).toBeInTheDocument()
   })
 
-  it('un turno sin actividad muestra ceros, guiones y los avisos de "todavía no hay" en las tres secciones', async () => {
+  it('un turno sin actividad muestra ceros, guiones y los avisos de "todavía no hay" en las cuatro secciones', async () => {
     mockearRutasBase((ruta) => {
       if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
       if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
@@ -593,7 +607,8 @@ describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment"
     expect(screen.getByText('0')).toBeInTheDocument()
     expect(screen.getAllByText('—')).toHaveLength(2) // primer y último ticket, ambos null
     expect(screen.getByText('Todavía no hay ingresos en este turno.')).toBeInTheDocument()
-    expect(screen.getByText('Todavía no hay egresos en este turno.')).toBeInTheDocument()
+    // "todavía no hay egresos" aparece una vez por tabla (por categoría y por área).
+    expect(screen.getAllByText('Todavía no hay egresos en este turno.')).toHaveLength(2)
     // sin actividad, no debería renderizarse una fila de "Retiros" suelta.
     expect(screen.queryByText('Retiros')).not.toBeInTheDocument()
   })

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -420,7 +420,7 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
       </div>
 
       {/* follow-up "Resumen parcial D6-content enrichment" (legacy doc 01 D6 "Ver Parcial"):
-          tickets, ingresos por área y egresos por categoría + retiros — contenido de reporte
+          tickets, ingresos por área y egresos por categoría/área + retiros — contenido de reporte
           aditivo, nunca alimenta la derivación del arqueo de arriba. */}
       {!cargandoResumen && resumen && (
         <div className="row g-3 mt-1">
@@ -473,37 +473,71 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
 
           <div className="col-lg-4">
             <h6>Egresos</h6>
-            <div className="table-responsive">
-              <table className="table table-sm table-striped table-bordered align-middle">
-                <thead>
-                  <tr>
-                    <th>Categoría</th>
-                    <th className="text-end">Total</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {resumen.egresos.porCategoria.length === 0 && resumen.egresos.retiros === 0 ? (
-                    <tr>
-                      <td colSpan={2} className="text-center text-muted">
-                        Todavía no hay egresos en este turno.
-                      </td>
-                    </tr>
-                  ) : (
-                    <>
-                      {resumen.egresos.porCategoria.map((e) => (
-                        <tr key={e.categoria}>
-                          <td>{etiquetaCategoriaGasto(e.categoria)}</td>
-                          <td className="text-end">{formatearMoneda(e.total)}</td>
+            <div className="row g-2">
+              <div className="col-6">
+                <div className="small text-muted mb-1">Por categoría</div>
+                <div className="table-responsive">
+                  <table className="table table-sm table-striped table-bordered align-middle">
+                    <thead>
+                      <tr>
+                        <th>Categoría</th>
+                        <th className="text-end">Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {resumen.egresos.porCategoria.length === 0 && resumen.egresos.retiros === 0 ? (
+                        <tr>
+                          <td colSpan={2} className="text-center text-muted">
+                            Todavía no hay egresos en este turno.
+                          </td>
+                        </tr>
+                      ) : (
+                        <>
+                          {resumen.egresos.porCategoria.map((e) => (
+                            <tr key={e.categoria}>
+                              <td>{etiquetaCategoriaGasto(e.categoria)}</td>
+                              <td className="text-end">{formatearMoneda(e.total)}</td>
+                            </tr>
+                          ))}
+                          <tr>
+                            <td>Retiros</td>
+                            <td className="text-end">{formatearMoneda(resumen.egresos.retiros)}</td>
+                          </tr>
+                        </>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="col-6">
+                <div className="small text-muted mb-1">Por área</div>
+                <div className="table-responsive">
+                  <table className="table table-sm table-striped table-bordered align-middle">
+                    <thead>
+                      <tr>
+                        <th>Área</th>
+                        <th className="text-end">Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {resumen.egresos.porArea.map((a) => (
+                        <tr key={a.idArea ?? 'sin-area'}>
+                          <td>{a.nombreArea}</td>
+                          <td className="text-end">{formatearMoneda(a.total)}</td>
                         </tr>
                       ))}
-                      <tr>
-                        <td>Retiros</td>
-                        <td className="text-end">{formatearMoneda(resumen.egresos.retiros)}</td>
-                      </tr>
-                    </>
-                  )}
-                </tbody>
-              </table>
+                      {resumen.egresos.porArea.length === 0 && (
+                        <tr>
+                          <td colSpan={2} className="text-center text-muted">
+                            Todavía no hay egresos en este turno.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -517,7 +551,7 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
  * punto de venta seleccionado, apertura cuando no hay uno abierto, movimientos físicos fuera de
  * la venta y el resumen parcial en vivo — misma derivación que el cierre (Slice 7). Precedente de
  * forma: `Pos.tsx`. El resumen (`ServicioDeResumenDeTurno`) también expone el contenido D6
- * (cantidad de tickets, primer/último ticket, ingresos por área y egresos por categoría +
+ * (cantidad de tickets, primer/último ticket, ingresos por área y egresos por categoría/área +
  * retiros; follow-up "Resumen parcial D6-content enrichment") — ver el doc-comment de
  * `ResumenDeTurno` en `api/tipos.ts`.
  */

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -5,7 +5,9 @@ import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import {
+  CATEGORIAS_GASTO,
   TIPOS_MOVIMIENTO_CAJA,
+  type CategoriaGasto,
   type MedioPagoAlta,
   type MedioPagoListado,
   type PuntoVentaListado,
@@ -44,6 +46,10 @@ function formatearMoneda(valor: number): string {
 
 function formatearFechaHora(iso: string): string {
   return new Date(iso).toLocaleString('es-AR')
+}
+
+function etiquetaCategoriaGasto(categoria: CategoriaGasto): string {
+  return CATEGORIAS_GASTO.find((c) => c.valor === categoria)?.etiqueta ?? categoria
 }
 
 type PropsFormularioApertura = {
@@ -412,6 +418,96 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
           )}
         </div>
       </div>
+
+      {/* follow-up "Resumen parcial D6-content enrichment" (legacy doc 01 D6 "Ver Parcial"):
+          tickets, ingresos por área y egresos por categoría + retiros — contenido de reporte
+          aditivo, nunca alimenta la derivación del arqueo de arriba. */}
+      {!cargandoResumen && resumen && (
+        <div className="row g-3 mt-1">
+          <div className="col-lg-4">
+            <h6>Tickets</h6>
+            <div className="small text-muted">Cantidad</div>
+            <div className="mb-2">{resumen.cantidadTickets}</div>
+            <div className="small text-muted">Primer ticket</div>
+            <div className="mb-2">
+              {resumen.primerTicket
+                ? `#${resumen.primerTicket.numero} · ${formatearFechaHora(resumen.primerTicket.fecha)}`
+                : '—'}
+            </div>
+            <div className="small text-muted">Último ticket</div>
+            <div>
+              {resumen.ultimoTicket
+                ? `#${resumen.ultimoTicket.numero} · ${formatearFechaHora(resumen.ultimoTicket.fecha)}`
+                : '—'}
+            </div>
+          </div>
+
+          <div className="col-lg-4">
+            <h6>Ingresos por área</h6>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Área</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resumen.ingresosPorArea.map((a) => (
+                    <tr key={a.idArea}>
+                      <td>{a.nombreArea}</td>
+                      <td className="text-end">{formatearMoneda(a.total)}</td>
+                    </tr>
+                  ))}
+                  {resumen.ingresosPorArea.length === 0 && (
+                    <tr>
+                      <td colSpan={2} className="text-center text-muted">
+                        Todavía no hay ingresos en este turno.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="col-lg-4">
+            <h6>Egresos</h6>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Categoría</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resumen.egresos.porCategoria.length === 0 && resumen.egresos.retiros === 0 ? (
+                    <tr>
+                      <td colSpan={2} className="text-center text-muted">
+                        Todavía no hay egresos en este turno.
+                      </td>
+                    </tr>
+                  ) : (
+                    <>
+                      {resumen.egresos.porCategoria.map((e) => (
+                        <tr key={e.categoria}>
+                          <td>{etiquetaCategoriaGasto(e.categoria)}</td>
+                          <td className="text-end">{formatearMoneda(e.total)}</td>
+                        </tr>
+                      ))}
+                      <tr>
+                        <td>Retiros</td>
+                        <td className="text-end">{formatearMoneda(resumen.egresos.retiros)}</td>
+                      </tr>
+                    </>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -420,10 +516,10 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
  * Pantalla de caja (stage-6-turnos-caja, Slice 6, design: Web Composition): estado del turno del
  * punto de venta seleccionado, apertura cuando no hay uno abierto, movimientos físicos fuera de
  * la venta y el resumen parcial en vivo — misma derivación que el cierre (Slice 7). Precedente de
- * forma: `Pos.tsx`. El resumen que devuelve `GET …/resumen` (`ServicioDeResumenDeTurno`) expone
- * solo el esperado derivado por medio — no hay desglose de tickets ni de gastos por categoría en
- * el contrato real, así que esta pantalla no los muestra (ver el doc-comment de `ResumenDeTurno`
- * en `api/tipos.ts`).
+ * forma: `Pos.tsx`. El resumen (`ServicioDeResumenDeTurno`) también expone el contenido D6
+ * (cantidad de tickets, primer/último ticket, ingresos por área y egresos por categoría +
+ * retiros; follow-up "Resumen parcial D6-content enrichment") — ver el doc-comment de
+ * `ResumenDeTurno` en `api/tipos.ts`.
  */
 export function Caja() {
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)

--- a/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
@@ -51,7 +51,7 @@ function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTu
     primerTicket: null,
     ultimoTicket: null,
     ingresosPorArea: [],
-    egresos: { porCategoria: [], retiros: 0 },
+    egresos: { porCategoria: [], porArea: [], retiros: 0 },
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.test.tsx
@@ -47,6 +47,11 @@ function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTu
     idTurnoCaja: 501,
     idMedioAncla: 1,
     medios: [{ idMedioPago: 1, importeEsperado: 640 }],
+    cantidadTickets: 0,
+    primerTicket: null,
+    ultimoTicket: null,
+    ingresosPorArea: [],
+    egresos: { porCategoria: [], retiros: 0 },
     ...sobrescribir,
   }
 }

--- a/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
+++ b/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
@@ -21,7 +21,7 @@ namespace Ways.IntegrationTests;
 /// Follow-up de stage-6-turnos-caja, "Resumen parcial D6-content enrichment" (archive-report.md,
 /// Deferred/Follow-Ups (a); design.md Data Flow: "GET …/resumen (D6: áreas, medios, tickets,
 /// egresos)"; docs/01 D6 "Ver Parcial") — <see cref="LectorDeContenidoDeResumen"/>: cantidad de
-/// tickets, primer/último ticket, ingresos por área y egresos por categoría + retiros.
+/// tickets, primer/último ticket, ingresos por área y egresos por categoría/área + retiros.
 ///
 /// Deliberadamente en un archivo SEPARADO de <see cref="CajaCierreEndpointsTests"/>: ese archivo
 /// prueba la derivación del arqueo (<c>Medios</c>) — invariante intacto, no tocado acá. Este
@@ -164,7 +164,9 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
             IdTenant = ctx.IdTenant,
             IdComprobanteVenta = comprobante.Id,
             IdMedioPago = idMedioPago,
-            Importe = importe,
+            // el pago nunca es negativo, incluso para una NCX con Total negativo (mismo criterio
+            // que ck_pagos_comprobante_importe_no_negativo).
+            Importe = Math.Abs(importe),
             Vuelto = 0m,
             CreatedAt = ahora,
             UpdatedAt = ahora
@@ -181,11 +183,12 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
     }
 
-    private static async Task RegistrarGastoAsync(Contexto ctx, CategoriaGasto categoria, int idMedioPago, decimal importe)
+    private static async Task RegistrarGastoAsync(
+        Contexto ctx, CategoriaGasto categoria, int idMedioPago, decimal importe, int? idArea = null)
     {
         var respuesta = await ctx.Admin.PostAsJsonAsync(
             "/api/gastos",
-            new SolicitudDeGasto(ctx.IdPuntoVenta, categoria, null, null, "Gasto de prueba", null, idMedioPago, null, importe));
+            new SolicitudDeGasto(ctx.IdPuntoVenta, categoria, null, idArea, "Gasto de prueba", null, idMedioPago, null, importe));
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
     }
@@ -208,8 +211,10 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         await SembrarVentaAsync(
             ctx, turno.Id, idAreaAlmacen, ctx.IdMedioEfectivo, 999m, baseFecha.AddMinutes(3), EstadoComprobante.Anulado);
 
-        await RegistrarGastoAsync(ctx, CategoriaGasto.Proveedor, ctx.IdMedioEfectivo, 30m);
-        await RegistrarGastoAsync(ctx, CategoriaGasto.Sueldos, ctx.IdMedioEfectivo, 70m);
+        await RegistrarGastoAsync(ctx, CategoriaGasto.Proveedor, ctx.IdMedioEfectivo, 30m, idAreaAlmacen);
+        await RegistrarGastoAsync(ctx, CategoriaGasto.Sueldos, ctx.IdMedioEfectivo, 70m, idAreaVerduleria);
+        // sin área declarada — cae en el bucket "Sin área", no se descarta.
+        await RegistrarGastoAsync(ctx, CategoriaGasto.Otros, ctx.IdMedioEfectivo, 15m, idArea: null);
         await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Retiro, 40m, "retiro de prueba");
         // el refuerzo NUNCA es un egreso — no debe aparecer en Egresos.
         await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Refuerzo, 10m, "refuerzo de prueba");
@@ -235,12 +240,25 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.Equal("Verdulería", verduleria.NombreArea);
         Assert.Equal(200m, verduleria.Total);
 
-        Assert.Equal(2, resumen.Egresos.PorCategoria.Count);
+        Assert.Equal(3, resumen.Egresos.PorCategoria.Count);
         var proveedor = resumen.Egresos.PorCategoria.Single(e => e.Categoria == CategoriaGasto.Proveedor);
         Assert.Equal(30m, proveedor.Total);
         var sueldos = resumen.Egresos.PorCategoria.Single(e => e.Categoria == CategoriaGasto.Sueldos);
         Assert.Equal(70m, sueldos.Total);
+        var otros = resumen.Egresos.PorCategoria.Single(e => e.Categoria == CategoriaGasto.Otros);
+        Assert.Equal(15m, otros.Total);
         Assert.Equal(40m, resumen.Egresos.Retiros);
+
+        Assert.Equal(3, resumen.Egresos.PorArea.Count);
+        var egresoAlmacen = resumen.Egresos.PorArea.Single(e => e.IdArea == idAreaAlmacen);
+        Assert.Equal("Almacén", egresoAlmacen.NombreArea);
+        Assert.Equal(30m, egresoAlmacen.Total);
+        var egresoVerduleria = resumen.Egresos.PorArea.Single(e => e.IdArea == idAreaVerduleria);
+        Assert.Equal("Verdulería", egresoVerduleria.NombreArea);
+        Assert.Equal(70m, egresoVerduleria.Total);
+        var egresoSinArea = resumen.Egresos.PorArea.Single(e => e.IdArea == null);
+        Assert.Equal("Sin área", egresoSinArea.NombreArea);
+        Assert.Equal(15m, egresoSinArea.Total);
     }
 
     [Fact]
@@ -257,6 +275,7 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.Null(resumen.UltimoTicket);
         Assert.Empty(resumen.IngresosPorArea);
         Assert.Empty(resumen.Egresos.PorCategoria);
+        Assert.Empty(resumen.Egresos.PorArea);
         Assert.Equal(0m, resumen.Egresos.Retiros);
     }
 
@@ -275,5 +294,27 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.Equal(1, resumen!.CantidadTickets);
         Assert.Equal(unico.Numero, resumen.PrimerTicket!.Numero);
         Assert.Equal(unico.Numero, resumen.UltimoTicket!.Numero);
+    }
+
+    /// <summary>Ingresos por área es un SUM de <c>ItemComprobanteVenta.Total</c> (signado): una
+    /// NCX (devolución) escribe una línea con <c>Total</c> negativo, así que el total del área
+    /// tiene que netear la TX y la NCX en la misma agrupación — no filtrar, no valor absoluto
+    /// (código correcto por inspección; este test lo fija).</summary>
+    [Fact]
+    public async Task LosIngresosPorAreaNeteanUnaTxConSuNcxDelMismoArea()
+    {
+        var ctx = await PrepararAsync(nameof(LosIngresosPorAreaNeteanUnaTxConSuNcxDelMismoArea));
+        var idArea = await SembrarAreaAsync(ctx, "Almacén");
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var baseFecha = DateTimeOffset.UtcNow;
+        await SembrarVentaAsync(ctx, turno.Id, idArea, ctx.IdMedioEfectivo, 100m, baseFecha);
+        await SembrarVentaAsync(ctx, turno.Id, idArea, ctx.IdMedioEfectivo, -30m, baseFecha.AddMinutes(1));
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        var almacen = resumen!.IngresosPorArea.Single(a => a.IdArea == idArea);
+        Assert.Equal(70m, almacen.Total); // 100 + (-30)
     }
 }

--- a/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
+++ b/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
@@ -1,0 +1,279 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Follow-up de stage-6-turnos-caja, "Resumen parcial D6-content enrichment" (archive-report.md,
+/// Deferred/Follow-Ups (a); design.md Data Flow: "GET …/resumen (D6: áreas, medios, tickets,
+/// egresos)"; docs/01 D6 "Ver Parcial") — <see cref="LectorDeContenidoDeResumen"/>: cantidad de
+/// tickets, primer/último ticket, ingresos por área y egresos por categoría + retiros.
+///
+/// Deliberadamente en un archivo SEPARADO de <see cref="CajaCierreEndpointsTests"/>: ese archivo
+/// prueba la derivación del arqueo (<c>Medios</c>) — invariante intacto, no tocado acá. Este
+/// archivo prueba SOLO el contenido nuevo, aditivo, de <see cref="ResumenDeTurno"/>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdCliente, int IdTipoComprobanteTx,
+        int IdMedioEfectivo, int IdMedioTarjeta, int IdListaPrecio, int IdAlicuotaIva, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+        var idMedioTarjeta = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Electronico)
+            .Select(m => m.Id).FirstAsync();
+        var idCliente = await db.Clientes.Select(c => c.Id).FirstAsync();
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista resumen-contenido", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, idCliente, idTipoComprobanteTx,
+            idMedioEfectivo, idMedioTarjeta, lista.Id, idAlicuotaIva, admin);
+    }
+
+    private async Task<int> SembrarAreaAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = ctx.IdTenant, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return area.Id;
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, fondoInicial, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private long _numeroSecuencial = 1;
+
+    /// <summary>Siembra directo un comprobante emitido (o anulado) con UN ítem (área) y UN pago —
+    /// mismo criterio que <c>VentasStockYCuentaCorrienteRlsTests</c>: la venta no pasa por el
+    /// checkout completo, que no es parte de esta prueba.</summary>
+    private async Task<(long Numero, DateTimeOffset Fecha)> SembrarVentaAsync(
+        Contexto ctx, int idTurno, int idArea, int idMedioPago, decimal importe, DateTimeOffset fecha,
+        EstadoComprobante estado = EstadoComprobante.Emitido)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var numero = Interlocked.Increment(ref _numeroSecuencial);
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = numero,
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = importe,
+            DescuentoTotal = 0m,
+            Total = importe,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.ItemsComprobanteVenta.Add(new ItemComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            Orden = 1,
+            Descripcion = "Ítem de prueba",
+            IdArea = idArea,
+            IdListaPrecio = ctx.IdListaPrecio,
+            IdAlicuotaIva = ctx.IdAlicuotaIva,
+            PorcentajeIva = 21m,
+            Cantidad = 1m,
+            PrecioUnitario = importe,
+            Descuento = 0m,
+            Total = importe,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            IdMedioPago = idMedioPago,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return (numero, fecha);
+    }
+
+    private static async Task RegistrarMovimientoAsync(Contexto ctx, int idTurno, TipoMovimientoCaja tipo, decimal importe, string motivo)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/caja/turnos/{idTurno}/movimientos", new SolicitudDeMovimiento(tipo, importe, motivo));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    private static async Task RegistrarGastoAsync(Contexto ctx, CategoriaGasto categoria, int idMedioPago, decimal importe)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(ctx.IdPuntoVenta, categoria, null, null, "Gasto de prueba", null, idMedioPago, null, importe));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    [Fact]
+    public async Task ElResumenExponeTicketsIngresosPorAreaYEgresosDeUnTurnoConActividad()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenExponeTicketsIngresosPorAreaYEgresosDeUnTurnoConActividad));
+        var idAreaAlmacen = await SembrarAreaAsync(ctx, "Almacén");
+        var idAreaVerduleria = await SembrarAreaAsync(ctx, "Verdulería");
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var baseFecha = DateTimeOffset.UtcNow;
+        var primero = await SembrarVentaAsync(ctx, turno.Id, idAreaAlmacen, ctx.IdMedioEfectivo, 100m, baseFecha);
+        await SembrarVentaAsync(ctx, turno.Id, idAreaVerduleria, ctx.IdMedioTarjeta, 200m, baseFecha.AddMinutes(1));
+        var ultimo = await SembrarVentaAsync(ctx, turno.Id, idAreaAlmacen, ctx.IdMedioEfectivo, 50m, baseFecha.AddMinutes(2));
+
+        // anulado: no debe aportar ni a la cantidad de tickets ni a los ingresos por área
+        // (mismo criterio que la derivación del arqueo, spec: Anulados Are Excluded).
+        await SembrarVentaAsync(
+            ctx, turno.Id, idAreaAlmacen, ctx.IdMedioEfectivo, 999m, baseFecha.AddMinutes(3), EstadoComprobante.Anulado);
+
+        await RegistrarGastoAsync(ctx, CategoriaGasto.Proveedor, ctx.IdMedioEfectivo, 30m);
+        await RegistrarGastoAsync(ctx, CategoriaGasto.Sueldos, ctx.IdMedioEfectivo, 70m);
+        await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Retiro, 40m, "retiro de prueba");
+        // el refuerzo NUNCA es un egreso — no debe aparecer en Egresos.
+        await RegistrarMovimientoAsync(ctx, turno.Id, TipoMovimientoCaja.Refuerzo, 10m, "refuerzo de prueba");
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        Assert.Equal(3, resumen!.CantidadTickets);
+        Assert.NotNull(resumen.PrimerTicket);
+        Assert.NotNull(resumen.UltimoTicket);
+        // Se compara por Numero (identidad exacta, sin ambigüedad de precisión) — Fecha viaja
+        // por Postgres (resolución de microsegundos) y no se compara byte a byte contra el
+        // DateTimeOffset en memoria sembrado, para no flakear por redondeo de precisión.
+        Assert.Equal(primero.Numero, resumen.PrimerTicket!.Numero);
+        Assert.Equal(ultimo.Numero, resumen.UltimoTicket!.Numero);
+        Assert.True(resumen.PrimerTicket.Fecha <= resumen.UltimoTicket.Fecha);
+
+        Assert.Equal(2, resumen.IngresosPorArea.Count);
+        var almacen = resumen.IngresosPorArea.Single(a => a.IdArea == idAreaAlmacen);
+        Assert.Equal("Almacén", almacen.NombreArea);
+        Assert.Equal(150m, almacen.Total); // 100 + 50 — el anulado (999) no suma.
+        var verduleria = resumen.IngresosPorArea.Single(a => a.IdArea == idAreaVerduleria);
+        Assert.Equal("Verdulería", verduleria.NombreArea);
+        Assert.Equal(200m, verduleria.Total);
+
+        Assert.Equal(2, resumen.Egresos.PorCategoria.Count);
+        var proveedor = resumen.Egresos.PorCategoria.Single(e => e.Categoria == CategoriaGasto.Proveedor);
+        Assert.Equal(30m, proveedor.Total);
+        var sueldos = resumen.Egresos.PorCategoria.Single(e => e.Categoria == CategoriaGasto.Sueldos);
+        Assert.Equal(70m, sueldos.Total);
+        Assert.Equal(40m, resumen.Egresos.Retiros);
+    }
+
+    [Fact]
+    public async Task ElResumenDeUnTurnoSinActividadExponeCerosYTicketsNulos()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenDeUnTurnoSinActividadExponeCerosYTicketsNulos));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        Assert.Equal(0, resumen!.CantidadTickets);
+        Assert.Null(resumen.PrimerTicket);
+        Assert.Null(resumen.UltimoTicket);
+        Assert.Empty(resumen.IngresosPorArea);
+        Assert.Empty(resumen.Egresos.PorCategoria);
+        Assert.Equal(0m, resumen.Egresos.Retiros);
+    }
+
+    [Fact]
+    public async Task UnTurnoConUnSoloTicketTieneElMismoTicketComoPrimeroYUltimo()
+    {
+        var ctx = await PrepararAsync(nameof(UnTurnoConUnSoloTicketTieneElMismoTicketComoPrimeroYUltimo));
+        var idArea = await SembrarAreaAsync(ctx, "Almacén");
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var unico = await SembrarVentaAsync(ctx, turno.Id, idArea, ctx.IdMedioEfectivo, 500m, DateTimeOffset.UtcNow);
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        Assert.Equal(1, resumen!.CantidadTickets);
+        Assert.Equal(unico.Numero, resumen.PrimerTicket!.Numero);
+        Assert.Equal(unico.Numero, resumen.UltimoTicket!.Numero);
+    }
+}


### PR DESCRIPTION
## Resumen

Follow-up diferido del archive de la etapa 6 (WARNING del verify): el resumen parcial completa la paridad con el "Ver Parcial" del legacy (doc 01 D6).

- Cantidad de tickets, primer/último ticket (por fecha con desempate por id, anulados excluidos).
- **Ingresos por área** (del snapshot `items.id_area`, suma con signo — las NCX netean, probado).
- **Egresos por área Y por categoría** + retiros (las dos dimensiones que exige el D6; bucket "Sin área" para gastos sin área).
- Reader hermano (`LectorDeContenidoDeResumen`, 7 queries fijas): la derivación per-medio del arqueo queda byte-intacta — identidad resumen/cierre y presupuesto de queries re-probados sin editar.
- D6 completo salvo "saldo" (depende de la etapa 7), declarado en el doc-comment.

## Verificación

- Suites: Domain 306, Application 209, Integration 485 (+4), vitest 221 (+2 extendidos), contra Postgres real; tsc/oxlint/vite build limpios; sin cambios de esquema.
- Judgment-day: ronda 1 — juez A MAJOR (faltaba la dimensión de egresos por área, con el dato ya disponible), juez B CLEAN con un MINOR (neteo NCX sin pin). Ambos corregidos: la dimensión se completó (no se documentó como omisión — el sentido del follow-up era cerrar D6) y el neteo quedó pinneado. Ronda 2 verificada por el orquestador (patrón espejo prescripto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)