### PR TITLE
feat(cc): ajuste manual y estado de cuenta (etapa 7, slice 4)

### DIFF
--- a/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
@@ -41,6 +41,27 @@ public static class CuentaCorrienteEndpoints
         .RequireAuthorization(Politicas.SupervisionDeCuentaCorriente)
         .WithSummary("Ejecuta la reliquidación a precio del día — irreversible, sin turno.");
 
+        // stage-7-cuenta-corriente (Slice 4, task 4.4, design: API Surface): ajuste manual — sin
+        // turno, mismo criterio que la reliquidación. SupervisionDeCuentaCorriente apilado sobre
+        // OperacionDePos (mismo patrón que las dos rutas de reliquidación de arriba).
+        grupo.MapPost("/ajustes", async (
+            ServicioDeCuentaCorriente servicio, int idCliente, SolicitudDeAjuste solicitud, CancellationToken ct) =>
+        {
+            var movimiento = await servicio.RegistrarAjusteAsync(idCliente, solicitud, ct);
+            return Results.Created($"/api/clientes/{idCliente}/cuenta-corriente", movimiento);
+        })
+        .RequireAuthorization(Politicas.SupervisionDeCuentaCorriente)
+        .WithSummary("Registra un ajuste manual de cuenta corriente — importe con signo, detalle obligatorio.");
+
+        // stage-7-cuenta-corriente (Slice 4, task 4.4, design: API Surface): estado de cuenta —
+        // header + movimientos en un único GET, bajo OperacionDePos (el grupo entero, sin policy
+        // apilada — un Vendedor tiene que poder consultar la cuenta corriente de un cliente).
+        grupo.MapGet("/", async (
+            ServicioDeCuentaCorriente servicio, int idCliente, DateTimeOffset? desde, DateTimeOffset? hasta,
+            bool? historico, CancellationToken ct) =>
+            Results.Ok(await servicio.ObtenerEstadoDeCuentaAsync(idCliente, desde, hasta, historico ?? false, ct)))
+        .WithSummary("Estado de cuenta: header (saldo/acuerdo/disponibilidad) + movimientos con saldo corrido.");
+
         return app;
     }
 }

--- a/src/Ways.Application/CuentaCorriente/Contratos.cs
+++ b/src/Ways.Application/CuentaCorriente/Contratos.cs
@@ -1,3 +1,5 @@
+using Ways.Domain.CuentaCorriente;
+
 namespace Ways.Application.CuentaCorriente;
 
 /// <summary>
@@ -22,3 +24,36 @@ public sealed record PagoDeCuenta(int IdMedioPago, decimal Importe, string? Refe
 /// tenant-scoped como cualquier otro id de punto de venta) — se persiste en el movimiento
 /// <c>ActualizacionPrecios</c> resultante.</summary>
 public sealed record SolicitudDeReliquidacion(int IdPuntoVenta);
+
+/// <summary>
+/// Cuerpo de <c>POST /api/clientes/{id}/cuenta-corriente/ajustes</c> (design: API Surface;
+/// Transactions — AJUSTE MANUAL). <see cref="Importe"/> viaja con signo, decidido por el llamador
+/// (spec: Ajuste Requires A Detalle — "importe MAY be positive or negative"); <see cref="Detalle"/>
+/// es obligatorio (<see cref="Domain.CuentaCorriente.ReglaDeAjusteDeCuenta"/>).
+/// </summary>
+public sealed record SolicitudDeAjuste(int IdPuntoVenta, decimal Importe, string? Detalle);
+
+/// <summary>
+/// Fila del ledger proyectada para el estado de cuenta (design decisión 9: <c>saldo_resultante</c>
+/// es la ÚNICA fuente del saldo corriente, nunca re-derivado). <see cref="Etiqueta"/> es
+/// <c>null</c> para todo tipo salvo <see cref="TipoMovimientoCc.Ajuste"/> — ahí distingue manual de
+/// contramovimiento (design decisión 8/9; <see cref="Domain.CuentaCorriente.CalculadorDeEstadoDeCuenta"/>).
+/// </summary>
+public sealed record MovimientoDeCuentaCorriente(
+    int Id, DateTimeOffset Fecha, TipoMovimientoCc Tipo, decimal Importe, decimal SaldoResultante,
+    string? Detalle, int? IdComprobanteVenta, EtiquetaDeAjuste? Etiqueta);
+
+/// <summary>Header de estado de cuenta (design decisión 9: "un único GET devuelve header + page",
+/// leído de la MISMA fila de <c>clientes</c> que pidió el operador — no puede desalinearse del
+/// ledger que está mirando). <see cref="Disponibilidad"/> es <c>null</c> cuando
+/// <see cref="CreditoIlimitado"/> (nunca un número fabricado).</summary>
+public sealed record EstadoDeCuentaHeader(decimal Saldo, decimal LimiteCredito, bool CreditoIlimitado, decimal? Disponibilidad);
+
+/// <summary>Respuesta completa de <c>GET /api/clientes/{id}/cuenta-corriente</c> — header +
+/// movimientos en un único payload (design decisión 9). <see cref="Historico"/>/<see cref="Desde"/>/
+/// <see cref="Hasta"/> reflejan la ventana EFECTIVA aplicada (spec: Default Last Month Filter,
+/// Desde/Hasta, And Histórico), no lo pedido crudo — así el cliente HTTP sabe qué ventana ve sin
+/// tener que recalcular el default.</summary>
+public sealed record EstadoDeCuenta(
+    EstadoDeCuentaHeader Header, IReadOnlyList<MovimientoDeCuentaCorriente> Movimientos, bool Historico,
+    DateTimeOffset? Desde, DateTimeOffset? Hasta);

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -183,7 +183,9 @@ public class ServicioDeCuentaCorriente(
         DateTimeOffset? hastaEfectivo = null;
         if (!historico)
         {
-            desdeEfectivo = desde ?? (hasta is null ? reloj.Ahora.AddMonths(-1) : null);
+            // Un hasta explícito sin desde también recorta la ventana a un mes — sin este piso,
+            // hasta-only devolvía TODO el ledger desde el día uno con Historico=false.
+            desdeEfectivo = desde ?? (hasta is { } hastaSinDesde ? hastaSinDesde.AddMonths(-1) : reloj.Ahora.AddMonths(-1));
             hastaEfectivo = hasta;
         }
 
@@ -198,8 +200,11 @@ public class ServicioDeCuentaCorriente(
             consulta = consulta.Where(m => m.Fecha <= hastaAplicado);
         }
 
+        // Newest-first (legacy: `ORDER BY fecha DESC`, doc-01:375 — "saldo corriendo hacia atrás
+        // desde el saldo actual") y convención de resumen bancario. El cómputo del saldo (columna
+        // saldo_resultante persistida) es ortogonal a este orden de display.
         var filas = await consulta
-            .OrderBy(m => m.Fecha).ThenBy(m => m.Id)
+            .OrderByDescending(m => m.Fecha).ThenByDescending(m => m.Id)
             .Select(m => new
             {
                 m.Id, m.Fecha, m.Tipo, m.Importe, m.SaldoResultante, m.Detalle, m.IdComprobanteVenta

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -102,6 +102,119 @@ public class ServicioDeCuentaCorriente(
                 pagos, NormalizarOpcional(solicitud.Observaciones), ct));
     }
 
+    /// <summary>Design: Transactions — AJUSTE MANUAL (orden pineado: "fuera:
+    /// ReglaDeAjusteDeCuenta … ; cliente ; punto de venta"). Una sola transacción de dos
+    /// statements — sin turno (mismo criterio que la reliquidación: un ajuste no mueve plata
+    /// física).</summary>
+    public async Task<MovimientoDeCuentaCorriente> RegistrarAjusteAsync(
+        int idCliente, SolicitudDeAjuste solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        // 1. ReglaDeAjusteDeCuenta — pura, corre ANTES de cualquier consulta a la base (spec:
+        // Ajuste with no detalle is rejected — "rejected … before any write").
+        ReglaDeAjusteDeCuenta.Validar(solicitud.Importe, solicitud.Detalle);
+        var detalleNormalizado = solicitud.Detalle!.Trim();
+
+        // 2. Cliente — mismo guard CF que RegistrarPagoAsync/ServicioDeReliquidacion (un ajuste
+        // manual tampoco tiene sentido de negocio sobre el Consumidor Final, que no maneja
+        // cuenta corriente).
+        var cliente = await ResolverClienteAsync(idCliente, ct);
+        if (cliente.EsConsumidorFinal)
+        {
+            throw new ErrorDominio(
+                "cliente_sin_cuenta_corriente", "El Consumidor Final no tiene cuenta corriente.", 400);
+        }
+
+        // 3. Punto de venta — provenance, no autoridad (design: Open Questions — el ajuste no
+        // tiene turno del que derivarlo).
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarAjusteAsync(
+                idTenant, idEmpleado, momento, idCliente, puntoVenta.Id, solicitud.Importe, detalleNormalizado, ct));
+    }
+
+    private async Task<MovimientoDeCuentaCorriente> EjecutarAjusteAsync(
+        int idTenant, int idEmpleado, DateTimeOffset momento, int idCliente, int idPuntoVenta, decimal importe,
+        string detalle, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 1. Saldo — el mismo UPDATE ... RETURNING que el resto de la cuenta corriente, lock de
+        // la fila cliente.
+        var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
+            conexion, transaccionCruda, idTenant, idCliente, importe, ct);
+
+        // 2. Movimiento — id_comprobante_venta NULL (design decisión 8: la marca estructural de
+        // "es un ajuste manual, no un contramovimiento de anulación").
+        var idMovimiento = await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+            conexion, transaccionCruda, idTenant, idCliente, momento, idPuntoVenta, idEmpleado,
+            TipoMovimientoCc.Ajuste, idComprobanteVenta: null, idPagoComprobante: null, importe, nuevoSaldo, detalle, ct);
+
+        await transaccion.CommitAsync(ct);
+
+        return new MovimientoDeCuentaCorriente(
+            idMovimiento, momento, TipoMovimientoCc.Ajuste, importe, nuevoSaldo, detalle, IdComprobanteVenta: null,
+            Etiqueta: EtiquetaDeAjuste.Manual);
+    }
+
+    /// <summary>Design decisión 9: header + movimientos en un único <c>GET</c>, sin lock (lectura
+    /// pura) — <c>saldo_resultante</c> es la ÚNICA fuente de la corrida, nunca re-derivada.
+    /// <paramref name="historico"/> gana sobre <paramref name="desde"/>/<paramref name="hasta"/>
+    /// (spec: histórico returns the full ledger); si ninguno de los tres viene, aplica el default
+    /// de último mes (spec: No filter returns the last month) — un <paramref name="desde"/>/
+    /// <paramref name="hasta"/> explícito nunca lo pisa.</summary>
+    public async Task<EstadoDeCuenta> ObtenerEstadoDeCuentaAsync(
+        int idCliente, DateTimeOffset? desde, DateTimeOffset? hasta, bool historico, CancellationToken ct = default)
+    {
+        var cliente = await ResolverClienteAsync(idCliente, ct);
+
+        var disponibilidad = CalculadorDeEstadoDeCuenta.CalcularDisponibilidad(
+            cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado);
+        var header = new EstadoDeCuentaHeader(cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado, disponibilidad);
+
+        DateTimeOffset? desdeEfectivo = null;
+        DateTimeOffset? hastaEfectivo = null;
+        if (!historico)
+        {
+            desdeEfectivo = desde ?? (hasta is null ? reloj.Ahora.AddMonths(-1) : null);
+            hastaEfectivo = hasta;
+        }
+
+        var consulta = db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente);
+        if (desdeEfectivo is { } desdeAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha >= desdeAplicado);
+        }
+
+        if (hastaEfectivo is { } hastaAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha <= hastaAplicado);
+        }
+
+        var filas = await consulta
+            .OrderBy(m => m.Fecha).ThenBy(m => m.Id)
+            .Select(m => new
+            {
+                m.Id, m.Fecha, m.Tipo, m.Importe, m.SaldoResultante, m.Detalle, m.IdComprobanteVenta
+            })
+            .ToListAsync(ct);
+
+        var movimientos = filas
+            .Select(f => new MovimientoDeCuentaCorriente(
+                f.Id, f.Fecha, f.Tipo, f.Importe, f.SaldoResultante, f.Detalle, f.IdComprobanteVenta,
+                f.Tipo == TipoMovimientoCc.Ajuste ? CalculadorDeEstadoDeCuenta.EtiquetarAjuste(f.IdComprobanteVenta) : null))
+            .ToList();
+
+        return new EstadoDeCuenta(header, movimientos, historico, desdeEfectivo, hastaEfectivo);
+    }
+
     private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(
         int idTenant, int idEmpleado, DateTimeOffset momento, int idTipoComprobante, long numero, int idPuntoVenta,
         int idTurnoCaja, int idCliente, decimal importeAplicado, IReadOnlyList<PagoDeCuenta> pagos,

--- a/src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuenta.cs
+++ b/src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuenta.cs
@@ -1,0 +1,34 @@
+namespace Ways.Domain.CuentaCorriente;
+
+/// <summary>
+/// Distingue un <see cref="MovimientoCuentaCorriente"/> <see cref="TipoMovimientoCc.Ajuste"/> por
+/// su origen (design decisión 8/9): un ajuste manual (esta capability, Slice 4) nunca lleva
+/// <c>id_comprobante_venta</c>; el contramovimiento de anulación (stage 5) siempre lo lleva —
+/// ninguna columna nueva codifica la diferencia, la etiqueta se DERIVA (spec:
+/// ajustes-de-cuenta-corriente / Ajuste Is Distinct From The Anulación Contramovimiento).
+/// </summary>
+public enum EtiquetaDeAjuste
+{
+    Manual,
+    AnulacionContramovimiento
+}
+
+/// <summary>
+/// Pura, sin DB (design decisión 9, mismo listón que <see cref="ReliquidadorDeConsumos"/>): la
+/// derivación de <c>disponibilidad</c> del header de estado de cuenta y la etiqueta estructural de
+/// un movimiento <see cref="TipoMovimientoCc.Ajuste"/>.
+/// </summary>
+public static class CalculadorDeEstadoDeCuenta
+{
+    /// <summary><c>credito_ilimitado</c> ⇒ <c>null</c>, NUNCA un número fabricado (design decisión
+    /// 9, pinned: "disponibilidad is decimal?, NULL ⇒ ilimitado") — el llamador (web, Slice 5) es
+    /// quien decide cómo rotular <c>null</c> en pantalla.</summary>
+    public static decimal? CalcularDisponibilidad(decimal saldo, decimal limiteCredito, bool creditoIlimitado) =>
+        creditoIlimitado ? null : limiteCredito - saldo;
+
+    /// <summary>Aplica solo a filas <see cref="TipoMovimientoCc.Ajuste"/> — el llamador es
+    /// responsable de no invocarla sobre otro <see cref="TipoMovimientoCc"/> (design: "no new
+    /// column", la predicate ES <c>id_comprobante_venta IS NULL</c>).</summary>
+    public static EtiquetaDeAjuste EtiquetarAjuste(int? idComprobanteVenta) =>
+        idComprobanteVenta is null ? EtiquetaDeAjuste.Manual : EtiquetaDeAjuste.AnulacionContramovimiento;
+}

--- a/src/Ways.Domain/CuentaCorriente/ReglaDeAjusteDeCuenta.cs
+++ b/src/Ways.Domain/CuentaCorriente/ReglaDeAjusteDeCuenta.cs
@@ -1,0 +1,36 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.CuentaCorriente;
+
+/// <summary>
+/// Regla pura del ajuste manual (design decisión 8, pinned: "no necesita esquema, ni CHECK";
+/// tasks.md task 4.1) — orden de validación IGUAL al de design: Transactions, AJUSTE MANUAL
+/// ("fuera: ReglaDeAjusteDeCuenta … ; cliente ; punto de venta"), corre ANTES de tocar la base.
+/// <see cref="Validar"/> no distingue signo: <c>importe</c> positivo aumenta la deuda, negativo la
+/// reduce (spec: Ajuste Requires A Detalle — "importe MAY be positive or negative").
+/// </summary>
+public static class ReglaDeAjusteDeCuenta
+{
+    /// <summary>Design decisión 8: <c>length(btrim(detalle)) &gt;= 5</c> — mismo umbral que
+    /// <c>ck_movimientos_caja_motivo_minimo</c> (stage-6), acá vive en Domain porque no hay CHECK
+    /// (stage-5 ya escribe filas <c>tipo = ajuste</c> con <c>detalle</c> NULL para el
+    /// contramovimiento de anulación, así que una CHECK de esquema rompería datos existentes).</summary>
+    public const int LongitudMinimaDetalle = 5;
+
+    public static void Validar(decimal importe, string? detalle)
+    {
+        if (importe == 0m)
+        {
+            throw new ErrorDominio("ajuste_importe_invalido", "El importe del ajuste no puede ser cero.", 400);
+        }
+
+        var detalleNormalizado = detalle?.Trim();
+        if (string.IsNullOrEmpty(detalleNormalizado) || detalleNormalizado.Length < LongitudMinimaDetalle)
+        {
+            throw new ErrorDominio(
+                "ajuste_detalle_requerido",
+                $"El detalle del ajuste es obligatorio y tiene que tener al menos {LongitudMinimaDetalle} caracteres.",
+                400);
+        }
+    }
+}

--- a/tests/Ways.Domain.Tests/CuentaCorriente/CalculadorDeEstadoDeCuentaTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/CalculadorDeEstadoDeCuentaTests.cs
@@ -1,0 +1,52 @@
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Domain.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 4 (task 4.5, design decisión 9; spec: estado-de-cuenta / Header
+/// Computes Disponibilidad Server-Side, ajustes-de-cuenta-corriente / Ajuste Is Distinct From The
+/// Anulación Contramovimiento) — pura, sin base de datos.
+/// </summary>
+public class CalculadorDeEstadoDeCuentaTests
+{
+    // ---- Disponibilidad ------------------------------------------------------------------------
+
+    [Fact]
+    public void DisponibilidadParaUnClienteConCreditoLimitadoEsElAcuerdoMenosElSaldo()
+    {
+        var disponibilidad = CalculadorDeEstadoDeCuenta.CalcularDisponibilidad(
+            saldo: 300m, limiteCredito: 1000m, creditoIlimitado: false);
+        Assert.Equal(700m, disponibilidad);
+    }
+
+    [Fact]
+    public void DisponibilidadEsNuloCuandoElCreditoEsIlimitado()
+    {
+        var disponibilidad = CalculadorDeEstadoDeCuenta.CalcularDisponibilidad(
+            saldo: 300m, limiteCredito: 0m, creditoIlimitado: true);
+        Assert.Null(disponibilidad);
+    }
+
+    [Fact]
+    public void DisponibilidadPuedeSerNegativaCuandoElSaldoSuperaElLimite()
+    {
+        var disponibilidad = CalculadorDeEstadoDeCuenta.CalcularDisponibilidad(
+            saldo: 1200m, limiteCredito: 1000m, creditoIlimitado: false);
+        Assert.Equal(-200m, disponibilidad);
+    }
+
+    // ---- Etiqueta de ajuste (derivación estructural, sin columna nueva) ------------------------
+
+    [Fact]
+    public void UnAjusteSinComprobanteSeEtiquetaComoManual()
+    {
+        Assert.Equal(EtiquetaDeAjuste.Manual, CalculadorDeEstadoDeCuenta.EtiquetarAjuste(null));
+    }
+
+    [Fact]
+    public void UnAjusteConComprobanteSeEtiquetaComoContramovimientoDeAnulacion()
+    {
+        Assert.Equal(
+            EtiquetaDeAjuste.AnulacionContramovimiento, CalculadorDeEstadoDeCuenta.EtiquetarAjuste(idComprobanteVenta: 42));
+    }
+}

--- a/tests/Ways.Domain.Tests/CuentaCorriente/ReglaDeAjusteDeCuentaTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/ReglaDeAjusteDeCuentaTests.cs
@@ -1,0 +1,77 @@
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Domain.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 4 (task 4.5, design decisión 8; spec:
+/// ajustes-de-cuenta-corriente / Ajuste Requires A Detalle) — pura, sin base de datos.
+/// </summary>
+public class ReglaDeAjusteDeCuentaTests
+{
+    [Fact]
+    public void UnDetalleVacioSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(50m, string.Empty));
+        Assert.Equal("ajuste_detalle_requerido", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void UnDetalleNuloSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(50m, null));
+        Assert.Equal("ajuste_detalle_requerido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnDetalleSoloDeEspaciosSeConsideraFaltante()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(50m, "     "));
+        Assert.Equal("ajuste_detalle_requerido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnDetalleDeMenosDeCincoCaracteresSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(50m, "abcd"));
+        Assert.Equal("ajuste_detalle_requerido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnDetalleDeExactamenteCincoCaracteresEsAceptado()
+    {
+        var excepcion = Record.Exception(() => ReglaDeAjusteDeCuenta.Validar(50m, "abcde"));
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void UnDetalleConEspaciosAlBordeSeRecortaAntesDeMedirLaLongitud()
+    {
+        // "  ab  " recortado queda en "ab" (2 chars) — tiene que rechazarse igual que "ab" sin
+        // padding, no colarse por el largo crudo del string sin recortar.
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(50m, "  ab  "));
+        Assert.Equal("ajuste_detalle_requerido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnImporteCeroSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() => ReglaDeAjusteDeCuenta.Validar(0m, "Detalle válido"));
+        Assert.Equal("ajuste_importe_invalido", excepcion.Codigo);
+    }
+
+    [Fact]
+    public void UnImportePositivoConDetalleValidoEsAceptado()
+    {
+        var excepcion = Record.Exception(() => ReglaDeAjusteDeCuenta.Validar(100m, "Descuento por reclamo"));
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void UnImporteNegativoConDetalleValidoEsAceptado()
+    {
+        var excepcion = Record.Exception(() => ReglaDeAjusteDeCuenta.Validar(-50m, "Descuento por reclamo"));
+        Assert.Null(excepcion);
+    }
+}

--- a/tests/Ways.IntegrationTests/AjustesDeCuentaCorrienteTests.cs
+++ b/tests/Ways.IntegrationTests/AjustesDeCuentaCorrienteTests.cs
@@ -1,0 +1,268 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 4 (tasks 4.6-4.7): <c>POST
+/// /api/clientes/{id}/cuenta-corriente/ajustes</c> punta a punta — validación de detalle, signo,
+/// distinción estructural contra el contramovimiento de anulación, atomicidad y autorización bajo
+/// <see cref="Ways.Api.Seguridad.Politicas.SupervisionDeCuentaCorriente"/>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AjustesDeCuentaCorrienteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordUsuario = "una-contraseña-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdPuntoVenta, int IdListaPrecio, int IdConsumidorFinal, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idConsumidorFinal = await db.Clientes
+            .Where(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal).Select(c => c.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, idListaPrecio, idConsumidorFinal, admin);
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre, decimal saldo = 0m)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = saldo, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private static async Task<HttpResponseMessage> RegistrarAjusteAsync(
+        Contexto ctx, int idCliente, SolicitudDeAjuste solicitud, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsJsonAsync($"/api/clientes/{idCliente}/cuenta-corriente/ajustes", solicitud);
+
+    // ---- task 4.6: detalle requerido, signo, atomicidad ---------------------------------------
+
+    [Fact]
+    public async Task UnAjusteSinDetalleEsRechazadoAntesDeCualquierEscritura()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteSinDetalleEsRechazadoAntesDeCualquierEscritura));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste sin detalle", saldo: 300m);
+
+        var respuesta = await RegistrarAjusteAsync(ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, -50m, ""));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("ajuste_detalle_requerido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(300m, saldo);
+    }
+
+    [Fact]
+    public async Task UnAjusteConImporteCeroEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteConImporteCeroEsRechazado));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste importe cero");
+
+        var respuesta = await RegistrarAjusteAsync(ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, 0m, "Detalle válido"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("ajuste_importe_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnAjusteNegativoReduceElSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteNegativoReduceElSaldo));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste negativo", saldo: 300m);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, -50m, "Descuento por reclamo"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(250m, saldo);
+    }
+
+    [Fact]
+    public async Task UnAjustePositivoAumentaElSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjustePositivoAumentaElSaldo));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste positivo", saldo: 100m);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, 40m, "Cargo por diferencia de precio"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var movimiento = JsonSerializer.Deserialize<MovimientoDeCuentaCorriente>(cuerpo, OpcionesJson)!;
+
+        // spec: Ajuste snapshots the resulting saldo — saldo_resultante == Cliente.Saldo tras el
+        // UPDATE, misma transacción.
+        Assert.Equal(140m, movimiento.SaldoResultante);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(140m, saldo);
+    }
+
+    [Fact]
+    public async Task UnAjusteManualCarecerDeComprobanteYQuedaDistinguibleDeUnaAnulacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteManualCarecerDeComprobanteYQuedaDistinguibleDeUnaAnulacion));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste sin comprobante", saldo: 200m);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, -20m, "Ajuste manual de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente).SingleAsync();
+
+        // spec: A manual ajuste carries no comprobante link.
+        Assert.Equal(TipoMovimientoCc.Ajuste, movimiento.Tipo);
+        Assert.Null(movimiento.IdComprobanteVenta);
+        Assert.Null(movimiento.IdPagoComprobante);
+        Assert.Equal("Ajuste manual de prueba", movimiento.Detalle);
+    }
+
+    [Fact]
+    public async Task UnClienteConsumidorFinalEsRechazadoDelAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnClienteConsumidorFinalEsRechazadoDelAjuste));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdConsumidorFinal, new SolicitudDeAjuste(ctx.IdPuntoVenta, 50m, "Ajuste sobre CF"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("cliente_sin_cuenta_corriente", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 4.7: matriz de autorización ------------------------------------------------------
+
+    private async Task<HttpClient> CrearUsuarioConRolAsync(Contexto ctx, string nombre, RolConocido rol)
+    {
+        var mail = $"{nombre.ToLowerInvariant()}@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario(nombre, mail, (int)rol, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    [Fact]
+    public async Task UnSupervisorPuedePostearUnAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorPuedePostearUnAjuste));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste supervisor");
+        using var supervisor = await CrearUsuarioConRolAsync(ctx, "supervisor-ajuste", RolConocido.Supervisor);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, 10m, "Ajuste de supervisor"), supervisor);
+
+        Assert.True(respuesta.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminPuedePostearUnAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminPuedePostearUnAjuste));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste admin");
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, 10m, "Ajuste de admin"));
+
+        Assert.True(respuesta.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelAjuste));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente ajuste vendedor");
+        using var vendedor = await CrearUsuarioConRolAsync(ctx, "vendedor-ajuste", RolConocido.Vendedor);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, idCliente, new SolicitudDeAjuste(ctx.IdPuntoVenta, 10m, "Ajuste de vendedor"), vendedor);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAjusteSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/clientes/1/cuenta-corriente/ajustes", new SolicitudDeAjuste(1, 10m, "Ajuste sin token"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAjusteContraUnClienteDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnAjusteContraUnClienteDeOtroTenantDevuelve404) + "-A");
+        var idClienteDeA = await SembrarClienteAsync(ctxA, "Cliente A cross-tenant ajuste");
+
+        var ctxB = await PrepararAsync(nameof(UnAjusteContraUnClienteDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctxB, idClienteDeA, new SolicitudDeAjuste(ctxB.IdPuntoVenta, 10m, "Ajuste cross-tenant"));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/AjustesDeCuentaCorrienteTests.cs
+++ b/tests/Ways.IntegrationTests/AjustesDeCuentaCorrienteTests.cs
@@ -172,6 +172,7 @@ public class AjustesDeCuentaCorrienteTests(WaysApiFixture fixture) : IClassFixtu
         Assert.Null(movimiento.IdComprobanteVenta);
         Assert.Null(movimiento.IdPagoComprobante);
         Assert.Equal("Ajuste manual de prueba", movimiento.Detalle);
+        Assert.Equal(ctx.IdPuntoVenta, movimiento.IdPuntoVenta);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaTests.cs
@@ -145,10 +145,14 @@ public class EstadoDeCuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, "?historico=true");
 
         Assert.Equal(3, estado.Movimientos.Count);
-        Assert.Equal([100m, 50m, 120m], estado.Movimientos.Select(m => m.SaldoResultante).ToArray());
-        // Orden ASC por fecha (spec: ordered by fecha).
-        Assert.True(estado.Movimientos[0].Fecha < estado.Movimientos[1].Fecha);
-        Assert.True(estado.Movimientos[1].Fecha < estado.Movimientos[2].Fecha);
+        Assert.Equal([120m, 50m, 100m], estado.Movimientos.Select(m => m.SaldoResultante).ToArray());
+        // Orden DESC por fecha (legacy: `ORDER BY fecha DESC`, doc-01:375 — "saldo corriendo hacia
+        // atrás desde el saldo actual"); el cómputo de saldo_resultante es ortogonal a este orden.
+        Assert.True(estado.Movimientos[0].Fecha > estado.Movimientos[1].Fecha);
+        Assert.True(estado.Movimientos[1].Fecha > estado.Movimientos[2].Fecha);
+        // Sin filtro de fecha (solo histórico), el saldo_resultante de la fila más nueva coincide
+        // con el header.
+        Assert.Equal(estado.Header.Saldo, estado.Movimientos[0].SaldoResultante);
     }
 
     // ---- Filtro de fecha: default último mes / desde-hasta / histórico ---------------------------
@@ -203,6 +207,53 @@ public class EstadoDeCuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
 
         var movimiento = Assert.Single(estado.Movimientos);
         Assert.Equal(50m, movimiento.Importe);
+    }
+
+    [Fact]
+    public async Task UnHastaSinDesdeAcotaAlUltimoMesAntesDeHasta()
+    {
+        var ctx = await PrepararAsync(nameof(UnHastaSinDesdeAcotaAlUltimoMesAntesDeHasta));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente hasta sin desde", saldo: 0m);
+        var ancla = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+        // Antes del piso de un mes hacia atrás desde hasta — debe quedar afuera.
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, ancla.AddMonths(-2));
+        // Dentro de la ventana [hasta - 1 mes, hasta].
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 50m, 150m, ancla.AddDays(-10));
+        // Después de hasta — debe quedar afuera.
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 20m, 170m, ancla.AddDays(5));
+
+        var hasta = Uri.EscapeDataString(ancla.ToString("O"));
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, $"?hasta={hasta}");
+
+        var movimiento = Assert.Single(estado.Movimientos);
+        Assert.Equal(50m, movimiento.Importe);
+        Assert.False(estado.Historico);
+    }
+
+    [Fact]
+    public async Task DesdeYHastaSonInclusivosEnAmbosExtremos()
+    {
+        var ctx = await PrepararAsync(nameof(DesdeYHastaSonInclusivosEnAmbosExtremos));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente limites inclusivos", saldo: 0m);
+        var desdeAncla = new DateTimeOffset(2026, 1, 5, 12, 0, 0, TimeSpan.Zero);
+        var hastaAncla = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, desdeAncla);
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 50m, 150m, hastaAncla);
+        // Fuera del rango, para probar que el filtro realmente acota y no matchea siempre.
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 20m, 170m, desdeAncla.AddDays(-1));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 30m, 200m, hastaAncla.AddDays(1));
+
+        var desde = Uri.EscapeDataString(desdeAncla.ToString("O"));
+        var hasta = Uri.EscapeDataString(hastaAncla.ToString("O"));
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, $"?desde={desde}&hasta={hasta}");
+
+        // BETWEEN inclusivo en ambos extremos (legacy parity): el movimiento en desde y el que
+        // está en hasta entran los dos.
+        Assert.Equal(2, estado.Movimientos.Count);
+        Assert.Contains(estado.Movimientos, m => m.Importe == 100m);
+        Assert.Contains(estado.Movimientos, m => m.Importe == 50m);
     }
 
     // ---- Etiqueta estructural de ajuste (design decisión 8/9) -------------------------------------

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 4 (task 4.8; spec: estado-de-cuenta) — <c>GET
+/// /api/clientes/{id}/cuenta-corriente</c> punta a punta: header (saldo/acuerdo/disponibilidad),
+/// running balance leído de <c>saldo_resultante</c>, filtro de fecha por default/explícito/
+/// histórico, scoping cross-tenant y el caso vacío. La cobertura RLS cruda de
+/// <c>movimientos_cuenta_corriente</c> ya vive en <see cref="VentasStockYCuentaCorrienteRlsTests"/>
+/// (matriz de las cinco tablas de stage 5) — acá el cross-tenant se prueba a nivel API (ADR-8:
+/// mismo 404 para "no existe" y "es de otro tenant").
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class EstadoDeCuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdListaPrecio, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, idListaPrecio, admin);
+    }
+
+    private async Task<int> SembrarClienteAsync(
+        Contexto ctx, string nombre, decimal saldo = 0m, decimal limiteCredito = 0m, bool creditoIlimitado = true)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = limiteCredito,
+            CreditoIlimitado = creditoIlimitado, Saldo = saldo, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private async Task SembrarMovimientoAsync(
+        Contexto ctx, int idCliente, TipoMovimientoCc tipo, decimal importe, decimal saldoResultante, DateTimeOffset fecha)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.MovimientosCuentaCorriente.Add(new MovimientoCuentaCorriente
+        {
+            IdTenant = ctx.IdTenant, IdCliente = idCliente, Fecha = fecha, IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin, Tipo = tipo, IdComprobanteVenta = null, IdPagoComprobante = null,
+            Importe = importe, SaldoResultante = saldoResultante, Detalle = tipo == TipoMovimientoCc.Ajuste ? "Ajuste de prueba" : null
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<EstadoDeCuenta> LeerEstadoDeCuentaAsync(
+        Contexto ctx, int idCliente, string? query = null, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).GetAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente{query}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        return JsonSerializer.Deserialize<EstadoDeCuenta>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- Header: disponibilidad ------------------------------------------------------------------
+
+    [Fact]
+    public async Task DisponibilidadParaUnClienteConCreditoLimitado()
+    {
+        var ctx = await PrepararAsync(nameof(DisponibilidadParaUnClienteConCreditoLimitado));
+        var idCliente = await SembrarClienteAsync(
+            ctx, "Cliente credito limitado", saldo: 300m, limiteCredito: 1000m, creditoIlimitado: false);
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente);
+
+        Assert.Equal(300m, estado.Header.Saldo);
+        Assert.Equal(1000m, estado.Header.LimiteCredito);
+        Assert.False(estado.Header.CreditoIlimitado);
+        Assert.Equal(700m, estado.Header.Disponibilidad);
+    }
+
+    [Fact]
+    public async Task DisponibilidadEsNulaCuandoElCreditoEsIlimitado()
+    {
+        var ctx = await PrepararAsync(nameof(DisponibilidadEsNulaCuandoElCreditoEsIlimitado));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente credito ilimitado", saldo: 300m, creditoIlimitado: true);
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente);
+
+        Assert.True(estado.Header.CreditoIlimitado);
+        Assert.Null(estado.Header.Disponibilidad);
+    }
+
+    // ---- Movement list: saldo_resultante como running balance ------------------------------------
+
+    [Fact]
+    public async Task LaListaDeMovimientosLeeElSaldoResultanteDeCadaFilaSinRederivarlo()
+    {
+        var ctx = await PrepararAsync(nameof(LaListaDeMovimientosLeeElSaldoResultanteDeCadaFilaSinRederivarlo));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente running balance", saldo: 120m);
+        var ahora = DateTimeOffset.UtcNow;
+
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, ahora.AddDays(-3));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Pago, -50m, 50m, ahora.AddDays(-2));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Ajuste, 70m, 120m, ahora.AddDays(-1));
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, "?historico=true");
+
+        Assert.Equal(3, estado.Movimientos.Count);
+        Assert.Equal([100m, 50m, 120m], estado.Movimientos.Select(m => m.SaldoResultante).ToArray());
+        // Orden ASC por fecha (spec: ordered by fecha).
+        Assert.True(estado.Movimientos[0].Fecha < estado.Movimientos[1].Fecha);
+        Assert.True(estado.Movimientos[1].Fecha < estado.Movimientos[2].Fecha);
+    }
+
+    // ---- Filtro de fecha: default último mes / desde-hasta / histórico ---------------------------
+
+    [Fact]
+    public async Task SinFiltroSoloDevuelveElUltimoMes()
+    {
+        var ctx = await PrepararAsync(nameof(SinFiltroSoloDevuelveElUltimoMes));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente dos anios", saldo: 0m);
+        var ahora = DateTimeOffset.UtcNow;
+
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, ahora.AddYears(-2));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 50m, 150m, ahora.AddDays(-5));
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente);
+
+        var movimiento = Assert.Single(estado.Movimientos);
+        Assert.Equal(50m, movimiento.Importe);
+        Assert.False(estado.Historico);
+    }
+
+    [Fact]
+    public async Task HistoricoDevuelveElLedgerCompleto()
+    {
+        var ctx = await PrepararAsync(nameof(HistoricoDevuelveElLedgerCompleto));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente historico", saldo: 0m);
+        var ahora = DateTimeOffset.UtcNow;
+
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, ahora.AddYears(-2));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 50m, 150m, ahora.AddDays(-5));
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, "?historico=true");
+
+        Assert.Equal(2, estado.Movimientos.Count);
+        Assert.True(estado.Historico);
+    }
+
+    [Fact]
+    public async Task UnDesdeHastaExplicitoAcotaLaVentana()
+    {
+        var ctx = await PrepararAsync(nameof(UnDesdeHastaExplicitoAcotaLaVentana));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente desde hasta", saldo: 0m);
+        var ancla = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 100m, 100m, ancla.AddDays(-10));
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 50m, 150m, ancla);
+        await SembrarMovimientoAsync(ctx, idCliente, TipoMovimientoCc.Consumo, 20m, 170m, ancla.AddDays(10));
+
+        var desde = Uri.EscapeDataString(ancla.AddDays(-1).ToString("O"));
+        var hasta = Uri.EscapeDataString(ancla.AddDays(1).ToString("O"));
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, $"?desde={desde}&hasta={hasta}");
+
+        var movimiento = Assert.Single(estado.Movimientos);
+        Assert.Equal(50m, movimiento.Importe);
+    }
+
+    // ---- Etiqueta estructural de ajuste (design decisión 8/9) -------------------------------------
+
+    [Fact]
+    public async Task LaListaEtiquetaUnAjusteManualComoDistintoDeUnaAnulacion()
+    {
+        var ctx = await PrepararAsync(nameof(LaListaEtiquetaUnAjusteManualComoDistintoDeUnaAnulacion));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente etiqueta ajuste", saldo: 200m);
+
+        var respuestaAjuste = await ctx.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/ajustes",
+            new SolicitudDeAjuste(ctx.IdPuntoVenta, -20m, "Ajuste manual"));
+        Assert.True(respuestaAjuste.IsSuccessStatusCode);
+
+        var estado = await LeerEstadoDeCuentaAsync(ctx, idCliente, "?historico=true");
+
+        var movimiento = Assert.Single(estado.Movimientos);
+        Assert.Equal(TipoMovimientoCc.Ajuste, movimiento.Tipo);
+        Assert.Equal(EtiquetaDeAjuste.Manual, movimiento.Etiqueta);
+    }
+
+    // ---- Scoping: cross-tenant y cliente nuevo -----------------------------------------------------
+
+    [Fact]
+    public async Task EstadoDeCuentaContraUnClienteDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(EstadoDeCuentaContraUnClienteDeOtroTenantDevuelve404) + "-A");
+        var idClienteDeA = await SembrarClienteAsync(ctxA, "Cliente A cross-tenant estado");
+
+        var ctxB = await PrepararAsync(nameof(EstadoDeCuentaContraUnClienteDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxB.Admin.GetAsync($"/api/clientes/{idClienteDeA}/cuenta-corriente");
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnClienteNuevoSinActividadDevuelveSaldoCeroYListaVaciaCon200()
+    {
+        var ctx = await PrepararAsync(nameof(UnClienteNuevoSinActividadDevuelveSaldoCeroYListaVaciaCon200));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente sin actividad", saldo: 0m);
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/clientes/{idCliente}/cuenta-corriente");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var estado = JsonSerializer.Deserialize<EstadoDeCuenta>(cuerpo, OpcionesJson)!;
+        Assert.Equal(0m, estado.Header.Saldo);
+        Assert.Empty(estado.Movimientos);
+    }
+
+    [Fact]
+    public async Task EstadoDeCuentaSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.GetAsync("/api/clientes/1/cuenta-corriente");
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/SaldoLedgerInvarianteTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoLedgerInvarianteTests.cs
@@ -1,0 +1,259 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Precios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-7-cuenta-corriente, Slice 4 (task 4.9 — Success Criterion; spec: consumo-cuenta-corriente
+/// / Saldo Is The Maintained Cache Of The Ledger, "Saldo matches the sum across a mixed sequence").
+/// Cierra la etapa: <c>Cliente.Saldo</c> tiene que igualar la suma de
+/// <c>movimientos_cuenta_corriente.importe</c> del cliente en CADA paso de una secuencia que
+/// combina los cuatro escritores reales (consumo vía checkout CC, pago a cuenta, ajuste manual,
+/// reliquidación) más la anulación de uno de ellos — no solo al final.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class SaldoLedgerInvarianteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
+        int IdMedioEfectivo, int IdMedioCuentaCorriente, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area invariante", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, area.Id, idAlicuotaIva, idListaPrecio,
+            idMedioEfectivo, medioCc.Id, admin);
+    }
+
+    private static async Task<TurnoResumen> AbrirTurnoAsync(Contexto ctx)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 0m, "Apertura de prueba"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!;
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Ways.Domain.Articulos.Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = Ways.Domain.Articulos.UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = 0m, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private static async Task<ComprobanteEmitido> RealizarConsumoAsync(
+        Contexto ctx, int idCliente, int idArticulo, decimal cantidad, decimal precio)
+    {
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, cantidad * precio, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<ComprobanteEmitido> RegistrarPagoAsync(Contexto ctx, int idCliente, decimal importe)
+    {
+        var solicitud = new SolicitudDePagoACuenta(
+            ctx.IdPuntoVenta, [new PagoDeCuenta(ctx.IdMedioEfectivo, importe, null, 0m)], null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/clientes/{idCliente}/cuenta-corriente/pagos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task RegistrarAjusteAsync(Contexto ctx, int idCliente, decimal importe, string detalle)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/ajustes", new SolicitudDeAjuste(ctx.IdPuntoVenta, importe, detalle));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    private async Task SubirPrecioAsync(Contexto ctx, int idArticulo, decimal precioAnterior, decimal precioNuevo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = ctx.IdListaPrecio, Monto = precioNuevo,
+            VigenteDesde = ahora, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        var vieja = await db.Precios
+            .Where(p => p.IdArticulo == idArticulo && p.VigenteHasta == null && p.Monto == precioAnterior).SingleAsync();
+        vieja.VigenteHasta = ahora;
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<decimal> EjecutarReliquidacionAsync(Contexto ctx, int idCliente)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoDeReliquidacion>(cuerpo, OpcionesJson)!.Delta;
+    }
+
+    private static async Task<HttpResponseMessage> AnularAsync(Contexto ctx, int idComprobante) =>
+        await ctx.Admin.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+
+    /// <summary>El invariante en sí: <c>Cliente.Saldo</c> == Σ
+    /// <c>movimientos_cuenta_corriente.importe</c> del cliente, leído directo de la base (nunca de
+    /// la respuesta HTTP — la respuesta se proyecta de la entidad trackeada, no prueba persistencia
+    /// por sí sola, mismo criterio que el resto de la suite).</summary>
+    private async Task AssertInvarianteAsync(Contexto ctx, int idCliente)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).SingleAsync();
+        var sumaDeMovimientos = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdCliente == idCliente).SumAsync(m => m.Importe);
+        Assert.Equal(saldo, sumaDeMovimientos);
+    }
+
+    [Fact]
+    public async Task ElSaldoIgualaLaSumaDeMovimientosEnCadaPasoDeUnaSecuenciaMixta()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoIgualaLaSumaDeMovimientosEnCadaPasoDeUnaSecuenciaMixta));
+        await AbrirTurnoAsync(ctx);
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-invariante", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente invariante");
+
+        // 1. Consumo (venta CC): 2 × 100 = 200, saldo 0 → 200.
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 2m, 100m);
+        await AssertInvarianteAsync(ctx, idCliente);
+
+        // 2. Pago a cuenta (RC): 80, saldo 200 → 120.
+        var rc = await RegistrarPagoAsync(ctx, idCliente, 80m);
+        await AssertInvarianteAsync(ctx, idCliente);
+
+        // 3. Ajuste manual: -20, saldo 120 → 100.
+        await RegistrarAjusteAsync(ctx, idCliente, -20m, "Descuento por reclamo — invariante");
+        await AssertInvarianteAsync(ctx, idCliente);
+
+        // 4. Reliquidación: el precio sube de 100 a 150 después de la venta — delta = (150-100)×2 =
+        // 100 (factor 1, financiamiento total vía CC). saldo 100 → 200.
+        await SubirPrecioAsync(ctx, idArticulo, precioAnterior: 100m, precioNuevo: 150m);
+        var delta = await EjecutarReliquidacionAsync(ctx, idCliente);
+        Assert.Equal(100m, delta);
+        await AssertInvarianteAsync(ctx, idCliente);
+
+        // 5. Anulación de la RC del paso 2: contramovimiento +80, saldo 200 → 280.
+        var respuestaAnulacion = await AnularAsync(ctx, rc.Id);
+        var cuerpoAnulacion = await respuestaAnulacion.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+        await AssertInvarianteAsync(ctx, idCliente);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldoFinal = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).SingleAsync();
+        Assert.Equal(280m, saldoFinal);
+
+        var tipos = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdCliente == idCliente).Select(m => m.Tipo).ToListAsync();
+        Assert.Contains(TipoMovimientoCc.Consumo, tipos);
+        Assert.Contains(TipoMovimientoCc.Pago, tipos);
+        Assert.Contains(TipoMovimientoCc.Ajuste, tipos);
+        Assert.Contains(TipoMovimientoCc.ActualizacionPrecios, tipos);
+        // El contramovimiento de la anulación también es `Ajuste` (stage 5) — dos filas Ajuste en
+        // total: la manual del paso 3 y la de la anulación del paso 5.
+        Assert.Equal(2, tipos.Count(t => t == TipoMovimientoCc.Ajuste));
+    }
+}

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -69,6 +69,10 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // reemplaza el chequeo de rol real (SuperficieDeAutorizacionTests de PagosACuentaTests/
         // ReliquidacionTests cubre 403 Vendedor).
         ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/reliquidacion"),
+        // stage-7-cuenta-corriente (Slice 4, task 4.4): ajuste manual — mismo criterio que la
+        // línea de arriba (apila SupervisionDeCuentaCorriente en vez de GestionDeCatalogo, ver
+        // CuentaCorrienteEndpoints); 403 Vendedor cubierto en AjustesDeCuentaCorrienteTests.
+        ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/ajustes"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

Slice 4/6 de la etapa 7: el backend de cuenta corriente queda completo.

- `ReglaDeAjusteDeCuenta` (pura): importe ≠ 0, detalle ≥5 post-trim (precedente del motivo de caja). Ajuste manual con `id_comprobante_venta NULL` — estructuralmente distinguible del contramovimiento de anulación, y así etiquetado en el estado.
- **Estado de cuenta**: header saldo/límite/disponibilidad (`null` = ilimitado, contrato tipado), lista de movimientos **newest-first como el legacy y todo resumen bancario** (doc 01:375 — triage del orquestador sobre la ambigüedad spec/diseño), saldo corrido leído de `saldo_resultante` sin re-derivar, default último mes + desde/hasta inclusivos + histórico explícito. El `hasta`-only ahora acota al mes previo a `hasta` — se cerró la puerta accidental al ledger completo.
- **Invariante de secuencia mixta cerrado** (criterio de éxito de la etapa): consumo → pago → ajuste → reliquidación → anulación por los writers HTTP reales, `saldo == Σ movimientos` verificado en CADA paso.
- Autorización: ajuste bajo `SupervisionDeCuentaCorriente` (Vendedor 403); estado bajo `OperacionDePos` (el cajero consulta).

## Verificación

- Suites: Domain 356 (+14), Application 212, Integration 555 (+24), vitest 221, contra Postgres real.
- Judgment-day: ronda 1 — A 1 MAJOR (hasta-only sin piso, sin test) + adjudicación de las 4 llamadas de interpretación del apply (todas legítimas); B 1 MAJOR (orden de display invertido vs legacy — el diseño decidió el CÁLCULO del saldo, no el orden) + 2 minors. Todos corregidos con evidencia de mutación. Ronda 2 verificada por el orquestador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)