### PR TITLE
feat(compras): ciclo de vida del comprobante de compra (etapa 8, slice 2)

### DIFF
--- a/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
+++ b/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
@@ -168,68 +168,78 @@ only — nothing in stages 5–7 changes shape.
   same articulo (highest `orden` wins the cost), empty line set;
   `SugeridorDePrecio` reuse asserted, not re-implemented. *(design: Testing
   Strategy — Unit Domain)*
-- [ ] 2.3 Create `src/Ways.Application/Compras/ServicioDeCompras.cs`:
+- [x] 2.3 Create `src/Ways.Application/Compras/ServicioDeCompras.cs`:
   `CrearBorradorAsync`, `ActualizarBorradorAsync` (`PUT`, full item
   replace-set under `SELECT … FOR UPDATE … WHERE estado='borrador'`, physical
   `DELETE`+`INSERT`), `ListarAsync`. *(design decision 2)*
-- [ ] 2.4 `ServicioDeCompras.ConfirmarAsync`: estado-guarded
+- [x] 2.4 `ServicioDeCompras.ConfirmarAsync`: estado-guarded
   `UPDATE … RETURNING` as the first statement, items read **after** it under
   that lock, per-item ledger `INSERT` + cache upsert (asc `id_articulo`),
   `costo_nominal` overwrite (`actualiza_costo AND costo_unitario > 0`,
   deduplicated with highest `orden` winning), `precio_sugerido` via the
   existing `SugeridorDePrecio`, `EstrategiaSinReintento`. *(design decisions
   1, 4, 5; Transactions — CONFIRMAR COMPRA)*
-- [ ] 2.5 `ServicioDeCompras.AnularAsync`: estado-guarded `UPDATE … RETURNING`
+- [x] 2.5 `ServicioDeCompras.AnularAsync`: estado-guarded `UPDATE … RETURNING`
   (`confirmada → anulada`), contramovimientos from the **original ledger**
   (never recalculated from items), `409 compra_anulacion_stock_negativo`
   when any resulting cache would go negative, informational-only linked-gasto
   count — **no block** (the inverted rule). *(design decision 6; Transactions
   — ANULAR COMPRA)*
-- [ ] 2.6 `ServicioDeCompras`: `ObtenerAsync` (detail with `precioSugerido`
+- [x] 2.6 `ServicioDeCompras`: `ObtenerAsync` (detail with `precioSugerido`
   per item) + `AplicarPrecioSugeridoAsync` looping
   `AbrirNuevoPrecioAsync` once per articulo, each its own transaction,
   per-line results. *(design decision 8)*
-- [ ] 2.7 Create `ComprasEndpoints.cs`: 7 routes — writes stack
+- [x] 2.7 Create `ComprasEndpoints.cs`: 7 routes — writes stack
   `GestionDeCatalogo` over `OperacionDePos`, reads stay `OperacionDePos`.
   Update `SuperficieDeAutorizacionTests` allowlist. *(design: API Surface)*
-- [ ] 2.8 [P] Integration: borrador create/edit/remove-item across several
+- [x] 2.8 [P] Integration: borrador create/edit/remove-item across several
   requests writes no `movimientos_stock` row; confirmada/anulada reject an
   item edit `409 compra_no_editable`. *(spec: comprobantes-compra / Borrador
   Is Mutable Because It Has No Ledger Effect)*
-- [ ] 2.9 [P] Integration: same `(proveedor, tipo, numero_externo)` confirmed
+- [x] 2.9 [P] Integration: same `(proveedor, tipo, numero_externo)` confirmed
   twice rejected `409 compra_duplicada`; an annulled number is re-enterable;
   confirming without `numero_externo` rejected `400
-  compra_numero_externo_requerido`. *(spec: comprobantes-compra / Numero
-  Externo Identity And Dedupe)*
-- [ ] 2.10 Integration: confirmar writes stock+cache+cost together in one
+  compra_numero_externo_requerido`. **Deviation**: the collision is proven at
+  the earliest write that persists the duplicate identity (the second
+  `POST`/`PUT`), not literally "at confirm" — the partial unique excludes
+  only `estado = anulada`, so it fires on ANY save that repeats a live
+  `(proveedor, tipo, numero_externo)`, matching design's own Backstop Map
+  framing ("two concurrent **saves**"), not a confirm-only race. *(spec:
+  comprobantes-compra / Numero Externo Identity And Dedupe)*
+- [x] 2.10 Integration: confirmar writes stock+cache+cost together in one
   transaction; a fault-point failure at each step leaves `estado`, stock,
   cache and `costo_nominal` untouched; a second confirm of an already-
   `confirmada` compra rejected `409 compra_ya_procesada`, no duplicate
   movements. *(spec: comprobantes-compra / Confirmar Is One All-Or-Nothing
   Transaction)*
-- [ ] 2.11 Integration: confirm stores `precio_sugerido` without opening a
+- [x] 2.11 Integration: confirm stores `precio_sugerido` without opening a
   new price; the explicit apply action opens a new `precios` row preserving
   history. *(spec: comprobantes-compra / Precio Sugerido Is A Suggestion)*
-- [ ] 2.12 Integration: anulación reverses stock and restores the cache;
+- [x] 2.12 Integration: anulación reverses stock and restores the cache;
   refused `409` when the goods were already sold (names the articulo); no
   `costo_nominal` reversion; anulando a `borrador` rejected `409
   compra_no_procesada`. *(spec: comprobantes-compra / Anulación Reverses By
   Contramovimientos)*
-- [ ] 2.13 Integration (racy surfaces, forced rendezvous): double confirm of
+- [x] 2.13 Integration (racy surfaces, forced rendezvous): double confirm of
   the same borrador — exactly one winner, the loser `409
   compra_no_es_borrador`; confirm × concurrent borrador edit. *(design:
   Backstop Map — "five racy surfaces" 1–2; `ParametrosTests` precedent)*
-- [ ] 2.14 [P] Integration (authorization): Admin confirms and anula
+- [x] 2.14 [P] Integration (authorization): Admin confirms and anula
   (authorization-wise); Vendedor `403` on every compra write path; Vendedor
   reads the compra list. *(spec: comprobantes-compra / Authorization)*
-- [ ] 2.15 [P] Integration (budget): constant command count for a 2 / 20 /
+- [x] 2.15 [P] Integration (budget): constant command count for a 2 / 20 /
   100-item compra's confirm and anular. `DbCommand` interceptor test.
   *(design: Transactions — "Read budget")*
 - [ ] 2.16 Run a **dedicated full judgment-day round** on this slice's diff
   alone before opening the PR — the project's newest guarded state machine.
-  *(Orchestrator Decision 4)*
-- [ ] 2.17 Regression: entire stage 5–7 suite green; `ServicioDeStock`,
-  `ServicioDeVentas`, `CalculadorDeArqueo` untouched.
+  *(Orchestrator Decision 4)* **Not run by this apply batch** — judgment-day
+  requires two independent blind review agents, which is an orchestration
+  action outside an executor's scope (sdd-apply is delegate-only, does not
+  launch sub-agents). Recommend the orchestrator run judgment-day next,
+  before opening the PR.
+- [x] 2.17 Regression: entire stage 5–7 suite green; `ServicioDeStock`,
+  `ServicioDeVentas`, `CalculadorDeArqueo` untouched (byte-identical — no
+  edit made to either file this slice; confirmed via `git status`).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~CalculadorDeCompra|FullyQualifiedName~ServicioDeCompras`
 

--- a/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
+++ b/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
@@ -156,11 +156,11 @@ with the inverted gasto rule (no block, negative-stock refusal); entire stage
 5–7 suite green through it. **Rollback**: new files + one endpoint group
 only — nothing in stages 5–7 changes shape.
 
-- [ ] 2.1 [P] Create `src/Ways.Domain/Compras/CalculadorDeCompra.cs` + records
+- [x] 2.1 [P] Create `src/Ways.Domain/Compras/CalculadorDeCompra.cs` + records
   `LineaDeCompra`/`ItemCalculado`/`CompraCalculada`: `cantidad`, `bruto`,
   `total(i)`, header totals branching on `discrimina_iva`, `costoEfectivo`.
   *(design: Compra Arithmetic; Interfaces/Contracts)*
-- [ ] 2.2 [P] Unit: `CalculadorDeCompra` exhaustive — `cantidad` from
+- [x] 2.2 [P] Unit: `CalculadorDeCompra` exhaustive — `cantidad` from
   unidades/bultos, both IVA regimes, `iva_total NULL` when not
   discriminando, `costoEfectivo` with and without IVA, the `numeric(14,4) →
   numeric(14,2)` narrowing `AwayFromZero`, `descuento > bruto` rejected

--- a/src/Ways.Api/Endpoints/ComprasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ComprasEndpoints.cs
@@ -1,0 +1,79 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Compras;
+using Ways.Domain.Compras;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// Comprobantes de compra (design: API Surface) — lecturas bajo <c>OperacionDePos</c>, toda
+/// escritura apila <c>GestionDeCatalogo</c> (Admin-only): el ciclo de vida entero de una compra
+/// mueve dinero y stock, mismo criterio que <c>POST /api/stock/ajustes</c>.
+/// </summary>
+public static class ComprasEndpoints
+{
+    public static IEndpointRouteBuilder MapearCompras(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/compras")
+            .WithTags("Compras")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapGet("/", (
+            ServicioDeCompras servicio,
+            int? idProveedor,
+            EstadoCompra? estado,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idProveedor, estado, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Lista comprobantes de compra con filtros y paginado.");
+
+        grupo.MapGet("/{id:int}", (ServicioDeCompras servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerAsync(id, ct))
+        .WithSummary("Detalle de una compra: header + items + precioSugerido por item.");
+
+        grupo.MapPost("/", async (ServicioDeCompras servicio, SolicitudDeCompra solicitud, CancellationToken ct) =>
+        {
+            var creada = await servicio.CrearBorradorAsync(solicitud, ct);
+            return Results.Created($"/api/compras/{creada.Id}", creada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Crea un borrador de compra (header + items opcionales).");
+
+        grupo.MapPut("/{id:int}", async (ServicioDeCompras servicio, int id, SolicitudDeCompra solicitud, CancellationToken ct) =>
+        {
+            var actualizada = await servicio.ActualizarBorradorAsync(id, solicitud, ct);
+            return Results.Ok(actualizada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Reemplaza el header y el set completo de items de un borrador (borrador únicamente).");
+
+        grupo.MapPost("/{id:int}/confirmar", async (ServicioDeCompras servicio, int id, CancellationToken ct) =>
+        {
+            var confirmada = await servicio.ConfirmarAsync(id, ct);
+            return Results.Ok(confirmada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Confirma un borrador: entra el stock, se actualiza costo_nominal, se congela precio_sugerido.");
+
+        grupo.MapPost("/{id:int}/anular", async (ServicioDeCompras servicio, int id, CancellationToken ct) =>
+        {
+            var resultado = await servicio.AnularAsync(id, ct);
+            return Results.Ok(resultado);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Anula una compra confirmada: contramovimientos de stock, nunca revierte costo_nominal.");
+
+        grupo.MapPost("/{id:int}/precios", async (
+            ServicioDeCompras servicio, int id, SolicitudDeAplicarPrecios solicitud, CancellationToken ct) =>
+        {
+            var resultados = await servicio.AplicarPrecioSugeridoAsync(id, solicitud, ct);
+            return Results.Ok(resultados);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Aplica precio_sugerido por item vía ServicioDePrecios, per-line results.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -173,6 +173,7 @@ app.MapearStock();
 app.MapearCaja();
 app.MapearGastos();
 app.MapearCuentaCorriente();
+app.MapearCompras();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -4,6 +4,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
@@ -92,6 +93,12 @@ public interface IWaysDbContext
     // stage-6-turnos-caja, Slice 3: ServicioDeGastos es el primer consumidor de Application de
     // este DbSet — Slice 1 solo adelantaba el modelo a la migración (design: Table Shapes C).
     DbSet<Gasto> Gastos { get; }
+
+    // stage-8-compras-transferencias-inventario, Slice 2: ServicioDeCompras es el primer
+    // consumidor de Application de estos 2 — Slice 1 solo adelantaba el modelo a la migración
+    // (design: Table Shapes A/B).
+    DbSet<ComprobanteCompra> ComprobantesCompra { get; }
+    DbSet<ItemComprobanteCompra> ItemsComprobanteCompra { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Application/Compras/Contratos.cs
+++ b/src/Ways.Application/Compras/Contratos.cs
@@ -1,0 +1,96 @@
+using Ways.Domain.Compras;
+
+namespace Ways.Application.Compras;
+
+/// <summary>Una línea del cuerpo de <c>POST/PUT /api/compras</c> (design: Interfaces/Contracts)
+/// — ningún request lleva <c>cantidad</c>, <c>total</c> ni <c>delta</c> (design decisión 3):
+/// <c>CalculadorDeCompra</c> deriva todo eso server-side.</summary>
+public sealed record LineaDeCompraSolicitada(
+    int IdArticulo,
+    string Descripcion,
+    decimal Unidades,
+    decimal? Bultos,
+    decimal? UnidadesPorBulto,
+    decimal CostoUnitario,
+    decimal Descuento,
+    int IdAlicuotaIva,
+    bool ActualizaCosto = true);
+
+/// <summary>Cuerpo de <c>POST /api/compras</c> (crea un borrador) y de <c>PUT
+/// /api/compras/{id}</c> (design decisión 2: replace-set completo del header + los items — un
+/// PUT reemplaza <see cref="Items"/> entero, nunca un CRUD incremental por item).</summary>
+public sealed record SolicitudDeCompra(
+    int IdProveedor,
+    int IdTipoComprobante,
+    int IdPuntoVenta,
+    string? NumeroExterno,
+    DateOnly? FechaComprobante,
+    string? Observaciones,
+    IReadOnlyList<LineaDeCompraSolicitada> Items);
+
+/// <summary>Un item ya persistido, con su <c>precioSugerido</c> (design: API Surface — "Header +
+/// items + precioSugerido per item"). Sin <c>unidades</c> propio: solo <see cref="Cantidad"/>
+/// (ya derivada) y los dos inputs de auditoría (<see cref="Bultos"/>/<see
+/// cref="UnidadesPorBulto"/>) se persisten (design: Table Shapes — B).</summary>
+public sealed record ItemDeCompra(
+    int Orden,
+    int IdArticulo,
+    string Descripcion,
+    decimal Cantidad,
+    decimal? Bultos,
+    decimal? UnidadesPorBulto,
+    decimal CostoUnitario,
+    decimal Descuento,
+    int IdAlicuotaIva,
+    decimal PorcentajeIva,
+    decimal Total,
+    bool ActualizaCosto,
+    decimal? PrecioSugerido);
+
+/// <summary>Detalle completo de una compra — respuesta de <c>GET /api/compras/{id}</c>,
+/// <c>POST /api/compras</c>, <c>PUT /api/compras/{id}</c>, <c>POST …/confirmar</c>.</summary>
+public sealed record CompraDetalle(
+    int Id,
+    int IdProveedor,
+    int IdTipoComprobante,
+    int IdPuntoVenta,
+    string? NumeroExterno,
+    DateOnly? FechaComprobante,
+    DateTimeOffset? FechaRecepcion,
+    decimal Subtotal,
+    decimal DescuentoTotal,
+    decimal? IvaTotal,
+    decimal Total,
+    string? Observaciones,
+    EstadoCompra Estado,
+    IReadOnlyList<ItemDeCompra> Items);
+
+/// <summary>Fila de <c>GET /api/compras</c> — shape reducido, mismo criterio que
+/// <c>ComprobanteListado</c>/<c>GastoListado</c>. <see cref="EstadoPago"/> lo resuelve
+/// <c>ServicioDeSaldoDeProveedor</c> (Slice 4) — <c>null</c> en esta slice.</summary>
+public sealed record CompraListada(
+    int Id,
+    int IdProveedor,
+    int IdTipoComprobante,
+    string? NumeroExterno,
+    EstadoCompra Estado,
+    DateTimeOffset? FechaRecepcion,
+    decimal Total);
+
+/// <summary>Página de resultados de <c>GET /api/compras</c> — mismo shape que
+/// <c>PaginaDeVentas</c>/<c>PaginaDeGastos</c>.</summary>
+public sealed record PaginaDeCompras(IReadOnlyList<CompraListada> Items, int Total, int Pagina, int Tamanio);
+
+/// <summary>Respuesta de <c>POST /api/compras/{id}/anular</c> — <see cref="GastosLigados"/> es
+/// la regla invertida (design decisión 6): la anulación NUNCA bloquea por gastos ligados, solo
+/// REPORTA cuántos pagos quedaron colgados de la compra anulada.</summary>
+public sealed record ResultadoAnulacion(CompraDetalle Compra, int GastosLigados);
+
+/// <summary>Cuerpo de <c>POST /api/compras/{id}/precios</c> (design decisión 8) — la lista de
+/// precios es siempre explícita: una compra no tiene una lista propia asociada.</summary>
+public sealed record SolicitudDeAplicarPrecios(int IdListaPrecio, bool ConfirmarReemplazo = false);
+
+/// <summary>Resultado por línea de aplicar <c>precio_sugerido</c> — partial success es el
+/// contrato honesto (design decisión 8): una línea rechazada (p.ej. un precio pendiente sin
+/// confirmar) no aborta las demás.</summary>
+public sealed record ResultadoAplicarPrecio(int IdArticulo, bool Aplicado, decimal? Precio, string? Error);

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -261,10 +261,10 @@ public class ServicioDeCompras(
         // 1. UPDATE ... RETURNING — autoridad única de la transición (design decisión 1). El
         // lock de fila serializa dos confirmar concurrentes: el que pierde re-evalúa el WHERE
         // contra el estado YA COMITEADO por el ganador, 0 filas, nunca un 500 ni una doble
-        // escritura de stock. La RETURNING trae también id_tipo_comprobante/numero_externo/
-        // fecha_comprobante — los valores que ESTE lock vio, nunca los leídos antes de entrar a
-        // la transacción (design: Transactions — CONFIRMAR COMPRA): un PUT concurrente puede
-        // cambiar cualquiera de los tres entre el pre-chequeo de ConfirmarAsync y este lock. El
+        // escritura de stock. La RETURNING trae id_tipo_comprobante — el valor que ESTE lock
+        // vio, nunca el leído antes de entrar a la transacción (design: Transactions — CONFIRMAR
+        // COMPRA): un PUT concurrente puede cambiarlo entre el pre-chequeo de ConfirmarAsync y
+        // este lock, y discrimina_iva se resuelve recién acá adentro con ese valor. El
         // WHERE de este UPDATE exige además numero_externo/fecha_comprobante NOT NULL (ver el
         // doc-comment de ConfirmarHeaderAsync), así que 0 filas puede deberse a dos motivos
         // distintos que hay que reclasificar bajo lock: la compra ya no está en borrador, o
@@ -475,10 +475,11 @@ public class ServicioDeCompras(
     // ---- statements crudos: confirmar/anular (sibling raw SQL, ver el doc-comment de la clase) ----
 
     /// <summary>Fila devuelta por el UPDATE...RETURNING de <see cref="ConfirmarHeaderAsync"/> —
-    /// design: Transactions — CONFIRMAR COMPRA, paso 1. Los cinco valores son los que ESTE lock
-    /// vio, nunca los leídos antes de entrar a la transacción.</summary>
-    private readonly record struct EncabezadoConfirmado(
-        int IdProveedor, int IdPuntoVenta, int IdTipoComprobante, string? NumeroExterno, DateOnly? FechaComprobante);
+    /// design: Transactions — CONFIRMAR COMPRA, paso 1. Los valores son los que ESTE lock vio,
+    /// nunca los leídos antes de entrar a la transacción. Solo se devuelven las columnas que la
+    /// transacción consume: la completitud de numero_externo/fecha_comprobante ya la valida el
+    /// propio predicado del UPDATE, así que devolverlas sería código muerto.</summary>
+    private readonly record struct EncabezadoConfirmado(int IdPuntoVenta, int IdTipoComprobante);
 
     /// <summary>El predicado incluye <c>numero_externo</c>/<c>fecha_comprobante IS NOT NULL</c>
     /// además de <c>estado='borrador'</c> — validación bajo el mismo lock, resuelta por el propio
@@ -499,7 +500,7 @@ public class ServicioDeCompras(
             "UPDATE comprobantes_compra SET estado = 'confirmada'::estado_compra, fecha_recepcion = $1, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'borrador'::estado_compra " +
             "AND numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL " +
-            "RETURNING id_proveedor, id_punto_venta, id_tipo_comprobante, numero_externo, fecha_comprobante";
+            "RETURNING id_punto_venta, id_tipo_comprobante";
 
         AgregarParametro(comando, momento);
         AgregarParametro(comando, id);
@@ -511,12 +512,7 @@ public class ServicioDeCompras(
             return null;
         }
 
-        return new EncabezadoConfirmado(
-            lector.GetInt32(0),
-            lector.GetInt32(1),
-            lector.GetInt32(2),
-            lector.IsDBNull(3) ? null : lector.GetString(3),
-            lector.IsDBNull(4) ? null : DateOnly.FromDateTime(lector.GetDateTime(4)));
+        return new EncabezadoConfirmado(lector.GetInt32(0), lector.GetInt32(1));
     }
 
     private static async Task<int?> MarcarAnuladaAsync(

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -1,0 +1,744 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Precios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+
+namespace Ways.Application.Compras;
+
+/// <summary>
+/// Ciclo de vida del comprobante de compra — el centerpiece de stage-8 (design: Technical
+/// Approach, "the document header row is the serialization point of every state transition of
+/// una compra"). Dedicado (no reusa ningún ABM), mismo criterio que
+/// <see cref="Ways.Application.Ventas.ServicioDeVentas"/>: <see cref="ConfirmarAsync"/> y
+/// <see cref="AnularAsync"/> son el único punto de escritura de <c>movimientos_stock</c>
+/// (<c>motivo = compra/anulacion</c>) y de <c>articulos.costo_nominal</c> de esta etapa.
+///
+/// <see cref="ServicioDeStock"/>/<see cref="Ways.Application.Ventas.ServicioDeVentas"/> NO se
+/// tocan (Slice 2 non-negotiable) — los statements crudos de stock de acá son propios de esta
+/// clase (sibling raw SQL), duplicados a propósito del shape de
+/// <c>ServicioDeStock.InsertarMovimientoStockAsync</c>/<c>UpsertStockAsync</c> en vez de
+/// compartir un helper: <c>ServicioDeStock</c> gana esos parámetros recién en Slice 3.
+/// </summary>
+public class ServicioDeCompras(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDePrecios servicioDePrecios)
+{
+    // ---- lectura --------------------------------------------------------------------------------
+
+    public async Task<CompraDetalle> ObtenerAsync(int id, CancellationToken ct = default)
+    {
+        var comprobante = await BuscarComprobanteAsync(id, ct);
+        var items = await db.ItemsComprobanteCompra
+            .Where(i => i.IdComprobanteCompra == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        return Proyectar(comprobante, items);
+    }
+
+    public async Task<PaginaDeCompras> ListarAsync(
+        int? idProveedor = null,
+        EstadoCompra? estado = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = db.ComprobantesCompra.AsQueryable();
+
+        if (idProveedor is { } p)
+        {
+            query = query.Where(c => c.IdProveedor == p);
+        }
+
+        if (estado is { } e)
+        {
+            query = query.Where(c => c.Estado == e);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(c => c.FechaRecepcion >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(c => c.FechaRecepcion <= h);
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(c => c.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(c => new CompraListada(c.Id, c.IdProveedor, c.IdTipoComprobante, c.NumeroExterno, c.Estado, c.FechaRecepcion, c.Total))
+            .ToListAsync(ct);
+
+        return new PaginaDeCompras(items, total, pagina, tamanio);
+    }
+
+    // ---- borrador: crear + replace-set (design decisión 2) ---------------------------------------
+
+    public async Task<CompraDetalle> CrearBorradorAsync(SolicitudDeCompra solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var (tipo, _, _, _, porcentajePorAlicuota, margenes) = await ResolverContextoAsync(solicitud, ct);
+        var (lineas, calculada) = Calcular(solicitud.Items, tipo.DiscriminaIva, porcentajePorAlicuota, margenes);
+
+        var comprobante = new ComprobanteCompra
+        {
+            IdTenant = idTenant,
+            IdProveedor = solicitud.IdProveedor,
+            IdTipoComprobante = solicitud.IdTipoComprobante,
+            NumeroExterno = NormalizarOpcional(solicitud.NumeroExterno),
+            FechaComprobante = solicitud.FechaComprobante,
+            FechaRecepcion = null,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdEmpleado = idEmpleado,
+            Subtotal = calculada.Subtotal,
+            DescuentoTotal = calculada.DescuentoTotal,
+            IvaTotal = calculada.IvaTotal,
+            Total = calculada.Total,
+            Observaciones = NormalizarOpcional(solicitud.Observaciones),
+            Estado = EstadoCompra.Borrador,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.ComprobantesCompra.Add(comprobante);
+        await db.SaveChangesAsync(ct);
+
+        var itemsEntidad = MaterializarItems(comprobante.Id, idTenant, lineas, calculada, momento);
+        db.ItemsComprobanteCompra.AddRange(itemsEntidad);
+        await db.SaveChangesAsync(ct);
+
+        return Proyectar(comprobante, itemsEntidad);
+    }
+
+    /// <summary>Design decisión 2: replace-set completo bajo <c>SELECT … FOR UPDATE … WHERE
+    /// estado='borrador'</c> — el lock de fila hace que "el último committer gana" sea una
+    /// garantía real (no una carrera) y el predicado de estado en el mismo statement hace que
+    /// editar una confirmada sea estructuralmente imposible, no solo chequeado.</summary>
+    public async Task<CompraDetalle> ActualizarBorradorAsync(int id, SolicitudDeCompra solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var (tipo, _, _, _, porcentajePorAlicuota, margenes) = await ResolverContextoAsync(solicitud, ct);
+        var (lineas, calculada) = Calcular(solicitud.Items, tipo.DiscriminaIva, porcentajePorAlicuota, margenes);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarActualizacionAsync(id, idTenant, solicitud, lineas, calculada, momento, ct));
+    }
+
+    private async Task<CompraDetalle> EjecutarActualizacionAsync(
+        int id, int idTenant, SolicitudDeCompra solicitud, IReadOnlyList<LineaDeCompra> lineas, CompraCalculada calculada,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var bloqueado = await BloquearBorradorAsync(conexion, transaccionCruda, id, idTenant, ct);
+        if (!bloqueado)
+        {
+            var existe = await db.ComprobantesCompra.AsNoTracking().AnyAsync(c => c.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+            }
+
+            throw new ErrorDominio("compra_no_editable", "Solo una compra en borrador puede editarse.", 409);
+        }
+
+        // El lock de fila crudo de arriba ya serializa cualquier escritor concurrente sobre este
+        // header — esta lectura vía EF (sin FOR UPDATE propio) es segura, ve el estado ya
+        // comiteado bajo el mismo lock (mismo criterio que ServicioDePrecios.BuscarFilaAbiertaAsync
+        // tras TomarLockDelParAsync).
+        var comprobante = await db.ComprobantesCompra.FirstAsync(c => c.Id == id, ct);
+
+        var itemsExistentes = await db.ItemsComprobanteCompra.Where(i => i.IdComprobanteCompra == id).ToListAsync(ct);
+        db.ItemsComprobanteCompra.RemoveRange(itemsExistentes);
+
+        comprobante.IdProveedor = solicitud.IdProveedor;
+        comprobante.IdTipoComprobante = solicitud.IdTipoComprobante;
+        comprobante.NumeroExterno = NormalizarOpcional(solicitud.NumeroExterno);
+        comprobante.FechaComprobante = solicitud.FechaComprobante;
+        comprobante.IdPuntoVenta = solicitud.IdPuntoVenta;
+        comprobante.Observaciones = NormalizarOpcional(solicitud.Observaciones);
+        comprobante.Subtotal = calculada.Subtotal;
+        comprobante.DescuentoTotal = calculada.DescuentoTotal;
+        comprobante.IvaTotal = calculada.IvaTotal;
+        comprobante.Total = calculada.Total;
+        comprobante.UpdatedAt = momento;
+
+        var itemsNuevos = MaterializarItems(id, idTenant, lineas, calculada, momento);
+        db.ItemsComprobanteCompra.AddRange(itemsNuevos);
+
+        await db.SaveChangesAsync(ct);
+        await transaccion.CommitAsync(ct);
+
+        return Proyectar(comprobante, itemsNuevos);
+    }
+
+    // ---- confirmar (design: Transactions — CONFIRMAR COMPRA) --------------------------------------
+
+    public async Task<CompraDetalle> ConfirmarAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        // Camino secuencial (spec: canónico) — una compra visiblemente ya procesada se rechaza
+        // ACÁ, antes de entrar a la transacción, con el código que el spec pinea
+        // (compra_ya_procesada). El UPDATE...RETURNING atómico de abajo sigue siendo la única
+        // autoridad race-safe: si otro confirmar gana la carrera entre esta lectura y ese UPDATE,
+        // la rama de 0 filas lo atrapa con el código genérico del backstop
+        // (compra_no_es_borrador, design: Transactions — "double confirm... the loser").
+        var preLectura = await db.ComprobantesCompra.AsNoTracking().FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (preLectura is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+        }
+
+        if (preLectura.Estado != EstadoCompra.Borrador)
+        {
+            throw new ErrorDominio("compra_ya_procesada", "La compra ya fue procesada.", 409);
+        }
+
+        // spec: "Confirming without a numero_externo is rejected... before any write" — chequeo
+        // de servicio explícito, distinto del backstop de esquema
+        // (ck_comprobantes_compra_confirmada_completa → compra_incompleta_para_confirmar), que
+        // queda como defensa de una escritura fuera de banda.
+        if (preLectura.NumeroExterno is null)
+        {
+            throw new ErrorDominio(
+                "compra_numero_externo_requerido",
+                "La compra necesita un número de comprobante del proveedor para confirmarse.",
+                400);
+        }
+
+        var tipo = await db.TiposComprobante.FirstAsync(t => t.Id == preLectura.IdTipoComprobante, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarConfirmarAsync(id, idTenant, idEmpleado, tipo.DiscriminaIva, momento, ct));
+    }
+
+    private async Task<CompraDetalle> EjecutarConfirmarAsync(
+        int id, int idTenant, int idEmpleado, bool discriminaIva, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 1. UPDATE ... RETURNING — autoridad única de la transición (design decisión 1). El
+        // lock de fila serializa dos confirmar concurrentes: el que pierde re-evalúa el WHERE
+        // contra el estado YA COMITEADO por el ganador, 0 filas, nunca un 500 ni una doble
+        // escritura de stock.
+        var idPuntoVenta = await ConfirmarHeaderAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
+        if (idPuntoVenta is null)
+        {
+            var existe = await db.ComprobantesCompra.AsNoTracking().AnyAsync(c => c.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+            }
+
+            throw new ErrorDominio("compra_no_es_borrador", "La compra ya no está en borrador.", 409);
+        }
+
+        // 2. El read set de items queda congelado bajo el lock del header (design decisión 1).
+        var items = await db.ItemsComprobanteCompra
+            .Where(i => i.IdComprobanteCompra == id)
+            .OrderBy(i => i.IdArticulo)
+            .ToListAsync(ct);
+
+        if (items.Count == 0)
+        {
+            throw new ErrorDominio("compra_sin_items", "La compra no tiene items para confirmar.", 400);
+        }
+
+        // 3. Un movimiento + upsert de stock por item, orden ascendente id_articulo (design:
+        // Transactions — lock order discipline).
+        foreach (var item in items)
+        {
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta.Value, item.Cantidad,
+                MotivoStock.Compra, id, idEmpleado, momento, ct);
+
+            await UpsertStockAsync(conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta.Value, item.Cantidad, ct);
+        }
+
+        // 4. costo_nominal — solo actualiza_costo AND costo_unitario > 0, deduplicado con el
+        // mayor orden ganando (design decisión 4; CalculadorDeCompra.ResolverActualizacionesDeCosto).
+        var itemsParaCosto = items
+            .Select(i => (
+                i.Orden, i.IdArticulo, i.ActualizaCosto, i.CostoUnitario,
+                CostoEfectivo: CalculadorDeCompra.CalcularCostoEfectivoDesdeItem(i.Total, i.Cantidad, i.PorcentajeIva, discriminaIva)))
+            .ToList();
+
+        var costosAActualizar = CalculadorDeCompra.ResolverActualizacionesDeCosto(itemsParaCosto);
+
+        foreach (var (idArticulo, costo) in costosAActualizar.OrderBy(kv => kv.Key))
+        {
+            await ActualizarCostoNominalAsync(conexion, transaccionCruda, idTenant, idArticulo, costo, momento, ct);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerAsync(id, ct);
+    }
+
+    // ---- anular (design: Transactions — ANULAR COMPRA; decisión 6, la regla invertida) -----------
+
+    public async Task<ResultadoAnulacion> AnularAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var preLectura = await db.ComprobantesCompra.AsNoTracking().FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (preLectura is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+        }
+
+        // spec: "Anulando a borrador is rejected... 409 compra_no_procesada — a borrador has no
+        // ledger effect to reverse" — el código canónico del scenario, distinto del backstop
+        // atómico genérico de abajo.
+        if (preLectura.Estado == EstadoCompra.Borrador)
+        {
+            throw new ErrorDominio(
+                "compra_no_procesada", "Una compra en borrador no tiene movimientos que revertir.", 409);
+        }
+
+        if (preLectura.Estado == EstadoCompra.Anulada)
+        {
+            throw new ErrorDominio("compra_no_confirmada", "La compra ya está anulada.", 409);
+        }
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () => await EjecutarAnulacionAsync(id, idTenant, idEmpleado, momento, ct));
+    }
+
+    private async Task<ResultadoAnulacion> EjecutarAnulacionAsync(
+        int id, int idTenant, int idEmpleado, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 1. UPDATE ... RETURNING — misma autoridad única que confirmar.
+        var idPuntoVenta = await MarcarAnuladaAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
+        if (idPuntoVenta is null)
+        {
+            var existe = await db.ComprobantesCompra.AsNoTracking().AnyAsync(c => c.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+            }
+
+            throw new ErrorDominio("compra_no_confirmada", "La compra no está confirmada.", 409);
+        }
+
+        // 2. El ledger ORIGINAL, nunca recalculado desde items (design: doc-comment de
+        // ServicioDeVentas.AnularAsync, mismo criterio acá).
+        var movimientosOriginales = await db.MovimientosStock
+            .Where(m => m.IdComprobanteCompra == id && m.Motivo == MotivoStock.Compra)
+            .OrderBy(m => m.IdArticulo)
+            .ToListAsync(ct);
+
+        foreach (var original in movimientosOriginales)
+        {
+            var inversa = -original.Cantidad;
+
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa,
+                MotivoStock.Anulacion, id, idEmpleado, momento, ct);
+
+            var nueva = await UpsertStockAsync(
+                conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
+
+            if (nueva < 0m)
+            {
+                throw new ErrorDominio(
+                    "compra_anulacion_stock_negativo",
+                    $"El artículo {original.IdArticulo} quedaría con stock negativo al anular esta compra.",
+                    409);
+            }
+        }
+
+        // 4. Informativo — la regla invertida (design decisión 6): NUNCA bloquea.
+        var gastosLigados = await db.Gastos.CountAsync(g => g.IdComprobanteCompra == id, ct);
+
+        await transaccion.CommitAsync(ct);
+
+        var detalle = await ObtenerAsync(id, ct);
+        return new ResultadoAnulacion(detalle, gastosLigados);
+    }
+
+    // ---- aplicar precio sugerido (design decisión 8) -----------------------------------------------
+
+    /// <summary>Loop de <c>AbrirNuevoPrecioAsync</c>, cada llamada su PROPIA transacción — un
+    /// rechazo de una línea (p.ej. <c>precio_pendiente_existe</c>) no aborta las demás (design
+    /// decisión 8: partial success es el contrato honesto).</summary>
+    public async Task<IReadOnlyList<ResultadoAplicarPrecio>> AplicarPrecioSugeridoAsync(
+        int id, SolicitudDeAplicarPrecios solicitud, CancellationToken ct = default)
+    {
+        var comprobante = await BuscarComprobanteAsync(id, ct);
+        if (comprobante.Estado != EstadoCompra.Confirmada)
+        {
+            throw new ErrorDominio(
+                "compra_no_confirmada", "Solo una compra confirmada tiene precio_sugerido para aplicar.", 409);
+        }
+
+        var items = await db.ItemsComprobanteCompra
+            .Where(i => i.IdComprobanteCompra == id && i.PrecioSugerido != null)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        var resultados = new List<ResultadoAplicarPrecio>(items.Count);
+
+        foreach (var item in items)
+        {
+            try
+            {
+                var precio = await servicioDePrecios.EstablecerPrecioAsync(
+                    item.IdArticulo,
+                    new AltaPrecio(solicitud.IdListaPrecio, item.PrecioSugerido!.Value, solicitud.ConfirmarReemplazo),
+                    ct);
+
+                resultados.Add(new ResultadoAplicarPrecio(item.IdArticulo, true, precio.Precio, null));
+            }
+            catch (ErrorDominio error)
+            {
+                resultados.Add(new ResultadoAplicarPrecio(item.IdArticulo, false, null, error.Message));
+            }
+        }
+
+        return resultados;
+    }
+
+    // ---- statements crudos: confirmar/anular (sibling raw SQL, ver el doc-comment de la clase) ----
+
+    private static async Task<int?> ConfirmarHeaderAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE comprobantes_compra SET estado = 'confirmada'::estado_compra, fecha_recepcion = $1, updated_at = $1 " +
+            "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'borrador'::estado_compra " +
+            "RETURNING id_punto_venta";
+
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, id);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is null ? null : Convert.ToInt32(resultado);
+    }
+
+    private static async Task<int?> MarcarAnuladaAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE comprobantes_compra SET estado = 'anulada'::estado_compra, updated_at = $1 " +
+            "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'confirmada'::estado_compra " +
+            "RETURNING id_punto_venta";
+
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, id);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is null ? null : Convert.ToInt32(resultado);
+    }
+
+    private static async Task<bool> BloquearBorradorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT 1 FROM comprobantes_compra " +
+            "WHERE id_comprobante_compra = $1 AND id_tenant = $2 AND estado = 'borrador'::estado_compra " +
+            "FOR UPDATE";
+
+        AgregarParametro(comando, id);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    private static async Task InsertarMovimientoStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal cantidad, MotivoStock motivo, int idComprobanteCompra, int idEmpleado, DateTimeOffset creadoEl,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_stock " +
+            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_compra, id_empleado, creado_el) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, cantidad);
+        AgregarParametro(comando, motivo);
+        AgregarParametro(comando, idComprobanteCompra);
+        AgregarParametro(comando, idEmpleado);
+        AgregarParametro(comando, creadoEl);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task<decimal> UpsertStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock (id_articulo, id_punto_venta, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4) " +
+            "ON CONFLICT (id_articulo, id_punto_venta) DO UPDATE " +
+            "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, delta);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El upsert de stock no devolvió ninguna fila.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    private static async Task ActualizarCostoNominalAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, decimal costoNominal,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE articulos SET costo_nominal = $1, updated_at = $2 WHERE id_articulo = $3 AND id_tenant = $4";
+
+        AgregarParametro(comando, costoNominal);
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idTenant);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    // ---- resolución de contexto (fuera de transacción) ---------------------------------------------
+
+    private async Task<(
+        TipoComprobante Tipo, Proveedor Proveedor, PuntoVenta PuntoVenta,
+        IReadOnlyDictionary<int, Articulo> ArticuloPorId, IReadOnlyDictionary<int, decimal> PorcentajePorAlicuota,
+        IReadOnlyDictionary<int, (decimal? MargenGrupo, decimal? MargenProveedor)> Margenes)>
+        ResolverContextoAsync(SolicitudDeCompra solicitud, CancellationToken ct)
+    {
+        var tipo = await ResolverTipoDeCompraAsync(solicitud.IdTipoComprobante, ct);
+        var proveedor = await ResolverProveedorAsync(solicitud.IdProveedor, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var idsArticulo = solicitud.Items.Select(i => i.IdArticulo).Distinct().ToList();
+        var articuloPorId = idsArticulo.Count == 0
+            ? new Dictionary<int, Articulo>()
+            : await db.Articulos.Where(a => idsArticulo.Contains(a.Id)).ToDictionaryAsync(a => a.Id, ct);
+
+        var idsArticuloFaltantes = idsArticulo.Except(articuloPorId.Keys).ToList();
+        if (idsArticuloFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el artículo {idsArticuloFaltantes[0]}.", 400);
+        }
+
+        var idsAlicuota = solicitud.Items.Select(i => i.IdAlicuotaIva).Distinct().ToList();
+        var porcentajePorAlicuota = idsAlicuota.Count == 0
+            ? new Dictionary<int, decimal>()
+            : await db.AlicuotasIva.Where(a => idsAlicuota.Contains(a.Id)).ToDictionaryAsync(a => a.Id, a => a.Porcentaje, ct);
+
+        var idsAlicuotaFaltantes = idsAlicuota.Except(porcentajePorAlicuota.Keys).ToList();
+        if (idsAlicuotaFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe la alícuota de IVA {idsAlicuotaFaltantes[0]}.", 400);
+        }
+
+        var margenes = await ResolverMargenesAsync(articuloPorId, ct);
+
+        return (tipo, proveedor, puntoVenta, articuloPorId, porcentajePorAlicuota, margenes);
+    }
+
+    private async Task<IReadOnlyDictionary<int, (decimal? MargenGrupo, decimal? MargenProveedor)>> ResolverMargenesAsync(
+        IReadOnlyDictionary<int, Articulo> articuloPorId, CancellationToken ct)
+    {
+        var idsGrupo = articuloPorId.Values.Where(a => a.IdGrupo is not null).Select(a => a.IdGrupo!.Value).Distinct().ToList();
+        var margenPorGrupo = idsGrupo.Count == 0
+            ? new Dictionary<int, decimal?>()
+            : await db.Grupos.Where(g => idsGrupo.Contains(g.Id)).ToDictionaryAsync(g => g.Id, g => g.Margen, ct);
+
+        var idsProveedor = articuloPorId.Values
+            .Where(a => a.IdProveedorHabitual is not null)
+            .Select(a => a.IdProveedorHabitual!.Value)
+            .Distinct()
+            .ToList();
+        var margenPorProveedor = idsProveedor.Count == 0
+            ? new Dictionary<int, decimal?>()
+            : await db.Proveedores.Where(p => idsProveedor.Contains(p.Id)).ToDictionaryAsync(p => p.Id, p => p.Margen, ct);
+
+        return articuloPorId.ToDictionary(
+            kv => kv.Key,
+            kv => (
+                kv.Value.IdGrupo is { } g && margenPorGrupo.TryGetValue(g, out var mg) ? mg : (decimal?)null,
+                kv.Value.IdProveedorHabitual is { } p && margenPorProveedor.TryGetValue(p, out var mp) ? mp : (decimal?)null));
+    }
+
+    private static (IReadOnlyList<LineaDeCompra> Lineas, CompraCalculada Calculada) Calcular(
+        IReadOnlyList<LineaDeCompraSolicitada> items, bool discriminaIva,
+        IReadOnlyDictionary<int, decimal> porcentajePorAlicuota,
+        IReadOnlyDictionary<int, (decimal? MargenGrupo, decimal? MargenProveedor)> margenes)
+    {
+        var orden = 1;
+        var lineas = items
+            .Select(i => new LineaDeCompra(
+                orden++, i.IdArticulo, i.Descripcion, i.Unidades, i.Bultos, i.UnidadesPorBulto,
+                i.CostoUnitario, i.Descuento, i.IdAlicuotaIva, porcentajePorAlicuota[i.IdAlicuotaIva], i.ActualizaCosto))
+            .ToList();
+
+        var calculada = CalculadorDeCompra.Calcular(lineas, discriminaIva, margenes);
+        return (lineas, calculada);
+    }
+
+    private static List<ItemComprobanteCompra> MaterializarItems(
+        int idComprobante, int idTenant, IReadOnlyList<LineaDeCompra> lineas, CompraCalculada calculada, DateTimeOffset momento)
+    {
+        var items = new List<ItemComprobanteCompra>(lineas.Count);
+
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var linea = lineas[i];
+            var item = calculada.Items[i];
+
+            items.Add(new ItemComprobanteCompra
+            {
+                IdTenant = idTenant,
+                IdComprobanteCompra = idComprobante,
+                Orden = linea.Orden,
+                IdArticulo = linea.IdArticulo,
+                Descripcion = linea.Descripcion,
+                Cantidad = item.Cantidad,
+                Bultos = linea.Bultos,
+                UnidadesPorBulto = linea.UnidadesPorBulto,
+                CostoUnitario = linea.CostoUnitario,
+                Descuento = linea.Descuento,
+                IdAlicuotaIva = linea.IdAlicuotaIva,
+                PorcentajeIva = linea.PorcentajeIva,
+                Total = item.Total,
+                ActualizaCosto = linea.ActualizaCosto,
+                PrecioSugerido = item.PrecioSugerido,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            });
+        }
+
+        return items;
+    }
+
+    private async Task<TipoComprobante> ResolverTipoDeCompraAsync(int idTipoComprobante, CancellationToken ct)
+    {
+        var tipo = await db.TiposComprobante.FirstOrDefaultAsync(t => t.Id == idTipoComprobante, ct);
+
+        if (tipo is null || !tipo.Activo || tipo.Clase != ClaseComprobante.Compra)
+        {
+            throw new ErrorDominio(
+                "tipo_de_compra_invalido", $"El tipo de comprobante {idTipoComprobante} no es un tipo de compra válido.", 400);
+        }
+
+        return tipo;
+    }
+
+    private async Task<Proveedor> ResolverProveedorAsync(int idProveedor, CancellationToken ct) =>
+        await db.Proveedores.FirstOrDefaultAsync(p => p.Id == idProveedor, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+            ?? throw ErrorDominio.NoEncontrado($"No existe el proveedor {idProveedor}.");
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<ComprobanteCompra> BuscarComprobanteAsync(int id, CancellationToken ct) =>
+        await db.ComprobantesCompra.FirstOrDefaultAsync(c => c.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeCompras requiere un actor de tenant; GestionDeCatalogo no admite plataforma.");
+
+    private static CompraDetalle Proyectar(ComprobanteCompra comprobante, IReadOnlyList<ItemComprobanteCompra> items) => new(
+        comprobante.Id, comprobante.IdProveedor, comprobante.IdTipoComprobante, comprobante.IdPuntoVenta,
+        comprobante.NumeroExterno, comprobante.FechaComprobante, comprobante.FechaRecepcion,
+        comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.IvaTotal, comprobante.Total,
+        comprobante.Observaciones, comprobante.Estado,
+        items
+            .OrderBy(i => i.Orden)
+            .Select(i => new ItemDeCompra(
+                i.Orden, i.IdArticulo, i.Descripcion, i.Cantidad, i.Bultos, i.UnidadesPorBulto,
+                i.CostoUnitario, i.Descuento, i.IdAlicuotaIva, i.PorcentajeIva, i.Total, i.ActualizaCosto,
+                i.PrecioSugerido))
+            .ToList());
+}

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -226,7 +226,9 @@ public class ServicioDeCompras(
         // spec: "Confirming without a numero_externo is rejected... before any write" — chequeo
         // de servicio explícito, distinto del backstop de esquema
         // (ck_comprobantes_compra_confirmada_completa → compra_incompleta_para_confirmar), que
-        // queda como defensa de una escritura fuera de banda.
+        // queda como defensa de una escritura fuera de banda. fecha_comprobante comparte la
+        // misma CHECK de esquema (sin código propio pineado por el spec), así que reusa el
+        // código del backstop.
         if (preLectura.NumeroExterno is null)
         {
             throw new ErrorDominio(
@@ -235,15 +237,21 @@ public class ServicioDeCompras(
                 400);
         }
 
-        var tipo = await db.TiposComprobante.FirstAsync(t => t.Id == preLectura.IdTipoComprobante, ct);
+        if (preLectura.FechaComprobante is null)
+        {
+            throw new ErrorDominio(
+                "compra_incompleta_para_confirmar",
+                "La compra necesita una fecha de comprobante para confirmarse.",
+                400);
+        }
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
         return await estrategia.ExecuteAsync(async () =>
-            await EjecutarConfirmarAsync(id, idTenant, idEmpleado, tipo.DiscriminaIva, momento, ct));
+            await EjecutarConfirmarAsync(id, idTenant, idEmpleado, momento, ct));
     }
 
     private async Task<CompraDetalle> EjecutarConfirmarAsync(
-        int id, int idTenant, int idEmpleado, bool discriminaIva, DateTimeOffset momento, CancellationToken ct)
+        int id, int idTenant, int idEmpleado, DateTimeOffset momento, CancellationToken ct)
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
@@ -253,14 +261,32 @@ public class ServicioDeCompras(
         // 1. UPDATE ... RETURNING — autoridad única de la transición (design decisión 1). El
         // lock de fila serializa dos confirmar concurrentes: el que pierde re-evalúa el WHERE
         // contra el estado YA COMITEADO por el ganador, 0 filas, nunca un 500 ni una doble
-        // escritura de stock.
-        var idPuntoVenta = await ConfirmarHeaderAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
-        if (idPuntoVenta is null)
+        // escritura de stock. La RETURNING trae también id_tipo_comprobante/numero_externo/
+        // fecha_comprobante — los valores que ESTE lock vio, nunca los leídos antes de entrar a
+        // la transacción (design: Transactions — CONFIRMAR COMPRA): un PUT concurrente puede
+        // cambiar cualquiera de los tres entre el pre-chequeo de ConfirmarAsync y este lock. El
+        // WHERE de este UPDATE exige además numero_externo/fecha_comprobante NOT NULL (ver el
+        // doc-comment de ConfirmarHeaderAsync), así que 0 filas puede deberse a dos motivos
+        // distintos que hay que reclasificar bajo lock: la compra ya no está en borrador, o
+        // sigue en borrador pero un PUT concurrente la dejó incompleta.
+        if (await ConfirmarHeaderAsync(conexion, transaccionCruda, id, idTenant, momento, ct) is not { } encabezado)
         {
-            var existe = await db.ComprobantesCompra.AsNoTracking().AnyAsync(c => c.Id == id, ct);
-            if (!existe)
+            var actual = await db.ComprobantesCompra.AsNoTracking()
+                .Where(c => c.Id == id)
+                .Select(c => (EstadoCompra?)c.Estado)
+                .FirstOrDefaultAsync(ct);
+
+            if (actual is null)
             {
                 throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
+            }
+
+            if (actual == EstadoCompra.Borrador)
+            {
+                throw new ErrorDominio(
+                    "compra_incompleta_para_confirmar",
+                    "La compra necesita número de comprobante y fecha para confirmarse.",
+                    400);
             }
 
             throw new ErrorDominio("compra_no_es_borrador", "La compra ya no está en borrador.", 409);
@@ -277,15 +303,22 @@ public class ServicioDeCompras(
             throw new ErrorDominio("compra_sin_items", "La compra no tiene items para confirmar.", 400);
         }
 
+        // discriminaIva del tipo QUE VIO este lock (encabezado.IdTipoComprobante), nunca el
+        // resuelto antes de entrar a la transacción — un PUT concurrente que cambia el tipo
+        // (p.ej. C-FB → C-FA) entre el pre-chequeo y este lock no puede corromper costo_nominal
+        // con un discriminaIva stale (design: Transactions — CONFIRMAR COMPRA, paso 1).
+        var tipo = await db.TiposComprobante.FirstAsync(t => t.Id == encabezado.IdTipoComprobante, ct);
+        var discriminaIva = tipo.DiscriminaIva;
+
         // 3. Un movimiento + upsert de stock por item, orden ascendente id_articulo (design:
         // Transactions — lock order discipline).
         foreach (var item in items)
         {
             await InsertarMovimientoStockAsync(
-                conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta.Value, item.Cantidad,
+                conexion, transaccionCruda, idTenant, item.IdArticulo, encabezado.IdPuntoVenta, item.Cantidad,
                 MotivoStock.Compra, id, idEmpleado, momento, ct);
 
-            await UpsertStockAsync(conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta.Value, item.Cantidad, ct);
+            await UpsertStockAsync(conexion, transaccionCruda, idTenant, item.IdArticulo, encabezado.IdPuntoVenta, item.Cantidad, ct);
         }
 
         // 4. costo_nominal — solo actualiza_costo AND costo_unitario > 0, deduplicado con el
@@ -441,7 +474,23 @@ public class ServicioDeCompras(
 
     // ---- statements crudos: confirmar/anular (sibling raw SQL, ver el doc-comment de la clase) ----
 
-    private static async Task<int?> ConfirmarHeaderAsync(
+    /// <summary>Fila devuelta por el UPDATE...RETURNING de <see cref="ConfirmarHeaderAsync"/> —
+    /// design: Transactions — CONFIRMAR COMPRA, paso 1. Los cinco valores son los que ESTE lock
+    /// vio, nunca los leídos antes de entrar a la transacción.</summary>
+    private readonly record struct EncabezadoConfirmado(
+        int IdProveedor, int IdPuntoVenta, int IdTipoComprobante, string? NumeroExterno, DateOnly? FechaComprobante);
+
+    /// <summary>El predicado incluye <c>numero_externo</c>/<c>fecha_comprobante IS NOT NULL</c>
+    /// además de <c>estado='borrador'</c> — validación bajo el mismo lock, resuelta por el propio
+    /// predicado del UPDATE en vez de un chequeo posterior en C#: sin esto, un PUT concurrente que
+    /// vacía esas columnas entre el pre-chequeo amistoso de <see cref="ConfirmarAsync"/> y este
+    /// lock haría que este UPDATE viole <c>ck_comprobantes_compra_confirmada_completa</c> — un
+    /// <c>PostgresException</c> crudo (nunca envuelto en <c>DbUpdateException</c>, a diferencia del
+    /// camino de EF <c>SaveChanges</c>) que <c>ManejadorDeErrores</c> no puede clasificar y deja
+    /// pasar como 500. <c>Ways.Application</c> no referencia Npgsql (Npgsql solo vive en
+    /// Infrastructure), así que la única forma de evitar ese 500 sin acoplar la capa es que el
+    /// propio predicado impida la violación en vez de atraparla después.</summary>
+    private static async Task<EncabezadoConfirmado?> ConfirmarHeaderAsync(
         DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
@@ -449,14 +498,25 @@ public class ServicioDeCompras(
         comando.CommandText =
             "UPDATE comprobantes_compra SET estado = 'confirmada'::estado_compra, fecha_recepcion = $1, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'borrador'::estado_compra " +
-            "RETURNING id_punto_venta";
+            "AND numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL " +
+            "RETURNING id_proveedor, id_punto_venta, id_tipo_comprobante, numero_externo, fecha_comprobante";
 
         AgregarParametro(comando, momento);
         AgregarParametro(comando, id);
         AgregarParametro(comando, idTenant);
 
-        var resultado = await comando.ExecuteScalarAsync(ct);
-        return resultado is null ? null : Convert.ToInt32(resultado);
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return new EncabezadoConfirmado(
+            lector.GetInt32(0),
+            lector.GetInt32(1),
+            lector.GetInt32(2),
+            lector.IsDBNull(3) ? null : lector.GetString(3),
+            lector.IsDBNull(4) ? null : DateOnly.FromDateTime(lector.GetDateTime(4)));
     }
 
     private static async Task<int?> MarcarAnuladaAsync(

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Ways.Application.Articulos;
 using Ways.Application.Caja;
 using Ways.Application.Catalogos;
 using Ways.Application.Clientes;
+using Ways.Application.Compras;
 using Ways.Application.CuentaCorriente;
 using Ways.Application.Gastos;
 using Ways.Application.Ofertas;
@@ -70,6 +71,11 @@ public static class DependencyInjection
 
         services.AddScoped<ServicioDeAprovisionamiento>();
         services.AddScoped<ServicioDeOrganizacion>();
+
+        // stage-8-compras-transferencias-inventario, Slice 2: el ciclo de vida entero de la
+        // compra — reusa ServicioDePrecios (AplicarPrecioSugeridoAsync), nunca
+        // ServicioDeStock/ServicioDeVentas (Slice 2 non-negotiable).
+        services.AddScoped<ServicioDeCompras>();
 
         return services;
     }

--- a/src/Ways.Domain/Compras/CalculadorDeCompra.cs
+++ b/src/Ways.Domain/Compras/CalculadorDeCompra.cs
@@ -1,0 +1,151 @@
+using Ways.Domain.Common;
+using Ways.Domain.Precios;
+
+namespace Ways.Domain.Compras;
+
+/// <summary>
+/// Una línea de compra tal como llega del request (design: Interfaces/Contracts) — <see
+/// cref="Unidades"/>/<see cref="Bultos"/>/<see cref="UnidadesPorBulto"/> son los inputs crudos;
+/// <see cref="CalculadorDeCompra.Calcular"/> deriva <c>cantidad</c> a partir de ellos (design
+/// decisión 3: ningún endpoint acepta <c>cantidad</c> directamente).
+/// </summary>
+public sealed record LineaDeCompra(
+    int Orden, int IdArticulo, string Descripcion,
+    decimal Unidades, decimal? Bultos, decimal? UnidadesPorBulto,
+    decimal CostoUnitario, decimal Descuento,
+    int IdAlicuotaIva, decimal PorcentajeIva, bool ActualizaCosto);
+
+/// <summary>Una línea ya calculada (design: Compra Arithmetic) — <see cref="CostoEfectivo"/> es
+/// lo que <c>ServicioDeCompras.ConfirmarAsync</c> escribe en <c>articulos.costo_nominal</c>
+/// (design decisión 4); <see cref="PrecioSugerido"/> es la sugerencia vía <see
+/// cref="SugeridorDePrecio"/>, nunca aplicada por el cálculo en sí.</summary>
+public sealed record ItemCalculado(
+    int Orden, int IdArticulo, decimal Cantidad, decimal Total,
+    decimal CostoEfectivo, decimal? PrecioSugerido);
+
+/// <summary>Resultado completo de <see cref="CalculadorDeCompra.Calcular"/>.</summary>
+public sealed record CompraCalculada(
+    decimal Subtotal, decimal DescuentoTotal, decimal? IvaTotal, decimal Total,
+    IReadOnlyList<ItemCalculado> Items);
+
+/// <summary>
+/// Aritmética de una compra (design: Compra Arithmetic) — pura, sin acceso a base de datos, el
+/// único lugar donde estas fórmulas existen (mismo listón que <c>CalculadorDeArqueo</c>/
+/// <c>CalculadorDeTotales</c>). <see cref="MidpointRounding.AwayFromZero"/> en cada redondeo,
+/// nunca el banker's rounding default de .NET — mismo criterio POS que el resto del proyecto.
+/// </summary>
+public static class CalculadorDeCompra
+{
+    /// <summary>
+    /// <paramref name="discriminaIva"/> viene de <c>tipos_comprobante.discrimina_iva</c> del tipo
+    /// de la compra; <paramref name="margenes"/> alimenta al <see cref="SugeridorDePrecio"/>
+    /// existente, que devuelve <c>null</c> cuando no hay margen configurado para ese artículo.
+    /// </summary>
+    public static CompraCalculada Calcular(
+        IReadOnlyList<LineaDeCompra> lineas, bool discriminaIva,
+        IReadOnlyDictionary<int, (decimal? MargenGrupo, decimal? MargenProveedor)> margenes)
+    {
+        var items = new List<ItemCalculado>(lineas.Count);
+        var subtotal = 0m;
+        var descuentoTotal = 0m;
+        var ivaTotal = discriminaIva ? 0m : (decimal?)null;
+
+        foreach (var linea in lineas)
+        {
+            var cantidad = Redondear(linea.Unidades + (linea.Bultos ?? 0m) * (linea.UnidadesPorBulto ?? 0m), 3);
+
+            if (cantidad <= 0m)
+            {
+                throw new ErrorDominio(
+                    "cantidad_de_item_invalida", "La cantidad de un ítem de compra tiene que ser positiva.", 400);
+            }
+
+            if (linea.CostoUnitario < 0m)
+            {
+                throw new ErrorDominio(
+                    "costo_de_item_invalido", "El costo unitario de un ítem de compra no puede ser negativo.", 400);
+            }
+
+            if (linea.Descuento < 0m)
+            {
+                throw new ErrorDominio(
+                    "importes_de_item_invalidos", "El descuento de un ítem de compra no puede ser negativo.", 400);
+            }
+
+            var bruto = Redondear(cantidad * linea.CostoUnitario, 2);
+
+            if (linea.Descuento > bruto)
+            {
+                throw new ErrorDominio(
+                    "descuento_de_item_invalido", "El descuento de un ítem no puede superar su importe bruto.", 400);
+            }
+
+            var total = bruto - linea.Descuento;
+
+            decimal costoEfectivo;
+            if (discriminaIva)
+            {
+                var ivaDeLinea = Redondear(total * linea.PorcentajeIva / 100m, 2);
+                ivaTotal += ivaDeLinea;
+                costoEfectivo = Redondear(total * (1 + linea.PorcentajeIva / 100m) / cantidad, 2);
+            }
+            else
+            {
+                costoEfectivo = Redondear(total / cantidad, 2);
+            }
+
+            var (margenGrupo, margenProveedor) = margenes.TryGetValue(linea.IdArticulo, out var margen)
+                ? margen
+                : (null, null);
+            var precioSugerido = SugeridorDePrecio.Sugerir(costoEfectivo, null, null, margenGrupo, margenProveedor);
+
+            items.Add(new ItemCalculado(linea.Orden, linea.IdArticulo, cantidad, total, costoEfectivo, precioSugerido));
+
+            subtotal += bruto;
+            descuentoTotal += linea.Descuento;
+        }
+
+        var total2 = discriminaIva ? subtotal - descuentoTotal + (ivaTotal ?? 0m) : subtotal - descuentoTotal;
+
+        return new CompraCalculada(subtotal, descuentoTotal, ivaTotal, total2, items);
+    }
+
+    /// <summary>Deriva <c>costoEfectivo</c> directo de los valores YA persistidos de un item
+    /// (<c>total</c>/<c>cantidad</c>/<c>porcentaje_iva</c>) — usado por
+    /// <c>ServicioDeCompras.ConfirmarAsync</c>, que no vuelve a pasar por <see cref="Calcular"/>
+    /// (evita re-derivar <c>cantidad</c> desde <c>unidades</c>/<c>bultos</c> una segunda vez).
+    /// Misma fórmula que <see cref="Calcular"/> (design: Compra Arithmetic), aplicada al dato ya
+    /// congelado en la fila.</summary>
+    public static decimal CalcularCostoEfectivoDesdeItem(decimal total, decimal cantidad, decimal porcentajeIva, bool discriminaIva) =>
+        discriminaIva
+            ? Redondear(total * (1 + porcentajeIva / 100m) / cantidad, 2)
+            : Redondear(total / cantidad, 2);
+
+    /// <summary>Design: Compra Arithmetic — "dos líneas del mismo artículo... el costo_nominal se
+    /// deduplica en memoria con el mayor orden ganando, así que se emite exactamente un UPDATE
+    /// por artículo". Filtra por <c>actualizaCosto AND costoUnitario &gt; 0</c> (design decisión
+    /// 4, el guard anti-bonificación) antes de dedupear.</summary>
+    public static IReadOnlyDictionary<int, decimal> ResolverActualizacionesDeCosto(
+        IReadOnlyList<(int Orden, int IdArticulo, bool ActualizaCosto, decimal CostoUnitario, decimal CostoEfectivo)> items)
+    {
+        var ganador = new Dictionary<int, (int Orden, decimal Costo)>();
+
+        foreach (var item in items)
+        {
+            if (!item.ActualizaCosto || item.CostoUnitario <= 0m)
+            {
+                continue;
+            }
+
+            if (!ganador.TryGetValue(item.IdArticulo, out var actual) || item.Orden > actual.Orden)
+            {
+                ganador[item.IdArticulo] = (item.Orden, item.CostoEfectivo);
+            }
+        }
+
+        return ganador.ToDictionary(kv => kv.Key, kv => kv.Value.Costo);
+    }
+
+    private static decimal Redondear(decimal valor, int decimales) =>
+        Math.Round(valor, decimales, MidpointRounding.AwayFromZero);
+}

--- a/tests/Ways.Domain.Tests/Compras/CalculadorDeCompraTests.cs
+++ b/tests/Ways.Domain.Tests/Compras/CalculadorDeCompraTests.cs
@@ -1,0 +1,297 @@
+using Ways.Domain.Common;
+using Ways.Domain.Compras;
+
+namespace Ways.Domain.Tests.Compras;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 2 (task 2.2, design: Compra Arithmetic /
+/// Testing Strategy — "the bulk of the stage's test mass") — pura, sin base de datos.
+/// </summary>
+public class CalculadorDeCompraTests
+{
+    private static readonly IReadOnlyDictionary<int, (decimal? MargenGrupo, decimal? MargenProveedor)> SinMargenes =
+        new Dictionary<int, (decimal?, decimal?)>();
+
+    private static LineaDeCompra Linea(
+        int orden = 1, int idArticulo = 1, decimal unidades = 1m, decimal? bultos = null,
+        decimal? unidadesPorBulto = null, decimal costoUnitario = 100m, decimal descuento = 0m,
+        int idAlicuotaIva = 1, decimal porcentajeIva = 21m, bool actualizaCosto = true) =>
+        new(orden, idArticulo, "item de prueba", unidades, bultos, unidadesPorBulto, costoUnitario, descuento,
+            idAlicuotaIva, porcentajeIva, actualizaCosto);
+
+    // ---- cantidad: unidades + bultos * unidadesPorBulto ---------------------------------------
+
+    [Fact]
+    public void LaCantidadEsSoloUnidadesCuandoNoHayBultos()
+    {
+        var resultado = CalculadorDeCompra.Calcular([Linea(unidades: 5m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(5m, resultado.Items[0].Cantidad);
+    }
+
+    [Fact]
+    public void LaCantidadSumaBultosPorUnidadesPorBultoALasUnidades()
+    {
+        // 2 unidades sueltas + 3 bultos de 10 = 32.
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(unidades: 2m, bultos: 3m, unidadesPorBulto: 10m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(32m, resultado.Items[0].Cantidad);
+    }
+
+    [Fact]
+    public void LaCantidadRedondeaAwayFromZeroATresDecimales()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(unidades: 1.0005m, costoUnitario: 1m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(1.001m, resultado.Items[0].Cantidad);
+    }
+
+    [Fact]
+    public void UnaCantidadCeroOMenorEsRechazada()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            CalculadorDeCompra.Calcular([Linea(unidades: 0m)], discriminaIva: false, SinMargenes));
+
+        Assert.Equal("cantidad_de_item_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    // ---- descuento > bruto ---------------------------------------------------------------------
+
+    [Fact]
+    public void UnDescuentoMayorAlBrutoEsRechazado()
+    {
+        // Bruto = 1 * 100 = 100; descuento 150 > 100.
+        var error = Assert.Throws<ErrorDominio>(() =>
+            CalculadorDeCompra.Calcular([Linea(costoUnitario: 100m, descuento: 150m)], discriminaIva: false, SinMargenes));
+
+        Assert.Equal("descuento_de_item_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void UnDescuentoIgualAlBrutoEsAceptadoYDaTotalCero()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(costoUnitario: 100m, descuento: 100m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(0m, resultado.Items[0].Total);
+        Assert.Equal(0m, resultado.Total);
+    }
+
+    [Fact]
+    public void UnCostoUnitarioNegativoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            CalculadorDeCompra.Calcular([Linea(costoUnitario: -1m)], discriminaIva: false, SinMargenes));
+
+        Assert.Equal("costo_de_item_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void UnDescuentoNegativoEsRechazado()
+    {
+        var error = Assert.Throws<ErrorDominio>(() =>
+            CalculadorDeCompra.Calcular([Linea(descuento: -1m)], discriminaIva: false, SinMargenes));
+
+        Assert.Equal("importes_de_item_invalidos", error.Codigo);
+    }
+
+    // ---- discrimina_iva = true (C-FA): costoUnitario neto de IVA -------------------------------
+
+    [Fact]
+    public void ConIvaDiscriminadoElTotalSumaElIvaYElCostoEfectivoLoIncluye()
+    {
+        // 1 unidad a 100 neto, IVA 21% -> iva 21, total 121, costoEfectivo = 121 / 1 = 121.
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(costoUnitario: 100m, porcentajeIva: 21m)], discriminaIva: true, SinMargenes);
+
+        Assert.Equal(100m, resultado.Subtotal);
+        Assert.Equal(21m, resultado.IvaTotal);
+        Assert.Equal(121m, resultado.Total);
+        Assert.Equal(121m, resultado.Items[0].CostoEfectivo);
+    }
+
+    [Fact]
+    public void ConIvaDiscriminadoYVariasCantidadesElCostoEfectivoEsPorUnidad()
+    {
+        // 2 unidades a 100 neto, IVA 21% -> total de línea (200 - 0) = 200, con IVA = 242,
+        // costoEfectivo = 242 / 2 = 121 (mismo costo unitario efectivo que la prueba anterior).
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(unidades: 2m, costoUnitario: 100m, porcentajeIva: 21m)], discriminaIva: true, SinMargenes);
+
+        Assert.Equal(121m, resultado.Items[0].CostoEfectivo);
+    }
+
+    // ---- discrimina_iva = false (C-FB/C-FC): costoUnitario ya incluye IVA ----------------------
+
+    [Fact]
+    public void SinIvaDiscriminadoElIvaTotalEsNuloYElCostoEfectivoNoLoIncluyeDeNuevo()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(costoUnitario: 121m, porcentajeIva: 21m)], discriminaIva: false, SinMargenes);
+
+        Assert.Null(resultado.IvaTotal);
+        Assert.Equal(121m, resultado.Total);
+        Assert.Equal(121m, resultado.Items[0].CostoEfectivo);
+    }
+
+    // ---- narrowing numeric(14,4) -> numeric(14,2) AwayFromZero ----------------------------------
+
+    [Fact]
+    public void ElCostoEfectivoRedondeaAwayFromZeroEnElMedio()
+    {
+        // 3 unidades a 33.335 (numeric 14,4) -> bruto 100.005 -> redondeado AwayFromZero a
+        // 100.01, no al par más cercano (100.00) que daría el banker's rounding default.
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(unidades: 3m, costoUnitario: 33.335m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(100.01m, resultado.Subtotal);
+        // costoEfectivo = total / cantidad = 100.01 / 3 = 33.3366... -> 33.34 AwayFromZero.
+        Assert.Equal(33.34m, resultado.Items[0].CostoEfectivo);
+    }
+
+    // ---- bonificación (costo cero) no debe tocar costo, pero SÍ es un total/costoEfectivo válido
+
+    [Fact]
+    public void UnaLineaDeBonificacionConCostoCeroEsAceptadaYDaCostoEfectivoCero()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(costoUnitario: 0m)], discriminaIva: false, SinMargenes);
+
+        Assert.Equal(0m, resultado.Items[0].Total);
+        Assert.Equal(0m, resultado.Items[0].CostoEfectivo);
+    }
+
+    // ---- precio sugerido: delegado a SugeridorDePrecio, nunca reimplementado -------------------
+
+    [Fact]
+    public void ElPrecioSugeridoSeDelegaEnSugeridorDePrecioConElCostoEfectivoComoBase()
+    {
+        var margenes = new Dictionary<int, (decimal?, decimal?)> { [1] = (50m, null) };
+
+        var resultado = CalculadorDeCompra.Calcular(
+            [Linea(idArticulo: 1, costoUnitario: 100m)], discriminaIva: false, margenes);
+
+        // costoEfectivo = 100 (sin IVA discriminado); margen grupo 50% -> Sugerir(100, null,
+        // null, 50, null) = 150.
+        var esperado = Ways.Domain.Precios.SugeridorDePrecio.Sugerir(100m, null, null, 50m, null);
+        Assert.Equal(esperado, resultado.Items[0].PrecioSugerido);
+        Assert.Equal(150m, resultado.Items[0].PrecioSugerido);
+    }
+
+    [Fact]
+    public void SinMargenNiCostoNominalElPrecioSugeridoEsNulo()
+    {
+        var resultado = CalculadorDeCompra.Calcular([Linea(idArticulo: 1)], discriminaIva: false, SinMargenes);
+
+        Assert.Null(resultado.Items[0].PrecioSugerido);
+    }
+
+    // ---- dos líneas del mismo artículo: cada una calcula su propio costo, nada se funde --------
+
+    [Fact]
+    public void DosLineasDelMismoArticuloCalculanSuPropioCostoEfectivoIndependiente()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [
+                Linea(orden: 1, idArticulo: 7, costoUnitario: 100m),
+                Linea(orden: 2, idArticulo: 7, costoUnitario: 200m)
+            ],
+            discriminaIva: false, SinMargenes);
+
+        Assert.Equal(2, resultado.Items.Count);
+        Assert.Equal(100m, resultado.Items[0].CostoEfectivo);
+        Assert.Equal(200m, resultado.Items[1].CostoEfectivo);
+    }
+
+    // ---- ResolverActualizacionesDeCosto: dedupe con el mayor orden ganando ---------------------
+
+    [Fact]
+    public void ResolverActualizacionesDeCostoDedupeaConElMayorOrdenGanando()
+    {
+        var items = new List<(int Orden, int IdArticulo, bool ActualizaCosto, decimal CostoUnitario, decimal CostoEfectivo)>
+        {
+            (1, 7, true, 100m, 100m),
+            (2, 7, true, 200m, 200m)
+        };
+
+        var resultado = CalculadorDeCompra.ResolverActualizacionesDeCosto(items);
+
+        Assert.Single(resultado);
+        Assert.Equal(200m, resultado[7]);
+    }
+
+    [Fact]
+    public void ResolverActualizacionesDeCostoExcluyeActualizaCostoFalso()
+    {
+        var items = new List<(int Orden, int IdArticulo, bool ActualizaCosto, decimal CostoUnitario, decimal CostoEfectivo)>
+        {
+            (1, 7, false, 100m, 100m)
+        };
+
+        var resultado = CalculadorDeCompra.ResolverActualizacionesDeCosto(items);
+
+        Assert.Empty(resultado);
+    }
+
+    [Fact]
+    public void ResolverActualizacionesDeCostoExcluyeCostoUnitarioCeroOMenor()
+    {
+        // Guard anti-bonificación (design decisión 4): una línea con costo cero no debe pisar
+        // articulos.costo_nominal aunque actualizaCosto sea true.
+        var items = new List<(int Orden, int IdArticulo, bool ActualizaCosto, decimal CostoUnitario, decimal CostoEfectivo)>
+        {
+            (1, 7, true, 0m, 0m)
+        };
+
+        var resultado = CalculadorDeCompra.ResolverActualizacionesDeCosto(items);
+
+        Assert.Empty(resultado);
+    }
+
+    [Fact]
+    public void CalcularCostoEfectivoDesdeItemReplicaLaMismaFormulaQueCalcular()
+    {
+        var conIva = CalculadorDeCompra.CalcularCostoEfectivoDesdeItem(total: 100m, cantidad: 1m, porcentajeIva: 21m, discriminaIva: true);
+        var sinIva = CalculadorDeCompra.CalcularCostoEfectivoDesdeItem(total: 121m, cantidad: 1m, porcentajeIva: 21m, discriminaIva: false);
+
+        Assert.Equal(121m, conIva);
+        Assert.Equal(121m, sinIva);
+    }
+
+    // ---- header: varias líneas ------------------------------------------------------------------
+
+    [Fact]
+    public void VariasLineasSumanSubtotalDescuentoYTotalCorrectamente()
+    {
+        var resultado = CalculadorDeCompra.Calcular(
+            [
+                Linea(orden: 1, idArticulo: 1, unidades: 1m, costoUnitario: 100m, descuento: 0m),
+                Linea(orden: 2, idArticulo: 2, unidades: 2m, costoUnitario: 50m, descuento: 10m)
+            ],
+            discriminaIva: false, SinMargenes);
+
+        // Línea 1: bruto 100, total 100. Línea 2: bruto 100, descuento 10, total 90.
+        Assert.Equal(200m, resultado.Subtotal);
+        Assert.Equal(10m, resultado.DescuentoTotal);
+        Assert.Equal(190m, resultado.Total);
+        Assert.Equal(resultado.Total, resultado.Items.Sum(i => i.Total));
+    }
+
+    // ---- edge case: lista vacía -------------------------------------------------------------------
+
+    [Fact]
+    public void UnaListaVaciaDeLineasDaTotalesEnCeroYSinItems()
+    {
+        var resultado = CalculadorDeCompra.Calcular([], discriminaIva: true, SinMargenes);
+
+        Assert.Empty(resultado.Items);
+        Assert.Equal(0m, resultado.Subtotal);
+        Assert.Equal(0m, resultado.DescuentoTotal);
+        Assert.Equal(0m, resultado.IvaTotal);
+        Assert.Equal(0m, resultado.Total);
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
@@ -45,7 +45,7 @@ public class ComprasAnulacionYConcurrenciaTests(WaysApiFixture fixture) : IClass
 
     private sealed record Contexto(
         int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21, int IdTipoCFA,
-        string MailAdmin, string PasswordAdmin);
+        int IdTipoCFB, string MailAdmin, string PasswordAdmin);
 
     private async Task<Contexto> PrepararAsync(string nombre)
     {
@@ -95,10 +95,11 @@ public class ComprasAnulacionYConcurrenciaTests(WaysApiFixture fixture) : IClass
         await db.SaveChangesAsync();
 
         var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
 
         return new Contexto(
             resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21, idTipoCFA,
-            mailAdmin, resultado.PasswordTemporal);
+            idTipoCFB, mailAdmin, resultado.PasswordTemporal);
     }
 
     private static SolicitudDeCompra SolicitudSimple(
@@ -503,6 +504,182 @@ public class ComprasAnulacionYConcurrenciaTests(WaysApiFixture fixture) : IClass
 
         // Un único movimiento de compra como máximo — nunca dos confirmaciones sobrevivieron.
         Assert.True(await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id) <= 1);
+    }
+
+    /// <summary>Pausa cada transacción manual (<c>EjecutarConfirmarAsync</c>/
+    /// <c>EjecutarAnulacionAsync</c>) justo DESPUÉS de <c>BeginTransactionAsync</c> — antes de que
+    /// el statement crudo <c>UPDATE ... RETURNING</c> corra — hasta que el test la libera. Fuerza
+    /// determinísticamente el interleaving "un PUT concurrente commitea ANTES de que el lock del
+    /// header confirme", sin depender del timing real del pool (mismo criterio de forced
+    /// rendezvous que <see cref="InterceptorDeRendezVousConfirmar"/>, pero enganchado al ciclo de
+    /// vida de la transacción en vez de a un <c>DbCommand</c> puntual).</summary>
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Design: Backstop Map — superficie racy 1, "confirm × concurrent tipo-switching
+    /// edit" (judgment-day, blocker judge B). Antes del fix, <c>discriminaIva</c> se resolvía del
+    /// <c>tipos_comprobante</c> leído ANTES del lock del header — un PUT que cambia el tipo
+    /// (C-FB, sin IVA discriminado → C-FA, con IVA discriminado) entre esa lectura y el lock podía
+    /// dejar <c>costo_nominal</c> calculado con el <c>discrimina_iva</c> del tipo VIEJO aunque la
+    /// compra confirmada terminó con el tipo NUEVO — un 21% de diferencia silenciosa. El fix
+    /// resuelve <c>discrimina_iva</c> DESPUÉS del lock, a partir de <c>id_tipo_comprobante</c> tal
+    /// como lo devuelve el <c>RETURNING</c> del propio <c>UPDATE</c>, así que siempre es
+    /// consistente con el tipo que ese lock efectivamente vio — cualquiera de las dos
+    /// interleavings es válida, la única que no lo es es la mezcla.</summary>
+    [Fact]
+    public async Task ConfirmarConCambioDeTipoDeIvaConcurrenteUsaElDiscriminaIvaQueElLockRealmenteVio()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarConCambioDeTipoDeIvaConcurrenteUsaElDiscriminaIvaQueElLockRealmenteVio));
+
+        var solicitudInicial = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, "tipo-switch-race", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 1m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, true)]);
+        var creada = await CrearBorradorAsync(ctx, solicitudInicial);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteConfirmar = factory.CreateClient();
+        var login = await clienteConfirmar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaConfirmar = clienteConfirmar.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        await transaccionIniciada.Task;
+
+        // El PUT gana la carrera: cambia el tipo (mismo costoUnitario) y COMMITEA antes de que el
+        // lock del header de confirmar corra.
+        var solicitudSwitch = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "tipo-switch-race", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 1m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, true)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", solicitudSwitch);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // El tipo persistido es SIEMPRE el que el lock de confirmar efectivamente vio: si el PUT
+        // hubiese ganado DESPUÉS del lock, habría chocado contra "estado != borrador" (409) y
+        // nunca habría llegado a cambiar el tipo.
+        var compra = await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id);
+        Assert.Equal(ctx.IdTipoCFA, compra.IdTipoComprobante);
+
+        var tipoGanador = await db.TiposComprobante.FirstAsync(t => t.Id == compra.IdTipoComprobante);
+        var item = await db.ItemsComprobanteCompra.SingleAsync(i => i.IdComprobanteCompra == creada.Id);
+        var costoEsperado = CalculadorDeCompra.CalcularCostoEfectivoDesdeItem(
+            item.Total, item.Cantidad, item.PorcentajeIva, tipoGanador.DiscriminaIva);
+
+        var articulo = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo);
+        Assert.Equal(costoEsperado, articulo.CostoNominal);
+
+        // discriminaIva=true (C-FA) ganó la carrera: 100 * 1.21 = 121 — nunca el 100 stale que el
+        // discriminaIva viejo de C-FB hubiese producido.
+        Assert.Equal(121.00m, articulo.CostoNominal);
+    }
+
+    /// <summary>Design: Backstop Map — superficie racy adicional, "confirm × concurrent field-
+    /// clearing edit" (judgment-day, blocker judge A). Un confirmar ordinario con
+    /// <c>fecha_comprobante = NULL</c> (nunca chequeada por el pre-check original, solo
+    /// <c>numero_externo</c>) llegaba crudo al <c>UPDATE ... RETURNING</c>, violaba
+    /// <c>ck_comprobantes_compra_confirmada_completa</c> y escapaba como 500 — <see
+    /// cref="PostgresException"/> nunca envuelta en <c>DbUpdateException</c> (a diferencia del
+    /// camino de EF <c>SaveChanges</c>), así que <c>ManejadorDeErrores</c> no la podía clasificar.
+    /// El caso ordinario (sin carrera) ya lo cubre <see
+    /// cref="ConfirmarSinFechaDeComprobanteEsRechazadaConElCodigoPineado"/>; esta prueba fuerza el
+    /// caso racy — un PUT que vacía <c>numero_externo</c>/<c>fecha_comprobante</c> DESPUÉS del
+    /// pre-chequeo amistoso de <c>ConfirmarAsync</c> pero ANTES del lock del header — para probar
+    /// que el WHERE guard bajo lock de <c>ConfirmarHeaderAsync</c> (nunca un catch de
+    /// <c>PostgresException</c>: <c>Ways.Application</c> no referencia Npgsql) también lo
+    /// atrapa.</summary>
+    [Fact]
+    public async Task ConfirmarConNumeroYFechaVaciadosPorUnPutConcurrenteEsRechazadoConBadRequestNoConError500()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarConNumeroYFechaVaciadosPorUnPutConcurrenteEsRechazadoConBadRequestNoConError500));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "vaciado-race"));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteConfirmar = factory.CreateClient();
+        var login = await clienteConfirmar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaConfirmar = clienteConfirmar.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        await transaccionIniciada.Task;
+
+        var solicitudVaciada = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, null, null, null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 10m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, true)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", solicitudVaciada);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.BadRequest, cuerpoConfirmar);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoConfirmar, OpcionesJson);
+        Assert.Equal("compra_incompleta_para_confirmar", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    /// <summary>Design: Backstop Map, caso ordinario (sin carrera) del blocker judge A —
+    /// <c>fecha_comprobante</c> nunca fue validada por el pre-check original (solo
+    /// <c>numero_externo</c>), así que un confirmar normal con fecha NULL llegaba crudo al
+    /// <c>UPDATE</c> y violaba <c>ck_comprobantes_compra_confirmada_completa</c> como 500. El
+    /// pre-chequeo amistoso ahora la rechaza ANTES de tocar la transacción, con el mismo código
+    /// del backstop de esquema (spec no pinea uno propio para <c>fecha_comprobante</c>).</summary>
+    [Fact]
+    public async Task ConfirmarSinFechaDeComprobanteEsRechazadaConElCodigoPineado()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarSinFechaDeComprobanteEsRechazadaConElCodigoPineado));
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "sin-fecha", null, null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 1m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, true)]);
+        var creada = await CrearBorradorAsync(ctx, solicitud);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.BadRequest, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("compra_incompleta_para_confirmar", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
     }
 
     // ---- task 2.15: presupuesto de comandos --------------------------------------------------------

--- a/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
@@ -1,0 +1,659 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 2: anulación (tasks 2.12), atomicidad
+/// forzada por punto de falla (task 2.10), las dos superficies racy de esta slice (task 2.13) y
+/// el presupuesto de comandos (task 2.15).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasAnulacionYConcurrenciaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21, int IdTipoCFA,
+        string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Compras-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21, idTipoCFA,
+            mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(
+        Contexto ctx, decimal unidades = 10m, decimal costoUnitario = 100m, string? numeroExterno = "0001-00000001") =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno, DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearBorradorAsync(Contexto ctx, SolicitudDeCompra? solicitud = null)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud ?? SolicitudSimple(ctx));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<CompraDetalle> ConfirmarAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    /// <summary>Simula una venta directa del ledger (sin pasar por el checkout completo, que
+    /// necesita turno/cliente/medios de pago) — a la refusal de anulación (design decisión 5) le
+    /// alcanza con que <c>stock.cantidad</c> haya bajado, no le importa cómo.</summary>
+    private async Task ReducirStockComoVentaAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.MovimientosStock.Add(new MovimientoStock
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, Cantidad = -cantidad,
+            Motivo = MotivoStock.Venta, IdEmpleado = idEmpleado, CreadoEl = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var stock = await db.Stock.FirstAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        stock.Cantidad -= cantidad;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SembrarGastoLigadoAsync(Contexto ctx, int idComprobanteCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+
+        var idMedioPago = await db.MediosPago.Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdEmpleadoApertura = idEmpleado,
+            FechaApertura = ahora, FondoInicial = 0m, Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        db.Gastos.Add(new Gasto
+        {
+            IdTenant = ctx.IdTenant, Fecha = ahora, IdPuntoVenta = ctx.IdPuntoVenta, IdTurnoCaja = turno.Id,
+            IdEmpleado = idEmpleado, Categoria = CategoriaGasto.Proveedor, IdProveedor = ctx.IdProveedor,
+            Concepto = "Pago de prueba", IdMedioPago = idMedioPago, Importe = 100m,
+            IdComprobanteCompra = idComprobanteCompra, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    // ---- task 2.12: anulación reversa por contramovimientos --------------------------------------
+
+    [Fact]
+    public async Task AnulacionReviertaElStockYRestauraElCache()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionReviertaElStockYRestauraElCache));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 50m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var resultado = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(EstadoCompra.Anulada, resultado.Compra.Estado);
+        Assert.Equal(0, resultado.GastosLigados);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(0m, cantidad);
+
+        Assert.Equal(
+            1, await db.MovimientosStock.CountAsync(
+                m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion && m.Cantidad == -50m));
+    }
+
+    [Fact]
+    public async Task AnulacionEsRechazadaCuandoLaMercaderiaYaFueVendida()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionEsRechazadaCuandoLaMercaderiaYaFueVendida));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 50m));
+        await ConfirmarAsync(ctx, creada.Id);
+        await ReducirStockComoVentaAsync(ctx, ctx.IdArticulo, 40m);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_anulacion_stock_negativo", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Confirmada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion));
+
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(10m, cantidad);
+    }
+
+    [Fact]
+    public async Task CostoNominalNoSeRevierteAlAnular()
+    {
+        var ctx = await PrepararAsync(nameof(CostoNominalNoSeRevierteAlAnular));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, costoUnitario: 100m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var articulo = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo);
+            Assert.Equal(121.00m, articulo.CostoNominal);
+        }
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var articulo = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo);
+            Assert.Equal(121.00m, articulo.CostoNominal);
+        }
+    }
+
+    [Fact]
+    public async Task AnulandoUnBorradorEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(AnulandoUnBorradorEsRechazado));
+        var creada = await CrearBorradorAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_no_procesada", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>La regla invertida (design decisión 6): la anulación NUNCA bloquea por un gasto
+    /// ligado — procede y solo REPORTA cuántos pagos quedaron colgados.</summary>
+    [Fact]
+    public async Task AnulacionProcedeConGastosLigadosYLosReportaEnLaRespuesta()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionProcedeConGastosLigadosYLosReportaEnLaRespuesta));
+        var creada = await CrearBorradorAsync(ctx);
+        await ConfirmarAsync(ctx, creada.Id);
+        await SembrarGastoLigadoAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoCompra.Anulada, resultado.Compra.Estado);
+        Assert.Equal(1, resultado.GastosLigados);
+    }
+
+    // ---- task 2.10: atomicidad, un punto de falla por prueba (confirmar) -------------------------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task<HttpResponseMessage> ConfirmarConPrivilegioRevocadoAsync(Contexto ctx, int id, string tabla, string privilegios)
+    {
+        await RevocarAsync(tabla, privilegios);
+        try
+        {
+            return await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        }
+        finally
+        {
+            await RestaurarAsync(tabla, privilegios);
+        }
+    }
+
+    [Fact]
+    public async Task UnaFallaAlEscribirElMovimientoDeStockDejaLaCompraEnBorrador()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirElMovimientoDeStockDejaLaCompraEnBorrador));
+        var creada = await CrearBorradorAsync(ctx);
+
+        var respuesta = await ConfirmarConPrivilegioRevocadoAsync(ctx, creada.Id, "movimientos_stock", "INSERT");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+        Assert.Equal(0, await db.Stock.CountAsync(s => s.IdArticulo == ctx.IdArticulo));
+    }
+
+    [Fact]
+    public async Task UnaFallaAlActualizarElCostoNominalDejaTodoSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlActualizarElCostoNominalDejaTodoSinCambios));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, costoUnitario: 100m));
+
+        var respuesta = await ConfirmarConPrivilegioRevocadoAsync(ctx, creada.Id, "articulos", "UPDATE");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+        Assert.Null((await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo)).CostoNominal);
+    }
+
+    // ---- task 2.10 (anulación): un punto de falla en la reversa -----------------------------------
+
+    [Fact]
+    public async Task UnaFallaAlRevertirElStockDejaLaCompraConfirmadaYSinReversa()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlRevertirElStockDejaLaCompraConfirmadaYSinReversa));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 20m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        await RevocarAsync("stock", "UPDATE");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        }
+        finally
+        {
+            await RestaurarAsync("stock", "UPDATE");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Confirmada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion));
+
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(20m, cantidad);
+    }
+
+    // ---- task 2.13: superficies racy, forced rendezvous (row lock natural) ------------------------
+
+    /// <summary>Design: Backstop Map — "genuinely racy surfaces... (1) double confirm of the same
+    /// borrador". <c>ConfirmarAsync</c> tiene DOS capas (a diferencia de
+    /// <c>ServicioDeVentas.AnularAsync</c>, que no tiene pre-chequeo secuencial): una lectura
+    /// previa (fuera de la transacción) que da el código canónico del spec
+    /// (<c>compra_ya_procesada</c>) cuando la compra YA está visiblemente procesada, y el
+    /// <c>UPDATE ... RETURNING</c> atómico como backstop race-safe (<c>compra_no_es_borrador</c>).
+    /// Sin forzar el rendezvous de las dos lecturas previas, el timing real del pool casi siempre
+    /// deja que una gane del todo antes de que la otra arranque, y el "perdedor" ve la capa 1 en
+    /// vez de la capa 2 — <c>InterceptorDeRendezVousConfirmar</c> retiene las dos lecturas hasta
+    /// que ambas llegaron, así las dos entran a la transacción viendo <c>borrador</c> y la carrera
+    /// real ocurre en el <c>UPDATE</c>.</summary>
+    [Fact]
+    public async Task DobleConfirmacionConcurrenteDaExactamenteUnGanador()
+    {
+        var ctx = await PrepararAsync(nameof(DobleConfirmacionConcurrenteDaExactamenteUnGanador));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "race-confirmar"));
+
+        using var gate = new CountdownEvent(2);
+        var interceptor = new InterceptorDeRendezVousConfirmar(gate);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaA = cliente.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var tareaB = cliente.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        var estados = respuestas.Select(r => r.StatusCode).OrderBy(s => s).ToList();
+
+        Assert.True(interceptor.Participantes >= 2, $"participantes={interceptor.Participantes}");
+        Assert.Equal([HttpStatusCode.OK, HttpStatusCode.Conflict], estados);
+
+        var perdedora = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await perdedora.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_no_es_borrador", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    /// <summary>Retiene las dos primeras consultas que leen <c>comprobantes_compra</c> — la
+    /// pre-lectura de <c>ServicioDeCompras.ConfirmarAsync</c> de cada request — hasta que ambas
+    /// llegaron. Mismo patrón que <c>ParametrosTests.InterceptorDeRendezVous</c>. No matchea
+    /// <c>items_comprobante_compra</c> (nombre de tabla distinto, sin "comprobantes_compra" como
+    /// substring).</summary>
+    private sealed class InterceptorDeRendezVousConfirmar(CountdownEvent gate) : DbCommandInterceptor
+    {
+        private int _participantes;
+
+        public int Participantes => _participantes;
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            EsperarSiCorresponde(command);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            EsperarSiCorresponde(command);
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        private void EsperarSiCorresponde(DbCommand command)
+        {
+            if (!command.CommandText.Contains("comprobantes_compra", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _participantes) > 2)
+            {
+                return;
+            }
+
+            gate.Signal();
+
+            var senializo = gate.Wait(TimeSpan.FromSeconds(10));
+            Assert.True(senializo, "El rendezvous de InterceptorDeRendezVousConfirmar no llegó a los 2 participantes a tiempo.");
+        }
+    }
+
+    /// <summary>Design: Backstop Map — superficie racy 2, "confirm × concurrent borrador edit".
+    /// Ambos toman el MISMO lock de fila como primer statement (design decisión 1) — cualquiera
+    /// de los dos resultados es representable: si el PUT gana primero, confirmar ve el estado ya
+    /// editado y confirma sobre eso; si confirmar gana primero, el PUT ve <c>estado != borrador</c>
+    /// al retomar el lock y se rechaza con <c>409</c>. Nunca un 500, nunca una mezcla corrupta.</summary>
+    [Fact]
+    public async Task ConfirmarYEditarElMismoBorradorEnParaleloNuncaCorrompenElEstado()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarYEditarElMismoBorradorEnParaleloNuncaCorrompenElEstado));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m));
+
+        var tareaConfirmar = ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var tareaEditar = ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", SolicitudSimple(ctx, unidades: 30m));
+
+        var confirmarResp = await tareaConfirmar;
+        var editarResp = await tareaEditar;
+
+        Assert.True(
+            confirmarResp.StatusCode is HttpStatusCode.OK or HttpStatusCode.Conflict,
+            $"confirmar: {confirmarResp.StatusCode}");
+        Assert.True(
+            editarResp.StatusCode is HttpStatusCode.OK or HttpStatusCode.Conflict,
+            $"editar: {editarResp.StatusCode}");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Cualquiera sea el resultado, el invariante de stock sigue en pie: la cantidad en caché
+        // coincide con la suma de sus movimientos (nunca una escritura a medias).
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == ctx.IdArticulo && m.IdPuntoVenta == ctx.IdPuntoVenta)
+            .SumAsync(m => m.Cantidad);
+        Assert.Equal(cantidad, sumaDeMovimientos);
+
+        // Un único movimiento de compra como máximo — nunca dos confirmaciones sobrevivieron.
+        Assert.True(await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id) <= 1);
+    }
+
+    // ---- task 2.15: presupuesto de comandos --------------------------------------------------------
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    [Fact]
+    public async Task ConfirmarEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeItems()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeItems));
+
+        var consultasConPocosItems = await MedirConsultasDeConfirmarAsync(ctx, cantidadDeItems: 2);
+        var consultasConMuchosItems = await MedirConsultasDeConfirmarAsync(ctx, cantidadDeItems: 20);
+        var consultasConMuchisimosItems = await MedirConsultasDeConfirmarAsync(ctx, cantidadDeItems: 100);
+
+        Assert.Equal(consultasConPocosItems, consultasConMuchosItems);
+        Assert.Equal(consultasConPocosItems, consultasConMuchisimosItems);
+    }
+
+    [Fact]
+    public async Task AnularEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeItems()
+    {
+        var ctx = await PrepararAsync(nameof(AnularEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeItems));
+
+        var consultasConPocosItems = await MedirConsultasDeAnularAsync(ctx, cantidadDeItems: 2);
+        var consultasConMuchosItems = await MedirConsultasDeAnularAsync(ctx, cantidadDeItems: 20);
+        var consultasConMuchisimosItems = await MedirConsultasDeAnularAsync(ctx, cantidadDeItems: 100);
+
+        Assert.Equal(consultasConPocosItems, consultasConMuchosItems);
+        Assert.Equal(consultasConPocosItems, consultasConMuchisimosItems);
+    }
+
+    private async Task<CompraDetalle> CrearBorradorDeNItemsAsync(Contexto ctx, int cantidadDeItems)
+    {
+        var lineas = new List<LineaDeCompraSolicitada>();
+        for (var i = 0; i < cantidadDeItems; i++)
+        {
+            int idArticulo;
+            await using (var dbSeed = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+            {
+                var ahora = DateTimeOffset.UtcNow;
+                var articulo = new Articulo
+                {
+                    IdTenant = ctx.IdTenant, CodigoInterno = $"presupuesto-{Guid.NewGuid():N}", Nombre = "Presupuesto",
+                    IdArea = await dbSeed.Areas.Select(a => a.Id).FirstAsync(), IdAlicuotaIva = ctx.IdAlicuotaIva21,
+                    UnidadVenta = UnidadVenta.Unidad, EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+                };
+                dbSeed.Articulos.Add(articulo);
+                await dbSeed.SaveChangesAsync();
+                idArticulo = articulo.Id;
+            }
+
+            lineas.Add(new LineaDeCompraSolicitada(idArticulo, $"Item {i}", 1m, null, null, 10m, 0m, ctx.IdAlicuotaIva21, true));
+        }
+
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, $"presupuesto-{Guid.NewGuid():N}",
+            DateOnly.FromDateTime(DateTime.UtcNow), null, lineas);
+
+        return await CrearBorradorAsync(ctx, solicitud);
+    }
+
+    private WaysDbContext CrearContextoConContador(int idTenant, ContadorDeComandos contador)
+    {
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, idTenant);
+
+        var opciones = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<Ways.Domain.Usuarios.EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<Ways.Domain.Organizacion.EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Ways.Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<Ways.Domain.Ventas.EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
+            })
+            .AddInterceptors(new Ways.Infrastructure.Multitenancy.InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        return new WaysDbContext(opciones, tenantActual);
+    }
+
+    private static ServicioDeCompras CrearServicio(WaysDbContext db, int idTenant) => new(
+        db, new RelojFijo(DateTimeOffset.UtcNow), new ContextoFijo(idTenant, usuarioId: 1),
+        new Ways.Application.Precios.ServicioDePrecios(db, new RelojFijo(DateTimeOffset.UtcNow), new ContextoFijo(idTenant, 1)));
+
+    private async Task<int> MedirConsultasDeConfirmarAsync(Contexto ctx, int cantidadDeItems)
+    {
+        var creada = await CrearBorradorDeNItemsAsync(ctx, cantidadDeItems);
+
+        var contador = new ContadorDeComandos();
+        await using var db = CrearContextoConContador(ctx.IdTenant, contador);
+        var servicio = CrearServicio(db, ctx.IdTenant);
+
+        await servicio.ConfirmarAsync(creada.Id);
+
+        return contador.Consultas;
+    }
+
+    private async Task<int> MedirConsultasDeAnularAsync(Contexto ctx, int cantidadDeItems)
+    {
+        var creada = await CrearBorradorDeNItemsAsync(ctx, cantidadDeItems);
+        await ConfirmarAsync(ctx, creada.Id);
+
+        var contador = new ContadorDeComandos();
+        await using var db = CrearContextoConContador(ctx.IdTenant, contador);
+        var servicio = CrearServicio(db, ctx.IdTenant);
+
+        await servicio.AnularAsync(creada.Id);
+
+        return contador.Consultas;
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasLifecycleTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasLifecycleTests.cs
@@ -1,0 +1,483 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 2 (the centerpiece): el ciclo de vida
+/// completo de <c>ServicioDeCompras</c> a través de la API real (tasks 2.8, 2.9, 2.10, 2.11,
+/// 2.14; design: Transactions — CONFIRMAR COMPRA).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasLifecycleTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "vendedor-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Vendedor,
+        int IdProveedor, int IdArticulo, int IdArticulo2, int IdAlicuotaIva21, int IdTipoCFA, int IdTipoCFB);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Compras-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            Margen = 50m, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-1-{Guid.NewGuid():N}", Nombre = "Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            IdProveedorHabitual = proveedor.Id, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-2-{Guid.NewGuid():N}", Nombre = "Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
+
+        var hasheador = new HasheadorPbkdf2();
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = resultado.IdTenant, NombreUsuario = "vendedor", Mail = mailVendedor, RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor), PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var vendedor = fixture.CreateClient();
+        var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, vendedor,
+            proveedor.Id, articulo1.Id, articulo2.Id, idAlicuotaIva21, idTipoCFA, idTipoCFB);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(
+        Contexto ctx, decimal unidades = 10m, decimal costoUnitario = 100m, string? numeroExterno = "0001-00000001",
+        bool actualizaCosto = true, int? idArticulo = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno, DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(idArticulo ?? ctx.IdArticulo, "Item de prueba", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, actualizaCosto)]);
+
+    private static async Task<CompraDetalle> CrearBorradorAsync(Contexto ctx, SolicitudDeCompra? solicitud = null)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud ?? SolicitudSimple(ctx));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<CompraDetalle> ConfirmarAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 2.8: borrador CRUD, sin efecto de ledger -----------------------------------------
+
+    [Fact]
+    public async Task UnBorradorSeCreaSinItemsYNoGeneraMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorSeCreaSinItemsYNoGeneraMovimientos));
+
+        var solicitud = new SolicitudDeCompra(ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, null, null, null, []);
+        var creada = await CrearBorradorAsync(ctx, solicitud);
+
+        Assert.Equal(EstadoCompra.Borrador, creada.Estado);
+        Assert.Empty(creada.Items);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    [Fact]
+    public async Task ItemsSeAgreganYQuitanEnVariosRequestsSinGenerarMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(ItemsSeAgreganYQuitanEnVariosRequestsSinGenerarMovimientos));
+        var creada = await CrearBorradorAsync(ctx);
+
+        var conDosItems = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-00000002", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [
+                new LineaDeCompraSolicitada(ctx.IdArticulo, "Item 1", 5m, null, null, 50m, 0m, ctx.IdAlicuotaIva21, true),
+                new LineaDeCompraSolicitada(ctx.IdArticulo2, "Item 2", 3m, null, null, 30m, 0m, ctx.IdAlicuotaIva21, true)
+            ]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", conDosItems);
+        Assert.Equal(HttpStatusCode.OK, respuestaPut.StatusCode);
+        var actualizada = (await respuestaPut.Content.ReadFromJsonAsync<CompraDetalle>(OpcionesJson))!;
+        Assert.Equal(2, actualizada.Items.Count);
+
+        var conUnItem = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-00000002", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item 1", 5m, null, null, 50m, 0m, ctx.IdAlicuotaIva21, true)]);
+        var respuestaPut2 = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", conUnItem);
+        Assert.Equal(HttpStatusCode.OK, respuestaPut2.StatusCode);
+        var conMenosItems = (await respuestaPut2.Content.ReadFromJsonAsync<CompraDetalle>(OpcionesJson))!;
+        Assert.Single(conMenosItems.Items);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+        Assert.Equal(1, await db.ItemsComprobanteCompra.CountAsync(i => i.IdComprobanteCompra == creada.Id));
+    }
+
+    [Fact]
+    public async Task UnaCompraConfirmadaRechazaLaEdicionDeItems()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCompraConfirmadaRechazaLaEdicionDeItems));
+        var creada = await CrearBorradorAsync(ctx);
+        await ConfirmarAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", SolicitudSimple(ctx));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_no_editable", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaCompraAnuladaRechazaLaEdicionDeItems()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCompraAnuladaRechazaLaEdicionDeItems));
+        var creada = await CrearBorradorAsync(ctx);
+        await ConfirmarAsync(ctx, creada.Id);
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", SolicitudSimple(ctx));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_no_editable", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.9: numero_externo identity + dedupe -----------------------------------------------
+
+    /// <summary>La unicidad parcial (<c>estado &lt;&gt; 'anulada'</c>) alcanza a un borrador Y a
+    /// una confirmada por igual (design: Backstop Map — "genuine race: two concurrent SAVES",
+    /// no "two concurrent confirms") — con la primera ya confirmada, el segundo choca al
+    /// intentar GUARDAR el mismo <c>numero_externo</c>, antes de siquiera llegar a confirmar.</summary>
+    [Fact]
+    public async Task ElMismoNumeroExternoDeUnaConfirmadaNoSePuedeReusarEnOtroBorrador()
+    {
+        var ctx = await PrepararAsync(nameof(ElMismoNumeroExternoDeUnaConfirmadaNoSePuedeReusarEnOtroBorrador));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "0003-00012345"));
+        await ConfirmarAsync(ctx, primera.Id);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, numeroExterno: "0003-00012345"));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_duplicada", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnNumeroExternoAnuladoSePuedeReingresarYConfirmar()
+    {
+        var ctx = await PrepararAsync(nameof(UnNumeroExternoAnuladoSePuedeReingresarYConfirmar));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "0003-00099999"));
+        await ConfirmarAsync(ctx, primera.Id);
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{primera.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var segunda = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "0003-00099999"));
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{segunda.Id}/confirmar", null);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task ConfirmarSinNumeroExternoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarSinNumeroExternoEsRechazado));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: null));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_numero_externo_requerido", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Test diferido de la Slice 1 (task deferred): la unicidad usa <c>citext</c> —
+    /// "F-0001" y "f-0001" son el MISMO valor para el índice parcial, así que guardar el
+    /// segundo borrador choca contra la primera fila con el mismo <c>23505</c> traducido.</summary>
+    [Fact]
+    public async Task UnNumeroExternoDifiereSoloEnMayusculasChocaPorCitext()
+    {
+        var ctx = await PrepararAsync(nameof(UnNumeroExternoDifiereSoloEnMayusculasChocaPorCitext));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, numeroExterno: "F-0001"));
+        await ConfirmarAsync(ctx, primera.Id);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, numeroExterno: "f-0001"));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_duplicada", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.10: confirmar escribe stock + cache + costo juntos ---------------------------------
+
+    [Fact]
+    public async Task ConfirmarEscribeMovimientoCacheYCostoNominalJuntos()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarEscribeMovimientoCacheYCostoNominalJuntos));
+
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-00000010", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [
+                new LineaDeCompraSolicitada(ctx.IdArticulo, "Actualiza costo", 10m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, true),
+                new LineaDeCompraSolicitada(ctx.IdArticulo2, "No actualiza costo", 5m, null, null, 50m, 0m, ctx.IdAlicuotaIva21, false)
+            ]);
+        var creada = await CrearBorradorAsync(ctx, solicitud);
+
+        var confirmada = await ConfirmarAsync(ctx, creada.Id);
+        Assert.Equal(EstadoCompra.Confirmada, confirmada.Estado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        Assert.Equal(2, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Compra));
+
+        var stock1 = await db.Stock.Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        var stock2 = await db.Stock.Where(s => s.IdArticulo == ctx.IdArticulo2 && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(10m, stock1);
+        Assert.Equal(5m, stock2);
+
+        var articulo1 = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo);
+        var articulo2 = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo2);
+        // C-FA discrimina IVA: costoEfectivo = total * (1 + 21%) / cantidad = 100 * 1.21 = 121.
+        Assert.Equal(121.00m, articulo1.CostoNominal);
+        Assert.Null(articulo2.CostoNominal);
+    }
+
+    [Fact]
+    public async Task ConfirmarUnaCompraYaConfirmadaEsRechazadaSinDuplicarMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUnaCompraYaConfirmadaEsRechazadaSinDuplicarMovimientos));
+        var creada = await CrearBorradorAsync(ctx);
+        await ConfirmarAsync(ctx, creada.Id);
+
+        var segundo = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        Assert.Equal(HttpStatusCode.Conflict, segundo.StatusCode);
+        var problema = await segundo.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_ya_procesada", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    [Fact]
+    public async Task ConfirmarUnBorradorSinItemsEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUnBorradorSinItemsEsRechazado));
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-00000099", DateOnly.FromDateTime(DateTime.UtcNow), null, []);
+        var creada = await CrearBorradorAsync(ctx, solicitud);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_sin_items", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.11: precio_sugerido es una sugerencia, nunca auto-aplicada ------------------------
+
+    [Fact]
+    public async Task ElBorradorCalculaYGuardaElPrecioSugeridoSinAbrirNingunPrecio()
+    {
+        var ctx = await PrepararAsync(nameof(ElBorradorCalculaYGuardaElPrecioSugeridoSinAbrirNingunPrecio));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, costoUnitario: 100m));
+
+        // C-FA (discrimina IVA): costoEfectivo = 121; margen proveedor 50% -> sugerido = 181.5.
+        Assert.Equal(181.5m, creada.Items[0].PrecioSugerido);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Precios.CountAsync());
+    }
+
+    [Fact]
+    public async Task ConfirmarNoAbreUnPrecioYAplicarLoHaceRespetandoHistoria()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarNoAbreUnPrecioYAplicarLoHaceRespetandoHistoria));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, costoUnitario: 100m));
+        var confirmada = await ConfirmarAsync(ctx, creada.Id);
+
+        Assert.Equal(181.5m, confirmada.Items[0].PrecioSugerido);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(0, await db.Precios.CountAsync());
+        }
+
+        int idListaPrecio;
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            var lista = new ListaPrecio
+            {
+                IdTenant = ctx.IdTenant, Nombre = "Lista de prueba", EsDefault = false, Modo = ModoLista.Fija,
+                Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.ListasPrecio.Add(lista);
+            await db.SaveChangesAsync();
+            idListaPrecio = lista.Id;
+        }
+
+        var respuestaAplicar = await ctx.Admin.PostAsJsonAsync(
+            $"/api/compras/{creada.Id}/precios", new SolicitudDeAplicarPrecios(idListaPrecio));
+        Assert.Equal(HttpStatusCode.OK, respuestaAplicar.StatusCode);
+        var resultados = (await respuestaAplicar.Content.ReadFromJsonAsync<List<ResultadoAplicarPrecio>>(OpcionesJson))!;
+
+        Assert.Single(resultados);
+        Assert.True(resultados[0].Aplicado);
+        Assert.Equal(181.5m, resultados[0].Precio);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            Assert.Equal(1, await db.Precios.CountAsync());
+            var precio = await db.Precios.FirstAsync();
+            Assert.Equal(181.5m, precio.Monto);
+            Assert.Null(precio.VigenteHasta);
+        }
+    }
+
+    // ---- task 2.14: autorización -------------------------------------------------------------------
+
+    [Fact]
+    public async Task AdminConfirmaYAnula()
+    {
+        var ctx = await PrepararAsync(nameof(AdminConfirmaYAnula));
+        var creada = await CrearBorradorAsync(ctx);
+        var confirmar = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        Assert.Equal(HttpStatusCode.OK, confirmar.StatusCode);
+
+        var anular = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anular.StatusCode);
+    }
+
+    [Fact]
+    public async Task VendedorEsBloqueadoEnTodoCaminoDeEscrituraDeCompra()
+    {
+        var ctx = await PrepararAsync(nameof(VendedorEsBloqueadoEnTodoCaminoDeEscrituraDeCompra));
+        var creada = await CrearBorradorAsync(ctx);
+
+        var crear = await ctx.Vendedor.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, numeroExterno: "vendedor-1"));
+        Assert.Equal(HttpStatusCode.Forbidden, crear.StatusCode);
+
+        var editar = await ctx.Vendedor.PutAsJsonAsync($"/api/compras/{creada.Id}", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, editar.StatusCode);
+
+        var confirmar = await ctx.Vendedor.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, confirmar.StatusCode);
+
+        await ConfirmarAsync(ctx, creada.Id);
+        var anular = await ctx.Vendedor.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Forbidden, anular.StatusCode);
+
+        var precios = await ctx.Vendedor.PostAsJsonAsync($"/api/compras/{creada.Id}/precios", new SolicitudDeAplicarPrecios(1));
+        Assert.Equal(HttpStatusCode.Forbidden, precios.StatusCode);
+    }
+
+    [Fact]
+    public async Task VendedorPuedeLeerElListadoDeCompras()
+    {
+        var ctx = await PrepararAsync(nameof(VendedorPuedeLeerElListadoDeCompras));
+        await CrearBorradorAsync(ctx);
+
+        var respuesta = await ctx.Vendedor.GetAsync("/api/compras");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    // ---- invariante extendido: motivo=Compra participa del stock.cantidad = Σ movimientos -----
+
+    [Fact]
+    public async Task LaCantidadDeStockEsLaSumaDeMovimientosIncluyendoCompra()
+    {
+        var ctx = await PrepararAsync(nameof(LaCantidadDeStockEsLaSumaDeMovimientosIncluyendoCompra));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 25m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == ctx.IdArticulo && m.IdPuntoVenta == ctx.IdPuntoVenta)
+            .SumAsync(m => m.Cantidad);
+
+        Assert.Equal(25m, cantidad);
+        Assert.Equal(cantidad, sumaDeMovimientos);
+    }
+}

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -59,6 +59,9 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // apilado, mismo criterio que los dos de arriba (spec: gastos / Gasto Authorization, un
         // Vendedor tiene que poder registrar un gasto).
         ("POST", "/api/gastos/"),
+        // stage-8-compras-transferencias-inventario (Slice 2, task 2.7): las cinco rutas de
+        // escritura de compras (crear/editar/confirmar/anular/aplicar-precios) SÍ apilan
+        // GestionDeCatalogo (design: API Surface) — no van en este allowlist. Nada nuevo acá.
         // stage-7-cuenta-corriente (Slice 2, task 2.7): pago a cuenta (RC) — sin GestionDeCatalogo
         // apilado, mismo criterio que "/api/ventas/" (un Vendedor tiene que poder cobrar una
         // cuenta corriente).
@@ -173,7 +176,10 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         "/api/caja/turnos",
         // stage-6-turnos-caja (Slice 3, task 3.5): GET /api/gastos (historial) — mismo criterio
         // que "/api/caja/turnos".
-        "/api/gastos"
+        "/api/gastos",
+        // stage-8-compras-transferencias-inventario (Slice 2, task 2.7): GET /api/compras
+        // (listado) y GET /api/compras/{id} (detalle) — mismo criterio que "/api/gastos".
+        "/api/compras"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —


### PR DESCRIPTION
## Resumen

Slice 2/6 de la etapa 8 — el centerpiece: la máquina de estados de compra completa, greenfield puro (el alta del legacy nunca persistía).

- `CalculadorDeCompra` (dominio puro, 22 tests): totales, **costo efectivo CON IVA** (C-FA discrimina vs C-FB/C-FC finales, aritmética pinneada a mano), estrechamiento 14,4→14,2 AwayFromZero, dedup "mayor orden gana", `precio_sugerido` vía el `SugeridorDePrecio` existente.
- `ServicioDeCompras`: borrador editable (replace-set bajo `FOR UPDATE` — la herida del lost-update no vuelve), **confirmar** con el `UPDATE...RETURNING` estado-guardado como única autoridad de transición (entrada de stock motivo=Compra + FK, upserts asc id_articulo, sobreescritura de costo bajo locks de artículos — el orden total de locks respetado), **anular** con contramovimientos, rechazo atómico si la reversión deja stock negativo, costo NO revertido, y la regla invertida que reporta gastos colgantes en vez de atrapar al operador.
- Aplicar precios = acción explícita separada por `AbrirNuevoPrecioAsync` (historia preservada); el confirm jamás toca precios.
- 7 endpoints (lecturas `OperacionDePos`, escrituras + `GestionDeCatalogo`, patrón StockEndpoints).

## Verificación

- Suites: Domain 378 (+22), Application 212, **Integration 636 (+32)**, vitest 322, contra Postgres real. Carreras: doble-confirm (rendezvous por interceptor), confirm×edición (incluido el switch de tipo de IVA), doble-anular; inyección de fallas todo-o-nada; presupuesto de queries constante; citext F-0001/f-0001; sum-invariant extendido a motivo=Compra.
- Judgment-day (ronda dedicada): ronda 1 — **2 BLOCKERs de la misma raíz** cazados por caminos independientes (el `RETURNING` recortado rompía el pseudocódigo vinculante: `discriminaIva` pre-lock corrompía el costo en la carrera de switch de tipo; la completitud sin re-verificar caía en 500 pelado con fecha NULL) — arreglados restaurando el diseño, con el guard EN el predicado del WHERE (ADR-16: sin Npgsql en Application) y doble evidencia de mutación (121 vs 100.00; el 500 reproducido). Ronda 2 — ambos jueces CLEAN; el pseudocódigo del diseño resultó inimplementable literal (el CHECK dispararía dentro del UPDATE) y la desviación quedó documentada; MINOR del record recortado aplicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)