### PR TITLE
feat(cc): pantalla de estado de cuenta y pago a cuenta (etapa 7, slice 5)

### DIFF
--- a/openspec/changes/stage-7-cuenta-corriente/tasks.md
+++ b/openspec/changes/stage-7-cuenta-corriente/tasks.md
@@ -405,28 +405,39 @@ merged/branch. **Finish**: the screen renders header + filtered movement
 list + a working pago modal for every role; `CuentaCorriente.tsx` compiles
 and is tested. **Rollback**: new route + entry point only.
 
-- [ ] 5.1 [P] Add `src/Ways.Web/src/api/cuentaCorriente.ts`: pure
+- [x] 5.1 [P] Add `src/Ways.Web/src/api/cuentaCorriente.ts`: pure
   request/response mappers for header + page + pagos; a
   **non-authoritative** disponibilidad mirror (same posture as `arqueo.ts`).
   *(design: Web Composition)*
-- [ ] 5.2 Add `src/Ways.Web/src/paginas/CuentaCorriente.tsx`: header (saldo /
+- [x] 5.2 Add `src/Ways.Web/src/paginas/CuentaCorriente.tsx`: header (saldo /
   acuerdo — `"ilimitado"` when applicable / disponibilidad), desde–hasta +
   "ver histórico" filters, movement table reading `saldoResultante` per row,
   pago modal. `react-async-state` rules 8 (`key={idCliente}` on the
   subtree), 9 (first-line re-entrancy guard + full-window disable on the
   pago), 3 (ledger generation bumped before the write), 7 (medios de pago
   load failure ⇒ visible aviso + actually-disabled "Registrar pago").
-  *(design: Web Composition; react-async-state obligations 3, 7, 8, 9)*
-- [ ] 5.3 Modify `Clientes.tsx`: per-row entry point to
-  `/clientes/:id/cuenta-corriente`; modify `App.tsx`: wire the route.
-  *(design: File Changes)*
-- [ ] 5.4 [P] Unit: `cuentaCorriente.ts` mappers, disponibilidad mirror.
+  Also implements a full rule-10 `turno_no_abierto` recovery on the pago
+  modal (same "Abrir turno" pattern as `PanelGateTurno`/`FormularioApertura`)
+  so Slice 6 has a real path to replicate. *(design: Web Composition;
+  react-async-state obligations 3, 7, 8, 9, 10)*
+- [x] 5.3 Modify `Clientes.tsx`: per-row entry point to
+  `/clientes/:id/cuenta-corriente`; modify `App.tsx`: wire the route under
+  `Politicas.OperacionDePos` (Vendedor/Supervisor/Admin). *(design: File
+  Changes)*
+- [x] 5.4 [P] Unit: `cuentaCorriente.ts` mappers, disponibilidad mirror.
+  35 tests: query builder, etiqueta de movimiento, disponibilidad mirror,
+  medio-físico filter, filas→cálculo, importeAplicado, the 7
+  `ValidadorDePagoACuenta`-mirrored rejection rules, request body shape.
   *(web-descriptor-tests)*
-- [ ] 5.5 Component: pago flow succeeds and refetches the ledger; empty
+- [x] 5.5 Component: pago flow succeeds and refetches the ledger; empty
   ledger renders an empty state, never a re-query; medios/estado-de-cuenta
-  failing to load shows an aviso and an actually-disabled "Registrar pago".
-  RTL + `user-event`, `vi.mock('../api/cliente')`. *(design: Testing
-  Strategy — Component (Web))*
+  failing to load shows an aviso and an actually-disabled "Registrar pago";
+  filters drive refetches with stale-response discard; double-click issues
+  exactly one POST; CC medio never offered; `turno_no_abierto` recovery
+  renders and does not auto-retry the payment; a 2xx payment is never
+  reported as a failure even when the post-write refetch fails; POST body
+  shape asserted. 11 tests. RTL + `user-event`, `vi.mock('../api/cliente')`.
+  *(design: Testing Strategy — Component (Web))*
 
 **Verify**: `npx vitest run src/paginas/CuentaCorriente.test.tsx src/api/cuentaCorriente.test.ts`
 

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -8,6 +8,7 @@ import { CierreDeCaja } from './paginas/CierreDeCaja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
 import { Clientes } from './paginas/Clientes'
+import { CuentaCorriente } from './paginas/CuentaCorriente'
 import { Empresas } from './paginas/Empresas'
 import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
@@ -90,6 +91,18 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Admin]}>
                   <Clientes />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-7-cuenta-corriente (Slice 5, design: Web Composition): estado de cuenta +
+                pago a cuenta — Politicas.OperacionDePos (todo rol opera), a diferencia de
+                /clientes que es admin-only. Entrada desde una fila de Clientes.tsx. */}
+            <Route
+              path="/clientes/:id/cuenta-corriente"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <CuentaCorriente />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/clientes.ts
+++ b/src/Ways.Web/src/api/clientes.ts
@@ -14,6 +14,7 @@ export const clienteDeClientes = {
     const cadena = parametros.toString()
     return api.get<PaginaDe<ClienteListado>>(`/clientes${cadena ? `?${cadena}` : ''}`)
   },
+  obtener: (id: number) => api.get<ClienteListado>(`/clientes/${id}`),
   crear: (datos: AltaCliente) => api.post<ClienteListado>('/clientes', datos),
   actualizar: (id: number, datos: EdicionCliente) => api.put<ClienteListado>(`/clientes/${id}`, datos),
   eliminar: (id: number) => api.delete(`/clientes/${id}`),

--- a/src/Ways.Web/src/api/cuentaCorriente.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.test.ts
@@ -8,6 +8,7 @@ import {
   filaPagoACuentaVacia,
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
+  rangoUltimoMes,
   validarPagoACuentaLocal,
   type FilaPagoACuenta,
   type PagoACuentaParaCalculo,
@@ -43,27 +44,58 @@ function pagoFixture(sobrescribir: Partial<PagoACuentaParaCalculo> = {}): PagoAC
   }
 }
 
+// Espeja `desplazamientoUtcLocal` (no exportada) para calcular el offset esperado con el MISMO
+// criterio que la implementación, sin fijar una zona horaria — el offset real depende de la
+// máquina donde corre el test (regresión: los strings sin offset fallaban en ART pero pasaban en
+// UTC, un test que fija "-03:00" a mano repetiría el mismo error en otra zona horaria).
+function offsetEsperado(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
 describe('construirQueryEstadoDeCuenta', () => {
   it('sin ningún filtro no manda query string — el servidor aplica su default de último mes', () => {
     expect(construirQueryEstadoDeCuenta('', '', false)).toBe('')
   })
 
-  it('desde solo expande al borde inicial del día', () => {
-    expect(construirQueryEstadoDeCuenta('2026-07-01', '', false)).toBe('?desde=2026-07-01T00%3A00%3A00')
+  it('desde solo expande al borde inicial del día, con el offset horario local del navegador', () => {
+    const offset = offsetEsperado(2026, 7, 1)
+    const esperado = new URLSearchParams({ desde: `2026-07-01T00:00:00${offset}` }).toString()
+    expect(construirQueryEstadoDeCuenta('2026-07-01', '', false)).toBe(`?${esperado}`)
   })
 
-  it('hasta solo expande al borde final del día', () => {
-    expect(construirQueryEstadoDeCuenta('', '2026-07-31', false)).toBe('?hasta=2026-07-31T23%3A59%3A59.999')
+  it('hasta solo expande al borde final del día, con el offset horario local del navegador', () => {
+    const offset = offsetEsperado(2026, 7, 31)
+    const esperado = new URLSearchParams({ hasta: `2026-07-31T23:59:59.999${offset}` }).toString()
+    expect(construirQueryEstadoDeCuenta('', '2026-07-31', false)).toBe(`?${esperado}`)
   })
 
-  it('desde y hasta juntos', () => {
-    const query = construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', false)
-    expect(query).toContain('desde=2026-07-01T00%3A00%3A00')
-    expect(query).toContain('hasta=2026-07-31T23%3A59%3A59.999')
+  it('desde y hasta juntos, cada uno con su propio offset', () => {
+    const offsetDesde = offsetEsperado(2026, 7, 1)
+    const offsetHasta = offsetEsperado(2026, 7, 31)
+    const query = decodeURIComponent(construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', false))
+    expect(query).toContain(`desde=2026-07-01T00:00:00${offsetDesde}`)
+    expect(query).toContain(`hasta=2026-07-31T23:59:59.999${offsetHasta}`)
   })
 
   it('historico gana sobre desde/hasta — ninguno de los dos viaja', () => {
     expect(construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', true)).toBe('?historico=true')
+  })
+})
+
+describe('rangoUltimoMes', () => {
+  it('desde = hoy − 1 mes, hasta = hoy (fechas locales, mismo default que el servidor)', () => {
+    const ahora = new Date(2026, 7, 15) // 15 de agosto de 2026 (mes 0-indexado)
+    expect(rangoUltimoMes(ahora)).toEqual({ desde: '2026-07-15', hasta: '2026-08-15' })
+  })
+
+  it('cruza el año cuando el mes actual es enero', () => {
+    const ahora = new Date(2026, 0, 10)
+    expect(rangoUltimoMes(ahora)).toEqual({ desde: '2025-12-10', hasta: '2026-01-10' })
   })
 })
 

--- a/src/Ways.Web/src/api/cuentaCorriente.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   aSolicitudDePagoACuenta,
   calcularImporteAplicado,
@@ -87,6 +87,30 @@ describe('construirQueryEstadoDeCuenta', () => {
   })
 })
 
+// Los tests de arriba espejan la fórmula de la implementación con `offsetEsperado` para no
+// depender de la zona horaria de la máquina que corre el test — pero eso deja pasar un flip de
+// signo circular. Estos dos fijan `getTimezoneOffset` a un valor conocido y assertan el literal
+// esperado, sin espejar ninguna fórmula.
+describe('construirQueryEstadoDeCuenta — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+    const query = decodeURIComponent(construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', false))
+    expect(query).toContain('desde=2026-07-01T00:00:00-03:00')
+    expect(query).toContain('hasta=2026-07-31T23:59:59.999-03:00')
+  })
+
+  it('minutos=-330 (UTC+5:30) produce +05:30, codificado como %2B05%3A30', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330)
+    const query = construirQueryEstadoDeCuenta('2026-07-01', '', false)
+    expect(query).toContain('%2B05%3A30')
+    expect(decodeURIComponent(query)).toContain('desde=2026-07-01T00:00:00+05:30')
+  })
+})
+
 describe('rangoUltimoMes', () => {
   it('desde = hoy − 1 mes, hasta = hoy (fechas locales, mismo default que el servidor)', () => {
     const ahora = new Date(2026, 7, 15) // 15 de agosto de 2026 (mes 0-indexado)
@@ -96,6 +120,21 @@ describe('rangoUltimoMes', () => {
   it('cruza el año cuando el mes actual es enero', () => {
     const ahora = new Date(2026, 0, 10)
     expect(rangoUltimoMes(ahora)).toEqual({ desde: '2025-12-10', hasta: '2026-01-10' })
+  })
+
+  it('fin de mes: 31 de marzo → 28 de febrero (semántica AddMonths-clamp, sin overflow a marzo)', () => {
+    const ahora = new Date(2026, 2, 31) // 2026 no es bisiesto
+    expect(rangoUltimoMes(ahora)).toEqual({ desde: '2026-02-28', hasta: '2026-03-31' })
+  })
+
+  it('fin de mes en año bisiesto: 31 de marzo → 29 de febrero', () => {
+    const ahora = new Date(2028, 2, 31) // 2028 es bisiesto
+    expect(rangoUltimoMes(ahora)).toEqual({ desde: '2028-02-29', hasta: '2028-03-31' })
+  })
+
+  it('fin de mes: 31 de julio → 30 de junio (junio tiene 30 días)', () => {
+    const ahora = new Date(2026, 6, 31)
+    expect(rangoUltimoMes(ahora)).toEqual({ desde: '2026-06-30', hasta: '2026-07-31' })
   })
 })
 

--- a/src/Ways.Web/src/api/cuentaCorriente.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aSolicitudDePagoACuenta,
+  calcularImporteAplicado,
+  construirQueryEstadoDeCuenta,
+  disponibilidadPrevia,
+  etiquetaDeMovimiento,
+  filaPagoACuentaVacia,
+  filasAPagosACuentaParaCalculo,
+  medioFisicoParaPagoACuenta,
+  validarPagoACuentaLocal,
+  type FilaPagoACuenta,
+  type PagoACuentaParaCalculo,
+} from './cuentaCorriente'
+import type { MedioPagoListado, MovimientoDeCuentaCorriente } from './tipos'
+
+function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
+  return {
+    id: 1,
+    nombre: 'Efectivo',
+    activo: true,
+    idEmpresa: null,
+    orden: 1,
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    recargoPorcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function pagoFixture(sobrescribir: Partial<PagoACuentaParaCalculo> = {}): PagoACuentaParaCalculo {
+  return {
+    idFila: 1,
+    idMedioPago: 1,
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    importe: 100,
+    vuelto: 0,
+    referencia: null,
+    ...sobrescribir,
+  }
+}
+
+describe('construirQueryEstadoDeCuenta', () => {
+  it('sin ningún filtro no manda query string — el servidor aplica su default de último mes', () => {
+    expect(construirQueryEstadoDeCuenta('', '', false)).toBe('')
+  })
+
+  it('desde solo expande al borde inicial del día', () => {
+    expect(construirQueryEstadoDeCuenta('2026-07-01', '', false)).toBe('?desde=2026-07-01T00%3A00%3A00')
+  })
+
+  it('hasta solo expande al borde final del día', () => {
+    expect(construirQueryEstadoDeCuenta('', '2026-07-31', false)).toBe('?hasta=2026-07-31T23%3A59%3A59.999')
+  })
+
+  it('desde y hasta juntos', () => {
+    const query = construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', false)
+    expect(query).toContain('desde=2026-07-01T00%3A00%3A00')
+    expect(query).toContain('hasta=2026-07-31T23%3A59%3A59.999')
+  })
+
+  it('historico gana sobre desde/hasta — ninguno de los dos viaja', () => {
+    expect(construirQueryEstadoDeCuenta('2026-07-01', '2026-07-31', true)).toBe('?historico=true')
+  })
+})
+
+describe('etiquetaDeMovimiento', () => {
+  const casos: { movimiento: Pick<MovimientoDeCuentaCorriente, 'tipo' | 'etiqueta'>; esperado: string }[] = [
+    { movimiento: { tipo: 'Consumo', etiqueta: null }, esperado: 'Consumo' },
+    { movimiento: { tipo: 'Pago', etiqueta: null }, esperado: 'Pago' },
+    { movimiento: { tipo: 'ActualizacionPrecios', etiqueta: null }, esperado: 'Actualización de precios' },
+    { movimiento: { tipo: 'Ajuste', etiqueta: 'Manual' }, esperado: 'Ajuste manual' },
+    { movimiento: { tipo: 'Ajuste', etiqueta: 'AnulacionContramovimiento' }, esperado: 'Contramov. de anulación' },
+  ]
+
+  for (const { movimiento, esperado } of casos) {
+    it(`${movimiento.tipo}${movimiento.etiqueta ? ` (${movimiento.etiqueta})` : ''} → "${esperado}"`, () => {
+      expect(etiquetaDeMovimiento(movimiento)).toBe(esperado)
+    })
+  }
+})
+
+describe('disponibilidadPrevia', () => {
+  it('crédito ilimitado siempre da null, sin importar el saldo', () => {
+    expect(disponibilidadPrevia(50000, 1000, true)).toBeNull()
+  })
+
+  it('crédito limitado deriva límite − saldo', () => {
+    expect(disponibilidadPrevia(300, 1000, false)).toBe(700)
+  })
+
+  it('un saldo que supera el límite da disponibilidad negativa', () => {
+    expect(disponibilidadPrevia(1500, 1000, false)).toBe(-500)
+  })
+})
+
+describe('medioFisicoParaPagoACuenta', () => {
+  it('un medio Efectivo es físico', () => {
+    expect(medioFisicoParaPagoACuenta(medioFixture({ comportamiento: 'Efectivo' }))).toBe(true)
+  })
+
+  it('un medio Electronico es físico', () => {
+    expect(medioFisicoParaPagoACuenta(medioFixture({ comportamiento: 'Electronico' }))).toBe(true)
+  })
+
+  it('un medio CuentaCorriente NUNCA es físico — una deuda no puede pagar otra deuda', () => {
+    expect(medioFisicoParaPagoACuenta(medioFixture({ comportamiento: 'CuentaCorriente' }))).toBe(false)
+  })
+})
+
+describe('filasAPagosACuentaParaCalculo', () => {
+  const medioPorId = { 1: medioFixture() }
+
+  it('descarta una fila sin medio elegido', () => {
+    const filas: FilaPagoACuenta[] = [{ id: 1, idMedioPago: '', importe: '100', referencia: '', vuelto: '' }]
+    expect(filasAPagosACuentaParaCalculo(filas, medioPorId)).toEqual([])
+  })
+
+  it('descarta una fila sin importe positivo', () => {
+    const filas: FilaPagoACuenta[] = [{ id: 1, idMedioPago: 1, importe: '0', referencia: '', vuelto: '' }]
+    expect(filasAPagosACuentaParaCalculo(filas, medioPorId)).toEqual([])
+  })
+
+  it('una fila completa se convierte a pago de cálculo, vuelto vacío ⇒ 0', () => {
+    const filas: FilaPagoACuenta[] = [{ id: 1, idMedioPago: 1, importe: '500', referencia: '', vuelto: '' }]
+    expect(filasAPagosACuentaParaCalculo(filas, medioPorId)).toEqual([
+      {
+        idFila: 1,
+        idMedioPago: 1,
+        comportamiento: 'Efectivo',
+        admiteVuelto: true,
+        requiereReferencia: false,
+        importe: 500,
+        vuelto: 0,
+        referencia: null,
+      },
+    ])
+  })
+
+  it('recorta la referencia y respeta el vuelto tipeado', () => {
+    const filas: FilaPagoACuenta[] = [{ id: 1, idMedioPago: 1, importe: '500', referencia: '  ref-1  ', vuelto: '20' }]
+    const resultado = filasAPagosACuentaParaCalculo(filas, medioPorId)
+    expect(resultado[0].referencia).toBe('ref-1')
+    expect(resultado[0].vuelto).toBe(20)
+  })
+})
+
+describe('filaPagoACuentaVacia', () => {
+  it('arma una fila vacía con el id dado', () => {
+    expect(filaPagoACuentaVacia(3)).toEqual({ id: 3, idMedioPago: '', importe: '', referencia: '', vuelto: '' })
+  })
+})
+
+describe('calcularImporteAplicado', () => {
+  it('importeAplicado = Σ importe − Σ vuelto', () => {
+    expect(calcularImporteAplicado([{ importe: 1000, vuelto: 200 }, { importe: 500, vuelto: 0 }])).toBe(1300)
+  })
+
+  it('redondea a 2 decimales', () => {
+    expect(calcularImporteAplicado([{ importe: 10.005, vuelto: 0 }])).toBe(10.01)
+  })
+
+  it('un array vacío da 0', () => {
+    expect(calcularImporteAplicado([])).toBe(0)
+  })
+})
+
+describe('validarPagoACuentaLocal — orden observable, espejo de ValidadorDePagoACuenta', () => {
+  it('acepta una mezcla válida', () => {
+    expect(validarPagoACuentaLocal({ pagos: [pagoFixture()], vueltoMaximo: 20 })).toBeNull()
+  })
+
+  it('regla 1: importe negativo', () => {
+    expect(validarPagoACuentaLocal({ pagos: [pagoFixture({ importe: -10 })], vueltoMaximo: 20 })).toEqual({
+      codigo: 'pago_importe_negativo',
+      mensaje: 'El importe de un pago no puede ser negativo.',
+    })
+  })
+
+  it('regla 2: vuelto negativo', () => {
+    expect(validarPagoACuentaLocal({ pagos: [pagoFixture({ vuelto: -5 })], vueltoMaximo: 20 })).toEqual({
+      codigo: 'vuelto_negativo',
+      mensaje: 'El vuelto de un pago no puede ser negativo.',
+    })
+  })
+
+  it('regla 3: cuenta corriente nunca es un medio válido para una RC', () => {
+    expect(
+      validarPagoACuentaLocal({
+        pagos: [pagoFixture({ comportamiento: 'CuentaCorriente' })],
+        vueltoMaximo: 20,
+      }),
+    ).toEqual({
+      codigo: 'pago_a_cuenta_sin_medios_fisicos',
+      mensaje: 'Un pago a cuenta no admite cuenta corriente como medio de pago.',
+    })
+  })
+
+  it('regla 4: vuelto sobre un medio que no admite vuelto', () => {
+    expect(
+      validarPagoACuentaLocal({
+        pagos: [pagoFixture({ admiteVuelto: false, vuelto: 10 })],
+        vueltoMaximo: 20,
+      }),
+    ).toEqual({ codigo: 'medio_no_admite_vuelto', mensaje: 'El medio de pago elegido no admite vuelto.' })
+  })
+
+  it('regla 5: Σ vuelto supera el vuelto máximo', () => {
+    expect(validarPagoACuentaLocal({ pagos: [pagoFixture({ vuelto: 25 })], vueltoMaximo: 20 })).toEqual({
+      codigo: 'vuelto_excedido',
+      mensaje: 'El vuelto supera el máximo permitido.',
+    })
+  })
+
+  it('regla 6: referencia requerida y ausente', () => {
+    expect(
+      validarPagoACuentaLocal({
+        pagos: [pagoFixture({ requiereReferencia: true, referencia: null })],
+        vueltoMaximo: 20,
+      }),
+    ).toEqual({ codigo: 'referencia_de_pago_requerida', mensaje: 'Este medio de pago requiere una referencia.' })
+  })
+
+  it('regla 7: importeAplicado <= 0 (Σ importe == Σ vuelto)', () => {
+    expect(
+      validarPagoACuentaLocal({
+        pagos: [pagoFixture({ importe: 100, vuelto: 100, admiteVuelto: true })],
+        vueltoMaximo: 200,
+      }),
+    ).toEqual({ codigo: 'pago_a_cuenta_sin_importe', mensaje: 'Tenés que ingresar al menos un pago a cuenta.' })
+  })
+
+  it('sin ningún pago, importeAplicado es 0 ⇒ rechazado', () => {
+    expect(validarPagoACuentaLocal({ pagos: [], vueltoMaximo: 20 })).toEqual({
+      codigo: 'pago_a_cuenta_sin_importe',
+      mensaje: 'Tenés que ingresar al menos un pago a cuenta.',
+    })
+  })
+})
+
+describe('aSolicitudDePagoACuenta', () => {
+  it('arma el cuerpo del POST con la forma exacta del contrato', () => {
+    const solicitud = aSolicitudDePagoACuenta(7, [pagoFixture({ importe: 500, vuelto: 0, referencia: 'ref' })], '  nota  ')
+    expect(solicitud).toEqual({
+      idPuntoVenta: 7,
+      pagos: [{ idMedioPago: 1, importe: 500, referencia: 'ref', vuelto: 0 }],
+      observaciones: 'nota',
+    })
+  })
+
+  it('observaciones en blanco se normaliza a null', () => {
+    const solicitud = aSolicitudDePagoACuenta(7, [pagoFixture()], '   ')
+    expect(solicitud.observaciones).toBeNull()
+  })
+})

--- a/src/Ways.Web/src/api/cuentaCorriente.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.ts
@@ -1,0 +1,215 @@
+/**
+ * Cliente HTTP + reglas puras de cuenta corriente (stage-7-cuenta-corriente, Slice 5): estado de
+ * cuenta (header + ledger) y pago a cuenta (RC). `validarPagoACuentaLocal` espeja
+ * `ValidadorDePagoACuenta` (Ways.Domain.CuentaCorriente) para dar feedback instantáneo en
+ * pantalla — nunca es autoritativo, el servidor vuelve a validar todo (mismo criterio que
+ * `pagos.ts`, stage-5). `disponibilidadPrevia` espeja
+ * `CalculadorDeEstadoDeCuenta.CalcularDisponibilidad` — mismo criterio no-autoritativo que
+ * `arqueo.ts`.
+ */
+import { api } from './cliente'
+import type {
+  ComportamientoMedioPago,
+  ComprobanteEmitido,
+  EstadoDeCuenta,
+  MedioPagoListado,
+  MovimientoDeCuentaCorriente,
+  PagoDeCuenta,
+  SolicitudDePagoACuenta,
+} from './tipos'
+
+function redondear(valor: number): number {
+  return Math.round((valor + Number.EPSILON) * 100) / 100
+}
+
+/** Arma el query string de `GET …/cuenta-corriente` — `historico` gana sobre `desde`/`hasta`
+ * (mismo criterio que `ObtenerEstadoDeCuentaAsync`); un `desde`/`hasta` vacío se omite (el
+ * servidor aplica su propio default de último mes). Un `desde`/`hasta` de un `<input type="date">`
+ * (`YYYY-MM-DD`) se expande a los bordes inclusivos del día. */
+export function construirQueryEstadoDeCuenta(desde: string, hasta: string, historico: boolean): string {
+  const parametros = new URLSearchParams()
+  if (historico) {
+    parametros.set('historico', 'true')
+  } else {
+    if (desde) parametros.set('desde', `${desde}T00:00:00`)
+    if (hasta) parametros.set('hasta', `${hasta}T23:59:59.999`)
+  }
+  const cadena = parametros.toString()
+  return cadena ? `?${cadena}` : ''
+}
+
+export const clienteDeCuentaCorriente = {
+  /** `GET /api/clientes/{id}/cuenta-corriente?desde=&hasta=&historico=` — header + página en un
+   * único payload (design decisión 9), 200 siempre (nunca 404, incluso para un cliente sin
+   * ningún movimiento). */
+  obtenerEstado: (idCliente: number, desde: string, hasta: string, historico: boolean) =>
+    api.get<EstadoDeCuenta>(
+      `/clientes/${idCliente}/cuenta-corriente${construirQueryEstadoDeCuenta(desde, hasta, historico)}`,
+    ),
+  /** `POST /api/clientes/{id}/cuenta-corriente/pagos` — 201 con el comprobante RC, o
+   * `409 turno_no_abierto` si el punto de venta no tiene turno abierto (spec: RC Requires An
+   * Open Turno — rechazado antes que cualquier otro procesamiento). */
+  registrarPago: (idCliente: number, solicitud: SolicitudDePagoACuenta) =>
+    api.post<ComprobanteEmitido>(`/clientes/${idCliente}/cuenta-corriente/pagos`, solicitud),
+}
+
+/** Etiqueta de pantalla por tipo de movimiento — un `Ajuste` se distingue por `etiqueta` (manual
+ * vs. contramovimiento de anulación, espejo de `CalculadorDeEstadoDeCuenta.EtiquetarAjuste`). */
+export function etiquetaDeMovimiento(m: Pick<MovimientoDeCuentaCorriente, 'tipo' | 'etiqueta'>): string {
+  switch (m.tipo) {
+    case 'Consumo':
+      return 'Consumo'
+    case 'Pago':
+      return 'Pago'
+    case 'ActualizacionPrecios':
+      return 'Actualización de precios'
+    case 'Ajuste':
+      return m.etiqueta === 'AnulacionContramovimiento' ? 'Contramov. de anulación' : 'Ajuste manual'
+  }
+}
+
+/** Espejo de `CalculadorDeEstadoDeCuenta.CalcularDisponibilidad` — `null` cuando
+ * `creditoIlimitado` (nunca un número fabricado). Se usa para previsualizar la disponibilidad
+ * tras un pago a cuenta antes de enviarlo (mismo criterio no-autoritativo que `arqueo.ts`). */
+export function disponibilidadPrevia(saldo: number, limiteCredito: number, creditoIlimitado: boolean): number | null {
+  return creditoIlimitado ? null : limiteCredito - saldo
+}
+
+// ---- Pago a cuenta: filas del panel + validación local --------------------------------------
+
+/** `CuentaCorriente` nunca es un medio válido para pagar una RC — a diferencia de
+ * `medioDisponibleParaCliente` (pagos.ts), esto no depende del cliente: una deuda no puede pagar
+ * otra deuda (design decisión 6, spec: RC Forbids Cuenta Corriente Medios). */
+export function medioFisicoParaPagoACuenta(medio: MedioPagoListado): boolean {
+  return medio.comportamiento !== 'CuentaCorriente'
+}
+
+export type FilaPagoACuenta = { id: number; idMedioPago: number | ''; importe: string; referencia: string; vuelto: string }
+
+export function filaPagoACuentaVacia(id: number): FilaPagoACuenta {
+  return { id, idMedioPago: '', importe: '', referencia: '', vuelto: '' }
+}
+
+export type PagoACuentaParaCalculo = {
+  idFila: number
+  idMedioPago: number
+  comportamiento: ComportamientoMedioPago
+  admiteVuelto: boolean
+  requiereReferencia: boolean
+  importe: number
+  vuelto: number
+  referencia: string | null
+}
+
+/** Filas del panel → pagos de cálculo, descartando las que el cajero todavía no terminó de
+ * completar (sin medio elegido o sin un importe positivo) — mismo criterio que
+ * `filasAPagosParaCalculo` (pagos.ts). */
+export function filasAPagosACuentaParaCalculo(
+  filas: FilaPagoACuenta[],
+  medioPorId: Record<number, MedioPagoListado>,
+): PagoACuentaParaCalculo[] {
+  const pagos: PagoACuentaParaCalculo[] = []
+  for (const fila of filas) {
+    if (fila.idMedioPago === '') continue
+    const medio = medioPorId[fila.idMedioPago]
+    if (!medio) continue
+    const importe = Number(fila.importe)
+    if (fila.importe.trim() === '' || !Number.isFinite(importe) || importe <= 0) continue
+    const vueltoCandidato = fila.vuelto.trim() === '' ? 0 : Number(fila.vuelto)
+    pagos.push({
+      idFila: fila.id,
+      idMedioPago: medio.id,
+      comportamiento: medio.comportamiento,
+      admiteVuelto: medio.admiteVuelto,
+      requiereReferencia: medio.requiereReferencia,
+      importe,
+      vuelto: Number.isFinite(vueltoCandidato) ? vueltoCandidato : 0,
+      referencia: fila.referencia.trim() === '' ? null : fila.referencia.trim(),
+    })
+  }
+  return pagos
+}
+
+/** `importeAplicado = Σ importe − Σ vuelto` (legacy parity, espejo de
+ * `ValidadorDePagoACuenta.Validar` — la RC no tiene ningún campo de importe propio, este es el
+ * único lugar donde ese número existe). */
+export function calcularImporteAplicado(pagos: { importe: number; vuelto: number }[]): number {
+  const sumaImportes = pagos.reduce((acumulado, p) => acumulado + p.importe, 0)
+  const sumaVueltos = pagos.reduce((acumulado, p) => acumulado + p.vuelto, 0)
+  return redondear(sumaImportes - sumaVueltos)
+}
+
+export type RechazoDePagoACuenta = { codigo: string; mensaje: string }
+
+/**
+ * Espejo pixel-a-pixel del orden de `ValidadorDePagoACuenta.Validar` (Ways.Domain.CuentaCorriente)
+ * — corta en el primer rechazo, nunca acumula errores, mismos códigos de dominio. Nunca
+ * autoritativo: solo guía al cajero antes de intentar el pago real.
+ */
+export function validarPagoACuentaLocal(params: {
+  pagos: PagoACuentaParaCalculo[]
+  vueltoMaximo: number
+}): RechazoDePagoACuenta | null {
+  const { pagos, vueltoMaximo } = params
+
+  for (const pago of pagos) {
+    if (pago.importe < 0) {
+      return { codigo: 'pago_importe_negativo', mensaje: 'El importe de un pago no puede ser negativo.' }
+    }
+  }
+
+  for (const pago of pagos) {
+    if (pago.vuelto < 0) {
+      return { codigo: 'vuelto_negativo', mensaje: 'El vuelto de un pago no puede ser negativo.' }
+    }
+  }
+
+  for (const pago of pagos) {
+    if (pago.comportamiento === 'CuentaCorriente') {
+      return {
+        codigo: 'pago_a_cuenta_sin_medios_fisicos',
+        mensaje: 'Un pago a cuenta no admite cuenta corriente como medio de pago.',
+      }
+    }
+  }
+
+  for (const pago of pagos) {
+    if (pago.vuelto > 0 && !pago.admiteVuelto) {
+      return { codigo: 'medio_no_admite_vuelto', mensaje: 'El medio de pago elegido no admite vuelto.' }
+    }
+  }
+
+  const sumaVueltos = pagos.reduce((acumulado, p) => acumulado + p.vuelto, 0)
+  if (sumaVueltos > vueltoMaximo) {
+    return { codigo: 'vuelto_excedido', mensaje: 'El vuelto supera el máximo permitido.' }
+  }
+
+  for (const pago of pagos) {
+    if (pago.requiereReferencia && (pago.referencia ?? '').trim() === '') {
+      return { codigo: 'referencia_de_pago_requerida', mensaje: 'Este medio de pago requiere una referencia.' }
+    }
+  }
+
+  const importeAplicado = calcularImporteAplicado(pagos)
+  if (importeAplicado <= 0) {
+    return { codigo: 'pago_a_cuenta_sin_importe', mensaje: 'Tenés que ingresar al menos un pago a cuenta.' }
+  }
+
+  return null
+}
+
+/** Pagos de cálculo → `SolicitudDePagoACuenta` — recorta observaciones vacías a `null` (mismo
+ * criterio que el resto de la web). */
+export function aSolicitudDePagoACuenta(
+  idPuntoVenta: number,
+  pagos: PagoACuentaParaCalculo[],
+  observaciones: string,
+): SolicitudDePagoACuenta {
+  const cuerpo: PagoDeCuenta[] = pagos.map((p) => ({
+    idMedioPago: p.idMedioPago,
+    importe: p.importe,
+    referencia: p.referencia,
+    vuelto: p.vuelto,
+  }))
+  return { idPuntoVenta, pagos: cuerpo, observaciones: observaciones.trim() === '' ? null : observaciones.trim() }
+}

--- a/src/Ways.Web/src/api/cuentaCorriente.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.ts
@@ -70,7 +70,14 @@ function fechaLocalAIso(fecha: Date): string {
  * inputs de filtro nunca queden vacíos mostrando una ventana invisible. */
 export function rangoUltimoMes(ahora: Date = new Date()): { desde: string; hasta: string } {
   const hasta = fechaLocalAIso(ahora)
-  const desde = fechaLocalAIso(new Date(ahora.getFullYear(), ahora.getMonth() - 1, ahora.getDate()))
+  const anio = ahora.getFullYear()
+  const mes = ahora.getMonth()
+  // `new Date(anio, mes, 0)` cae en el último día del mes anterior — semántica AddMonths-clamp
+  // (.NET): un 31 de marzo no puede convertirse en un inexistente "31 de febrero", se recorta al
+  // último día real del mes anterior (28/29 de febrero, 30 de junio, etc.).
+  const diasDelMesAnterior = new Date(anio, mes, 0).getDate()
+  const dia = Math.min(ahora.getDate(), diasDelMesAnterior)
+  const desde = fechaLocalAIso(new Date(anio, mes - 1, dia))
   return { desde, hasta }
 }
 

--- a/src/Ways.Web/src/api/cuentaCorriente.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.ts
@@ -22,20 +22,56 @@ function redondear(valor: number): number {
   return Math.round((valor + Number.EPSILON) * 100) / 100
 }
 
+/** Offset UTC del navegador (`±HH:MM`) para la fecha local dada — el servidor corre en UTC
+ * (Docker) mientras el local opera en ART (UTC-3); sin este offset explícito, un `desde`/`hasta`
+ * sin zona se interpreta como UTC del lado del servidor y un movimiento nocturno queda fuera del
+ * día que el cajero ve en pantalla. Se calcula por fecha (no una única vez) para no romper en un
+ * cambio de DST dentro del rango. */
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
 /** Arma el query string de `GET …/cuenta-corriente` — `historico` gana sobre `desde`/`hasta`
  * (mismo criterio que `ObtenerEstadoDeCuentaAsync`); un `desde`/`hasta` vacío se omite (el
  * servidor aplica su propio default de último mes). Un `desde`/`hasta` de un `<input type="date">`
- * (`YYYY-MM-DD`) se expande a los bordes inclusivos del día. */
+ * (`YYYY-MM-DD`) se expande a los bordes inclusivos del día, con el offset horario local del
+ * navegador (nunca un `Z`/sin-offset que el servidor interpretaría como UTC). */
 export function construirQueryEstadoDeCuenta(desde: string, hasta: string, historico: boolean): string {
   const parametros = new URLSearchParams()
   if (historico) {
     parametros.set('historico', 'true')
   } else {
-    if (desde) parametros.set('desde', `${desde}T00:00:00`)
-    if (hasta) parametros.set('hasta', `${hasta}T23:59:59.999`)
+    if (desde) parametros.set('desde', fechaIsoConOffset(desde, '00:00:00'))
+    if (hasta) parametros.set('hasta', fechaIsoConOffset(hasta, '23:59:59.999'))
   }
   const cadena = parametros.toString()
   return cadena ? `?${cadena}` : ''
+}
+
+function fechaLocalAIso(fecha: Date): string {
+  const anio = fecha.getFullYear()
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0')
+  const dia = String(fecha.getDate()).padStart(2, '0')
+  return `${anio}-${mes}-${dia}`
+}
+
+/** Ventana por defecto de la pantalla (design.md, decisión 9: "the screen sends last-month by
+ * default") — replica en el cliente el default del servidor (`hoy − 1 mes` → `hoy`) para que los
+ * inputs de filtro nunca queden vacíos mostrando una ventana invisible. */
+export function rangoUltimoMes(ahora: Date = new Date()): { desde: string; hasta: string } {
+  const hasta = fechaLocalAIso(ahora)
+  const desde = fechaLocalAIso(new Date(ahora.getFullYear(), ahora.getMonth() - 1, ahora.getDate()))
+  return { desde, hasta }
 }
 
 export const clienteDeCuentaCorriente = {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -759,3 +759,54 @@ export type ComprobanteEmitido = {
   items: ItemEmitido[]
   pagos: PagoEmitido[]
 }
+
+// --- Cuenta corriente: estado de cuenta y pago a cuenta (stage-7-cuenta-corriente, Slice 5) ---
+// Espejo de `Ways.Application.CuentaCorriente.Contratos` — header + movimientos en un único GET
+// (design decisión 9), pago a cuenta (RC) sin ningún campo de importe propio (design decisión 6,
+// `importeAplicado = Σ importe − Σ vuelto`).
+
+export type TipoMovimientoCc = 'Consumo' | 'Pago' | 'Ajuste' | 'ActualizacionPrecios'
+
+/** Distingue un movimiento `Ajuste` por su origen — solo viene poblado para ese tipo (design
+ * decisión 8/9, espejo de `EtiquetaDeAjuste`). */
+export type EtiquetaDeAjuste = 'Manual' | 'AnulacionContramovimiento'
+
+/** Header de estado de cuenta — `disponibilidad: null` cuando `creditoIlimitado` (nunca un
+ * número fabricado, espejo de `EstadoDeCuentaHeader`). */
+export type EstadoDeCuentaHeader = {
+  saldo: number
+  limiteCredito: number
+  creditoIlimitado: boolean
+  disponibilidad: number | null
+}
+
+/** Una fila del ledger — `saldoResultante` es la ÚNICA fuente del saldo corrido, nunca
+ * re-derivada en pantalla (espejo de `MovimientoDeCuentaCorriente`). */
+export type MovimientoDeCuentaCorriente = {
+  id: number
+  fecha: string
+  tipo: TipoMovimientoCc
+  importe: number
+  saldoResultante: number
+  detalle: string | null
+  idComprobanteVenta: number | null
+  etiqueta: EtiquetaDeAjuste | null
+}
+
+/** Respuesta de `GET /api/clientes/{id}/cuenta-corriente` — `historico`/`desde`/`hasta` reflejan
+ * la ventana EFECTIVA aplicada por el servidor, no lo pedido crudo (espejo de `EstadoDeCuenta`). */
+export type EstadoDeCuenta = {
+  header: EstadoDeCuentaHeader
+  movimientos: MovimientoDeCuentaCorriente[]
+  historico: boolean
+  desde: string | null
+  hasta: string | null
+}
+
+/** Un medio de pago de la RC — mismo shape que `PagoDeVenta`, redeclarado porque una RC no es un
+ * checkout (design decisión 1, espejo de `PagoDeCuenta`). */
+export type PagoDeCuenta = { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }
+
+/** Cuerpo de `POST /api/clientes/{id}/cuenta-corriente/pagos` — sin ningún campo de importe
+ * propio (design decisión 6, espejo de `SolicitudDePagoACuenta`). */
+export type SolicitudDePagoACuenta = { idPuntoVenta: number; pagos: PagoDeCuenta[]; observaciones: string | null }

--- a/src/Ways.Web/src/paginas/Clientes.tsx
+++ b/src/Ways.Web/src/paginas/Clientes.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeCatalogosFiscales } from '../api/catalogos'
 import { clienteDeClientes } from '../api/clientes'
@@ -271,6 +272,16 @@ export function Clientes() {
                       </span>
                     </td>
                     <td className="text-end text-nowrap">
+                      {/* stage-7-cuenta-corriente (Slice 5, design: Web Composition): entrada al
+                          estado de cuenta — el cliente lo identifica la URL, la fila lo pasa por
+                          state para no pagar un GET extra por el nombre a mostrar. */}
+                      <Link
+                        className="btn btn-sm btn-outline-secondary rounded-0 me-1"
+                        to={`/clientes/${c.id}/cuenta-corriente`}
+                        state={{ cliente: c }}
+                      >
+                        Estado de cuenta
+                      </Link>
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-primary rounded-0 me-1"

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -1,0 +1,408 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CuentaCorriente } from './CuentaCorriente'
+import { ErrorApi } from '../api/cliente'
+import type {
+  ClienteListado,
+  ComprobanteEmitido,
+  EstadoDeCuenta,
+  MedioPagoListado,
+  MovimientoDeCuentaCorriente,
+  ParametroResuelto,
+  PuntoVentaListado,
+} from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
+  return {
+    id: 1,
+    nombre: 'Efectivo',
+    activo: true,
+    idEmpresa: null,
+    orden: 1,
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    recargoPorcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+// `importe`/`saldoResultante` deliberadamente distintos del `saldo` del header (500) y entre sí,
+// para que ningún assert de "$500,00" choque con una fila de la tabla en los tests.
+function movimientoFixture(sobrescribir: Partial<MovimientoDeCuentaCorriente> = {}): MovimientoDeCuentaCorriente {
+  return {
+    id: 1,
+    fecha: '2026-08-01T12:00:00Z',
+    tipo: 'Consumo',
+    importe: 300,
+    saldoResultante: 200,
+    detalle: null,
+    idComprobanteVenta: 10,
+    etiqueta: null,
+    ...sobrescribir,
+  }
+}
+
+function estadoFixture(sobrescribir: Partial<EstadoDeCuenta> = {}): EstadoDeCuenta {
+  return {
+    header: { saldo: 500, limiteCredito: 5000, creditoIlimitado: false, disponibilidad: 4500 },
+    movimientos: [movimientoFixture()],
+    historico: false,
+    desde: '2026-07-01T00:00:00Z',
+    hasta: null,
+    ...sobrescribir,
+  }
+}
+
+function comprobanteFixture(sobrescribir: Partial<ComprobanteEmitido> = {}): ComprobanteEmitido {
+  return {
+    id: 99,
+    numero: 3,
+    numeroVisible: '0007-00000003',
+    estado: 'Emitido',
+    fecha: '2026-08-04T15:00:00Z',
+    idPuntoVenta: 7,
+    idCliente: 5,
+    idComprobanteAsociado: null,
+    subtotal: 500,
+    descuentoTotal: 0,
+    total: 500,
+    direccionEntrega: null,
+    observaciones: null,
+    items: [],
+    pagos: [{ idMedioPago: 1, importe: 500, referencia: null, vuelto: 0 }],
+    ...sobrescribir,
+  }
+}
+
+const medioEfectivo = medioFixture()
+const puntoVentaCentro = puntoVentaFixture()
+
+function renderPantalla(idCliente: number | string = 5, state?: { cliente: ClienteListado }) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: `/clientes/${idCliente}/cuenta-corriente`, state }]}>
+      <Routes>
+        <Route path="/clientes/:id/cuenta-corriente" element={<CuentaCorriente />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** Rutas comunes a toda la pantalla (medios de pago + puntos de venta + estado de cuenta +
+ * vuelto_maximo) — un override toma prioridad sobre el default para que un test pueda reemplazar
+ * cualquiera de estas rutas base. */
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
+    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+    if (ruta.startsWith('/parametros/vuelto_maximo')) {
+      return Promise.resolve<ParametroResuelto>({ clave: 'vuelto_maximo', valor: '20' })
+    }
+    if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+/** Abre el modal de pago y completa una fila válida (Efectivo, importe dado) — espera a que
+ * "Registrar pago" esté habilitado (vuelto_maximo ya resuelto). */
+async function abrirModalYCompletarFila(importe = '500') {
+  renderPantalla()
+  await screen.findByText('$500,00')
+  await userEvent.click(screen.getByRole('button', { name: 'Ingresar pago' }))
+  await screen.findByText('Ingresar pago a cuenta')
+  await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), 'Efectivo')
+  await userEvent.type(screen.getByLabelText('Importe'), importe)
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Registrar pago' })).not.toBeDisabled())
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+})
+
+describe('CuentaCorriente — header y ledger', () => {
+  it('muestra saldo, límite de crédito y disponibilidad', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    expect(screen.getByText('$5.000,00')).toBeInTheDocument()
+    expect(screen.getByText('$4.500,00')).toBeInTheDocument()
+  })
+
+  it('crédito ilimitado muestra "Ilimitado" en límite y disponibilidad, nunca un número fabricado', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente')) {
+        return Promise.resolve<EstadoDeCuenta>(
+          estadoFixture({ header: { saldo: 0, limiteCredito: 0, creditoIlimitado: true, disponibilidad: null } }),
+        )
+      }
+      return undefined
+    })
+    renderPantalla()
+
+    await screen.findByText('Cliente #5', { exact: false })
+    expect(screen.getAllByText('Ilimitado')).toHaveLength(2)
+  })
+
+  it('un período sin movimientos muestra el estado vacío, con exactamente un GET (nunca una re-consulta)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture({ movimientos: [] }))
+      return undefined
+    })
+    renderPantalla()
+
+    expect(await screen.findByText('No hay movimientos en el período seleccionado.')).toBeInTheDocument()
+    const llamadasEstado = apiGetMock.mock.calls.filter((c) => (c[0] as string).includes('/cuenta-corriente'))
+    expect(llamadasEstado).toHaveLength(1)
+  })
+
+  it('la falla al cargar medios de pago muestra un aviso y deja "Ingresar pago" realmente deshabilitado', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') {
+        return Promise.reject(new ErrorApi(500, 'error', 'No se pudieron cargar los medios de pago.'))
+      }
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderPantalla()
+
+    expect(await screen.findByText(/No se pudieron cargar los medios de pago\./)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeDisabled())
+  })
+
+  it('el Consumidor Final (conocido por state de navegación) deja "Ingresar pago" deshabilitado', async () => {
+    mockearRutasBase()
+    const cf: ClienteListado = {
+      id: 1,
+      numero: 1,
+      nombre: 'Consumidor Final',
+      apellido: null,
+      razonSocial: null,
+      tipoDocumento: null,
+      numeroDocumento: null,
+      idCondicionFiscal: 1,
+      nacimiento: null,
+      domicilio: null,
+      telefono: null,
+      celular: null,
+      email: null,
+      observaciones: null,
+      idListaPrecio: 1,
+      limiteCredito: 0,
+      creditoIlimitado: false,
+      saldo: 0,
+      activo: true,
+      idEmpresa: null,
+      esConsumidorFinal: true,
+    }
+
+    renderPantalla(1, { cliente: cf })
+
+    await screen.findByText('$500,00')
+    expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeDisabled()
+  })
+})
+
+describe('CuentaCorriente — filtros (react-async-state regla 2)', () => {
+  it('los filtros disparan un nuevo GET; una respuesta obsoleta que llega tarde nunca pisa la más reciente', async () => {
+    let llamadas = 0
+    let resolverSegunda: (v: EstadoDeCuenta) => void = () => {}
+    const segundaPendiente = new Promise<EstadoDeCuenta>((resolve) => {
+      resolverSegunda = resolve
+    })
+
+    mockearRutasBase((ruta) => {
+      if (!ruta.includes('/cuenta-corriente')) return undefined
+      llamadas += 1
+      if (llamadas === 1) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      if (llamadas === 2) return segundaPendiente
+      if (llamadas === 3) {
+        return Promise.resolve<EstadoDeCuenta>(
+          estadoFixture({ movimientos: [movimientoFixture({ id: 3, importe: 999, saldoResultante: 111 })] }),
+        )
+      }
+      return Promise.reject(new Error('llamada inesperada'))
+    })
+
+    renderPantalla()
+    await screen.findByLabelText('Ver histórico completo')
+
+    // 1ra: activa histórico (queda pendiente, lenta).
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+    expect(screen.getByLabelText('Desde')).toBeDisabled()
+
+    // 2da: lo desactiva de nuevo — dispara una generación MÁS NUEVA, que resuelve rápido.
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+
+    await waitFor(() => expect(screen.getByText('$999,00')).toBeInTheDocument())
+
+    // La respuesta obsoleta (de la generación anterior) llega tarde con datos distintos — no
+    // puede pisar lo que ya se muestra.
+    await act(async () => {
+      resolverSegunda(estadoFixture({ movimientos: [movimientoFixture({ id: 2, importe: 777, saldoResultante: 888 })] }))
+      await Promise.resolve()
+    })
+    expect(screen.getByText('$999,00')).toBeInTheDocument()
+    expect(screen.queryByText('$777,00')).not.toBeInTheDocument()
+    expect(screen.queryByText('$888,00')).not.toBeInTheDocument()
+  })
+})
+
+describe('CuentaCorriente — modal de pago a cuenta', () => {
+  it('un medio CuentaCorriente nunca aparece en el selector de medios del pago (design decisión 6)', async () => {
+    const medioCc = medioFixture({ id: 2, nombre: 'Cuenta corriente del cliente', comportamiento: 'CuentaCorriente' })
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo, medioCc])
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
+      if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderPantalla()
+    await screen.findByText('$500,00')
+    await userEvent.click(screen.getByRole('button', { name: 'Ingresar pago' }))
+    await screen.findByText('Ingresar pago a cuenta')
+
+    const opciones = within(screen.getByLabelText('Medio de pago')).getAllByRole('option')
+    expect(opciones.map((o) => o.textContent)).not.toContain('Cuenta corriente del cliente')
+    expect(opciones.map((o) => o.textContent)).toContain('Efectivo')
+  })
+
+  it('doble click en "Registrar pago" dispara exactamente un POST', async () => {
+    mockearRutasBase()
+    let resolverPago: (c: ComprobanteEmitido) => void = () => {}
+    const pagoPendiente = new Promise<ComprobanteEmitido>((resolve) => {
+      resolverPago = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/pagos') return pagoPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalYCompletarFila()
+
+    const boton = screen.getByRole('button', { name: 'Registrar pago' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/pagos')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Registrando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverPago(comprobanteFixture())
+      await Promise.resolve()
+    })
+  })
+
+  it('arma el cuerpo del POST de pago con la forma exacta del contrato', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/pagos') return Promise.resolve<ComprobanteEmitido>(comprobanteFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalYCompletarFila('500')
+    await userEvent.type(screen.getByLabelText('Observaciones'), '  nota de prueba  ')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar pago' }))
+
+    await screen.findByText(/Pago registrado/)
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/clientes/5/cuenta-corriente/pagos')
+    expect(llamada?.[1]).toEqual({
+      idPuntoVenta: 7,
+      pagos: [{ idMedioPago: 1, importe: 500, referencia: null, vuelto: 0 }],
+      observaciones: 'nota de prueba',
+    })
+  })
+
+  it('un pago 2xx nunca se reporta como fallo, aunque el refetch del ledger posterior falle', async () => {
+    let llamadasEstado = 0
+    mockearRutasBase((ruta) => {
+      if (!ruta.includes('/cuenta-corriente')) return undefined
+      llamadasEstado += 1
+      if (llamadasEstado === 1) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      return Promise.reject(new Error('boom'))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/pagos') return Promise.resolve<ComprobanteEmitido>(comprobanteFixture())
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalYCompletarFila()
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar pago' }))
+
+    expect(await screen.findByText('Pago registrado: comprobante 0007-00000003.')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('No se pudo cargar el estado de cuenta.')).toBeInTheDocument())
+    // el aviso de éxito del pago sigue en pantalla — el fallo del refetch no lo pisa.
+    expect(screen.getByText('Pago registrado: comprobante 0007-00000003.')).toBeInTheDocument()
+  })
+
+  it('turno_no_abierto durante el pago ofrece abrir el turno ahí mismo — sin reintento automático del pago', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/pagos') {
+        return Promise.reject(new ErrorApi(409, 'turno_no_abierto', 'No hay un turno abierto en este punto de venta.'))
+      }
+      if (ruta === '/caja/turnos') return Promise.resolve({})
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalYCompletarFila()
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar pago' }))
+
+    await screen.findByText('No hay un turno abierto')
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/pagos')).toHaveLength(1)
+
+    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
+
+    await screen.findByText('Ingresar pago a cuenta')
+    // sin reintento automático: reabrir el turno no reenvía el pago solo.
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/pagos')).toHaveLength(1)
+  })
+})

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -229,6 +229,7 @@ describe('CuentaCorriente — header y ledger', () => {
 
   it('la falla al cargar medios de pago muestra un aviso y deja "Ingresar pago" realmente deshabilitado', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
+      if (/^\/clientes\/\d+$/.test(ruta)) return Promise.resolve<ClienteListado>(clienteFixture())
       if (ruta === '/catalogos/medios-pago') {
         return Promise.reject(new ErrorApi(500, 'error', 'No se pudieron cargar los medios de pago.'))
       }
@@ -260,6 +261,20 @@ describe('CuentaCorriente — header y ledger', () => {
     await screen.findByText('#0005 — Juan Pérez', { exact: false })
     expect(screen.queryByText('Cliente #5', { exact: false })).not.toBeInTheDocument()
     expect(apiGetMock.mock.calls.some((c) => c[0] === '/clientes/5')).toBe(true)
+  })
+
+  it('Fix 2: si el fetch del cliente falla (sin state, único camino del Vendedor) el gate falla CERRADO — aviso visible y "Ingresar pago" deshabilitado, nunca habilitado por default', async () => {
+    mockearRutasBase((ruta) =>
+      /^\/clientes\/\d+$/.test(ruta)
+        ? Promise.reject(new ErrorApi(500, 'error', 'No se pudo confirmar el cliente.'))
+        : undefined,
+    )
+
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    expect(await screen.findByText(/No se pudo confirmar el cliente\./)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeDisabled())
   })
 
   it('un Consumidor Final llegado por URL directa (sin state) también deja "Ingresar pago" deshabilitado con el aviso de CF, una vez resuelta la identidad', async () => {
@@ -306,6 +321,13 @@ describe('CuentaCorriente — filtros (react-async-state regla 2)', () => {
 
     expect((screen.getByLabelText('Desde') as HTMLInputElement).value).toBe('')
     expect((screen.getByLabelText('Hasta') as HTMLInputElement).value).toBe('')
+
+    // Fix 4: destildar repuebla la ventana (último mes) — los inputs nunca quedan en blanco
+    // mostrando una ventana invisible.
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+
+    expect((screen.getByLabelText('Desde') as HTMLInputElement).value).not.toBe('')
+    expect((screen.getByLabelText('Hasta') as HTMLInputElement).value).not.toBe('')
   })
 
   it('los filtros disparan un nuevo GET; una respuesta obsoleta que llega tarde nunca pisa la más reciente', async () => {
@@ -356,6 +378,7 @@ describe('CuentaCorriente — modal de pago a cuenta', () => {
   it('un medio CuentaCorriente nunca aparece en el selector de medios del pago (design decisión 6)', async () => {
     const medioCc = medioFixture({ id: 2, nombre: 'Cuenta corriente del cliente', comportamiento: 'CuentaCorriente' })
     apiGetMock.mockImplementation((ruta: string) => {
+      if (/^\/clientes\/\d+$/.test(ruta)) return Promise.resolve<ClienteListado>(clienteFixture())
       if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo, medioCc])
       if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture())

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -50,6 +50,33 @@ function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoLi
   }
 }
 
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 5,
+    numero: 5,
+    nombre: 'Juan',
+    apellido: 'Pérez',
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 5000,
+    creditoIlimitado: false,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: false,
+    ...sobrescribir,
+  }
+}
+
 function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
   return {
     id: 7,
@@ -127,13 +154,15 @@ function renderPantalla(idCliente: number | string = 5, state?: { cliente: Clien
   )
 }
 
-/** Rutas comunes a toda la pantalla (medios de pago + puntos de venta + estado de cuenta +
- * vuelto_maximo) — un override toma prioridad sobre el default para que un test pueda reemplazar
- * cualquiera de estas rutas base. */
+/** Rutas comunes a toda la pantalla (cliente + medios de pago + puntos de venta + estado de
+ * cuenta + vuelto_maximo) — un override toma prioridad sobre el default para que un test pueda
+ * reemplazar cualquiera de estas rutas base. `GET /clientes/:id` cubre el fetch de identidad
+ * cuando no llega `location.state` (Fix 2: único camino del Vendedor / cualquier refresh). */
 function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     const propia = sobrescribirGet?.(ruta)
     if (propia) return propia
+    if (/^\/clientes\/\d+$/.test(ruta)) return Promise.resolve<ClienteListado>(clienteFixture())
     if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
     if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
     if (ruta.startsWith('/parametros/vuelto_maximo')) {
@@ -182,7 +211,7 @@ describe('CuentaCorriente — header y ledger', () => {
     })
     renderPantalla()
 
-    await screen.findByText('Cliente #5', { exact: false })
+    await screen.findByText('#0005 — Juan Pérez', { exact: false })
     expect(screen.getAllByText('Ilimitado')).toHaveLength(2)
   })
 
@@ -216,38 +245,69 @@ describe('CuentaCorriente — header y ledger', () => {
 
   it('el Consumidor Final (conocido por state de navegación) deja "Ingresar pago" deshabilitado', async () => {
     mockearRutasBase()
-    const cf: ClienteListado = {
-      id: 1,
-      numero: 1,
-      nombre: 'Consumidor Final',
-      apellido: null,
-      razonSocial: null,
-      tipoDocumento: null,
-      numeroDocumento: null,
-      idCondicionFiscal: 1,
-      nacimiento: null,
-      domicilio: null,
-      telefono: null,
-      celular: null,
-      email: null,
-      observaciones: null,
-      idListaPrecio: 1,
-      limiteCredito: 0,
-      creditoIlimitado: false,
-      saldo: 0,
-      activo: true,
-      idEmpresa: null,
-      esConsumidorFinal: true,
-    }
+    const cf = clienteFixture({ id: 1, numero: 1, nombre: 'Consumidor Final', apellido: null, esConsumidorFinal: true })
 
     renderPantalla(1, { cliente: cf })
 
     await screen.findByText('$500,00')
     expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeDisabled()
   })
+
+  it('sin state de navegación (único camino del Vendedor / cualquier refresh) busca el cliente por GET y muestra el nombre real, no el placeholder', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('#0005 — Juan Pérez', { exact: false })
+    expect(screen.queryByText('Cliente #5', { exact: false })).not.toBeInTheDocument()
+    expect(apiGetMock.mock.calls.some((c) => c[0] === '/clientes/5')).toBe(true)
+  })
+
+  it('un Consumidor Final llegado por URL directa (sin state) también deja "Ingresar pago" deshabilitado con el aviso de CF, una vez resuelta la identidad', async () => {
+    const cf = clienteFixture({ esConsumidorFinal: true, nombre: 'Consumidor', apellido: 'Final' })
+    mockearRutasBase((ruta) => (/^\/clientes\/\d+$/.test(ruta) ? Promise.resolve<ClienteListado>(cf) : undefined))
+
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeDisabled())
+    expect(screen.getByRole('button', { name: 'Ingresar pago' })).toHaveAttribute(
+      'title',
+      'El Consumidor Final no tiene cuenta corriente.',
+    )
+  })
 })
 
 describe('CuentaCorriente — filtros (react-async-state regla 2)', () => {
+  it('la ventana por defecto (design.md: "último mes") se precarga en Desde/Hasta y viaja en la consulta inicial', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+
+    const inputDesde = screen.getByLabelText('Desde') as HTMLInputElement
+    const inputHasta = screen.getByLabelText('Hasta') as HTMLInputElement
+    expect(inputDesde.value).not.toBe('')
+    expect(inputHasta.value).not.toBe('')
+
+    const llamadaEstado = apiGetMock.mock.calls.find((c) => (c[0] as string).includes('/cuenta-corriente'))
+    const query = decodeURIComponent(llamadaEstado?.[0] as string)
+    expect(query).toContain(`desde=${inputDesde.value}T00:00:00`)
+    expect(query).toContain(`hasta=${inputHasta.value}T23:59:59.999`)
+  })
+
+  it('"Ver histórico completo" limpia los inputs Desde/Hasta — la ventana en efecto (sin recorte) queda visible', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    expect((screen.getByLabelText('Desde') as HTMLInputElement).value).not.toBe('')
+
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+
+    expect((screen.getByLabelText('Desde') as HTMLInputElement).value).toBe('')
+    expect((screen.getByLabelText('Hasta') as HTMLInputElement).value).toBe('')
+  })
+
   it('los filtros disparan un nuevo GET; una respuesta obsoleta que llega tarde nunca pisa la más reciente', async () => {
     let llamadas = 0
     let resolverSegunda: (v: EstadoDeCuenta) => void = () => {}
@@ -404,5 +464,9 @@ describe('CuentaCorriente — modal de pago a cuenta', () => {
     await screen.findByText('Ingresar pago a cuenta')
     // sin reintento automático: reabrir el turno no reenvía el pago solo.
     expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/pagos')).toHaveLength(1)
+    // los datos del pago que ya se habían cargado en el modal siguen ahí — no se pierden al
+    // recuperarse del gate de turno (el JSDoc de PanelAperturaDeTurnoEnModal lo promete).
+    expect(screen.getByLabelText('Medio de pago')).toHaveValue('1')
+    expect(screen.getByLabelText('Importe')).toHaveValue(500)
   })
 })

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -500,6 +500,7 @@ type PropsPantalla = {
   idCliente: number
   clienteInfo: ClienteListado | null
   cargandoCliente: boolean
+  errorCliente: string
   medios: MedioPagoListado[] | null
   errorMedios: string
   puntosVenta: PuntoVentaListado[] | null
@@ -512,6 +513,7 @@ function PantallaCuentaCorriente({
   idCliente,
   clienteInfo,
   cargandoCliente,
+  errorCliente,
   medios,
   errorMedios,
   puntosVenta,
@@ -562,8 +564,13 @@ function PantallaCuentaCorriente({
   }, [cargarEstado])
 
   const esConsumidorFinal = clienteInfo?.esConsumidorFinal ?? false
+  // Fix 2 (react-async-state regla 7): `clienteInfo !== null` falla cerrado tanto mientras la
+  // identidad todavía carga como cuando el fetch terminó en error — un cliente NUNCA verificado
+  // no puede habilitar el pago, sin importar qué valor por default tuviera `esConsumidorFinal`.
   const puedeIngresarPago =
     !cargandoCliente &&
+    clienteInfo !== null &&
+    errorCliente === '' &&
     medios !== null &&
     errorMedios === '' &&
     puntosVenta !== null &&
@@ -571,12 +578,11 @@ function PantallaCuentaCorriente({
     puntosVenta.length > 0 &&
     !esConsumidorFinal
 
-  // Mientras la identidad del cliente todavía se está resolviendo (sin `location.state`, p. ej. el
-  // único camino del Vendedor o cualquier refresh) el gate de Consumidor Final falla cerrado: el
-  // botón queda deshabilitado hasta confirmar el dato real, nunca habilitado por default.
   let motivoBloqueoPago: string | undefined
   if (cargandoCliente) {
     motivoBloqueoPago = 'Cargando los datos del cliente…'
+  } else if (errorCliente) {
+    motivoBloqueoPago = 'No se pudo confirmar el cliente — no se puede ingresar un pago hasta que esto se resuelva.'
   } else if (esConsumidorFinal) {
     motivoBloqueoPago = 'El Consumidor Final no tiene cuenta corriente.'
   } else if (!puedeIngresarPago) {
@@ -595,9 +601,9 @@ function PantallaCuentaCorriente({
       >
         {avisoPago && <div className="alert alert-success rounded-0">{avisoPago}</div>}
         {errorEstado && <div className="alert alert-danger rounded-0">{errorEstado}</div>}
-        {(errorMedios || errorPuntosVenta) && (
+        {(errorCliente || errorMedios || errorPuntosVenta) && (
           <div className="alert alert-warning rounded-0 py-1 px-2 small">
-            {errorMedios || errorPuntosVenta} No se puede ingresar un pago hasta que esto se resuelva.
+            {errorCliente || errorMedios || errorPuntosVenta} No se puede ingresar un pago hasta que esto se resuelva.
           </div>
         )}
 
@@ -671,11 +677,17 @@ function PantallaCuentaCorriente({
                     onChange={(e) => {
                       const marcado = e.target.checked
                       setHistorico(marcado)
-                      // "Ver histórico" limpia la ventana — los inputs, deshabilitados y vacíos,
-                      // reflejan que la consulta ya no tiene ningún recorte de fecha.
                       if (marcado) {
+                        // "Ver histórico" limpia la ventana — los inputs, deshabilitados y
+                        // vacíos, reflejan que la consulta ya no tiene ningún recorte de fecha.
                         setDesde('')
                         setHasta('')
+                      } else {
+                        // Al destildar, la ventana efectiva vuelve a ser la de último mes — los
+                        // inputs nunca quedan en blanco mostrando una ventana invisible.
+                        const ventana = rangoUltimoMes()
+                        setDesde(ventana.desde)
+                        setHasta(ventana.hasta)
                       }
                     }}
                   />
@@ -769,6 +781,7 @@ export function CuentaCorriente() {
   // resuelve, `puedeIngresarPago` falla cerrado vía `cargandoCliente`.
   const [clienteInfo, setClienteInfo] = useState<ClienteListado | null>(clienteDeState)
   const [cargandoCliente, setCargandoCliente] = useState(clienteDeState === null)
+  const [errorCliente, setErrorCliente] = useState('')
   const generacionClienteRef = useRef(0)
 
   const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
@@ -781,12 +794,14 @@ export function CuentaCorriente() {
     if (clienteDeState !== null || !idClienteValido) {
       setClienteInfo(clienteDeState)
       setCargandoCliente(false)
+      setErrorCliente('')
       return
     }
 
     let vigente = true
     const miGeneracion = (generacionClienteRef.current += 1)
     setCargandoCliente(true)
+    setErrorCliente('')
 
     clienteDeClientes
       .obtener(idCliente)
@@ -794,9 +809,13 @@ export function CuentaCorriente() {
         if (!vigente || generacionClienteRef.current !== miGeneracion) return
         setClienteInfo(cliente)
       })
-      .catch(() => {
+      .catch((e) => {
         if (!vigente || generacionClienteRef.current !== miGeneracion) return
         setClienteInfo(null)
+        // Fix 2 (react-async-state regla 7): sin este aviso, un fallo de red dejaba
+        // `clienteInfo` en null y el gate de Consumidor Final (`?? false`) habilitaba
+        // "Ingresar pago" para un cliente NUNCA verificado.
+        setErrorCliente(e instanceof ErrorApi ? e.message : 'No se pudo confirmar el cliente.')
       })
       .finally(() => {
         if (!vigente || generacionClienteRef.current !== miGeneracion) return
@@ -859,6 +878,7 @@ export function CuentaCorriente() {
       idCliente={idCliente}
       clienteInfo={clienteInfo}
       cargandoCliente={cargandoCliente}
+      errorCliente={errorCliente}
       medios={medios}
       errorMedios={errorMedios}
       puntosVenta={puntosVenta}

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useParams } from 'react-router'
 import { clienteDeCaja } from '../api/caja'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { api, ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import {
   aSolicitudDePagoACuenta,
@@ -13,6 +14,7 @@ import {
   filaPagoACuentaVacia,
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
+  rangoUltimoMes,
   validarPagoACuentaLocal,
   type FilaPagoACuenta,
 } from '../api/cuentaCorriente'
@@ -221,9 +223,12 @@ function ModalPagoACuenta({ idCliente, puntosVenta, medios, header, onCerrar, on
   // regla 2: cada cambio de punto de venta dispara una nueva resolución de vuelto_maximo — una
   // respuesta desactualizada nunca puede pisar la más reciente.
   useEffect(() => {
+    // El botón de pago no puede correr con el vuelto_maximo del PV anterior mientras se resuelve
+    // el nuevo — se limpia ANTES de cualquier chequeo, no solo en la rama sin PV.
+    setParametros(null)
+
     const puntoVentaSeleccionado = puntosVenta.find((p) => p.id === idPuntoVenta) ?? null
     if (!puntoVentaSeleccionado) {
-      setParametros(null)
       setErrorParametros('')
       return
     }
@@ -494,6 +499,7 @@ function ModalPagoACuenta({ idCliente, puntosVenta, medios, header, onCerrar, on
 type PropsPantalla = {
   idCliente: number
   clienteInfo: ClienteListado | null
+  cargandoCliente: boolean
   medios: MedioPagoListado[] | null
   errorMedios: string
   puntosVenta: PuntoVentaListado[] | null
@@ -502,9 +508,21 @@ type PropsPantalla = {
 
 /** Remontada por `key={idCliente}` (regla 8) — ningún estado de acá (filtros, ledger, modal de
  * pago) sobrevive a un cambio de cliente. */
-function PantallaCuentaCorriente({ idCliente, clienteInfo, medios, errorMedios, puntosVenta, errorPuntosVenta }: PropsPantalla) {
-  const [desde, setDesde] = useState('')
-  const [hasta, setHasta] = useState('')
+function PantallaCuentaCorriente({
+  idCliente,
+  clienteInfo,
+  cargandoCliente,
+  medios,
+  errorMedios,
+  puntosVenta,
+  errorPuntosVenta,
+}: PropsPantalla) {
+  // design.md decisión 9: "the screen sends last-month by default" — se precarga acá para que los
+  // inputs de filtro nunca muestren una ventana vacía mientras el default real (calculado por
+  // `construirQueryEstadoDeCuenta`, Fix 1) ya viaja en la consulta.
+  const [ventanaInicial] = useState(() => rangoUltimoMes())
+  const [desde, setDesde] = useState(ventanaInicial.desde)
+  const [hasta, setHasta] = useState(ventanaInicial.hasta)
   const [historico, setHistorico] = useState(false)
 
   const [estado, setEstado] = useState<EstadoDeCuenta | null>(null)
@@ -545,10 +563,21 @@ function PantallaCuentaCorriente({ idCliente, clienteInfo, medios, errorMedios, 
 
   const esConsumidorFinal = clienteInfo?.esConsumidorFinal ?? false
   const puedeIngresarPago =
-    medios !== null && errorMedios === '' && puntosVenta !== null && errorPuntosVenta === '' && puntosVenta.length > 0 && !esConsumidorFinal
+    !cargandoCliente &&
+    medios !== null &&
+    errorMedios === '' &&
+    puntosVenta !== null &&
+    errorPuntosVenta === '' &&
+    puntosVenta.length > 0 &&
+    !esConsumidorFinal
 
+  // Mientras la identidad del cliente todavía se está resolviendo (sin `location.state`, p. ej. el
+  // único camino del Vendedor o cualquier refresh) el gate de Consumidor Final falla cerrado: el
+  // botón queda deshabilitado hasta confirmar el dato real, nunca habilitado por default.
   let motivoBloqueoPago: string | undefined
-  if (esConsumidorFinal) {
+  if (cargandoCliente) {
+    motivoBloqueoPago = 'Cargando los datos del cliente…'
+  } else if (esConsumidorFinal) {
     motivoBloqueoPago = 'El Consumidor Final no tiene cuenta corriente.'
   } else if (!puedeIngresarPago) {
     motivoBloqueoPago = 'No se pudieron cargar los datos necesarios para registrar un pago.'
@@ -639,7 +668,16 @@ function PantallaCuentaCorriente({ idCliente, clienteInfo, medios, errorMedios, 
                     type="checkbox"
                     className="form-check-input rounded-0"
                     checked={historico}
-                    onChange={(e) => setHistorico(e.target.checked)}
+                    onChange={(e) => {
+                      const marcado = e.target.checked
+                      setHistorico(marcado)
+                      // "Ver histórico" limpia la ventana — los inputs, deshabilitados y vacíos,
+                      // reflejan que la consulta ya no tiene ningún recorte de fecha.
+                      if (marcado) {
+                        setDesde('')
+                        setHasta('')
+                      }
+                    }}
                   />
                   <label className="form-check-label" htmlFor="cc-filtro-historico">
                     Ver histórico completo
@@ -722,13 +760,53 @@ export function CuentaCorriente() {
   const idClienteValido = id !== undefined && Number.isFinite(idCliente)
 
   const location = useLocation()
-  const clienteInfo = (location.state as { cliente?: ClienteListado } | null)?.cliente ?? null
+  const clienteDeState = (location.state as { cliente?: ClienteListado } | null)?.cliente ?? null
+
+  // El Vendedor SIEMPRE llega acá sin `location.state` (URL directa, único camino del rol) y
+  // cualquier refresh lo pierde también — sin este fetch, el header mentía "Cliente #N" y el gate
+  // de Consumidor Final quedaba deshabilitado del lado del cliente (el servidor lo sigue
+  // rechazando, pero el botón se veía habilitado). Generación-gateado (regla 2): mientras se
+  // resuelve, `puedeIngresarPago` falla cerrado vía `cargandoCliente`.
+  const [clienteInfo, setClienteInfo] = useState<ClienteListado | null>(clienteDeState)
+  const [cargandoCliente, setCargandoCliente] = useState(clienteDeState === null)
+  const generacionClienteRef = useRef(0)
 
   const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
   const [errorMedios, setErrorMedios] = useState('')
 
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
   const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  useEffect(() => {
+    if (clienteDeState !== null || !idClienteValido) {
+      setClienteInfo(clienteDeState)
+      setCargandoCliente(false)
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionClienteRef.current += 1)
+    setCargandoCliente(true)
+
+    clienteDeClientes
+      .obtener(idCliente)
+      .then((cliente) => {
+        if (!vigente || generacionClienteRef.current !== miGeneracion) return
+        setClienteInfo(cliente)
+      })
+      .catch(() => {
+        if (!vigente || generacionClienteRef.current !== miGeneracion) return
+        setClienteInfo(null)
+      })
+      .finally(() => {
+        if (!vigente || generacionClienteRef.current !== miGeneracion) return
+        setCargandoCliente(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idCliente, idClienteValido, clienteDeState])
 
   useEffect(() => {
     let vigente = true
@@ -780,6 +858,7 @@ export function CuentaCorriente() {
       key={idCliente}
       idCliente={idCliente}
       clienteInfo={clienteInfo}
+      cargandoCliente={cargandoCliente}
       medios={medios}
       errorMedios={errorMedios}
       puntosVenta={puntosVenta}

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -1,0 +1,789 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useLocation, useParams } from 'react-router'
+import { clienteDeCaja } from '../api/caja'
+import { clienteDeCatalogo } from '../api/catalogos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import {
+  aSolicitudDePagoACuenta,
+  calcularImporteAplicado,
+  clienteDeCuentaCorriente,
+  disponibilidadPrevia,
+  etiquetaDeMovimiento,
+  filaPagoACuentaVacia,
+  filasAPagosACuentaParaCalculo,
+  medioFisicoParaPagoACuenta,
+  validarPagoACuentaLocal,
+  type FilaPagoACuenta,
+} from '../api/cuentaCorriente'
+import type {
+  ClienteListado,
+  ComprobanteEmitido,
+  EstadoDeCuenta,
+  EstadoDeCuentaHeader,
+  MedioPagoAlta,
+  MedioPagoListado,
+  ParametroResuelto,
+  PuntoVentaListado,
+} from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const CLAVE_PUNTO_VENTA = 'ways.cuentaCorriente.idPuntoVenta'
+
+const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+function leerPuntoVentaGuardado(): number | null {
+  try {
+    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
+    return crudo ? Number(crudo) : null
+  } catch {
+    return null
+  }
+}
+
+function guardarPuntoVentaSeleccionado(id: number) {
+  try {
+    localStorage.setItem(CLAVE_PUNTO_VENTA, String(id))
+  } catch {
+    // localStorage puede no estar disponible (modo privado del navegador) — la selección
+    // simplemente no persiste entre sesiones, el resto de la pantalla sigue funcionando.
+  }
+}
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+function formatearDisponibilidad(valor: number | null): string {
+  return valor === null ? 'Ilimitado' : formatearMoneda(valor)
+}
+
+function nombreDeCliente(idCliente: number, cliente: ClienteListado | null): string {
+  if (!cliente) return `Cliente #${idCliente}`
+  const nombreCompleto = cliente.razonSocial ?? [cliente.nombre, cliente.apellido].filter(Boolean).join(' ')
+  return `#${String(cliente.numero).padStart(4, '0')} — ${nombreCompleto}`
+}
+
+type PropsAperturaEnModal = { idPuntoVenta: number; onAbierto: () => void; onCancelar: () => void }
+
+/**
+ * Rule 10 (react-async-state): mismo recurso de recuperación que `PanelGateTurno` (Pos.tsx) /
+ * `FormularioApertura` (Caja.tsx) — un `409 turno_no_abierto` durante un pago a cuenta ofrece
+ * abrir el turno ahí mismo, sin perder los datos del pago que ya se cargaron en el modal. El pago
+ * NUNCA se reintenta solo (regla 9): el cajero vuelve a apretar «Registrar pago» a mano.
+ */
+function PanelAperturaDeTurnoEnModal({ idPuntoVenta, onAbierto, onCancelar }: PropsAperturaEnModal) {
+  const [fondoInicial, setFondoInicial] = useState('')
+  const [observaciones, setObservaciones] = useState('')
+  const [abriendo, setAbriendo] = useState(false)
+  const abriendoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  async function abrir() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (abriendoRef.current) return
+
+    const fondo = Number(fondoInicial)
+    if (fondoInicial.trim() === '' || !Number.isFinite(fondo) || fondo < 0) {
+      setError('El fondo inicial tiene que ser un número mayor o igual a 0.')
+      return
+    }
+
+    abriendoRef.current = true
+    setAbriendo(true)
+    setError('')
+
+    try {
+      await clienteDeCaja.abrir({
+        idPuntoVenta,
+        fondoInicial: fondo,
+        observaciones: observaciones.trim() === '' ? null : observaciones.trim(),
+      })
+      onAbierto()
+    } catch (e) {
+      if (e instanceof ErrorApi && e.codigo === 'turno_ya_abierto') {
+        // Autocuración (mismo criterio que FormularioApertura/PanelGateTurno): otra
+        // pestaña/cajero ganó la carrera de apertura — el turno YA está abierto, la continuación
+        // de éxito es la correcta.
+        onAbierto()
+      } else {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo abrir el turno.')
+      }
+    } finally {
+      abriendoRef.current = false
+      setAbriendo(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="modal-header">
+        <h5 className="modal-title">No hay un turno abierto</h5>
+      </div>
+      <div className="modal-body">
+        <p className="text-muted">
+          Para registrar un pago a cuenta hace falta abrir un turno de caja en este punto de venta. Los datos del
+          pago que ya cargaste quedan como están — al abrir el turno volvés a este formulario para apretar
+          «Registrar pago» de nuevo.
+        </p>
+        {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+        <div className="row g-2 align-items-end">
+          <div className="col-md-6">
+            <label className="form-label" htmlFor="cc-gate-fondo-inicial">
+              Fondo inicial
+            </label>
+            <input
+              id="cc-gate-fondo-inicial"
+              type="number"
+              step="0.01"
+              min="0"
+              className="form-control rounded-0"
+              value={fondoInicial}
+              disabled={abriendo}
+              onChange={(e) => setFondoInicial(e.target.value)}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label" htmlFor="cc-gate-observaciones">
+              Observaciones
+            </label>
+            <input
+              id="cc-gate-observaciones"
+              type="text"
+              className="form-control rounded-0"
+              value={observaciones}
+              disabled={abriendo}
+              onChange={(e) => setObservaciones(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="modal-footer">
+        <button type="button" className="btn btn-outline-secondary rounded-0" disabled={abriendo} onClick={onCancelar}>
+          Cancelar
+        </button>
+        <button type="button" className="btn btn-primary rounded-0" disabled={abriendo} onClick={abrir}>
+          {abriendo ? 'Abriendo…' : 'Abrir turno'}
+        </button>
+      </div>
+    </>
+  )
+}
+
+type PropsModalPago = {
+  idCliente: number
+  puntosVenta: PuntoVentaListado[]
+  medios: MedioPagoListado[]
+  header: EstadoDeCuentaHeader
+  onCerrar: () => void
+  onAntesDeEscribir: () => void
+  onRegistrado: (comprobante: ComprobanteEmitido) => void
+}
+
+/**
+ * Modal de pago a cuenta (design: Web Composition). `react-async-state`: regla 9 (guard de
+ * reentrancia + deshabilitado de ventana completa mientras `registrando`), regla 3 (el llamador
+ * bumpea la generación del ledger ANTES de este POST, vía `onAntesDeEscribir`), regla 6 (el
+ * refetch posterior vive en el padre, fuera del try/catch de esta escritura), regla 10 (recupera
+ * `turno_no_abierto` con el mismo patrón que `PanelGateTurno`/`FormularioApertura`).
+ */
+function ModalPagoACuenta({ idCliente, puntosVenta, medios, header, onCerrar, onAntesDeEscribir, onRegistrado }: PropsModalPago) {
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number>(
+    () => puntosVenta.find((p) => p.id === leerPuntoVentaGuardado())?.id ?? puntosVenta[0].id,
+  )
+
+  const [parametros, setParametros] = useState<{ vueltoMaximo: number } | null>(null)
+  const [errorParametros, setErrorParametros] = useState('')
+  const generacionParametrosRef = useRef(0)
+
+  const proximaFilaIdRef = useRef(1)
+  const [filas, setFilas] = useState<FilaPagoACuenta[]>(() => [filaPagoACuentaVacia(proximaFilaIdRef.current++)])
+  const [observaciones, setObservaciones] = useState('')
+
+  const [registrando, setRegistrando] = useState(false)
+  const registrandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [gateTurno, setGateTurno] = useState(false)
+
+  const mediosFisicos = useMemo(() => medios.filter(medioFisicoParaPagoACuenta), [medios])
+  const medioPorId = useMemo(() => {
+    const indice: Record<number, MedioPagoListado> = {}
+    for (const m of medios) indice[m.id] = m
+    return indice
+  }, [medios])
+
+  // regla 2: cada cambio de punto de venta dispara una nueva resolución de vuelto_maximo — una
+  // respuesta desactualizada nunca puede pisar la más reciente.
+  useEffect(() => {
+    const puntoVentaSeleccionado = puntosVenta.find((p) => p.id === idPuntoVenta) ?? null
+    if (!puntoVentaSeleccionado) {
+      setParametros(null)
+      setErrorParametros('')
+      return
+    }
+
+    const miGeneracion = (generacionParametrosRef.current += 1)
+    let vigente = true
+
+    api
+      .get<ParametroResuelto>(
+        `/parametros/vuelto_maximo?idEmpresa=${puntoVentaSeleccionado.idEmpresa}&idPuntoVenta=${puntoVentaSeleccionado.id}`,
+      )
+      .then((valor) => {
+        if (!vigente || generacionParametrosRef.current !== miGeneracion) return
+        setParametros({ vueltoMaximo: Number(valor.valor) })
+        setErrorParametros('')
+      })
+      .catch((e) => {
+        if (!vigente || generacionParametrosRef.current !== miGeneracion) return
+        setParametros(null)
+        setErrorParametros(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los parámetros de pago.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idPuntoVenta, puntosVenta])
+
+  function cambiarPuntoVenta(id: number) {
+    if (registrandoRef.current) return
+    setIdPuntoVenta(id)
+    guardarPuntoVentaSeleccionado(id)
+  }
+
+  function actualizarFila(id: number, cambios: Partial<FilaPagoACuenta>) {
+    if (registrandoRef.current) return
+    // regla 1: updater funcional, nunca lee `filas` del cierre.
+    setFilas((prev) => prev.map((f) => (f.id === id ? { ...f, ...cambios } : f)))
+  }
+
+  function agregarFila() {
+    if (registrandoRef.current) return
+    setFilas((prev) => [...prev, filaPagoACuentaVacia(proximaFilaIdRef.current++)])
+  }
+
+  function quitarFila(id: number) {
+    if (registrandoRef.current) return
+    setFilas((prev) => (prev.length <= 1 ? prev : prev.filter((f) => f.id !== id)))
+  }
+
+  const pagosCalculo = filasAPagosACuentaParaCalculo(filas, medioPorId)
+  const importeAplicado = calcularImporteAplicado(pagosCalculo)
+  const saldoEstimado = header.saldo - importeAplicado
+  const disponibilidadEstimada = disponibilidadPrevia(saldoEstimado, header.limiteCredito, header.creditoIlimitado)
+
+  async function registrarPago() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (registrandoRef.current) return
+
+    if (!parametros) {
+      setError('No se pudieron cargar los parámetros de pago.')
+      return
+    }
+
+    const rechazo = validarPagoACuentaLocal({ pagos: pagosCalculo, vueltoMaximo: parametros.vueltoMaximo })
+    if (rechazo) {
+      setError(rechazo.mensaje)
+      return
+    }
+
+    registrandoRef.current = true
+    setRegistrando(true)
+    setError('')
+
+    // regla 3: bumpear la generación del ledger ANTES de la escritura.
+    onAntesDeEscribir()
+
+    try {
+      const solicitud = aSolicitudDePagoACuenta(idPuntoVenta, pagosCalculo, observaciones)
+      const comprobante = await clienteDeCuentaCorriente.registrarPago(idCliente, solicitud)
+      registrandoRef.current = false
+      setRegistrando(false)
+      // regla 6: el refetch del ledger vive en el padre, aislado de este try/catch.
+      onRegistrado(comprobante)
+    } catch (e) {
+      registrandoRef.current = false
+      setRegistrando(false)
+      if (e instanceof ErrorApi && e.codigo === 'turno_no_abierto') {
+        setGateTurno(true)
+      } else {
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo registrar el pago.')
+      }
+    }
+  }
+
+  return (
+    <>
+      <div className="modal d-block" tabIndex={-1} role="dialog">
+        <div className="modal-dialog modal-lg" role="document">
+          <div className="modal-content rounded-0">
+            {gateTurno ? (
+              <PanelAperturaDeTurnoEnModal idPuntoVenta={idPuntoVenta} onAbierto={() => setGateTurno(false)} onCancelar={onCerrar} />
+            ) : (
+              <>
+                <div className="modal-header">
+                  <h5 className="modal-title">Ingresar pago a cuenta</h5>
+                </div>
+                <div className="modal-body">
+                  {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+                  {errorParametros && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorParametros}</div>}
+
+                  <div className="mb-3" style={{ maxWidth: 320 }}>
+                    <label className="form-label" htmlFor="cc-pago-punto-venta">
+                      Punto de venta
+                    </label>
+                    <select
+                      id="cc-pago-punto-venta"
+                      className="form-select rounded-0"
+                      value={idPuntoVenta}
+                      disabled={registrando}
+                      onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
+                    >
+                      {puntosVenta.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.nombre}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {filas.map((fila) => {
+                    const medioDeFila = fila.idMedioPago === '' ? null : medioPorId[fila.idMedioPago]
+                    return (
+                      <div className="row g-2 align-items-end mb-2" key={fila.id}>
+                        <div className="col-md-3">
+                          <label className="form-label" htmlFor={`cc-pago-medio-${fila.id}`}>
+                            Medio de pago
+                          </label>
+                          <select
+                            id={`cc-pago-medio-${fila.id}`}
+                            className="form-select rounded-0"
+                            value={fila.idMedioPago}
+                            disabled={registrando}
+                            onChange={(e) =>
+                              actualizarFila(fila.id, { idMedioPago: e.target.value === '' ? '' : Number(e.target.value) })
+                            }
+                          >
+                            <option value="">Elegir…</option>
+                            {mediosFisicos.map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.nombre}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="col-md-2">
+                          <label className="form-label" htmlFor={`cc-pago-importe-${fila.id}`}>
+                            Importe
+                          </label>
+                          <input
+                            id={`cc-pago-importe-${fila.id}`}
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            className="form-control rounded-0"
+                            value={fila.importe}
+                            disabled={registrando}
+                            onChange={(e) => actualizarFila(fila.id, { importe: e.target.value })}
+                          />
+                        </div>
+                        <div className="col-md-3">
+                          <label className="form-label" htmlFor={`cc-pago-referencia-${fila.id}`}>
+                            Referencia{medioDeFila?.requiereReferencia ? ' (obligatoria)' : ''}
+                          </label>
+                          <input
+                            id={`cc-pago-referencia-${fila.id}`}
+                            type="text"
+                            className="form-control rounded-0"
+                            value={fila.referencia}
+                            disabled={registrando}
+                            onChange={(e) => actualizarFila(fila.id, { referencia: e.target.value })}
+                          />
+                        </div>
+                        <div className="col-md-2">
+                          <label className="form-label" htmlFor={`cc-pago-vuelto-${fila.id}`}>
+                            Vuelto
+                          </label>
+                          <input
+                            id={`cc-pago-vuelto-${fila.id}`}
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            className="form-control rounded-0"
+                            value={fila.vuelto}
+                            disabled={registrando || !medioDeFila?.admiteVuelto}
+                            onChange={(e) => actualizarFila(fila.id, { vuelto: e.target.value })}
+                          />
+                        </div>
+                        <div className="col-md-2">
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm rounded-0 w-100"
+                            disabled={registrando || filas.length === 1}
+                            onClick={() => quitarFila(fila.id)}
+                          >
+                            Quitar
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
+
+                  <button type="button" className="btn btn-outline-secondary btn-sm rounded-0 mb-3" disabled={registrando} onClick={agregarFila}>
+                    + Agregar otro medio
+                  </button>
+
+                  <div className="mb-3">
+                    <label className="form-label" htmlFor="cc-pago-observaciones">
+                      Observaciones
+                    </label>
+                    <input
+                      id="cc-pago-observaciones"
+                      type="text"
+                      className="form-control rounded-0"
+                      value={observaciones}
+                      disabled={registrando}
+                      onChange={(e) => setObservaciones(e.target.value)}
+                    />
+                  </div>
+
+                  <div className="row g-3">
+                    <div className="col-md-4">
+                      <div className="small text-muted">Importe aplicado</div>
+                      <div>{formatearMoneda(importeAplicado)}</div>
+                    </div>
+                    <div className="col-md-4">
+                      <div className="small text-muted">Saldo estimado tras el pago</div>
+                      <div>{formatearMoneda(saldoEstimado)}</div>
+                    </div>
+                    <div className="col-md-4">
+                      <div className="small text-muted">Disponibilidad estimada</div>
+                      <div>{formatearDisponibilidad(disponibilidadEstimada)}</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-outline-secondary rounded-0" disabled={registrando} onClick={onCerrar}>
+                    Cancelar
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-primary rounded-0"
+                    disabled={registrando || !parametros || pagosCalculo.length === 0}
+                    onClick={registrarPago}
+                  >
+                    {registrando ? 'Registrando…' : 'Registrar pago'}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop show" />
+    </>
+  )
+}
+
+type PropsPantalla = {
+  idCliente: number
+  clienteInfo: ClienteListado | null
+  medios: MedioPagoListado[] | null
+  errorMedios: string
+  puntosVenta: PuntoVentaListado[] | null
+  errorPuntosVenta: string
+}
+
+/** Remontada por `key={idCliente}` (regla 8) — ningún estado de acá (filtros, ledger, modal de
+ * pago) sobrevive a un cambio de cliente. */
+function PantallaCuentaCorriente({ idCliente, clienteInfo, medios, errorMedios, puntosVenta, errorPuntosVenta }: PropsPantalla) {
+  const [desde, setDesde] = useState('')
+  const [hasta, setHasta] = useState('')
+  const [historico, setHistorico] = useState(false)
+
+  const [estado, setEstado] = useState<EstadoDeCuenta | null>(null)
+  const [cargandoEstado, setCargandoEstado] = useState(true)
+  const [errorEstado, setErrorEstado] = useState('')
+  const generacionEstadoRef = useRef(0)
+
+  const [modalPagoAbierto, setModalPagoAbierto] = useState(false)
+  const [avisoPago, setAvisoPago] = useState('')
+
+  // regla 2: cada cambio de filtro dispara una nueva consulta — una respuesta desactualizada
+  // nunca puede pisar la más reciente.
+  const cargarEstado = useCallback(() => {
+    const miGeneracion = (generacionEstadoRef.current += 1)
+    setCargandoEstado(true)
+    setErrorEstado('')
+
+    clienteDeCuentaCorriente
+      .obtenerEstado(idCliente, desde, hasta, historico)
+      .then((datos) => {
+        if (generacionEstadoRef.current !== miGeneracion) return
+        setEstado(datos)
+      })
+      .catch((e) => {
+        if (generacionEstadoRef.current !== miGeneracion) return
+        setEstado(null)
+        setErrorEstado(e instanceof ErrorApi ? e.message : 'No se pudo cargar el estado de cuenta.')
+      })
+      .finally(() => {
+        if (generacionEstadoRef.current !== miGeneracion) return
+        setCargandoEstado(false)
+      })
+  }, [idCliente, desde, hasta, historico])
+
+  useEffect(() => {
+    cargarEstado()
+  }, [cargarEstado])
+
+  const esConsumidorFinal = clienteInfo?.esConsumidorFinal ?? false
+  const puedeIngresarPago =
+    medios !== null && errorMedios === '' && puntosVenta !== null && errorPuntosVenta === '' && puntosVenta.length > 0 && !esConsumidorFinal
+
+  let motivoBloqueoPago: string | undefined
+  if (esConsumidorFinal) {
+    motivoBloqueoPago = 'El Consumidor Final no tiene cuenta corriente.'
+  } else if (!puedeIngresarPago) {
+    motivoBloqueoPago = 'No se pudieron cargar los datos necesarios para registrar un pago.'
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={`Estado de cuenta — ${nombreDeCliente(idCliente, clienteInfo)}`}
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/clientes">
+            Volver a clientes
+          </Link>
+        }
+      >
+        {avisoPago && <div className="alert alert-success rounded-0">{avisoPago}</div>}
+        {errorEstado && <div className="alert alert-danger rounded-0">{errorEstado}</div>}
+        {(errorMedios || errorPuntosVenta) && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorMedios || errorPuntosVenta} No se puede ingresar un pago hasta que esto se resuelva.
+          </div>
+        )}
+
+        {cargandoEstado && !estado && <Cargando />}
+
+        {estado && (
+          <>
+            <div className="row g-3 mb-3 align-items-end">
+              <div className="col-md-3">
+                <div className="small text-muted">Saldo</div>
+                <div className="fs-5">{formatearMoneda(estado.header.saldo)}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="small text-muted">Límite de crédito</div>
+                <div>{estado.header.creditoIlimitado ? 'Ilimitado' : formatearMoneda(estado.header.limiteCredito)}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="small text-muted">Disponibilidad</div>
+                <div>{formatearDisponibilidad(estado.header.disponibilidad)}</div>
+              </div>
+              <div className="col-md-3 text-md-end">
+                <button
+                  type="button"
+                  className="btn btn-primary rounded-0"
+                  disabled={!puedeIngresarPago}
+                  title={motivoBloqueoPago}
+                  onClick={() => {
+                    setAvisoPago('')
+                    setModalPagoAbierto(true)
+                  }}
+                >
+                  Ingresar pago
+                </button>
+              </div>
+            </div>
+
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="cc-filtro-desde">
+                  Desde
+                </label>
+                <input
+                  id="cc-filtro-desde"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={desde}
+                  disabled={historico}
+                  onChange={(e) => setDesde(e.target.value)}
+                />
+              </div>
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="cc-filtro-hasta">
+                  Hasta
+                </label>
+                <input
+                  id="cc-filtro-hasta"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={hasta}
+                  disabled={historico}
+                  onChange={(e) => setHasta(e.target.value)}
+                />
+              </div>
+              <div className="col-md-3">
+                <div className="form-check">
+                  <input
+                    id="cc-filtro-historico"
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={historico}
+                    onChange={(e) => setHistorico(e.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="cc-filtro-historico">
+                    Ver histórico completo
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            {cargandoEstado && <p className="text-muted">Actualizando…</p>}
+
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Tipo</th>
+                    <th>Detalle</th>
+                    <th className="text-end">Importe</th>
+                    <th className="text-end">Saldo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {estado.movimientos.map((m) => (
+                    <tr key={m.id}>
+                      <td>{formatearFechaHora(m.fecha)}</td>
+                      <td>{etiquetaDeMovimiento(m)}</td>
+                      <td>{m.detalle ?? '—'}</td>
+                      <td className="text-end">{formatearMoneda(m.importe)}</td>
+                      <td className="text-end">{formatearMoneda(m.saldoResultante)}</td>
+                    </tr>
+                  ))}
+                  {estado.movimientos.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="text-center text-muted py-4">
+                        No hay movimientos en el período seleccionado.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </Box>
+
+      {modalPagoAbierto && estado && medios && puntosVenta && (
+        <ModalPagoACuenta
+          idCliente={idCliente}
+          puntosVenta={puntosVenta}
+          medios={medios}
+          header={estado.header}
+          onCerrar={() => setModalPagoAbierto(false)}
+          onAntesDeEscribir={() => {
+            generacionEstadoRef.current += 1
+          }}
+          onRegistrado={(comprobante) => {
+            setModalPagoAbierto(false)
+            setAvisoPago(`Pago registrado: comprobante ${comprobante.numeroVisible}.`)
+            // regla 6: el refetch queda aislado del try/catch de la escritura del modal — si
+            // falla, no pisa el aviso de éxito de arriba (solo el propio error de carga del
+            // ledger, que ya tiene su mensaje distinguible).
+            cargarEstado()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Pantalla de estado de cuenta (stage-7-cuenta-corriente, Slice 5, design: Web Composition):
+ * header (saldo/acuerdo/disponibilidad), ledger newest-first con filtros desde/hasta/histórico y
+ * el modal de pago a cuenta. Entrada desde una fila de `Clientes.tsx` (`Politicas.OperacionDePos`
+ * — todo rol opera, a diferencia de `/clientes` que es admin-only: un Vendedor llega acá por URL
+ * directa, no todavía desde una acción de `Clientes.tsx`).
+ */
+export function CuentaCorriente() {
+  const { id } = useParams<{ id: string }>()
+  const idCliente = Number(id)
+  const idClienteValido = id !== undefined && Number.isFinite(idCliente)
+
+  const location = useLocation()
+  const clienteInfo = (location.state as { cliente?: ClienteListado } | null)?.cliente ?? null
+
+  const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
+  const [errorMedios, setErrorMedios] = useState('')
+
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+
+    clienteMediosPago
+      .listar(false)
+      .then((lista) => {
+        if (!vigente) return
+        setMedios(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setMedios([])
+        setErrorMedios(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los medios de pago.')
+      })
+
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  if (!idClienteValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Estado de cuenta" variante="warning">
+          <p className="text-muted">No se especificó el cliente.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/clientes">
+            Volver a clientes
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return (
+    <PantallaCuentaCorriente
+      key={idCliente}
+      idCliente={idCliente}
+      clienteInfo={clienteInfo}
+      medios={medios}
+      errorMedios={errorMedios}
+      puntosVenta={puntosVenta}
+      errorPuntosVenta={errorPuntosVenta}
+    />
+  )
+}


### PR DESCRIPTION
## Resumen

Slice 5/6 de la etapa 7: el estado de cuenta llega a la pantalla — el F4 del legacy con el saldo del D6 por fin destrabado.

- `CuentaCorriente.tsx` (ruta `/clientes/:id/cuenta-corriente`, `OperacionDePos`): header saldo/acuerdo/disponibilidad ("Ilimitado" para null), ledger newest-first con saldo corrido leído verbatim, filtros con la ventana SIEMPRE visible (último mes pre-poblado con semántica AddMonths-clamp, histórico explícito en ambas direcciones), y el modal "Ingresar pago" (solo medios físicos, preview de saldo resultante, recuperación de `turno_no_abierto` con el patrón del POS — regla 10 aplicada, self-heal en la carrera incluido).
- **Identidad del cliente fail-closed**: sin router state (el camino del Vendedor), la pantalla fetchea `GET /clientes/{id}` con generación; nombre real en el header y el gate de Consumidor Final verificado — el botón de pago se deshabilita mientras carga Y ante error, con aviso visible.
- **Fechas con offset explícito del browser**: los filtros viajan con `-03:00` real — una venta de las 22:00 aparece en el "hoy" del cajero, no en el del server UTC.
- Espejo completo del validador de 7 reglas en el mismo orden que el server.

## Verificación

- vitest 279/279 (x2), tsc/oxlint/vite build limpios. Cero archivos backend.
- Judgment-day — el loop más largo de la corrida, funcionando por diseño: ronda 1 (4 MAJORs: timezone, identidad/CF por router state, ventana invisible, + minors), ronda 2 sobre los fixes (2 BLOCKERs cazados DENTRO de los fixes: overflow de fin de mes en `rangoUltimoMes` y el gate CF fallando abierto en el error del fetch; + test circular del offset), ronda 3 (los 4 prescriptos aplicados con doble evidencia de mutación; dos tests preexistentes que dependían del bug quedaron honestos). Cierre verificado por el orquestador contra las prescripciones.
- Bandera de producto para el owner: el único punto de entrada de UI (`/clientes`) es Admin-only mientras la pantalla es `OperacionDePos` — el Vendedor llega por URL directa; documentado, decisión de navegación pendiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)