### PR TITLE
feat(cc): marcador de reliquidacion y comprobante RC (etapa 7, slice 1)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -80,9 +80,9 @@ alicuotas_iva (               -- [global]
 tipos_comprobante (           -- [global]
     id_tipo_comprobante,
     clase           clase_comprobante,       -- enum: venta | compra
-    codigo          citext,                  -- FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE
+    codigo          citext,                  -- FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE, RC
     nombre,                                  -- "Factura A", "Nota de Crédito X", "Presupuesto"
-    letra           char(1) NULL,            -- A, B, C, X; NULL para presupuesto
+    letra           char(1) NULL,            -- A, B, C, X; NULL para presupuesto y RC
     signo           smallint,                -- +1 suma a la cuenta, −1 resta (NC = −1)
     discrimina_iva  boolean,                 -- A: neto + IVA por alícuota; B/C/X: total
     es_fiscal       boolean,                 -- ¿reporta a AFIP/ARCA cuando exista FE?
@@ -91,6 +91,13 @@ tipos_comprobante (           -- [global]
     activo
 )
 ```
+
+**`RC` (etapa 7 — pago a cuenta, doc 10 §8):** mismo perfil que `PRE` — `letra NULL`,
+`es_fiscal false`, `afecta_stock false`, `discrimina_iva false` —, pero `signo +1` porque el
+dinero entra (el signo negativo vive en el movimiento de cuenta corriente, nunca en el total
+del comprobante). Se siembra dos veces: en la lista de arriba para una base nueva y, de forma
+idempotente, dentro de la migración `CuentaCorrienteEtapa7` para una base ya migrada — este
+seed corre solo cuando la tabla está vacía.
 
 **Regla de la letra** (se implementa en dominio, no en tablas): la letra sale del cruce
 `condición fiscal de la empresa emisora × condición fiscal del cliente`. RI → RI emite A;

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -126,6 +126,13 @@ public class ManejadorDeErrores(
             // punto_venta/turno/empleado/proveedor/area/medio_pago) y también
             // fk_comprobantes_venta_turno — todas siguen la convención fk_* del resto del
             // esquema.
+            //
+            // stage-7-cuenta-corriente (Slice 1, task 1.8, design: Backstop Map): confirmado sin
+            // cambio de código — el mismo match por prefijo "fk_" ya cubre
+            // fk_movimientos_cuenta_corriente_actualizacion (el self-FK del marcador de
+            // reliquidación). En operación normal es inalcanzable — el id viene del RETURNING de
+            // la misma transacción que la fila que apunta —, así que el único camino para
+            // ejercitarla es un INSERT crudo fuera de banda (test de esquema, no de cliente HTTP).
             DbUpdateException { InnerException: PostgresException { SqlState: "23503", ConstraintName: string fk } }
                 when fk.StartsWith("fk_", StringComparison.Ordinal) =>
                 LogYClasificarReferenciaInvalida(fk, log),

--- a/src/Ways.Domain/CuentaCorriente/MovimientoCuentaCorriente.cs
+++ b/src/Ways.Domain/CuentaCorriente/MovimientoCuentaCorriente.cs
@@ -44,4 +44,13 @@ public class MovimientoCuentaCorriente
     public decimal SaldoResultante { get; set; }
 
     public string? Detalle { get; set; }
+
+    /// <summary>Marca este <c>Consumo</c> como cubierto por la reliquidación apuntada
+    /// (design decision 2 — self-FK a la fila <see cref="TipoMovimientoCc.ActualizacionPrecios"/>
+    /// que lo reliquidó, en vez de un booleano). <c>NULL</c> mientras el consumo sigue elegible
+    /// para la próxima corrida (design: Table Shapes A; la predicate de elegibilidad ES el
+    /// índice parcial <c>ix_movimientos_cuenta_corriente_consumos_pendientes</c>). Escrito
+    /// únicamente por el paso 8 de la transacción de reliquidación, en la misma transacción que
+    /// la fila que apunta.</summary>
+    public int? IdMovimientoActualizacion { get; set; }
 }

--- a/src/Ways.Domain/CuentaCorriente/TipoMovimientoCc.cs
+++ b/src/Ways.Domain/CuentaCorriente/TipoMovimientoCc.cs
@@ -2,11 +2,11 @@ namespace Ways.Domain.CuentaCorriente;
 
 /// <summary>
 /// Tipo de un <see cref="MovimientoCuentaCorriente"/> (doc 10 §8). Enum nativo de Postgres
-/// (<c>tipo_movimiento_cc</c>). Stage 5 solo abre camino de escritura para <see cref="Consumo"/>
+/// (<c>tipo_movimiento_cc</c>). Stage 5 abrió camino de escritura para <see cref="Consumo"/>
 /// (venta con cuenta corriente) y filas con forma de <see cref="Ajuste"/> usadas como
-/// contramovimiento de anulación (spec: consumo-cuenta-corriente / Movimiento Schema At Rest) —
-/// <see cref="Pago"/> y <see cref="ActualizacionPrecios"/> son valores reservados de stage 7
-/// (reliquidación F4, fuera de alcance).
+/// contramovimiento de anulación (spec: consumo-cuenta-corriente / Movimiento Schema At Rest).
+/// Stage 7 abre <see cref="Pago"/> (pago a cuenta, comprobante RC) y
+/// <see cref="ActualizacionPrecios"/> (reliquidación a precio del día).
 /// </summary>
 public enum TipoMovimientoCc
 {

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoCuentaCorrienteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoCuentaCorrienteConfiguration.cs
@@ -43,8 +43,18 @@ public class MovimientoCuentaCorrienteConfiguration : IEntityTypeConfiguration<M
         builder.Property(m => m.Importe).HasColumnName("importe").HasColumnType("numeric(14,2)").IsRequired();
         builder.Property(m => m.SaldoResultante).HasColumnName("saldo_resultante").HasColumnType("numeric(14,2)").IsRequired();
         builder.Property(m => m.Detalle).HasColumnName("detalle").HasColumnType("text");
+        builder.Property(m => m.IdMovimientoActualizacion).HasColumnName("id_movimiento_actualizacion");
+
+        builder.HasAlternateKey(m => new { m.Id, m.IdTenant })
+            .HasName("ak_movimientos_cuenta_corriente_id_movimiento_id_tenant");
 
         builder.HasIndex(m => m.IdTenant).HasDatabaseName("ix_movimientos_cuenta_corriente_tenant");
+
+        // La predicate de elegibilidad de la reliquidación ES este índice (design: Table Shapes A):
+        // self-vacuuming a medida que los consumos se reliquidan.
+        builder.HasIndex(m => new { m.IdCliente, m.IdTenant })
+            .HasDatabaseName("ix_movimientos_cuenta_corriente_consumos_pendientes")
+            .HasFilter("tipo = 'consumo' AND id_movimiento_actualizacion IS NULL");
 
         // Índice de negocio (extracto de cuenta corriente por cliente, spec: Saldo Is The
         // Maintained Cache Of The Ledger) que además sirve de soporte de la FK compuesta a
@@ -99,6 +109,26 @@ public class MovimientoCuentaCorrienteConfiguration : IEntityTypeConfiguration<M
             .HasForeignKey(m => new { m.IdPagoComprobante, m.IdTenant })
             .HasPrincipalKey(p => new { p.Id, p.IdTenant })
             .HasConstraintName("fk_movimientos_cuenta_corriente_pago_comprobante")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // DESVIACIÓN DOCUMENTADA vs. design (Table Shapes A, "no second index for the reverse
+        // audit lookup"): EF Core re-agrega un índice de soporte para toda FK sin cobertura en
+        // ModelFinalizingConvention, aun si se lo remueve a mano dentro de este Configure() —
+        // suprimirlo por completo exigiría desregistrar ForeignKeyIndexConvention para todo el
+        // modelo, un cambio global fuera de alcance de esta slice. Se declara explícito con el
+        // nombre de la convención del resto de la tabla en vez de dejar el nombre autogenerado
+        // de EF (IX_movimientos_cuenta_corriente_id_movimiento_actualizacion_id~).
+        builder.HasIndex(m => new { m.IdMovimientoActualizacion, m.IdTenant })
+            .HasDatabaseName("ix_movimientos_cuenta_corriente_actualizacion");
+
+        // Self-FK (design decision 2 — el marcador de reliquidación): apunta a la fila
+        // ActualizacionPrecios que cubrió este consumo. Requiere la AK compuesta declarada
+        // arriba, mismo criterio que el resto de las FKs de esta tabla.
+        builder.HasOne<MovimientoCuentaCorriente>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdMovimientoActualizacion, m.IdTenant })
+            .HasPrincipalKey(m => new { m.Id, m.IdTenant })
+            .HasConstraintName("fk_movimientos_cuenta_corriente_actualizacion")
             .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -53,11 +53,13 @@ public class InicializadorDeBaseDeDatos(
         ("No gravado", 0.00m)
     ];
 
-    /// <summary>Doc 10 §1: "FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE". Solo el lado
+    /// <summary>Doc 10 §1: "FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE, RC". Solo el lado
     /// venta — comprobantes de compra (proveedores) no son parte de esta etapa (doc 10,
     /// "Etapas sugeridas": clientes/proveedores desbloquean comprobantes recién en la etapa
     /// 2). <c>CodigoAfip</c> queda <c>NULL</c> por la misma razón que en las condiciones
-    /// fiscales.</summary>
+    /// fiscales. <c>RC</c> (etapa 7 — pago a cuenta) también se inserta de forma idempotente
+    /// en la migración <c>CuentaCorrienteEtapa7</c>, porque este seed solo corre en una base
+    /// vacía (design: Table Shapes B).</summary>
     private static readonly (string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock)[] TiposComprobanteBase =
     [
         ("FA", "Factura A", 'A', 1, true, true, true),
@@ -69,7 +71,8 @@ public class InicializadorDeBaseDeDatos(
         ("NDA", "Nota de Débito A", 'A', 1, true, true, true),
         ("TX", "Ticket X", 'X', 1, false, false, true),
         ("NCX", "Nota de Crédito X", 'X', -1, false, false, true),
-        ("PRE", "Presupuesto", null, 1, false, false, false)
+        ("PRE", "Presupuesto", null, 1, false, false, false),
+        ("RC", "Recibo de cobranza", null, 1, false, false, false)
     ];
 
     public async Task EjecutarAsync(SemillaRoot semilla, CancellationToken ct = default)

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260805050151_CuentaCorrienteEtapa7.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260805050151_CuentaCorrienteEtapa7.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -21,9 +22,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805050151_CuentaCorrienteEtapa7")]
+    partial class CuentaCorrienteEtapa7
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260805050151_CuentaCorrienteEtapa7.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260805050151_CuentaCorrienteEtapa7.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class CuentaCorrienteEtapa7 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "id_movimiento_actualizacion",
+                table: "movimientos_cuenta_corriente",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "ak_movimientos_cuenta_corriente_id_movimiento_id_tenant",
+                table: "movimientos_cuenta_corriente",
+                columns: new[] { "id_movimiento", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_cuenta_corriente_actualizacion",
+                table: "movimientos_cuenta_corriente",
+                columns: new[] { "id_movimiento_actualizacion", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_cuenta_corriente_consumos_pendientes",
+                table: "movimientos_cuenta_corriente",
+                columns: new[] { "id_cliente", "id_tenant" },
+                filter: "tipo = 'consumo' AND id_movimiento_actualizacion IS NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_movimientos_cuenta_corriente_actualizacion",
+                table: "movimientos_cuenta_corriente",
+                columns: new[] { "id_movimiento_actualizacion", "id_tenant" },
+                principalTable: "movimientos_cuenta_corriente",
+                principalColumns: new[] { "id_movimiento", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            // design: Table Shapes B — el tipo de comprobante RC (pago a cuenta) se siembra acá
+            // de forma idempotente porque InicializadorDeBaseDeDatos solo siembra
+            // tipos_comprobante cuando la tabla está vacía (InicializadorDeBaseDeDatos.cs:417):
+            // una base ya migrada (stage 6 en adelante) nunca recibiría la fila de otro modo.
+            //
+            // DESVIACIÓN DOCUMENTADA vs. task 1.3 (detectada corriendo la suite completa, no
+            // solo el test dedicado): el guard original era "WHERE NOT EXISTS (... codigo =
+            // 'RC')" sin más. Contra una base GENUINAMENTE vacía (el camino normal de
+            // Database.MigrateAsync() antes de que corra el seeder), ese INSERT deja UNA fila
+            // en tipos_comprobante durante la migración — y el chequeo de "tabla vacía" que
+            // hace el seeder (:417) pasa a ver la tabla como no-vacía, saltándose las otras
+            // diez filas de TiposComprobanteBase (FA…PRE) por completo. Se agrega "EXISTS
+            // (SELECT 1 FROM tipos_comprobante)" al guard: el INSERT de esta migración solo
+            // corre si la tabla YA tenía catálogo (el escenario real que existe para cubrir —
+            // una base migrada desde stage 6), nunca contra una base recién creada, que queda
+            // intacta para que el seeder la puebla completa y atómica (con RC ya incluido en
+            // TiposComprobanteBase).
+            migrationBuilder.Sql(
+                """
+                INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, created_at, updated_at)
+                SELECT 'venta', 'RC', 'Recibo de cobranza', NULL, 1, false, false, false, true, now(), now()
+                WHERE EXISTS (SELECT 1 FROM tipos_comprobante)
+                  AND NOT EXISTS (SELECT 1 FROM tipos_comprobante WHERE codigo = 'RC');
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // design: Migration/Rollout — desactiva en vez de borrar, para que un RC ya emitido
+            // (y su movimiento Pago) sigan siendo legibles después de un rollback.
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo = 'RC';");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_movimientos_cuenta_corriente_actualizacion",
+                table: "movimientos_cuenta_corriente");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "ak_movimientos_cuenta_corriente_id_movimiento_id_tenant",
+                table: "movimientos_cuenta_corriente");
+
+            migrationBuilder.DropIndex(
+                name: "ix_movimientos_cuenta_corriente_actualizacion",
+                table: "movimientos_cuenta_corriente");
+
+            migrationBuilder.DropIndex(
+                name: "ix_movimientos_cuenta_corriente_consumos_pendientes",
+                table: "movimientos_cuenta_corriente");
+
+            migrationBuilder.DropColumn(
+                name: "id_movimiento_actualizacion",
+                table: "movimientos_cuenta_corriente");
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -1,0 +1,231 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 1 (task 1.9/1.10, db-error-backstops, design: Backstop Map;
+/// Table Shapes B — "the key gate finding"): dos escenarios que el resto de la suite no cubre.
+///
+/// (1) <c>fk_movimientos_cuenta_corriente_actualizacion</c> — el self-FK del marcador de
+/// reliquidación es inalcanzable bajo operación normal (el id viene del <c>RETURNING</c> de la
+/// misma transacción que la fila que apunta, Slice 3); un INSERT crudo lo fuerza, mismo patrón
+/// que <c>TurnosCajaYGastosBackstopTests</c>.
+///
+/// (2) El INSERT idempotente de <c>RC</c> en la migración <c>CuentaCorrienteEtapa7</c> —
+/// <c>InicializadorDeBaseDeDatos.EjecutarAsync</c> solo siembra <c>tipos_comprobante</c> cuando
+/// la tabla está vacía (:417), así que una base real ya migrada a stage 6 NUNCA recibiría RC de
+/// otro modo. Se prueba armando una base de datos aislada dentro del mismo contenedor,
+/// migrada solo hasta <c>TurnosCajaYGastosEtapa6</c>, con un catálogo pre-existente (tabla NO
+/// vacía) — el escenario real que el gate exige probar, no asumir.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string MigracionStage6 = "20260804222255_TurnosCajaYGastosEtapa6";
+
+    private sealed record Prerequisitos(int IdTenant, int IdPuntoVenta, int IdEmpleado, int IdCliente);
+
+    private async Task<Prerequisitos> SembrarPrerequisitosAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        var listaPrecio = new ListaPrecio
+        {
+            IdTenant = tenant.Id, Nombre = nombre, EsDefault = true, Modo = ModoLista.Fija, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(listaPrecio);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = tenant.Id,
+            Numero = 2,
+            Nombre = nombre,
+            IdCondicionFiscal = condicionFiscal.Id,
+            IdListaPrecio = listaPrecio.Id,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return new Prerequisitos(tenant.Id, puntoVenta.Id, usuario.Id, cliente.Id);
+    }
+
+    // ---- fk_movimientos_cuenta_corriente_actualizacion (task 1.10) ---------------------------
+
+    [Fact]
+    public async Task UnMovimientoConIdMovimientoActualizacionInexistenteViolaLaFkDeActualizacion()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnMovimientoConIdMovimientoActualizacionInexistenteViolaLaFkDeActualizacion));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_cuenta_corriente (id_tenant, id_cliente, fecha, id_punto_venta, " +
+            "id_empleado, tipo, importe, saldo_resultante, id_movimiento_actualizacion) " +
+            "VALUES ($1, $2, now(), $3, $4, 'consumo', 10, 10, 999999)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_movimientos_cuenta_corriente_actualizacion", excepcion.ConstraintName);
+    }
+
+    // ---- RC idempotente en una base ya migrada desde stage 6 (task 1.9) ----------------------
+
+    [Fact]
+    public async Task RcResuelveEnUnaBaseYaMigradaDesdeStage6SinDuplicar()
+    {
+        var nombreBase = $"ways_stage6_{Guid.NewGuid():N}";
+        var cadenaAdmin = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = "postgres" }.ConnectionString;
+        var cadenaNueva = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = nombreBase }.ConnectionString;
+
+        await using (var admin = new NpgsqlConnection(cadenaAdmin))
+        {
+            await admin.OpenAsync();
+            await using var crear = admin.CreateCommand();
+            crear.CommandText = $"CREATE DATABASE \"{nombreBase}\"";
+            await crear.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+                .UseNpgsql(cadenaNueva, npgsql =>
+                {
+                    npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                    npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                    npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                    npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                    npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                    npgsql.MapEnum<ModoLista>("modo_lista");
+                    npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                    npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                    npgsql.MapEnum<MotivoStock>("motivo_stock");
+                    npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                    npgsql.MapEnum<EstadoTurno>("estado_turno");
+                    npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                    npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                    npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                })
+                .Options;
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(MigracionStage6);
+            }
+
+            // Simula el catálogo de una base real que ya pasó por InicializadorDeBaseDeDatos
+            // ANTES de que RC existiera — el guard de :417 solo siembra si la tabla está vacía.
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+                await using var comando = conexion.CreateCommand();
+                comando.CommandText =
+                    "INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, " +
+                    "es_fiscal, afecta_stock, activo, created_at, updated_at) " +
+                    "VALUES ('venta', 'TX', 'Ticket X', 'X', 1, false, false, true, true, now(), now())";
+                await comando.ExecuteNonQueryAsync();
+            }
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(); // aplica CuentaCorrienteEtapa7, la única pendiente
+            }
+
+            await using var verificacion = new NpgsqlConnection(cadenaNueva);
+            await verificacion.OpenAsync();
+
+            async Task<int> ContarRcAsync()
+            {
+                await using var comando = verificacion.CreateCommand();
+                comando.CommandText = "SELECT count(*) FROM tipos_comprobante WHERE codigo = 'RC'";
+                return Convert.ToInt32(await comando.ExecuteScalarAsync());
+            }
+
+            Assert.Equal(1, await ContarRcAsync());
+
+            // Re-ejecuta a mano el mismo INSERT idempotente de la migración (simula un reintento
+            // de arranque) y confirma que sigue sin duplicar.
+            await using (var comando = verificacion.CreateCommand())
+            {
+                comando.CommandText =
+                    """
+                    INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, created_at, updated_at)
+                    SELECT 'venta', 'RC', 'Recibo de cobranza', NULL, 1, false, false, false, true, now(), now()
+                    WHERE NOT EXISTS (SELECT 1 FROM tipos_comprobante WHERE codigo = 'RC');
+                    """;
+                await comando.ExecuteNonQueryAsync();
+            }
+
+            Assert.Equal(1, await ContarRcAsync());
+        }
+        finally
+        {
+            await using var admin = new NpgsqlConnection(cadenaAdmin);
+            await admin.OpenAsync();
+            await using var dropear = admin.CreateCommand();
+            dropear.CommandText = $"DROP DATABASE IF EXISTS \"{nombreBase}\" WITH (FORCE)";
+            await dropear.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -128,6 +128,25 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
         Assert.Equal("fk_movimientos_cuenta_corriente_actualizacion", excepcion.ConstraintName);
     }
 
+    // Pin directo del guard AND EXISTS del seed de RC: en una base fresca la migración no debe
+    // insertar nada (el seeder ve la tabla vacía y siembra el catálogo completo, RC incluido).
+    // Sin este pin, quitar el guard solo se detectaba por fallas colaterales en otra suite.
+    [Fact]
+    public async Task UnaBaseFrescaTerminaConElCatalogoCompletoDeTiposIncluidoRc()
+    {
+        // El seeder corre en el arranque del host: hay que bootearlo antes de mirar el catálogo.
+        using var cliente = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var codigos = await db.TiposComprobante.Select(t => t.Codigo).OrderBy(c => c).ToListAsync();
+
+        Assert.Equal(11, codigos.Count);
+        Assert.Contains("RC", codigos);
+        Assert.Contains("FA", codigos);
+        Assert.Contains("TX", codigos);
+    }
+
     // ---- RC idempotente en una base ya migrada desde stage 6 (task 1.9) ----------------------
 
     [Fact]


### PR DESCRIPTION
## Resumen

Slice 1/6 de la etapa 7 (stage-7-cuenta-corriente), gate de DB ejercido por el orquestador bajo delegación autónoma explícita del owner.

- Migración `CuentaCorrienteEtapa7`: `movimientos_cuenta_corriente.id_movimiento_actualizacion int NULL` (self-FK compuesta con `id_tenant` — la referencia cross-tenant es imposible por construcción) + AK `(id_movimiento, id_tenant)` + índice parcial de elegibilidad `WHERE tipo='consumo' AND id_movimiento_actualizacion IS NULL`.
- Comprobante `RC` (pago a cuenta) por doble vía: `INSERT ... WHERE NOT EXISTS ... AND EXISTS(...)` idempotente en la migración + append al seed-list. El guard `AND EXISTS` es el fix de un bug crítico cazado en el apply: sin él, una base fresca recibía RC antes del seeder y el catálogo quedaba sin las otras 10 filas.
- `Down()` honesto: desactiva RC (`activo=false`) — el resolver de tipos filtra por activo, así que bloquea emisiones nuevas sin romper la lectura de RCs históricos.
- Nota RC en doc 10 §1 (condición del gate cumplida).

## Verificación

- Build 0 warnings; `has-pending-model-changes` limpio.
- Suites (rebasado sobre main con D6): Domain 306, Application 209, Integration 488/488 (+3), vitest 221, contra Postgres real.
- Judgment-day: ronda 1 — ambos jueces CLEAN (estados de base fresca/migrada/con-RC/parcial probados; FK compuesta verificada en el SQL generado; Down honesto confirmado contra el resolver). Nota convergente de ambos (pin dedicado del catálogo fresco) aplicada por el orquestador: test de conteo 11 + RC con boot del host, verificado con la suite completa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)