### PR TITLE
fix(cc): normalizar el delta cero del preview de reliquidacion

### DIFF
--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -44,7 +44,11 @@ public class ServicioDeReliquidacion(
         }
 
         var precioPorArticulo = await ResolverPreciosAsync(consumos, cliente.IdListaPrecio, momento, ct);
-        return ReliquidadorDeConsumos.Calcular(consumos, precioPorArticulo);
+        var resultado = ReliquidadorDeConsumos.Calcular(consumos, precioPorArticulo);
+
+        // Delta cero ⇒ mismo criterio que EjecutarTransaccionAsync: el commit no marca nada, así
+        // que el preview tiene que anticipar esa misma respuesta (never two formulas).
+        return resultado.Delta == 0m ? resultado with { IdsMovimientosCubiertos = [] } : resultado;
     }
 
     /// <summary>Commit — design: Transactions, RELIQUIDACIÓN (8 pasos, orden pineado). La mitad

--- a/tests/Ways.IntegrationTests/ReliquidacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionTests.cs
@@ -879,6 +879,29 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         Assert.Null(marcadorBaja);
     }
 
+    [Fact]
+    public async Task UnPreviewConDeltaTotalCeroPorDeltasQueSeCancelanNoMuestraNingunConsumoCubierto()
+    {
+        // Mismo escenario de deltas que se cancelan (+50/-50) que
+        // UnDeltaTotalCeroPorDeltasQueSeCancelanNoDejaNingunConsumoMarcadoComoCubierto, pero
+        // consultado por GET: el preview tiene que anticipar la MISMA respuesta que el commit
+        // (never two formulas) — nada de "cubiertos" para un delta que no va a escribir nada.
+        var ctx = await PrepararAsync(nameof(UnPreviewConDeltaTotalCeroPorDeltasQueSeCancelanNoMuestraNingunConsumoCubierto));
+        var idArticuloSube = await SembrarArticuloConPrecioAsync(ctx, "articulo-preview-cancela-sube", 100m);
+        var idArticuloBaja = await SembrarArticuloConPrecioAsync(ctx, "articulo-preview-cancela-baja", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente preview delta cancela");
+
+        await RealizarConsumoAsync(ctx, idCliente, idArticuloSube, 1m, 100m);
+        await RealizarConsumoAsync(ctx, idCliente, idArticuloBaja, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticuloSube, 150m); // delta +50.
+        await SubirPrecioAsync(ctx, idArticuloBaja, 50m); // delta -50.
+
+        var resultado = await LeerResultadoAsync(await PreviewAsync(ctx, idCliente));
+
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Empty(resultado.IdsMovimientosCubiertos);
+    }
+
     // ---- el cap de 500 consumos por corrida, punta a punta -------------------------------------
 
     /// <summary>Seed crudo en lote (<c>AddRange</c> + un único <c>SaveChangesAsync</c> por tabla,


### PR DESCRIPTION
## Resumen

Micro-follow-up del hallazgo del juez A en la ronda del slice 6: `PreviewAsync` devolvía el resultado crudo del calculador mientras `EjecutarTransaccionAsync` normalizaba el delta-cero — el preview mostraba "Consumos cubiertos: N" para una corrida que ejecutaría como no-op. El supervisor confirmaba una acción irreversible sobre cobertura que no iba a existir.

- `PreviewAsync` aplica la MISMA normalización que el commit (`IdsMovimientosCubiertos = []` con delta 0) — contrato preview == commit para el no-op.
- Test de integración con deltas compensados (+50/−50) contra el GET, con evidencia de mutación.
- Frontend: sin cambios — `reliquidacionEsNoOp` ya deriva de la lista, la UI ya renderiza el no-op pre-confirmación correctamente.

## Verificación

Domain 356 / Application 212 / Integration 556 (+1) / vitest 322, contra Postgres real. Build 0 warnings, sin migración. Fix de una línea prescripto por el juez con mutación verificada (ronda del orquestador).

🤖 Generated with [Claude Code](https://claude.com/claude-code)