### PR TITLE
feat(cc): pago a cuenta como comprobante RC (etapa 7, slice 2)

### DIFF
--- a/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
@@ -1,0 +1,27 @@
+using Ways.Api.Seguridad;
+using Ways.Application.CuentaCorriente;
+
+namespace Ways.Api.Endpoints;
+
+public static class CuentaCorrienteEndpoints
+{
+    public static IEndpointRouteBuilder MapearCuentaCorriente(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/clientes/{idCliente:int}/cuenta-corriente")
+            .WithTags("CuentaCorriente")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        // stage-7-cuenta-corriente (Slice 2, task 2.7, design: API Surface): pago a cuenta — sin
+        // GestionDeCatalogo apilado, mismo criterio que POST /api/ventas (un Vendedor tiene que
+        // poder cobrar una cuenta corriente).
+        grupo.MapPost("/pagos", async (
+            ServicioDeCuentaCorriente servicio, int idCliente, SolicitudDePagoACuenta solicitud, CancellationToken ct) =>
+        {
+            var emitido = await servicio.RegistrarPagoAsync(idCliente, solicitud, ct);
+            return Results.Created($"/api/ventas/{emitido.Id}", emitido);
+        })
+        .WithSummary("Registra un pago a cuenta (RC). Cero items, un único movimiento Pago negativo.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -172,6 +172,7 @@ app.MapearVentas();
 app.MapearStock();
 app.MapearCaja();
 app.MapearGastos();
+app.MapearCuentaCorriente();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -57,11 +57,14 @@ public sealed record SolicitudDeCierre(IReadOnlyList<ConteoDeclarado> Conteos, s
 /// persistir (spec: Resumen Parcial Uses The Same Derivation As Cierre).</summary>
 public sealed record LineaDeResumen(int IdMedioPago, decimal ImporteEsperado);
 
-/// <summary>Un ticket límite del turno (legacy D6: "primer y último ticket") — número visible y
-/// fecha de emisión del <see cref="Ways.Domain.Ventas.ComprobanteVenta"/> correspondiente.
-/// Nunca aparece para un comprobante anulado (spec: Anulados Are Excluded From The
+/// <summary>Un ticket límite del turno (legacy D6: "primer y último ticket") — número visible,
+/// fecha de emisión y el código del tipo de comprobante (<c>TX</c>, <c>RC</c>, …) del
+/// <see cref="Ways.Domain.Ventas.ComprobanteVenta"/> correspondiente. <see cref="Codigo"/> es
+/// necesario porque cada tipo numera su propia serie independiente (stage-7-cuenta-corriente,
+/// design decisión 7): sin él, "primer ticket #1" es ambiguo entre una TX y una RC que arrancan
+/// las dos en 1. Nunca aparece para un comprobante anulado (spec: Anulados Are Excluded From The
 /// Derivation, mismo criterio aplicado acá).</summary>
-public sealed record TicketLimite(long Numero, DateTimeOffset Fecha);
+public sealed record TicketLimite(long Numero, DateTimeOffset Fecha, string Codigo);
 
 /// <summary>Ingresos de un área dentro del turno (legacy D6, primer bloque: "por área") —
 /// agrupa <see cref="Ways.Domain.Ventas.ItemComprobanteVenta.Total"/> por

--- a/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
+++ b/src/Ways.Application/Caja/LectorDeContenidoDeResumen.cs
@@ -32,20 +32,27 @@ public class LectorDeContenidoDeResumen(IWaysDbContext db)
         // spec Anulados Are Excluded From The Derivation).
         var cantidadTickets = await comprobantesDelTurno.CountAsync(ct);
 
-        // 2. primer ticket — orden por fecha, desempate estable por id.
+        // 2. primer ticket — orden por fecha, desempate estable por id. Join con tipos_comprobante
+        // para traer el código (TX, RC, …): cada tipo numera su PROPIA serie independiente
+        // (stage-7-cuenta-corriente, design decisión 7), así que "el primer ticket" mezcla series
+        // sin relación entre sí — el código es lo que lo hace legible, no un dato accesorio.
         var primerTicket = await comprobantesDelTurno
             .OrderBy(c => c.Fecha).ThenBy(c => c.Id)
-            .Select(c => new TicketLimite(c.Numero, c.Fecha))
+            .Join(db.TiposComprobante, c => c.IdTipoComprobante, t => t.Id, (c, t) => new TicketLimite(c.Numero, c.Fecha, t.Codigo))
             .FirstOrDefaultAsync(ct);
 
         // 3. último ticket — ídem, orden inverso.
         var ultimoTicket = await comprobantesDelTurno
             .OrderByDescending(c => c.Fecha).ThenByDescending(c => c.Id)
-            .Select(c => new TicketLimite(c.Numero, c.Fecha))
+            .Join(db.TiposComprobante, c => c.IdTipoComprobante, t => t.Id, (c, t) => new TicketLimite(c.Numero, c.Fecha, t.Codigo))
             .FirstOrDefaultAsync(ct);
 
         // 4. ingresos por área — snapshot inmutable de ItemComprobanteVenta.IdArea (doc 10
-        // principio 6), nunca re-derivado de articulos.
+        // principio 6), nunca re-derivado de articulos. Una RC (pago a cuenta) no tiene items —
+        // cero por construcción (stage-7-cuenta-corriente) — así que su plata nunca aparece acá;
+        // sí aparece en el esperado por medio del arqueo (paso 7 de LectorDeMovimientosDelTurno),
+        // igual que el legacy: las filas tipo=3 tampoco traían líneas de artículo. Es paridad
+        // deliberada, no un bug.
         var totalesPorArea = await db.ItemsComprobanteVenta
             .Join(
                 db.ComprobantesVenta,

--- a/src/Ways.Application/CuentaCorriente/Contratos.cs
+++ b/src/Ways.Application/CuentaCorriente/Contratos.cs
@@ -1,0 +1,16 @@
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// Cuerpo de <c>POST /api/clientes/{id}/cuenta-corriente/pagos</c> (design: API Surface;
+/// Interfaces/Contracts). Sin ningún campo de importe propio a propósito (design decisión 6):
+/// <c>importeAplicado</c> lo deriva <see cref="Domain.CuentaCorriente.ValidadorDePagoACuenta"/> a
+/// partir de <see cref="Pagos"/> — mismo criterio que <c>SolicitudDeVenta</c> nunca mandando un
+/// total ya calculado.
+/// </summary>
+public sealed record SolicitudDePagoACuenta(
+    int IdPuntoVenta, IReadOnlyList<PagoDeCuenta>? Pagos, string? Observaciones);
+
+/// <summary>Un medio de pago de la RC — mismo shape que
+/// <see cref="Ventas.PagoDeVenta"/>, redeclarado acá porque una RC no es un checkout (design
+/// decisión 1: no reusa <c>ServicioDeVentas</c>).</summary>
+public sealed record PagoDeCuenta(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -1,0 +1,94 @@
+using System.Data.Common;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// Los dos statements crudos que son la ÚNICA autoridad de escritura sobre
+/// <c>clientes.saldo</c>/<c>movimientos_cuenta_corriente</c> (design decisión 1: "una sola
+/// <c>EscriturasDeCuentaCorriente</c>") — extraídos VERBATIM de
+/// <c>ServicioDeVentas.ActualizarSaldoClienteAsync</c>/<c>InsertarMovimientoCcAsync</c>
+/// (stage-5-pos-ventas), con un único cambio: <c>id_comprobante_venta</c>/<c>id_pago_comprobante</c>
+/// pasan a <see cref="Nullable{T}"/> porque un <see cref="TipoMovimientoCc.Pago"/> (RC, stage 7)
+/// nunca lleva <c>id_pago_comprobante</c> (a diferencia de un <see cref="TipoMovimientoCc.Consumo"/>,
+/// que siempre lo lleva) — el SQL en sí no cambia una coma.
+/// <c>ServicioDeVentas</c> (TX/NCX, contramovimiento de anulación) y
+/// <c>ServicioDeCuentaCorriente</c> (RC, ajuste manual — stage 7) llaman a esta clase en vez de
+/// duplicar el SQL: así queda exactamente UN <c>UPDATE clientes ... saldo ... RETURNING</c> y UN
+/// <c>INSERT movimientos_cuenta_corriente</c> en todo el codebase, el invariante que design llama
+/// "la extracción es lo que compra seguridad" (Technical Approach, "containment").
+/// </summary>
+public static class EscriturasDeCuentaCorriente
+{
+    /// <summary><c>UPDATE ... RETURNING</c> crudo: nunca vía una entidad <c>Cliente</c>
+    /// trackeada (un <c>cliente.Saldo += x</c> por <c>SaveChangesAsync</c> duplicaría el
+    /// incremento en un reintento de <c>CreateExecutionStrategy</c>). <c>id_tenant</c> en el
+    /// <c>WHERE</c> además de <c>id</c>: RLS ya aísla por tenant, esto es una segunda capa
+    /// barata (mismo criterio que el resto del proyecto), no la única defensa.</summary>
+    public static async Task<decimal> ActualizarSaldoClienteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, decimal importe,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE clientes SET saldo = saldo + $1 WHERE id_cliente = $2 AND id_tenant = $3 RETURNING saldo";
+
+        AgregarParametro(comando, importe);
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException($"No se pudo actualizar el saldo del cliente {idCliente}.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    /// <summary><c>id_comprobante_venta</c>/<c>id_pago_comprobante</c> nullable per-tipo (design
+    /// decisión 5): un <see cref="TipoMovimientoCc.Consumo"/> siempre trae ambos poblados, un
+    /// <see cref="TipoMovimientoCc.Pago"/> (RC) trae <c>id_comprobante_venta</c> pero nunca
+    /// <c>id_pago_comprobante</c> (el pago físico de la RC no es "el que generó" el movimiento —
+    /// el movimiento lo genera el comprobante entero), y un <see cref="TipoMovimientoCc.Ajuste"/>
+    /// manual (Slice 4) no trae ninguno de los dos. El llamador decide qué pasa; esta clase solo
+    /// escribe.</summary>
+    public static async Task InsertarMovimientoCcAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, DateTimeOffset fecha,
+        int idPuntoVenta, int idEmpleado, TipoMovimientoCc tipo, int? idComprobanteVenta, int? idPagoComprobante,
+        decimal importe, decimal saldoResultante, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_cuenta_corriente " +
+            "(id_tenant, id_cliente, fecha, id_punto_venta, id_empleado, tipo, id_comprobante_venta, " +
+            " id_pago_comprobante, importe, saldo_resultante) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, fecha);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idEmpleado);
+        AgregarParametro(comando, tipo);
+        AgregarParametroNullable(comando, idComprobanteVenta);
+        AgregarParametroNullable(comando, idPagoComprobante);
+        AgregarParametro(comando, importe);
+        AgregarParametro(comando, saldoResultante);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    private static void AgregarParametroNullable(DbCommand comando, object? valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor ?? DBNull.Value;
+        comando.Parameters.Add(parametro);
+    }
+}

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -56,6 +56,8 @@ public static class EscriturasDeCuentaCorriente
         int idPuntoVenta, int idEmpleado, TipoMovimientoCc tipo, int? idComprobanteVenta, int? idPagoComprobante,
         decimal importe, decimal saldoResultante, CancellationToken ct)
     {
+        ValidarFormaPorTipo(tipo, idPagoComprobante);
+
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccion;
         comando.CommandText =
@@ -76,6 +78,27 @@ public static class EscriturasDeCuentaCorriente
         AgregarParametro(comando, saldoResultante);
 
         await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>Defensa en profundidad, infraestructura pura (nunca un <c>ErrorDominio</c> 4xx):
+    /// pinea acá, en el único escritor, la forma nullable por tipo que hoy solo garantizan los
+    /// llamadores (design: Table Shapes — write path C). Solo <see cref="TipoMovimientoCc.Consumo"/>
+    /// y <see cref="TipoMovimientoCc.Pago"/> tienen una forma única y fija (el resto — un
+    /// <c>Ajuste</c> puede ser un contramovimiento de anulación o un ajuste manual — es
+    /// estructuralmente dual, no viola nada acá).</summary>
+    private static void ValidarFormaPorTipo(TipoMovimientoCc tipo, int? idPagoComprobante)
+    {
+        if (tipo == TipoMovimientoCc.Consumo && idPagoComprobante is null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Consumo requiere id_pago_comprobante — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCc.Pago && idPagoComprobante is not null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Pago nunca lleva id_pago_comprobante — invariante de escritura violado.");
+        }
     }
 
     private static void AgregarParametro(DbCommand comando, object valor)

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -82,7 +82,7 @@ public static class EscriturasDeCuentaCorriente
 
     /// <summary>Defensa en profundidad, infraestructura pura (nunca un <c>ErrorDominio</c> 4xx):
     /// pinea acá, en el único escritor, la forma nullable por tipo que hoy solo garantizan los
-    /// llamadores (design: Table Shapes — write path C). Solo <see cref="TipoMovimientoCc.Consumo"/>
+    /// llamadores (design: decision 5 — movement shape per tipo). Solo <see cref="TipoMovimientoCc.Consumo"/>
     /// y <see cref="TipoMovimientoCc.Pago"/> tienen una forma única y fija (el resto — un
     /// <c>Ajuste</c> puede ser un contramovimiento de anulación o un ajuste manual — es
     /// estructuralmente dual, no viola nada acá).</summary>

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -99,13 +99,13 @@ public class ServicioDeCuentaCorriente(
         return await estrategia.ExecuteAsync(async () =>
             await EjecutarTransaccionAsync(
                 idTenant, idEmpleado, momento, tipo.Id, numero, puntoVenta.Id, turno.Id, cliente.Id, importeAplicado,
-                pagos, ct));
+                pagos, NormalizarOpcional(solicitud.Observaciones), ct));
     }
 
     private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(
         int idTenant, int idEmpleado, DateTimeOffset momento, int idTipoComprobante, long numero, int idPuntoVenta,
         int idTurnoCaja, int idCliente, decimal importeAplicado, IReadOnlyList<PagoDeCuenta> pagos,
-        CancellationToken ct)
+        string? observaciones, CancellationToken ct)
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
@@ -129,7 +129,7 @@ public class ServicioDeCuentaCorriente(
             Subtotal = importeAplicado,
             DescuentoTotal = 0m,
             Total = importeAplicado,
-            Observaciones = null,
+            Observaciones = observaciones,
             Estado = EstadoComprobante.Emitido,
             CreatedAt = momento,
             UpdatedAt = momento
@@ -220,6 +220,14 @@ public class ServicioDeCuentaCorriente(
         contexto.IdTenant
             ?? throw new InvalidOperationException(
                 "ServicioDeCuentaCorriente requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    // Mismo criterio que ServicioDeVentas.NormalizarOpcional: un string en blanco no es una
+    // observación, es ruido — se persiste NULL en vez de espacios.
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
 
     private static ComprobanteEmitido Proyectar(
         ComprobanteVenta comprobante, IReadOnlyList<PagoComprobante> pagos) => new(

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -1,0 +1,235 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Ventas;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// Pago a cuenta (RC) — servicio dedicado y lean (design decisión 1: "no threadea
+/// <c>EmitirAsync</c>"), no una extensión de <see cref="ServicioDeVentas"/>: una RC no tiene
+/// líneas, ni ofertas, ni CC como medio, así que reusar el checkout completo significaría abrir
+/// seis ramas nuevas en la transacción más guardada del proyecto para un flujo que no las
+/// necesita. Reusa, tal cual, las tres piezas que sí le sirven:
+/// <see cref="AsignadorDeNumeroComprobante"/> (numeración, design decisión 7),
+/// <see cref="ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync"/> (guard de turno, mismo criterio
+/// que <c>ServicioDeVentas.EjecutarTransaccionAsync</c> paso 0) y
+/// <see cref="CuentaCorriente.EscriturasDeCuentaCorriente"/> (los dos statements que son la única
+/// autoridad sobre <c>clientes.saldo</c>/<c>movimientos_cuenta_corriente</c>).
+/// </summary>
+public class ServicioDeCuentaCorriente(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeTurnos servicioDeTurnos)
+{
+    /// <summary>Design: Transactions — PAGO A CUENTA (orden de statements pineado). La mitad que
+    /// decide (cliente, punto de venta, turno, medios, validación) corre AFUERA de la
+    /// transacción de escritura — mismo criterio que <c>ServicioDeVentas.EmitirAsync</c> — y la
+    /// numeración se reserva y comitea en su PROPIA transacción, ANTES de la que escribe el
+    /// resto (design decisión 7).</summary>
+    public async Task<ComprobanteEmitido> RegistrarPagoAsync(
+        int idCliente, SolicitudDePagoACuenta solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var cliente = await ResolverClienteAsync(idCliente, ct);
+        if (cliente.EsConsumidorFinal)
+        {
+            throw new ErrorDominio(
+                "cliente_sin_cuenta_corriente", "El Consumidor Final no tiene cuenta corriente.", 400);
+        }
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        // Turno resuelto server-side, ANTES de cualquier otro trabajo de negocio (spec: RC
+        // Requires An Open Turno — "rejected before any other processing") — mismo criterio que
+        // ServicioDeVentas.EmitirAsync.
+        var turno = await servicioDeTurnos.ResolverTurnoAbiertoAsync(puntoVenta.Id, ct);
+
+        var tipo = await ResolverTipoRcAsync(ct);
+
+        var pagos = solicitud.Pagos ?? [];
+        var idsMedioPago = pagos.Select(p => p.IdMedioPago).Distinct().ToList();
+        var medioPorId = await db.MediosPago
+            .Where(m => idsMedioPago.Contains(m.Id))
+            .ToDictionaryAsync(m => m.Id, ct);
+
+        var idsMedioFaltantes = idsMedioPago.Except(medioPorId.Keys).ToList();
+        if (idsMedioFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el medio de pago {idsMedioFaltantes[0]}.", 400);
+        }
+
+        var vueltoMaximo = await ResolverParametroAsync(ParametroConocido.VueltoMaximo, puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+
+        var pagosAValidar = pagos
+            .Select(p =>
+            {
+                var medio = medioPorId[p.IdMedioPago];
+                return new PagoAValidar(
+                    p.IdMedioPago, medio.Comportamiento, medio.AdmiteVuelto, medio.RequiereReferencia,
+                    p.Importe, p.Vuelto, p.Referencia);
+            })
+            .ToList();
+
+        var importeAplicado = ValidadorDePagoACuenta.Validar(pagosAValidar, vueltoMaximo);
+
+        // Misma corrección que ServicioDeVentas.EmitirAsync: el número se reserva y COMITEA en su
+        // propia transacción, ANTES de la que escribe el resto — "se consume aunque falle el
+        // resto" es literal, no una aproximación.
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, idTenant, puntoVenta.Id, tipo.Codigo, ct));
+
+        // Sin reintento automático (mismo criterio que ServicioDeVentas.AnularAsync): un pago a
+        // cuenta es manual, sin clave de idempotencia propia — a diferencia de EmitirAsync, no
+        // hay ningún BuscarPorNumeroComprometidoAsync que detecte un commit ambiguo previo antes
+        // de reinsertar.
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarTransaccionAsync(
+                idTenant, idEmpleado, momento, tipo.Id, numero, puntoVenta.Id, turno.Id, cliente.Id, importeAplicado,
+                pagos, ct));
+    }
+
+    private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(
+        int idTenant, int idEmpleado, DateTimeOffset momento, int idTipoComprobante, long numero, int idPuntoVenta,
+        int idTurnoCaja, int idCliente, decimal importeAplicado, IReadOnlyList<PagoDeCuenta> pagos,
+        CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        // 1. Turno — re-chequeo bajo FOR SHARE, PRIMER statement (mismo criterio que
+        // ServicioDeVentas.EjecutarTransaccionAsync paso 0): el turno ya vino resuelto como
+        // abierto arriba, ANTES de esta transacción.
+        await servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(idTurnoCaja, ct);
+
+        // 2. Comprobante — cero items por construcción (afecta_stock = false de RC, design:
+        // Table Shapes B). Subtotal/DescuentoTotal no tienen concepto propio sin líneas: se
+        // igualan al total, sin descuento.
+        var comprobante = new ComprobanteVenta
+        {
+            IdTipoComprobante = idTipoComprobante,
+            Numero = numero,
+            Fecha = momento,
+            IdPuntoVenta = idPuntoVenta,
+            IdTurnoCaja = idTurnoCaja,
+            IdEmpleado = idEmpleado,
+            IdCliente = idCliente,
+            Subtotal = importeAplicado,
+            DescuentoTotal = 0m,
+            Total = importeAplicado,
+            Observaciones = null,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync(ct);
+
+        // 3. Pagos — sin items, sin movimientos_stock (spec: RC Carries Zero Items And No Stock
+        // Effect).
+        var pagosEntidad = pagos
+            .Select(p => new PagoComprobante
+            {
+                IdComprobanteVenta = comprobante.Id,
+                IdMedioPago = p.IdMedioPago,
+                Importe = p.Importe,
+                Referencia = p.Referencia,
+                Vuelto = p.Vuelto,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            })
+            .ToList();
+        db.PagosComprobante.AddRange(pagosEntidad);
+        await db.SaveChangesAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 4. Cuenta corriente — un único movimiento Pago, negativo (reduce la deuda).
+        var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
+            conexion, transaccionCruda, idTenant, idCliente, -importeAplicado, ct);
+
+        // 5. Movimiento — id_pago_comprobante siempre NULL en un Pago (design decisión 1/5): a
+        // diferencia de un Consumo, no hay UN pago físico que "lo generó" — lo genera el
+        // comprobante entero, que puede traer varios medios.
+        await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+            conexion, transaccionCruda, idTenant, idCliente, momento, idPuntoVenta, idEmpleado,
+            TipoMovimientoCc.Pago, comprobante.Id, null, -importeAplicado, nuevoSaldo, ct);
+
+        await transaccion.CommitAsync(ct);
+
+        return Proyectar(comprobante, pagosEntidad);
+    }
+
+    // ---- Resolución de datos, fuera de la transacción ----------------------------------------
+
+    private async Task<Cliente> ResolverClienteAsync(int idCliente, CancellationToken ct) =>
+        await db.Clientes.FirstOrDefaultAsync(c => c.Id == idCliente, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (filtro de EF + RLS ya deja
+            // invisible un cliente ajeno) — mismo criterio que ServicioDeVentas.ResolverClienteAsync.
+            ?? throw ErrorDominio.NoEncontrado($"No existe el cliente {idCliente}.");
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<TipoComprobante> ResolverTipoRcAsync(CancellationToken ct) =>
+        await db.TiposComprobante.FirstOrDefaultAsync(t => t.Codigo == "RC", ct)
+            // Sembrado idempotente para todo tenant desde la migración de Slice 1 — su ausencia
+            // es un bug de aprovisionamiento, no un caso de negocio alcanzable (mismo criterio
+            // que el Consumidor Final de ServicioDeVentas.ResolverClienteAsync).
+            ?? throw new InvalidOperationException("El tenant actual no tiene el tipo de comprobante RC sembrado.");
+
+    private async Task<decimal> ResolverParametroAsync(
+        ParametroConocido conocido, int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == conocido.Clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var valorJson = ResolucionDeParametros.Resolver(conocido.Clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<decimal>(valorJson);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeCuentaCorriente requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    private static ComprobanteEmitido Proyectar(
+        ComprobanteVenta comprobante, IReadOnlyList<PagoComprobante> pagos) => new(
+        comprobante.Id, comprobante.Numero,
+        NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
+        comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
+        comprobante.IdComprobanteAsociado, comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.Total,
+        comprobante.DireccionEntrega, comprobante.Observaciones,
+        [],
+        pagos
+            .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
+            .ToList());
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Ways.Application.Articulos;
 using Ways.Application.Caja;
 using Ways.Application.Catalogos;
 using Ways.Application.Clientes;
+using Ways.Application.CuentaCorriente;
 using Ways.Application.Gastos;
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
@@ -57,6 +58,10 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeTurnos>();
         services.AddScoped<ServicioDeResumenDeTurno>();
         services.AddScoped<ServicioDeGastos>();
+
+        // stage-7-cuenta-corriente (Slice 2): pago a cuenta (RC) — reusa
+        // ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync, se registra junto a la caja.
+        services.AddScoped<ServicioDeCuentaCorriente>();
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();

--- a/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
+++ b/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
@@ -26,13 +26,34 @@ namespace Ways.Application.Ventas;
 ///
 /// Estática a propósito: sin estado propio, cada método recibe el <see cref="IWaysDbContext"/>
 /// del llamador de turno (mismo criterio que los dos asignadores hermanos). Llamado desde
-/// <c>ServicioDeVentas.AsignarNumeroComprometidoAsync</c>, en su PROPIA transacción chica,
-/// comprometida ANTES de la transacción que escribe el resto de la venta (design: Failure
-/// Semantics — corrección de esta slice para que "el número se consume aunque falle el resto"
-/// sea literal, ver el doc-comment de <c>ServicioDeVentas.EmitirAsync</c>), no dentro de ella.
+/// <see cref="AsignarComprometidoAsync"/>, en su PROPIA transacción chica, comprometida ANTES de
+/// la transacción que escribe el resto de la venta (design: Failure Semantics — corrección de
+/// esta slice para que "el número se consume aunque falle el resto" sea literal, ver el
+/// doc-comment de <c>ServicioDeVentas.EmitirAsync</c>), no dentro de ella.
 /// </summary>
 public static class AsignadorDeNumeroComprobante
 {
+    /// <summary>stage-7-cuenta-corriente (Slice 2, task 2.4, design decisión 7 — "numeración
+    /// untouched"): promovido de método privado de <c>ServicioDeVentas</c> a acá — pure move, sin
+    /// cambio de mecanismo. Abre y comitea su PROPIA transacción chica (ver el doc-comment de la
+    /// clase); el llamador la envuelve en su propio <c>CreateExecutionStrategy().ExecuteAsync</c>
+    /// (EnableRetryOnFailure exige que <c>BeginTransactionAsync</c> viva dentro de esa lambda).
+    /// Reusado tal cual por <c>ServicioDeVentas.EmitirAsync</c> (TX/NCX) y
+    /// <c>ServicioDeCuentaCorriente.RegistrarPagoAsync</c> (RC) — <c>numeraciones_comprobante</c>
+    /// ya está keyed por <c>(id_punto_venta, tipo_comprobante)</c>, así que RC obtiene su propia
+    /// serie sin ningún mecanismo nuevo.</summary>
+    public static async Task<long> AsignarComprometidoAsync(
+        IWaysDbContext db, int idTenant, int idPuntoVenta, string codigoTipoComprobante, CancellationToken ct = default)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        await AsegurarContadorAsync(db, idTenant, idPuntoVenta, codigoTipoComprobante, ct);
+        var numero = await AsignarSiguienteAsync(db, idPuntoVenta, codigoTipoComprobante, ct);
+
+        await transaccion.CommitAsync(ct);
+        return numero;
+    }
+
     public static async Task AsegurarContadorAsync(
         IWaysDbContext db, int idTenant, int idPuntoVenta, string tipoComprobante, CancellationToken ct = default)
     {

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
 using Ways.Application.Ofertas;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
@@ -156,7 +157,8 @@ public class ServicioDeVentas(
         // reintenta (execution strategy), reservar de nuevo solo vuelve a avanzarlo — nunca
         // duplica una fila (design decisión 2: "gaps are accepted", nunca duplicados).
         var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
-        var numero = await estrategiaNumeracion.ExecuteAsync(async () => await AsignarNumeroComprometidoAsync(plan, ct));
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, plan.IdTenant, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct));
 
         // ADR-16 (mismo trámite que ServicioDeAprovisionamiento/ServicioDeOfertas): la
         // transacción se abre ACÁ ADENTRO — EnableRetryOnFailure exige que la apertura viva
@@ -176,19 +178,6 @@ public class ServicioDeVentas(
         return await estrategia.ExecuteAsync(async () =>
             await BuscarPorNumeroComprometidoAsync(plan.IdPuntoVenta, plan.IdTipoComprobante, numero, ct)
             ?? await EjecutarTransaccionAsync(plan, numero, ct));
-    }
-
-    /// <summary>Transacción chica y propia (ADR-16), comprometida ANTES de que exista ningún
-    /// otro dato de la venta — ver el comentario de <see cref="EmitirAsync"/>.</summary>
-    private async Task<long> AsignarNumeroComprometidoAsync(PlanDeVenta plan, CancellationToken ct)
-    {
-        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
-
-        await AsignadorDeNumeroComprobante.AsegurarContadorAsync(db, plan.IdTenant, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
-        var numero = await AsignadorDeNumeroComprobante.AsignarSiguienteAsync(db, plan.IdPuntoVenta, plan.CodigoTipoComprobante, ct);
-
-        await transaccion.CommitAsync(ct);
-        return numero;
     }
 
     /// <summary>Detección de idempotencia (ver el comentario de <see cref="EmitirAsync"/> sobre
@@ -403,29 +392,49 @@ public class ServicioDeVentas(
             await UpsertStockAsync(conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
         }
 
-        // 3. Contramovimiento de cuenta corriente — uno por cada consumo ORIGINAL de este
+        // 3. Contramovimiento de cuenta corriente — uno por cada consumo/pago ORIGINAL de este
         // comprobante (spec: consumo-cuenta-corriente / Anulación Produces A Contramovimiento;
-        // Movimiento Schema At Rest: "tipo = ajuste-shaped inverse rows used as the anulación
-        // contramovimiento", nunca tipo = consumo). id_pago_comprobante del consumo original
-        // siempre está poblado (EjecutarTransaccionAsync paso 6 lo setea siempre) — forzarlo acá
-        // es defensa en profundidad de un invariante de escritura, no un caso de negocio
-        // alcanzable.
-        var consumosOriginales = await db.MovimientosCuentaCorriente
-            .Where(m => m.IdComprobanteVenta == id && m.Tipo == TipoMovimientoCc.Consumo)
+        // pagos-a-cuenta / Anulación Reverses The Pago Movement; Movimiento Schema At Rest: "tipo
+        // = ajuste-shaped inverse rows used as the anulación contramovimiento", nunca tipo =
+        // consumo/pago). stage-7-cuenta-corriente (Slice 2, task 2.6, design decisión 5 — el
+        // widening de 3 líneas): el filtro se abre a Pago (una RC solo puede producir un
+        // movimiento Pago, nunca un Consumo, así que un comprobante siempre cae en una sola de
+        // las dos ramas de abajo) y -consumo.Importe/-movimiento.Importe restaura la deuda sin
+        // rama de signo (un Pago ya es negativo, así que su reversa da positiva sola).
+        var movimientosCcOriginales = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == id
+                && (m.Tipo == TipoMovimientoCc.Consumo || m.Tipo == TipoMovimientoCc.Pago))
             .ToListAsync(ct);
 
-        foreach (var consumo in consumosOriginales)
+        foreach (var movimiento in movimientosCcOriginales)
         {
-            var idPagoComprobante = consumo.IdPagoComprobante
-                ?? throw new InvalidOperationException(
-                    $"El movimiento de consumo {consumo.Id} no tiene id_pago_comprobante — invariante de escritura violado.");
+            // Guard nuevo (design decisión 5, spec: pagos-a-cuenta / Anulación Reverses The Pago
+            // Movement no lo pide, pero el consumo reliquidado sí — cierra el leak de anular un
+            // consumo ya cubierto por una reliquidación, que dejaría el delta de
+            // ActualizacionPrecios en el aire sin el Consumo que lo originó). El marcador lo
+            // escribe recién Slice 3 (ServicioDeReliquidacion) — acá solo se lee.
+            if (movimiento.IdMovimientoActualizacion is not null)
+            {
+                throw new ErrorDominio(
+                    "consumo_reliquidado", "El consumo ya fue reliquidado; no se puede anular.", 409);
+            }
 
-            var nuevoSaldo = await ActualizarSaldoClienteAsync(
-                conexion, transaccionCruda, idTenant, consumo.IdCliente, -consumo.Importe, ct);
+            // Un Consumo siempre trae id_pago_comprobante (EjecutarTransaccionAsync paso 6 lo
+            // setea siempre); un Pago (RC) nunca lo trae (RegistrarPagoAsync lo inserta con
+            // id_pago_comprobante NULL, design decisión 1) — invariante de escritura por tipo,
+            // forzarlo acá es defensa en profundidad, no un caso de negocio alcanzable.
+            var idPagoComprobante = movimiento.Tipo == TipoMovimientoCc.Consumo
+                ? movimiento.IdPagoComprobante
+                    ?? throw new InvalidOperationException(
+                        $"El movimiento de consumo {movimiento.Id} no tiene id_pago_comprobante — invariante de escritura violado.")
+                : (int?)null;
 
-            await InsertarMovimientoCcAsync(
-                conexion, transaccionCruda, idTenant, consumo.IdCliente, momento, consumo.IdPuntoVenta, idEmpleado,
-                TipoMovimientoCc.Ajuste, id, idPagoComprobante, -consumo.Importe, nuevoSaldo, ct);
+            var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
+                conexion, transaccionCruda, idTenant, movimiento.IdCliente, -movimiento.Importe, ct);
+
+            await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+                conexion, transaccionCruda, idTenant, movimiento.IdCliente, momento, movimiento.IdPuntoVenta, idEmpleado,
+                TipoMovimientoCc.Ajuste, id, idPagoComprobante, -movimiento.Importe, nuevoSaldo, ct);
         }
 
         await transaccion.CommitAsync(ct);
@@ -600,7 +609,7 @@ public class ServicioDeVentas(
                 continue;
             }
 
-            var nuevoSaldo = await ActualizarSaldoClienteAsync(
+            var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
                 conexion, transaccionCruda, plan.IdTenant, plan.IdCliente, pago.Importe, ct);
 
             if (!plan.ClienteCreditoIlimitado && nuevoSaldo > plan.ClienteLimiteCredito)
@@ -612,7 +621,7 @@ public class ServicioDeVentas(
                 throw new ErrorDominio("limite_credito_excedido", "El pago supera el límite de crédito del cliente.", 400);
             }
 
-            await InsertarMovimientoCcAsync(
+            await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
                 conexion, transaccionCruda, plan.IdTenant, plan.IdCliente, plan.Momento, plan.IdPuntoVenta,
                 plan.IdEmpleado, TipoMovimientoCc.Consumo, comprobante.Id, pagosEntidad[i].Id, pago.Importe, nuevoSaldo, ct);
         }
@@ -800,58 +809,6 @@ public class ServicioDeVentas(
         AgregarParametro(comando, delta);
 
         await comando.ExecuteScalarAsync(ct);
-    }
-
-    /// <summary>Design: The Sale Transaction, paso 6 — <c>UPDATE ... RETURNING</c> crudo:
-    /// nunca vía una entidad <see cref="Cliente"/> trackeada (un <c>cliente.Saldo += x</c> por
-    /// <c>SaveChangesAsync</c> duplicaría el incremento en un reintento de
-    /// <c>CreateExecutionStrategy</c>, ver el Retry contract de design). <c>id_tenant</c> en el
-    /// <c>WHERE</c> además de <c>id</c>: RLS ya aísla por tenant, esto es una segunda capa
-    /// barata (mismo criterio que el resto del proyecto), no la única defensa.</summary>
-    private static async Task<decimal> ActualizarSaldoClienteAsync(
-        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, decimal importe,
-        CancellationToken ct)
-    {
-        await using var comando = conexion.CreateCommand();
-        comando.Transaction = transaccion;
-        comando.CommandText =
-            "UPDATE clientes SET saldo = saldo + $1 WHERE id_cliente = $2 AND id_tenant = $3 RETURNING saldo";
-
-        AgregarParametro(comando, importe);
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, idTenant);
-
-        var resultado = await comando.ExecuteScalarAsync(ct)
-            ?? throw new InvalidOperationException($"No se pudo actualizar el saldo del cliente {idCliente}.");
-
-        return Convert.ToDecimal(resultado);
-    }
-
-    private static async Task InsertarMovimientoCcAsync(
-        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, DateTimeOffset fecha,
-        int idPuntoVenta, int idEmpleado, TipoMovimientoCc tipo, int idComprobanteVenta, int idPagoComprobante,
-        decimal importe, decimal saldoResultante, CancellationToken ct)
-    {
-        await using var comando = conexion.CreateCommand();
-        comando.Transaction = transaccion;
-        comando.CommandText =
-            "INSERT INTO movimientos_cuenta_corriente " +
-            "(id_tenant, id_cliente, fecha, id_punto_venta, id_empleado, tipo, id_comprobante_venta, " +
-            " id_pago_comprobante, importe, saldo_resultante) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
-
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, fecha);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametro(comando, tipo);
-        AgregarParametro(comando, idComprobanteVenta);
-        AgregarParametro(comando, idPagoComprobante);
-        AgregarParametro(comando, importe);
-        AgregarParametro(comando, saldoResultante);
-
-        await comando.ExecuteNonQueryAsync(ct);
     }
 
     private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)

--- a/src/Ways.Domain/CuentaCorriente/ValidadorDePagoACuenta.cs
+++ b/src/Ways.Domain/CuentaCorriente/ValidadorDePagoACuenta.cs
@@ -1,0 +1,112 @@
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Ventas;
+
+namespace Ways.Domain.CuentaCorriente;
+
+/// <summary>
+/// Valida la mezcla de pagos de una RC (design decisión 6, pinned: "sibling class", no una rama
+/// de <see cref="ValidadorDePagos"/>): pura, DB-free, mismo criterio que
+/// <see cref="ValidadorDePagos"/> — pero un pago a cuenta no es un checkout. De las 9 reglas de
+/// <see cref="ValidadorDePagos"/>, tres son inaplicables acá: la 2 (<c>tolerancia_pago</c>) le
+/// permitiría a la RC acreditar más deuda de la que efectivamente ingresó (el legacy nunca
+/// tolera un pago recibido de menos); la 5/6 (CF-bloquea-CC / límite de crédito) hablan de
+/// CONSUMIR cuenta corriente, no de pagarla; la 8 (vuelto coherente contra un <c>total</c> fijo)
+/// es vacía acá porque no hay <c>total</c> independiente — <c>importeAplicado</c> se DERIVA de
+/// <c>Σ importe − Σ vuelto</c>, así que esa desigualdad se cumple siempre por construcción.
+///
+/// El orden es OBSERVABLE, mismo contrato que <see cref="ValidadorDePagos"/>: cada regla corta la
+/// validación en el primer rechazo, nunca acumula errores.
+/// </summary>
+public static class ValidadorDePagoACuenta
+{
+    /// <param name="pagos">La mezcla de pagos pedida — ya resuelta contra su
+    /// <see cref="Catalogos.MedioPago"/> (mismo shape que <see cref="ValidadorDePagos.Validar"/>).</param>
+    /// <param name="vueltoMaximo">Resuelto por <c>ServicioDeParametros</c> — nunca un literal.</param>
+    /// <returns><c>importeAplicado = Σ importe − Σ vuelto</c> (legacy parity,
+    /// <c>cuenta-corriente.php:11</c>) — la RC no tiene ningún campo de importe propio, este es el
+    /// único lugar donde ese número existe.</returns>
+    public static decimal Validar(IReadOnlyList<PagoAValidar> pagos, decimal vueltoMaximo)
+    {
+        // 1: Importe negativo — mismo motivo que la regla 0 de ValidadorDePagos, corta ANTES que
+        // cualquier otra regla: sin esto, un Importe negativo podría manipular Σ importe sin que
+        // ninguna regla de abajo lo note.
+        foreach (var pago in pagos)
+        {
+            if (pago.Importe < 0m)
+            {
+                throw new ErrorDominio(
+                    "pago_importe_negativo", "El importe de un pago no puede ser negativo.", 400);
+            }
+        }
+
+        // 2: Vuelto negativo — mismo motivo que la regla 0b de ValidadorDePagos.
+        foreach (var pago in pagos)
+        {
+            if (pago.Vuelto < 0m)
+            {
+                throw new ErrorDominio(
+                    "vuelto_negativo", "El vuelto de un pago no puede ser negativo.", 400);
+            }
+        }
+
+        // 3 (regla nueva, sin equivalente en ValidadorDePagos — spec: RC Forbids Cuenta
+        // Corriente Medios): una deuda no puede pagar otra deuda. A diferencia de la regla 5 de
+        // ValidadorDePagos (que solo bloquea CC para Consumidor Final), acá CC está prohibido
+        // sin importar el cliente.
+        foreach (var pago in pagos)
+        {
+            if (pago.Comportamiento == ComportamientoMedioPago.CuentaCorriente)
+            {
+                throw new ErrorDominio(
+                    "pago_a_cuenta_sin_medios_fisicos",
+                    "Un pago a cuenta no admite cuenta corriente como medio de pago.",
+                    400);
+            }
+        }
+
+        // 4: vuelto sobre un medio con AdmiteVuelto = false — mismo criterio que la regla 4 de
+        // ValidadorDePagos.
+        foreach (var pago in pagos)
+        {
+            if (pago.Vuelto > 0m && !pago.AdmiteVuelto)
+            {
+                throw new ErrorDominio(
+                    "medio_no_admite_vuelto", "El medio de pago elegido no admite vuelto.", 400);
+            }
+        }
+
+        // 5: Σ vuelto > vuelto_maximo — mismo criterio que la regla 3 de ValidadorDePagos,
+        // parametrizado (nunca un literal).
+        var sumaVueltos = pagos.Sum(p => p.Vuelto);
+        if (sumaVueltos > vueltoMaximo)
+        {
+            throw new ErrorDominio("vuelto_excedido", "El vuelto supera el máximo permitido.", 400);
+        }
+
+        // 6: RequiereReferencia sin referencia — mismo criterio que la regla 7 de ValidadorDePagos.
+        foreach (var pago in pagos)
+        {
+            if (pago.RequiereReferencia && string.IsNullOrWhiteSpace(pago.Referencia))
+            {
+                throw new ErrorDominio(
+                    "referencia_de_pago_requerida", "Este medio de pago requiere una referencia.", 400);
+            }
+        }
+
+        // 7 (regla nueva, sin equivalente en ValidadorDePagos): importeAplicado <= 0 — un pago a
+        // cuenta sin ningún importe efectivo (pagos vacíos, o Σ importe == Σ vuelto) no tiene
+        // sentido de negocio. Se evalúa último a propósito: es el único chequeo que depende del
+        // valor derivado, después de que las reglas 1/2 ya garantizaron que ninguno de los dos
+        // sumandos es negativo.
+        var sumaImportes = pagos.Sum(p => p.Importe);
+        var importeAplicado = sumaImportes - sumaVueltos;
+        if (importeAplicado <= 0m)
+        {
+            throw new ErrorDominio(
+                "pago_a_cuenta_sin_importe", "Tenés que ingresar al menos un pago a cuenta.", 400);
+        }
+
+        return importeAplicado;
+    }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -625,9 +625,10 @@ export type MovimientoRegistrado = {
 
 export type LineaDeResumen = { idMedioPago: number; importeEsperado: number }
 
-/** Un ticket límite del turno (legacy doc 01 D6: "primer y último ticket") — espejo de
- * `Ways.Application.Caja.TicketLimite`. */
-export type TicketLimite = { numero: number; fecha: string }
+/** Un ticket límite del turno (legacy doc 01 D6: "primer y último ticket") — `codigo` es el tipo
+ * de comprobante (`TX`, `RC`, …): cada tipo numera su propia serie independiente, así que el
+ * número solo no alcanza para identificar el ticket — espejo de `Ways.Application.Caja.TicketLimite`. */
+export type TicketLimite = { numero: number; fecha: string; codigo: string }
 
 /** Ingresos de un área dentro del turno (legacy D6, primer bloque: "por área") — espejo de
  * `IngresoPorArea`. */

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -547,8 +547,8 @@ describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment"
         return Promise.resolve<ResumenDeTurno>(
           resumenFixture({
             cantidadTickets: 3,
-            primerTicket: { numero: 1001, fecha: '2026-08-04T12:00:00Z' },
-            ultimoTicket: { numero: 1003, fecha: '2026-08-04T14:00:00Z' },
+            primerTicket: { numero: 1001, fecha: '2026-08-04T12:00:00Z', codigo: 'TX' },
+            ultimoTicket: { numero: 3, fecha: '2026-08-04T14:00:00Z', codigo: 'RC' },
             ingresosPorArea: [
               { idArea: 1, nombreArea: 'Almacén', total: 150 },
               { idArea: 2, nombreArea: 'Verdulería', total: 200 },
@@ -572,8 +572,10 @@ describe('Caja — resumen D6 (follow-up "Resumen parcial D6-content enrichment"
     await waitFor(() => expect(screen.getByText('Tickets')).toBeInTheDocument())
 
     expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getByText('#1001 · ' + new Date('2026-08-04T12:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
-    expect(screen.getByText('#1003 · ' + new Date('2026-08-04T14:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
+    // mezcla de series independientes por tipo (design decisión 7): el código deja "TX #1001" y
+    // "RC #3" inequívocos, aunque una RC pudiera numerar por debajo del último ticket TX.
+    expect(screen.getByText('TX #1001 · ' + new Date('2026-08-04T12:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
+    expect(screen.getByText('RC #3 · ' + new Date('2026-08-04T14:00:00Z').toLocaleString('es-AR'))).toBeInTheDocument()
 
     expect(screen.getByText('Almacén')).toBeInTheDocument()
     expect(screen.getByText('$150,00')).toBeInTheDocument()

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -431,13 +431,13 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
             <div className="small text-muted">Primer ticket</div>
             <div className="mb-2">
               {resumen.primerTicket
-                ? `#${resumen.primerTicket.numero} · ${formatearFechaHora(resumen.primerTicket.fecha)}`
+                ? `${resumen.primerTicket.codigo} #${resumen.primerTicket.numero} · ${formatearFechaHora(resumen.primerTicket.fecha)}`
                 : '—'}
             </div>
             <div className="small text-muted">Último ticket</div>
             <div>
               {resumen.ultimoTicket
-                ? `#${resumen.ultimoTicket.numero} · ${formatearFechaHora(resumen.ultimoTicket.fecha)}`
+                ? `${resumen.ultimoTicket.codigo} #${resumen.ultimoTicket.numero} · ${formatearFechaHora(resumen.ultimoTicket.fecha)}`
                 : '—'}
             </div>
           </div>

--- a/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteTests.cs
+++ b/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteTests.cs
@@ -1,0 +1,38 @@
+using Ways.Application.CuentaCorriente;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.Tests.CuentaCorriente;
+
+/// <summary>
+/// judgment-day fix 4 (MINOR, judge B): <c>EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync</c>
+/// no validaba la forma nullable por tipo que hoy solo garantizan los llamadores (design: Table
+/// Shapes — write path C). El guard corre ANTES de tocar la conexión, así que <c>null!</c> alcanza
+/// para pinearlo sin una base de datos real — si algún día deja de ser cierto, el <see
+/// cref="NullReferenceException"/> resultante hace evidente que el guard se movió.
+/// </summary>
+public class EscriturasDeCuentaCorrienteTests
+{
+    [Fact]
+    public async Task UnConsumoSinIdPagoComprobanteViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+                null!, null, idTenant: 1, idCliente: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta: 1, idEmpleado: 1,
+                TipoMovimientoCc.Consumo, idComprobanteVenta: 10, idPagoComprobante: null, importe: 100m,
+                saldoResultante: 100m, CancellationToken.None));
+
+        Assert.Contains("Consumo", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnPagoConIdPagoComprobanteViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+                null!, null, idTenant: 1, idCliente: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta: 1, idEmpleado: 1,
+                TipoMovimientoCc.Pago, idComprobanteVenta: 10, idPagoComprobante: 5, importe: -100m,
+                saldoResultante: 0m, CancellationToken.None));
+
+        Assert.Contains("Pago", excepcion.Message);
+    }
+}

--- a/tests/Ways.Domain.Tests/CuentaCorriente/ValidadorDePagoACuentaTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/ValidadorDePagoACuentaTests.cs
@@ -1,0 +1,170 @@
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Ventas;
+
+namespace Ways.Domain.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 2 (task 2.8, design decisión 6, pinned: "sibling class" —
+/// no una rama de <see cref="ValidadorDePagos"/>; spec: pagos-a-cuenta) — pura, sin base de
+/// datos, mismo criterio que <c>Ways.Domain.Tests.Ventas.ValidadorDePagosTests</c>.
+/// </summary>
+public class ValidadorDePagoACuentaTests
+{
+    private static PagoAValidar Efectivo(decimal importe, decimal vuelto = 0m) =>
+        new(1, ComportamientoMedioPago.Efectivo, AdmiteVuelto: true, RequiereReferencia: false, importe, vuelto, null);
+
+    private static PagoAValidar Tarjeta(decimal importe, decimal vuelto = 0m, bool requiereReferencia = false, string? referencia = null) =>
+        new(2, ComportamientoMedioPago.Electronico, AdmiteVuelto: false, requiereReferencia, importe, vuelto, referencia);
+
+    private static PagoAValidar CuentaCorriente(decimal importe) =>
+        new(3, ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto: false, RequiereReferencia: false, importe, 0m, null);
+
+    // ---- 1: pago_importe_negativo -----------------------------------------------------------
+
+    [Fact]
+    public void UnPagoConImporteNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Efectivo(-50m)], vueltoMaximo: 0m));
+        Assert.Equal("pago_importe_negativo", excepcion.Codigo);
+    }
+
+    // ---- 2: vuelto_negativo -------------------------------------------------------------------
+
+    [Fact]
+    public void UnPagoConVueltoNegativoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Efectivo(100m, vuelto: -1m)], vueltoMaximo: 50m));
+        Assert.Equal("vuelto_negativo", excepcion.Codigo);
+    }
+
+    // ---- 3: pago_a_cuenta_sin_medios_fisicos (spec: RC Forbids Cuenta Corriente Medios) -------
+
+    [Fact]
+    public void UnPagoConMedioCuentaCorrienteSeRechaza()
+    {
+        // A diferencia de ValidadorDePagos (regla 5, solo bloquea CC para Consumidor Final), acá
+        // CC está prohibido sin importar el cliente — una deuda no puede pagar otra deuda.
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([CuentaCorriente(100m)], vueltoMaximo: 0m));
+        Assert.Equal("pago_a_cuenta_sin_medios_fisicos", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnaMezclaConUnMedioFisicoYUnoDeCuentaCorrienteSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Efectivo(100m), CuentaCorriente(50m)], vueltoMaximo: 0m));
+        Assert.Equal("pago_a_cuenta_sin_medios_fisicos", excepcion.Codigo);
+    }
+
+    // ---- 4: medio_no_admite_vuelto -------------------------------------------------------------
+
+    [Fact]
+    public void VueltoRechazadoSobreUnMedioSinAdmiteVuelto()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Tarjeta(120m, vuelto: 20m)], vueltoMaximo: 50m));
+        Assert.Equal("medio_no_admite_vuelto", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void SinVueltoSobreUnMedioSinAdmiteVueltoNoSeRechazaPorEstaRegla()
+    {
+        var excepcion = Record.Exception(() => ValidadorDePagoACuenta.Validar([Tarjeta(100m)], vueltoMaximo: 0m));
+        Assert.True(excepcion is null || ((ErrorDominio)excepcion).Codigo != "medio_no_admite_vuelto");
+    }
+
+    // ---- 5: vuelto_excedido ---------------------------------------------------------------------
+
+    [Fact]
+    public void VueltoSobreElMaximoParametrizadoSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Efectivo(120m, vuelto: 25m)], vueltoMaximo: 20m));
+        Assert.Equal("vuelto_excedido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void VueltoExactoEnElMaximoEsAceptado()
+    {
+        var importeAplicado = ValidadorDePagoACuenta.Validar([Efectivo(120m, vuelto: 20m)], vueltoMaximo: 20m);
+        Assert.Equal(100m, importeAplicado);
+    }
+
+    // ---- 6: referencia_de_pago_requerida ---------------------------------------------------
+
+    [Fact]
+    public void ReferenciaRequeridaYFaltanteSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Tarjeta(100m, requiereReferencia: true, referencia: null)], vueltoMaximo: 0m));
+        Assert.Equal("referencia_de_pago_requerida", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void ReferenciaVaciaOEnBlancoSeConsideraFaltante()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Tarjeta(100m, requiereReferencia: true, referencia: "   ")], vueltoMaximo: 0m));
+        Assert.Equal("referencia_de_pago_requerida", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void ReferenciaProvistaEsAceptada()
+    {
+        var importeAplicado = ValidadorDePagoACuenta.Validar(
+            [Tarjeta(100m, requiereReferencia: true, referencia: "CUPON-123")], vueltoMaximo: 0m);
+        Assert.Equal(100m, importeAplicado);
+    }
+
+    // ---- 7: pago_a_cuenta_sin_importe (spec: derivación importeAplicado) ---------------------
+
+    [Fact]
+    public void SinPagosSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ValidadorDePagoACuenta.Validar([], vueltoMaximo: 0m));
+        Assert.Equal("pago_a_cuenta_sin_importe", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void ImporteAplicadoCeroPorVueltoIgualAlImporteSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([Efectivo(100m, vuelto: 100m)], vueltoMaximo: 100m));
+        Assert.Equal("pago_a_cuenta_sin_importe", excepcion.Codigo);
+    }
+
+    // ---- Derivación de importeAplicado (design decisión 6) -----------------------------------
+
+    [Fact]
+    public void ImporteAplicadoEsLaSumaDeImportesMenosLaSumaDeVueltos()
+    {
+        var importeAplicado = ValidadorDePagoACuenta.Validar(
+            [Efectivo(150m, vuelto: 10m), Tarjeta(50m)], vueltoMaximo: 20m);
+        Assert.Equal(190m, importeAplicado);
+    }
+
+    // ---- Orden de rechazo observable ----------------------------------------------------------
+
+    [Fact]
+    public void UnPagoQueViolaLasReglas3Y5ReportaLaRegla3()
+    {
+        // Regla 3 (medio físico): un medio de cuenta corriente, prohibido de por sí.
+        // Regla 5 (vuelto máximo): si se llegara a evaluar, el vuelto igual excedería el máximo.
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            ValidadorDePagoACuenta.Validar([CuentaCorriente(100m), Efectivo(50m, vuelto: 999m)], vueltoMaximo: 20m));
+        Assert.Equal("pago_a_cuenta_sin_medios_fisicos", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnaMezclaValidaConVariosMediosFisicosEsAceptada()
+    {
+        var importeAplicado = ValidadorDePagoACuenta.Validar(
+            [Efectivo(100m), Tarjeta(50m, requiereReferencia: true, referencia: "OP-1")], vueltoMaximo: 0m);
+        Assert.Equal(150m, importeAplicado);
+    }
+}

--- a/tests/Ways.IntegrationTests/AnulacionTests.cs
+++ b/tests/Ways.IntegrationTests/AnulacionTests.cs
@@ -438,6 +438,91 @@ public class AnulacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtu
         Assert.Equal(HttpStatusCode.OK, reintento.StatusCode);
     }
 
+    // ---- judgment-day fix 2: consumo_reliquidado (design decisión 5) ---------------------------
+
+    /// <summary>El escritor de reliquidación (<c>ServicioDeReliquidacion</c>) todavía no existe —
+    /// Slice 3. Para pinear HOY el guard de <c>ServicioDeVentas.EjecutarAnulacionAsync</c> que lo
+    /// consume (línea "if (movimiento.IdMovimientoActualizacion is not null)"), esta prueba
+    /// simula a mano el efecto del paso 8 de la transacción de reliquidación (design.md,
+    /// Transactions — RELIQUIDACIÓN): una fila <c>ActualizacionPrecios</c> stub que satisface el
+    /// self-FK <c>fk_movimientos_cuenta_corriente_actualizacion</c>, y el marcador puesto sobre el
+    /// consumo — sobre la conexión cruda con el contexto de tenant de <c>ways_app</c> (mismo
+    /// criterio que <see cref="CuentaCorrienteEtapa7BackstopTests"/>), para que la sesión de RLS
+    /// sea idéntica a la de una escritura real.</summary>
+    [Fact]
+    public async Task AnularUnConsumoYaReliquidadoEsRechazado409ConsumoReliquidadoSinCambiarNada()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnConsumoYaReliquidadoEsRechazado409ConsumoReliquidadoSinCambiarNada));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-consumo-reliquidado", 200m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente Consumo Reliquidado", limiteCredito: 1000m);
+
+        var emitido = await EmitirAsync(ctx, idCliente, idArticulo, 200m, idMedio: ctx.IdMedioCuentaCorriente);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var movimientoConsumo = await db.MovimientosCuentaCorriente
+                .SingleAsync(m => m.IdComprobanteVenta == emitido.Id
+                    && m.Tipo == Ways.Domain.CuentaCorriente.TipoMovimientoCc.Consumo);
+
+            await MarcarConsumoComoReliquidadoAsync(ctx, movimientoConsumo);
+        }
+
+        var respuestaAnulacion = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        var cuerpo = await respuestaAnulacion.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuestaAnulacion.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("consumo_reliquidado", problema.GetProperty("codigo").GetString());
+
+        await using var dbDespues = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Nada cambia: ni el estado del comprobante, ni el saldo, ni un contramovimiento nuevo —
+        // el throw dentro del foreach revierte la transacción entera (BeginTransactionAsync
+        // envuelve el paso 1, que ya había marcado 'anulado', junto con este guard).
+        var estado = await dbDespues.ComprobantesVenta.Where(c => c.Id == emitido.Id).Select(c => c.Estado).SingleAsync();
+        Assert.Equal(EstadoComprobante.Emitido, estado);
+
+        var saldo = await dbDespues.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).SingleAsync();
+        Assert.Equal(200m, saldo);
+
+        Assert.Equal(
+            0,
+            await dbDespues.MovimientosCuentaCorriente.CountAsync(
+                m => m.IdComprobanteVenta == emitido.Id && m.Tipo == Ways.Domain.CuentaCorriente.TipoMovimientoCc.Ajuste));
+    }
+
+    private async Task MarcarConsumoComoReliquidadoAsync(
+        Contexto ctx, Ways.Domain.CuentaCorriente.MovimientoCuentaCorriente movimientoConsumo)
+    {
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant);
+
+        int idActualizacion;
+        await using (var insertar = cruda.CreateCommand())
+        {
+            insertar.CommandText =
+                "INSERT INTO movimientos_cuenta_corriente " +
+                "(id_tenant, id_cliente, fecha, id_punto_venta, id_empleado, tipo, importe, saldo_resultante, detalle) " +
+                "VALUES ($1, $2, now(), $3, $4, 'actualizacion_precios', 0, $5, $6) RETURNING id_movimiento";
+            insertar.Parameters.Add(new NpgsqlParameter { Value = ctx.IdTenant });
+            insertar.Parameters.Add(new NpgsqlParameter { Value = movimientoConsumo.IdCliente });
+            insertar.Parameters.Add(new NpgsqlParameter { Value = movimientoConsumo.IdPuntoVenta });
+            insertar.Parameters.Add(new NpgsqlParameter { Value = movimientoConsumo.IdEmpleado });
+            insertar.Parameters.Add(new NpgsqlParameter { Value = movimientoConsumo.SaldoResultante });
+            insertar.Parameters.Add(new NpgsqlParameter
+            {
+                Value = "stub de prueba — el escritor real (ServicioDeReliquidacion) es Slice 3, todavía no existe"
+            });
+            idActualizacion = (int)(await insertar.ExecuteScalarAsync())!;
+        }
+
+        await using var marcar = cruda.CreateCommand();
+        marcar.CommandText =
+            "UPDATE movimientos_cuenta_corriente SET id_movimiento_actualizacion = $1 WHERE id_movimiento = $2";
+        marcar.Parameters.Add(new NpgsqlParameter { Value = idActualizacion });
+        marcar.Parameters.Add(new NpgsqlParameter { Value = movimientoConsumo.Id });
+        await marcar.ExecuteNonQueryAsync();
+    }
+
     // ---- Triaged: anulación de una NCX invierte el signo correctamente -------------------------
 
     /// <summary>Una devolución (NCX) escribe un movimiento de stock ORIGINAL positivo (motivo =

--- a/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
+++ b/tests/Ways.IntegrationTests/CajaResumenContenidoTests.cs
@@ -4,11 +4,14 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
 using Ways.Application.Gastos;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
@@ -96,6 +99,26 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
         await db.SaveChangesAsync();
 
         return area.Id;
+    }
+
+    /// <summary>Cliente propio (no el Consumidor Final que devuelve <c>ctx.IdCliente</c>) para
+    /// registrar una RC — mismo criterio que <c>PagosACuentaTests.SembrarClienteAsync</c>.</summary>
+    private async Task<int> SembrarClienteConCuentaCorrienteAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
     }
 
     private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
@@ -316,5 +339,50 @@ public class CajaResumenContenidoTests(WaysApiFixture fixture) : IClassFixture<W
 
         var almacen = resumen!.IngresosPorArea.Single(a => a.IdArea == idArea);
         Assert.Equal(70m, almacen.Total); // 100 + (-30)
+    }
+
+    /// <summary>judgment-day fix 3: la coherencia de tres puntas de una RC en el resumen D6 (design
+    /// decisión "RC carries zero items and no stock effect", legacy D1 parity de cantidad de
+    /// tickets) — pineada en UN solo test para que no se pueda romper una punta sin que las otras
+    /// tres queden mudas. (a) <c>cantidadTickets</c> INCLUYE la RC — dos series independientes
+    /// (design decisión 7) contadas juntas. (b) los ingresos por área NO la incluyen — una RC no
+    /// tiene items, cero por construcción. (c) el esperado por medio SÍ la incluye — misma plata
+    /// física que ve el arqueo. El primer/último ticket, además, quedan identificados sin
+    /// ambigüedad por <c>Codigo</c> ("TX"/"RC"), no solo por número.</summary>
+    [Fact]
+    public async Task UnaRcParticipaEnTicketsYEnElEsperadoPorMedioPeroNuncaEnLosIngresosPorArea()
+    {
+        var ctx = await PrepararAsync(nameof(UnaRcParticipaEnTicketsYEnElEsperadoPorMedioPeroNuncaEnLosIngresosPorArea));
+        var idArea = await SembrarAreaAsync(ctx, "Almacén RC");
+        var turno = await AbrirTurnoAsync(ctx);
+        var idClienteRc = await SembrarClienteConCuentaCorrienteAsync(ctx, "Cliente RC resumen");
+
+        var tx = await SembrarVentaAsync(ctx, turno.Id, idArea, ctx.IdMedioEfectivo, 100m, DateTimeOffset.UtcNow);
+
+        var solicitudRc = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioEfectivo, 50m, null, 0m)], null);
+        var respuestaRc = await ctx.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idClienteRc}/cuenta-corriente/pagos", solicitudRc);
+        var cuerpoRc = await respuestaRc.Content.ReadAsStringAsync();
+        Assert.True(respuestaRc.StatusCode == HttpStatusCode.Created, cuerpoRc);
+        var rc = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoRc, OpcionesJson)!;
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno.Id}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        // (a) cantidad de tickets — TX y RC son series independientes, pero las dos cuentan.
+        Assert.Equal(2, resumen!.CantidadTickets);
+        Assert.Equal("TX", resumen.PrimerTicket!.Codigo);
+        Assert.Equal(tx.Numero, resumen.PrimerTicket.Numero);
+        Assert.Equal("RC", resumen.UltimoTicket!.Codigo);
+        Assert.Equal(rc.Numero, resumen.UltimoTicket.Numero);
+
+        // (b) ingresos por área — la RC no tiene items, su plata nunca aparece acá.
+        var area = resumen.IngresosPorArea.Single(a => a.IdArea == idArea);
+        Assert.Equal(100m, area.Total);
+
+        // (c) esperado por medio — misma plata física que arma el arqueo, la RC sí cuenta.
+        var esperadoEfectivo = resumen.Medios.Single(m => m.IdMedioPago == ctx.IdMedioEfectivo).ImporteEsperado;
+        Assert.Equal(150m, esperadoEfectivo);
     }
 }

--- a/tests/Ways.IntegrationTests/PagosACuentaTests.cs
+++ b/tests/Ways.IntegrationTests/PagosACuentaTests.cs
@@ -186,6 +186,12 @@ public class PagosACuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
         var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
 
         Assert.Null(emitido.Observaciones);
+
+        // Releer de la base: la respuesta se proyecta de la entidad trackeada, no prueba
+        // persistencia por sí sola.
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fila = await db.ComprobantesVenta.SingleAsync(c => c.Id == emitido.Id);
+        Assert.Null(fila.Observaciones);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/PagosACuentaTests.cs
+++ b/tests/Ways.IntegrationTests/PagosACuentaTests.cs
@@ -1,0 +1,732 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 2 (tasks 2.9-2.15, 2.17): <c>POST
+/// /api/clientes/{id}/cuenta-corriente/pagos</c> punta a punta — emisión de RC, atomicidad,
+/// participación en el arqueo, numeración independiente, anulación y el presupuesto de consultas.
+/// Mismo criterio que <see cref="VentasTurnoWiringTests"/>: <see cref="PrepararAsync"/> NUNCA abre
+/// un turno por defecto, cada prueba lo hace explícito.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class PagosACuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "una-contraseña-larga";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpresa, int IdEmpleadoAdmin, int IdListaPrecio,
+        int IdMedioEfectivo, int IdMedioTarjeta, int IdMedioCuentaCorriente, int IdConsumidorFinal, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        var medioTarjeta = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Tarjeta", Orden = 2,
+            Comportamiento = ComportamientoMedioPago.Electronico, AdmiteVuelto = false, RequiereReferencia = true,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioTarjeta);
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        var idConsumidorFinal = await db.Clientes
+            .Where(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal).Select(c => c.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdEmpresa, resultado.IdUsuarioAdmin, idListaPrecio,
+            idMedioEfectivo, medioTarjeta.Id, medioCc.Id, idConsumidorFinal, admin);
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre, decimal saldo = 0m)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = saldo, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx, decimal fondoInicial = 0m)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, fondoInicial, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private static SolicitudDePagoACuenta SolicitudSimple(Contexto ctx, decimal importe) =>
+        new(ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioEfectivo, importe, null, 0m)], null);
+
+    private static async Task<HttpResponseMessage> RegistrarPagoAsync(
+        Contexto ctx, int idCliente, SolicitudDePagoACuenta solicitud) =>
+        await ctx.Admin.PostAsJsonAsync($"/api/clientes/{idCliente}/cuenta-corriente/pagos", solicitud);
+
+    // ---- task 2.9: forma del comprobante RC, turno, medios, CF ------------------------------
+
+    [Fact]
+    public async Task RcEmisionPersisteCeroItemsYCeroMovimientosDeStock()
+    {
+        var ctx = await PrepararAsync(nameof(RcEmisionPersisteCeroItemsYCeroMovimientosDeStock));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC items");
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        Assert.Empty(emitido.Items);
+        Assert.False(emitido.Estado == EstadoComprobante.Anulado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ItemsComprobanteVenta.CountAsync(i => i.IdComprobanteVenta == emitido.Id));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == emitido.Id));
+
+        // comprobantes-venta / RC emission never touches fiscal fields.
+        var (netoGravado, ivaTotal) = await db.ComprobantesVenta
+            .Where(c => c.Id == emitido.Id).Select(c => new { c.NetoGravado, c.IvaTotal })
+            .Select(x => new ValueTuple<decimal?, decimal?>(x.NetoGravado, x.IvaTotal)).SingleAsync();
+        Assert.Null(netoGravado);
+        Assert.Null(ivaTotal);
+    }
+
+    [Fact]
+    public async Task RcSinTurnoAbiertoEsRechazada409AntesDeCualquierEscritura()
+    {
+        var ctx = await PrepararAsync(nameof(RcSinTurnoAbiertoEsRechazada409AntesDeCualquierEscritura));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC sin turno");
+        // Sin AbrirTurnoAsync a propósito.
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(0m, saldo);
+    }
+
+    [Fact]
+    public async Task RcAdjuntaElTurnoAbiertoResuelto()
+    {
+        var ctx = await PrepararAsync(nameof(RcAdjuntaElTurnoAbiertoResuelto));
+        var turno = await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC turno");
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 100m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idTurnoPersistido = await db.ComprobantesVenta
+            .Where(c => c.Id == emitido.Id).Select(c => c.IdTurnoCaja).SingleAsync();
+        Assert.Equal(turno.Id, idTurnoPersistido);
+    }
+
+    [Fact]
+    public async Task RcConMedioCuentaCorrienteEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(RcConMedioCuentaCorrienteEsRechazada));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC medio CC");
+
+        var solicitud = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioCuentaCorriente, 100m, null, 0m)], null);
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("pago_a_cuenta_sin_medios_fisicos", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+    }
+
+    [Fact]
+    public async Task RcParaConsumidorFinalEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(RcParaConsumidorFinalEsRechazada));
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await RegistrarPagoAsync(ctx, ctx.IdConsumidorFinal, SolicitudSimple(ctx, 100m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("cliente_sin_cuenta_corriente", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task RcAceptadaConMediosFisicosMixtos()
+    {
+        var ctx = await PrepararAsync(nameof(RcAceptadaConMediosFisicosMixtos));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC mixto");
+
+        var solicitud = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta,
+            [
+                new PagoDeCuenta(ctx.IdMedioEfectivo, 100m, null, 0m),
+                new PagoDeCuenta(ctx.IdMedioTarjeta, 50m, "OP-1", 0m)
+            ],
+            null);
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+        Assert.Equal(150m, emitido.Total);
+    }
+
+    // ---- task 2.10: un único movimiento Pago, atomicidad, sobrepago -------------------------
+
+    [Fact]
+    public async Task RcEmisionEscribeUnMovimientoPagoYBajaElSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(RcEmisionEscribeUnMovimientoPagoYBajaElSaldo));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC saldo", saldo: 500m);
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == emitido.Id).ToListAsync();
+        var movimiento = Assert.Single(movimientos);
+        Assert.Equal(TipoMovimientoCc.Pago, movimiento.Tipo);
+        Assert.Equal(-200m, movimiento.Importe);
+        // consumo-cuenta-corriente / Pago snapshots the resulting saldo.
+        Assert.Equal(300m, movimiento.SaldoResultante);
+        Assert.Null(movimiento.IdPagoComprobante);
+
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(300m, saldo);
+    }
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>Fault injection determinística — mismo criterio que
+    /// <c>VentasAtomicidadYConcurrenciaTests.IntentarConPrivilegioRevocadoAsync</c>: REVOCA el
+    /// privilegio sobre <c>pagos_comprobante</c> (con <c>ways_owner</c>), fuerza el 500 DESPUÉS de
+    /// que <c>comprobantes_venta</c> ya insertó dentro de la MISMA transacción (spec: A failure
+    /// after the comprobante insert rolls back everything), y restaura el privilegio.</summary>
+    [Fact]
+    public async Task UnaFallaDespuesDelInsertDelComprobanteRevierteTodo()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaDespuesDelInsertDelComprobanteRevierteTodo));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC atomicidad", saldo: 500m);
+
+        await RevocarAsync("pagos_comprobante", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        }
+        finally
+        {
+            await RestaurarAsync("pagos_comprobante", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(0, await db.PagosComprobante.CountAsync());
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(500m, saldo);
+    }
+
+    [Fact]
+    public async Task SobrepagoProduceSaldoAFavorSinRechazo()
+    {
+        var ctx = await PrepararAsync(nameof(SobrepagoProduceSaldoAFavorSinRechazo));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC sobrepago", saldo: 100m);
+
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 150m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(-50m, saldo);
+    }
+
+    // ---- task 2.11: anulación de una RC ------------------------------------------------------
+
+    [Fact]
+    public async Task AnulandoUnaRcRestauraElSaldoConUnContramovimientoPositivo()
+    {
+        var ctx = await PrepararAsync(nameof(AnulandoUnaRcRestauraElSaldoConUnContramovimientoPositivo));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC anulacion", saldo: 500m);
+
+        var respuestaPago = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        Assert.Equal(HttpStatusCode.Created, respuestaPago.StatusCode);
+        var emitido = (await respuestaPago.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        await using (var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(300m, await dbAntes.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync());
+        }
+
+        var respuestaAnulacion = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        var cuerpo = await respuestaAnulacion.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnulacion.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(500m, saldo);
+
+        var contramovimientos = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == emitido.Id && m.Tipo == TipoMovimientoCc.Ajuste).ToListAsync();
+        var contramovimiento = Assert.Single(contramovimientos);
+        Assert.Equal(200m, contramovimiento.Importe);
+        Assert.Null(contramovimiento.IdPagoComprobante);
+    }
+
+    [Fact]
+    public async Task AnulacionDeUnaRcEsRechazada409TurnoCerradoCuandoElTurnoYaCerro()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionDeUnaRcEsRechazada409TurnoCerradoCuandoElTurnoYaCerro));
+        var turno = await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC turno cerrado", saldo: 500m);
+
+        var respuestaPago = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        Assert.Equal(HttpStatusCode.Created, respuestaPago.StatusCode);
+        var emitido = (await respuestaPago.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 200m)], null);
+        var respuestaCierre = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+        Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+        var respuestaAnulacion = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        var cuerpo = await respuestaAnulacion.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuestaAnulacion.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("turno_cerrado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.12: numeración independiente de TX ------------------------------------------
+
+    [Fact]
+    public async Task RcYTxNumeranIndependientementeEnElMismoPuntoDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(RcYTxNumeranIndependientementeEnElMismoPuntoDeVenta));
+        await AbrirTurnoAsync(ctx);
+        var idClienteCc = await SembrarClienteAsync(ctx, "Cliente RC numeracion");
+        var idClienteTx = await SembrarClienteAsync(ctx, "Cliente TX numeracion");
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-numeracion-rc", 100m);
+
+        var solicitudTx = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idClienteTx, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var respuestaTxPrevia = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudTx);
+            Assert.Equal(HttpStatusCode.Created, respuestaTxPrevia.StatusCode);
+        }
+
+        var respuestaRc = await RegistrarPagoAsync(ctx, idClienteCc, SolicitudSimple(ctx, 50m));
+        Assert.Equal(HttpStatusCode.Created, respuestaRc.StatusCode);
+        var rc = (await respuestaRc.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(1L, rc.Numero);
+
+        var respuestaTxSiguiente = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudTx);
+        Assert.Equal(HttpStatusCode.Created, respuestaTxSiguiente.StatusCode);
+        var txSiguiente = (await respuestaTxSiguiente.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+        Assert.Equal(4L, txSiguiente.Numero);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idArea = await db.Areas.Select(a => a.Id).FirstOrDefaultAsync();
+        if (idArea == 0)
+        {
+            var area = new Area
+            {
+                IdTenant = ctx.IdTenant, Nombre = "Area RC", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.Areas.Add(area);
+            await db.SaveChangesAsync();
+            idArea = area.Id;
+        }
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Ways.Domain.Articulos.Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = idArea, IdAlicuotaIva = idAlicuotaIva, UnidadVenta = Ways.Domain.Articulos.UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Ways.Domain.Precios.Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    // ---- task 2.13: participación en el arqueo -----------------------------------------------
+
+    [Fact]
+    public async Task UnaRcDeEfectivoCuentaParaElEsperadoDeEfectivoJuntoConUnaTx()
+    {
+        var ctx = await PrepararAsync(nameof(UnaRcDeEfectivoCuentaParaElEsperadoDeEfectivoJuntoConUnaTx));
+        var turno = await AbrirTurnoAsync(ctx);
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-arqueo-rc", 1000m);
+        var idClienteTx = await SembrarClienteAsync(ctx, "Cliente TX arqueo");
+        var idClienteRc = await SembrarClienteAsync(ctx, "Cliente RC arqueo");
+
+        var solicitudTx = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idClienteTx, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 1000m, null, 0m)],
+            null, null);
+        var respuestaTx = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudTx);
+        Assert.Equal(HttpStatusCode.Created, respuestaTx.StatusCode);
+
+        var respuestaRc = await RegistrarPagoAsync(ctx, idClienteRc, SolicitudSimple(ctx, 300m));
+        Assert.Equal(HttpStatusCode.Created, respuestaRc.StatusCode);
+
+        var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 1300m)], null);
+        var respuestaCierre = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+        var cuerpoCierre = await respuestaCierre.Content.ReadAsStringAsync();
+        Assert.True(respuestaCierre.StatusCode == HttpStatusCode.OK, cuerpoCierre);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var importeEsperado = await db.ArqueosTurno
+            .Where(a => a.IdTurnoCaja == turno.Id && a.IdMedioPago == ctx.IdMedioEfectivo)
+            .Select(a => a.ImporteEsperado).SingleAsync();
+        Assert.Equal(1300m, importeEsperado);
+    }
+
+    // ---- task 2.14: carrera pago a cuenta vs cierre -------------------------------------------
+
+    [Fact]
+    public async Task UnPagoACuentaQueCompiteConUnCierreQuedaContadoEnElArqueoORechazadoNuncaSinContar()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(UnPagoACuentaQueCompiteConUnCierreQuedaContadoEnElArqueoORechazadoNuncaSinContar)}-{ronda}");
+            // Fondo inicial > 0 deja el ancla (efectivo) SIEMPRE arqueable (design: CalculadorDeArqueo,
+            // "hayMovimientoFisicoDelAncla") sin importar si el pago a cuenta gana o pierde la
+            // carrera — mismo criterio que VentasTurnoWiringTests, que sembraba un pago previo con
+            // el mismo propósito.
+            var turno = await AbrirTurnoAsync(ctx, fondoInicial: 500m);
+            var idCliente = await SembrarClienteAsync(ctx, "Cliente RC race cierre", saldo: 1000m);
+
+            var solicitudDeCierre = new SolicitudDeCierre([new ConteoDeclarado(ctx.IdMedioEfectivo, 500m)], null);
+
+            var tareaPago = RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 100m));
+            var tareaCierre = ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+
+            var respuestaPago = await tareaPago;
+            var respuestaCierre = await tareaCierre;
+
+            Assert.Contains(respuestaPago.StatusCode, new[] { HttpStatusCode.Created, HttpStatusCode.Conflict });
+            if (respuestaPago.StatusCode == HttpStatusCode.Conflict)
+            {
+                var problema = await respuestaPago.Content.ReadFromJsonAsync<JsonElement>();
+                Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+            }
+
+            Assert.Equal(HttpStatusCode.OK, respuestaCierre.StatusCode);
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var importeEsperado = await db.ArqueosTurno
+                .Where(a => a.IdTurnoCaja == turno.Id && a.IdMedioPago == ctx.IdMedioEfectivo)
+                .Select(a => a.ImporteEsperado).SingleAsync();
+
+            var esperado = respuestaPago.StatusCode == HttpStatusCode.Created ? 600m : 500m;
+            Assert.Equal(esperado, importeEsperado);
+        }
+    }
+
+    // ---- task 2.15: presupuesto de consultas, constante independiente de la cantidad de medios --
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    private async Task<int> EmitirRcYContarConsultasAsync(Contexto ctx, int idCliente, IReadOnlyList<PagoDeCuenta> pagos)
+    {
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Ways.Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<Ways.Domain.Articulos.UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: ctx.IdEmpleadoAdmin);
+        var lector = new LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new ServicioDeTurnos(db, reloj, contexto, lector);
+        var servicio = new ServicioDeCuentaCorriente(db, reloj, contexto, servicioDeTurnos);
+
+        var emitido = await servicio.RegistrarPagoAsync(idCliente, new SolicitudDePagoACuenta(ctx.IdPuntoVenta, pagos, null));
+        Assert.False(emitido.Estado == EstadoComprobante.Anulado);
+
+        return contador.Consultas;
+    }
+
+    [Fact]
+    public async Task PagoACuentaEmiteUnPresupuestoConstanteDeConsultasIndependienteDeLaCantidadDeMedios()
+    {
+        var ctx = await PrepararAsync(nameof(PagoACuentaEmiteUnPresupuestoConstanteDeConsultasIndependienteDeLaCantidadDeMedios));
+        await AbrirTurnoAsync(ctx);
+        var idClienteUnMedio = await SembrarClienteAsync(ctx, "Cliente budget 1 medio");
+        var idClienteTresMedios = await SembrarClienteAsync(ctx, "Cliente budget 3 medios");
+
+        var consultasUnMedio = await EmitirRcYContarConsultasAsync(
+            ctx, idClienteUnMedio, [new PagoDeCuenta(ctx.IdMedioEfectivo, 100m, null, 0m)]);
+
+        var consultasTresMedios = await EmitirRcYContarConsultasAsync(
+            ctx, idClienteTresMedios,
+            [
+                new PagoDeCuenta(ctx.IdMedioEfectivo, 50m, null, 0m),
+                new PagoDeCuenta(ctx.IdMedioTarjeta, 30m, "OP-1", 0m),
+                new PagoDeCuenta(ctx.IdMedioTarjeta, 20m, "OP-2", 0m)
+            ]);
+
+        // Presupuesto constante — independiente de la cantidad de medios (design: Transactions —
+        // "Read budget"). 8 consultas EF/SaveChanges visibles (cliente, punto de venta, turno,
+        // tipo RC, medios de pago, vuelto_maximo, INSERT comprobante, INSERT pagos); el "≤ 7" del
+        // design no lista la resolución del tipo de comprobante 'RC' en su "fuera" — deviation
+        // documentada en el resumen de retorno del apply, la propiedad que importa (constante,
+        // no escala con la cantidad de medios) queda probada igual.
+        Assert.Equal(8, consultasUnMedio);
+        Assert.Equal(consultasUnMedio, consultasTresMedios);
+    }
+
+    // ---- authorization (house lessons: 401/403/cross-tenant-404) -----------------------------
+
+    private async Task<HttpClient> CrearVendedorAsync(Contexto ctx, string nombre)
+    {
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-rc", mailVendedor, (int)RolConocido.Vendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return vendedor;
+    }
+
+    [Fact]
+    public async Task UnVendedorPuedeRegistrarUnPagoACuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorPuedeRegistrarUnPagoACuenta));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC vendedor");
+        using var vendedor = await CrearVendedorAsync(ctx, nameof(UnVendedorPuedeRegistrarUnPagoACuenta));
+
+        var respuesta = await vendedor.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/pagos", SolicitudSimple(ctx, 50m));
+
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRolFueraDeOperacionDePosEsRechazadoDelPagoACuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnRolFueraDeOperacionDePosEsRechazadoDelPagoACuenta));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC root");
+
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var respuesta = await root.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/pagos", SolicitudSimple(ctx, 50m));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task RegistrarUnPagoACuentaSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/clientes/1/cuenta-corriente/pagos", new SolicitudDePagoACuenta(1, [], null));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task RegistrarUnPagoACuentaContraUnClienteDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(RegistrarUnPagoACuentaContraUnClienteDeOtroTenantDevuelve404) + "-A");
+        var idClienteDeA = await SembrarClienteAsync(ctxA, "Cliente A cross-tenant");
+
+        var ctxB = await PrepararAsync(nameof(RegistrarUnPagoACuentaContraUnClienteDeOtroTenantDevuelve404) + "-B");
+        await AbrirTurnoAsync(ctxB);
+
+        var respuesta = await ctxB.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idClienteDeA}/cuenta-corriente/pagos", SolicitudSimple(ctxB, 50m));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/PagosACuentaTests.cs
+++ b/tests/Ways.IntegrationTests/PagosACuentaTests.cs
@@ -142,17 +142,26 @@ public class PagosACuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
         await AbrirTurnoAsync(ctx);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente RC items");
 
-        var respuesta = await RegistrarPagoAsync(ctx, idCliente, SolicitudSimple(ctx, 200m));
+        var solicitud = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioEfectivo, 200m, null, 0m)], "  Pago parcial de saldo  ");
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, solicitud);
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
         var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
 
         Assert.Empty(emitido.Items);
         Assert.False(emitido.Estado == EstadoComprobante.Anulado);
+        // task judgment-day fix 1: Observaciones viajaba en la solicitud pero se descartaba en
+        // silencio (EjecutarTransaccionAsync hardcodeaba null) — recortado, nunca en blanco.
+        Assert.Equal("Pago parcial de saldo", emitido.Observaciones);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(0, await db.ItemsComprobanteVenta.CountAsync(i => i.IdComprobanteVenta == emitido.Id));
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == emitido.Id));
+
+        var observacionesPersistidas = await db.ComprobantesVenta
+            .Where(c => c.Id == emitido.Id).Select(c => c.Observaciones).SingleAsync();
+        Assert.Equal("Pago parcial de saldo", observacionesPersistidas);
 
         // comprobantes-venta / RC emission never touches fiscal fields.
         var (netoGravado, ivaTotal) = await db.ComprobantesVenta
@@ -160,6 +169,23 @@ public class PagosACuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
             .Select(x => new ValueTuple<decimal?, decimal?>(x.NetoGravado, x.IvaTotal)).SingleAsync();
         Assert.Null(netoGravado);
         Assert.Null(ivaTotal);
+    }
+
+    [Fact]
+    public async Task RcConObservacionesEnBlancoLasPersisteComoNull()
+    {
+        var ctx = await PrepararAsync(nameof(RcConObservacionesEnBlancoLasPersisteComoNull));
+        await AbrirTurnoAsync(ctx);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente RC obs blancas");
+
+        var solicitud = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioEfectivo, 100m, null, 0m)], "   ");
+        var respuesta = await RegistrarPagoAsync(ctx, idCliente, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        Assert.Null(emitido.Observaciones);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -59,6 +59,10 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // apilado, mismo criterio que los dos de arriba (spec: gastos / Gasto Authorization, un
         // Vendedor tiene que poder registrar un gasto).
         ("POST", "/api/gastos/"),
+        // stage-7-cuenta-corriente (Slice 2, task 2.7): pago a cuenta (RC) — sin GestionDeCatalogo
+        // apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que poder cobrar una
+        // cuenta corriente).
+        ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/pagos"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

Slice 2/6 de la etapa 7 (stage-7-cuenta-corriente): el pago a cuenta como comprobante real.

- `RC` fluye por la maquinaria de comprobantes: numeración propia (serie independiente por tipo), turno `FOR SHARE` como primer statement, pagos físicos, y UN movimiento `Pago` negativo con el saldo actualizado atómicamente. La plata física del cobro entra al arqueo del cierre por la derivación existente, sin tocarla.
- **`EscriturasDeCuentaCorriente` extraída** de `ServicioDeVentas` (una sola implementación del UPDATE atómico de saldo + INSERT de movimiento) con guard defensivo de forma por tipo. `ServicioDeVentas` queda con -43 líneas netas.
- `ValidadorDePagoACuenta` puro (7 reglas: solo medios físicos, CF rechazado, importe > 0...). `ValidadorDePagos` intacto — la tolerancia de pago no se filtra.
- `AnularAsync` ensanchado mínimo: el contramovimiento cubre `Pago`, y el guard nuevo `409 consumo_reliquidado` (verificado por mutación) protege contra anular un consumo ya cubierto por una reliquidación.
- D6 coherente: primer/último ticket llevan el código de tipo ("TX #1001" / "RC #3" — series independientes legibles); el gap de áreas del RC documentado como paridad legacy (tipo=3 tampoco tenía líneas).

## Verificación

- Suites: Domain 322 (+16), Application 211 (+2), Integration 510 (+22), vitest 221, contra Postgres real; presupuesto de queries del RC = 8 constante (contabilidad honesta del extra por la resolución del tipo).
- Judgment-day (ronda dedicada — toca la transacción custodiada): ronda 1 — 4 hallazgos entre ambos jueces (Observaciones descartada [2ª aparición del patrón → skill nueva `dto-contract-honesty`], guard sin test, coherencia D6 del RC, forma del writer sin blindar), todos corregidos con evidencia de mutación; el TOCTOU anulación×reliquidación agendado como tarea 3.13 antes de que exista el escritor del marcador. Ronda 2 — ambos jueces CLEAN; 2 minors de trámite aplicados por el orquestador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)