### PR TITLE
feat(cc): motor de reliquidacion a precio del dia (etapa 7, slice 3)

### DIFF
--- a/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
@@ -22,6 +22,25 @@ public static class CuentaCorrienteEndpoints
         })
         .WithSummary("Registra un pago a cuenta (RC). Cero items, un único movimiento Pago negativo.");
 
+        // stage-7-cuenta-corriente (Slice 3, task 3.5, design: API Surface): preview — la MISMA
+        // ReliquidadorDeConsumos que el commit, sin lock, nunca autoritativo.
+        // SupervisionDeCuentaCorriente apilado sobre OperacionDePos (mismo patrón que
+        // GestionDeCatalogo en ArticulosEndpoints): con SupervisionDeCuentaCorriente ⊆
+        // OperacionDePos, el AND de las dos policies deja el efecto neto en Supervisor+Admin.
+        grupo.MapGet("/reliquidacion", async (
+            ServicioDeReliquidacion servicio, int idCliente, CancellationToken ct) =>
+            Results.Ok(await servicio.PreviewAsync(idCliente, ct)))
+        .RequireAuthorization(Politicas.SupervisionDeCuentaCorriente)
+        .WithSummary("Preview de reliquidación a precio del día — mismo cálculo que el commit, sin lock, nunca autoritativo.");
+
+        // stage-7-cuenta-corriente (Slice 3, task 3.5): commit — irreversible, sin turno (design
+        // decisión 4).
+        grupo.MapPost("/reliquidacion", async (
+            ServicioDeReliquidacion servicio, int idCliente, SolicitudDeReliquidacion solicitud, CancellationToken ct) =>
+            Results.Ok(await servicio.EjecutarAsync(idCliente, solicitud, ct)))
+        .RequireAuthorization(Politicas.SupervisionDeCuentaCorriente)
+        .WithSummary("Ejecuta la reliquidación a precio del día — irreversible, sin turno.");
+
         return app;
     }
 }

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -47,6 +47,15 @@ public static class Politicas
     /// exclusivamente bajo <see cref="GestionDeOrganizacion"/>.</summary>
     public const string LecturaDePuntosVenta = "lectura_puntos_venta";
 
+    /// <summary>Supervisor o admin — la puerta de la reliquidación a precio del día y el ajuste
+    /// manual de cuenta corriente (stage-7-cuenta-corriente, tasks.md Orchestrator Decision 2;
+    /// spec: operacion-de-pos / SupervisionDeCuentaCorriente Policy Gates Reliquidación And
+    /// Ajuste Manual). Nombrada genéricamente a propósito (no "ReliquidacionDeCuenta") para que
+    /// el tightening diferido de cierre (open question de stage 6) pueda apilarse acá sin una
+    /// segunda policy. Vendedor queda afuera: es la única desviación deliberada de paridad
+    /// legacy de esta etapa (el legacy no tiene ningún gate de rol sobre cuenta corriente).</summary>
+    public const string SupervisionDeCuentaCorriente = "supervision_cuenta_corriente";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -82,6 +91,12 @@ public static class Politicas
                             ((int)RolConocido.Root).ToString(),
                             ((int)RolConocido.Admin).ToString(),
                             ((int)RolConocido.Supervisor).ToString(),
-                            ((int)RolConocido.Vendedor).ToString()));
+                            ((int)RolConocido.Vendedor).ToString()))
+            .AddPolicy(SupervisionDeCuentaCorriente, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(
+                            ClaimsWays.RolId,
+                            ((int)RolConocido.Supervisor).ToString(),
+                            ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Application/CuentaCorriente/Contratos.cs
+++ b/src/Ways.Application/CuentaCorriente/Contratos.cs
@@ -14,3 +14,11 @@ public sealed record SolicitudDePagoACuenta(
 /// <see cref="Ventas.PagoDeVenta"/>, redeclarado acá porque una RC no es un checkout (design
 /// decisión 1: no reusa <c>ServicioDeVentas</c>).</summary>
 public sealed record PagoDeCuenta(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);
+
+/// <summary>
+/// Cuerpo de <c>POST /api/clientes/{id}/cuenta-corriente/reliquidacion</c> (design: API Surface).
+/// <see cref="IdPuntoVenta"/> es provenance, no autoridad (design: Open Questions — la
+/// reliquidación no tiene turno del que derivarlo, así que viaja en el request, validado
+/// tenant-scoped como cualquier otro id de punto de venta) — se persiste en el movimiento
+/// <c>ActualizacionPrecios</c> resultante.</summary>
+public sealed record SolicitudDeReliquidacion(int IdPuntoVenta);

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -50,21 +50,31 @@ public static class EscriturasDeCuentaCorriente
     /// <c>id_pago_comprobante</c> (el pago físico de la RC no es "el que generó" el movimiento —
     /// el movimiento lo genera el comprobante entero), y un <see cref="TipoMovimientoCc.Ajuste"/>
     /// manual (Slice 4) no trae ninguno de los dos. El llamador decide qué pasa; esta clase solo
-    /// escribe.</summary>
-    public static async Task InsertarMovimientoCcAsync(
+    /// escribe.
+    ///
+    /// stage-7-cuenta-corriente (Slice 3): <c>RETURNING id_movimiento</c> — la reliquidación
+    /// (<c>ServicioDeReliquidacion</c>) necesita el id de la fila recién insertada para el paso 8
+    /// de su transacción (marcar cada consumo cubierto con un self-FK a esta fila). Los llamadores
+    /// preexistentes (<c>ServicioDeVentas</c>/<c>ServicioDeCuentaCorriente</c>) siguen sin usar el
+    /// valor devuelto — <c>await</c> sin asignar sigue compilando igual. <paramref name="detalle"/>
+    /// nuevo (Slice 3): <c>NULL</c> para <see cref="TipoMovimientoCc.Consumo"/>/<see cref="TipoMovimientoCc.Pago"/>,
+    /// el JSON auditable para <see cref="TipoMovimientoCc.ActualizacionPrecios"/> (design: Table
+    /// Shapes A — columna <c>text</c>, doc-10 §8).</summary>
+    public static async Task<int> InsertarMovimientoCcAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, DateTimeOffset fecha,
         int idPuntoVenta, int idEmpleado, TipoMovimientoCc tipo, int? idComprobanteVenta, int? idPagoComprobante,
-        decimal importe, decimal saldoResultante, CancellationToken ct)
+        decimal importe, decimal saldoResultante, string? detalle, CancellationToken ct)
     {
-        ValidarFormaPorTipo(tipo, idPagoComprobante);
+        ValidarFormaPorTipo(tipo, idComprobanteVenta, idPagoComprobante);
 
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccion;
         comando.CommandText =
             "INSERT INTO movimientos_cuenta_corriente " +
             "(id_tenant, id_cliente, fecha, id_punto_venta, id_empleado, tipo, id_comprobante_venta, " +
-            " id_pago_comprobante, importe, saldo_resultante) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+            " id_pago_comprobante, importe, saldo_resultante, detalle) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) " +
+            "RETURNING id_movimiento";
 
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, idCliente);
@@ -76,17 +86,20 @@ public static class EscriturasDeCuentaCorriente
         AgregarParametroNullable(comando, idPagoComprobante);
         AgregarParametro(comando, importe);
         AgregarParametro(comando, saldoResultante);
+        AgregarParametroNullable(comando, detalle);
 
-        await comando.ExecuteNonQueryAsync(ct);
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("No se pudo insertar el movimiento de cuenta corriente.");
+        return Convert.ToInt32(resultado);
     }
 
     /// <summary>Defensa en profundidad, infraestructura pura (nunca un <c>ErrorDominio</c> 4xx):
     /// pinea acá, en el único escritor, la forma nullable por tipo que hoy solo garantizan los
-    /// llamadores (design: decision 5 — movement shape per tipo). Solo <see cref="TipoMovimientoCc.Consumo"/>
-    /// y <see cref="TipoMovimientoCc.Pago"/> tienen una forma única y fija (el resto — un
-    /// <c>Ajuste</c> puede ser un contramovimiento de anulación o un ajuste manual — es
-    /// estructuralmente dual, no viola nada acá).</summary>
-    private static void ValidarFormaPorTipo(TipoMovimientoCc tipo, int? idPagoComprobante)
+    /// llamadores (design: decision 5 — movement shape per tipo). <see cref="TipoMovimientoCc.Consumo"/>,
+    /// <see cref="TipoMovimientoCc.Pago"/> y (Slice 3) <see cref="TipoMovimientoCc.ActualizacionPrecios"/>
+    /// tienen una forma única y fija (el resto — un <c>Ajuste</c> puede ser un contramovimiento de
+    /// anulación o un ajuste manual — es estructuralmente dual, no viola nada acá).</summary>
+    private static void ValidarFormaPorTipo(TipoMovimientoCc tipo, int? idComprobanteVenta, int? idPagoComprobante)
     {
         if (tipo == TipoMovimientoCc.Consumo && idPagoComprobante is null)
         {
@@ -98,6 +111,13 @@ public static class EscriturasDeCuentaCorriente
         {
             throw new InvalidOperationException(
                 "Un movimiento de tipo Pago nunca lleva id_pago_comprobante — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCc.ActualizacionPrecios && (idComprobanteVenta is not null || idPagoComprobante is not null))
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo ActualizacionPrecios no lleva id_comprobante_venta ni id_pago_comprobante — " +
+                "invariante de escritura violado.");
         }
     }
 

--- a/src/Ways.Application/CuentaCorriente/LectorDeConsumosReliquidables.cs
+++ b/src/Ways.Application/CuentaCorriente/LectorDeConsumosReliquidables.cs
@@ -25,7 +25,8 @@ public class LectorDeConsumosReliquidables(IWaysDbContext db)
     /// <c>ix_movimientos_cuenta_corriente_consumos_pendientes</c> ES esta predicate), <c>importe
     /// &gt; 0</c>, el comprobante <c>estado = 'emitido'</c> (un anulado NUNCA se reliquida — deja
     /// pasar la deuda contra-movida por la anulación) y <c>comprobante.total &gt; 0</c>. Ordenado
-    /// por <c>fecha ASC</c>.</summary>
+    /// por <c>fecha ASC, id ASC</c> — el desempate por <c>id</c> hace determinístico el corte del
+    /// slot 500 cuando dos consumos comparten <c>fecha</c>.</summary>
     public async Task<IReadOnlyList<ConsumoAReliquidar>> LeerElegiblesAsync(int idCliente, CancellationToken ct)
     {
         var elegibles = await (
@@ -37,7 +38,7 @@ public class LectorDeConsumosReliquidables(IWaysDbContext db)
                     && m.Importe > 0
                     && c.Estado == EstadoComprobante.Emitido
                     && c.Total > 0
-                orderby m.Fecha ascending
+                orderby m.Fecha ascending, m.Id ascending
                 select new { m.Id, IdComprobanteVenta = c.Id, m.Importe, c.Total })
             .Take(LimiteDeLaConsulta)
             .ToListAsync(ct);

--- a/src/Ways.Application/CuentaCorriente/LectorDeConsumosReliquidables.cs
+++ b/src/Ways.Application/CuentaCorriente/LectorDeConsumosReliquidables.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// El escaneo de elegibilidad de la reliquidación (design decision 3, task 3.3): 2 consultas fijas
+/// (elegibilidad + items), independiente de N — el mismo presupuesto constante que el resto de la
+/// cuenta corriente. DEBE llamarse DESPUÉS de que el llamador ya tomó el lock del cliente (design
+/// decisión 4: "scan runs after it, inside the same transaction") — este lector no toma ningún
+/// lock propio, confía en el del llamador.
+/// </summary>
+public class LectorDeConsumosReliquidables(IWaysDbContext db)
+{
+    /// <summary>Uno más que el cap real (<see cref="ReliquidadorDeConsumos.LimiteConsumosPorCorrida"/>)
+    /// — el sentinel que le permite al calculador puro derivar <c>HayMas</c> de su propio input,
+    /// sin una segunda consulta de conteo (design: Eligibility — "capped at 500 consumos per
+    /// run").</summary>
+    private const int LimiteDeLaConsulta = ReliquidadorDeConsumos.LimiteConsumosPorCorrida + 1;
+
+    /// <summary>Elegibilidad (design: Eligibility, todos los predicados requeridos): <c>tipo =
+    /// 'consumo'</c>, <c>id_movimiento_actualizacion IS NULL</c> (el índice parcial
+    /// <c>ix_movimientos_cuenta_corriente_consumos_pendientes</c> ES esta predicate), <c>importe
+    /// &gt; 0</c>, el comprobante <c>estado = 'emitido'</c> (un anulado NUNCA se reliquida — deja
+    /// pasar la deuda contra-movida por la anulación) y <c>comprobante.total &gt; 0</c>. Ordenado
+    /// por <c>fecha ASC</c>.</summary>
+    public async Task<IReadOnlyList<ConsumoAReliquidar>> LeerElegiblesAsync(int idCliente, CancellationToken ct)
+    {
+        var elegibles = await (
+                from m in db.MovimientosCuentaCorriente
+                join c in db.ComprobantesVenta on m.IdComprobanteVenta equals (int?)c.Id
+                where m.IdCliente == idCliente
+                    && m.Tipo == TipoMovimientoCc.Consumo
+                    && m.IdMovimientoActualizacion == null
+                    && m.Importe > 0
+                    && c.Estado == EstadoComprobante.Emitido
+                    && c.Total > 0
+                orderby m.Fecha ascending
+                select new { m.Id, IdComprobanteVenta = c.Id, m.Importe, c.Total })
+            .Take(LimiteDeLaConsulta)
+            .ToListAsync(ct);
+
+        if (elegibles.Count == 0)
+        {
+            return [];
+        }
+
+        var idsComprobante = elegibles.Select(e => e.IdComprobanteVenta).Distinct().ToList();
+        var items = await db.ItemsComprobanteVenta
+            .Where(i => idsComprobante.Contains(i.IdComprobanteVenta))
+            .Select(i => new { i.IdComprobanteVenta, i.IdArticulo, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total })
+            .ToListAsync(ct);
+
+        var itemsPorComprobante = items.ToLookup(i => i.IdComprobanteVenta);
+
+        return elegibles
+            .Select(e => new ConsumoAReliquidar(
+                e.Id, e.IdComprobanteVenta, e.Importe, e.Total,
+                itemsPorComprobante[e.IdComprobanteVenta]
+                    .Select(i => new LineaAReliquidar(i.IdArticulo, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total))
+                    .ToList()))
+            .ToList();
+    }
+}

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -166,7 +166,7 @@ public class ServicioDeCuentaCorriente(
         // comprobante entero, que puede traer varios medios.
         await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
             conexion, transaccionCruda, idTenant, idCliente, momento, idPuntoVenta, idEmpleado,
-            TipoMovimientoCc.Pago, comprobante.Id, null, -importeAplicado, nuevoSaldo, ct);
+            TipoMovimientoCc.Pago, comprobante.Id, null, -importeAplicado, nuevoSaldo, detalle: null, ct);
 
         await transaccion.CommitAsync(ct);
 

--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -98,9 +98,11 @@ public class ServicioDeReliquidacion(
         {
             // Zero delta ⇒ no-op: COMMIT sin escribir nada (design: The Re-Pricing Derivation —
             // "the same consumos are re-evaluated against the prices of the day the client
-            // actually pays").
+            // actually pays"). La lista de cubiertos del calculador refleja lo PROCESADO, no lo
+            // MARCADO — acá no se escribe ningún marcador, así que la respuesta tiene que reflejar
+            // la DB real: sin cubiertos.
             await transaccion.CommitAsync(ct);
-            return resultado;
+            return resultado with { IdsMovimientosCubiertos = [] };
         }
 
         var conexion = await ObtenerConexionAbiertaAsync(ct);

--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -1,0 +1,249 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Precios;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// Reliquidación a precio del día — el centro de la etapa (design: Technical Approach, "one
+/// derivation, no second copy"). <see cref="PreviewAsync"/> y <see cref="EjecutarAsync"/> llaman a
+/// la MISMA <see cref="ReliquidadorDeConsumos"/> con los MISMOS inputs; la única diferencia entre
+/// los dos es que <see cref="EjecutarAsync"/> corre bajo el lock del cliente y escribe, mientras
+/// <see cref="PreviewAsync"/> nunca lockea ni escribe (design: API Surface — "never authoritative").
+///
+/// Sin turno (design decisión 4, pinned): no mueve plata física, no aporta ningún término a
+/// <c>CalculadorDeArqueo</c>. El PRIMER statement de la transacción de <see cref="EjecutarAsync"/>
+/// es el lock del cliente — el escaneo de elegibles corre DESPUÉS, bajo ese lock, así que una
+/// venta concurrente del mismo cliente se serializa contra esta corrida (design: Concurrency
+/// guarantees).
+/// </summary>
+public class ServicioDeReliquidacion(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, LectorDeConsumosReliquidables lector,
+    ServicioDePrecios servicioDePrecios)
+{
+    /// <summary>Preview — <c>GET</c>, sin lock, nunca autoritativo (design: API Surface). Un
+    /// consumo que se marca ENTRE este preview y el commit siguiente simplemente deja de aparecer
+    /// en el commit — no hay ninguna reserva ni "congelamiento" del resultado del preview.</summary>
+    public async Task<ResultadoDeReliquidacion> PreviewAsync(int idCliente, CancellationToken ct = default)
+    {
+        var cliente = await ResolverClienteAsync(idCliente, ct);
+        var momento = reloj.Ahora;
+
+        var consumos = await lector.LeerElegiblesAsync(idCliente, ct);
+        if (consumos.Count == 0)
+        {
+            return new ResultadoDeReliquidacion(0m, [], [], false);
+        }
+
+        var precioPorArticulo = await ResolverPreciosAsync(consumos, cliente.IdListaPrecio, momento, ct);
+        return ReliquidadorDeConsumos.Calcular(consumos, precioPorArticulo);
+    }
+
+    /// <summary>Commit — design: Transactions, RELIQUIDACIÓN (8 pasos, orden pineado). La mitad
+    /// que decide (cliente, punto de venta) corre AFUERA de la transacción de escritura — mismo
+    /// criterio que el resto de la cuenta corriente.</summary>
+    public async Task<ResultadoDeReliquidacion> EjecutarAsync(
+        int idCliente, SolicitudDeReliquidacion solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        await ResolverClienteAsync(idCliente, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        // Sin reintento automático (mismo criterio que ServicioDeVentas.AnularAsync/
+        // ServicioDeCuentaCorriente.RegistrarPagoAsync): una reliquidación es manual, sin clave de
+        // idempotencia propia.
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarTransaccionAsync(idTenant, idEmpleado, momento, idCliente, puntoVenta.Id, ct));
+    }
+
+    private async Task<ResultadoDeReliquidacion> EjecutarTransaccionAsync(
+        int idTenant, int idEmpleado, DateTimeOffset momento, int idCliente, int idPuntoVenta, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        // 1. Lock del cliente — PRIMER statement, SIN turno (design decisión 4, pinned).
+        var (_, idListaPrecio) = await BloquearClienteAsync(idTenant, idCliente, ct);
+
+        // 2/3. Escaneo de elegibles + items — bajo el lock recién tomado (design: "scan runs
+        // after it, inside the same transaction").
+        var consumos = await lector.LeerElegiblesAsync(idCliente, ct);
+        if (consumos.Count == 0)
+        {
+            // Cero elegibles ⇒ no-op limpio, sin escribir nada (spec: A Run With No Eligible
+            // Consumos Is A No-Op).
+            await transaccion.CommitAsync(ct);
+            return new ResultadoDeReliquidacion(0m, [], [], false);
+        }
+
+        // 4. Precios vigentes en lote — NUNCA ServicioDeOfertas.ResolverAsync (design decisión 3:
+        // reaplicar las ofertas de HOY sería la inversión exacta de "el descuento se anula").
+        var precioPorArticulo = await ResolverPreciosAsync(consumos, idListaPrecio, momento, ct);
+
+        // 5. Cálculo puro — la MISMA fórmula que PreviewAsync (design: "never two formulas").
+        var resultado = ReliquidadorDeConsumos.Calcular(consumos, precioPorArticulo);
+
+        if (resultado.Delta == 0m)
+        {
+            // Zero delta ⇒ no-op: COMMIT sin escribir nada (design: The Re-Pricing Derivation —
+            // "the same consumos are re-evaluated against the prices of the day the client
+            // actually pays").
+            await transaccion.CommitAsync(ct);
+            return resultado;
+        }
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 6. Saldo — el mismo UPDATE ... RETURNING que el resto de la cuenta corriente.
+        var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
+            conexion, transaccionCruda, idTenant, idCliente, resultado.Delta, ct);
+
+        // 7. Movimiento — un único ActualizacionPrecios; id_comprobante_venta/id_pago_comprobante
+        // NULL (no lo origina un comprobante puntual, sino la corrida completa).
+        var detalle = JsonSerializer.Serialize(resultado.Detalle);
+        var idMovimiento = await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+            conexion, transaccionCruda, idTenant, idCliente, momento, idPuntoVenta, idEmpleado,
+            TipoMovimientoCc.ActualizacionPrecios, idComprobanteVenta: null, idPagoComprobante: null, resultado.Delta,
+            nuevoSaldo, detalle, ct);
+
+        // 8. Marcador — self-FK sobre cada consumo cubierto (design decisión 2).
+        var filasMarcadas = await MarcarConsumosCubiertosAsync(
+            conexion, transaccionCruda, idTenant, resultado.IdsMovimientosCubiertos, idMovimiento, ct);
+
+        if (filasMarcadas != resultado.IdsMovimientosCubiertos.Count)
+        {
+            // Defensa en profundidad (design: paso 8 — "rowcount ≠ |ids| ⇒ throw, imposible bajo
+            // el lock"): bajo el lock del cliente ningún otro escritor puede haber tocado el
+            // marcador de estos consumos entre el escaneo (paso 2) y este UPDATE.
+            throw new InvalidOperationException(
+                $"El marcador de reliquidación afectó {filasMarcadas} filas, se esperaban " +
+                $"{resultado.IdsMovimientosCubiertos.Count} — invariante de escritura violado.");
+        }
+
+        await transaccion.CommitAsync(ct);
+        return resultado;
+    }
+
+    // ---- Resolución de datos --------------------------------------------------------------------
+
+    private async Task<IReadOnlyDictionary<int, decimal?>> ResolverPreciosAsync(
+        IReadOnlyList<ConsumoAReliquidar> consumos, int idListaPrecio, DateTimeOffset momento, CancellationToken ct)
+    {
+        var idsArticulo = consumos
+            .SelectMany(c => c.Lineas)
+            .Where(l => l.IdArticulo is not null)
+            .Select(l => l.IdArticulo!.Value)
+            .Distinct()
+            .ToList();
+
+        if (idsArticulo.Count == 0)
+        {
+            return new Dictionary<int, decimal?>();
+        }
+
+        var precios = await servicioDePrecios.PreciosVigentesEnLoteAsync(idsArticulo, [idListaPrecio], momento, ct);
+        return precios.ToDictionary(kv => kv.Key.IdArticulo, kv => kv.Value);
+    }
+
+    private async Task<(decimal Saldo, int IdListaPrecio)> BloquearClienteAsync(
+        int idTenant, int idCliente, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccionCruda;
+        comando.CommandText = "SELECT saldo, id_lista_precio FROM clientes WHERE id_cliente = $1 AND id_tenant = $2 FOR UPDATE";
+
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, idTenant);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            throw new InvalidOperationException(
+                $"El cliente {idCliente} no existe bajo el lock — invariante violado (ya se validó su existencia fuera de la transacción).");
+        }
+
+        var saldo = lector.GetFieldValue<decimal>(0);
+        var idListaPrecio = lector.GetInt32(1);
+        return (saldo, idListaPrecio);
+    }
+
+    /// <summary>Paso 8 — self-FK sobre cada consumo cubierto (design decisión 2). El
+    /// <c>WHERE id_movimiento_actualizacion IS NULL</c> es defensa en profundidad: bajo el lock
+    /// del cliente ningún otro escritor puede haber marcado estos consumos entre el escaneo y
+    /// este UPDATE, así que en operación normal nunca reduce el rowcount por sí solo.</summary>
+    private static async Task<int> MarcarConsumosCubiertosAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, IReadOnlyList<int> idsMovimiento,
+        int idMovimientoActualizacion, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE movimientos_cuenta_corriente SET id_movimiento_actualizacion = $1 " +
+            "WHERE id_movimiento = ANY($2) AND id_tenant = $3 AND id_movimiento_actualizacion IS NULL";
+
+        AgregarParametro(comando, idMovimientoActualizacion);
+        AgregarParametro(comando, idsMovimiento.ToArray());
+        AgregarParametro(comando, idTenant);
+
+        return await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task<Cliente> ResolverClienteAsync(int idCliente, CancellationToken ct)
+    {
+        var cliente = await db.Clientes.FirstOrDefaultAsync(c => c.Id == idCliente, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" — mismo criterio que
+            // ServicioDeCuentaCorriente.ResolverClienteAsync.
+            ?? throw ErrorDominio.NoEncontrado($"No existe el cliente {idCliente}.");
+
+        if (cliente.EsConsumidorFinal)
+        {
+            throw new ErrorDominio(
+                "cliente_sin_cuenta_corriente", "El Consumidor Final no tiene cuenta corriente.", 400);
+        }
+
+        return cliente;
+    }
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeReliquidacion requiere un actor de tenant; SupervisionDeCuentaCorriente no admite plataforma.");
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -63,6 +63,11 @@ public static class DependencyInjection
         // ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync, se registra junto a la caja.
         services.AddScoped<ServicioDeCuentaCorriente>();
 
+        // stage-7-cuenta-corriente (Slice 3): reliquidación a precio del día — el lector de
+        // elegibles alimenta tanto el preview como el commit del servicio.
+        services.AddScoped<LectorDeConsumosReliquidables>();
+        services.AddScoped<ServicioDeReliquidacion>();
+
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();
 

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -406,14 +406,36 @@ public class ServicioDeVentas(
                 && (m.Tipo == TipoMovimientoCc.Consumo || m.Tipo == TipoMovimientoCc.Pago))
             .ToListAsync(ct);
 
+        // stage-7-cuenta-corriente (Slice 3, task 3.13, judgment-day slice-2 finding, judge A):
+        // el guard de abajo NO puede confiar en IdMovimientoActualizacion tal como lo trajo el
+        // ToListAsync de arriba — esa lectura corre SIN lock, así que una reliquidación
+        // concurrente podría comitear su marcador justo ENTRE esa lectura y el commit de esta
+        // anulación, produciendo un estado irrepresentable ("revertido y reliquidado" a la vez).
+        // El lock del cliente cierra la ventana: ServicioDeReliquidacion toma el MISMO lock
+        // (SELECT ... FOR UPDATE) como el PRIMER statement de su transacción — si esta anulación
+        // lo toma primero, la reliquidación concurrente queda bloqueada hasta que esta transacción
+        // termine; si la reliquidación ya lo tenía, esta anulación espera acá y retoma el lock
+        // DESPUÉS de su commit, así que el re-chequeo de abajo, ya bajo el lock, ve el marcador
+        // recién comiteado y falla cerrado con el mismo 409. Todos los movimientos de un mismo
+        // comprobante comparten el mismo cliente (un comprobante tiene un único IdCliente), así
+        // que un solo lock alcanza para todo el foreach — orden total sin cambios (turnos_caja →
+        // clientes → ledger): el guard de turno (paso 0, arriba) ya corrió antes que este lock.
+        if (movimientosCcOriginales.Count > 0)
+        {
+            await BloquearClienteAsync(conexion, transaccionCruda, idTenant, movimientosCcOriginales[0].IdCliente, ct);
+        }
+
         foreach (var movimiento in movimientosCcOriginales)
         {
-            // Guard nuevo (design decisión 5, spec: pagos-a-cuenta / Anulación Reverses The Pago
-            // Movement no lo pide, pero el consumo reliquidado sí — cierra el leak de anular un
-            // consumo ya cubierto por una reliquidación, que dejaría el delta de
-            // ActualizacionPrecios en el aire sin el Consumo que lo originó). El marcador lo
-            // escribe recién Slice 3 (ServicioDeReliquidacion) — acá solo se lee.
-            if (movimiento.IdMovimientoActualizacion is not null)
+            // Re-chequeo BAJO el lock recién tomado — nunca el valor materializado por el
+            // ToListAsync sin lock de arriba, que es justamente la lectura vulnerable al TOCTOU
+            // que este método cierra (spec: pagos-a-cuenta / Anulación Reverses The Pago Movement
+            // no lo pide, pero el consumo reliquidado sí — cierra el leak de anular un consumo ya
+            // cubierto por una reliquidación, que dejaría el delta de ActualizacionPrecios en el
+            // aire sin el Consumo que lo originó).
+            var idMovimientoActualizacion = await LeerMarcadorDeReliquidacionAsync(
+                conexion, transaccionCruda, idTenant, movimiento.Id, ct);
+            if (idMovimientoActualizacion is not null)
             {
                 throw new ErrorDominio(
                     "consumo_reliquidado", "El consumo ya fue reliquidado; no se puede anular.", 409);
@@ -434,7 +456,7 @@ public class ServicioDeVentas(
 
             await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
                 conexion, transaccionCruda, idTenant, movimiento.IdCliente, momento, movimiento.IdPuntoVenta, idEmpleado,
-                TipoMovimientoCc.Ajuste, id, idPagoComprobante, -movimiento.Importe, nuevoSaldo, ct);
+                TipoMovimientoCc.Ajuste, id, idPagoComprobante, -movimiento.Importe, nuevoSaldo, detalle: null, ct);
         }
 
         await transaccion.CommitAsync(ct);
@@ -468,6 +490,42 @@ public class ServicioDeVentas(
         {
             throw new ErrorDominio("turno_cerrado", "El turno de este comprobante está cerrado.", 409);
         }
+    }
+
+    /// <summary>task 3.13: lock del cliente ANTES de re-chequear el marcador de reliquidación de
+    /// cada movimiento — mismo criterio "lock primero, decide después" que design decisión 4
+    /// (<c>ServicioDeReliquidacion</c>, paso 1, el mismo <c>SELECT ... FOR UPDATE</c>).</summary>
+    private static async Task BloquearClienteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idCliente, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText = "SELECT 1 FROM clientes WHERE id_cliente = $1 AND id_tenant = $2 FOR UPDATE";
+
+        AgregarParametro(comando, idCliente);
+        AgregarParametro(comando, idTenant);
+
+        await comando.ExecuteScalarAsync(ct);
+    }
+
+    /// <summary>task 3.13: re-lee <c>id_movimiento_actualizacion</c> directo de la base, bajo el
+    /// lock del cliente ya tomado por <see cref="BloquearClienteAsync"/> — nunca el valor
+    /// materializado por el <c>ToListAsync</c> sin lock de <see cref="EjecutarAnulacionAsync"/>,
+    /// que es la lectura vulnerable al TOCTOU que este método cierra.</summary>
+    private static async Task<int?> LeerMarcadorDeReliquidacionAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idMovimiento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT id_movimiento_actualizacion FROM movimientos_cuenta_corriente " +
+            "WHERE id_movimiento = $1 AND id_tenant = $2";
+
+        AgregarParametro(comando, idMovimiento);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is null or DBNull ? null : Convert.ToInt32(resultado);
     }
 
     /// <summary>Único UPDATE atómico de la transición de estado — ver el doc-comment de
@@ -623,7 +681,8 @@ public class ServicioDeVentas(
 
             await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
                 conexion, transaccionCruda, plan.IdTenant, plan.IdCliente, plan.Momento, plan.IdPuntoVenta,
-                plan.IdEmpleado, TipoMovimientoCc.Consumo, comprobante.Id, pagosEntidad[i].Id, pago.Importe, nuevoSaldo, ct);
+                plan.IdEmpleado, TipoMovimientoCc.Consumo, comprobante.Id, pagosEntidad[i].Id, pago.Importe, nuevoSaldo,
+                detalle: null, ct);
         }
 
         await transaccion.CommitAsync(ct);

--- a/src/Ways.Domain/CuentaCorriente/ReliquidadorDeConsumos.cs
+++ b/src/Ways.Domain/CuentaCorriente/ReliquidadorDeConsumos.cs
@@ -1,0 +1,135 @@
+namespace Ways.Domain.CuentaCorriente;
+
+/// <summary>
+/// Línea histórica de un consumo a reliquidar — snapshot de <c>ItemComprobanteVenta</c> (design:
+/// The Re-Pricing Derivation). <see cref="PrecioUnitario"/>/<see cref="Descuento"/> NO entran en
+/// la fórmula (solo <see cref="TotalHistorico"/>, el <c>items.total</c> verbatim, nunca
+/// recalculado) — viajan acá únicamente para el detalle auditable. La señal de "esta línea tuvo
+/// oferta" es <c>Descuento &gt; 0</c>, nunca <c>id_oferta IS NOT NULL</c>: por eso este record ni
+/// siquiera trae <c>id_oferta</c> — la fórmula revierte cualquier descuento por construcción
+/// (<see cref="ReliquidadorDeConsumos.Calcular"/> recalcula el total del día desde cero, sin
+/// descuento, sin importar de dónde vino el descuento histórico).
+/// </summary>
+public readonly record struct LineaAReliquidar(
+    int? IdArticulo, decimal Cantidad, decimal PrecioUnitario, decimal Descuento, decimal TotalHistorico);
+
+/// <summary>Un <c>Consumo</c> elegible con sus líneas ya resueltas (design: Interfaces/Contracts).
+/// <see cref="ImporteFinanciado"/> es <c>movimientos_cuenta_corriente.importe</c> del propio
+/// consumo (la porción fiada del comprobante); <see cref="TotalComprobante"/> es
+/// <c>comprobantes_venta.total</c> — el cociente de los dos es la fracción financiada (design:
+/// "Financed fraction").</summary>
+public sealed record ConsumoAReliquidar(
+    int IdMovimiento, int IdComprobanteVenta, decimal ImporteFinanciado, decimal TotalComprobante,
+    IReadOnlyList<LineaAReliquidar> Lineas);
+
+/// <summary>Detalle auditable de una línea (design: "sufficient to reconstruct the calculation").
+/// <see cref="Motivo"/> no nulo ⇒ línea omitida (<see cref="PrecioActual"/>/<see cref="TotalDelDia"/>
+/// quedan <c>null</c>, <see cref="Delta"/> queda en <c>0</c>) — nunca fatal, nunca acredita.</summary>
+public sealed record DetalleDeLinea(
+    int? IdArticulo, decimal Cantidad, decimal PrecioHistorico, decimal? PrecioActual, decimal TotalHistorico,
+    decimal? TotalDelDia, decimal Delta, string? Motivo);
+
+/// <summary>Detalle auditable de un consumo cubierto — <see cref="Delta"/> ya lleva aplicada la
+/// fracción financiada (design: "Only the financed money is re-indexed").</summary>
+public sealed record DetalleDeConsumo(
+    int IdMovimiento, int IdComprobanteVenta, decimal Delta, IReadOnlyList<DetalleDeLinea> Lineas);
+
+/// <summary><see cref="IdsMovimientosCubiertos"/> lista TODOS los consumos procesados en esta
+/// corrida (hasta el cap), incluidos los que aportaron delta <c>0</c> por líneas no precificables
+/// — el llamador (<c>ServicioDeReliquidacion</c>) decide si los marca, según si <see cref="Delta"/>
+/// (el total de la corrida) es distinto de cero (design: "Zero delta ⇒ no movement and no
+/// marker").</summary>
+public sealed record ResultadoDeReliquidacion(
+    decimal Delta, IReadOnlyList<int> IdsMovimientosCubiertos, IReadOnlyList<DetalleDeConsumo> Detalle, bool HayMas);
+
+/// <summary>
+/// El re-pricer puro — el centro de la etapa (design: The Re-Pricing Derivation, "one formula,
+/// exists once"). Sin DB, mismo listón que <c>CalculadorDeArqueo</c>: la MISMA función alimenta el
+/// preview (<c>GET</c>, sin lock) y el commit (<c>POST</c>, bajo el lock del cliente) — un re-pricer
+/// que existiera dos veces sería el defecto que convertiría esta feature en un incidente de
+/// confianza (design: Technical Approach).
+///
+/// <para><c>totalDelDia(i) = round(cantidad × precioActual, 2, AwayFromZero)</c> — SIN descuento,
+/// nunca <c>precioActual × (totalHistorico / (cantidad × precioUnitario))</c> (esa fórmula
+/// preservaría el ratio del descuento en vez de anularlo, exactamente el error que doc-01:398
+/// prohíbe). <c>delta(i) = totalDelDia(i) − totalHistorico(i)</c> decompone en el re-pricing MÁS
+/// el descuento anulado sin que este código tenga que separar los dos términos — la resta sola ya
+/// los suma.</para>
+/// </summary>
+public static class ReliquidadorDeConsumos
+{
+    /// <summary>Design: Eligibility — "capped at 500 consumos per run". El lector pasa hasta
+    /// <c>LimiteConsumosPorCorrida + 1</c> filas (ordenadas por fecha ASC) para que este método
+    /// pueda derivar <see cref="ResultadoDeReliquidacion.HayMas"/> de su propio input, sin
+    /// necesitar un parámetro aparte ni una segunda consulta de conteo.</summary>
+    public const int LimiteConsumosPorCorrida = 500;
+
+    public static ResultadoDeReliquidacion Calcular(
+        IReadOnlyList<ConsumoAReliquidar> consumos, IReadOnlyDictionary<int, decimal?> precioActualPorArticulo)
+    {
+        var hayMas = consumos.Count > LimiteConsumosPorCorrida;
+        var aProcesar = hayMas ? consumos.Take(LimiteConsumosPorCorrida).ToList() : consumos;
+
+        var deltaTotal = 0m;
+        var idsCubiertos = new List<int>(aProcesar.Count);
+        var detalle = new List<DetalleDeConsumo>(aProcesar.Count);
+
+        foreach (var consumo in aProcesar)
+        {
+            var (deltaConsumo, detallesDeLinea) = CalcularConsumo(consumo, precioActualPorArticulo);
+
+            deltaTotal += deltaConsumo;
+            idsCubiertos.Add(consumo.IdMovimiento);
+            detalle.Add(new DetalleDeConsumo(consumo.IdMovimiento, consumo.IdComprobanteVenta, deltaConsumo, detallesDeLinea));
+        }
+
+        return new ResultadoDeReliquidacion(deltaTotal, idsCubiertos, detalle, hayMas);
+    }
+
+    private static (decimal Delta, IReadOnlyList<DetalleDeLinea> Detalle) CalcularConsumo(
+        ConsumoAReliquidar consumo, IReadOnlyDictionary<int, decimal?> precioActualPorArticulo)
+    {
+        var detallesDeLinea = new List<DetalleDeLinea>(consumo.Lineas.Count);
+        var deltaBruto = 0m;
+
+        foreach (var linea in consumo.Lineas)
+        {
+            if (linea.IdArticulo is not { } idArticulo)
+            {
+                detallesDeLinea.Add(new DetalleDeLinea(
+                    null, linea.Cantidad, linea.PrecioUnitario, null, linea.TotalHistorico, null, 0m,
+                    "Línea de concepto libre (sin artículo) — no re-precificable."));
+                continue;
+            }
+
+            var precioActual = precioActualPorArticulo.TryGetValue(idArticulo, out var precio) ? precio : null;
+            if (precioActual is null)
+            {
+                detallesDeLinea.Add(new DetalleDeLinea(
+                    idArticulo, linea.Cantidad, linea.PrecioUnitario, null, linea.TotalHistorico, null, 0m,
+                    "Sin precio vigente en la lista actual del cliente."));
+                continue;
+            }
+
+            var totalDelDia = Math.Round(linea.Cantidad * precioActual.Value, 2, MidpointRounding.AwayFromZero);
+            var deltaLinea = totalDelDia - linea.TotalHistorico;
+            deltaBruto += deltaLinea;
+
+            detallesDeLinea.Add(new DetalleDeLinea(
+                idArticulo, linea.Cantidad, linea.PrecioUnitario, precioActual, linea.TotalHistorico, totalDelDia,
+                deltaLinea, null));
+        }
+
+        // Fracción financiada (design: "Financed fraction", deviación declarada) — con
+        // financiamiento total (factor = 1) colapsa exacto a la fórmula legacy (asserted por
+        // test). comprobante.total == 0 nunca debería llegar acá (la elegibilidad ya exige
+        // comprobante.total > 0, design: Eligibility) — defensa en profundidad, no un caso de
+        // negocio alcanzable.
+        var factor = consumo.TotalComprobante == 0m
+            ? 0m
+            : Math.Min(1m, consumo.ImporteFinanciado / consumo.TotalComprobante);
+        var deltaConsumo = Math.Round(deltaBruto * factor, 2, MidpointRounding.AwayFromZero);
+
+        return (deltaConsumo, detallesDeLinea);
+    }
+}

--- a/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteTests.cs
+++ b/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteTests.cs
@@ -19,7 +19,7 @@ public class EscriturasDeCuentaCorrienteTests
             EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
                 null!, null, idTenant: 1, idCliente: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta: 1, idEmpleado: 1,
                 TipoMovimientoCc.Consumo, idComprobanteVenta: 10, idPagoComprobante: null, importe: 100m,
-                saldoResultante: 100m, CancellationToken.None));
+                saldoResultante: 100m, detalle: null, CancellationToken.None));
 
         Assert.Contains("Consumo", excepcion.Message);
     }
@@ -31,8 +31,23 @@ public class EscriturasDeCuentaCorrienteTests
             EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
                 null!, null, idTenant: 1, idCliente: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta: 1, idEmpleado: 1,
                 TipoMovimientoCc.Pago, idComprobanteVenta: 10, idPagoComprobante: 5, importe: -100m,
-                saldoResultante: 0m, CancellationToken.None));
+                saldoResultante: 0m, detalle: null, CancellationToken.None));
 
         Assert.Contains("Pago", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaActualizacionDePreciosConIdComprobanteVentaViolaLaFormaYLanza()
+    {
+        // stage-7-cuenta-corriente (Slice 3): ActualizacionPrecios no lleva id_comprobante_venta
+        // (no lo origina un comprobante puntual, sino la corrida completa) — mismo guard de forma
+        // por tipo que Consumo/Pago.
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+                null!, null, idTenant: 1, idCliente: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta: 1, idEmpleado: 1,
+                TipoMovimientoCc.ActualizacionPrecios, idComprobanteVenta: 10, idPagoComprobante: null, importe: 50m,
+                saldoResultante: 150m, detalle: "[]", CancellationToken.None));
+
+        Assert.Contains("ActualizacionPrecios", excepcion.Message);
     }
 }

--- a/tests/Ways.Domain.Tests/CuentaCorriente/ReliquidadorDeConsumosTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/ReliquidadorDeConsumosTests.cs
@@ -1,0 +1,314 @@
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Domain.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-7-cuenta-corriente (Slice 3, task 3.2, design: Testing Strategy — Unit (Domain)):
+/// exhaustiva del re-pricer puro — el centro de la etapa. Sin DB, mismo listón que
+/// <c>CalculadorDeArqueoTests</c>.
+/// </summary>
+public class ReliquidadorDeConsumosTests
+{
+    private static ConsumoAReliquidar UnConsumo(int idMovimiento, params LineaAReliquidar[] lineas) =>
+        new(idMovimiento, IdComprobanteVenta: idMovimiento * 10, ImporteFinanciado: lineas.Sum(l => l.TotalHistorico),
+            TotalComprobante: lineas.Sum(l => l.TotalHistorico), lineas);
+
+    // ---- plain re-price up/down ---------------------------------------------------------------
+
+    [Fact]
+    public void UnaLineaSinOfertaSeReprecificaHaciaArribaSinLogicaDeDescuento()
+    {
+        // spec: reliquidacion-a-precio-del-dia / Non-offer line re-prices without any discount logic.
+        var linea = new LineaAReliquidar(IdArticulo: 1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 120m });
+
+        Assert.Equal(20m, resultado.Delta);
+        Assert.False(resultado.HayMas);
+        var detalleLinea = Assert.Single(Assert.Single(resultado.Detalle).Lineas);
+        Assert.Equal(120m, detalleLinea.TotalDelDia);
+        Assert.Equal(20m, detalleLinea.Delta);
+        Assert.Null(detalleLinea.Motivo);
+    }
+
+    [Fact]
+    public void UnaLineaSinOfertaSeReprecificaHaciaAbajo()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 2m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 200m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 90m });
+
+        // 2 × 90 = 180 − 200 = -20.
+        Assert.Equal(-20m, resultado.Delta);
+    }
+
+    // ---- offer reversion, ambas direcciones + el worked example ------------------------------
+
+    [Fact]
+    public void UnaLineaDeOfertaReviertelDescuentoAlPrecioActualCompletoNoAlRatio()
+    {
+        // spec: reliquidacion-a-precio-del-dia / Offer line re-prices to the full current price —
+        // worked example verbatim: sold at list 100 with a 10 discount (line total 90), current
+        // list price 120 ⇒ delta 30 (nunca 18, que sería preservar el ratio del descuento).
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 10m, TotalHistorico: 90m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 120m });
+
+        Assert.Equal(30m, resultado.Delta);
+        Assert.NotEqual(18m, resultado.Delta);
+    }
+
+    [Fact]
+    public void ElWorkedExampleDelDesignDaDelta600ConDiezUnidadesYDiezPorCientoDeDescuento()
+    {
+        // design: The Re-Pricing Derivation — 10 units sold at 100 with a 10% offer discount
+        // (line total 900), current price 150 ⇒ delta 600 = 500 de re-pricing + 100 de descuento
+        // anulado.
+        var linea = new LineaAReliquidar(1, Cantidad: 10m, PrecioUnitario: 100m, Descuento: 100m, TotalHistorico: 900m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 150m });
+
+        Assert.Equal(600m, resultado.Delta);
+    }
+
+    [Fact]
+    public void UnaLineaDeOfertaTambienReviertelDescuentoCuandoElPrecioActualBajo()
+    {
+        // "Both directions": el precio actual puede caer respecto del precio de lista original y
+        // el descuento SIGUE anulándose — el delta puede terminar negativo si el precio actual
+        // cae por debajo del total ya descontado.
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 20m, TotalHistorico: 80m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 70m });
+
+        // 70 (precio actual completo, sin descuento) − 80 (histórico con descuento) = -10.
+        Assert.Equal(-10m, resultado.Delta);
+    }
+
+    // ---- factor = 1 colapsa a la fórmula legacy ------------------------------------------------
+
+    [Fact]
+    public void ConFinanciamientoTotalElFactorEsUnoYColapsaALaFormulaLegacy()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = new ConsumoAReliquidar(
+            IdMovimiento: 1, IdComprobanteVenta: 10, ImporteFinanciado: 100m, TotalComprobante: 100m, [linea]);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 130m });
+
+        Assert.Equal(30m, resultado.Delta);
+    }
+
+    // ---- financiamiento parcial: proration ------------------------------------------------------
+
+    [Fact]
+    public void ConFinanciamientoParcialSoloLaFraccionFinanciadaSeReindexa()
+    {
+        // Comprobante de 1000, línea con delta bruto de 100 (900 histórico, 1000 actual), pero
+        // solo 200 de los 1000 fueron a cuenta corriente (factor 0.2) ⇒ delta = 100 × 0.2 = 20.
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 900m, Descuento: 0m, TotalHistorico: 900m);
+        var consumo = new ConsumoAReliquidar(
+            IdMovimiento: 1, IdComprobanteVenta: 10, ImporteFinanciado: 200m, TotalComprobante: 1000m, [linea]);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 1000m });
+
+        Assert.Equal(20m, resultado.Delta);
+    }
+
+    [Fact]
+    public void ElFactorNuncaSuperaUnoAunqueImporteFinanciadoSuperaElTotal()
+    {
+        // Defensa: min(1, importeFinanciado/total) — un importeFinanciado > total (no debería
+        // pasar bajo operación normal) nunca produce un factor > 1.
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = new ConsumoAReliquidar(
+            IdMovimiento: 1, IdComprobanteVenta: 10, ImporteFinanciado: 500m, TotalComprobante: 100m, [linea]);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 150m });
+
+        // factor = min(1, 5) = 1 ⇒ delta = 50 × 1 = 50, no 250.
+        Assert.Equal(50m, resultado.Delta);
+    }
+
+    // ---- líneas no precificables: IdArticulo NULL / sin precio vigente -----------------------
+
+    [Fact]
+    public void UnaLineaSinArticuloSeOmiteConMotivoSinAbortar()
+    {
+        var lineaLibre = new LineaAReliquidar(IdArticulo: null, Cantidad: 1m, PrecioUnitario: 50m, Descuento: 0m, TotalHistorico: 50m);
+        var lineaNormal = new LineaAReliquidar(IdArticulo: 1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = UnConsumo(1, lineaLibre, lineaNormal);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 120m });
+
+        // Solo la línea normal aporta delta (20) — la libre no aborta ni acredita.
+        Assert.Equal(20m, resultado.Delta);
+        var detalle = Assert.Single(resultado.Detalle);
+        var lineaLibreDetalle = detalle.Lineas.Single(l => l.IdArticulo is null);
+        Assert.NotNull(lineaLibreDetalle.Motivo);
+        Assert.Equal(0m, lineaLibreDetalle.Delta);
+        Assert.Null(lineaLibreDetalle.TotalDelDia);
+    }
+
+    [Fact]
+    public void UnaLineaSinPrecioVigenteSeOmiteConMotivoSinAbortar()
+    {
+        var lineaSinPrecio = new LineaAReliquidar(IdArticulo: 2, Cantidad: 1m, PrecioUnitario: 50m, Descuento: 0m, TotalHistorico: 50m);
+        var lineaNormal = new LineaAReliquidar(IdArticulo: 1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = UnConsumo(1, lineaSinPrecio, lineaNormal);
+
+        // El diccionario ni siquiera trae la key 2 (artículo sin precio vigente en la lista actual).
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 120m });
+
+        Assert.Equal(20m, resultado.Delta);
+        var lineaSinPrecioDetalle = Assert.Single(resultado.Detalle).Lineas.Single(l => l.IdArticulo == 2);
+        Assert.NotNull(lineaSinPrecioDetalle.Motivo);
+        Assert.Equal(0m, lineaSinPrecioDetalle.Delta);
+    }
+
+    [Fact]
+    public void UnaLineaConPrecioExplicitamenteNuloEnElDiccionarioSeOmiteConMotivo()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = null });
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.NotNull(Assert.Single(resultado.Detalle).Lineas.Single().Motivo);
+    }
+
+    // ---- all-lines-skipped ⇒ delta 0 -------------------------------------------------------------
+
+    [Fact]
+    public void UnConsumoConTodasSusLineasOmitidasAportaDeltaCero()
+    {
+        var lineaLibre = new LineaAReliquidar(null, Cantidad: 1m, PrecioUnitario: 50m, Descuento: 0m, TotalHistorico: 50m);
+        var lineaSinPrecio = new LineaAReliquidar(2, Cantidad: 1m, PrecioUnitario: 30m, Descuento: 0m, TotalHistorico: 30m);
+        var consumo = UnConsumo(1, lineaLibre, lineaSinPrecio);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?>());
+
+        Assert.Equal(0m, resultado.Delta);
+        // Sigue "cubierto" — Calcular no decide si se marca, eso lo decide el llamador según el
+        // delta TOTAL de la corrida (design: "Skipping is neutral").
+        Assert.Equal([1], resultado.IdsMovimientosCubiertos);
+    }
+
+    // ---- empty input -------------------------------------------------------------------------
+
+    [Fact]
+    public void SinConsumosElResultadoEsDeltaCeroYSinCubiertos()
+    {
+        var resultado = ReliquidadorDeConsumos.Calcular([], new Dictionary<int, decimal?>());
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Empty(resultado.IdsMovimientosCubiertos);
+        Assert.Empty(resultado.Detalle);
+        Assert.False(resultado.HayMas);
+    }
+
+    // ---- redondeo AwayFromZero -----------------------------------------------------------------
+
+    [Fact]
+    public void ElRedondeoDeLineaEsAwayFromZero()
+    {
+        // 3 × 33.335 = 100.005 → redondea a 100.01 (AwayFromZero), no a 100.00 (banker's rounding).
+        var linea = new LineaAReliquidar(1, Cantidad: 3m, PrecioUnitario: 33m, Descuento: 0m, TotalHistorico: 99m);
+        var consumo = UnConsumo(1, linea);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 33.335m });
+
+        var detalleLinea = Assert.Single(Assert.Single(resultado.Detalle).Lineas);
+        Assert.Equal(100.01m, detalleLinea.TotalDelDia);
+    }
+
+    [Fact]
+    public void ElRedondeoDelFactorDeConsumoEsAwayFromZero()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        // deltaBruto = 10; factor = 1/3 ⇒ 10 × 0.333... = 3.333... → redondea a 3.33.
+        var consumo = new ConsumoAReliquidar(1, 10, ImporteFinanciado: 1m, TotalComprobante: 3m, [linea]);
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumo], new Dictionary<int, decimal?> { [1] = 110m });
+
+        Assert.Equal(3.33m, resultado.Delta);
+    }
+
+    // ---- el cap de 500 consumos por corrida ----------------------------------------------------
+
+    [Fact]
+    public void ConMasDe500ConsumosSoloProcesaLosPrimeros500YMarcaHayMas()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumos = Enumerable.Range(1, 501)
+            .Select(id => UnConsumo(id, linea with { }))
+            .ToList();
+
+        var resultado = ReliquidadorDeConsumos.Calcular(consumos, new Dictionary<int, decimal?> { [1] = 100m });
+
+        Assert.True(resultado.HayMas);
+        Assert.Equal(500, resultado.IdsMovimientosCubiertos.Count);
+        Assert.Equal(500, resultado.Detalle.Count);
+        // Los primeros 500, en el orden de entrada (el lector ya los trae ordenados por fecha ASC).
+        Assert.Equal(Enumerable.Range(1, 500), resultado.IdsMovimientosCubiertos);
+    }
+
+    [Fact]
+    public void ConExactamente500ConsumosNoHayMas()
+    {
+        var linea = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumos = Enumerable.Range(1, 500)
+            .Select(id => UnConsumo(id, linea with { }))
+            .ToList();
+
+        var resultado = ReliquidadorDeConsumos.Calcular(consumos, new Dictionary<int, decimal?> { [1] = 100m });
+
+        Assert.False(resultado.HayMas);
+        Assert.Equal(500, resultado.IdsMovimientosCubiertos.Count);
+    }
+
+    // ---- dos comprobantes, tres líneas, un movimiento (agregación) -----------------------------
+
+    [Fact]
+    public void ElDeltaTotalEsLaSumaDeLosDeltasDeCadaConsumo()
+    {
+        var lineaA1 = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var lineaA2 = new LineaAReliquidar(2, Cantidad: 1m, PrecioUnitario: 50m, Descuento: 0m, TotalHistorico: 50m);
+        var consumoA = UnConsumo(1, lineaA1, lineaA2);
+
+        var lineaB = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumoB = UnConsumo(2, lineaB);
+
+        var precios = new Dictionary<int, decimal?> { [1] = 130m, [2] = 45m };
+
+        // consumoA: (130-100) + (45-50) = 25; consumoB: 130-100 = 30 ⇒ total 55.
+        var resultado = ReliquidadorDeConsumos.Calcular([consumoA, consumoB], precios);
+        Assert.Equal(55m, resultado.Delta);
+        Assert.Equal(2, resultado.Detalle.Count);
+    }
+
+    [Fact]
+    public void DosComprobantesTresLineasConDeltas30Y20YMenos5DanCuarentaYCinco()
+    {
+        // spec: reliquidacion-a-precio-del-dia / Two comprobantes, three lines, one movement.
+        var lineaA = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumoA = UnConsumo(1, lineaA); // delta 30 con precio actual 130.
+
+        var lineaB1 = new LineaAReliquidar(2, Cantidad: 1m, PrecioUnitario: 80m, Descuento: 0m, TotalHistorico: 80m);
+        var lineaB2 = new LineaAReliquidar(3, Cantidad: 1m, PrecioUnitario: 60m, Descuento: 0m, TotalHistorico: 60m);
+        var consumoB = UnConsumo(2, lineaB1, lineaB2); // delta 20 + (-5) = 15.
+
+        var precios = new Dictionary<int, decimal?> { [1] = 130m, [2] = 100m, [3] = 55m };
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumoA, consumoB], precios);
+
+        Assert.Equal(45m, resultado.Delta);
+        Assert.Equal(2, resultado.IdsMovimientosCubiertos.Count);
+    }
+}

--- a/tests/Ways.Domain.Tests/CuentaCorriente/ReliquidadorDeConsumosTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/ReliquidadorDeConsumosTests.cs
@@ -200,6 +200,30 @@ public class ReliquidadorDeConsumosTests
         Assert.Equal([1], resultado.IdsMovimientosCubiertos);
     }
 
+    // ---- delta total cero por deltas que se cancelan (contrato del calculador, no del servicio) --
+
+    [Fact]
+    public void DosConsumosConDeltasQueSeCancelanDanDeltaTotalCeroPeroElCalculadorSigueReportandoLosDosProcesados()
+    {
+        // El calculador reporta lo PROCESADO, nunca lo MARCADO — quien decide si se marca es el
+        // llamador (ServicioDeReliquidacion), según si el Delta TOTAL de la corrida es distinto de
+        // cero. Acá +X y −X se cancelan (Delta == 0) pero el contrato de Calcular no cambia: los
+        // dos consumos siguen apareciendo en IdsMovimientosCubiertos.
+        var lineaSube = new LineaAReliquidar(1, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumoSube = UnConsumo(1, lineaSube); // delta +20 con precio actual 120.
+
+        var lineaBaja = new LineaAReliquidar(2, Cantidad: 1m, PrecioUnitario: 100m, Descuento: 0m, TotalHistorico: 100m);
+        var consumoBaja = UnConsumo(2, lineaBaja); // delta -20 con precio actual 80.
+
+        var precios = new Dictionary<int, decimal?> { [1] = 120m, [2] = 80m };
+
+        var resultado = ReliquidadorDeConsumos.Calcular([consumoSube, consumoBaja], precios);
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Equal(2, resultado.IdsMovimientosCubiertos.Count);
+        Assert.Equal([1, 2], resultado.IdsMovimientosCubiertos);
+    }
+
     // ---- empty input -------------------------------------------------------------------------
 
     [Fact]

--- a/tests/Ways.IntegrationTests/AnulacionReliquidacionRaceTests.cs
+++ b/tests/Ways.IntegrationTests/AnulacionReliquidacionRaceTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente (Slice 3, task 3.13, judgment-day slice-2 finding, judge A): cierra el
+/// TOCTOU entre <c>ServicioDeVentas.AnularAsync</c> y <c>ServicioDeReliquidacion.EjecutarAsync</c>
+/// — las dos transacciones ahora comparten el MISMO lock del cliente (<c>SELECT ... FROM clientes
+/// ... FOR UPDATE</c>, tomado como su primer statement de escritura real), así que Postgres
+/// serializa genuinamente cuál de las dos avanza primero. Carrera natural con <c>Task.WhenAll</c>
+/// sobre varias rondas — mismo criterio que
+/// <c>CajaCierreAtomicidadYConcurrenciaTests.DosCierresConcurrentesDelMismoTurnoProducenExactamenteUnGanador</c>
+/// y <c>ReliquidacionTests.DosReliquidacionesConcurrentesDelMismoClienteEscribenExactamenteUnMovimiento</c>:
+/// las dos primeras usan exactamente el mismo tipo de <c>SELECT ... FOR UPDATE</c> crudo vía
+/// ADO.NET (no vía LINQ), que <c>DbCommandInterceptor</c> no puede interceptar (solo ve comandos
+/// que EF Core arma para sus propias consultas/SaveChanges) — así que un rendezvous forzado con
+/// <c>DbCommandInterceptor</c> (el mecanismo de <c>ParametrosTests</c>, que sí apunta a una
+/// consulta LINQ) no aplica acá; la serialización real del lock de Postgres es la que prueba el
+/// invariante, ronda tras ronda.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AnulacionReliquidacionRaceTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
+        int IdMedioCuentaCorriente);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area race", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        db.TurnosCaja.Add(new TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva, idListaPrecio, medioCc.Id);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Ways.Domain.Articulos.Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = Ways.Domain.Articulos.UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = 0m, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private async Task SubirPrecioAsync(Contexto ctx, int idArticulo, decimal nuevoPrecio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var vieja = await db.Precios
+            .Where(p => p.IdArticulo == idArticulo && p.IdListaPrecio == ctx.IdListaPrecio && p.VigenteHasta == null)
+            .SingleAsync();
+        vieja.VigenteHasta = ahora;
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = ctx.IdListaPrecio, Monto = nuevoPrecio,
+            VigenteDesde = ahora, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task AnulacionYReliquidacionDelMismoClienteEnCarreraGananExactamenteUna()
+    {
+        for (var ronda = 0; ronda < 5; ronda++)
+        {
+            var ctx = await PrepararAsync($"{nameof(AnulacionYReliquidacionDelMismoClienteEnCarreraGananExactamenteUna)}-{ronda}");
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, $"articulo-toctou-{ronda}", 100m);
+            var idCliente = await SembrarClienteAsync(ctx, $"Cliente toctou {ronda}");
+
+            var solicitudVenta = new SolicitudDeVenta(
+                ctx.IdPuntoVenta, idCliente, "TX", null,
+                [new LineaDeVenta(idArticulo, 1m, null)],
+                [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 100m, null, 0m)],
+                null, null);
+            var respuestaVenta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudVenta);
+            Assert.Equal(HttpStatusCode.Created, respuestaVenta.StatusCode);
+            var venta = (await respuestaVenta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+            await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+            var tareaAnulacion = ctx.Admin.PostAsync($"/api/ventas/{venta.Id}/anulacion", null);
+            var tareaReliquidacion = ctx.Admin.PostAsJsonAsync(
+                $"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
+
+            var respuestaAnulacion = await tareaAnulacion;
+            var respuestaReliquidacion = await tareaReliquidacion;
+
+            // La reliquidación NUNCA falla por la carrera en sí (siempre es 200, no-op incluido):
+            // o corre ANTES de la anulación (marca el consumo, delta 50) o corre DESPUÉS (el
+            // consumo ya no está 'emitido', el scan de elegibilidad lo excluye, no-op limpio).
+            var cuerpoReliquidacion = await respuestaReliquidacion.Content.ReadAsStringAsync();
+            Assert.True(respuestaReliquidacion.StatusCode == HttpStatusCode.OK, cuerpoReliquidacion);
+
+            // La anulación gana (200) o pierde por reliquidación (409 consumo_reliquidado) — nunca
+            // ninguna otra cosa.
+            Assert.Contains(respuestaAnulacion.StatusCode, new[] { HttpStatusCode.OK, HttpStatusCode.Conflict });
+            if (respuestaAnulacion.StatusCode == HttpStatusCode.Conflict)
+            {
+                var problema = await respuestaAnulacion.Content.ReadFromJsonAsync<JsonElement>();
+                Assert.Equal("consumo_reliquidado", problema.GetProperty("codigo").GetString());
+            }
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var movimientoConsumo = await db.MovimientosCuentaCorriente
+                .Where(m => m.IdComprobanteVenta == venta.Id && m.Tipo == TipoMovimientoCc.Consumo).SingleAsync();
+            var estadoComprobante = await db.ComprobantesVenta.Where(c => c.Id == venta.Id).Select(c => c.Estado).SingleAsync();
+
+            if (respuestaAnulacion.StatusCode == HttpStatusCode.OK)
+            {
+                // La anulación ganó: el comprobante quedó anulado y su consumo NUNCA puede
+                // terminar marcado como reliquidado — el estado "revertido y reliquidado" a la
+                // vez es justamente el que este fix vuelve irrepresentable.
+                Assert.Equal(EstadoComprobante.Anulado, estadoComprobante);
+                Assert.Null(movimientoConsumo.IdMovimientoActualizacion);
+            }
+            else
+            {
+                // La reliquidación ganó: el consumo quedó marcado y el comprobante sigue emitido
+                // — la anulación, al perder la carrera, nunca revirtió nada.
+                Assert.Equal(EstadoComprobante.Emitido, estadoComprobante);
+                Assert.NotNull(movimientoConsumo.IdMovimientoActualizacion);
+            }
+
+            // Invariante final, sin importar quién ganó: Cliente.Saldo == Σ importe.
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            var sumaMovimientos = await db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente).SumAsync(m => m.Importe);
+            Assert.Equal(sumaMovimientos, saldo);
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/ReliquidacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionTests.cs
@@ -1,0 +1,834 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Precios;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente (Slice 3, tasks 3.6-3.12, 3.14): la reliquidación a precio del día
+/// punta a punta contra Postgres real — identidad de derivación preview/commit, atomicidad de los
+/// tres statements de escritura reales (pasos 6/7/8; los pasos 1-5 son lock/lectura/puros, sin
+/// punto de falla propio, mismo criterio que <see cref="CajaCierreAtomicidadYConcurrenciaTests"/>),
+/// las dos carreras enumeradas por design (reliquidación × venta, dos reliquidaciones),
+/// idempotencia, un único movimiento por corrida, la lista de precios ACTUAL del cliente, el
+/// presupuesto de consultas y la matriz de autorización.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordUsuario = "una-contraseña-larga";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
+        int IdListaPrecioAlterna, int IdMedioCuentaCorriente, int IdTipoComprobanteTx, HttpClient Admin);
+
+    private long _numeroSecuencial = 1;
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area RQ", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        var listaAlterna = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista alterna RQ", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(listaAlterna);
+        await db.SaveChangesAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        // La reliquidación no exige turno (design decisión 4), pero el checkout que crea los
+        // Consumo sí — sembrado directo, mismo criterio que VentasCheckoutTests.
+        db.TurnosCaja.Add(new TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, area.Id, idAlicuotaIva, idListaPrecio,
+            listaAlterna.Id, medioCc.Id, idTipoComprobanteTx, admin);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio, int? idListaPrecio = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Ways.Domain.Articulos.Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = Ways.Domain.Articulos.UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = idListaPrecio ?? ctx.IdListaPrecio,
+            Monto = precio, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre, int? idListaPrecio = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = idListaPrecio ?? ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = 0m, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    /// <summary>Un Consumo real, vía checkout (design: el único camino de escritura de la etapa
+    /// que produce un item snapshot honesto para re-precificar).</summary>
+    private static async Task<ComprobanteEmitido> RealizarConsumoAsync(
+        Contexto ctx, int idCliente, int idArticulo, decimal cantidad, decimal precio)
+    {
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, cantidad * precio, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    /// <summary>Seed crudo (sin checkout) para pruebas de volumen/presupuesto — mismo criterio que
+    /// <c>CajaCierreAtomicidadYConcurrenciaTests.SembrarPagoAsync</c>: no hace falta el camino de
+    /// escritura completo cuando lo que se mide es la forma de la consulta, no el negocio.</summary>
+    private async Task SembrarConsumoCrudoAsync(Contexto ctx, int idCliente, int idArticulo, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant, IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial), Fecha = ahora, IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin, IdCliente = idCliente, Subtotal = precio, DescuentoTotal = 0m, Total = precio,
+            Estado = EstadoComprobante.Emitido, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.ItemsComprobanteVenta.Add(new ItemComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant, IdComprobanteVenta = comprobante.Id, Orden = 1, IdArticulo = idArticulo,
+            Descripcion = "item de prueba", IdArea = ctx.IdArea, IdListaPrecio = ctx.IdListaPrecio,
+            IdAlicuotaIva = ctx.IdAlicuotaIva, PorcentajeIva = 0m, Cantidad = 1m, PrecioUnitario = precio, Descuento = 0m,
+            Total = precio, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        db.MovimientosCuentaCorriente.Add(new MovimientoCuentaCorriente
+        {
+            IdTenant = ctx.IdTenant, IdCliente = idCliente, Fecha = ahora, IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin, Tipo = TipoMovimientoCc.Consumo, IdComprobanteVenta = comprobante.Id,
+            IdPagoComprobante = null, Importe = precio, SaldoResultante = 0m
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<HttpResponseMessage> PreviewAsync(Contexto ctx, int idCliente, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).GetAsync($"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion");
+
+    private static async Task<HttpResponseMessage> EjecutarAsync(Contexto ctx, int idCliente, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
+
+    private static async Task<ResultadoDeReliquidacion> LeerResultadoAsync(HttpResponseMessage respuesta)
+    {
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoDeReliquidacion>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 3.6: identidad de derivación (preview == commit) --------------------------------
+
+    [Fact]
+    public async Task ElPreviewInmediatamenteAntesDelCommitDaUnDeltaByteIdenticoAlMovimientoComiteado()
+    {
+        var ctx = await PrepararAsync(nameof(ElPreviewInmediatamenteAntesDelCommitDaUnDeltaByteIdenticoAlMovimientoComiteado));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-derivacion", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente derivacion");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+
+        // Sube el precio DESPUÉS de la venta — la reliquidación tiene algo que re-precificar.
+        await SembrarArticuloConPrecioAsync(ctx, "articulo-derivacion-precio-nuevo", 1m); // no-op, fuerza refresco de contexto
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            db.Precios.Add(new Precio
+            {
+                IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = ctx.IdListaPrecio, Monto = 150m,
+                VigenteDesde = ahora, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            });
+            var vieja = await db.Precios.Where(p => p.IdArticulo == idArticulo && p.VigenteHasta == null && p.Monto == 100m).SingleAsync();
+            vieja.VigenteHasta = ahora;
+            await db.SaveChangesAsync();
+        }
+
+        var preview = await LeerResultadoAsync(await PreviewAsync(ctx, idCliente));
+        var ejecucion = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        Assert.Equal(preview.Delta, ejecucion.Delta);
+        Assert.Equal(50m, ejecucion.Delta);
+
+        await using var dbFinal = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await dbFinal.MovimientosCuentaCorriente
+            .Where(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios).SingleAsync();
+        Assert.Equal(ejecucion.Delta, movimiento.Importe);
+    }
+
+    // ---- task 3.7: atomicidad en los 3 statements de escritura reales (pasos 6/7/8) -----------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task<HttpResponseMessage> EjecutarConPrivilegioRevocadoAsync(
+        Contexto ctx, int idCliente, string tabla, string privilegios)
+    {
+        await RevocarAsync(tabla, privilegios);
+        try
+        {
+            return await EjecutarAsync(ctx, idCliente);
+        }
+        finally
+        {
+            await RestaurarAsync(tabla, privilegios);
+        }
+    }
+
+    private async Task<(decimal Saldo, int Movimientos)> LeerEstadoAsync(Contexto ctx, int idCliente)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        var movimientos = await db.MovimientosCuentaCorriente
+            .CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios);
+        return (saldo, movimientos);
+    }
+
+    [Fact]
+    public async Task UnaFallaAlEscribirElSaldoDelClienteNoPersisteNadaEnElLedger()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirElSaldoDelClienteNoPersisteNadaEnElLedger));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-fault-saldo", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente fault saldo");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var respuesta = await EjecutarConPrivilegioRevocadoAsync(ctx, idCliente, "clientes", "UPDATE");
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        // El saldo queda tal como lo dejó el Consumo original (100) — la reliquidación nunca
+        // llegó a sumarle su delta.
+        var (saldo, movimientos) = await LeerEstadoAsync(ctx, idCliente);
+        Assert.Equal(100m, saldo);
+        Assert.Equal(0, movimientos);
+    }
+
+    [Fact]
+    public async Task UnaFallaAlInsertarElMovimientoNoPersisteNadaYElSaldoQuedaSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlInsertarElMovimientoNoPersisteNadaYElSaldoQuedaSinCambios));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-fault-insert", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente fault insert");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var respuesta = await EjecutarConPrivilegioRevocadoAsync(ctx, idCliente, "movimientos_cuenta_corriente", "INSERT");
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        // El UPDATE de saldo (paso 6) YA corrió cuando el INSERT del movimiento (paso 7) falla —
+        // prueba que el rollback deshace también un statement anterior de la misma transacción.
+        // El saldo tiene que quedar en 100 (el Consumo original), nunca en 150 (100 + el delta 50
+        // que el UPDATE de saldo alcanzó a escribir antes del rollback).
+        var (saldo, movimientos) = await LeerEstadoAsync(ctx, idCliente);
+        Assert.Equal(100m, saldo);
+        Assert.Equal(0, movimientos);
+    }
+
+    [Fact]
+    public async Task UnaFallaAlMarcarLosConsumosNoPersisteNadaNiElMovimientoNiElSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlMarcarLosConsumosNoPersisteNadaNiElMovimientoNiElSaldo));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-fault-marcador", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente fault marcador");
+        var consumo = await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var respuesta = await EjecutarConPrivilegioRevocadoAsync(ctx, idCliente, "movimientos_cuenta_corriente", "UPDATE");
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        // El INSERT del movimiento ActualizacionPrecios (paso 7) YA corrió — prueba que el
+        // rollback también lo deshace, no solo el UPDATE del marcador (paso 8) que tiró la
+        // excepción. El saldo tiene que quedar en 100 (el Consumo original).
+        var (saldo, movimientos) = await LeerEstadoAsync(ctx, idCliente);
+        Assert.Equal(100m, saldo);
+        Assert.Equal(0, movimientos);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var marcador = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == consumo.Id && m.Tipo == TipoMovimientoCc.Consumo)
+            .Select(m => m.IdMovimientoActualizacion).SingleAsync();
+        Assert.Null(marcador);
+    }
+
+    private async Task SubirPrecioAsync(Contexto ctx, int idArticulo, decimal nuevoPrecio, int? idListaPrecio = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var lista = idListaPrecio ?? ctx.IdListaPrecio;
+
+        var vieja = await db.Precios
+            .Where(p => p.IdArticulo == idArticulo && p.IdListaPrecio == lista && p.VigenteHasta == null)
+            .SingleAsync();
+        vieja.VigenteHasta = ahora;
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = lista, Monto = nuevoPrecio,
+            VigenteDesde = ahora, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    // ---- task 3.8: reliquidación × venta, dos reliquidaciones concurrentes --------------------
+
+    [Fact]
+    public async Task UnaReliquidacionQueCompiteConUnaVentaDelMismoClienteNoPierdeNiDuplicaNingunConsumo()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync(
+                $"{nameof(UnaReliquidacionQueCompiteConUnaVentaDelMismoClienteNoPierdeNiDuplicaNingunConsumo)}-{ronda}");
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, $"articulo-race-{ronda}", 100m);
+            var idCliente = await SembrarClienteAsync(ctx, $"Cliente race {ronda}");
+            await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+            await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+            var tareaReliquidacion = EjecutarAsync(ctx, idCliente);
+            var tareaVenta = RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 150m);
+
+            var respuestaReliquidacion = await tareaReliquidacion;
+            await tareaVenta;
+
+            Assert.True(respuestaReliquidacion.IsSuccessStatusCode);
+
+            // Invariante robusto a la interleaving real (no depende de forzar el rendezvous, mismo
+            // criterio que CajaCierreAtomicidadYConcurrenciaTests): Cliente.Saldo == Σ importe,
+            // sin importar el orden real en que ambas transacciones se sirvieron.
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            var sumaMovimientos = await db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente).SumAsync(m => m.Importe);
+            Assert.Equal(sumaMovimientos, saldo);
+
+            // Los dos Consumo del cliente (el original + el de la venta que compitió) tienen que
+            // seguir siendo exactamente dos filas — ninguna se pierde ni se duplica.
+            Assert.Equal(2, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.Consumo));
+        }
+    }
+
+    [Fact]
+    public async Task DosReliquidacionesConcurrentesDelMismoClienteEscribenExactamenteUnMovimiento()
+    {
+        for (var ronda = 0; ronda < 3; ronda++)
+        {
+            var ctx = await PrepararAsync($"{nameof(DosReliquidacionesConcurrentesDelMismoClienteEscribenExactamenteUnMovimiento)}-{ronda}");
+            var idArticulo = await SembrarArticuloConPrecioAsync(ctx, $"articulo-doble-{ronda}", 100m);
+            var idCliente = await SembrarClienteAsync(ctx, $"Cliente doble {ronda}");
+            await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+            await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+            var tareaA = EjecutarAsync(ctx, idCliente);
+            var tareaB = EjecutarAsync(ctx, idCliente);
+
+            var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+            // Las dos tienen que ser 200 — la que pierde la carrera re-escanea, encuentra el
+            // conjunto vacío y devuelve un no-op limpio, NUNCA un 409 (design: "Exactamente one
+            // movement, no 409 needed").
+            Assert.All(respuestas, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
+
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            Assert.Equal(1, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+
+            // 100 (Consumo original) + 50 (delta) = 150.
+            var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+            Assert.Equal(150m, saldo);
+        }
+    }
+
+    // ---- task 3.9: idempotencia, marcador, lista de precios ACTUAL -----------------------------
+
+    [Fact]
+    public async Task CorrerLaReliquidacionDosVecesEsUnNoOpLimpioLaSegundaVez()
+    {
+        var ctx = await PrepararAsync(nameof(CorrerLaReliquidacionDosVecesEsUnNoOpLimpioLaSegundaVez));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-idempotencia", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente idempotencia");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var primera = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+        Assert.Equal(50m, primera.Delta);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            // 100 (Consumo original) + 50 (delta) = 150.
+            Assert.Equal(150m, await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync());
+        }
+
+        var segunda = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+        Assert.Equal(0m, segunda.Delta);
+        Assert.Empty(segunda.IdsMovimientosCubiertos);
+
+        await using var dbFinal = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(150m, await dbFinal.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync());
+        Assert.Equal(1, await dbFinal.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+    }
+
+    [Fact]
+    public async Task LaReprecificacionUsaLaListaDePreciosActualDelClienteNoLaDeLaVenta()
+    {
+        var ctx = await PrepararAsync(nameof(LaReprecificacionUsaLaListaDePreciosActualDelClienteNoLaDeLaVenta));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-lista-actual", 100m);
+        // El mismo artículo también tiene precio en la lista alterna — la reliquidación tiene que
+        // ignorar la lista de venta (ctx.IdListaPrecio) y usar la que el cliente tiene AHORA.
+        await SembrarArticuloConPrecioAsync(ctx, "articulo-lista-actual-alterna", 999m, ctx.IdListaPrecioAlterna);
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            db.Precios.Add(new Precio
+            {
+                IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = ctx.IdListaPrecioAlterna, Monto = 200m,
+                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente lista actual", ctx.IdListaPrecio);
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+
+        // Mueve al cliente a la lista alterna DESPUÉS de la venta.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var cliente = await db.Clientes.SingleAsync(c => c.Id == idCliente);
+            cliente.IdListaPrecio = ctx.IdListaPrecioAlterna;
+            await db.SaveChangesAsync();
+        }
+
+        var resultado = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        // 200 (lista alterna) − 100 (histórico) = 100 — nunca contra la lista original de venta.
+        Assert.Equal(100m, resultado.Delta);
+    }
+
+    [Fact]
+    public async Task UnConsumoYaReliquidadoSeExcluyeDeLaSiguienteCorrida()
+    {
+        var ctx = await PrepararAsync(nameof(UnConsumoYaReliquidadoSeExcluyeDeLaSiguienteCorrida));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-excluido", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente excluido");
+        var consumoViejo = await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var primera = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+        Assert.Single(primera.IdsMovimientosCubiertos);
+
+        // Un consumo NUEVO se agrega — la corrida siguiente cubre solo el nuevo, nunca reprocesa
+        // el ya marcado (spec: A previously reliquidated consumo is skipped).
+        await SubirPrecioAsync(ctx, idArticulo, 200m);
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 200m);
+
+        var segunda = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+        Assert.Single(segunda.IdsMovimientosCubiertos);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var marcadorViejo = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == consumoViejo.Id && m.Tipo == TipoMovimientoCc.Consumo)
+            .Select(m => m.IdMovimientoActualizacion).SingleAsync();
+        Assert.NotNull(marcadorViejo);
+    }
+
+    // ---- task 3.10: un único movimiento por N comprobantes/líneas; sin reversión --------------
+
+    [Fact]
+    public async Task DosComprobantesEscribenExactamenteUnMovimientoConElDeltaSumado()
+    {
+        var ctx = await PrepararAsync(nameof(DosComprobantesEscribenExactamenteUnMovimientoConElDeltaSumado));
+        var idArticuloA = await SembrarArticuloConPrecioAsync(ctx, "articulo-suma-a", 100m);
+        var idArticuloB = await SembrarArticuloConPrecioAsync(ctx, "articulo-suma-b", 80m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente suma");
+
+        await RealizarConsumoAsync(ctx, idCliente, idArticuloA, 1m, 100m);
+        await RealizarConsumoAsync(ctx, idCliente, idArticuloB, 1m, 80m);
+        await SubirPrecioAsync(ctx, idArticuloA, 130m);
+        await SubirPrecioAsync(ctx, idArticuloB, 100m);
+
+        var resultado = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        // (130-100) + (100-80) = 50.
+        Assert.Equal(50m, resultado.Delta);
+        Assert.Equal(2, resultado.IdsMovimientosCubiertos.Count);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+    }
+
+    [Fact]
+    public async Task UnMovimientoDeActualizacionPreciosNoEsAnulableViaLaSuperficieDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnMovimientoDeActualizacionPreciosNoEsAnulableViaLaSuperficieDeVentas));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-no-anulable", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente no anulable");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+        await EjecutarAsync(ctx, idCliente);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idMovimiento = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios)
+            .Select(m => m.Id).SingleAsync();
+
+        // No existe ruta que direccione un movimiento — la única superficie de anulación del
+        // proyecto es /api/ventas/{id}/anulacion, direccionada por id de COMPROBANTE. Un
+        // ActualizacionPrecios nunca tiene un comprobante propio, así que el id del movimiento no
+        // resuelve a nada anulable (spec: No reversal endpoint exists for ActualizacionPrecios).
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{idMovimiento}/anulacion", null);
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- task 3.11: presupuesto de consultas, constante independiente de N ---------------------
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<object> ScalarExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            Consultas++;
+            return base.ScalarExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            Consultas++;
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    private async Task<int> EjecutarYContarConsultasAsync(Contexto ctx, int idCliente)
+    {
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Ways.Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<Ways.Domain.Articulos.UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: ctx.IdEmpleadoAdmin);
+        var lector = new LectorDeConsumosReliquidables(db);
+        var servicioDePrecios = new ServicioDePrecios(db, reloj, contexto);
+        var servicio = new ServicioDeReliquidacion(db, reloj, contexto, lector, servicioDePrecios);
+
+        await servicio.EjecutarAsync(idCliente, new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
+
+        return contador.Consultas;
+    }
+
+    [Fact]
+    public async Task LaReliquidacionEmiteUnPresupuestoConstanteDeConsultasIndependienteDeLaCantidadDeConsumos()
+    {
+        var ctx = await PrepararAsync(nameof(LaReliquidacionEmiteUnPresupuestoConstanteDeConsultasIndependienteDeLaCantidadDeConsumos));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-presupuesto", 10m);
+
+        var idCliente2 = await SembrarClienteAsync(ctx, "Cliente presupuesto 2");
+        for (var i = 0; i < 2; i++)
+        {
+            await SembrarConsumoCrudoAsync(ctx, idCliente2, idArticulo, 10m);
+        }
+
+        var idCliente50 = await SembrarClienteAsync(ctx, "Cliente presupuesto 50");
+        for (var i = 0; i < 50; i++)
+        {
+            await SembrarConsumoCrudoAsync(ctx, idCliente50, idArticulo, 10m);
+        }
+
+        var idCliente200 = await SembrarClienteAsync(ctx, "Cliente presupuesto 200");
+        for (var i = 0; i < 200; i++)
+        {
+            await SembrarConsumoCrudoAsync(ctx, idCliente200, idArticulo, 10m);
+        }
+
+        await SubirPrecioAsync(ctx, idArticulo, 15m);
+
+        var consultasCon2 = await EjecutarYContarConsultasAsync(ctx, idCliente2);
+        var consultasCon50 = await EjecutarYContarConsultasAsync(ctx, idCliente50);
+        var consultasCon200 = await EjecutarYContarConsultasAsync(ctx, idCliente200);
+
+        Assert.Equal(consultasCon2, consultasCon50);
+        Assert.Equal(consultasCon2, consultasCon200);
+    }
+
+    // ---- task 3.12: matriz de autorización -----------------------------------------------------
+
+    private async Task<HttpClient> CrearUsuarioConRolAsync(Contexto ctx, string nombre, RolConocido rol)
+    {
+        var mail = $"{nombre.ToLowerInvariant()}@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario(nombre, mail, (int)rol, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDeLaReliquidacionPreviewYCommit()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDeLaReliquidacionPreviewYCommit));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente vendedor rechazado");
+        using var vendedor = await CrearUsuarioConRolAsync(ctx, "vendedor-rq", RolConocido.Vendedor);
+
+        var preview = await PreviewAsync(ctx, idCliente, vendedor);
+        Assert.Equal(HttpStatusCode.Forbidden, preview.StatusCode);
+
+        var commit = await EjecutarAsync(ctx, idCliente, vendedor);
+        Assert.Equal(HttpStatusCode.Forbidden, commit.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorPuedeCorrerElPreviewYElCommit()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorPuedeCorrerElPreviewYElCommit));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente supervisor");
+        using var supervisor = await CrearUsuarioConRolAsync(ctx, "supervisor-rq", RolConocido.Supervisor);
+
+        var preview = await PreviewAsync(ctx, idCliente, supervisor);
+        Assert.True(preview.IsSuccessStatusCode);
+
+        var commit = await EjecutarAsync(ctx, idCliente, supervisor);
+        Assert.True(commit.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminPuedeCorrerElPreviewYElCommit()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminPuedeCorrerElPreviewYElCommit));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente admin");
+
+        var preview = await PreviewAsync(ctx, idCliente);
+        Assert.True(preview.IsSuccessStatusCode);
+
+        var commit = await EjecutarAsync(ctx, idCliente);
+        Assert.True(commit.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task LaReliquidacionSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var preview = await cliente.GetAsync("/api/clientes/1/cuenta-corriente/reliquidacion");
+        Assert.Equal(HttpStatusCode.Unauthorized, preview.StatusCode);
+
+        var commit = await cliente.PostAsJsonAsync(
+            "/api/clientes/1/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(1));
+        Assert.Equal(HttpStatusCode.Unauthorized, commit.StatusCode);
+    }
+
+    [Fact]
+    public async Task LaReliquidacionContraUnClienteDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(LaReliquidacionContraUnClienteDeOtroTenantDevuelve404) + "-A");
+        var idClienteDeA = await SembrarClienteAsync(ctxA, "Cliente A cross-tenant RQ");
+
+        var ctxB = await PrepararAsync(nameof(LaReliquidacionContraUnClienteDeOtroTenantDevuelve404) + "-B");
+
+        var preview = await PreviewAsync(ctxB, idClienteDeA);
+        Assert.Equal(HttpStatusCode.NotFound, preview.StatusCode);
+
+        var commit = await EjecutarAsync(ctxB, idClienteDeA);
+        Assert.Equal(HttpStatusCode.NotFound, commit.StatusCode);
+    }
+
+    // ---- no-op semantics -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnClienteSinConsumosElegiblesEsUnNoOpLimpio()
+    {
+        var ctx = await PrepararAsync(nameof(UnClienteSinConsumosElegiblesEsUnNoOpLimpio));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente sin consumos");
+
+        var resultado = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Empty(resultado.IdsMovimientosCubiertos);
+        Assert.False(resultado.HayMas);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente));
+    }
+}

--- a/tests/Ways.IntegrationTests/ReliquidacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionTests.cs
@@ -532,9 +532,13 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         Assert.Single(primera.IdsMovimientosCubiertos);
 
         // Un consumo NUEVO se agrega — la corrida siguiente cubre solo el nuevo, nunca reprocesa
-        // el ya marcado (spec: A previously reliquidated consumo is skipped).
+        // el ya marcado (spec: A previously reliquidated consumo is skipped). El precio sube DE
+        // NUEVO después de la compra para que el nuevo consumo aporte un delta distinto de cero —
+        // si quedara en cero la corrida sería un no-op y no escribiría ningún marcador (mismo
+        // criterio que UnDeltaTotalCeroPorDeltasQueSeCancelanNoDejaNingunConsumoMarcadoComoCubierto).
         await SubirPrecioAsync(ctx, idArticulo, 200m);
-        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 200m);
+        var consumoNuevo = await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 200m);
+        await SubirPrecioAsync(ctx, idArticulo, 250m);
 
         var segunda = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
         Assert.Single(segunda.IdsMovimientosCubiertos);
@@ -544,6 +548,11 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
             .Where(m => m.IdComprobanteVenta == consumoViejo.Id && m.Tipo == TipoMovimientoCc.Consumo)
             .Select(m => m.IdMovimientoActualizacion).SingleAsync();
         Assert.NotNull(marcadorViejo);
+
+        var marcadorNuevo = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == consumoNuevo.Id && m.Tipo == TipoMovimientoCc.Consumo)
+            .Select(m => m.IdMovimientoActualizacion).SingleAsync();
+        Assert.NotNull(marcadorNuevo);
     }
 
     // ---- task 3.10: un único movimiento por N comprobantes/líneas; sin reversión --------------
@@ -830,5 +839,146 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente));
+    }
+
+    [Fact]
+    public async Task UnDeltaTotalCeroPorDeltasQueSeCancelanNoDejaNingunConsumoMarcadoComoCubierto()
+    {
+        // Dos consumos elegibles, uno sube (+50) y otro baja (-50) — el delta TOTAL de la corrida
+        // da 0, así que el servicio no escribe absolutamente nada (paso 6/7/8 se saltean). La
+        // respuesta tiene que reflejar esa realidad de la DB: IdsMovimientosCubiertos vacío, nunca
+        // la lista de "procesados" que devuelve el calculador puro.
+        var ctx = await PrepararAsync(nameof(UnDeltaTotalCeroPorDeltasQueSeCancelanNoDejaNingunConsumoMarcadoComoCubierto));
+        var idArticuloSube = await SembrarArticuloConPrecioAsync(ctx, "articulo-cancela-sube", 100m);
+        var idArticuloBaja = await SembrarArticuloConPrecioAsync(ctx, "articulo-cancela-baja", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente delta cancela");
+
+        var consumoSube = await RealizarConsumoAsync(ctx, idCliente, idArticuloSube, 1m, 100m);
+        var consumoBaja = await RealizarConsumoAsync(ctx, idCliente, idArticuloBaja, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticuloSube, 150m); // delta +50.
+        await SubirPrecioAsync(ctx, idArticuloBaja, 50m); // delta -50.
+
+        var respuesta = await EjecutarAsync(ctx, idCliente);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var resultado = await LeerResultadoAsync(respuesta);
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Empty(resultado.IdsMovimientosCubiertos);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync(
+            m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+
+        var marcadorSube = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == consumoSube.Id && m.Tipo == TipoMovimientoCc.Consumo)
+            .Select(m => m.IdMovimientoActualizacion).SingleAsync();
+        var marcadorBaja = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == consumoBaja.Id && m.Tipo == TipoMovimientoCc.Consumo)
+            .Select(m => m.IdMovimientoActualizacion).SingleAsync();
+        Assert.Null(marcadorSube);
+        Assert.Null(marcadorBaja);
+    }
+
+    // ---- el cap de 500 consumos por corrida, punta a punta -------------------------------------
+
+    /// <summary>Seed crudo en lote (<c>AddRange</c> + un único <c>SaveChangesAsync</c> por tabla,
+    /// en vez de N×3 round-trips) — mismo criterio que <see cref="SembrarConsumoCrudoAsync"/>: el
+    /// camino de escritura completo no hace falta para probar la FORMA del cap de 500, solo el
+    /// volumen de filas.</summary>
+    private async Task<List<int>> SembrarConsumosCrudosEnLoteAsync(
+        Contexto ctx, int idCliente, int idArticulo, decimal precio, int cantidad, DateTimeOffset fecha)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var comprobantes = Enumerable.Range(0, cantidad)
+            .Select(_ => new ComprobanteVenta
+            {
+                IdTenant = ctx.IdTenant, IdTipoComprobante = ctx.IdTipoComprobanteTx,
+                Numero = Interlocked.Increment(ref _numeroSecuencial), Fecha = fecha, IdPuntoVenta = ctx.IdPuntoVenta,
+                IdEmpleado = ctx.IdEmpleadoAdmin, IdCliente = idCliente, Subtotal = precio, DescuentoTotal = 0m,
+                Total = precio, Estado = EstadoComprobante.Emitido, CreatedAt = fecha, UpdatedAt = fecha
+            })
+            .ToList();
+        db.ComprobantesVenta.AddRange(comprobantes);
+        await db.SaveChangesAsync();
+
+        var items = comprobantes
+            .Select(c => new ItemComprobanteVenta
+            {
+                IdTenant = ctx.IdTenant, IdComprobanteVenta = c.Id, Orden = 1, IdArticulo = idArticulo,
+                Descripcion = "item de prueba", IdArea = ctx.IdArea, IdListaPrecio = ctx.IdListaPrecio,
+                IdAlicuotaIva = ctx.IdAlicuotaIva, PorcentajeIva = 0m, Cantidad = 1m, PrecioUnitario = precio,
+                Descuento = 0m, Total = precio, CreatedAt = fecha, UpdatedAt = fecha
+            })
+            .ToList();
+        db.ItemsComprobanteVenta.AddRange(items);
+        await db.SaveChangesAsync();
+
+        var movimientos = comprobantes
+            .Select(c => new MovimientoCuentaCorriente
+            {
+                IdTenant = ctx.IdTenant, IdCliente = idCliente, Fecha = fecha, IdPuntoVenta = ctx.IdPuntoVenta,
+                IdEmpleado = ctx.IdEmpleadoAdmin, Tipo = TipoMovimientoCc.Consumo, IdComprobanteVenta = c.Id,
+                IdPagoComprobante = null, Importe = precio, SaldoResultante = 0m
+            })
+            .ToList();
+        db.MovimientosCuentaCorriente.AddRange(movimientos);
+        await db.SaveChangesAsync();
+
+        return movimientos.OrderBy(m => m.Id).Select(m => m.Id).ToList();
+    }
+
+    [Fact]
+    public async Task ConQuinientosUnoElegiblesLaPrimeraCorridaCubreLosQuinientosMasViejosYLaSegundaElResto()
+    {
+        var ctx = await PrepararAsync(nameof(ConQuinientosUnoElegiblesLaPrimeraCorridaCubreLosQuinientosMasViejosYLaSegundaElResto));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-cap-500", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente cap 500");
+
+        // Misma fecha para las 501 filas — el desempate determinístico por id (Fix del lector) es
+        // lo que decide cuáles 500 quedan del lado de la primera corrida.
+        var fecha = DateTimeOffset.UtcNow;
+        var idsMovimiento = await SembrarConsumosCrudosEnLoteAsync(ctx, idCliente, idArticulo, 100m, 501, fecha);
+        Assert.Equal(501, idsMovimiento.Count);
+
+        await SubirPrecioAsync(ctx, idArticulo, 110m); // delta +10 por consumo.
+
+        var primera = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        Assert.Equal(500, primera.IdsMovimientosCubiertos.Count);
+        Assert.True(primera.HayMas);
+        Assert.Equal(5000m, primera.Delta); // 500 × 10.
+
+        var idsEsperadosPrimeraCorrida = idsMovimiento.Take(500).ToList();
+        Assert.Equal(idsEsperadosPrimeraCorrida, primera.IdsMovimientosCubiertos.OrderBy(id => id).ToList());
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(1, await db.MovimientosCuentaCorriente.CountAsync(
+                m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+
+            var idUltimoNoCubierto = idsMovimiento[500];
+            var marcadorPendiente = await db.MovimientosCuentaCorriente
+                .Where(m => m.Id == idUltimoNoCubierto).Select(m => m.IdMovimientoActualizacion).SingleAsync();
+            Assert.Null(marcadorPendiente);
+        }
+
+        var segunda = await LeerResultadoAsync(await EjecutarAsync(ctx, idCliente));
+
+        Assert.Single(segunda.IdsMovimientosCubiertos);
+        Assert.Equal(idsMovimiento[500], segunda.IdsMovimientosCubiertos[0]);
+        Assert.False(segunda.HayMas);
+        Assert.Equal(10m, segunda.Delta);
+
+        await using var dbFinal = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(2, await dbFinal.MovimientosCuentaCorriente.CountAsync(
+            m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+
+        var saldoFinal = await dbFinal.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        // El seed crudo (SembrarConsumosCrudosEnLoteAsync) inserta los 501 Consumo directo en el
+        // ledger sin pasar por el checkout, así que nunca toca Cliente.Saldo (mismo criterio que
+        // SembrarConsumoCrudoAsync) — el único efecto en saldo es el de las dos corridas de
+        // reliquidación (5000 + 10).
+        Assert.Equal(primera.Delta + segunda.Delta, saldoFinal);
     }
 }

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -63,6 +63,12 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que poder cobrar una
         // cuenta corriente).
         ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/pagos"),
+        // stage-7-cuenta-corriente (Slice 3, task 3.5): commit de reliquidación — sin
+        // GestionDeCatalogo apilado (apila SupervisionDeCuentaCorriente en su lugar, ver
+        // CuentaCorrienteEndpoints); este guard solo vigila la ausencia de GestionDeCatalogo, no
+        // reemplaza el chequeo de rol real (SuperficieDeAutorizacionTests de PagosACuentaTests/
+        // ReliquidacionTests cubre 403 Vendedor).
+        ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/reliquidacion"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

Slice 3/6 de la etapa 7 — el centerpiece: la F4 del legacy ("la feature más particular del sistema") como motor auditable.

- `ReliquidadorDeConsumos` (dominio puro, 19 tests): re-precia cada consumo pendiente contra la lista ACTUAL del cliente — reversión de ofertas al precio pleno (el ejemplo del spec pinneado con el assert explícito contra la lectura errónea), prorrateo por fracción financiada (`min(1, importe/total)` — el legacy sobrecobraba las ventas parcialmente fiadas), líneas sin precio salteadas con nota, deltas negativos reducen deuda sin clamping.
- `ServicioDeReliquidacion`: transacción con `FOR UPDATE` del cliente como primer statement, scan de elegibilidad bajo el lock (anulados jamás entran), UN movimiento `ActualizacionPrecios` con detalle JSON auditable + saldo por el writer compartido + marcador self-FK en cada consumo cubierto. No-op limpio sin escritura; preview GET nunca autoritativo (identidad preview==execute probada).
- **TOCTOU anulación×reliquidación cerrado** (tarea 3.13, hallazgo del slice 2): el guard re-lee el marcador bajo el lock del cliente; el estado "anulado y reliquidado" es irrepresentable — trazado a mano por el juez A y probado por carrera de 5 rondas.
- `Politicas.SupervisionDeCuentaCorriente` (Supervisor+Admin): la reliquidación muta saldos en lote — Vendedor 403.
- Tope de 500 por corrida determinista (`fecha, id`) y probado end-to-end con 501 consumos reales en dos corridas encadenadas.

## Verificación

- Suites: Domain 342 (+20), Application 212 (+1), Integration 531 (+21), vitest 221, contra Postgres real. Inyección de fallas en los pasos de escritura (rollback total de saldo+movimiento+marcadores juntos); carreras reliquidación×venta, dos reliquidaciones, anulación×reliquidación.
- Judgment-day: ronda 1 — juez A CLEAN (matemática re-derivada y coincidente; orden de locks de los 4 caminos sin ciclo); juez B 1 MAJOR (la respuesta mentía sobre cobertura en el neteo a cero — corregida con evidencia de mutación; un test preexistente dependía del bug y quedó honesto) + 2 MINORs (tie-breaker determinista, prueba del tope 500) — todos aplicados. Ronda 2 verificada por el orquestador (fixes prescriptos de dos líneas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)