### PR TITLE
feat(compras): esquema de comprobantes de compra y FKs diferidas (etapa 8, slice 1)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -99,6 +99,18 @@ del comprobante). Se siembra dos veces: en la lista de arriba para una base nuev
 idempotente, dentro de la migración `CuentaCorrienteEtapa7` para una base ya migrada — este
 seed corre solo cuando la tabla está vacía.
 
+**`C-FA`/`C-FB`/`C-FC` (etapa 8 — comprobantes de compra, doc 10 §5):** `clase compra`,
+`letra` A/B/C, `signo +1` (entran mercadería), `discrimina_iva` solo en `C-FA` (el costo del
+proveedor es neto de IVA), `es_fiscal false` (el sistema nunca *emite* la factura del
+proveedor — la flag distingue si reporta a AFIP/ARCA como emisor, no si hay crédito de IVA),
+`afecta_stock true`. El prefijo `C-` es **obligatorio, no cosmético**:
+`ux_tipos_comprobante_codigo` es UNIQUE sobre `codigo` solo (sin `clase`), así que un código
+de compra sin prefijo podría colisionar con uno de venta existente y quedar resuelto por el
+camino equivocado. No se siembran notas de crédito de proveedor — la anulación es la única
+reversión de una compra confirmada (proposal decisión 10). Mismo mecanismo de siembra doble
+que `RC`: en la lista de arriba para una base nueva y, de forma idempotente, dentro de la
+migración `ComprasYTransferenciasEtapa8` para una base ya migrada.
+
 **Regla de la letra** (se implementa en dominio, no en tablas): la letra sale del cruce
 `condición fiscal de la empresa emisora × condición fiscal del cliente`. RI → RI emite A;
 RI → CF/monotributo emite B; monotributista emite C a todos; el ticket no fiscal de hoy
@@ -403,6 +415,26 @@ Ciclo: se carga en `borrador` (se puede ir armando con el remito en la mano), y 
 actualiza `costo_nominal` donde `actualiza_costo`, y ofrece actualizar precios de venta
 según margen del grupo/proveedor. `anulada` revierte con contramovimientos.
 
+> **Estado (Etapa 8, Slice 1 — schema + seed gate):** `comprobantes_compra`/
+> `items_comprobante_compra` creadas por la migración `ComprasYTransferenciasEtapa8`, con dos
+> ajustes de conformidad sobre el esquema de arriba (DB CHANGE GATE, autonomous mode
+> 2026-08-05): (1) la unicidad de `numero_externo` gana `id_tenant` en la clave —
+> `(id_tenant, id_proveedor, id_tipo_comprobante, numero_externo)` — porque toda tabla
+> `[operativa]` está tenant-scoped y el esquema de arriba omite `id_tenant` por convención;
+> (2) es una **unicidad PARCIAL** (`WHERE estado <> 'anulada' AND numero_externo IS NOT
+> NULL`), no una UNIQUE llana: excluye `numero_externo NULL` mientras es borrador y permite
+> reingresar el número de una factura anulada por error de carga. `id_articulo` en
+> `items_comprobante_compra` es **`NOT NULL`**, a diferencia de `items_comprobante_venta`
+> (§4): una línea de compra sin artículo no puede mover stock ni actualizar costo — sería un
+> gasto, y los gastos ya existen como concepto separado. Nueva CHECK
+> `ck_comprobantes_compra_confirmada_completa` (`estado = 'borrador' OR (numero_externo,
+> fecha_comprobante, fecha_recepcion todos NOT NULL)`), no especificada arriba, cierra a nivel
+> esquema la regla de negocio "no se confirma sin identidad de factura". `estado_compra` se
+> registra únicamente vía `npgsql.MapEnum<EstadoCompra>` en `DependencyInjection.cs` y
+> `WaysDbContextFactory.cs` — nunca también con `HasPostgresEnum`, mismo criterio que el
+> resto de los enums nativos del proyecto. La aritmética de la compra (`CalculadorDeCompra`),
+> el ciclo `borrador → confirmada → anulada` y la actualización de `costo_nominal` son Slice 2.
+
 **Relación con gastos:** la compra registra la mercadería; el gasto registra la plata.
 `gastos` gana `id_comprobante_compra NULL`: pagarle al proveedor referencia la factura.
 Una compra puede estar impaga (sin gasto asociado) — eso ya da una cuenta corriente de
@@ -426,12 +458,19 @@ van a `movimientos_caja` (§7).
 > **Estado (Etapa 6, Slice 1):** `gastos` se crea en esta etapa, pero **sin**
 > `id_comprobante_compra`: `comprobantes_compra` no existe todavía (etapa 8), así que un
 > `int NULL` sin FK sería una referencia sin garantía — mismo criterio que
-> `movimientos_stock.id_comprobante_compra` (§6). La etapa 8 agrega la columna y su FK
-> juntas, en la misma migración que crea `comprobantes_compra` (design de
-> stage-6-turnos-caja: Table Shapes — write path C). `id_turno_caja` sí se crea **NOT NULL**
+> `movimientos_stock.id_comprobante_compra` (§6). `id_turno_caja` sí se crea **NOT NULL**
 > desde esta etapa (a diferencia de la ambigüedad de la tabla de arriba, que lo muestra
 > nullable): todo gasto se registra contra un turno abierto, resuelto server-side, nunca
 > input de cliente.
+>
+> **Estado (Etapa 8, Slice 1 — RESUELTO):** `gastos.id_comprobante_compra` aterriza en esta
+> slice, junto con su FK compuesta `(id_comprobante_compra, id_tenant)` RESTRICT y su índice
+> de soporte — la deuda declarada arriba queda pagada, sin cambio de forma en ninguna otra
+> columna. Poblado por `ServicioDeGastos` (etapa 8, Slice 4) bajo un `SELECT ... FOR SHARE`
+> sobre el header de la compra (TOCTOU cerrado contra una anulación concurrente); solo válido
+> cuando `categoria = proveedor` y la compra referenciada está `confirmada`. El vínculo es
+> historia, no un bloqueo: anular la compra vinculada sigue permitido (design decisión 6 —
+> ningún camino de reversión de gasto existe todavía).
 
 ## 6. Stock
 
@@ -456,13 +495,16 @@ movimientos_stock (           -- [operativa]
 
 > **Estado (Etapa 5, Slice 3):** `stock` y `movimientos_stock` implementadas — `motivo` solo
 > tiene camino de escritura para `venta`/`anulacion`/`ajuste` en esta etapa; `compra`/
-> `transferencia`/`inventario` quedan como valores reservados del enum, sin escritor. La columna
-> `id_comprobante_compra` de arriba **no se crea todavía**: `comprobantes_compra` no existe
-> (doc 10 §5, etapa 8), así que un `int NULL` sin FK sería una referencia sin garantía. La etapa
-> 8 agrega la columna y su FK juntas, en la misma migración que crea `comprobantes_compra`
-> (deviación declarada de este documento, design de stage-5-pos-ventas: Table Shapes — write
-> path B). `id_punto_venta_destino` sí se crea en esta etapa (columna lista para
-> transferencias), pero ningún camino de escritura la usa todavía.
+> `transferencia`/`inventario` quedan como valores reservados del enum, sin escritor.
+> `id_punto_venta_destino` sí se crea en esta etapa (columna lista para transferencias), pero
+> ningún camino de escritura la usa todavía.
+>
+> **Estado (Etapa 8, Slice 1 — RESUELTO):** `movimientos_stock.id_comprobante_compra` aterriza
+> en esta slice, junto con su FK compuesta `(id_comprobante_compra, id_tenant)` RESTRICT y su
+> índice de soporte — la deuda declarada arriba (columna sin FK) queda pagada. `motivo = compra`
+> abre camino de escritura recién en Slice 2 (`ServicioDeCompras.ConfirmarAsync`/`AnularAsync`);
+> `transferencia`/`inventario` lo abren en Slice 3 (`ServicioDeStock.TransferirAsync`/
+> `ContarAsync`) — ningún escritor nuevo se agrega en esta slice, solo el esquema.
 > Nota de implementación: los FK de `id_empleado` (comprobantes_venta, movimientos_stock,
 > movimientos_cuenta_corriente) son simples hacia `usuarios.id_usuario` — no compuestos con
 > `id_tenant` — porque la clave alterna requerida forzaría `id_tenant NOT NULL` en `usuarios`,

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -48,6 +48,23 @@ public class ManejadorDeErrores(
                 when string.Equals(uxComprobante, "ux_comprobantes_venta_numero", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "Ya existe un comprobante con ese número en este punto de venta y tipo.", "numero_de_comprobante_duplicado"),
 
+            // stage-8-compras-transferencias-inventario (Slice 1, task 1.10, db-error-backstops,
+            // design: Backstop Map — "ordering trap"): mismo tratamiento que
+            // ux_comprobantes_venta_numero de arriba — su nombre contiene "_numero", así que
+            // tiene que resolverse por nombre EXACTO acá, ANTES de ClasificarUnicidad (que lo
+            // clasificaría como "numero_duplicado", el mensaje de ux_clientes_numero).
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string uxCompra } }
+                when string.Equals(uxCompra, "ux_comprobantes_compra_numero_externo", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe una compra con ese número de comprobante para este proveedor y tipo.", "compra_duplicada"),
+
+            // stage-8-compras-transferencias-inventario (Slice 1, task 1.10, db-error-backstops,
+            // design: Backstop Map): orden es server-asignado dentro del replace-set (Slice 2) —
+            // exención documentada de prueba de carrera, misma familia que
+            // ux_items_comprobante_venta_orden.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string uxOrdenCompra } }
+                when string.Equals(uxOrdenCompra, "ux_items_comprobante_compra_orden", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un ítem con ese orden en esta compra.", "orden_de_item_duplicado"),
+
             // Backstop genérico (judgment-day, slice 3 ronda 1) para las ~10 unicidades nuevas
             // de catálogos/parámetros/catálogos fiscales: mismo mecanismo de carrera que los
             // dos casos de arriba, pero agrupado por familia (a partir del nombre del índice,
@@ -133,6 +150,13 @@ public class ManejadorDeErrores(
             // reliquidación). En operación normal es inalcanzable — el id viene del RETURNING de
             // la misma transacción que la fila que apunta —, así que el único camino para
             // ejercitarla es un INSERT crudo fuera de banda (test de esquema, no de cliente HTTP).
+            //
+            // stage-8-compras-transferencias-inventario (Slice 1, task 1.10, db-error-backstops):
+            // confirmado sin cambio de código — el mismo match por prefijo "fk_" ya cubre las FKs
+            // nuevas de esta slice (comprobantes_compra: tenant/proveedor/punto_venta/empleado/
+            // tipo_comprobante; items_comprobante_compra: tenant/comprobante/articulo/
+            // alicuota_iva; fk_movimientos_stock_comprobante_compra; fk_gastos_comprobante_compra)
+            // — todas siguen la convención fk_* del resto del esquema.
             DbUpdateException { InnerException: PostgresException { SqlState: "23503", ConstraintName: string fk } }
                 when fk.StartsWith("fk_", StringComparison.Ordinal) =>
                 LogYClasificarReferenciaInvalida(fk, log),
@@ -171,6 +195,20 @@ public class ManejadorDeErrores(
             DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckCaja } }
                 when ClasificarCheckDeCaja(ckCaja) is { } checkCaja =>
                 (checkCaja.EstadoHttp, checkCaja.Titulo, checkCaja.Codigo),
+
+            // stage-8-compras-transferencias-inventario (Slice 1, task 1.10, db-error-backstops,
+            // design: Backstop Map): switch por nombre EXACTO detrás de un guard de prefijo
+            // "ck_comprobantes_compra_"/"ck_items_comprobante_compra_" — mismo criterio que
+            // ClasificarCheckDeOfertas ("ck_ofertas_"), no el de ClasificarCheckDeVentas/
+            // ClasificarCheckDeCaja (sin prefijo compartido). CalculadorDeCompra/ServicioDeCompras
+            // (Slice 2) ya validan estos cinco invariantes en el camino de servicio — bajo
+            // operación normal ninguna rama es alcanzable, quedan como backstop de una escritura
+            // cruda/fuera de banda.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23514", ConstraintName: string ckCompra } }
+                when (ckCompra.StartsWith("ck_comprobantes_compra_", StringComparison.Ordinal)
+                        || ckCompra.StartsWith("ck_items_comprobante_compra_", StringComparison.Ordinal))
+                    && ClasificarCheckDeCompras(ckCompra) is { } checkCompra =>
+                (checkCompra.EstadoHttp, checkCompra.Titulo, checkCompra.Codigo),
 
             // Backstop genérico (db-error-backstops, judgment-day slice 3 ronda 1): cualquier
             // valor numérico que desborda la precisión/escala de su columna (p.ej. un margen o
@@ -561,6 +599,41 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status400BadRequest,
                     "La cadena de tesorería es inconsistente (final tiene que ser inicio + ingreso − egreso).",
                     "tesoreria_cadena_invalida"),
+
+            _ => null
+        };
+
+    /// <summary>stage-8-compras-transferencias-inventario (Slice 1, task 1.10, db-error-backstops,
+    /// design: Backstop Map): switch por nombre EXACTO de las cinco CHECKs nuevas de
+    /// <c>comprobantes_compra</c>/<c>items_comprobante_compra</c>, detrás del guard de prefijo
+    /// del caso de arriba (el criterio de <c>ClasificarCheckDeOfertas</c>).</summary>
+    private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeCompras(string nombreDeCheck) =>
+        nombreDeCheck switch
+        {
+            "ck_comprobantes_compra_confirmada_completa" =>
+                (StatusCodes.Status400BadRequest,
+                    "La compra no puede confirmarse sin número de comprobante y fecha.",
+                    "compra_incompleta_para_confirmar"),
+
+            "ck_comprobantes_compra_totales_no_negativos" =>
+                (StatusCodes.Status400BadRequest,
+                    "Los totales de la compra no pueden ser negativos.",
+                    "totales_de_compra_invalidos"),
+
+            "ck_items_comprobante_compra_cantidad_positiva" =>
+                (StatusCodes.Status400BadRequest,
+                    "La cantidad de un ítem de compra tiene que ser positiva.",
+                    "cantidad_de_item_invalida"),
+
+            "ck_items_comprobante_compra_costo_no_negativo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El costo unitario de un ítem de compra no puede ser negativo.",
+                    "costo_de_item_invalido"),
+
+            "ck_items_comprobante_compra_importes_no_negativos" =>
+                (StatusCodes.Status400BadRequest,
+                    "Los importes de un ítem de compra no pueden ser negativos.",
+                    "importes_de_item_invalidos"),
 
             _ => null
         };

--- a/src/Ways.Domain/Compras/ComprobanteCompra.cs
+++ b/src/Ways.Domain/Compras/ComprobanteCompra.cs
@@ -1,0 +1,58 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Compras;
+
+/// <summary>
+/// Comprobante de compra (doc 10 §5, design: Table Shapes — A). Operativa-scoped (<c>id_tenant</c>
+/// + <c>id_punto_venta</c>, doc 09), misma base que <see cref="Ways.Domain.Ventas.ComprobanteVenta"/>
+/// (<see cref="EntidadTenant"/>) — <see cref="UpdatedAt"/> es genuinamente significativo acá: un
+/// <see cref="Estado"/> <see cref="EstadoCompra.Borrador"/> es el único documento mutable del
+/// sistema (design decisión 2). <see cref="EntidadBase.DeletedAt"/> nunca se escribe — no existe
+/// endpoint de borrado, el registro transiciona de estado, nunca se elimina.
+///
+/// <see cref="NumeroExterno"/>/<see cref="FechaComprobante"/> quedan <c>NULL</c> mientras
+/// <see cref="Estado"/> es <see cref="EstadoCompra.Borrador"/> (doc-10:374-375) —
+/// <c>ck_comprobantes_compra_confirmada_completa</c> es el backstop de esquema de esa regla.
+/// <see cref="FechaRecepcion"/> lo escribe únicamente <c>ServicioDeCompras.ConfirmarAsync</c>
+/// (Slice 2) desde <c>IRelojDelSistema.Ahora</c> — nunca input de cliente.
+/// </summary>
+public class ComprobanteCompra : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdProveedor { get; set; }
+
+    /// <summary><c>clase = compra</c> se exige en el servicio (Slice 2), no por esquema — el
+    /// mismo criterio que <c>ComprobanteVenta.IdTipoComprobante</c> con <c>clase = venta</c>.</summary>
+    public int IdTipoComprobante { get; set; }
+
+    /// <summary>El número del proveedor (doc-10:374-375) — acá no hay correlativo propio, a
+    /// diferencia de <c>ComprobanteVenta.Numero</c>. <c>NULL</c> mientras <c>Borrador</c>.</summary>
+    public string? NumeroExterno { get; set; }
+
+    /// <summary>La fecha de la factura del proveedor — <c>NULL</c> mientras <c>Borrador</c>.</summary>
+    public DateOnly? FechaComprobante { get; set; }
+
+    /// <summary>Escrito por la confirmación desde <c>IRelojDelSistema.Ahora</c> — nunca input de
+    /// cliente (design: Transactions — CONFIRMAR COMPRA).</summary>
+    public DateTimeOffset? FechaRecepcion { get; set; }
+
+    /// <summary>El local donde entra la mercadería (doc-10:378).</summary>
+    public int IdPuntoVenta { get; set; }
+
+    /// <summary><c>IContextoDeUsuario.UsuarioId</c> — mismo criterio que
+    /// <c>ComprobanteVenta.IdEmpleado</c> (FK simple, deviación documentada).</summary>
+    public int IdEmpleado { get; set; }
+
+    public decimal Subtotal { get; set; }
+    public decimal DescuentoTotal { get; set; }
+    public decimal Total { get; set; }
+
+    /// <summary><c>NULL</c> cuando <c>tipos_comprobante.discrimina_iva = false</c> (design:
+    /// Compra Arithmetic) — misma postura que <c>ComprobanteVenta.IvaTotal</c>.</summary>
+    public decimal? IvaTotal { get; set; }
+
+    public string? Observaciones { get; set; }
+
+    public EstadoCompra Estado { get; set; } = EstadoCompra.Borrador;
+}

--- a/src/Ways.Domain/Compras/EstadoCompra.cs
+++ b/src/Ways.Domain/Compras/EstadoCompra.cs
@@ -1,0 +1,20 @@
+namespace Ways.Domain.Compras;
+
+/// <summary>
+/// Ciclo de vida de un <see cref="ComprobanteCompra"/> (doc 10 §5, design: Table Shapes — C).
+/// Enum nativo de Postgres (<c>estado_compra</c>), registrado por
+/// <c>npgsql.MapEnum&lt;EstadoCompra&gt;("estado_compra")</c> en ambos sitios (Slice 1, task
+/// 1.6) — nunca también vía <c>HasPostgresEnum</c>.
+///
+/// <see cref="Borrador"/> es el único estado editable (mutación segura porque no produjo ningún
+/// movimiento todavía); <see cref="Confirmada"/> y <see cref="Anulada"/> son terminales de
+/// escritura de items — la única transición posterior a <see cref="Confirmada"/> es hacia
+/// <see cref="Anulada"/> (<c>ServicioDeCompras.AnularAsync</c>, Slice 2, <c>UPDATE ... WHERE
+/// estado = 'confirmada'</c> condicional, el mismo patrón que <c>ComprobanteVenta.Estado</c>).
+/// </summary>
+public enum EstadoCompra
+{
+    Borrador,
+    Confirmada,
+    Anulada
+}

--- a/src/Ways.Domain/Compras/ItemComprobanteCompra.cs
+++ b/src/Ways.Domain/Compras/ItemComprobanteCompra.cs
@@ -1,0 +1,66 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Compras;
+
+/// <summary>
+/// Línea de un <see cref="ComprobanteCompra"/> (doc 10 §5, design: Table Shapes — B). Child
+/// scope: <c>id_tenant</c> únicamente, sin FK propia a <c>puntos_venta</c> — se deriva del
+/// comprobante padre, mismo criterio que <c>ItemComprobanteVenta</c>.
+///
+/// A diferencia de <c>ItemComprobanteVenta</c>, <see cref="IdArticulo"/> es deliberadamente
+/// <c>NOT NULL</c> (design: Table Shapes — B): una línea de compra sin artículo no puede mover
+/// stock ni actualizar costo — sería un gasto, y los gastos ya existen como concepto separado.
+///
+/// Mientras el comprobante está en <see cref="EstadoCompra.Borrador"/> las filas se reemplazan
+/// físicamente (<c>DELETE</c> + <c>INSERT</c>, design decisión 2, <c>ServicioDeCompras.
+/// ActualizarBorradorAsync</c>) — no hay edición incremental de una fila existente.
+/// </summary>
+public class ItemComprobanteCompra : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdComprobanteCompra { get; set; }
+
+    /// <summary>Asignado por el servidor en cada replace-set (design decisión 2) — nunca input
+    /// de cliente.</summary>
+    public int Orden { get; set; }
+
+    public int IdArticulo { get; set; }
+
+    /// <summary>Snapshot al momento del guardado del borrador.</summary>
+    public required string Descripcion { get; set; }
+
+    /// <summary>Derivado (design: Compra Arithmetic): <c>unidades + (bultos ?? 0) ×
+    /// (unidadesPorBulto ?? 0)</c>, nunca input directo de cliente (design decisión 3).</summary>
+    public decimal Cantidad { get; set; }
+
+    /// <summary>Inputs conservados para auditoría (doc-10:391) — no participan en ningún cálculo
+    /// posterior a la derivación de <see cref="Cantidad"/>.</summary>
+    public decimal? Bultos { get; set; }
+    public decimal? UnidadesPorBulto { get; set; }
+
+    /// <summary><c>numeric(14,4)</c>: costos con más precisión que los precios de venta
+    /// (doc-10:392) — la CHECK permite <c>0</c> a propósito (líneas de bonificación son reales,
+    /// design decisión 4).</summary>
+    public decimal CostoUnitario { get; set; }
+
+    /// <summary>Importe de línea (misma semántica que <c>ItemComprobanteVenta.Descuento</c>).</summary>
+    public decimal Descuento { get; set; }
+
+    public int IdAlicuotaIva { get; set; }
+
+    /// <summary>Snapshot — informativo cuando el tipo no discrimina IVA.</summary>
+    public decimal PorcentajeIva { get; set; }
+
+    /// <summary>Derivado: <c>bruto − descuento</c> (design: Compra Arithmetic).</summary>
+    public decimal Total { get; set; }
+
+    /// <summary>Si esta línea pisa <c>articulos.costo_nominal</c> al confirmar (doc-10:396) —
+    /// combinado con <c>CostoUnitario &gt; 0</c> (design decisión 4).</summary>
+    public bool ActualizaCosto { get; set; } = true;
+
+    /// <summary>Sugerencia calculada al guardar el borrador (design: Compra Arithmetic) —
+    /// nunca aplicada por la confirmación (design decisión 3). <c>NULL</c> solo si el artículo
+    /// no tiene margen configurado.</summary>
+    public decimal? PrecioSugerido { get; set; }
+}

--- a/src/Ways.Domain/Gastos/Gasto.cs
+++ b/src/Ways.Domain/Gastos/Gasto.cs
@@ -8,11 +8,10 @@ namespace Ways.Domain.Gastos;
 /// gana <c>updated_at</c>/baja lógica igual que <c>Cliente</c>/<c>Proveedor</c>, a diferencia de
 /// los ledgers append-only de esta misma etapa.
 ///
-/// <c>id_comprobante_compra</c> NO existe todavía (proposal decisión 1, design: Table Shapes —
-/// write path C): <c>comprobantes_compra</c> no existe, así que la columna se difiere a la
-/// etapa 8 (que la crea junto con su FK, mismo patrón que
-/// <see cref="Ways.Domain.Stock.MovimientoStock"/> con su propio FK diferido de compra) en vez
-/// de dejar un <c>int?</c> sin constraint.
+/// <see cref="IdComprobanteCompra"/> aterriza en stage-8 Slice 1 (design: Table Shapes — D):
+/// columna + FK compuesta juntas, mismo patrón que <see cref="Ways.Domain.Stock.MovimientoStock.IdComprobanteCompra"/>.
+/// Poblado por <c>ServicioDeGastos</c> (Slice 4) bajo el guard <c>SELECT ... FOR SHARE</c> sobre
+/// el header de la compra (design decisión 7).
 /// </summary>
 public class Gasto : EntidadTenant
 {
@@ -42,4 +41,10 @@ public class Gasto : EntidadTenant
 
     /// <summary>Siempre <c>&gt; 0</c> (spec: Importe Must Be Positive, <c>ck_gastos_importe_positivo</c>).</summary>
     public decimal Importe { get; set; }
+
+    /// <summary>Vincula el gasto a la compra que paga (design decisión 7) — solo válido cuando
+    /// <see cref="Categoria"/> es <see cref="CategoriaGasto.Proveedor"/> y la compra está
+    /// <c>confirmada</c>; el vínculo es historia, nunca bloquea la anulación de la compra
+    /// (design decisión 6, la regla invertida).</summary>
+    public int? IdComprobanteCompra { get; set; }
 }

--- a/src/Ways.Domain/Stock/MotivoStock.cs
+++ b/src/Ways.Domain/Stock/MotivoStock.cs
@@ -2,10 +2,10 @@ namespace Ways.Domain.Stock;
 
 /// <summary>
 /// Motivo de un <see cref="MovimientoStock"/> (doc 10 §6). Enum nativo de Postgres
-/// (<c>motivo_stock</c>). Stage 5 solo abre camino de escritura para <see cref="Venta"/>,
-/// <see cref="Anulacion"/> y <see cref="Ajuste"/> — <see cref="Compra"/>,
-/// <see cref="Transferencia"/> e <see cref="Inventario"/> son valores reservados sin escritor
-/// todavía (design: Table Shapes — write path B).
+/// (<c>motivo_stock</c>). <see cref="Compra"/> abre camino de escritura en stage-8 Slice 2
+/// (<c>ServicioDeCompras.ConfirmarAsync</c>/<c>AnularAsync</c>); <see cref="Transferencia"/> e
+/// <see cref="Inventario"/> lo abren en Slice 3 (<c>ServicioDeStock.TransferirAsync</c>/
+/// <c>ContarAsync</c>) — ningún escritor nuevo se agrega en esta slice (schema + seed gate).
 /// </summary>
 public enum MotivoStock
 {

--- a/src/Ways.Domain/Stock/MovimientoStock.cs
+++ b/src/Ways.Domain/Stock/MovimientoStock.cs
@@ -13,9 +13,10 @@ namespace Ways.Domain.Stock;
 /// <see cref="Ventas.NumeracionComprobante"/>/<see cref="Ways.Domain.Stock.Stock"/>, con filtro
 /// de tenant escrito a mano en <c>WaysDbContext.AplicarFiltroDeTenantEnMovimientoStock</c>.
 ///
-/// <see cref="IdComprobanteCompra"/> NO existe todavía (design: Table Shapes — write path B):
-/// <c>comprobantes_compra</c> no existe, así que la columna se difiere a la etapa 8 (que la
-/// crea junto con su FK) en vez de dejar un <c>int?</c> sin constraint.
+/// <see cref="IdComprobanteCompra"/> aterriza en stage-8 Slice 1 (design: Table Shapes — D, la
+/// FK diferida de doc-10:457-465): columna + FK compuesta juntas, en la misma migración que crea
+/// <c>comprobantes_compra</c> — nunca escrita fuera de <c>ServicioDeCompras.ConfirmarAsync</c>/
+/// <c>AnularAsync</c> (Slice 2).
 /// </summary>
 public class MovimientoStock
 {
@@ -36,10 +37,14 @@ public class MovimientoStock
     /// <see cref="MotivoStock.Anulacion"/> (design: The Sale Transaction).</summary>
     public int? IdComprobanteVenta { get; set; }
 
-    /// <summary>Transferencias entre locales (doc 10 §6) — columna creada pero nunca escrita
-    /// en esta etapa (design: Table Shapes — write path B, "created, never written"): la
-    /// feature de transferencia no tiene camino de escritura hasta que <c>motivo_stock.
-    /// Transferencia</c> se active.</summary>
+    /// <summary>Poblado solo cuando <see cref="Motivo"/> es <see cref="MotivoStock.Compra"/> o
+    /// la <see cref="MotivoStock.Anulacion"/> que la revierte (design: Table Shapes — D;
+    /// Transactions — CONFIRMAR COMPRA / ANULAR COMPRA).</summary>
+    public int? IdComprobanteCompra { get; set; }
+
+    /// <summary>Transferencias entre locales (doc 10 §6) — columna creada en stage 5, escrita
+    /// recién en stage-8 Slice 3 (<c>ServicioDeStock.TransferirAsync</c>): las dos filas
+    /// espejadas de una transferencia llevan acá el destino (design decisión 5 del proposal).</summary>
     public int? IdPuntoVentaDestino { get; set; }
 
     public int IdEmpleado { get; set; }

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
@@ -103,6 +104,7 @@ public static class DependencyInjection
             npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
             npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
             npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+            npgsql.MapEnum<EstadoCompra>("estado_compra");
             npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
         });
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteCompraConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteCompraConfiguration.cs
@@ -1,0 +1,136 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="ComprobanteCompra"/> (design: Table Shapes — A). Las dos CHECKs son defensa
+/// en profundidad — <c>CalculadorDeCompra</c>/<c>ServicioDeCompras</c> (Slice 2) ya garantizan
+/// ambos invariantes en el camino de servicio, misma familia que
+/// <c>ck_comprobantes_venta_numero_positivo</c>.
+/// </summary>
+public class ComprobanteCompraConfiguration : IEntityTypeConfiguration<ComprobanteCompra>
+{
+    public void Configure(EntityTypeBuilder<ComprobanteCompra> builder)
+    {
+        builder.ToTable("comprobantes_compra", t =>
+        {
+            // design: Table Shapes — A. "confirmada sin identidad de factura" queda
+            // irrepresentable a nivel esquema: un anulada FUE confirmada primero, así que
+            // también la satisface.
+            t.HasCheckConstraint(
+                "ck_comprobantes_compra_confirmada_completa",
+                "estado = 'borrador' OR (numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL AND fecha_recepcion IS NOT NULL)");
+
+            // >= 0, no > 0: un remito totalmente bonificado que totaliza cero es real (design:
+            // Table Shapes — A).
+            t.HasCheckConstraint(
+                "ck_comprobantes_compra_totales_no_negativos",
+                "subtotal >= 0 AND descuento_total >= 0 AND total >= 0 AND (iva_total IS NULL OR iva_total >= 0)");
+        });
+
+        builder.HasKey(c => c.Id).HasName("pk_comprobantes_compra");
+
+        builder.Property(c => c.Id)
+            .HasColumnName("id_comprobante_compra")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(c => c.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        // Habilita las FKs compuestas de items_comprobante_compra (mismo patrón que
+        // ComprobanteVentaConfiguration).
+        builder.HasAlternateKey(c => new { c.Id, c.IdTenant })
+            .HasName("ak_comprobantes_compra_id_comprobante_compra_id_tenant");
+
+        builder.Property(c => c.IdProveedor).HasColumnName("id_proveedor").IsRequired();
+        builder.Property(c => c.IdTipoComprobante).HasColumnName("id_tipo_comprobante").IsRequired();
+
+        builder.Property(c => c.NumeroExterno).HasColumnName("numero_externo").HasColumnType("citext");
+        builder.Property(c => c.FechaComprobante).HasColumnName("fecha_comprobante").HasColumnType("date");
+        builder.Property(c => c.FechaRecepcion).HasColumnName("fecha_recepcion");
+
+        builder.Property(c => c.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
+        builder.Property(c => c.IdEmpleado).HasColumnName("id_empleado").IsRequired();
+
+        builder.Property(c => c.Subtotal).HasColumnName("subtotal").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(c => c.DescuentoTotal).HasColumnName("descuento_total").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(c => c.Total).HasColumnName("total").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(c => c.IvaTotal).HasColumnName("iva_total").HasColumnType("numeric(14,2)");
+
+        builder.Property(c => c.Observaciones).HasColumnName("observaciones").HasColumnType("text");
+
+        builder.Property(c => c.Estado)
+            .HasColumnName("estado")
+            .HasColumnType("estado_compra")
+            .IsRequired();
+
+        builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(c => c.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(c => c.EstaEliminada);
+
+        // ux_comprobantes_compra_numero_externo: partial UNIQUE (design: Table Shapes — A, DB
+        // CHANGE GATE). Excluye estado='anulada' (una factura mal cargada anulada se puede
+        // reingresar) y numero_externo NULL (mientras es borrador). ⚠ Su nombre contiene
+        // "_numero" — ManejadorDeErrores tiene que resolverla por nombre EXACTO ANTES de
+        // ClasificarUnicidad (design: Backstop Map, "ordering trap"), el mismo tratamiento que
+        // ux_comprobantes_venta_numero.
+        builder.HasIndex(c => new { c.IdTenant, c.IdProveedor, c.IdTipoComprobante, c.NumeroExterno })
+            .HasDatabaseName("ux_comprobantes_compra_numero_externo")
+            .IsUnique()
+            .HasFilter("estado <> 'anulada' AND numero_externo IS NOT NULL");
+
+        builder.HasIndex(c => c.IdTenant).HasDatabaseName("ix_comprobantes_compra_tenant");
+        builder.HasIndex(c => new { c.IdProveedor, c.IdTenant }).HasDatabaseName("ix_comprobantes_compra_proveedor");
+
+        builder.HasIndex(c => new { c.IdPuntoVenta, c.IdTenant, c.FechaRecepcion })
+            .HasDatabaseName("ix_comprobantes_compra_punto_venta_fecha");
+
+        builder.HasIndex(c => c.IdTipoComprobante).HasDatabaseName("ix_comprobantes_compra_tipo_comprobante");
+        builder.HasIndex(c => c.IdEmpleado).HasDatabaseName("ix_comprobantes_compra_empleado");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(c => c.IdTenant)
+            .HasConstraintName("fk_comprobantes_compra_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Proveedor>()
+            .WithMany()
+            .HasForeignKey(c => new { c.IdProveedor, c.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_comprobantes_compra_proveedor")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(c => new { c.IdPuntoVenta, c.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_comprobantes_compra_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // tipos_comprobante es global (ADR-11) — FK simple, sin id_tenant. clase = compra se
+        // exige en el servicio (Slice 2), no acá.
+        builder.HasOne<TipoComprobante>()
+            .WithMany()
+            .HasForeignKey(c => c.IdTipoComprobante)
+            .HasConstraintName("fk_comprobantes_compra_tipo_comprobante")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // id_empleado: FK SIMPLE, misma deviación deliberada que
+        // ComprobanteVentaConfiguration.fk_comprobantes_venta_empleado documenta.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(c => c.IdEmpleado)
+            .HasConstraintName("fk_comprobantes_compra_empleado")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/GastoConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/GastoConfiguration.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Proveedores;
@@ -52,6 +53,10 @@ public class GastoConfiguration : IEntityTypeConfiguration<Gasto>
 
         builder.Property(g => g.Importe).HasColumnName("importe").HasColumnType("numeric(14,2)").IsRequired();
 
+        // stage-8-compras-transferencias-inventario, Slice 1 (design: Table Shapes — D, la FK
+        // diferida de doc-10:426-434): columna + FK compuesta aterrizan juntas en esta migración.
+        builder.Property(g => g.IdComprobanteCompra).HasColumnName("id_comprobante_compra");
+
         builder.Property(g => g.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(g => g.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(g => g.DeletedAt).HasColumnName("deleted_at");
@@ -62,6 +67,7 @@ public class GastoConfiguration : IEntityTypeConfiguration<Gasto>
         builder.HasIndex(g => new { g.IdTurnoCaja, g.IdTenant }).HasDatabaseName("ix_gastos_turno");
         builder.HasIndex(g => new { g.IdPuntoVenta, g.IdTenant, g.Fecha }).HasDatabaseName("ix_gastos_punto_venta_fecha");
         builder.HasIndex(g => new { g.IdProveedor, g.IdTenant }).HasDatabaseName("ix_gastos_proveedor");
+        builder.HasIndex(g => new { g.IdComprobanteCompra, g.IdTenant }).HasDatabaseName("ix_gastos_comprobante_compra");
 
         // Índices de soporte de FK (evitan el índice implícito PascalCase de EF, misma trampa
         // que documenta ComprobanteVentaConfiguration).
@@ -101,6 +107,13 @@ public class GastoConfiguration : IEntityTypeConfiguration<Gasto>
             .HasForeignKey(g => new { g.IdProveedor, g.IdTenant })
             .HasPrincipalKey(p => new { p.Id, p.IdTenant })
             .HasConstraintName("fk_gastos_proveedor")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ComprobanteCompra>()
+            .WithMany()
+            .HasForeignKey(g => new { g.IdComprobanteCompra, g.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_gastos_comprobante_compra")
             .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasOne<Area>()

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteCompraConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteCompraConfiguration.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="ItemComprobanteCompra"/> (design: Table Shapes — B). Child scope:
+/// <c>id_tenant</c> únicamente, sin FK propia a <c>puntos_venta</c> (se deriva del comprobante
+/// padre) — mismo criterio que <c>ItemComprobanteVentaConfiguration</c>.
+/// </summary>
+public class ItemComprobanteCompraConfiguration : IEntityTypeConfiguration<ItemComprobanteCompra>
+{
+    public void Configure(EntityTypeBuilder<ItemComprobanteCompra> builder)
+    {
+        builder.ToTable("items_comprobante_compra", t =>
+        {
+            t.HasCheckConstraint("ck_items_comprobante_compra_cantidad_positiva", "cantidad > 0");
+
+            // >= 0, no > 0: una línea de bonificación (costo cero) es real (design decisión 4;
+            // Table Shapes — B).
+            t.HasCheckConstraint("ck_items_comprobante_compra_costo_no_negativo", "costo_unitario >= 0");
+
+            t.HasCheckConstraint(
+                "ck_items_comprobante_compra_importes_no_negativos",
+                "descuento >= 0 AND total >= 0");
+        });
+
+        builder.HasKey(i => i.Id).HasName("pk_items_comprobante_compra");
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id_item")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(i => i.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(i => i.IdComprobanteCompra).HasColumnName("id_comprobante_compra").IsRequired();
+        builder.Property(i => i.Orden).HasColumnName("orden").IsRequired();
+
+        // Deliberadamente NOT NULL (design: Table Shapes — B), a diferencia de
+        // ItemComprobanteVenta.IdArticulo: una línea sin artículo no puede mover stock ni
+        // actualizar costo — sería un gasto.
+        builder.Property(i => i.IdArticulo).HasColumnName("id_articulo").IsRequired();
+
+        builder.Property(i => i.Descripcion).HasColumnName("descripcion").HasColumnType("text").IsRequired();
+
+        builder.Property(i => i.Cantidad).HasColumnName("cantidad").HasColumnType("numeric(12,3)").IsRequired();
+        builder.Property(i => i.Bultos).HasColumnName("bultos").HasColumnType("numeric(10,2)");
+        builder.Property(i => i.UnidadesPorBulto).HasColumnName("unidades_por_bulto").HasColumnType("numeric(10,2)");
+
+        builder.Property(i => i.CostoUnitario).HasColumnName("costo_unitario").HasColumnType("numeric(14,4)").IsRequired();
+
+        builder.Property(i => i.Descuento)
+            .HasColumnName("descuento")
+            .HasColumnType("numeric(14,2)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(i => i.IdAlicuotaIva).HasColumnName("id_alicuota_iva").IsRequired();
+        builder.Property(i => i.PorcentajeIva).HasColumnName("porcentaje_iva").HasColumnType("numeric(5,2)").IsRequired();
+
+        builder.Property(i => i.Total).HasColumnName("total").HasColumnType("numeric(14,2)").IsRequired();
+
+        builder.Property(i => i.ActualizaCosto)
+            .HasColumnName("actualiza_costo")
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Property(i => i.PrecioSugerido).HasColumnName("precio_sugerido").HasColumnType("numeric(14,2)");
+
+        builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(i => i.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(i => i.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(i => i.EstaEliminada);
+
+        builder.HasIndex(i => new { i.IdComprobanteCompra, i.Orden })
+            .HasDatabaseName("ux_items_comprobante_compra_orden")
+            .IsUnique();
+
+        builder.HasIndex(i => i.IdTenant).HasDatabaseName("ix_items_comprobante_compra_tenant");
+        builder.HasIndex(i => new { i.IdComprobanteCompra, i.IdTenant }).HasDatabaseName("ix_items_comprobante_compra_comprobante");
+        builder.HasIndex(i => new { i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_comprobante_compra_articulo");
+        builder.HasIndex(i => i.IdAlicuotaIva).HasDatabaseName("ix_items_comprobante_compra_alicuota_iva");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(i => i.IdTenant)
+            .HasConstraintName("fk_items_comprobante_compra_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ComprobanteCompra>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdComprobanteCompra, i.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_items_comprobante_compra_comprobante")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Articulo>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdArticulo, i.IdTenant })
+            .HasPrincipalKey(a => new { a.Id, a.IdTenant })
+            .HasConstraintName("fk_items_comprobante_compra_articulo")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // alicuotas_iva es global (ADR-11) — FK simple, sin id_tenant.
+        builder.HasOne<AlicuotaIva>()
+            .WithMany()
+            .HasForeignKey(i => i.IdAlicuotaIva)
+            .HasConstraintName("fk_items_comprobante_compra_alicuota_iva")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ways.Domain.Articulos;
+using Ways.Domain.Compras;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
@@ -45,9 +46,10 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
 
         builder.Property(m => m.IdComprobanteVenta).HasColumnName("id_comprobante_venta");
 
-        // id_comprobante_compra deferido a la etapa 8 (design: Table Shapes — write path B):
-        // comprobantes_compra no existe todavía, así que esta columna NO se crea en esta
-        // migración (docs/10-modelo-de-datos.md registra la deviación, task 3.2).
+        // stage-8-compras-transferencias-inventario, Slice 1 (design: Table Shapes — D, la FK
+        // diferida de doc-10:457-465): columna + FK compuesta aterrizan juntas en esta migración.
+        builder.Property(m => m.IdComprobanteCompra).HasColumnName("id_comprobante_compra");
+
         builder.Property(m => m.IdPuntoVentaDestino).HasColumnName("id_punto_venta_destino");
 
         builder.Property(m => m.IdEmpleado).HasColumnName("id_empleado").IsRequired();
@@ -63,6 +65,7 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
             .HasDatabaseName("ix_movimientos_stock_articulo_punto_venta");
 
         builder.HasIndex(m => new { m.IdComprobanteVenta, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_comprobante_venta");
+        builder.HasIndex(m => new { m.IdComprobanteCompra, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_comprobante_compra");
 
         // Índices de soporte de FK compuesta (evitan el índice implícito PascalCase de EF): la
         // columna líder de cada uno no coincide con la de ix_movimientos_stock_articulo_punto_venta
@@ -107,6 +110,13 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
             .HasForeignKey(m => new { m.IdComprobanteVenta, m.IdTenant })
             .HasPrincipalKey(c => new { c.Id, c.IdTenant })
             .HasConstraintName("fk_movimientos_stock_comprobante_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ComprobanteCompra>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdComprobanteCompra, m.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_movimientos_stock_comprobante_compra")
             .OnDelete(DeleteBehavior.Restrict);
 
         // id_empleado: FK SIMPLE (no compuesta), misma deviación deliberada que

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -53,26 +53,38 @@ public class InicializadorDeBaseDeDatos(
         ("No gravado", 0.00m)
     ];
 
-    /// <summary>Doc 10 §1: "FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE, RC". Solo el lado
-    /// venta — comprobantes de compra (proveedores) no son parte de esta etapa (doc 10,
-    /// "Etapas sugeridas": clientes/proveedores desbloquean comprobantes recién en la etapa
-    /// 2). <c>CodigoAfip</c> queda <c>NULL</c> por la misma razón que en las condiciones
-    /// fiscales. <c>RC</c> (etapa 7 — pago a cuenta) también se inserta de forma idempotente
-    /// en la migración <c>CuentaCorrienteEtapa7</c>, porque este seed solo corre en una base
-    /// vacía (design: Table Shapes B).</summary>
-    private static readonly (string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock)[] TiposComprobanteBase =
+    /// <summary>Doc 10 §1: "FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE, RC" (lado venta) más
+    /// <c>C-FA</c>/<c>C-FB</c>/<c>C-FC</c> (lado compra, stage-8, design: Table Shapes — E,
+    /// decisión 7/12 del proposal). <c>CodigoAfip</c> queda <c>NULL</c> por la misma razón que
+    /// en las condiciones fiscales. <c>RC</c> (etapa 7) y los tres <c>C-*</c> (etapa 8) también
+    /// se insertan de forma idempotente en sus propias migraciones (<c>CuentaCorrienteEtapa7</c>/
+    /// <c>ComprasYTransferenciasEtapa8</c>), porque este seed solo corre en una base vacía
+    /// (design: Table Shapes E). <see cref="ClaseComprobante"/> gana campo propio acá — hasta
+    /// stage-7 estaba hardcodeado a <see cref="ClaseComprobante.Venta"/> en el mapeo de abajo,
+    /// porque no existía otra clase con camino de seed.
+    /// <c>ux_tipos_comprobante_codigo</c> es UNIQUE sobre <c>codigo</c> SOLO (sin <c>clase</c>),
+    /// así que el prefijo <c>C-</c> es BINDING, no cosmético (design decisión 7, "the key gate
+    /// finding"): sin él, un código de compra podría colisionar con uno de venta.</summary>
+    private static readonly (ClaseComprobante Clase, string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock)[] TiposComprobanteBase =
     [
-        ("FA", "Factura A", 'A', 1, true, true, true),
-        ("FB", "Factura B", 'B', 1, false, true, true),
-        ("FC", "Factura C", 'C', 1, false, true, true),
-        ("NCA", "Nota de Crédito A", 'A', -1, true, true, true),
-        ("NCB", "Nota de Crédito B", 'B', -1, false, true, true),
-        ("NCC", "Nota de Crédito C", 'C', -1, false, true, true),
-        ("NDA", "Nota de Débito A", 'A', 1, true, true, true),
-        ("TX", "Ticket X", 'X', 1, false, false, true),
-        ("NCX", "Nota de Crédito X", 'X', -1, false, false, true),
-        ("PRE", "Presupuesto", null, 1, false, false, false),
-        ("RC", "Recibo de cobranza", null, 1, false, false, false)
+        (ClaseComprobante.Venta, "FA", "Factura A", 'A', 1, true, true, true),
+        (ClaseComprobante.Venta, "FB", "Factura B", 'B', 1, false, true, true),
+        (ClaseComprobante.Venta, "FC", "Factura C", 'C', 1, false, true, true),
+        (ClaseComprobante.Venta, "NCA", "Nota de Crédito A", 'A', -1, true, true, true),
+        (ClaseComprobante.Venta, "NCB", "Nota de Crédito B", 'B', -1, false, true, true),
+        (ClaseComprobante.Venta, "NCC", "Nota de Crédito C", 'C', -1, false, true, true),
+        (ClaseComprobante.Venta, "NDA", "Nota de Débito A", 'A', 1, true, true, true),
+        (ClaseComprobante.Venta, "TX", "Ticket X", 'X', 1, false, false, true),
+        (ClaseComprobante.Venta, "NCX", "Nota de Crédito X", 'X', -1, false, false, true),
+        (ClaseComprobante.Venta, "PRE", "Presupuesto", null, 1, false, false, false),
+        (ClaseComprobante.Venta, "RC", "Recibo de cobranza", null, 1, false, false, false),
+
+        // stage-8-compras-transferencias-inventario (design decisión 12/7 del proposal): solo
+        // tres tipos — notas de crédito de proveedor están fuera de alcance (anulación es la
+        // única reversión). es_fiscal=false: nunca EMITIMOS la factura del proveedor.
+        (ClaseComprobante.Compra, "C-FA", "Factura A de compra", 'A', 1, true, false, true),
+        (ClaseComprobante.Compra, "C-FB", "Factura B de compra", 'B', 1, false, false, true),
+        (ClaseComprobante.Compra, "C-FC", "Factura C de compra", 'C', 1, false, false, true)
     ];
 
     public async Task EjecutarAsync(SemillaRoot semilla, CancellationToken ct = default)
@@ -421,7 +433,7 @@ public class InicializadorDeBaseDeDatos(
         {
             db.TiposComprobante.AddRange(TiposComprobanteBase.Select(t => new TipoComprobante
             {
-                Clase = ClaseComprobante.Venta,
+                Clase = t.Clase,
                 Codigo = t.Codigo,
                 Nombre = t.Nombre,
                 Letra = t.Letra,

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260805181153_ComprasYTransferenciasEtapa8.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260805181153_ComprasYTransferenciasEtapa8.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -22,9 +23,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805181153_ComprasYTransferenciasEtapa8")]
+    partial class ComprasYTransferenciasEtapa8
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260805181153_ComprasYTransferenciasEtapa8.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260805181153_ComprasYTransferenciasEtapa8.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Domain.Compras;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class ComprasYTransferenciasEtapa8 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.AddColumn<int>(
+                name: "id_comprobante_compra",
+                table: "movimientos_stock",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "id_comprobante_compra",
+                table: "gastos",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "comprobantes_compra",
+                columns: table => new
+                {
+                    id_comprobante_compra = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_proveedor = table.Column<int>(type: "integer", nullable: false),
+                    id_tipo_comprobante = table.Column<int>(type: "integer", nullable: false),
+                    numero_externo = table.Column<string>(type: "citext", nullable: true),
+                    fecha_comprobante = table.Column<DateOnly>(type: "date", nullable: true),
+                    fecha_recepcion = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    id_empleado = table.Column<int>(type: "integer", nullable: false),
+                    subtotal = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    descuento_total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    iva_total = table.Column<decimal>(type: "numeric(14,2)", nullable: true),
+                    observaciones = table.Column<string>(type: "text", nullable: true),
+                    estado = table.Column<EstadoCompra>(type: "estado_compra", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_comprobantes_compra", x => x.id_comprobante_compra);
+                    table.UniqueConstraint("ak_comprobantes_compra_id_comprobante_compra_id_tenant", x => new { x.id_comprobante_compra, x.id_tenant });
+                    table.CheckConstraint("ck_comprobantes_compra_confirmada_completa", "estado = 'borrador' OR (numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL AND fecha_recepcion IS NOT NULL)");
+                    table.CheckConstraint("ck_comprobantes_compra_totales_no_negativos", "subtotal >= 0 AND descuento_total >= 0 AND total >= 0 AND (iva_total IS NULL OR iva_total >= 0)");
+                    table.ForeignKey(
+                        name: "fk_comprobantes_compra_empleado",
+                        column: x => x.id_empleado,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_comprobantes_compra_proveedor",
+                        columns: x => new { x.id_proveedor, x.id_tenant },
+                        principalTable: "proveedores",
+                        principalColumns: new[] { "id_proveedor", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_comprobantes_compra_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_comprobantes_compra_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_comprobantes_compra_tipo_comprobante",
+                        column: x => x.id_tipo_comprobante,
+                        principalTable: "tipos_comprobante",
+                        principalColumn: "id_tipo_comprobante",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "items_comprobante_compra",
+                columns: table => new
+                {
+                    id_item = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_comprobante_compra = table.Column<int>(type: "integer", nullable: false),
+                    orden = table.Column<int>(type: "integer", nullable: false),
+                    id_articulo = table.Column<int>(type: "integer", nullable: false),
+                    descripcion = table.Column<string>(type: "text", nullable: false),
+                    cantidad = table.Column<decimal>(type: "numeric(12,3)", nullable: false),
+                    bultos = table.Column<decimal>(type: "numeric(10,2)", nullable: true),
+                    unidades_por_bulto = table.Column<decimal>(type: "numeric(10,2)", nullable: true),
+                    costo_unitario = table.Column<decimal>(type: "numeric(14,4)", nullable: false),
+                    descuento = table.Column<decimal>(type: "numeric(14,2)", nullable: false, defaultValue: 0m),
+                    id_alicuota_iva = table.Column<int>(type: "integer", nullable: false),
+                    porcentaje_iva = table.Column<decimal>(type: "numeric(5,2)", nullable: false),
+                    total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    actualiza_costo = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    precio_sugerido = table.Column<decimal>(type: "numeric(14,2)", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_items_comprobante_compra", x => x.id_item);
+                    table.CheckConstraint("ck_items_comprobante_compra_cantidad_positiva", "cantidad > 0");
+                    table.CheckConstraint("ck_items_comprobante_compra_costo_no_negativo", "costo_unitario >= 0");
+                    table.CheckConstraint("ck_items_comprobante_compra_importes_no_negativos", "descuento >= 0 AND total >= 0");
+                    table.ForeignKey(
+                        name: "fk_items_comprobante_compra_alicuota_iva",
+                        column: x => x.id_alicuota_iva,
+                        principalTable: "alicuotas_iva",
+                        principalColumn: "id_alicuota_iva",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_comprobante_compra_articulo",
+                        columns: x => new { x.id_articulo, x.id_tenant },
+                        principalTable: "articulos",
+                        principalColumns: new[] { "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_comprobante_compra_comprobante",
+                        columns: x => new { x.id_comprobante_compra, x.id_tenant },
+                        principalTable: "comprobantes_compra",
+                        principalColumns: new[] { "id_comprobante_compra", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_comprobante_compra_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_stock_comprobante_compra",
+                table: "movimientos_stock",
+                columns: new[] { "id_comprobante_compra", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_gastos_comprobante_compra",
+                table: "gastos",
+                columns: new[] { "id_comprobante_compra", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_compra_empleado",
+                table: "comprobantes_compra",
+                column: "id_empleado");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_compra_proveedor",
+                table: "comprobantes_compra",
+                columns: new[] { "id_proveedor", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_compra_punto_venta_fecha",
+                table: "comprobantes_compra",
+                columns: new[] { "id_punto_venta", "id_tenant", "fecha_recepcion" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_compra_tenant",
+                table: "comprobantes_compra",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_compra_tipo_comprobante",
+                table: "comprobantes_compra",
+                column: "id_tipo_comprobante");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_comprobantes_compra_numero_externo",
+                table: "comprobantes_compra",
+                columns: new[] { "id_tenant", "id_proveedor", "id_tipo_comprobante", "numero_externo" },
+                unique: true,
+                filter: "estado <> 'anulada' AND numero_externo IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_compra_alicuota_iva",
+                table: "items_comprobante_compra",
+                column: "id_alicuota_iva");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_compra_articulo",
+                table: "items_comprobante_compra",
+                columns: new[] { "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_compra_comprobante",
+                table: "items_comprobante_compra",
+                columns: new[] { "id_comprobante_compra", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_compra_tenant",
+                table: "items_comprobante_compra",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_items_comprobante_compra_orden",
+                table: "items_comprobante_compra",
+                columns: new[] { "id_comprobante_compra", "orden" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_gastos_comprobante_compra",
+                table: "gastos",
+                columns: new[] { "id_comprobante_compra", "id_tenant" },
+                principalTable: "comprobantes_compra",
+                principalColumns: new[] { "id_comprobante_compra", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_movimientos_stock_comprobante_compra",
+                table: "movimientos_stock",
+                columns: new[] { "id_comprobante_compra", "id_tenant" },
+                principalTable: "comprobantes_compra",
+                principalColumns: new[] { "id_comprobante_compra", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            // RLS (ADR-4/ADR-15, DB CHANGE GATE exercised in autonomous mode 2026-08-05): cada
+            // tabla nueva activa su policy en la misma migración que la crea (design:
+            // Migration/Rollout).
+            migrationBuilder.HabilitarRlsDeTenant("comprobantes_compra");
+            migrationBuilder.HabilitarRlsDeTenant("items_comprobante_compra");
+
+            // design: Table Shapes — E (mismo patrón que CuentaCorrienteEtapa7 con RC): el seed
+            // de InicializadorDeBaseDeDatos.SembrarCatalogosFiscalesAsync solo siembra
+            // tipos_comprobante cuando la tabla está VACÍA — una base ya migrada desde stage 7
+            // en adelante nunca recibiría los tres tipos de compra de otro modo. El guard "AND
+            // EXISTS (SELECT 1 FROM tipos_comprobante)" es la lección de stage 7: sin él, este
+            // INSERT deja filas en una base GENUINAMENTE vacía durante la migración, y el
+            // chequeo de "tabla vacía" del seeder pasa a verla como no-vacía, saltándose las
+            // demás filas de TiposComprobanteBase por completo. Con el guard, este INSERT solo
+            // corre contra una base que YA tenía catálogo — el escenario real que hay que cubrir
+            // (una base migrada desde antes de esta etapa) — nunca contra una recién creada, que
+            // queda intacta para que el seeder la puebla completa y atómica (con los tres C-*
+            // ya incluidos en TiposComprobanteBase).
+            migrationBuilder.Sql(
+                """
+                INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, created_at, updated_at)
+                SELECT 'compra', v.codigo, v.nombre, v.letra, v.signo, v.discrimina_iva, false, true, true, now(), now()
+                FROM (VALUES
+                    ('C-FA', 'Factura A de compra', 'A', 1::smallint, true),
+                    ('C-FB', 'Factura B de compra', 'B', 1::smallint, false),
+                    ('C-FC', 'Factura C de compra', 'C', 1::smallint, false)
+                ) AS v(codigo, nombre, letra, signo, discrimina_iva)
+                WHERE EXISTS (SELECT 1 FROM tipos_comprobante)
+                  AND NOT EXISTS (SELECT 1 FROM tipos_comprobante WHERE codigo = v.codigo);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // design: Migration/Rollout — desactiva en vez de borrar, para que una compra ya
+            // confirmada (y sus movimientos) sigan siendo legibles después de un rollback.
+            // Mismo criterio que CuentaCorrienteEtapa7 con RC.
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo IN ('C-FA', 'C-FB', 'C-FC');");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_gastos_comprobante_compra",
+                table: "gastos");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_movimientos_stock_comprobante_compra",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropTable(
+                name: "items_comprobante_compra");
+
+            migrationBuilder.DropTable(
+                name: "comprobantes_compra");
+
+            migrationBuilder.DropIndex(
+                name: "ix_movimientos_stock_comprobante_compra",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropIndex(
+                name: "ix_gastos_comprobante_compra",
+                table: "gastos");
+
+            migrationBuilder.DropColumn(
+                name: "id_comprobante_compra",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropColumn(
+                name: "id_comprobante_compra",
+                table: "gastos");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -10,6 +10,7 @@ using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
+using Ways.Domain.Compras;
 using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
@@ -101,6 +102,13 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<ArqueoTurno> ArqueosTurno => Set<ArqueoTurno>();
     public DbSet<MovimientoTesoreria> MovimientosTesoreria => Set<MovimientoTesoreria>();
     public DbSet<Gasto> Gastos => Set<Gasto>();
+
+    // stage-8-compras-transferencias-inventario, Slice 1 (schema + seed gate, DB CHANGE GATE
+    // exercised in autonomous mode): modelo adelantado a la migración, mismo trámite que
+    // TurnoCaja/Gasto en stage-6 Slice 1 — sin exponer en IWaysDbContext todavía, Slice 2
+    // (ServicioDeCompras) es el primer consumidor de Application.
+    public DbSet<ComprobanteCompra> ComprobantesCompra => Set<ComprobanteCompra>();
+    public DbSet<ItemComprobanteCompra> ItemsComprobanteCompra => Set<ItemComprobanteCompra>();
 
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
@@ -4,6 +4,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
@@ -43,6 +44,7 @@ public class WaysDbContextFactory : IDesignTimeDbContextFactory<WaysDbContext>
                 npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
                 npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                 npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
             })
             .Options;
 

--- a/tests/Ways.IntegrationTests/ComprasSchemaBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasSchemaBackstopTests.cs
@@ -1,0 +1,636 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 1 (task 1.13, db-error-backstops, design:
+/// Backstop Map): raw-SQL INSERTs que bypasean por completo <c>CalculadorDeCompra</c>/
+/// <c>ServicioDeCompras</c> (Slice 2, todavía no existe) — mismo patrón que
+/// <c>TurnosCajaYGastosBackstopTests</c>/<c>VentasStockBackstopTests</c>. Prueban la traducción
+/// de esquema (SQLSTATE + <c>ConstraintName</c>), no un camino de cliente HTTP real.
+///
+/// El único caso genuinamente racy de esta slice es la unicidad parcial de
+/// <c>numero_externo</c> (design: Backstop Map, superficie racy 1 la ejerce Slice 2 con el
+/// servicio real; acá se prueba la carrera contra el índice desnudo, misma exención temporal que
+/// <c>ux_turnos_caja_abierto</c> tuvo en stage-6 Slice 1).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasSchemaBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const int IdInexistente = 999_999;
+
+    private sealed record Prerequisitos(
+        int IdTenant, int IdProveedor, int IdPuntoVenta, int IdEmpleado, int IdArticulo,
+        int IdAlicuotaIva, int IdTipoComprobanteCompra);
+
+    private async Task<Prerequisitos> SembrarPrerequisitosAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = tenant.Id,
+            RazonSocial = nombre,
+            IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        var idTipoCompra = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Prerequisitos(
+            tenant.Id, proveedor.Id, puntoVenta.Id, usuario.Id, articulo.Id, idAlicuotaIva, idTipoCompra);
+    }
+
+    private static async Task<int> InsertarComprobanteAsync(
+        NpgsqlConnection cruda, Prerequisitos p, string estado, string? numeroExterno)
+    {
+        // fecha_comprobante/fecha_recepcion se derivan en C# (no en una CASE de SQL sobre el
+        // mismo parámetro reusado): Npgsql no puede inferir el tipo de un parámetro que solo
+        // aparece dentro de expresiones condicionales (42P08).
+        var tieneIdentidad = numeroExterno is not null;
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_compra (id_tenant, id_proveedor, id_tipo_comprobante, numero_externo, " +
+            "fecha_comprobante, fecha_recepcion, id_punto_venta, id_empleado, subtotal, descuento_total, total, " +
+            "estado, created_at, updated_at) VALUES " +
+            "($1, $2, $3, $4::citext, $5, $6, $7, $8, 100, 0, 100, $9::estado_compra, now(), now()) " +
+            "RETURNING id_comprobante_compra";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdProveedor });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTipoComprobanteCompra });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)numeroExterno ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = tieneIdentidad ? DateOnly.FromDateTime(DateTime.UtcNow) : (object)DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = tieneIdentidad ? DateTimeOffset.UtcNow : (object)DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = estado });
+
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    // ---- ux_comprobantes_compra_numero_externo (partial UNIQUE) ------------------------------
+
+    [Fact]
+    public async Task DosComprobantesConElMismoNumeroExternoViolanLaUnicidadParcial()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosComprobantesConElMismoNumeroExternoViolanLaUnicidadParcial));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        await InsertarComprobanteAsync(cruda, p, "confirmada", "0001-00000001");
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(
+            () => InsertarComprobanteAsync(cruda, p, "confirmada", "0001-00000001"));
+
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_comprobantes_compra_numero_externo", excepcion.ConstraintName);
+    }
+
+    /// <summary>El predicado parcial (<c>WHERE estado &lt;&gt; 'anulada'</c>) es lo que hace
+    /// posible reingresar una factura mal cargada que se anuló: sin la carga parcial, esta
+    /// segunda inserción también chocaría.</summary>
+    [Fact]
+    public async Task UnNumeroExternoDeUnComprobanteAnuladoSePuedeReingresar()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnNumeroExternoDeUnComprobanteAnuladoSePuedeReingresar));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        var idOriginal = await InsertarComprobanteAsync(cruda, p, "confirmada", "0001-00000002");
+
+        await using (var anular = cruda.CreateCommand())
+        {
+            anular.CommandText = "UPDATE comprobantes_compra SET estado = 'anulada'::estado_compra WHERE id_comprobante_compra = $1";
+            anular.Parameters.Add(new NpgsqlParameter { Value = idOriginal });
+            await anular.ExecuteNonQueryAsync();
+        }
+
+        // No debe tirar: el original está anulado, así que el predicado parcial lo excluye del
+        // índice y el reingreso es una nueva fila legítima con el mismo numero_externo.
+        var idReingreso = await InsertarComprobanteAsync(cruda, p, "confirmada", "0001-00000002");
+
+        Assert.NotEqual(idOriginal, idReingreso);
+    }
+
+    /// <summary>Carrera genuina (task 1.13): dos INSERTs concurrentes del mismo
+    /// <c>(proveedor, tipo, numero_externo)</c> — exactamente un ganador, el otro choca contra
+    /// el índice parcial. Misma exención temporal que <c>ux_turnos_caja_abierto</c> en stage-6
+    /// Slice 1: la carrera real por el camino de servicio (confirmar dos borradores con el mismo
+    /// número) es tarea de Slice 2.</summary>
+    [Fact]
+    public async Task DosInsertsConcurrentesDelMismoNumeroExternoDanExactamenteUnGanador()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosInsertsConcurrentesDelMismoNumeroExternoDanExactamenteUnGanador));
+
+        await using var conexionA = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var conexionB = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        var tareaA = InsertarComprobanteAsync(conexionA, p, "confirmada", "0001-00000003");
+        var tareaB = InsertarComprobanteAsync(conexionB, p, "confirmada", "0001-00000003");
+
+        // Espera las dos tareas sin dejar que la primera excepción cancele la espera de la otra
+        // (a diferencia de Task.WhenAll, que relanza apenas la primera falla).
+        await Task.WhenAll(tareaA.ContinueWith(_ => { }), tareaB.ContinueWith(_ => { }));
+
+        var tareas = new[] { tareaA, tareaB };
+        var exitosos = tareas.Count(t => t.IsCompletedSuccessfully);
+        var fallidos = tareas.Count(t => t.IsFaulted);
+
+        Assert.Equal(1, exitosos);
+        Assert.Equal(1, fallidos);
+
+        var tareaFallida = tareas.Single(t => t.IsFaulted);
+        var excepcion = Assert.IsType<PostgresException>(tareaFallida.Exception!.InnerException);
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_comprobantes_compra_numero_externo", excepcion.ConstraintName);
+    }
+
+    // ---- ux_items_comprobante_compra_orden ----------------------------------------------------
+
+    private static async Task InsertarItemAsync(NpgsqlConnection cruda, Prerequisitos p, int idComprobante, int orden)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, $3, $4, 'item de prueba', 1, 10, 0, $5, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = orden });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task DosItemsConElMismoOrdenEnLaMismaCompraViolanLaUnicidad()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosItemsConElMismoOrdenEnLaMismaCompraViolanLaUnicidad));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await InsertarItemAsync(cruda, p, idComprobante, 1);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => InsertarItemAsync(cruda, p, idComprobante, 1));
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_items_comprobante_compra_orden", excepcion.ConstraintName);
+    }
+
+    // ---- ck_comprobantes_compra_confirmada_completa -------------------------------------------
+
+    [Fact]
+    public async Task UnaCompraConfirmadaSinNumeroExternoViolaLaCheckDeConfirmadaCompleta()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnaCompraConfirmadaSinNumeroExternoViolaLaCheckDeConfirmadaCompleta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(
+            () => InsertarComprobanteAsync(cruda, p, "confirmada", null));
+
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_compra_confirmada_completa", excepcion.ConstraintName);
+    }
+
+    // ---- ck_comprobantes_compra_totales_no_negativos -------------------------------------------
+
+    [Fact]
+    public async Task UnaCompraConTotalNegativoViolaLaCheckDeTotalesNoNegativos()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnaCompraConTotalNegativoViolaLaCheckDeTotalesNoNegativos));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_compra (id_tenant, id_proveedor, id_tipo_comprobante, id_punto_venta, " +
+            "id_empleado, subtotal, descuento_total, total, estado, created_at, updated_at) " +
+            "VALUES ($1, $2, $3, $4, $5, 100, 0, -10, 'borrador', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdProveedor });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTipoComprobanteCompra });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_compra_totales_no_negativos", excepcion.ConstraintName);
+    }
+
+    // ---- las tres CHECKs de items_comprobante_compra --------------------------------------------
+
+    [Fact]
+    public async Task UnItemConCantidadCeroViolaLaCheckDeCantidadPositiva()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemConCantidadCeroViolaLaCheckDeCantidadPositiva));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 0, 10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_comprobante_compra_cantidad_positiva", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnItemConCostoUnitarioNegativoViolaLaCheckDeCostoNoNegativo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemConCostoUnitarioNegativoViolaLaCheckDeCostoNoNegativo));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, -10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_comprobante_compra_costo_no_negativo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnItemConTotalNegativoViolaLaCheckDeImportesNoNegativos()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemConTotalNegativoViolaLaCheckDeImportesNoNegativos));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, 10, 0, $4, 21, -10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_comprobante_compra_importes_no_negativos", excepcion.ConstraintName);
+    }
+
+    // ---- FKs de comprobantes_compra -------------------------------------------------------------
+
+    private async Task<PostgresException> InsertarComprobanteConFkInvalidaAsync(
+        Prerequisitos p, string columna, int valorInvalido)
+    {
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        var valores = new Dictionary<string, object>
+        {
+            ["id_proveedor"] = p.IdProveedor,
+            ["id_tipo_comprobante"] = p.IdTipoComprobanteCompra,
+            ["id_punto_venta"] = p.IdPuntoVenta,
+            ["id_empleado"] = p.IdEmpleado
+        };
+        valores[columna] = valorInvalido;
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_compra (id_tenant, id_proveedor, id_tipo_comprobante, id_punto_venta, " +
+            "id_empleado, subtotal, descuento_total, total, estado, created_at, updated_at) " +
+            "VALUES ($1, $2, $3, $4, $5, 100, 0, 100, 'borrador', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = valores["id_proveedor"] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = valores["id_tipo_comprobante"] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = valores["id_punto_venta"] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = valores["id_empleado"] });
+
+        return await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+    }
+
+    [Fact]
+    public async Task UnProveedorInexistenteViolaLaFkDeProveedor()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnProveedorInexistenteViolaLaFkDeProveedor));
+        var excepcion = await InsertarComprobanteConFkInvalidaAsync(p, "id_proveedor", IdInexistente);
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_comprobantes_compra_proveedor", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnPuntoVentaInexistenteViolaLaFkDePuntoVenta()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnPuntoVentaInexistenteViolaLaFkDePuntoVenta));
+        var excepcion = await InsertarComprobanteConFkInvalidaAsync(p, "id_punto_venta", IdInexistente);
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_comprobantes_compra_punto_venta", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnEmpleadoInexistenteViolaLaFkDeEmpleado()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnEmpleadoInexistenteViolaLaFkDeEmpleado));
+        var excepcion = await InsertarComprobanteConFkInvalidaAsync(p, "id_empleado", IdInexistente);
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_comprobantes_compra_empleado", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnTipoDeComprobanteInexistenteViolaLaFkDeTipoComprobante()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnTipoDeComprobanteInexistenteViolaLaFkDeTipoComprobante));
+        var excepcion = await InsertarComprobanteConFkInvalidaAsync(p, "id_tipo_comprobante", IdInexistente);
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_comprobantes_compra_tipo_comprobante", excepcion.ConstraintName);
+    }
+
+    /// <summary>El simple FK de <c>id_tenant</c> no se puede aislar de las FKs compuestas de
+    /// <c>proveedor</c>/<c>punto_venta</c> (ambas también referencian <c>id_tenant</c>): con un
+    /// tenant apócrifo, Postgres valida las constraints en el orden en que se declararon
+    /// (alfabético en esta migración) y <c>fk_comprobantes_compra_proveedor</c> cae ANTES que
+    /// <c>fk_comprobantes_compra_tenant</c>. Se prueba entonces que ALGUNA <c>fk_</c> nueva de
+    /// esta tabla dispara — que es exactamente lo que el backstop genérico necesita, sin
+    /// importar cuál de las FKs compuestas ganó la carrera de validación.</summary>
+    [Fact]
+    public async Task UnTenantInexistenteViolaAlgunaFkDeComprobante()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnTenantInexistenteViolaAlgunaFkDeComprobante));
+
+        // id_tenant apócrifo: usa una conexión de plataforma (sin RLS de por medio) para
+        // aislar la FK del backstop de WITH CHECK (RLS), que ya prueba ComprasSchemaRlsTests.
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("plataforma", null);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_compra (id_tenant, id_proveedor, id_tipo_comprobante, id_punto_venta, " +
+            "id_empleado, subtotal, descuento_total, total, estado, created_at, updated_at) " +
+            "VALUES ($1, $2, $3, $4, $5, 100, 0, 100, 'borrador', now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdProveedor });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTipoComprobanteCompra });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.StartsWith("fk_comprobantes_compra_", excepcion.ConstraintName);
+    }
+
+    // ---- FKs de items_comprobante_compra ---------------------------------------------------------
+
+    [Fact]
+    public async Task UnArticuloInexistenteViolaLaFkDeArticuloDeItem()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnArticuloInexistenteViolaLaFkDeArticuloDeItem));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, 10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_comprobante_compra_articulo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaAlicuotaInexistenteViolaLaFkDeAlicuotaDeItem()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnaAlicuotaInexistenteViolaLaFkDeAlicuotaDeItem));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, 10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_comprobante_compra_alicuota_iva", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnComprobanteInexistenteViolaLaFkDeComprobanteDeItem()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnComprobanteInexistenteViolaLaFkDeComprobanteDeItem));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, 10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_comprobante_compra_comprobante", excepcion.ConstraintName);
+    }
+
+    /// <summary>Mismo motivo que <c>UnTenantInexistenteViolaAlgunaFkDeComprobante</c>: el simple
+    /// FK de <c>id_tenant</c> no se puede aislar de las FKs compuestas de <c>comprobante</c>/
+    /// <c>articulo</c> (ambas también referencian <c>id_tenant</c>) — Postgres valida en orden
+    /// alfabético de declaración, y <c>fk_items_comprobante_compra_articulo</c> cae primero.</summary>
+    [Fact]
+    public async Task UnTenantInexistenteViolaAlgunaFkDeItem()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnTenantInexistenteViolaAlgunaFkDeItem));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        var idComprobante = await InsertarComprobanteAsync(cruda, p, "borrador", null);
+
+        // id_tenant apócrifo del ÍTEM: conexión de plataforma para aislar del backstop de WITH
+        // CHECK (RLS), que ya prueba ComprasSchemaRlsTests.
+        await using var crudaPlataforma = await fixture.AbrirConexionCrudaAsync("plataforma", null);
+        await using var comando = crudaPlataforma.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "created_at, updated_at) VALUES ($1, $2, 1, $3, 'item', 1, 10, 0, $4, 21, 10, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.StartsWith("fk_items_comprobante_compra_", excepcion.ConstraintName);
+    }
+
+    // ---- Las dos FKs diferidas: movimientos_stock/gastos → comprobantes_compra ------------------
+
+    [Fact]
+    public async Task UnMovimientoDeStockConComprobanteDeCompraInexistenteViolaLaFkDiferida()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnMovimientoDeStockConComprobanteDeCompraInexistenteViolaLaFkDiferida));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_stock (id_tenant, id_articulo, id_punto_venta, cantidad, motivo, " +
+            "id_comprobante_compra, id_empleado, creado_el) " +
+            "VALUES ($1, $2, $3, 5, 'compra', $4, $5, now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_movimientos_stock_comprobante_compra", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnGastoConComprobanteDeCompraInexistenteViolaLaFkDiferida()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnGastoConComprobanteDeCompraInexistenteViolaLaFkDiferida));
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var medioPago = new MedioPago
+        {
+            IdTenant = p.IdTenant,
+            Nombre = "efectivo",
+            Orden = 1,
+            Comportamiento = ComportamientoMedioPago.Efectivo,
+            AdmiteVuelto = true,
+            RequiereReferencia = false,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioPago);
+        await db.SaveChangesAsync();
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = p.IdTenant,
+            IdPuntoVenta = p.IdPuntoVenta,
+            IdEmpleadoApertura = p.IdEmpleado,
+            FechaApertura = ahora,
+            FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO gastos (id_tenant, fecha, id_punto_venta, id_turno_caja, id_empleado, categoria, " +
+            "concepto, id_medio_pago, importe, id_comprobante_compra, created_at, updated_at) " +
+            "VALUES ($1, now(), $2, $3, $4, 'proveedor', 'pago de prueba', $5, 10, $6, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = turno.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = medioPago.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = IdInexistente });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_gastos_comprobante_compra", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasSchemaRlsTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasSchemaRlsTests.cs
@@ -1,0 +1,323 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 1 (task 1.12, design: Table Shapes — F):
+/// mismo patrón que <c>TurnosCajaYGastosRlsTests</c> — SQL crudo, independiente de EF, 0 filas
+/// para SELECT/UPDATE cross-tenant, 42501 para el INSERT que viola <c>WITH CHECK</c>, más un
+/// proof a nivel EF (LINQ) por tabla. Cubre las dos tablas nuevas de esta slice
+/// (<c>comprobantes_compra</c>/<c>items_comprobante_compra</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasSchemaRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    public static TheoryData<string, string> TablasDeTenant => new()
+    {
+        { "comprobantes_compra", "id_comprobante_compra" },
+        { "items_comprobante_compra", "id_item" }
+    };
+
+    private sealed record Escenario(
+        int IdTenant, int IdProveedor, int IdPuntoVenta, int IdEmpleado, int IdArticulo,
+        int IdAlicuotaIva, int IdTipoComprobanteCompra, int IdComprobanteCompra, int IdItem);
+
+    /// <summary>Arma la cadena completa de prerequisitos y una fila en cada una de las dos
+    /// tablas nuevas, todas del mismo tenant A.</summary>
+    private async Task<Escenario> SembrarEscenarioAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = tenant.Id,
+            RazonSocial = nombre,
+            IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        var idTipoCompra = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        var comprobante = new ComprobanteCompra
+        {
+            IdTenant = tenant.Id,
+            IdProveedor = proveedor.Id,
+            IdTipoComprobante = idTipoCompra,
+            IdPuntoVenta = puntoVenta.Id,
+            IdEmpleado = usuario.Id,
+            Subtotal = 100m,
+            DescuentoTotal = 0m,
+            Total = 100m,
+            Estado = EstadoCompra.Borrador,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesCompra.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        var item = new ItemComprobanteCompra
+        {
+            IdTenant = tenant.Id,
+            IdComprobanteCompra = comprobante.Id,
+            Orden = 1,
+            IdArticulo = articulo.Id,
+            Descripcion = nombre,
+            Cantidad = 1m,
+            CostoUnitario = 100m,
+            Descuento = 0m,
+            IdAlicuotaIva = idAlicuotaIva,
+            PorcentajeIva = 21m,
+            Total = 100m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ItemsComprobanteCompra.Add(item);
+        await db.SaveChangesAsync();
+
+        return new Escenario(
+            tenant.Id, proveedor.Id, puntoVenta.Id, usuario.Id, articulo.Id, idAlicuotaIva,
+            idTipoCompra, comprobante.Id, item.Id);
+    }
+
+    private static int IdDeFila(Escenario escenario, string tabla) => tabla switch
+    {
+        "comprobantes_compra" => escenario.IdComprobanteCompra,
+        "items_comprobante_compra" => escenario.IdItem,
+        _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+    };
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoVeLaFilaPorSelect(string tabla, string columnaId)
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla);
+        var idFila = IdDeFila(escenario, tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnaSesionDeOtroTenantNoVeLaFilaPorSelect) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"SELECT count(*) FROM {tabla} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarLaFila(string tabla, string columnaId)
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla);
+        var idFila = IdDeFila(escenario, tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnaSesionDeOtroTenantNoPuedeActualizarLaFila) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+
+        var (columna, valor) = tabla switch
+        {
+            "comprobantes_compra" => ("observaciones", "'tocado por intruso'"),
+            "items_comprobante_compra" => ("descripcion", "'tocado por intruso'"),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = $"UPDATE {tabla} SET {columna} = {valor} WHERE {columnaId} = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idFila });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ): ambas tablas heredan <c>EntidadTenant</c>, así que el
+    /// filtro genérico de <c>WaysDbContext.AplicarFiltroDeTenant</c> las cubre sin filtro manual
+    /// — a diferencia de <c>movimientos_stock</c>.</summary>
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant(string tabla, string columnaId)
+    {
+        _ = columnaId;
+        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
+
+        var visible = tabla switch
+        {
+            "comprobantes_compra" => await sesionB.ComprobantesCompra.AnyAsync(c => c.Id == escenario.IdComprobanteCompra),
+            "items_comprobante_compra" => await sesionB.ItemsComprobanteCompra.AnyAsync(i => i.Id == escenario.IdItem),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        Assert.False(visible);
+    }
+
+    [Theory]
+    [MemberData(nameof(TablasDeTenant))]
+    public async Task UnInsertConIdTenantAjenoSeRechaza(string tabla, string columnaId)
+    {
+        _ = columnaId;
+        var escenario = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoSeRechaza) + tabla);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nameof(UnInsertConIdTenantAjenoSeRechaza) + tabla + "-B",
+            Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+
+        // Sesión del tenant A intentando insertar con id_tenant del tenant B (ajeno) — WITH
+        // CHECK tiene que rechazarla antes de que cualquier FK/CHECK se evalúe.
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", escenario.IdTenant);
+
+        var ahora = DateTimeOffset.UtcNow;
+
+        (string Sql, Action<NpgsqlCommand> Bind) insert = tabla switch
+        {
+            "comprobantes_compra" => (
+                "INSERT INTO comprobantes_compra (id_tenant, id_proveedor, id_tipo_comprobante, " +
+                "id_punto_venta, id_empleado, subtotal, descuento_total, total, estado, created_at, updated_at) " +
+                "VALUES ($1, $2, $3, $4, $5, 10, 0, 10, 'borrador', $6, $6)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdProveedor });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdTipoComprobanteCompra });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdEmpleado });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                }),
+            // orden = 2 a propósito: esquiva ux_items_comprobante_compra_orden contra la fila ya
+            // sembrada con orden = 1 — lo que se prueba acá es el 42501, no la unicidad.
+            "items_comprobante_compra" => (
+                "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+                "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+                "created_at, updated_at) VALUES ($1, $2, 2, $3, 'intruso', 1, 10, 0, $4, 21, 10, $5, $5)",
+                c =>
+                {
+                    c.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdComprobanteCompra });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdArticulo });
+                    c.Parameters.Add(new NpgsqlParameter { Value = escenario.IdAlicuotaIva });
+                    c.Parameters.Add(new NpgsqlParameter { Value = ahora });
+                }),
+            _ => throw new ArgumentOutOfRangeException(nameof(tabla), tabla, "Tabla no cubierta por este helper.")
+        };
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = insert.Sql;
+        insert.Bind(comando);
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) — se dispara antes de
+        // cualquier FK/CHECK, sin importar que el resto de columnas referencien filas válidas
+        // del tenant A.
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 1 (task 1.14, spec: comprobantes-compra /
+/// Compra-Clase Tipos Are Platform-Seeded; GATE condition (ii)): mismo patrón que
+/// <c>CuentaCorrienteEtapa7BackstopTests</c> — prueba el seed dual-path en DOS bases distintas
+/// en vez de asumirlo:
+///
+/// (1) una base fresca, donde el seeder de <c>InicializadorDeBaseDeDatos</c> puebla el catálogo
+/// completo atómicamente (los tres <c>C-*</c> incluidos vía <c>TiposComprobanteBase</c>);
+///
+/// (2) una base migrada desde stage 7 con un catálogo pre-existente (tabla NO vacía) — el
+/// escenario real que el guard <c>AND EXISTS</c> de la migración <c>ComprasYTransferenciasEtapa8</c>
+/// existe para cubrir.
+///
+/// Las dos pruebas también fijan que los ONCE códigos de venta preexistentes quedan
+/// <c>Clase = venta</c> sin tocar (GATE condition (ii): <c>ux_tipos_comprobante_codigo</c> es
+/// UNIQUE sobre <c>codigo</c> SOLO, así que un choque de código real rompería el seed entero —
+/// su ausencia es la prueba de que el prefijo <c>C-</c> cumple su propósito).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string MigracionStage7 = "20260805050151_CuentaCorrienteEtapa7";
+
+    private static readonly string[] CodigosDeVentaEsperados =
+        ["FA", "FB", "FC", "NCA", "NCB", "NCC", "NDA", "TX", "NCX", "PRE", "RC"];
+
+    private static readonly string[] CodigosDeCompraEsperados = ["C-FA", "C-FB", "C-FC"];
+
+    [Fact]
+    public async Task UnaBaseFrescaSiembraLosTresTiposDeCompraSinTocarElCatalogoDeVenta()
+    {
+        using var cliente = fixture.CreateClient(); // arranca el host: siembra el catálogo completo
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var venta = await db.TiposComprobante
+            .Where(t => t.Clase == ClaseComprobante.Venta)
+            .Select(t => t.Codigo)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        var compra = await db.TiposComprobante
+            .Where(t => t.Clase == ClaseComprobante.Compra)
+            .Select(t => t.Codigo)
+            .OrderBy(c => c)
+            .ToListAsync();
+
+        Assert.Equal(CodigosDeVentaEsperados.OrderBy(c => c), venta);
+        Assert.Equal(CodigosDeCompraEsperados.OrderBy(c => c), compra);
+
+        var todosActivos = await db.TiposComprobante.AllAsync(t => t.Activo);
+        Assert.True(todosActivos);
+    }
+
+    [Fact]
+    public async Task LosTiposDeCompraAterrizanEnUnaBaseYaMigradaDesdeStage7SinDuplicarYSinTocarVenta()
+    {
+        var nombreBase = $"ways_stage7_{Guid.NewGuid():N}";
+        var cadenaAdmin = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = "postgres" }.ConnectionString;
+        var cadenaNueva = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = nombreBase }.ConnectionString;
+
+        await using (var admin = new NpgsqlConnection(cadenaAdmin))
+        {
+            await admin.OpenAsync();
+            await using var crear = admin.CreateCommand();
+            crear.CommandText = $"CREATE DATABASE \"{nombreBase}\"";
+            await crear.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+                .UseNpgsql(cadenaNueva, npgsql =>
+                {
+                    npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                    npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                    npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                    npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                    npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                    npgsql.MapEnum<ModoLista>("modo_lista");
+                    npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                    npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                    npgsql.MapEnum<MotivoStock>("motivo_stock");
+                    npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                    npgsql.MapEnum<EstadoTurno>("estado_turno");
+                    npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                    npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                    npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                    npgsql.MapEnum<EstadoCompra>("estado_compra");
+                })
+                .Options;
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(MigracionStage7);
+            }
+
+            // Simula el catálogo de una base real ya operando en stage 7 — los once códigos de
+            // venta, ANTES de que la migración de stage 8 exista.
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+
+                foreach (var codigo in CodigosDeVentaEsperados)
+                {
+                    await using var comando = conexion.CreateCommand();
+                    comando.CommandText =
+                        "INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, " +
+                        "es_fiscal, afecta_stock, activo, created_at, updated_at) " +
+                        "VALUES ('venta', $1, $1, NULL, 1, false, false, true, true, now(), now())";
+                    comando.Parameters.Add(new NpgsqlParameter { Value = codigo });
+                    await comando.ExecuteNonQueryAsync();
+                }
+            }
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(); // aplica ComprasYTransferenciasEtapa8, la única pendiente
+            }
+
+            await using var verificacion = new NpgsqlConnection(cadenaNueva);
+            await verificacion.OpenAsync();
+
+            async Task<List<string>> ListarCodigosAsync(string clase)
+            {
+                await using var comando = verificacion.CreateCommand();
+                comando.CommandText = "SELECT codigo FROM tipos_comprobante WHERE clase = $1::clase_comprobante ORDER BY codigo";
+                comando.Parameters.Add(new NpgsqlParameter { Value = clase });
+                var resultado = new List<string>();
+                await using var lector = await comando.ExecuteReaderAsync();
+                while (await lector.ReadAsync())
+                {
+                    resultado.Add(lector.GetString(0));
+                }
+                return resultado;
+            }
+
+            Assert.Equal(CodigosDeCompraEsperados.OrderBy(c => c), await ListarCodigosAsync("compra"));
+            Assert.Equal(CodigosDeVentaEsperados.OrderBy(c => c), await ListarCodigosAsync("venta"));
+
+            // Re-ejecuta a mano el mismo INSERT idempotente de la migración (simula un reintento
+            // de arranque) y confirma que sigue sin duplicar.
+            await using (var comando = verificacion.CreateCommand())
+            {
+                comando.CommandText =
+                    """
+                    INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, created_at, updated_at)
+                    SELECT 'compra', v.codigo, v.nombre, v.letra, v.signo, v.discrimina_iva, false, true, true, now(), now()
+                    FROM (VALUES
+                        ('C-FA', 'Factura A de compra', 'A', 1::smallint, true),
+                        ('C-FB', 'Factura B de compra', 'B', 1::smallint, false),
+                        ('C-FC', 'Factura C de compra', 'C', 1::smallint, false)
+                    ) AS v(codigo, nombre, letra, signo, discrimina_iva)
+                    WHERE EXISTS (SELECT 1 FROM tipos_comprobante)
+                      AND NOT EXISTS (SELECT 1 FROM tipos_comprobante WHERE codigo = v.codigo);
+                    """;
+                await comando.ExecuteNonQueryAsync();
+            }
+
+            Assert.Equal(CodigosDeCompraEsperados.OrderBy(c => c), await ListarCodigosAsync("compra"));
+        }
+        finally
+        {
+            await using var admin = new NpgsqlConnection(cadenaAdmin);
+            await admin.OpenAsync();
+            await using var dropear = admin.CreateCommand();
+            dropear.CommandText = $"DROP DATABASE IF EXISTS \"{nombreBase}\" WITH (FORCE)";
+            await dropear.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -7,6 +7,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
@@ -131,6 +132,11 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
     // Pin directo del guard AND EXISTS del seed de RC: en una base fresca la migración no debe
     // insertar nada (el seeder ve la tabla vacía y siembra el catálogo completo, RC incluido).
     // Sin este pin, quitar el guard solo se detectaba por fallas colaterales en otra suite.
+    //
+    // stage-8-compras-transferencias-inventario (Slice 1, task 1.14): el total pasa de 11 a 14 —
+    // mismo motivo que RC en su momento: TiposComprobanteBase ahora también incluye C-FA/C-FB/
+    // C-FC (design: Table Shapes — E), y el mismo guard AND EXISTS del seed de compra deja una
+    // base fresca intacta para que este seeder la puebla completa y atómica.
     [Fact]
     public async Task UnaBaseFrescaTerminaConElCatalogoCompletoDeTiposIncluidoRc()
     {
@@ -141,10 +147,13 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
 
         var codigos = await db.TiposComprobante.Select(t => t.Codigo).OrderBy(c => c).ToListAsync();
 
-        Assert.Equal(11, codigos.Count);
+        Assert.Equal(14, codigos.Count);
         Assert.Contains("RC", codigos);
         Assert.Contains("FA", codigos);
         Assert.Contains("TX", codigos);
+        Assert.Contains("C-FA", codigos);
+        Assert.Contains("C-FB", codigos);
+        Assert.Contains("C-FC", codigos);
     }
 
     // ---- RC idempotente en una base ya migrada desde stage 6 (task 1.9) ----------------------
@@ -183,6 +192,7 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
                     npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
                     npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                     npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                    npgsql.MapEnum<EstadoCompra>("estado_compra");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresComprasTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresComprasTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 1 (task 1.10, db-error-backstops, design:
+/// Backstop Map — "ordering trap"): mismo patrón unit-style que
+/// <see cref="ManejadorDeErroresVentasTests"/> — sin <c>WaysApiFixture</c> ni Postgres real, la
+/// <see cref="PostgresException"/> se construye "a mano". No hay endpoint todavía en esta slice
+/// (<c>ServicioDeCompras</c> es Slice 2) para ejercer el round-trip HTTP completo, así que la
+/// prueba de que <c>ux_comprobantes_compra_numero_externo</c> gana la rama nueva ANTES de caer
+/// en la familia genérica de <c>ClasificarUnicidad</c> (que la clasificaría como
+/// <c>numero_duplicado</c>, el código de <c>ux_clientes_numero</c>, por la substring "_numero")
+/// vive acá — el mismo hallazgo que <c>ux_comprobantes_venta_numero</c> ya necesitó.
+/// </summary>
+public class ManejadorDeErroresComprasTests
+{
+    private sealed class ServicioDeProblemDetailsFalso : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Ultimo { get; private set; }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.FromResult(true);
+        }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static PostgresException CrearExcepcion(string sqlState, string constraintName) =>
+        new(
+            messageText: "mensaje de prueba",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: null,
+            columnName: null,
+            dataTypeName: null,
+            constraintName: constraintName,
+            file: null,
+            line: null,
+            routine: null);
+
+    private static async Task<(int Estado, string? Codigo)> ManejarAsync(Exception excepcion)
+    {
+        var servicioDeProblemDetails = new ServicioDeProblemDetailsFalso();
+        var manejador = new ManejadorDeErrores(servicioDeProblemDetails, NullLogger<ManejadorDeErrores>.Instance);
+        var contexto = new DefaultHttpContext();
+
+        var manejado = await manejador.TryHandleAsync(contexto, excepcion, CancellationToken.None);
+
+        Assert.True(manejado);
+        Assert.NotNull(servicioDeProblemDetails.Ultimo);
+
+        var problema = servicioDeProblemDetails.Ultimo!.ProblemDetails;
+        return (contexto.Response.StatusCode, problema.Extensions["codigo"] as string);
+    }
+
+    // ---- ux_comprobantes_compra_numero_externo (el trap de ordering) -------------------------
+
+    [Fact]
+    public async Task UxComprobantesCompraNumeroExternoGanaLaRamaNuevaAntesQueLaFamiliaGenericaDeNumero()
+    {
+        var postgres = CrearExcepcion("23505", "ux_comprobantes_compra_numero_externo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("compra_duplicada", codigo);
+        // La prueba negativa que cierra el trap: NUNCA el código genérico de ux_clientes_numero
+        // — sin la rama exacta ANTES de ClasificarUnicidad, la substring "_numero" la atraparía
+        // primero y la clasificaría mal.
+        Assert.NotEqual("numero_duplicado", codigo);
+    }
+
+    [Fact]
+    public async Task UxItemsComprobanteCompraOrdenSeTraduceA409OrdenDeItemDuplicado()
+    {
+        var postgres = CrearExcepcion("23505", "ux_items_comprobante_compra_orden");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("orden_de_item_duplicado", codigo);
+    }
+
+    // ---- ClasificarCheckDeCompras (detrás del guard de prefijo) -------------------------------
+
+    [Fact]
+    public async Task CkComprobantesCompraConfirmadaCompletaSeTraduceA400CompraIncompletaParaConfirmar()
+    {
+        var postgres = CrearExcepcion("23514", "ck_comprobantes_compra_confirmada_completa");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("compra_incompleta_para_confirmar", codigo);
+    }
+
+    [Fact]
+    public async Task CkComprobantesCompraTotalesNoNegativosSeTraduceA400TotalesDeCompraInvalidos()
+    {
+        var postgres = CrearExcepcion("23514", "ck_comprobantes_compra_totales_no_negativos");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("totales_de_compra_invalidos", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsComprobanteCompraCantidadPositivaSeTraduceA400CantidadDeItemInvalida()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_comprobante_compra_cantidad_positiva");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("cantidad_de_item_invalida", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsComprobanteCompraCostoNoNegativoSeTraduceA400CostoDeItemInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_comprobante_compra_costo_no_negativo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("costo_de_item_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsComprobanteCompraImportesNoNegativosSeTraduceA400ImportesDeItemInvalidos()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_comprobante_compra_importes_no_negativos");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("importes_de_item_invalidos", codigo);
+    }
+
+    // ---- FKs nuevas: el match genérico por prefijo "fk_" ya las cubre, sin cambio de código --
+
+    [Theory]
+    [InlineData("fk_comprobantes_compra_tenant")]
+    [InlineData("fk_comprobantes_compra_proveedor")]
+    [InlineData("fk_comprobantes_compra_punto_venta")]
+    [InlineData("fk_comprobantes_compra_empleado")]
+    [InlineData("fk_comprobantes_compra_tipo_comprobante")]
+    [InlineData("fk_items_comprobante_compra_tenant")]
+    [InlineData("fk_items_comprobante_compra_comprobante")]
+    [InlineData("fk_items_comprobante_compra_articulo")]
+    [InlineData("fk_items_comprobante_compra_alicuota_iva")]
+    [InlineData("fk_movimientos_stock_comprobante_compra")]
+    [InlineData("fk_gastos_comprobante_compra")]
+    public async Task CadaFkNuevaSeTraduceA400ReferenciaInvalida(string nombreDeFk)
+    {
+        var postgres = CrearExcepcion("23503", nombreDeFk);
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("fk", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("referencia_invalida", codigo);
+    }
+}

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -13,6 +13,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
@@ -212,6 +213,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
                 npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                 npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
                 npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
             })
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
@@ -245,6 +247,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
                 npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                 npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;


### PR DESCRIPTION
## Resumen

Slice 1/6 de la etapa 8 (stage-8-compras-transferencias-inventario) — el esquema de la última etapa del doc 10, gate autónomo ejercido y registrado.

- Migración `ComprasYTransferenciasEtapa8`: `comprobantes_compra` + `items_comprobante_compra` + enum `estado_compra` + RLS en la misma migración.
- **UNIQUE parcial** `(id_tenant, id_proveedor, id_tipo_comprobante, numero_externo) WHERE estado <> 'anulada'` — la factura del proveedor es la identidad (citext, sin correlativo propio); una anulada permite re-entrada.
- **Las dos FKs diferidas por fin aterrizan juntas**: `movimientos_stock.id_comprobante_compra` y `gastos.id_comprobante_compra` — el patrón que las etapas 6 y 7 dejaron comprometido, cumplido.
- Seeds `C-FA/C-FB/C-FC` por doble vía con el guard de base fresca (lección etapa 7); el prefijo C es lo único que protege al resolver de ventas (busca por código solo).
- **La trampa del `_numero` cerrada y probada**: `ux_comprobantes_compra_numero_externo` se resuelve por nombre exacto ANTES de `ClasificarUnicidad` — sin la rama, una factura duplicada reportaría un conflicto de cliente inexistente (test de grado mutación).

## Verificación

- Build 0 warnings; `has-pending-model-changes` limpio; suites Domain 356 / Application 212 / **Integration 604 (+48: 20 RLS 4-ángulos × 2 tablas + backstops + seeds en las tres formas de base)** / vitest 322, contra Postgres real.
- Judgment-day: **ambos jueces CLEAN en ronda 1** — el diff del seeder verificado byte a byte contra main (11 rows intactos), el razonamiento del StartsWith en FKs compuestos reproducido y validado, el Down() honesto. Un MINOR diferido al slice 2 (test citext case-insensitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)