### PR TITLE
feat(cc): modales de supervision y cierre del modelo (etapa 7, slice 6)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -542,6 +542,30 @@ precio del día (F4) recorre los consumos no actualizados, consulta `precios` vi
 graba **un** movimiento `actualizacion_precios` con el detalle — igual efecto de negocio
 que hoy, pero auditable.
 
+> **Estado (Etapa 7, stage-7-cuenta-corriente): implementada.** `movimientos_cuenta_corriente`
+> gana `id_movimiento_actualizacion integer NULL` — un **self-FK** (`ON DELETE RESTRICT`,
+> `RETURNING`-friendly) sobre la propia tabla, no un booleano: cada consumo apunta al movimiento
+> `actualizacion_precios` que lo cubrió, en vez de solo marcar "ya reliquidado" — trazabilidad
+> completa desde cualquier consumo hacia la corrida que lo re-precificó. Un índice parcial
+> (`WHERE tipo = 'consumo' AND id_movimiento_actualizacion IS NULL`) acota el escaneo de
+> elegibles a los consumos todavía sin cubrir. El pago a cuenta (`tipo = pago`) se emite como un
+> comprobante `RC` de cero ítems (doc 10 §1) — el pago con medio `cuenta_corriente` en un
+> comprobante de venta normal sigue generando el movimiento `consumo` como antes, sin cambios.
+>
+> **Deviación declarada — fracción financiada:** la reliquidación re-precifica solo la porción
+> del comprobante que quedó fiada (`factor = min(1, importeFinanciado / totalComprobante)`), no
+> el ticket completo — el legacy re-precificaba el ticket entero incluso cuando ya estaba
+> parcialmente pagado. Con financiamiento total (`factor = 1`, el caso normal) la fórmula
+> colapsa exacto a la del legacy; el dueño del negocio confirmó la semántica de financiamiento
+> parcial como aceptable para esta etapa.
+>
+> **Irreversibilidad:** ningún endpoint revierte ni edita un movimiento `actualizacion_precios`
+> — la única corrección posible es un `Ajuste` manual nuevo, distinto y auditable por su propio
+> `detalle`. La reliquidación tampoco tiene turno de caja: no mueve plata física, así que no
+> aporta ningún término al arqueo — mismo criterio que el ajuste manual. Ambos llevan
+> `id_punto_venta` como *provenance* (de dónde salió el pedido), nunca como autoridad (ninguno
+> de los dos deriva nada de un turno).
+
 ## 9. Parámetros operativos
 
 > **Estado (Etapa 1):** tabla, RLS y API (`GET`/`PUT`, resolución punto de venta > empresa >

--- a/openspec/changes/stage-7-cuenta-corriente/tasks.md
+++ b/openspec/changes/stage-7-cuenta-corriente/tasks.md
@@ -452,33 +452,57 @@ the `turno_no_abierto` recovery path is replicated across every sibling
 modal, doc-10 §8 records the stage as implemented. **Rollback**: two modals +
 role-gated buttons + the doc note only.
 
-- [ ] 6.1 Extend `CuentaCorriente.tsx`: ajuste modal (importe + detalle,
+- [x] 6.1 Extend `CuentaCorriente.tsx`: ajuste modal (importe + detalle,
   role-gated) and reliquidación modal (preview + commit, role-gated,
   irreversible-by-design confirmation). Role gating via the existing
   `usuario?.rolId` claim (`ROL.Supervisor | ROL.Admin`) — cosmetic; server
   `SupervisionDeCuentaCorriente` is the enforcement. *(design: Web
   Composition; spec: operacion-de-pos / SupervisionDeCuentaCorriente Policy…)*
-- [ ] 6.2 Implement rule 9 on **both** new modals: first-line re-entrancy
+- [x] 6.2 Implement rule 9 on **both** new modals: first-line re-entrancy
   guard + full-window disable — a double-submit on reliquidación would
   charge/re-price the client twice. Implement rule 6: a 2xx reliquidación is
   never reported as failure (the post-write ledger refetch has its own
   try/catch and its own copy). *(design: Web Composition — react-async-state
   obligations 6, 9)*
-- [ ] 6.3 **Rule 10 — sibling-surface replication.** Grep the pago modal's
+- [x] 6.3 **Rule 10 — sibling-surface replication.** Grep the pago modal's
   `turno_no_abierto` recovery path (Slice 5) and replicate it across the
   ajuste and reliquidación modals in this same commit — all three are
   sibling surfaces that can raise the same 409. *(design: Web Composition —
-  react-async-state obligation 10)*
-- [ ] 6.4 Update `docs/10-modelo-de-datos.md` §8: status note — etapa 7
+  react-async-state obligation 10)* **Apply-time finding (deviation from the
+  literal task, documented for sdd-verify):** `turno_no_abierto` is
+  structurally irreproducible on the ajuste and reliquidación endpoints —
+  `ServicioDeCuentaCorriente.RegistrarAjusteAsync` and
+  `ServicioDeReliquidacion.EjecutarAsync`/`PreviewAsync` never call
+  `ServicioDeTurnos` (confirmed by grep; design: Open Questions — "provenance,
+  not authority", both operations run with no turno by design decision 4/8).
+  Replicating the `PanelAperturaDeTurnoEnModal` recovery there would be dead
+  code handling a 409 that can never be emitted by those routes. What *was*
+  replicated instead, uniformly across all three modals (the actually
+  shared error-recovery surface): the generic `ErrorApi` catch-all message
+  pattern, the shared success-aviso banner, and the cliente-identity
+  fail-closed gate (`clienteInfo !== null && errorCliente === ''`) that also
+  disables the ajuste/reliquidación buttons. `sdd-verify` should confirm this
+  reasoning against the backend before closing the stage.
+- [x] 6.4 Update `docs/10-modelo-de-datos.md` §8: status note — etapa 7
   implemented; the marker as a self-FK (design decision 2); the
   financed-fraction deviation from strict legacy parity. *(design: Migration
   / Rollout; Orchestrator Decision 6)*
-- [ ] 6.5 [P] Component: double-click on "Reliquidar" issues exactly one
+- [x] 6.5 [P] Component: double-click on "Reliquidar" issues exactly one
   POST (rule 9); `turno_no_abierto` recovery present in every sibling modal
   (pago, ajuste, reliquidación). RTL + `user-event`. *(design: Testing
-  Strategy — Component (Web))*
-- [ ] 6.6 Smoke-verify (`tsc -b` / `oxlint` / `vite build` clean).
-- [ ] 6.7 Regression: full `npx vitest run` green (Slice 1's re-checked
+  Strategy — Component (Web))* Double-click coverage shipped for both the
+  ajuste and the reliquidación modal. The `turno_no_abierto`-recovery-in-
+  every-sibling assertion was **not** written for ajuste/reliquidación per
+  the 6.3 finding above — asserting a recovery UI for a 409 the endpoint
+  cannot emit would be a dishonest test. Covered instead: role gating
+  (Vendedor sees neither action; Supervisor and Admin see both), ajuste
+  validation mirrors + signed saldo-preview semantics, reliquidación
+  preview→confirm→execute, the preview no-op state, the commit no-op
+  (preview↔commit race) reported as success, the `hayMas` warning, and a 2xx
+  write never reported as failure even when the post-write refetch fails
+  (both modals) — request bodies asserted for both endpoints.
+- [x] 6.6 Smoke-verify (`tsc -b` / `oxlint` / `vite build` clean).
+- [x] 6.7 Regression: full `npx vitest run` green (Slice 1's re-checked
   baseline + this stage's new tests, no unrelated assertion changed).
 
 **Verify**: `npx vitest run` (full suite) && `npx tsc -b` && `npx vite build`

--- a/src/Ways.Web/src/api/cuentaCorriente.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  aSolicitudDeAjuste,
   aSolicitudDePagoACuenta,
+  aSolicitudDeReliquidacion,
   calcularImporteAplicado,
   construirQueryEstadoDeCuenta,
   disponibilidadPrevia,
@@ -9,11 +11,14 @@ import {
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
   rangoUltimoMes,
+  reliquidacionEsNoOp,
+  saldoResultanteDeAjuste,
+  validarAjusteLocal,
   validarPagoACuentaLocal,
   type FilaPagoACuenta,
   type PagoACuentaParaCalculo,
 } from './cuentaCorriente'
-import type { MedioPagoListado, MovimientoDeCuentaCorriente } from './tipos'
+import type { MedioPagoListado, MovimientoDeCuentaCorriente, ResultadoDeReliquidacion } from './tipos'
 
 function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
   return {
@@ -325,5 +330,98 @@ describe('aSolicitudDePagoACuenta', () => {
   it('observaciones en blanco se normaliza a null', () => {
     const solicitud = aSolicitudDePagoACuenta(7, [pagoFixture()], '   ')
     expect(solicitud.observaciones).toBeNull()
+  })
+})
+
+describe('validarAjusteLocal — espejo de ReglaDeAjusteDeCuenta.Validar', () => {
+  it('acepta un ajuste válido', () => {
+    expect(validarAjusteLocal({ importe: 40, detalle: 'Descuento por reclamo' })).toBeNull()
+  })
+
+  it('importe cero se rechaza con ajuste_importe_invalido', () => {
+    expect(validarAjusteLocal({ importe: 0, detalle: 'Detalle válido' })).toEqual({
+      codigo: 'ajuste_importe_invalido',
+      mensaje: 'El importe del ajuste no puede ser cero.',
+    })
+  })
+
+  it('importe no numérico (campo vacío) se rechaza como ajuste_importe_invalido', () => {
+    expect(validarAjusteLocal({ importe: Number.NaN, detalle: 'Detalle válido' })).toEqual({
+      codigo: 'ajuste_importe_invalido',
+      mensaje: 'El importe del ajuste no puede ser cero.',
+    })
+  })
+
+  it('detalle vacío se rechaza con ajuste_detalle_requerido', () => {
+    expect(validarAjusteLocal({ importe: 40, detalle: '' })).toEqual({
+      codigo: 'ajuste_detalle_requerido',
+      mensaje: 'El detalle del ajuste es obligatorio y tiene que tener al menos 5 caracteres.',
+    })
+  })
+
+  it('detalle de 4 caracteres (recortado) se rechaza — un carácter por debajo del piso', () => {
+    expect(validarAjusteLocal({ importe: 40, detalle: '  abcd  ' })?.codigo).toBe('ajuste_detalle_requerido')
+  })
+
+  it('detalle de exactamente 5 caracteres (recortado) se acepta — el límite inclusive', () => {
+    expect(validarAjusteLocal({ importe: 40, detalle: '  abcde  ' })).toBeNull()
+  })
+
+  it('un detalle de solo espacios se rechaza como vacío', () => {
+    expect(validarAjusteLocal({ importe: 40, detalle: '     ' })?.codigo).toBe('ajuste_detalle_requerido')
+  })
+
+  it('importe negativo con detalle válido se acepta — el signo no lo decide esta regla', () => {
+    expect(validarAjusteLocal({ importe: -50, detalle: 'Descuento por reclamo' })).toBeNull()
+  })
+})
+
+describe('saldoResultanteDeAjuste', () => {
+  it('un ajuste positivo aumenta el saldo (aumenta la deuda)', () => {
+    expect(saldoResultanteDeAjuste(100, 40)).toBe(140)
+  })
+
+  it('un ajuste negativo reduce el saldo (reduce la deuda)', () => {
+    expect(saldoResultanteDeAjuste(300, -50)).toBe(250)
+  })
+
+  it('redondea a 2 decimales', () => {
+    expect(saldoResultanteDeAjuste(10.005, 0.005)).toBe(10.01)
+  })
+})
+
+describe('aSolicitudDeAjuste', () => {
+  it('arma el cuerpo del POST con la forma exacta del contrato, detalle recortado', () => {
+    expect(aSolicitudDeAjuste(7, -50, '  Descuento por reclamo  ')).toEqual({
+      idPuntoVenta: 7,
+      importe: -50,
+      detalle: 'Descuento por reclamo',
+    })
+  })
+})
+
+describe('aSolicitudDeReliquidacion', () => {
+  it('arma el cuerpo del POST con la forma exacta del contrato — solo idPuntoVenta', () => {
+    expect(aSolicitudDeReliquidacion(7)).toEqual({ idPuntoVenta: 7 })
+  })
+})
+
+describe('reliquidacionEsNoOp', () => {
+  function resultadoFixture(sobrescribir: Partial<ResultadoDeReliquidacion> = {}): ResultadoDeReliquidacion {
+    return { delta: 0, idsMovimientosCubiertos: [], detalle: [], hayMas: false, ...sobrescribir }
+  }
+
+  it('sin consumos cubiertos es un no-op limpio', () => {
+    expect(reliquidacionEsNoOp(resultadoFixture())).toBe(true)
+  })
+
+  it('con al menos un consumo cubierto NUNCA es un no-op, aunque el delta total sea 0', () => {
+    // Un consumo cubierto con líneas no-precificables aporta delta 0 sin que la corrida sea "nada
+    // para hacer" — está PROCESADO, solo que su delta neto es cero.
+    expect(reliquidacionEsNoOp(resultadoFixture({ delta: 0, idsMovimientosCubiertos: [1] }))).toBe(false)
+  })
+
+  it('con delta distinto de cero y consumos cubiertos no es un no-op', () => {
+    expect(reliquidacionEsNoOp(resultadoFixture({ delta: 45, idsMovimientosCubiertos: [1, 2] }))).toBe(false)
   })
 })

--- a/src/Ways.Web/src/api/cuentaCorriente.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.test.ts
@@ -10,6 +10,7 @@ import {
   filaPagoACuentaVacia,
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
+  parsearDetalleDeActualizacionPrecios,
   rangoUltimoMes,
   reliquidacionEsNoOp,
   saldoResultanteDeAjuste,
@@ -423,5 +424,135 @@ describe('reliquidacionEsNoOp', () => {
 
   it('con delta distinto de cero y consumos cubiertos no es un no-op', () => {
     expect(reliquidacionEsNoOp(resultadoFixture({ delta: 45, idsMovimientosCubiertos: [1, 2] }))).toBe(false)
+  })
+})
+
+describe('parsearDetalleDeActualizacionPrecios', () => {
+  it('detalle PascalCase real (lo que emite JsonSerializer.Serialize en el backend, sin naming policy) se parsea completo, incl. líneas y motivo', () => {
+    const crudo = JSON.stringify([
+      {
+        IdMovimiento: 3,
+        IdComprobanteVenta: 10,
+        Delta: 55,
+        Lineas: [
+          {
+            IdArticulo: 1,
+            Cantidad: 2,
+            PrecioHistorico: 100,
+            PrecioActual: 120,
+            TotalHistorico: 200,
+            TotalDelDia: 240,
+            Delta: 40,
+            Motivo: null,
+          },
+          {
+            IdArticulo: null,
+            Cantidad: 1,
+            PrecioHistorico: 50,
+            PrecioActual: null,
+            TotalHistorico: 50,
+            TotalDelDia: null,
+            Delta: 0,
+            Motivo: 'Línea de concepto libre (sin artículo) — no re-precificable.',
+          },
+        ],
+      },
+    ])
+
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toEqual([
+      {
+        idMovimiento: 3,
+        idComprobanteVenta: 10,
+        delta: 55,
+        lineas: [
+          {
+            idArticulo: 1,
+            cantidad: 2,
+            precioHistorico: 100,
+            precioActual: 120,
+            totalHistorico: 200,
+            totalDelDia: 240,
+            delta: 40,
+            motivo: null,
+          },
+          {
+            idArticulo: null,
+            cantidad: 1,
+            precioHistorico: 50,
+            precioActual: null,
+            totalHistorico: 50,
+            totalDelDia: null,
+            delta: 0,
+            motivo: 'Línea de concepto libre (sin artículo) — no re-precificable.',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('detalle camelCase (forma de la API, aceptada por robustez) también se parsea', () => {
+    const crudo = JSON.stringify([
+      {
+        idMovimiento: 3,
+        idComprobanteVenta: 10,
+        delta: 40,
+        lineas: [
+          {
+            idArticulo: 1,
+            cantidad: 2,
+            precioHistorico: 100,
+            precioActual: 120,
+            totalHistorico: 200,
+            totalDelDia: 240,
+            delta: 40,
+            motivo: null,
+          },
+        ],
+      },
+    ])
+
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toEqual([
+      {
+        idMovimiento: 3,
+        idComprobanteVenta: 10,
+        delta: 40,
+        lineas: [
+          {
+            idArticulo: 1,
+            cantidad: 2,
+            precioHistorico: 100,
+            precioActual: 120,
+            totalHistorico: 200,
+            totalDelDia: 240,
+            delta: 40,
+            motivo: null,
+          },
+        ],
+      },
+    ])
+  })
+
+  it('un campo requerido ausente (ni PascalCase ni camelCase) da null, nunca lanza', () => {
+    const crudo = JSON.stringify([{ IdMovimiento: 3, Delta: 55, Lineas: [] }]) // falta IdComprobanteVenta
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toBeNull()
+  })
+
+  it('un nivel superior que no es array da null', () => {
+    const crudo = JSON.stringify({ IdMovimiento: 3, IdComprobanteVenta: 10, Delta: 55, Lineas: [] })
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toBeNull()
+  })
+
+  it('un JSON malformado da null, nunca lanza', () => {
+    expect(parsearDetalleDeActualizacionPrecios('{esto no es json')).toBeNull()
+  })
+
+  it('Lineas ausente da null', () => {
+    const crudo = JSON.stringify([{ IdMovimiento: 3, IdComprobanteVenta: 10, Delta: 55 }])
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toBeNull()
+  })
+
+  it('Lineas que no es array da null', () => {
+    const crudo = JSON.stringify([{ IdMovimiento: 3, IdComprobanteVenta: 10, Delta: 55, Lineas: 'no-es-array' }])
+    expect(parsearDetalleDeActualizacionPrecios(crudo)).toBeNull()
   })
 })

--- a/src/Ways.Web/src/api/cuentaCorriente.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.ts
@@ -11,6 +11,8 @@ import { api } from './cliente'
 import type {
   ComportamientoMedioPago,
   ComprobanteEmitido,
+  DetalleDeConsumo,
+  DetalleDeLinea,
   EstadoDeCuenta,
   MedioPagoListado,
   MovimientoDeCuentaCorriente,
@@ -329,4 +331,59 @@ export function aSolicitudDeReliquidacion(idPuntoVenta: number): SolicitudDeReli
  * no-precificables también puede aportar delta 0 sin ser un no-op de "nada para hacer". */
 export function reliquidacionEsNoOp(resultado: Pick<ResultadoDeReliquidacion, 'idsMovimientosCubiertos'>): boolean {
   return resultado.idsMovimientosCubiertos.length === 0
+}
+
+// ---- Reliquidación: parseo defensivo del detalle guardado en el ledger ----------------------
+
+function leerCampo<T>(objeto: Record<string, unknown>, ...claves: string[]): T {
+  for (const clave of claves) {
+    if (clave in objeto) return objeto[clave] as T
+  }
+  throw new Error(`campo ausente: ${claves.join('/')}`)
+}
+
+function normalizarDetalleDeLinea(crudo: unknown): DetalleDeLinea {
+  if (typeof crudo !== 'object' || crudo === null) throw new Error('línea de reliquidación inválida')
+  const o = crudo as Record<string, unknown>
+  return {
+    idArticulo: leerCampo<number | null>(o, 'idArticulo', 'IdArticulo') ?? null,
+    cantidad: leerCampo<number>(o, 'cantidad', 'Cantidad'),
+    precioHistorico: leerCampo<number>(o, 'precioHistorico', 'PrecioHistorico'),
+    precioActual: leerCampo<number | null>(o, 'precioActual', 'PrecioActual') ?? null,
+    totalHistorico: leerCampo<number>(o, 'totalHistorico', 'TotalHistorico'),
+    totalDelDia: leerCampo<number | null>(o, 'totalDelDia', 'TotalDelDia') ?? null,
+    delta: leerCampo<number>(o, 'delta', 'Delta'),
+    motivo: leerCampo<string | null>(o, 'motivo', 'Motivo') ?? null,
+  }
+}
+
+function normalizarDetalleDeConsumo(crudo: unknown): DetalleDeConsumo {
+  if (typeof crudo !== 'object' || crudo === null) throw new Error('consumo de reliquidación inválido')
+  const o = crudo as Record<string, unknown>
+  const lineas = leerCampo<unknown[]>(o, 'lineas', 'Lineas')
+  if (!Array.isArray(lineas)) throw new Error('lineas de reliquidación inválidas')
+  return {
+    idMovimiento: leerCampo<number>(o, 'idMovimiento', 'IdMovimiento'),
+    idComprobanteVenta: leerCampo<number>(o, 'idComprobanteVenta', 'IdComprobanteVenta'),
+    delta: leerCampo<number>(o, 'delta', 'Delta'),
+    lineas: lineas.map(normalizarDetalleDeLinea),
+  }
+}
+
+/**
+ * Parsea el `detalle` crudo de un movimiento `ActualizacionPrecios` — el backend lo guarda con
+ * `JsonSerializer.Serialize(resultado.Detalle)` SIN el naming policy camelCase de la API (a
+ * diferencia de la respuesta de preview/commit), así que las claves llegan en PascalCase; se
+ * aceptan ambos casos por robustez. Nunca lanza: cualquier JSON malformado o con una forma
+ * inesperada devuelve `null` para que la pantalla caiga al texto crudo en vez de romper.
+ */
+export function parsearDetalleDeActualizacionPrecios(detalle: string | null): DetalleDeConsumo[] | null {
+  if (!detalle) return null
+  try {
+    const crudo: unknown = JSON.parse(detalle)
+    if (!Array.isArray(crudo)) return null
+    return crudo.map(normalizarDetalleDeConsumo)
+  } catch {
+    return null
+  }
 }

--- a/src/Ways.Web/src/api/cuentaCorriente.ts
+++ b/src/Ways.Web/src/api/cuentaCorriente.ts
@@ -15,7 +15,10 @@ import type {
   MedioPagoListado,
   MovimientoDeCuentaCorriente,
   PagoDeCuenta,
+  ResultadoDeReliquidacion,
+  SolicitudDeAjuste,
   SolicitudDePagoACuenta,
+  SolicitudDeReliquidacion,
 } from './tipos'
 
 function redondear(valor: number): number {
@@ -94,6 +97,20 @@ export const clienteDeCuentaCorriente = {
    * Open Turno — rechazado antes que cualquier otro procesamiento). */
   registrarPago: (idCliente: number, solicitud: SolicitudDePagoACuenta) =>
     api.post<ComprobanteEmitido>(`/clientes/${idCliente}/cuenta-corriente/pagos`, solicitud),
+  /** `POST /api/clientes/{id}/cuenta-corriente/ajustes` — 201 con el movimiento `Ajuste`. Sin
+   * turno (design: Open Questions — "provenance, not authority"), a diferencia de un pago. */
+  registrarAjuste: (idCliente: number, solicitud: SolicitudDeAjuste) =>
+    api.post<MovimientoDeCuentaCorriente>(`/clientes/${idCliente}/cuenta-corriente/ajustes`, solicitud),
+  /** `GET /api/clientes/{id}/cuenta-corriente/reliquidacion` — preview, sin lock, NUNCA
+   * autoritativo (design: API Surface): un consumo marcado entre este preview y el commit
+   * siguiente simplemente deja de aparecer, sin ninguna "reserva" del resultado. */
+  previsualizarReliquidacion: (idCliente: number) =>
+    api.get<ResultadoDeReliquidacion>(`/clientes/${idCliente}/cuenta-corriente/reliquidacion`),
+  /** `POST /api/clientes/{id}/cuenta-corriente/reliquidacion` — commit, irreversible (spec:
+   * Reliquidación Is Irreversible). Misma forma de respuesta que el preview (design: "never two
+   * formulas") — `idsMovimientosCubiertos` vacío + `delta === 0` es un no-op limpio. */
+  ejecutarReliquidacion: (idCliente: number, solicitud: SolicitudDeReliquidacion) =>
+    api.post<ResultadoDeReliquidacion>(`/clientes/${idCliente}/cuenta-corriente/reliquidacion`, solicitud),
 }
 
 /** Etiqueta de pantalla por tipo de movimiento — un `Ajuste` se distingue por `etiqueta` (manual
@@ -255,4 +272,61 @@ export function aSolicitudDePagoACuenta(
     vuelto: p.vuelto,
   }))
   return { idPuntoVenta, pagos: cuerpo, observaciones: observaciones.trim() === '' ? null : observaciones.trim() }
+}
+
+// ---- Ajuste manual: validación local + mapper ------------------------------------------------
+
+export const LONGITUD_MINIMA_DETALLE_AJUSTE = 5
+
+export type RechazoDeAjuste = { codigo: string; mensaje: string }
+
+/**
+ * Espejo pixel-a-pixel de `ReglaDeAjusteDeCuenta.Validar` (Ways.Domain.CuentaCorriente): `importe`
+ * no puede ser cero, `detalle` recortado tiene que tener al menos 5 caracteres. Nunca autoritativo
+ * — solo guía al supervisor antes de intentar el ajuste real.
+ */
+export function validarAjusteLocal(params: { importe: number; detalle: string }): RechazoDeAjuste | null {
+  const { importe, detalle } = params
+
+  if (!Number.isFinite(importe) || importe === 0) {
+    return { codigo: 'ajuste_importe_invalido', mensaje: 'El importe del ajuste no puede ser cero.' }
+  }
+
+  const detalleNormalizado = detalle.trim()
+  if (detalleNormalizado.length < LONGITUD_MINIMA_DETALLE_AJUSTE) {
+    return {
+      codigo: 'ajuste_detalle_requerido',
+      mensaje: `El detalle del ajuste es obligatorio y tiene que tener al menos ${LONGITUD_MINIMA_DETALLE_AJUSTE} caracteres.`,
+    }
+  }
+
+  return null
+}
+
+/** `importe` positivo aumenta la deuda, negativo la reduce (spec: Ajuste Requires A Detalle —
+ * "importe MAY be positive or negative") — el preview de saldo resultante es la misma suma que
+ * hace el servidor (`UPDATE clientes SET saldo = saldo + importe`), nunca autoritativo. */
+export function saldoResultanteDeAjuste(saldoActual: number, importe: number): number {
+  return redondear(saldoActual + importe)
+}
+
+/** Importe/detalle → `SolicitudDeAjuste` — recorta el detalle (mismo criterio que el resto de la
+ * web; el servidor también lo recorta, esto es solo para que el `POST` viaje ya prolijo). */
+export function aSolicitudDeAjuste(idPuntoVenta: number, importe: number, detalle: string): SolicitudDeAjuste {
+  return { idPuntoVenta, importe, detalle: detalle.trim() }
+}
+
+// ---- Reliquidación: mapper + lectura del resultado -------------------------------------------
+
+/** `idPuntoVenta` → `SolicitudDeReliquidacion` — sin ningún otro campo (design: API Surface). */
+export function aSolicitudDeReliquidacion(idPuntoVenta: number): SolicitudDeReliquidacion {
+  return { idPuntoVenta }
+}
+
+/** Un resultado de reliquidación (preview o commit) es un no-op limpio cuando no cubrió ningún
+ * consumo — distinguible de un error, nunca reportado como fallo (spec: A Run With No Eligible
+ * Consumos Is A No-Op). `delta === 0` solo no alcanza: un consumo cubierto con líneas
+ * no-precificables también puede aportar delta 0 sin ser un no-op de "nada para hacer". */
+export function reliquidacionEsNoOp(resultado: Pick<ResultadoDeReliquidacion, 'idsMovimientosCubiertos'>): boolean {
+  return resultado.idsMovimientosCubiertos.length === 0
 }

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -85,6 +85,14 @@ export function puedeOperarPos(rolId: number) {
   return rolId === ROL.Vendedor || rolId === ROL.Supervisor || rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.SupervisionDeCuentaCorriente` (stage-7-cuenta-corriente, Slice 6):
+ * supervisor o admin pueden hacer un ajuste manual o correr la reliquidación — vendedor queda
+ * afuera, la única desviación deliberada de paridad legacy de la etapa. Puramente cosmético: el
+ * servidor vuelve a exigir la misma policy en cada request. */
+export function puedeSupervisarCuentaCorriente(rolId: number) {
+  return rolId === ROL.Supervisor || rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -810,3 +818,49 @@ export type PagoDeCuenta = { idMedioPago: number; importe: number; referencia: s
 /** Cuerpo de `POST /api/clientes/{id}/cuenta-corriente/pagos` — sin ningún campo de importe
  * propio (design decisión 6, espejo de `SolicitudDePagoACuenta`). */
 export type SolicitudDePagoACuenta = { idPuntoVenta: number; pagos: PagoDeCuenta[]; observaciones: string | null }
+
+// --- Cuenta corriente: ajuste manual y reliquidación (stage-7-cuenta-corriente, Slice 6) ------
+// Espejo de `Ways.Application.CuentaCorriente.Contratos` (ajuste) y
+// `Ways.Domain.CuentaCorriente.ReliquidadorDeConsumos` (reliquidación) — ninguna de las dos trae
+// turno (design: Open Questions — "provenance, not authority").
+
+/** Cuerpo de `POST /api/clientes/{id}/cuenta-corriente/ajustes` — `importe` viaja con signo,
+ * decidido por quien llama (espejo de `SolicitudDeAjuste`). */
+export type SolicitudDeAjuste = { idPuntoVenta: number; importe: number; detalle: string | null }
+
+/** Cuerpo de `POST /api/clientes/{id}/cuenta-corriente/reliquidacion` — `idPuntoVenta` es
+ * provenance, no autoridad (espejo de `SolicitudDeReliquidacion`). */
+export type SolicitudDeReliquidacion = { idPuntoVenta: number }
+
+/** Detalle auditable de una línea re-precificada — `motivo` no nulo ⇒ línea omitida
+ * (`precioActual`/`totalDelDia` quedan `null`, `delta` en `0`), nunca fatal (espejo de
+ * `DetalleDeLinea`). */
+export type DetalleDeLinea = {
+  idArticulo: number | null
+  cantidad: number
+  precioHistorico: number
+  precioActual: number | null
+  totalHistorico: number
+  totalDelDia: number | null
+  delta: number
+  motivo: string | null
+}
+
+/** Detalle auditable de un consumo cubierto — `delta` ya lleva aplicada la fracción financiada
+ * (espejo de `DetalleDeConsumo`). */
+export type DetalleDeConsumo = {
+  idMovimiento: number
+  idComprobanteVenta: number
+  delta: number
+  lineas: DetalleDeLinea[]
+}
+
+/** Respuesta de `GET`/`POST …/reliquidacion` — la MISMA forma para preview y commit (nunca dos
+ * fórmulas, design: "never two formulas"). `idsMovimientosCubiertos` vacío + `delta === 0` es un
+ * no-op limpio, distinguible de un error (espejo de `ResultadoDeReliquidacion`). */
+export type ResultadoDeReliquidacion = {
+  delta: number
+  idsMovimientosCubiertos: number[]
+  detalle: DetalleDeConsumo[]
+  hayMas: boolean
+}

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -609,6 +609,7 @@ describe('CuentaCorriente — modal de ajuste manual', () => {
 
     await userEvent.type(screen.getByLabelText('Importe'), '0')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Detalle válido')
+    await userEvent.click(screen.getByLabelText(/Entiendo que este ajuste modifica el saldo/))
     await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
 
     expect(screen.getByText('El importe del ajuste no puede ser cero.')).toBeInTheDocument()
@@ -621,6 +622,7 @@ describe('CuentaCorriente — modal de ajuste manual', () => {
 
     await userEvent.type(screen.getByLabelText('Importe'), '40')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), '  abcd  ')
+    await userEvent.click(screen.getByLabelText(/Entiendo que este ajuste modifica el saldo/))
     await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
 
     expect(
@@ -655,6 +657,7 @@ describe('CuentaCorriente — modal de ajuste manual', () => {
     await abrirModalAjuste()
     await userEvent.type(screen.getByLabelText('Importe'), '-50')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), '  Descuento por reclamo  ')
+    await userEvent.click(screen.getByLabelText(/Entiendo que este ajuste modifica el saldo/))
     await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
 
     await screen.findByText(/Ajuste registrado/)
@@ -677,6 +680,7 @@ describe('CuentaCorriente — modal de ajuste manual', () => {
     await abrirModalAjuste()
     await userEvent.type(screen.getByLabelText('Importe'), '40')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Corrección de saldo')
+    await userEvent.click(screen.getByLabelText(/Entiendo que este ajuste modifica el saldo/))
 
     const boton = screen.getByRole('button', { name: 'Registrar ajuste' })
     await userEvent.click(boton)
@@ -711,6 +715,7 @@ describe('CuentaCorriente — modal de ajuste manual', () => {
     await abrirModalAjuste()
     await userEvent.type(screen.getByLabelText('Importe'), '40')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Corrección')
+    await userEvent.click(screen.getByLabelText(/Entiendo que este ajuste modifica el saldo/))
     await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
 
     expect(await screen.findByText(/Ajuste registrado/)).toBeInTheDocument()
@@ -732,7 +737,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     await abrirModalReliquidacion()
 
     const dialogo = screen.getByRole('dialog')
-    await within(dialogo).findByText('$40,00')
+    await within(dialogo).findByTestId('cc-reliq-delta-estimado')
     expect(within(dialogo).getByRole('button', { name: 'Ejecutar reliquidación' })).toBeDisabled()
 
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
@@ -784,7 +789,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByText('$40,00')
+    await screen.findByTestId('cc-reliq-delta-estimado')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -811,7 +816,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByText('$40,00')
+    await screen.findByTestId('cc-reliq-delta-estimado')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
 
     const boton = screen.getByRole('button', { name: 'Ejecutar reliquidación' })
@@ -843,7 +848,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByText('$40,00')
+    await screen.findByTestId('cc-reliq-delta-estimado')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -869,7 +874,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByText('$40,00')
+    await screen.findByTestId('cc-reliq-delta-estimado')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -877,5 +882,97 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     await waitFor(() => expect(screen.getByText('No se pudo cargar el estado de cuenta.')).toBeInTheDocument())
     // el aviso de éxito de la reliquidación sigue en pantalla — el fallo del refetch no lo pisa.
     expect(screen.getByText(/Precios actualizados/)).toBeInTheDocument()
+  })
+
+  it('Fix 1: la vista previa muestra el detalle por consumo, con la línea omitida y su motivo', async () => {
+    const detalle: DetalleDeConsumo[] = [
+      detalleConsumoFixture({ idMovimiento: 1, delta: 40 }),
+      detalleConsumoFixture({
+        idMovimiento: 2,
+        delta: 0,
+        lineas: [
+          detalleLineaFixture({ precioActual: null, totalDelDia: null, delta: 0, motivo: 'articulo_no_encontrado' }),
+        ],
+      }),
+    ]
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(
+          resultadoReliquidacionFixture({ idsMovimientosCubiertos: [1, 2], detalle }),
+        )
+      }
+      return undefined
+    })
+
+    await abrirModalReliquidacion()
+    const dialogo = screen.getByRole('dialog')
+    await within(dialogo).findByTestId('cc-reliq-delta-estimado')
+
+    expect(within(dialogo).getByText('Movimiento #1 — $40,00')).toBeInTheDocument()
+    expect(within(dialogo).getByText('Movimiento #2 — $0,00')).toBeInTheDocument()
+    expect(within(dialogo).getByText('articulo_no_encontrado')).toBeInTheDocument()
+  })
+
+  it('Fix 4: el aviso de éxito muestra el delta EJECUTADO, nunca el delta previsualizado', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture({ delta: 40 }))
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/reliquidacion') {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture({ delta: 75 }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalReliquidacion()
+    await screen.findByTestId('cc-reliq-delta-estimado')
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+    await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
+
+    expect(await screen.findByText(/Precios actualizados: \$75,00/)).toBeInTheDocument()
+    expect(screen.queryByText(/Precios actualizados: \$40,00/)).not.toBeInTheDocument()
+  })
+})
+
+describe('CuentaCorriente — detalle de un movimiento ActualizacionPrecios en el ledger (Fix 1b)', () => {
+  it('un detalle JSON válido se muestra como un resumen legible, nunca el JSON crudo', async () => {
+    const detalleCrudo = JSON.stringify([detalleConsumoFixture({ idMovimiento: 3, delta: 55 })])
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) return undefined
+      if (ruta.includes('/cuenta-corriente')) {
+        return Promise.resolve<EstadoDeCuenta>(
+          estadoFixture({
+            movimientos: [movimientoFixture({ tipo: 'ActualizacionPrecios', detalle: detalleCrudo, importe: 55 })],
+          }),
+        )
+      }
+      return undefined
+    })
+
+    renderPantalla()
+
+    expect(await screen.findByText('1 consumo re-preciado')).toBeInTheDocument()
+    expect(screen.queryByText(detalleCrudo)).not.toBeInTheDocument()
+  })
+
+  it('un detalle malformado cae al texto crudo en vez de romper la fila', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) return undefined
+      if (ruta.includes('/cuenta-corriente')) {
+        return Promise.resolve<EstadoDeCuenta>(
+          estadoFixture({
+            movimientos: [movimientoFixture({ tipo: 'ActualizacionPrecios', detalle: '{esto no es json', importe: 10 })],
+          }),
+        )
+      }
+      return undefined
+    })
+
+    renderPantalla()
+
+    expect(await screen.findByText('{esto no es json')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -737,7 +737,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     await abrirModalReliquidacion()
 
     const dialogo = screen.getByRole('dialog')
-    await within(dialogo).findByTestId('cc-reliq-delta-estimado')
+    expect(await within(dialogo).findByTestId('cc-reliq-delta-estimado')).toHaveTextContent('$40,00')
     expect(within(dialogo).getByRole('button', { name: 'Ejecutar reliquidación' })).toBeDisabled()
 
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
@@ -789,7 +789,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByTestId('cc-reliq-delta-estimado')
+    expect(await screen.findByTestId('cc-reliq-delta-estimado')).toHaveTextContent('$40,00')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -816,7 +816,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByTestId('cc-reliq-delta-estimado')
+    expect(await screen.findByTestId('cc-reliq-delta-estimado')).toHaveTextContent('$40,00')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
 
     const boton = screen.getByRole('button', { name: 'Ejecutar reliquidación' })
@@ -848,7 +848,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByTestId('cc-reliq-delta-estimado')
+    expect(await screen.findByTestId('cc-reliq-delta-estimado')).toHaveTextContent('$40,00')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -874,7 +874,7 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
     })
 
     await abrirModalReliquidacion()
-    await screen.findByTestId('cc-reliq-delta-estimado')
+    expect(await screen.findByTestId('cc-reliq-delta-estimado')).toHaveTextContent('$40,00')
     await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
     await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
 
@@ -939,7 +939,28 @@ describe('CuentaCorriente — modal de reliquidación a precio del día', () => 
 
 describe('CuentaCorriente — detalle de un movimiento ActualizacionPrecios en el ledger (Fix 1b)', () => {
   it('un detalle JSON válido se muestra como un resumen legible, nunca el JSON crudo', async () => {
-    const detalleCrudo = JSON.stringify([detalleConsumoFixture({ idMovimiento: 3, delta: 55 })])
+    // El backend guarda este campo con `JsonSerializer.Serialize(resultado.Detalle)` SIN el naming
+    // policy camelCase de la API — las claves llegan en PascalCase real (espejo de
+    // `DetalleDeConsumo`/`DetalleDeLinea` en `ReliquidadorDeConsumos.cs`), nunca camelCase.
+    const detalleCrudo = JSON.stringify([
+      {
+        IdMovimiento: 3,
+        IdComprobanteVenta: 10,
+        Delta: 55,
+        Lineas: [
+          {
+            IdArticulo: 1,
+            Cantidad: 2,
+            PrecioHistorico: 100,
+            PrecioActual: 120,
+            TotalHistorico: 200,
+            TotalDelDia: 240,
+            Delta: 40,
+            Motivo: null,
+          },
+        ],
+      },
+    ])
     mockearRutasBase((ruta) => {
       if (ruta.includes('/cuenta-corriente/reliquidacion')) return undefined
       if (ruta.includes('/cuenta-corriente')) {

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -4,14 +4,19 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CuentaCorriente } from './CuentaCorriente'
 import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
 import type {
   ClienteListado,
   ComprobanteEmitido,
+  DetalleDeConsumo,
+  DetalleDeLinea,
   EstadoDeCuenta,
   MedioPagoListado,
   MovimientoDeCuentaCorriente,
   ParametroResuelto,
   PuntoVentaListado,
+  ResultadoDeReliquidacion,
+  UsuarioAutenticado,
 } from '../api/tipos'
 
 const apiGetMock = vi.fn()
@@ -33,6 +38,27 @@ vi.mock('../api/cliente', () => ({
       this.codigo = codigo
     }
   },
+}))
+
+/** `usuarioActual` es mutable a propósito (reset en `beforeEach`) — cada test de gating de rol
+ * (Vendedor vs. Supervisor/Admin) lo sobrescribe sin tener que remockear todo el módulo. */
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
 }))
 
 function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
@@ -141,6 +167,32 @@ function comprobanteFixture(sobrescribir: Partial<ComprobanteEmitido> = {}): Com
   }
 }
 
+function detalleLineaFixture(sobrescribir: Partial<DetalleDeLinea> = {}): DetalleDeLinea {
+  return {
+    idArticulo: 1,
+    cantidad: 2,
+    precioHistorico: 100,
+    precioActual: 120,
+    totalHistorico: 200,
+    totalDelDia: 240,
+    delta: 40,
+    motivo: null,
+    ...sobrescribir,
+  }
+}
+
+function detalleConsumoFixture(sobrescribir: Partial<DetalleDeConsumo> = {}): DetalleDeConsumo {
+  return { idMovimiento: 1, idComprobanteVenta: 10, delta: 40, lineas: [detalleLineaFixture()], ...sobrescribir }
+}
+
+function resultadoReliquidacionFixture(sobrescribir: Partial<ResultadoDeReliquidacion> = {}): ResultadoDeReliquidacion {
+  return { delta: 40, idsMovimientosCubiertos: [1], detalle: [detalleConsumoFixture()], hayMas: false, ...sobrescribir }
+}
+
+function resultadoReliquidacionNoOpFixture(): ResultadoDeReliquidacion {
+  return { delta: 0, idsMovimientosCubiertos: [], detalle: [], hayMas: false }
+}
+
 const medioEfectivo = medioFixture()
 const puntoVentaCentro = puntoVentaFixture()
 
@@ -155,9 +207,11 @@ function renderPantalla(idCliente: number | string = 5, state?: { cliente: Clien
 }
 
 /** Rutas comunes a toda la pantalla (cliente + medios de pago + puntos de venta + estado de
- * cuenta + vuelto_maximo) — un override toma prioridad sobre el default para que un test pueda
- * reemplazar cualquiera de estas rutas base. `GET /clientes/:id` cubre el fetch de identidad
- * cuando no llega `location.state` (Fix 2: único camino del Vendedor / cualquier refresh). */
+ * cuenta + vuelto_maximo + preview de reliquidación) — un override toma prioridad sobre el
+ * default para que un test pueda reemplazar cualquiera de estas rutas base. `GET /clientes/:id`
+ * cubre el fetch de identidad cuando no llega `location.state` (Fix 2: único camino del Vendedor /
+ * cualquier refresh). El preview de reliquidación se chequea ANTES que el catch-all de
+ * `/cuenta-corriente` — su ruta también contiene ese substring. */
 function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     const propia = sobrescribirGet?.(ruta)
@@ -167,6 +221,9 @@ function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> |
     if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
     if (ruta.startsWith('/parametros/vuelto_maximo')) {
       return Promise.resolve<ParametroResuelto>({ clave: 'vuelto_maximo', valor: '20' })
+    }
+    if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+      return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionNoOpFixture())
     }
     if (ruta.includes('/cuenta-corriente')) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
@@ -185,9 +242,27 @@ async function abrirModalYCompletarFila(importe = '500') {
   await waitFor(() => expect(screen.getByRole('button', { name: 'Registrar pago' })).not.toBeDisabled())
 }
 
+/** Abre el modal de ajuste manual — requiere Supervisor/Admin, `usuarioActual` es Supervisor por
+ * default (ver `beforeEach`). */
+async function abrirModalAjuste() {
+  renderPantalla()
+  await screen.findByText('$500,00')
+  await userEvent.click(screen.getByRole('button', { name: 'Ajuste manual' }))
+  await screen.findByText('Ajuste manual de cuenta corriente')
+}
+
+/** Abre el modal de reliquidación — el preview se dispara automáticamente al montar. */
+async function abrirModalReliquidacion() {
+  renderPantalla()
+  await screen.findByText('$500,00')
+  await userEvent.click(screen.getByRole('button', { name: 'Actualizar precios' }))
+  await screen.findByText('Actualizar precios (reliquidación)')
+}
+
 beforeEach(() => {
   apiGetMock.mockReset()
   apiPostMock.mockReset()
+  usuarioActual = usuarioFixture()
 })
 
 describe('CuentaCorriente — header y ledger', () => {
@@ -491,5 +566,316 @@ describe('CuentaCorriente — modal de pago a cuenta', () => {
     // recuperarse del gate de turno (el JSDoc de PanelAperturaDeTurnoEnModal lo promete).
     expect(screen.getByLabelText('Medio de pago')).toHaveValue('1')
     expect(screen.getByLabelText('Importe')).toHaveValue(500)
+  })
+})
+
+describe('CuentaCorriente — gating de rol (Supervisor+Admin) para ajuste y reliquidación', () => {
+  it('un Vendedor no ve las acciones de ajuste ni reliquidación', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    expect(screen.queryByRole('button', { name: 'Ajuste manual' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Actualizar precios' })).not.toBeInTheDocument()
+    // el pago sigue disponible para cualquier rol — OperacionDePos, no SupervisionDeCuentaCorriente.
+    expect(screen.getByRole('button', { name: 'Ingresar pago' })).toBeInTheDocument()
+  })
+
+  it('un Supervisor ve ambas acciones, habilitadas una vez cargados los datos', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Ajuste manual' })).not.toBeDisabled())
+    expect(screen.getByRole('button', { name: 'Actualizar precios' })).not.toBeDisabled()
+  })
+
+  it('un Admin también ve ambas acciones', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Ajuste manual' })).not.toBeDisabled())
+    expect(screen.getByRole('button', { name: 'Actualizar precios' })).not.toBeDisabled()
+  })
+})
+
+describe('CuentaCorriente — modal de ajuste manual', () => {
+  it('importe cero se rechaza localmente (ajuste_importe_invalido), sin llamar al servidor', async () => {
+    mockearRutasBase()
+    await abrirModalAjuste()
+
+    await userEvent.type(screen.getByLabelText('Importe'), '0')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Detalle válido')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    expect(screen.getByText('El importe del ajuste no puede ser cero.')).toBeInTheDocument()
+    expect(apiPostMock).not.toHaveBeenCalled()
+  })
+
+  it('un detalle recortado por debajo de 5 caracteres se rechaza localmente (ajuste_detalle_requerido)', async () => {
+    mockearRutasBase()
+    await abrirModalAjuste()
+
+    await userEvent.type(screen.getByLabelText('Importe'), '40')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), '  abcd  ')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    expect(
+      screen.getByText('El detalle del ajuste es obligatorio y tiene que tener al menos 5 caracteres.'),
+    ).toBeInTheDocument()
+    expect(apiPostMock).not.toHaveBeenCalled()
+  })
+
+  it('semántica con signo: positivo aumenta el saldo resultante, negativo lo reduce (header.saldo = 500)', async () => {
+    mockearRutasBase()
+    await abrirModalAjuste()
+
+    await userEvent.type(screen.getByLabelText('Importe'), '40')
+    expect(screen.getByText('Saldo resultante: $540,00')).toBeInTheDocument()
+
+    await userEvent.clear(screen.getByLabelText('Importe'))
+    await userEvent.type(screen.getByLabelText('Importe'), '-50')
+    expect(screen.getByText('Saldo resultante: $450,00')).toBeInTheDocument()
+  })
+
+  it('arma el cuerpo del POST con la forma exacta del contrato, detalle recortado, y refresca el ledger', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/ajustes') {
+        return Promise.resolve<MovimientoDeCuentaCorriente>(
+          movimientoFixture({ tipo: 'Ajuste', importe: -50, saldoResultante: 450, etiqueta: 'Manual' }),
+        )
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '-50')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), '  Descuento por reclamo  ')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    await screen.findByText(/Ajuste registrado/)
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/clientes/5/cuenta-corriente/ajustes')
+    expect(llamada?.[1]).toEqual({ idPuntoVenta: 7, importe: -50, detalle: 'Descuento por reclamo' })
+  })
+
+  it('doble click en "Registrar ajuste" dispara exactamente un POST', async () => {
+    mockearRutasBase()
+    let resolverAjuste: (m: MovimientoDeCuentaCorriente) => void = () => {}
+    const ajustePendiente = new Promise<MovimientoDeCuentaCorriente>((resolve) => {
+      resolverAjuste = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/ajustes') return ajustePendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '40')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Corrección de saldo')
+
+    const boton = screen.getByRole('button', { name: 'Registrar ajuste' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/ajustes')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Registrando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverAjuste(movimientoFixture({ tipo: 'Ajuste', importe: 40, etiqueta: 'Manual' }))
+      await Promise.resolve()
+    })
+  })
+
+  it('un ajuste 2xx nunca se reporta como fallo, aunque el refetch del ledger posterior falle', async () => {
+    let llamadasEstado = 0
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) return undefined
+      if (!ruta.includes('/cuenta-corriente')) return undefined
+      llamadasEstado += 1
+      if (llamadasEstado === 1) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      return Promise.reject(new Error('boom'))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/ajustes') {
+        return Promise.resolve<MovimientoDeCuentaCorriente>(movimientoFixture({ tipo: 'Ajuste', importe: 40, etiqueta: 'Manual' }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '40')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'Corrección')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    expect(await screen.findByText(/Ajuste registrado/)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('No se pudo cargar el estado de cuenta.')).toBeInTheDocument())
+    // el aviso de éxito del ajuste sigue en pantalla — el fallo del refetch no lo pisa.
+    expect(screen.getByText(/Ajuste registrado/)).toBeInTheDocument()
+  })
+})
+
+describe('CuentaCorriente — modal de reliquidación a precio del día', () => {
+  it('preview primero: muestra delta, consumos cubiertos y solo habilita ejecutar tras confirmar', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return undefined
+    })
+
+    await abrirModalReliquidacion()
+
+    const dialogo = screen.getByRole('dialog')
+    await within(dialogo).findByText('$40,00')
+    expect(within(dialogo).getByRole('button', { name: 'Ejecutar reliquidación' })).toBeDisabled()
+
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+    expect(within(dialogo).getByRole('button', { name: 'Ejecutar reliquidación' })).not.toBeDisabled()
+  })
+
+  it('hayMas en el preview muestra el aviso de que quedan más consumos pendientes', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture({ hayMas: true }))
+      }
+      return undefined
+    })
+
+    await abrirModalReliquidacion()
+
+    expect(
+      await screen.findByText(/Quedan más consumos pendientes — esta corrida no los cubre/),
+    ).toBeInTheDocument()
+  })
+
+  it('preview sin consumos elegibles muestra el estado no-op y solo permite cerrar', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionNoOpFixture())
+      }
+      return undefined
+    })
+
+    await abrirModalReliquidacion()
+
+    expect(await screen.findByText('No hay consumos pendientes de actualizar para este cliente.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Ejecutar reliquidación' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cerrar' })).toBeInTheDocument()
+  })
+
+  it('ejecuta la reliquidación tras confirmar y arma el cuerpo del POST con la forma exacta del contrato', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/reliquidacion') {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalReliquidacion()
+    await screen.findByText('$40,00')
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+    await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
+
+    await screen.findByText(/Precios actualizados/)
+
+    const llamada = apiPostMock.mock.calls.find((c) => c[0] === '/clientes/5/cuenta-corriente/reliquidacion')
+    expect(llamada?.[1]).toEqual({ idPuntoVenta: 7 })
+  })
+
+  it('doble click en "Ejecutar reliquidación" dispara exactamente un POST', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return undefined
+    })
+    let resolverReliquidacion: (r: ResultadoDeReliquidacion) => void = () => {}
+    const reliquidacionPendiente = new Promise<ResultadoDeReliquidacion>((resolve) => {
+      resolverReliquidacion = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/reliquidacion') return reliquidacionPendiente
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalReliquidacion()
+    await screen.findByText('$40,00')
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+
+    const boton = screen.getByRole('button', { name: 'Ejecutar reliquidación' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/clientes/5/cuenta-corriente/reliquidacion')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Ejecutando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverReliquidacion(resultadoReliquidacionFixture())
+      await Promise.resolve()
+    })
+  })
+
+  it('un commit no-op (carrera preview↔commit) se reporta como éxito, nunca como fallo', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/reliquidacion') {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionNoOpFixture())
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalReliquidacion()
+    await screen.findByText('$40,00')
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+    await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
+
+    expect(await screen.findByText('No había nada para actualizar.')).toBeInTheDocument()
+  })
+
+  it('una reliquidación 2xx nunca se reporta como fallo, aunque el refetch del ledger posterior falle', async () => {
+    let llamadasEstado = 0
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente/reliquidacion')) {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      if (!ruta.includes('/cuenta-corriente')) return undefined
+      llamadasEstado += 1
+      if (llamadasEstado === 1) return Promise.resolve<EstadoDeCuenta>(estadoFixture())
+      return Promise.reject(new Error('boom'))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/clientes/5/cuenta-corriente/reliquidacion') {
+        return Promise.resolve<ResultadoDeReliquidacion>(resultadoReliquidacionFixture())
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await abrirModalReliquidacion()
+    await screen.findByText('$40,00')
+    await userEvent.click(screen.getByLabelText(/Confirmo que quiero actualizar los precios/))
+    await userEvent.click(screen.getByRole('button', { name: 'Ejecutar reliquidación' }))
+
+    expect(await screen.findByText(/Precios actualizados/)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('No se pudo cargar el estado de cuenta.')).toBeInTheDocument())
+    // el aviso de éxito de la reliquidación sigue en pantalla — el fallo del refetch no lo pisa.
+    expect(screen.getByText(/Precios actualizados/)).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -16,6 +16,7 @@ import {
   filaPagoACuentaVacia,
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
+  parsearDetalleDeActualizacionPrecios,
   rangoUltimoMes,
   reliquidacionEsNoOp,
   saldoResultanteDeAjuste,
@@ -26,6 +27,7 @@ import {
 import type {
   ClienteListado,
   ComprobanteEmitido,
+  DetalleDeConsumo,
   EstadoDeCuenta,
   EstadoDeCuentaHeader,
   MedioPagoAlta,
@@ -73,6 +75,76 @@ function formatearFechaHora(iso: string): string {
 
 function formatearDisponibilidad(valor: number | null): string {
   return valor === null ? 'Ilimitado' : formatearMoneda(valor)
+}
+
+/**
+ * Detalle auditable por consumo (Fix 1: preview/commit de la reliquidación traían `detalle` pero
+ * nunca se mostraba). Cada consumo queda siempre visible (id + delta); las líneas — histórico →
+ * actual, delta y el `motivo` de las omitidas — quedan en un `<details>` expandible para que la
+ * lista no se coma la pantalla cuando el cap de 500 trae muchos consumos.
+ */
+function DetalleDeConsumosDeReliquidacion({ detalle }: { detalle: DetalleDeConsumo[] }) {
+  if (detalle.length === 0) return null
+  return (
+    <div className="mb-3">
+      <div className="small text-muted mb-1">Detalle por consumo</div>
+      {detalle.map((consumo) => (
+        <details key={consumo.idMovimiento} className="mb-1">
+          <summary>
+            Movimiento #{consumo.idMovimiento} — {formatearMoneda(consumo.delta)}
+          </summary>
+          <table className="table table-sm table-bordered mb-0 mt-1">
+            <thead>
+              <tr>
+                <th>Artículo</th>
+                <th>Cant.</th>
+                <th>Precio histórico</th>
+                <th>Precio actual</th>
+                <th>Delta</th>
+                <th>Motivo</th>
+              </tr>
+            </thead>
+            <tbody>
+              {consumo.lineas.map((linea, indice) => (
+                <tr key={indice}>
+                  <td>{linea.idArticulo ?? '—'}</td>
+                  <td>{linea.cantidad}</td>
+                  <td>{formatearMoneda(linea.precioHistorico)}</td>
+                  <td>{linea.precioActual === null ? '—' : formatearMoneda(linea.precioActual)}</td>
+                  <td>{formatearMoneda(linea.delta)}</td>
+                  <td>{linea.motivo ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      ))}
+    </div>
+  )
+}
+
+/** Detalle del ledger para un movimiento `ActualizacionPrecios` (Fix 1b) — el `detalle` guardado
+ * es el mismo JSON auditable de la reliquidación, nunca un texto libre: se parsea de forma
+ * defensiva y se muestra un resumen legible; un JSON malformado cae al texto crudo, nunca rompe la
+ * fila. */
+function DetalleDeMovimientoDeActualizacionPrecios({ detalle }: { detalle: string | null }) {
+  const consumos = parsearDetalleDeActualizacionPrecios(detalle)
+  if (consumos === null) return <>{detalle ?? '—'}</>
+  if (consumos.length === 0) return <>Sin consumos re-preciados.</>
+  return (
+    <details>
+      <summary>
+        {consumos.length} consumo{consumos.length === 1 ? '' : 's'} re-preciado{consumos.length === 1 ? '' : 's'}
+      </summary>
+      <ul className="mb-0 ps-3 small">
+        {consumos.map((consumo) => (
+          <li key={consumo.idMovimiento}>
+            Movimiento #{consumo.idMovimiento}: {formatearMoneda(consumo.delta)}
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
 }
 
 function nombreDeCliente(idCliente: number, cliente: ClienteListado | null): string {
@@ -529,6 +601,10 @@ function ModalAjusteDeCuenta({ idCliente, puntosVenta, header, onCerrar, onAntes
   )
   const [importe, setImporte] = useState('')
   const [detalle, setDetalle] = useState('')
+  // Fix 2 (mismo patrón que la reliquidación): un ajuste manual también modifica el saldo del
+  // cliente de forma directa — la confirmación explícita evita que un click apurado dispare un
+  // ajuste sin que el supervisor haya leído el importe/detalle que está a punto de registrar.
+  const [confirmado, setConfirmado] = useState(false)
 
   const [registrando, setRegistrando] = useState(false)
   const registrandoRef = useRef(false)
@@ -536,6 +612,7 @@ function ModalAjusteDeCuenta({ idCliente, puntosVenta, header, onCerrar, onAntes
 
   const importeNumerico = importe.trim() === '' ? Number.NaN : Number(importe)
   const saldoResultante = Number.isFinite(importeNumerico) ? saldoResultanteDeAjuste(header.saldo, importeNumerico) : null
+  const puedeRegistrar = !registrando && confirmado
 
   function cambiarPuntoVenta(id: number) {
     if (registrandoRef.current) return
@@ -546,6 +623,7 @@ function ModalAjusteDeCuenta({ idCliente, puntosVenta, header, onCerrar, onAntes
   async function registrarAjuste() {
     // regla 9: guard de reentrancia de primera línea.
     if (registrandoRef.current) return
+    if (!puedeRegistrar) return
 
     const rechazo = validarAjusteLocal({ importe: importeNumerico, detalle })
     if (rechazo) {
@@ -644,12 +722,26 @@ function ModalAjusteDeCuenta({ idCliente, puntosVenta, header, onCerrar, onAntes
 
               <div className="small text-muted">Saldo actual: {formatearMoneda(header.saldo)}</div>
               {saldoResultante !== null && <div className="fs-6">Saldo resultante: {formatearMoneda(saldoResultante)}</div>}
+
+              <div className="form-check mt-3">
+                <input
+                  id="cc-ajuste-confirmacion"
+                  type="checkbox"
+                  className="form-check-input rounded-0"
+                  checked={confirmado}
+                  disabled={registrando}
+                  onChange={(e) => setConfirmado(e.target.checked)}
+                />
+                <label className="form-check-label" htmlFor="cc-ajuste-confirmacion">
+                  Entiendo que este ajuste modifica el saldo del cliente.
+                </label>
+              </div>
             </div>
             <div className="modal-footer">
               <button type="button" className="btn btn-outline-secondary rounded-0" disabled={registrando} onClick={onCerrar}>
                 Cancelar
               </button>
-              <button type="button" className="btn btn-primary rounded-0" disabled={registrando} onClick={registrarAjuste}>
+              <button type="button" className="btn btn-primary rounded-0" disabled={!puedeRegistrar} onClick={registrarAjuste}>
                 {registrando ? 'Registrando…' : 'Registrar ajuste'}
               </button>
             </div>
@@ -780,7 +872,9 @@ function ModalReliquidacion({ idCliente, puntosVenta, onCerrar, onAntesDeEscribi
                   <div className="row g-3 mb-3">
                     <div className="col-md-6">
                       <div className="small text-muted">Delta estimado</div>
-                      <div className="fs-6">{formatearMoneda(preview.delta)}</div>
+                      <div className="fs-6" data-testid="cc-reliq-delta-estimado">
+                        {formatearMoneda(preview.delta)}
+                      </div>
                     </div>
                     <div className="col-md-6">
                       <div className="small text-muted">Consumos cubiertos</div>
@@ -793,6 +887,8 @@ function ModalReliquidacion({ idCliente, puntosVenta, onCerrar, onAntesDeEscribi
                       reliquidación de nuevo después.
                     </div>
                   )}
+
+                  <DetalleDeConsumosDeReliquidacion detalle={preview.detalle} />
 
                   <div className="mb-3" style={{ maxWidth: 320 }}>
                     <label className="form-label" htmlFor="cc-reliq-punto-venta">
@@ -989,7 +1085,8 @@ function PantallaCuentaCorriente({
         {errorEstado && <div className="alert alert-danger rounded-0">{errorEstado}</div>}
         {(errorCliente || errorMedios || errorPuntosVenta) && (
           <div className="alert alert-warning rounded-0 py-1 px-2 small">
-            {errorCliente || errorMedios || errorPuntosVenta} No se puede ingresar un pago hasta que esto se resuelva.
+            {errorCliente || errorMedios || errorPuntosVenta} No se pueden registrar operaciones de cuenta corriente
+            hasta que esto se resuelva.
           </div>
         )}
 
@@ -1132,7 +1229,13 @@ function PantallaCuentaCorriente({
                     <tr key={m.id}>
                       <td>{formatearFechaHora(m.fecha)}</td>
                       <td>{etiquetaDeMovimiento(m)}</td>
-                      <td>{m.detalle ?? '—'}</td>
+                      <td>
+                        {m.tipo === 'ActualizacionPrecios' ? (
+                          <DetalleDeMovimientoDeActualizacionPrecios detalle={m.detalle} />
+                        ) : (
+                          (m.detalle ?? '—')
+                        )}
+                      </td>
                       <td className="text-end">{formatearMoneda(m.importe)}</td>
                       <td className="text-end">{formatearMoneda(m.saldoResultante)}</td>
                     </tr>

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -6,7 +6,9 @@ import { api, ErrorApi } from '../api/cliente'
 import { clienteDeClientes } from '../api/clientes'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import {
+  aSolicitudDeAjuste,
   aSolicitudDePagoACuenta,
+  aSolicitudDeReliquidacion,
   calcularImporteAplicado,
   clienteDeCuentaCorriente,
   disponibilidadPrevia,
@@ -15,6 +17,9 @@ import {
   filasAPagosACuentaParaCalculo,
   medioFisicoParaPagoACuenta,
   rangoUltimoMes,
+  reliquidacionEsNoOp,
+  saldoResultanteDeAjuste,
+  validarAjusteLocal,
   validarPagoACuentaLocal,
   type FilaPagoACuenta,
 } from '../api/cuentaCorriente'
@@ -25,9 +30,13 @@ import type {
   EstadoDeCuentaHeader,
   MedioPagoAlta,
   MedioPagoListado,
+  MovimientoDeCuentaCorriente,
   ParametroResuelto,
   PuntoVentaListado,
+  ResultadoDeReliquidacion,
 } from '../api/tipos'
+import { puedeSupervisarCuentaCorriente } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 
@@ -496,6 +505,349 @@ function ModalPagoACuenta({ idCliente, puntosVenta, medios, header, onCerrar, on
   )
 }
 
+type PropsModalAjuste = {
+  idCliente: number
+  puntosVenta: PuntoVentaListado[]
+  header: EstadoDeCuentaHeader
+  onCerrar: () => void
+  onAntesDeEscribir: () => void
+  onRegistrado: (movimiento: MovimientoDeCuentaCorriente) => void
+}
+
+/**
+ * Modal de ajuste manual (Slice 6, design: Web Composition; spec: ajustes-de-cuenta-corriente —
+ * gated por `SupervisionDeCuentaCorriente`, cosmético en pantalla, real en el servidor).
+ * `react-async-state`: regla 9 (guard de reentrancia + deshabilitado de ventana completa), regla 3
+ * (el llamador bumpea la generación del ledger ANTES del POST), regla 6 (el refetch posterior vive
+ * en el padre). Sin turno (design: Open Questions — "provenance, not authority", mismo criterio
+ * que la reliquidación): a diferencia del pago, este endpoint nunca llama a `ServicioDeTurnos`, así
+ * que no hay ningún `turno_no_abierto` que recuperar acá (rule 10 sweep — ver el catch de abajo).
+ */
+function ModalAjusteDeCuenta({ idCliente, puntosVenta, header, onCerrar, onAntesDeEscribir, onRegistrado }: PropsModalAjuste) {
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number>(
+    () => puntosVenta.find((p) => p.id === leerPuntoVentaGuardado())?.id ?? puntosVenta[0].id,
+  )
+  const [importe, setImporte] = useState('')
+  const [detalle, setDetalle] = useState('')
+
+  const [registrando, setRegistrando] = useState(false)
+  const registrandoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  const importeNumerico = importe.trim() === '' ? Number.NaN : Number(importe)
+  const saldoResultante = Number.isFinite(importeNumerico) ? saldoResultanteDeAjuste(header.saldo, importeNumerico) : null
+
+  function cambiarPuntoVenta(id: number) {
+    if (registrandoRef.current) return
+    setIdPuntoVenta(id)
+    guardarPuntoVentaSeleccionado(id)
+  }
+
+  async function registrarAjuste() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (registrandoRef.current) return
+
+    const rechazo = validarAjusteLocal({ importe: importeNumerico, detalle })
+    if (rechazo) {
+      setError(rechazo.mensaje)
+      return
+    }
+
+    registrandoRef.current = true
+    setRegistrando(true)
+    setError('')
+
+    // regla 3: bumpear la generación del ledger ANTES de la escritura.
+    onAntesDeEscribir()
+
+    try {
+      const solicitud = aSolicitudDeAjuste(idPuntoVenta, importeNumerico, detalle)
+      const movimiento = await clienteDeCuentaCorriente.registrarAjuste(idCliente, solicitud)
+      registrandoRef.current = false
+      setRegistrando(false)
+      // regla 6: el refetch del ledger vive en el padre, aislado de este try/catch.
+      onRegistrado(movimiento)
+    } catch (e) {
+      registrandoRef.current = false
+      setRegistrando(false)
+      // Rule 10 sweep (design: Web Composition — "the three modals are sibling surfaces"): el
+      // ajuste manual no tiene turno (`ServicioDeCuentaCorriente.RegistrarAjusteAsync` nunca llama
+      // a `ServicioDeTurnos`), así que `turno_no_abierto` es estructuralmente irreproducible acá —
+      // replicar el panel de apertura de turno sería código muerto para un 409 que este endpoint
+      // nunca emite. `ajuste_importe_invalido`/`ajuste_detalle_requerido`/
+      // `cliente_sin_cuenta_corriente` caen en el mismo aviso genérico que ya usa el pago.
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo registrar el ajuste.')
+    }
+  }
+
+  return (
+    <>
+      <div className="modal d-block" tabIndex={-1} role="dialog">
+        <div className="modal-dialog" role="document">
+          <div className="modal-content rounded-0">
+            <div className="modal-header">
+              <h5 className="modal-title">Ajuste manual de cuenta corriente</h5>
+            </div>
+            <div className="modal-body">
+              {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+
+              <div className="mb-3" style={{ maxWidth: 320 }}>
+                <label className="form-label" htmlFor="cc-ajuste-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="cc-ajuste-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  disabled={registrando}
+                  onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
+                >
+                  {puntosVenta.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="cc-ajuste-importe">
+                  Importe
+                </label>
+                <input
+                  id="cc-ajuste-importe"
+                  type="number"
+                  step="0.01"
+                  className="form-control rounded-0"
+                  value={importe}
+                  disabled={registrando}
+                  onChange={(e) => setImporte(e.target.value)}
+                />
+                <div className="form-text">
+                  Positivo aumenta la deuda del cliente, negativo la reduce. Nunca puede ser cero.
+                </div>
+              </div>
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="cc-ajuste-detalle">
+                  Detalle (obligatorio)
+                </label>
+                <input
+                  id="cc-ajuste-detalle"
+                  type="text"
+                  className="form-control rounded-0"
+                  value={detalle}
+                  disabled={registrando}
+                  onChange={(e) => setDetalle(e.target.value)}
+                />
+              </div>
+
+              <div className="small text-muted">Saldo actual: {formatearMoneda(header.saldo)}</div>
+              {saldoResultante !== null && <div className="fs-6">Saldo resultante: {formatearMoneda(saldoResultante)}</div>}
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-outline-secondary rounded-0" disabled={registrando} onClick={onCerrar}>
+                Cancelar
+              </button>
+              <button type="button" className="btn btn-primary rounded-0" disabled={registrando} onClick={registrarAjuste}>
+                {registrando ? 'Registrando…' : 'Registrar ajuste'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop show" />
+    </>
+  )
+}
+
+type PropsModalReliquidacion = {
+  idCliente: number
+  puntosVenta: PuntoVentaListado[]
+  onCerrar: () => void
+  onAntesDeEscribir: () => void
+  onEjecutada: (resultado: ResultadoDeReliquidacion) => void
+}
+
+/**
+ * Modal de reliquidación a precio del día (Slice 6, design: Web Composition; spec:
+ * reliquidacion-a-precio-del-dia) — preview PRIMERO (`GET`, sin lock, nunca autoritativo), después
+ * la confirmación de irreversibilidad (mismo patrón que `CierreDeCaja.tsx`: checkbox explícito,
+ * nunca pre-tildado), recién ahí el commit. `react-async-state`: regla 9 (guard de reentrancia +
+ * deshabilitado de ventana completa — un doble submit re-precificaría al cliente dos veces), regla
+ * 6 (un commit 2xx NUNCA se reporta como fallo, el refetch del ledger vive en el padre, aislado).
+ * Sin turno (mismo motivo que `ModalAjusteDeCuenta`): sin recuperación de `turno_no_abierto` que
+ * replicar, ese 409 es irreproducible en este endpoint.
+ */
+function ModalReliquidacion({ idCliente, puntosVenta, onCerrar, onAntesDeEscribir, onEjecutada }: PropsModalReliquidacion) {
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number>(
+    () => puntosVenta.find((p) => p.id === leerPuntoVentaGuardado())?.id ?? puntosVenta[0].id,
+  )
+
+  const [preview, setPreview] = useState<ResultadoDeReliquidacion | null>(null)
+  const [cargandoPreview, setCargandoPreview] = useState(true)
+  const [errorPreview, setErrorPreview] = useState('')
+  const generacionPreviewRef = useRef(0)
+
+  const [confirmado, setConfirmado] = useState(false)
+  const [ejecutando, setEjecutando] = useState(false)
+  const ejecutandoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    const miGeneracion = (generacionPreviewRef.current += 1)
+    setCargandoPreview(true)
+    setErrorPreview('')
+
+    clienteDeCuentaCorriente
+      .previsualizarReliquidacion(idCliente)
+      .then((resultado) => {
+        if (!vigente || generacionPreviewRef.current !== miGeneracion) return
+        setPreview(resultado)
+      })
+      .catch((e) => {
+        if (!vigente || generacionPreviewRef.current !== miGeneracion) return
+        setPreview(null)
+        setErrorPreview(e instanceof ErrorApi ? e.message : 'No se pudo cargar la vista previa de la reliquidación.')
+      })
+      .finally(() => {
+        if (!vigente || generacionPreviewRef.current !== miGeneracion) return
+        setCargandoPreview(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idCliente])
+
+  function cambiarPuntoVenta(id: number) {
+    if (ejecutandoRef.current) return
+    setIdPuntoVenta(id)
+    guardarPuntoVentaSeleccionado(id)
+  }
+
+  const previewEsNoOp = preview !== null && reliquidacionEsNoOp(preview)
+  const puedeEjecutar = !cargandoPreview && errorPreview === '' && preview !== null && !previewEsNoOp && confirmado && !ejecutando
+
+  async function ejecutar() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (ejecutandoRef.current) return
+    if (!puedeEjecutar) return
+
+    ejecutandoRef.current = true
+    setEjecutando(true)
+    setError('')
+
+    // regla 3: bumpear la generación del ledger ANTES de la escritura.
+    onAntesDeEscribir()
+
+    try {
+      const solicitud = aSolicitudDeReliquidacion(idPuntoVenta)
+      const resultado = await clienteDeCuentaCorriente.ejecutarReliquidacion(idCliente, solicitud)
+      ejecutandoRef.current = false
+      setEjecutando(false)
+      // regla 6: el refetch del ledger vive en el padre, aislado de este try/catch — un commit
+      // 2xx nunca se reporta como fallo acá, incluida la variante no-op de la carrera preview↔commit.
+      onEjecutada(resultado)
+    } catch (e) {
+      ejecutandoRef.current = false
+      setEjecutando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo ejecutar la reliquidación.')
+    }
+  }
+
+  return (
+    <>
+      <div className="modal d-block" tabIndex={-1} role="dialog">
+        <div className="modal-dialog" role="document">
+          <div className="modal-content rounded-0">
+            <div className="modal-header">
+              <h5 className="modal-title">Actualizar precios (reliquidación)</h5>
+            </div>
+            <div className="modal-body">
+              {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+              {errorPreview && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPreview}</div>}
+
+              {cargandoPreview && <Cargando />}
+
+              {!cargandoPreview && preview && previewEsNoOp && (
+                <p className="text-muted">No hay consumos pendientes de actualizar para este cliente.</p>
+              )}
+
+              {!cargandoPreview && preview && !previewEsNoOp && (
+                <>
+                  <div className="row g-3 mb-3">
+                    <div className="col-md-6">
+                      <div className="small text-muted">Delta estimado</div>
+                      <div className="fs-6">{formatearMoneda(preview.delta)}</div>
+                    </div>
+                    <div className="col-md-6">
+                      <div className="small text-muted">Consumos cubiertos</div>
+                      <div className="fs-6">{preview.idsMovimientosCubiertos.length}</div>
+                    </div>
+                  </div>
+                  {preview.hayMas && (
+                    <div className="alert alert-warning rounded-0 py-1 px-2 small">
+                      Quedan más consumos pendientes — esta corrida no los cubre, va a hacer falta correr la
+                      reliquidación de nuevo después.
+                    </div>
+                  )}
+
+                  <div className="mb-3" style={{ maxWidth: 320 }}>
+                    <label className="form-label" htmlFor="cc-reliq-punto-venta">
+                      Punto de venta
+                    </label>
+                    <select
+                      id="cc-reliq-punto-venta"
+                      className="form-select rounded-0"
+                      value={idPuntoVenta}
+                      disabled={ejecutando}
+                      onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
+                    >
+                      {puntosVenta.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.nombre}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="form-check mb-3">
+                    <input
+                      id="cc-reliq-confirmacion"
+                      type="checkbox"
+                      className="form-check-input rounded-0"
+                      checked={confirmado}
+                      disabled={ejecutando}
+                      onChange={(e) => setConfirmado(e.target.checked)}
+                    />
+                    <label className="form-check-label" htmlFor="cc-reliq-confirmacion">
+                      Confirmo que quiero actualizar los precios de este cliente. La reliquidación es irreversible: no
+                      se puede deshacer, la única corrección posible es un ajuste manual posterior.
+                    </label>
+                  </div>
+                </>
+              )}
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-outline-secondary rounded-0" disabled={ejecutando} onClick={onCerrar}>
+                {previewEsNoOp ? 'Cerrar' : 'Cancelar'}
+              </button>
+              {!previewEsNoOp && (
+                <button type="button" className="btn btn-danger rounded-0" disabled={!puedeEjecutar} onClick={ejecutar}>
+                  {ejecutando ? 'Ejecutando…' : 'Ejecutar reliquidación'}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop show" />
+    </>
+  )
+}
+
 type PropsPantalla = {
   idCliente: number
   clienteInfo: ClienteListado | null
@@ -533,7 +885,17 @@ function PantallaCuentaCorriente({
   const generacionEstadoRef = useRef(0)
 
   const [modalPagoAbierto, setModalPagoAbierto] = useState(false)
-  const [avisoPago, setAvisoPago] = useState('')
+  const [modalAjusteAbierto, setModalAjusteAbierto] = useState(false)
+  const [modalReliquidacionAbierto, setModalReliquidacionAbierto] = useState(false)
+  // Aviso compartido por las tres acciones de escritura (pago, ajuste, reliquidación) — mismo
+  // patrón de banner único que ya usaba el pago (rule 10 sweep: el aviso de éxito aplica parejo).
+  const [aviso, setAviso] = useState('')
+
+  const { usuario } = useAuth()
+  // Cosmético (design: Web Composition — "el servidor vuelve a exigir SupervisionDeCuentaCorriente
+  // en cada request"): un Vendedor no ve estos botones, pero incluso si forzara el DOM el 403 del
+  // servidor sigue siendo la autoridad real.
+  const esSupervisorOAdmin = usuario !== null && puedeSupervisarCuentaCorriente(usuario.rolId)
 
   // regla 2: cada cambio de filtro dispara una nueva consulta — una respuesta desactualizada
   // nunca puede pisar la más reciente.
@@ -589,6 +951,30 @@ function PantallaCuentaCorriente({
     motivoBloqueoPago = 'No se pudieron cargar los datos necesarios para registrar un pago.'
   }
 
+  // El ajuste manual y la reliquidación no necesitan medios de pago (ninguno de los dos mueve
+  // plata física), pero sí cliente identificado y al menos un punto de venta — mismo criterio de
+  // fail-closed que `puedeIngresarPago` (Fix 2, regla 7).
+  const puedeSupervisarCC =
+    esSupervisorOAdmin &&
+    !cargandoCliente &&
+    clienteInfo !== null &&
+    errorCliente === '' &&
+    puntosVenta !== null &&
+    errorPuntosVenta === '' &&
+    puntosVenta.length > 0 &&
+    !esConsumidorFinal
+
+  let motivoBloqueoSupervision: string | undefined
+  if (cargandoCliente) {
+    motivoBloqueoSupervision = 'Cargando los datos del cliente…'
+  } else if (errorCliente) {
+    motivoBloqueoSupervision = 'No se pudo confirmar el cliente — no se puede continuar hasta que esto se resuelva.'
+  } else if (esConsumidorFinal) {
+    motivoBloqueoSupervision = 'El Consumidor Final no tiene cuenta corriente.'
+  } else if (!puedeSupervisarCC) {
+    motivoBloqueoSupervision = 'No se pudieron cargar los datos necesarios.'
+  }
+
   return (
     <div className="container-fluid py-4">
       <Box
@@ -599,7 +985,7 @@ function PantallaCuentaCorriente({
           </Link>
         }
       >
-        {avisoPago && <div className="alert alert-success rounded-0">{avisoPago}</div>}
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
         {errorEstado && <div className="alert alert-danger rounded-0">{errorEstado}</div>}
         {(errorCliente || errorMedios || errorPuntosVenta) && (
           <div className="alert alert-warning rounded-0 py-1 px-2 small">
@@ -625,18 +1011,48 @@ function PantallaCuentaCorriente({
                 <div>{formatearDisponibilidad(estado.header.disponibilidad)}</div>
               </div>
               <div className="col-md-3 text-md-end">
-                <button
-                  type="button"
-                  className="btn btn-primary rounded-0"
-                  disabled={!puedeIngresarPago}
-                  title={motivoBloqueoPago}
-                  onClick={() => {
-                    setAvisoPago('')
-                    setModalPagoAbierto(true)
-                  }}
-                >
-                  Ingresar pago
-                </button>
+                <div className="d-flex gap-2 justify-content-md-end flex-wrap">
+                  {esSupervisorOAdmin && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn btn-outline-secondary rounded-0"
+                        disabled={!puedeSupervisarCC}
+                        title={motivoBloqueoSupervision}
+                        onClick={() => {
+                          setAviso('')
+                          setModalAjusteAbierto(true)
+                        }}
+                      >
+                        Ajuste manual
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-outline-danger rounded-0"
+                        disabled={!puedeSupervisarCC}
+                        title={motivoBloqueoSupervision}
+                        onClick={() => {
+                          setAviso('')
+                          setModalReliquidacionAbierto(true)
+                        }}
+                      >
+                        Actualizar precios
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    className="btn btn-primary rounded-0"
+                    disabled={!puedeIngresarPago}
+                    title={motivoBloqueoPago}
+                    onClick={() => {
+                      setAviso('')
+                      setModalPagoAbierto(true)
+                    }}
+                  >
+                    Ingresar pago
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -747,10 +1163,51 @@ function PantallaCuentaCorriente({
           }}
           onRegistrado={(comprobante) => {
             setModalPagoAbierto(false)
-            setAvisoPago(`Pago registrado: comprobante ${comprobante.numeroVisible}.`)
+            setAviso(`Pago registrado: comprobante ${comprobante.numeroVisible}.`)
             // regla 6: el refetch queda aislado del try/catch de la escritura del modal — si
             // falla, no pisa el aviso de éxito de arriba (solo el propio error de carga del
             // ledger, que ya tiene su mensaje distinguible).
+            cargarEstado()
+          }}
+        />
+      )}
+
+      {modalAjusteAbierto && estado && puntosVenta && (
+        <ModalAjusteDeCuenta
+          idCliente={idCliente}
+          puntosVenta={puntosVenta}
+          header={estado.header}
+          onCerrar={() => setModalAjusteAbierto(false)}
+          onAntesDeEscribir={() => {
+            generacionEstadoRef.current += 1
+          }}
+          onRegistrado={(movimiento) => {
+            setModalAjusteAbierto(false)
+            setAviso(`Ajuste registrado: ${formatearMoneda(movimiento.importe)}.`)
+            // regla 6: el refetch queda aislado del try/catch de la escritura del modal.
+            cargarEstado()
+          }}
+        />
+      )}
+
+      {modalReliquidacionAbierto && estado && puntosVenta && (
+        <ModalReliquidacion
+          idCliente={idCliente}
+          puntosVenta={puntosVenta}
+          onCerrar={() => setModalReliquidacionAbierto(false)}
+          onAntesDeEscribir={() => {
+            generacionEstadoRef.current += 1
+          }}
+          onEjecutada={(resultado) => {
+            setModalReliquidacionAbierto(false)
+            // regla 6: un commit 2xx nunca se reporta como fallo — el no-op de la carrera
+            // preview↔commit (design: "a consumo committing during a run is simply picked up by
+            // the next run") también es un aviso de éxito, no un error.
+            setAviso(
+              reliquidacionEsNoOp(resultado)
+                ? 'No había nada para actualizar.'
+                : `Precios actualizados: ${formatearMoneda(resultado.delta)} sobre ${resultado.idsMovimientosCubiertos.length} consumo(s).${resultado.hayMas ? ' Quedan más consumos pendientes — corré la reliquidación de nuevo.' : ''}`,
+            )
             cargarEstado()
           }}
         />


### PR DESCRIPTION
## Resumen

Slice 6/6 de la etapa 7 — las dos palancas de supervisión llegan a la pantalla y el modelo se cierra en doc 10.

- **Ajuste manual** (Supervisor+Admin): importe con signo y semántica clara, detalle ≥5 espejado, preview del saldo resultante, y confirmación explícita (la palanca discrecional ahora tiene MÁS fricción que la derivada, como corresponde).
- **Reliquidación**: preview → confirmación de irreversibilidad → ejecución, con el **detalle auditable por consumo VISIBLE antes de confirmar** (por línea: precio histórico → actual, delta, motivo de líneas salteadas) y el resultado EJECUTADO siempre mostrado (nunca el previsualizado — pinneado con el test 40→75). El no-op renderiza honesto; hayMas invita a la segunda corrida.
- **El ledger parsea el JSON de ActualizacionPrecios** (claves PascalCase reales del backend, tolerante a ambos casos, fallback defensivo) — "N consumos re-preciados" expandible en vez de un blob crudo.
- Gating por rol cosmético (server autoritativo), uniformidad de avisos/gates en los tres modales, doc 10 §8 con la nota de cierre de la etapa.
- Desviación fundada: NO se replicó la recuperación de `turno_no_abierto` — ajuste y reliquidación no resuelven turno (verificado por ambos jueces contra el backend); código muerto evitado.

## Verificación

- vitest 322/322 (x2), tsc/oxlint/vite build limpios. Cero archivos backend.
- Judgment-day: ronda 1 (2 MAJORs: detalle auditable invisible + asimetría preview/commit del no-op [backend, va como micro-PR aparte]; + minors), ronda 2 sobre los fixes (ambos jueces convergentes: rama PascalCase del parser sin cobertura, 5 asserts de valor perdidos en la migración de selectores), ronda 3 test-only con mutación (typo en clave → rojo). Cierre limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)