### PR TITLE
feat(proveedores): saldo derivado y gastos ligados a compras (etapa 8, slice 4)

### DIFF
--- a/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
+++ b/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
@@ -346,58 +346,71 @@ avoids the `AND`-composition trap, and `CalculadorDeArqueo` is proven
 byte-unchanged. **Rollback**: new files + a `FOR SHARE` guard + one nullable
 DTO field only.
 
-- [ ] 4.1 Modify `src/Ways.Application/Gastos/ServicioDeGastos.cs` +
+- [x] 4.1 Modify `src/Ways.Application/Gastos/ServicioDeGastos.cs` +
   `Contratos.cs`: optional `IdComprobanteCompra`; when present,
   `SELECT … FOR SHARE` on `comprobantes_compra` **after** the existing turno
   lock; `estado ≠ confirmada ⇒ 409` (`compra_anulada`/`compra_no_confirmada`);
   `categoria ≠ proveedor ⇒ 400`; `id_proveedor` derived when absent, mismatch
   `⇒ 400`. *(design decision 7; Transactions — GASTO LIGADO A UNA COMPRA)*
-- [ ] 4.2 Create `src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs`:
+- [x] 4.2 Create `src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs`:
   derived read `Σ compras confirmadas − Σ gastos (categoria = proveedor)`, a
   single grouped query for per-compra payment status across a page (no
-  N+1). *(design decision 11)*
-- [ ] 4.3 Add `GET /api/proveedores/{id}/saldo` **mapped top-level**, not
+  N+1). *(design decision 11)* **Deviation**: implemented as exactly 2
+  aggregate/grouped queries (compras confirmadas + gastos agrupados por
+  `id_comprobante_compra`, incluida la clave `NULL` de los sin ligar) — el
+  mismo `GROUP BY` alimenta tanto el total del saldo como el desglose
+  por-compra, sin una tercera consulta por fila.
+- [x] 4.3 Add `GET /api/proveedores/{id}/saldo` **mapped top-level**, not
   inside the `/api/proveedores` group (`GestionDeCatalogo`) — `OperacionDePos`.
   *(design: API Surface — the AND-composition trap)*
-- [ ] 4.4 Modify `GastosEndpoints.cs`: DTO learns optional
+- [x] 4.4 Modify `GastosEndpoints.cs`: DTO learns optional
   `idComprobanteCompra`. Update `SuperficieDeAutorizacionTests` allowlist
-  with the new top-level saldo route. *(design: File Changes)*
-- [ ] 4.5 [P] Integration: a gasto links to the compra it pays under the
+  with the new top-level saldo route. *(design: File Changes)* **Deviation**:
+  the field lives in `Contratos.cs` (Gastos) — `GastosEndpoints.cs` forwards
+  the DTO as-is and needed no code change; the allowlist update landed as a
+  new `PrefijosDeLecturaReGateados` entry (`"/api/proveedores"`), since the
+  saldo route is a GET, not a write route (the write allowlist doesn't apply).
+- [x] 4.5 [P] Integration: a gasto links to the compra it pays under the
   existing open-turno gate; a non-proveedor categoria cannot link `400`; a
   compra-linked gasto still requires an open turno `409 turno_no_abierto`.
   *(spec: gastos / A Comprobante Compra Link Requires Categoria Proveedor)*
-- [ ] 4.6 Integration (racy surface, forced rendezvous): gasto ligado ×
+- [x] 4.6 Integration (racy surface, forced rendezvous): gasto ligado ×
   anulación of the same compra — the `FOR SHARE` lock closes the TOCTOU,
   both outcomes representable, neither corrupt. *(design: Backstop Map racy
   surface 5; decision 7 rationale)*
-- [ ] 4.7 [P] Integration: saldo reflects confirmed compras net of gastos;
+- [x] 4.7 [P] Integration: saldo reflects confirmed compras net of gastos;
   borradores and anuladas excluded; zero-activity proveedor returns `0`.
   *(spec: saldo-de-proveedor / Saldo Is A Derived Read, Never Persisted)*
-- [ ] 4.8 [P] Integration: per-compra payment status (`pagada`/`parcial`/
+- [x] 4.8 [P] Integration: per-compra payment status (`pagada`/`parcial`/
   `impaga`) from **linked** gastos only; an unlinked gasto reduces total
   saldo but does not mark a specific compra as paid. *(spec: saldo-de-
   proveedor / Per-Compra Payment Status, Saldo Is An Approximation)*
-- [ ] 4.9 Integration (**the arqueo-untouched proof**, the design's own gate
+- [x] 4.9 Integration (**the arqueo-untouched proof**, the design's own gate
   condition): `CalculadorDeArqueo` source is byte-identical before and after
   this stage; a proveedor gasto linked to a confirmed compra changes the
   turno's `importe_esperado` by exactly its importe through the existing
   `SUM(gastos.importe on that medio)` term, with no new branch. *(spec:
   arqueo-de-cierre / A Proveedor Gasto Linked To A Compra Introduces No New
-  Derivation Term — both scenarios)*
-- [ ] 4.10 [P] Integration: a hard delete of a proveedor referenced by a
+  Derivation Term — both scenarios)* Byte-identity confirmed via
+  `git diff --stat` (empty) on `CalculadorDeArqueo.cs`.
+- [x] 4.10 [P] Integration: a hard delete of a proveedor referenced by a
   `comprobante_compra` is rejected at the schema layer, mapped by
   `db-error-backstops`. *(spec: proveedores / Proveedor Referenced By A
   Comprobante Compra Cannot Be Removed)*
-- [ ] 4.11 [P] Integration: proveedor detail exposes the derived saldo entry
+- [x] 4.11 [P] Integration: proveedor detail exposes the derived saldo entry
   point; a cross-tenant proveedor saldo read returns not-found. *(spec:
   proveedores / Proveedor Saldo Read Entry Point; saldo-de-proveedor /
   Cross-Tenant Proveedor Saldo Is Invisible)*
-- [ ] 4.12 [P] Integration (authorization surface): Vendedor reads the
+- [x] 4.12 [P] Integration (authorization surface): Vendedor reads the
   compra list and a proveedor's saldo; paying a compra keeps the unchanged
   `OperacionDePos` gasto gate. *(spec: operacion-de-pos delta, all four
   scenarios)*
-- [ ] 4.13 Regression: full suite green; the `CalculadorDeArqueo` source
-  file untouched.
+- [x] 4.13 Regression: full suite green; the `CalculadorDeArqueo` source
+  file untouched. Domain 378/378, Application 212/212, Integration
+  664→689 (+25, all this slice's), vitest unrun in this worktree (no
+  `node_modules` installed — an environment gap unrelated to this slice,
+  which touches zero `Ways.Web` files). `ServicioDeStock`/`ServicioDeVentas`
+  untouched (confirmed via `git diff --stat`).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~ServicioDeSaldoDeProveedor|FullyQualifiedName~CalculadorDeArqueo`
 

--- a/src/Ways.Api/Endpoints/ProveedoresEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ProveedoresEndpoints.cs
@@ -1,4 +1,5 @@
 using Ways.Api.Seguridad;
+using Ways.Application.Compras;
 using Ways.Application.Proveedores;
 
 namespace Ways.Api.Endpoints;
@@ -45,6 +46,19 @@ public static class ProveedoresEndpoints
             return Results.NoContent();
         })
         .WithSummary("Baja lógica del proveedor.");
+
+        // stage-8-compras-transferencias-inventario (Slice 4, task 4.3, design: API Surface — el
+        // trap de composición AND): mapeada TOP-LEVEL sobre `app`, nunca sobre `grupo` —
+        // apilarla ahí compondría con GestionDeCatalogo (AND) y dejaría la lectura Admin-only,
+        // contra spec: saldo-de-proveedor / Authorization And Scoping (un Vendedor tiene que
+        // poder leerla). Ninguna policy nueva: OperacionDePos sola, misma puerta que el listado
+        // de compras.
+        app.MapGet("/api/proveedores/{id:int}/saldo", (
+            ServicioDeSaldoDeProveedor servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerAsync(id, ct))
+        .WithTags("Proveedores")
+        .RequireAuthorization(Politicas.OperacionDePos)
+        .WithSummary("Saldo derivado del proveedor: compras confirmadas menos gastos ligados.");
 
         return app;
     }

--- a/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
+++ b/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+
+namespace Ways.Application.Compras;
+
+/// <summary>
+/// El saldo derivado del proveedor (design decisión 11, spec: saldo-de-proveedor) — dedicado,
+/// nunca extiende <c>ServicioDeProveedores</c> (un ABM plano que no tiene por qué depender de
+/// dos agregados operativos para servir una lectura). Sin tabla, sin caché, sin estado propio:
+/// <c>Σ compras confirmadas − Σ gastos (categoria = proveedor)</c>, con el estado de pago
+/// por-compra derivado de los gastos LIGADOS únicamente (spec: Per-Compra Payment Status From
+/// Linked Gastos Only).
+///
+/// Exactamente 2 consultas (Data Flow del design), nunca N+1: la segunda agrupa TODOS los gastos
+/// de categoría proveedor del proveedor por <c>id_comprobante_compra</c> (incluida la fila NULL,
+/// que agrupa los gastos sin ligar) — de ahí sale tanto el total a restar del saldo como el
+/// desglose por-compra, en un solo <c>GROUP BY</c> (task 4.2: "a single grouped query... no
+/// N+1").
+/// </summary>
+public class ServicioDeSaldoDeProveedor(IWaysDbContext db)
+{
+    public async Task<SaldoDeProveedor> ObtenerAsync(int idProveedor, CancellationToken ct = default)
+    {
+        await ResolverProveedorAsync(idProveedor, ct);
+
+        var compras = await db.ComprobantesCompra
+            .Where(c => c.IdProveedor == idProveedor && c.Estado == EstadoCompra.Confirmada)
+            .Select(c => new { c.Id, c.NumeroExterno, c.Total })
+            .ToListAsync(ct);
+
+        // Agrupado por id_comprobante_compra — la fila con clave null agrupa los gastos SIN
+        // ligar (spec: An Unlinked Gasto Still Reduces The Total Saldo). Una sola consulta sirve
+        // tanto al total (spec: Saldo Is A Derived Read) como al desglose por-compra (spec:
+        // Per-Compra Payment Status From Linked Gastos Only).
+        var gastosPorCompra = await db.Gastos
+            .Where(g => g.IdProveedor == idProveedor && g.Categoria == CategoriaGasto.Proveedor)
+            .GroupBy(g => g.IdComprobanteCompra)
+            .Select(grupo => new { IdComprobanteCompra = grupo.Key, Total = grupo.Sum(g => g.Importe) })
+            .ToListAsync(ct);
+
+        var totalCompras = compras.Sum(c => c.Total);
+        var totalGastos = gastosPorCompra.Sum(g => g.Total);
+
+        var pagadoPorCompra = gastosPorCompra
+            .Where(g => g.IdComprobanteCompra is not null)
+            .ToDictionary(g => g.IdComprobanteCompra!.Value, g => g.Total);
+
+        var comprasConEstado = compras
+            .Select(c =>
+            {
+                var pagado = pagadoPorCompra.GetValueOrDefault(c.Id, 0m);
+                var estado = ResolverEstadoPago(pagado, c.Total);
+                return new CompraConEstadoPago(c.Id, c.NumeroExterno, c.Total, pagado, estado);
+            })
+            .OrderBy(c => c.IdComprobanteCompra)
+            .ToList();
+
+        return new SaldoDeProveedor(idProveedor, totalCompras - totalGastos, comprasConEstado);
+    }
+
+    /// <summary>spec: A Fully Paid Compra / An Unlinked Gasto Does Not Mark A Compra As Paid — sin
+    /// gastos ligados es <c>impaga</c>, con el total exacto o mayor es <c>pagada</c> (un
+    /// sobrepago no tiene remedio en esta etapa, ver design Open Questions), cualquier otro caso
+    /// es <c>parcial</c>.</summary>
+    private static EstadoPago ResolverEstadoPago(decimal pagado, decimal total)
+    {
+        if (pagado <= 0m)
+        {
+            return EstadoPago.Impaga;
+        }
+
+        return pagado >= total ? EstadoPago.Pagada : EstadoPago.Parcial;
+    }
+
+    private async Task ResolverProveedorAsync(int idProveedor, CancellationToken ct)
+    {
+        var existe = await db.Proveedores.AnyAsync(p => p.Id == idProveedor, ct);
+        if (!existe)
+        {
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (spec: Cross-Tenant
+            // Proveedor Saldo Is Invisible).
+            throw ErrorDominio.NoEncontrado($"No existe el proveedor {idProveedor}.");
+        }
+    }
+}
+
+/// <summary>Estado de pago de una compra confirmada, derivado de sus gastos LIGADOS únicamente
+/// (spec: saldo-de-proveedor / Per-Compra Payment Status From Linked Gastos Only) — un gasto sin
+/// ligar reduce el saldo total pero no resuelve el estado de ninguna compra puntual.</summary>
+public enum EstadoPago
+{
+    Impaga,
+    Parcial,
+    Pagada
+}
+
+/// <summary>Una compra confirmada del proveedor con su estado de pago derivado —
+/// <see cref="Pagado"/> es la suma de los gastos LIGADOS a esta compra puntual, nunca el saldo
+/// general del proveedor.</summary>
+public sealed record CompraConEstadoPago(
+    int IdComprobanteCompra, string? NumeroExterno, decimal Total, decimal Pagado, EstadoPago EstadoPago);
+
+/// <summary>Respuesta de <c>GET /api/proveedores/{id}/saldo</c> (design: API Surface) —
+/// <see cref="Saldo"/> es la aproximación declarada por el spec (saldo-de-proveedor / Saldo Is
+/// An Approximation, Not An Invariant): un gasto sin ligar la reduce igual, aunque no salde
+/// ninguna compra puntual.</summary>
+public sealed record SaldoDeProveedor(int IdProveedor, decimal Saldo, IReadOnlyList<CompraConEstadoPago> Compras);

--- a/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
+++ b/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
@@ -14,7 +14,8 @@ namespace Ways.Application.Compras;
 /// por-compra derivado de los gastos LIGADOS únicamente (spec: Per-Compra Payment Status From
 /// Linked Gastos Only).
 ///
-/// Exactamente 2 consultas (Data Flow del design), nunca N+1: la segunda agrupa TODOS los gastos
+/// Dos consultas agregadas más el guard de existencia del proveedor (Data Flow del design) — O(1),
+/// nunca N+1: la segunda consulta agregada agrupa TODOS los gastos
 /// de categoría proveedor del proveedor por <c>id_comprobante_compra</c> (incluida la fila NULL,
 /// que agrupa los gastos sin ligar) — de ahí sale tanto el total a restar del saldo como el
 /// desglose por-compra, en un solo <c>GROUP BY</c> (task 4.2: "a single grouped query... no

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -76,6 +76,9 @@ public static class DependencyInjection
         // compra — reusa ServicioDePrecios (AplicarPrecioSugeridoAsync), nunca
         // ServicioDeStock/ServicioDeVentas (Slice 2 non-negotiable).
         services.AddScoped<ServicioDeCompras>();
+        // stage-8-compras-transferencias-inventario, Slice 4: el saldo derivado del proveedor
+        // (design decisión 11) — dedicado, no extiende ServicioDeProveedores.
+        services.AddScoped<ServicioDeSaldoDeProveedor>();
 
         return services;
     }

--- a/src/Ways.Application/Gastos/Contratos.cs
+++ b/src/Ways.Application/Gastos/Contratos.cs
@@ -5,7 +5,13 @@ namespace Ways.Application.Gastos;
 /// <summary>Cuerpo de <c>POST /api/gastos</c> (design: API Surface) — sin <c>idTurnoCaja</c> a
 /// propósito, mismo criterio que <c>Ways.Application.Caja.SolicitudDeApertura</c>: el turno
 /// siempre lo resuelve el servidor desde <see cref="IdPuntoVenta"/> (spec: Gasto Requires An
-/// Open Turno, Gasto succeeds with an open turno), nunca este contrato.</summary>
+/// Open Turno, Gasto succeeds with an open turno), nunca este contrato.
+///
+/// <see cref="IdComprobanteCompra"/> aterriza en stage-8 Slice 4 (design decisión 7) — opcional,
+/// al final para no romper ningún call site posicional existente. Cuando viene seteado,
+/// <see cref="Categoria"/> tiene que ser <see cref="CategoriaGasto.Proveedor"/> (spec: gastos / A
+/// Comprobante Compra Link Requires Categoria Proveedor) e <see cref="IdProveedor"/> es opcional:
+/// se deriva de la compra cuando falta, se exige que coincida cuando viene.</summary>
 public sealed record SolicitudDeGasto(
     int IdPuntoVenta,
     CategoriaGasto Categoria,
@@ -15,7 +21,8 @@ public sealed record SolicitudDeGasto(
     string? Detalle,
     int IdMedioPago,
     string? NumeroFactura,
-    decimal Importe);
+    decimal Importe,
+    int? IdComprobanteCompra = null);
 
 /// <summary>Proyección de <see cref="Gasto"/> ya persistido — respuesta de <c>POST
 /// /api/gastos</c>.</summary>
@@ -32,7 +39,8 @@ public sealed record GastoRegistrado(
     int IdMedioPago,
     string? NumeroFactura,
     decimal Importe,
-    int IdEmpleado);
+    int IdEmpleado,
+    int? IdComprobanteCompra);
 
 /// <summary>Fila de <c>GET /api/gastos</c> (historial paginado) — mismo criterio de shape
 /// reducido que <c>Ways.Application.Caja.TurnoListado</c>.</summary>

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -1,4 +1,7 @@
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
 using Ways.Domain.Common;
@@ -12,6 +15,12 @@ namespace Ways.Application.Gastos;
 /// Slice 3). Reutiliza <see cref="ServicioDeTurnos.ResolverTurnoAbiertoAsync"/> (tasks.md,
 /// Orchestrator Decision 3) en vez de escribir su propia consulta de turno abierto — mismo
 /// criterio que <c>ServicioDeVentas.EmitirAsync</c> (Slice 5).
+///
+/// stage-8-compras-transferencias-inventario, Slice 4 (design decisión 7): cuando la solicitud
+/// trae <c>idComprobanteCompra</c>, un <c>SELECT ... FOR SHARE</c> crudo sobre el header de la
+/// compra — DESPUÉS del lock de turno existente — cierra el TOCTOU contra una anulación
+/// concurrente de la misma compra (el mismo statement crudo/sibling raw SQL que
+/// <c>ServicioDeCompras</c>, ver su doc-comment de clase).
 /// </summary>
 public class ServicioDeGastos(
     IWaysDbContext db, ServicioDeTurnos servicioDeTurnos, IRelojDelSistema reloj, IContextoDeUsuario contexto)
@@ -27,6 +36,9 @@ public class ServicioDeGastos(
         var momento = reloj.Ahora;
 
         ExigirImporteValido(solicitud.Importe);
+        // spec: gastos / A Comprobante Compra Link Requires Categoria Proveedor — "rejected
+        // before reaching the database": chequeo de dominio puro, ANTES de cualquier consulta.
+        ExigirCategoriaCoherenteConLaCompra(solicitud.Categoria, solicitud.IdComprobanteCompra);
 
         await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
         var turno = await servicioDeTurnos.ResolverTurnoAbiertoAsync(solicitud.IdPuntoVenta, ct);
@@ -94,6 +106,19 @@ public class ServicioDeGastos(
         }
     }
 
+    /// <summary>spec: gastos / A Comprobante Compra Link Requires Categoria Proveedor — chequeo de
+    /// dominio puro, sin DB: un gasto ligado a una compra SIEMPRE tiene que ser de categoría
+    /// proveedor (la compra la paga un proveedor, nunca sueldos/viáticos/etc.).</summary>
+    private static void ExigirCategoriaCoherenteConLaCompra(CategoriaGasto categoria, int? idComprobanteCompra)
+    {
+        if (idComprobanteCompra is not null && categoria != CategoriaGasto.Proveedor)
+        {
+            throw new ErrorDominio(
+                "gasto_de_compra_debe_ser_de_proveedor",
+                "Un gasto ligado a una compra tiene que ser de categoría proveedor.", 400);
+        }
+    }
+
     // ---- persistencia -------------------------------------------------------------------------
 
     /// <summary>task 4.17 (mismo guard que <c>ServicioDeTurnos.RegistrarMovimientoAsync</c>, reusado
@@ -101,7 +126,11 @@ public class ServicioDeGastos(
     /// de esta transacción de escritura): el turno ya vino resuelto como abierto (<see
     /// cref="ServicioDeTurnos.ResolverTurnoAbiertoAsync"/>, arriba, ANTES de abrir esta
     /// transacción) — sin este re-chequeo bajo <c>FOR SHARE</c>, un gasto concurrente a un
-    /// cierre podría comitear dentro de un turno cuyo arqueo YA se derivó (design decisión 1).</summary>
+    /// cierre podría comitear dentro de un turno cuyo arqueo YA se derivó (design decisión 1).
+    ///
+    /// Slice 4 (design decisión 7): el guard de la compra ligada corre DESPUÉS de ese lock de
+    /// turno — mismo orden que el design pseudocódigo (Transactions — GASTO LIGADO A UNA
+    /// COMPRA).</summary>
     private async Task<Gasto> InsertarGastoAsync(
         int idTenant, int idTurnoCaja, SolicitudDeGasto solicitud, int idEmpleado, DateTimeOffset momento,
         CancellationToken ct)
@@ -109,6 +138,12 @@ public class ServicioDeGastos(
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
         await servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(idTurnoCaja, ct);
+
+        var idProveedor = solicitud.IdProveedor;
+        if (solicitud.IdComprobanteCompra is { } idComprobanteCompra)
+        {
+            idProveedor = await ExigirCompraLigableAsync(idComprobanteCompra, idTenant, solicitud.IdProveedor, ct);
+        }
 
         var gasto = new Gasto
         {
@@ -118,13 +153,14 @@ public class ServicioDeGastos(
             IdTurnoCaja = idTurnoCaja,
             IdEmpleado = idEmpleado,
             Categoria = solicitud.Categoria,
-            IdProveedor = solicitud.IdProveedor,
+            IdProveedor = idProveedor,
             IdArea = solicitud.IdArea,
             Concepto = solicitud.Concepto,
             Detalle = solicitud.Detalle,
             IdMedioPago = solicitud.IdMedioPago,
             NumeroFactura = solicitud.NumeroFactura,
             Importe = solicitud.Importe,
+            IdComprobanteCompra = solicitud.IdComprobanteCompra,
             CreatedAt = momento,
             UpdatedAt = momento
         };
@@ -135,6 +171,81 @@ public class ServicioDeGastos(
         await transaccion.CommitAsync(ct);
 
         return gasto;
+    }
+
+    /// <summary>design decisión 7: <c>SELECT ... FOR SHARE</c> crudo sobre el header de la compra
+    /// — cierra el TOCTOU contra una anulación concurrente de la MISMA compra. La anulación toma
+    /// el lock EXCLUSIVO del header como su propio primer statement (<c>ServicioDeCompras.
+    /// MarcarAnuladaAsync</c>): este gasto o bien bloquea y retoma viendo <c>anulada</c> ya
+    /// comiteada (<c>409 compra_anulada</c>), o gana la carrera y queda simplemente visible para
+    /// la anulación que llega después — ambos estados representables, ninguno corrupto. <c>estado
+    /// ::text</c> en vez del enum nativo, mismo criterio cauteloso que
+    /// <see cref="ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync"/>. Devuelve el
+    /// <c>id_proveedor</c> de la compra: se usa para derivarlo cuando el request no lo trae (spec:
+    /// gastos / A Comprobante Compra Link — <c>id_proveedor</c> ausente se deriva, distinto se
+    /// rechaza).</summary>
+    private async Task<int> ExigirCompraLigableAsync(
+        int idComprobanteCompra, int idTenant, int? idProveedorSolicitado, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccionCruda;
+        comando.CommandText =
+            "SELECT estado::text, id_proveedor FROM comprobantes_compra " +
+            "WHERE id_comprobante_compra = $1 AND id_tenant = $2 FOR SHARE";
+        AgregarParametro(comando, idComprobanteCompra);
+        AgregarParametro(comando, idTenant);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+            throw ErrorDominio.NoEncontrado($"No existe la compra {idComprobanteCompra}.");
+        }
+
+        var estado = lector.GetString(0);
+        var idProveedorDeLaCompra = lector.GetInt32(1);
+
+        if (estado == "anulada")
+        {
+            throw new ErrorDominio("compra_anulada", "La compra ligada está anulada.", 409);
+        }
+
+        if (estado != "confirmada")
+        {
+            throw new ErrorDominio(
+                "compra_no_confirmada", "La compra ligada todavía no está confirmada.", 409);
+        }
+
+        if (idProveedorSolicitado is { } solicitado && solicitado != idProveedorDeLaCompra)
+        {
+            throw new ErrorDominio(
+                "proveedor_no_coincide_con_la_compra",
+                "El proveedor indicado no coincide con el proveedor de la compra.", 400);
+        }
+
+        return idProveedorDeLaCompra;
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
     }
 
     // ---- resolución interna ---------------------------------------------------------------
@@ -169,5 +280,6 @@ public class ServicioDeGastos(
         gasto.IdMedioPago,
         gasto.NumeroFactura,
         gasto.Importe,
-        gasto.IdEmpleado);
+        gasto.IdEmpleado,
+        gasto.IdComprobanteCompra);
 }

--- a/tests/Ways.IntegrationTests/GastosLigadosACompraTests.cs
+++ b/tests/Ways.IntegrationTests/GastosLigadosACompraTests.cs
@@ -1,0 +1,414 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Compras;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 4 (tasks 4.1, 4.5, 4.6, design decisión 7):
+/// el guard <c>SELECT ... FOR SHARE</c> que <c>ServicioDeGastos</c> toma sobre el header de la
+/// compra cuando la solicitud trae <c>idComprobanteCompra</c> — el vínculo feliz, los cuatro
+/// rechazos (categoría incoherente, compra inexistente/de otro tenant, borrador, anulada,
+/// proveedor que no coincide) y la superficie racy 5 del Backstop Map (gasto ligado ×
+/// anulación de la misma compra).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class GastosLigadosACompraTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdProveedor2, int IdArticulo,
+        int IdAlicuotaIva21, int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Compras-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        // MedioPago es tenant-scoped (CatalogoSimple : EntidadTenant) — bajo TenantActualFijo
+        // .Plataforma el filtro de EF no acota por tenant y .FirstAsync() puede devolver la fila
+        // de OTRO tenant creado en paralelo por otra prueba de esta misma colección, violando
+        // fk_gastos_medio_pago más adelante. Contexto tenant-scoped propio, mismo criterio que
+        // GastosEndpointsTests.PrepararAsync.
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idMedioEfectivo = await dbTenant.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var proveedor2 = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"{nombre}-otro", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.AddRange(proveedor, proveedor2);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, proveedor2.Id, articulo.Id,
+            idAlicuotaIva21, idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(Contexto ctx, int idProveedor, decimal costoUnitario = 100m, string? numeroExterno = "0001-00000001") =>
+        new(
+            idProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno, DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 10m, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearYConfirmarCompraAsync(
+        Contexto ctx, int? idProveedor = null, string? numeroExterno = "0001-00000001")
+    {
+        var respuestaCrear = await ctx.Admin.PostAsJsonAsync(
+            "/api/compras", SolicitudSimple(ctx, idProveedor ?? ctx.IdProveedor, numeroExterno: numeroExterno));
+        var cuerpoCrear = await respuestaCrear.Content.ReadAsStringAsync();
+        Assert.True(respuestaCrear.StatusCode == HttpStatusCode.Created, cuerpoCrear);
+        var creada = JsonSerializer.Deserialize<CompraDetalle>(cuerpoCrear, OpcionesJson)!;
+
+        var respuestaConfirmar = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpoConfirmar, OpcionesJson)!;
+    }
+
+    private static async Task<int> AbrirTurnoAsync(Contexto ctx)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 0m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!.Id;
+    }
+
+    private static SolicitudDeGasto SolicitudDeGastoLigado(
+        Contexto ctx, int idComprobanteCompra, decimal importe = 1000m, int? idProveedor = null,
+        CategoriaGasto categoria = CategoriaGasto.Proveedor) =>
+        new(
+            ctx.IdPuntoVenta, categoria, idProveedor, null, "Pago de compra", null, ctx.IdMedioEfectivo, null,
+            importe, idComprobanteCompra);
+
+    // ---- task 4.5: vínculo feliz + el pre-check de categoría, antes de la DB ------------------
+
+    [Fact]
+    public async Task UnGastoSeLigaAUnaCompraConfirmadaBajoElGateDeTurnoAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoSeLigaAUnaCompraConfirmadaBajoElGateDeTurnoAbierto));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id, importe: 500m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(compra.Id, gasto.IdComprobanteCompra);
+        Assert.Equal(ctx.IdProveedor, gasto.IdProveedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var persistido = await db.Gastos.FirstAsync(g => g.Id == gasto.Id);
+        Assert.Equal(compra.Id, persistido.IdComprobanteCompra);
+    }
+
+    [Fact]
+    public async Task UnaCategoriaDistintaDeProveedorNoPuedeLigarseAUnaCompraAntesDeLlegarALaBaseDeDatos()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCategoriaDistintaDeProveedorNoPuedeLigarseAUnaCompraAntesDeLlegarALaBaseDeDatos));
+
+        // Ni turno abierto ni una compra real: si el chequeo de categoría no corriera ANTES de
+        // tocar la base, la respuesta sería 409 turno_no_abierto (o 404), nunca este 400.
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Servicios, null, null, "Gasto mal categorizado", null,
+                ctx.IdMedioEfectivo, null, 100m, IdComprobanteCompra: 999999));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("gasto_de_compra_debe_ser_de_proveedor", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraSigueExigiendoTurnoAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraSigueExigiendoTurnoAbierto));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- rechazos de la compra ligada: inexistente / otro tenant / borrador / anulada ---------
+
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraInexistenteDevuelve404()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraInexistenteDevuelve404));
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, idComprobanteCompra: 999999));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraDeOtroTenantDevuelve404) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraDeOtroTenantDevuelve404) + "-B");
+        var compraDeB = await CrearYConfirmarCompraAsync(ctxB);
+        await AbrirTurnoAsync(ctxA);
+
+        var respuesta = await ctxA.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctxA, compraDeB.Id));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraEnBorradorEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraEnBorradorEsRechazado));
+        var respuestaCrear = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, ctx.IdProveedor));
+        var borrador = JsonSerializer.Deserialize<CompraDetalle>(await respuestaCrear.Content.ReadAsStringAsync(), OpcionesJson)!;
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, borrador.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_no_confirmada", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraAnuladaEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraAnuladaEsRechazado));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{compra.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("compra_anulada", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- id_proveedor: se deriva cuando falta, se exige que coincida cuando viene --------------
+
+    [Fact]
+    public async Task ElProveedorAusenteSeDerivaDeLaCompra()
+    {
+        var ctx = await PrepararAsync(nameof(ElProveedorAusenteSeDerivaDeLaCompra));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id, idProveedor: null));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(ctx.IdProveedor, gasto.IdProveedor);
+    }
+
+    [Fact]
+    public async Task UnProveedorQueNoCoincideConLaCompraEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnProveedorQueNoCoincideConLaCompraEsRechazado));
+        var compra = await CrearYConfirmarCompraAsync(ctx, idProveedor: ctx.IdProveedor);
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id, idProveedor: ctx.IdProveedor2));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("proveedor_no_coincide_con_la_compra", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 4.6: superficie racy 5, forced rendezvous (row lock natural) --------------------
+
+    /// <summary>Pausa cada transacción manual (<c>ServicioDeGastos.InsertarGastoAsync</c>/
+    /// <c>ServicioDeCompras.EjecutarAnulacionAsync</c>) justo DESPUÉS de
+    /// <c>BeginTransactionAsync</c>, hasta que el test la libera — mismo patrón que
+    /// <c>ComprasAnulacionYConcurrenciaTests.InterceptorDePausaTrasIniciarLaTransaccion</c>.</summary>
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>design decisión 7, Backstop Map racy surface 5: la anulación gana la carrera —
+    /// commitea ANTES de que la transacción del gasto retome y tome su <c>FOR SHARE</c>. El
+    /// gasto retoma viendo <c>anulada</c> ya comiteada — <c>409 compra_anulada</c>, nunca un
+    /// vínculo corrupto a una compra anulada.</summary>
+    [Fact]
+    public async Task LaAnulacionGanandoLaCarreraDejaAlGastoRechazadoSinVinculoCorrupto()
+    {
+        var ctx = await PrepararAsync(nameof(LaAnulacionGanandoLaCarreraDejaAlGastoRechazadoSinVinculoCorrupto));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+        await AbrirTurnoAsync(ctx);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteGasto = factory.CreateClient();
+        var login = await clienteGasto.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaGasto = clienteGasto.PostAsJsonAsync("/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id));
+
+        await transaccionIniciada.Task;
+
+        // La anulación corre y commitea COMPLETA mientras el gasto sigue pausado justo después
+        // de abrir su propia transacción — todavía no tomó ningún lock.
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{compra.Id}/anular", null);
+        var cuerpoAnulacion = await anulacion.Content.ReadAsStringAsync();
+        Assert.True(anulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+        var resultadoAnulacion = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpoAnulacion, OpcionesJson)!;
+        Assert.Equal(0, resultadoAnulacion.GastosLigados);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaGasto = await tareaGasto;
+        var cuerpoGasto = await respuestaGasto.Content.ReadAsStringAsync();
+        Assert.True(respuestaGasto.StatusCode == HttpStatusCode.Conflict, cuerpoGasto);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoGasto, OpcionesJson);
+        Assert.Equal("compra_anulada", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Gastos.CountAsync(g => g.IdComprobanteCompra == compra.Id));
+    }
+
+    /// <summary>design decisión 7, Backstop Map racy surface 5, la otra dirección: el gasto gana
+    /// la carrera — su transacción entera (turno + <c>FOR SHARE</c> + INSERT + COMMIT) corre y
+    /// commitea mientras la anulación sigue pausada justo después de abrir la suya, todavía sin
+    /// tomar el lock exclusivo del header. La anulación retoma, procede igual (regla invertida,
+    /// decisión 6 — nunca bloquea) y su conteo informativo ve el gasto recién comiteado, sin
+    /// staleness.</summary>
+    [Fact]
+    public async Task ElGastoGanandoLaCarreraQuedaCorrectamenteContadoPorLaAnulacionQueLlegaDespues()
+    {
+        var ctx = await PrepararAsync(nameof(ElGastoGanandoLaCarreraQuedaCorrectamenteContadoPorLaAnulacionQueLlegaDespues));
+        var compra = await CrearYConfirmarCompraAsync(ctx);
+        await AbrirTurnoAsync(ctx);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaAnulacion = clienteAnular.PostAsync($"/api/compras/{compra.Id}/anular", null);
+
+        await transaccionIniciada.Task;
+
+        var respuestaGasto = await ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDeGastoLigado(ctx, compra.Id, importe: 750m));
+        var cuerpoGasto = await respuestaGasto.Content.ReadAsStringAsync();
+        Assert.True(respuestaGasto.StatusCode == HttpStatusCode.Created, cuerpoGasto);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaAnulacion = await tareaAnulacion;
+        var cuerpoAnulacion = await respuestaAnulacion.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+        var resultadoAnulacion = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpoAnulacion, OpcionesJson)!;
+        Assert.Equal(1, resultadoAnulacion.GastosLigados);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.Gastos.CountAsync(g => g.IdComprobanteCompra == compra.Id));
+    }
+}

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
@@ -1,0 +1,524 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Compras;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-8-compras-transferencias-inventario, Slice 4: <c>GET /api/proveedores/{id}/saldo</c>
+/// punta a punta (tasks 4.2, 4.3, 4.7, 4.8, 4.11, 4.12) — la matemática derivada, el estado de
+/// pago por-compra, el punto de entrada, la autorización (incluida la prueba de regresión de la
+/// AND-composition: un Vendedor tiene que poder leer el saldo pese a que
+/// <c>/api/proveedores</c> es <c>GestionDeCatalogo</c>), el presupuesto de consultas y la prueba
+/// del arqueo byte-intacto (task 4.9). El backstop de esquema del proveedor referenciado (task
+/// 4.10) también vive acá — mismo agregado que el resto de esta slice.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class SaldoDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "vendedor-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Vendedor, int IdProveedor, int IdArticulo,
+        int IdAlicuotaIva21, int IdTipoCFA, int IdMedioEfectivo, int IdCliente, int IdTipoComprobanteTx,
+        int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Compras-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        // MedioPago y Cliente son tenant-scoped (CatalogoSimple/Cliente : EntidadTenant) — bajo
+        // TenantActualFijo.Plataforma el filtro de EF no acota por tenant y .FirstAsync() puede
+        // devolver una fila de OTRO tenant creado en paralelo por otra prueba de esta misma
+        // colección, violando fk_gastos_medio_pago/fk_comprobantes_venta_cliente más adelante.
+        // Contexto tenant-scoped propio, mismo criterio que
+        // CajaCierreEndpointsTests/GastosEndpointsTests.PrepararAsync.
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idMedioEfectivo = await dbTenant.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        var altaVendedor = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-saldo", mailVendedor, (int)RolConocido.Vendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, vendedor, proveedor.Id, articulo.Id, idAlicuotaIva21,
+            idTipoCFA, idMedioEfectivo, idCliente, idTipoComprobanteTx, resultado.IdUsuarioAdmin);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(
+        Contexto ctx, decimal costoUnitario, string numeroExterno) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno, DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 1m, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    /// <summary>Crea y confirma una compra de <paramref name="total"/> exacto — costo unitario
+    /// derivado hacia atrás de la fórmula C-FA (discrimina IVA 21%: <c>total = costo * 1.21</c>),
+    /// para que las aserciones de saldo trabajen con números redondos.</summary>
+    private static async Task<CompraDetalle> CrearYConfirmarCompraDeTotalAsync(Contexto ctx, decimal total, string numeroExterno)
+    {
+        var costoUnitario = Math.Round(total / 1.21m, 4);
+        var respuestaCrear = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, costoUnitario, numeroExterno));
+        var cuerpoCrear = await respuestaCrear.Content.ReadAsStringAsync();
+        Assert.True(respuestaCrear.StatusCode == HttpStatusCode.Created, cuerpoCrear);
+        var creada = JsonSerializer.Deserialize<CompraDetalle>(cuerpoCrear, OpcionesJson)!;
+
+        var respuestaConfirmar = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpoConfirmar, OpcionesJson)!;
+    }
+
+    private static async Task<int> AbrirTurnoAsync(Contexto ctx, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 0m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!.Id;
+    }
+
+    private static async Task<HttpResponseMessage> RegistrarGastoLigadoAsync(
+        Contexto ctx, HttpClient cliente, int idComprobanteCompra, decimal importe) =>
+        await cliente.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, null, null, "Pago de compra", null, ctx.IdMedioEfectivo,
+                null, importe, idComprobanteCompra));
+
+    private static async Task<SaldoDeProveedor> ObtenerSaldoAsync(Contexto ctx, int? idProveedor = null)
+    {
+        var respuesta = await ctx.Admin.GetAsync($"/api/proveedores/{idProveedor ?? ctx.IdProveedor}/saldo");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<SaldoDeProveedor>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 4.7: saldo derivado, nunca persistido --------------------------------------------
+
+    [Fact]
+    public async Task ElSaldoRefleneComprasConfirmadasNetoDeGastos()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoRefleneComprasConfirmadasNetoDeGastos));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 5000m, "saldo-0001");
+        await AbrirTurnoAsync(ctx);
+        var gasto = await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 3000m);
+        Assert.Equal(HttpStatusCode.Created, gasto.StatusCode);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(2000m, saldo.Saldo);
+    }
+
+    [Fact]
+    public async Task LosBorradoresYAnuladasQuedanExcluidosDelSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(LosBorradoresYAnuladasQuedanExcluidosDelSaldo));
+
+        var respuestaBorrador = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, 826.45m, "saldo-borrador"));
+        Assert.Equal(HttpStatusCode.Created, respuestaBorrador.StatusCode);
+
+        await CrearYConfirmarCompraDeTotalAsync(ctx, 2000m, "saldo-confirmada");
+
+        var paraAnular = await CrearYConfirmarCompraDeTotalAsync(ctx, 500m, "saldo-anulada");
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{paraAnular.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        // Solo la confirmada de 2000 aporta — ni el borrador de ~1000 ni la anulada de 500.
+        Assert.Equal(2000m, saldo.Saldo);
+        Assert.Single(saldo.Compras);
+        Assert.Equal(2000m, saldo.Compras[0].Total);
+    }
+
+    [Fact]
+    public async Task UnProveedorSinActividadTieneSaldoCero()
+    {
+        var ctx = await PrepararAsync(nameof(UnProveedorSinActividadTieneSaldoCero));
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(0m, saldo.Saldo);
+        Assert.Empty(saldo.Compras);
+    }
+
+    // ---- task 4.8: estado de pago por-compra, de gastos LIGADOS únicamente ---------------------
+
+    [Fact]
+    public async Task UnaCompraTotalmentePagadaQuedaPagada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCompraTotalmentePagadaQuedaPagada));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-pagada");
+        await AbrirTurnoAsync(ctx);
+        await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 1000m);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        var linea = Assert.Single(saldo.Compras);
+        Assert.Equal(EstadoPago.Pagada, linea.EstadoPago);
+        Assert.Equal(1000m, linea.Pagado);
+    }
+
+    [Fact]
+    public async Task UnGastoSinLigarNoMarcaUnaCompraComoPagadaPeroReduceElSaldoTotal()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoSinLigarNoMarcaUnaCompraComoPagadaPeroReduceElSaldoTotal));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 2000m, "saldo-sin-ligar");
+        await AbrirTurnoAsync(ctx);
+
+        // Gasto de categoría proveedor, mismo proveedor, SIN idComprobanteCompra.
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, ctx.IdProveedor, null, "Pago suelto", null,
+                ctx.IdMedioEfectivo, null, 500m));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(1500m, saldo.Saldo);
+        var linea = Assert.Single(saldo.Compras);
+        Assert.Equal(compra.Id, linea.IdComprobanteCompra);
+        Assert.Equal(0m, linea.Pagado);
+        Assert.Equal(EstadoPago.Impaga, linea.EstadoPago);
+    }
+
+    [Fact]
+    public async Task UnPagoParcialLigadoDaEstadoParcial()
+    {
+        var ctx = await PrepararAsync(nameof(UnPagoParcialLigadoDaEstadoParcial));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-parcial");
+        await AbrirTurnoAsync(ctx);
+        await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 400m);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        var linea = Assert.Single(saldo.Compras);
+        Assert.Equal(EstadoPago.Parcial, linea.EstadoPago);
+        Assert.Equal(400m, linea.Pagado);
+        Assert.Equal(600m, saldo.Saldo);
+    }
+
+    // ---- task 4.11: proveedor detail expone el punto de entrada del saldo derivado -------------
+
+    [Fact]
+    public async Task LaCompraDelSaldoCoincideConLaQueApareceEnElListadoDeCompras()
+    {
+        var ctx = await PrepararAsync(nameof(LaCompraDelSaldoCoincideConLaQueApareceEnElListadoDeCompras));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1200m, "saldo-entry-point");
+
+        var detalleProveedor = await ctx.Admin.GetAsync($"/api/proveedores/{ctx.IdProveedor}");
+        Assert.Equal(HttpStatusCode.OK, detalleProveedor.StatusCode);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+        Assert.Equal(ctx.IdProveedor, saldo.IdProveedor);
+        Assert.Contains(saldo.Compras, c => c.IdComprobanteCompra == compra.Id);
+    }
+
+    // ---- autorización: la prueba de regresión de la AND-composition (design: API Surface) ------
+
+    /// <summary>El hallazgo del design (finding 4): apilar la ruta de saldo DENTRO del grupo
+    /// <c>/api/proveedores</c> (<c>GestionDeCatalogo</c>) compondría con AND y dejaría la
+    /// lectura Admin-only. Esta prueba es la que CAPTURARÍA esa regresión: un Vendedor tiene que
+    /// poder leer el saldo.</summary>
+    [Fact]
+    public async Task UnVendedorLeeElSaldoDeUnProveedor()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorLeeElSaldoDeUnProveedor));
+        await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-vendedor");
+
+        var respuesta = await ctx.Vendedor.GetAsync($"/api/proveedores/{ctx.IdProveedor}/saldo");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelAbmDeProveedoresPeroNoDelSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelAbmDeProveedoresPeroNoDelSaldo));
+
+        var listado = await ctx.Vendedor.GetAsync("/api/proveedores");
+        Assert.Equal(HttpStatusCode.Forbidden, listado.StatusCode);
+
+        var saldo = await ctx.Vendedor.GetAsync($"/api/proveedores/{ctx.IdProveedor}/saldo");
+        Assert.Equal(HttpStatusCode.OK, saldo.StatusCode);
+    }
+
+    /// <summary>spec: operacion-de-pos delta / Paying A Compra Keeps The Existing Gastos Gate —
+    /// un Vendedor con turno abierto sigue pudiendo pagar una compra, sin ningún tier nuevo.</summary>
+    [Fact]
+    public async Task UnVendedorPagaUnaCompraBajoElGateInalteradoDeGastos()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorPagaUnaCompraBajoElGateInalteradoDeGastos));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-pago-vendedor");
+        await AbrirTurnoAsync(ctx, ctx.Vendedor);
+
+        var respuesta = await RegistrarGastoLigadoAsync(ctx, ctx.Vendedor, compra.Id, 1000m);
+
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnProveedorDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnProveedorDeOtroTenantDevuelve404) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnProveedorDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await ctxA.Admin.GetAsync($"/api/proveedores/{ctxB.IdProveedor}/saldo");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- task 4.2/decisión 11: presupuesto de consultas, sin N+1 --------------------------------
+
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private WaysDbContext CrearContextoConContador(int idTenant, ContadorDeComandos contador)
+    {
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, idTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        return new WaysDbContext(opciones, tenantActual);
+    }
+
+    private async Task<int> MedirConsultasDelSaldoAsync(Contexto ctx, int cantidadDeCompras)
+    {
+        for (var i = 0; i < cantidadDeCompras; i++)
+        {
+            await CrearYConfirmarCompraDeTotalAsync(ctx, 100m, $"presupuesto-{Guid.NewGuid():N}");
+        }
+
+        var contador = new ContadorDeComandos();
+        await using var db = CrearContextoConContador(ctx.IdTenant, contador);
+        var servicio = new ServicioDeSaldoDeProveedor(db);
+
+        await servicio.ObtenerAsync(ctx.IdProveedor);
+
+        return contador.Consultas;
+    }
+
+    [Fact]
+    public async Task ElSaldoEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeCompras()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeCompras));
+
+        var consultasConPocasCompras = await MedirConsultasDelSaldoAsync(ctx, cantidadDeCompras: 2);
+        var consultasConMuchasCompras = await MedirConsultasDelSaldoAsync(ctx, cantidadDeCompras: 10);
+
+        Assert.Equal(consultasConPocasCompras, consultasConMuchasCompras);
+    }
+
+    // ---- task 4.9: la prueba del arqueo byte-intacto (spec: arqueo-de-cierre delta) -------------
+
+    private long _numeroSecuencial = 1;
+
+    /// <summary>Siembra directo un comprobante de venta emitido con UN pago — mismo criterio que
+    /// <c>CajaCierreEndpointsTests.SembrarPagoAsync</c>: la derivación nunca toca
+    /// <c>items_comprobante_venta</c>.</summary>
+    private async Task SembrarPagoAsync(Contexto ctx, int idTurno, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = importe,
+            DescuentoTotal = 0m,
+            Total = importe,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            IdMedioPago = ctx.IdMedioEfectivo,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>spec: arqueo-de-cierre / A Proveedor Gasto Linked To A Compra Introduces No New
+    /// Derivation Term — el gasto ligado a una compra confirmada resta su importe exacto del
+    /// <c>importe_esperado</c> del medio en el que se pagó, a través del MISMO término
+    /// <c>SUM(gastos.importe on that medio)</c> que cualquier otro gasto — <c>CalculadorDeArqueo</c>
+    /// no gana ninguna rama nueva (la prueba complementaria de que el archivo queda
+    /// byte-idéntico corre por <c>git diff</c> al cierre de esta slice, no acá).</summary>
+    [Fact]
+    public async Task UnGastoDeProveedorLigadoAUnaCompraReduceElEsperadoAtravesDelTerminoExistente()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeProveedorLigadoAUnaCompraReduceElEsperadoAtravesDelTerminoExistente));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-arqueo");
+        var idTurno = await AbrirTurnoAsync(ctx);
+
+        await SembrarPagoAsync(ctx, idTurno, importe: 1500m);
+        var gasto = await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 400m);
+        Assert.Equal(HttpStatusCode.Created, gasto.StatusCode);
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{idTurno}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+        var efectivo = resumen!.Medios.Single(m => m.IdMedioPago == ctx.IdMedioEfectivo);
+
+        // 1500 (pago) - 400 (gasto de compra, mismo término que cualquier otro gasto) = 1100.
+        Assert.Equal(1100m, efectivo.ImporteEsperado);
+    }
+
+    // ---- task 4.10: FK RESTRICT de comprobantes_compra.id_proveedor (db-error-backstops) --------
+
+    /// <summary>spec: proveedores / Proveedor Referenced By A Comprobante Compra Cannot Be
+    /// Removed — bypass directo del servicio (<c>ServicioDeProveedores.EliminarAsync</c> es baja
+    /// LÓGICA), un DELETE físico por SQL crudo sobre la fila referenciada.</summary>
+    [Fact]
+    public async Task UnaEliminacionFisicaDeProveedorReferenciadoPorUnaCompraViolaLaFk()
+    {
+        var ctx = await PrepararAsync(nameof(UnaEliminacionFisicaDeProveedorReferenciadoPorUnaCompraViolaLaFk));
+        await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-fk-restrict");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "DELETE FROM proveedores WHERE id_proveedor = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = ctx.IdProveedor });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_comprobantes_compra_proveedor", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
@@ -214,6 +214,32 @@ public class SaldoDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal(2000m, saldo.Compras[0].Total);
     }
 
+    /// <summary>design decisión 6, la regla invertida: "annulling is allowed, the linked gastos
+    /// stay linked (the link is history, not a claim of debt), the response reports how many
+    /// payments the operator has left dangling, and the derived saldo keeps counting them as
+    /// money paid — which they are". Backstop de regresión: si algún día alguien "arregla" esto
+    /// para descontar el gasto colgante de la anulación, este test lo tiene que romper.</summary>
+    [Fact]
+    public async Task UnGastoLigadoAUnaCompraLuegoAnuladaSigueDescontandoDelSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoLigadoAUnaCompraLuegoAnuladaSigueDescontandoDelSaldo));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-dangling");
+        await AbrirTurnoAsync(ctx);
+        var gasto = await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 100m);
+        Assert.Equal(HttpStatusCode.Created, gasto.StatusCode);
+
+        var respuestaAnulacion = await ctx.Admin.PostAsync($"/api/compras/{compra.Id}/anular", null);
+        var cuerpoAnulacion = await respuestaAnulacion.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+        var resultadoAnulacion = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpoAnulacion, OpcionesJson)!;
+        Assert.Equal(1, resultadoAnulacion.GastosLigados);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(-100m, saldo.Saldo);
+        Assert.Empty(saldo.Compras);
+    }
+
     [Fact]
     public async Task UnProveedorSinActividadTieneSaldoCero()
     {
@@ -280,6 +306,31 @@ public class SaldoDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal(EstadoPago.Parcial, linea.EstadoPago);
         Assert.Equal(400m, linea.Pagado);
         Assert.Equal(600m, saldo.Saldo);
+    }
+
+    [Fact]
+    public async Task VariosGastosLigadosALaMismaCompraSeAcumulanHastaPagada()
+    {
+        var ctx = await PrepararAsync(nameof(VariosGastosLigadosALaMismaCompraSeAcumulanHastaPagada));
+        var compra = await CrearYConfirmarCompraDeTotalAsync(ctx, 1000m, "saldo-multi-gasto");
+        await AbrirTurnoAsync(ctx);
+        await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 300m);
+        await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 200m);
+
+        var saldoParcial = await ObtenerSaldoAsync(ctx);
+
+        var lineaParcial = Assert.Single(saldoParcial.Compras);
+        Assert.Equal(500m, lineaParcial.Pagado);
+        Assert.Equal(EstadoPago.Parcial, lineaParcial.EstadoPago);
+        Assert.Equal(500m, saldoParcial.Saldo);
+
+        await RegistrarGastoLigadoAsync(ctx, ctx.Admin, compra.Id, 500m);
+
+        var saldoPagada = await ObtenerSaldoAsync(ctx);
+
+        var lineaPagada = Assert.Single(saldoPagada.Compras);
+        Assert.Equal(1000m, lineaPagada.Pagado);
+        Assert.Equal(EstadoPago.Pagada, lineaPagada.EstadoPago);
     }
 
     // ---- task 4.11: proveedor detail expone el punto de entrada del saldo derivado -------------

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -182,7 +182,13 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         "/api/gastos",
         // stage-8-compras-transferencias-inventario (Slice 2, task 2.7): GET /api/compras
         // (listado) y GET /api/compras/{id} (detalle) — mismo criterio que "/api/gastos".
-        "/api/compras"
+        "/api/compras",
+        // stage-8-compras-transferencias-inventario (Slice 4, task 4.4): GET
+        // /api/proveedores/{id}/saldo — mapeada TOP-LEVEL bajo OperacionDePos (el AND-composition
+        // trap, ver ProveedoresEndpoints.cs). El prefijo también alcanza GET /api/proveedores
+        // (listado) y GET /api/proveedores/{id} (detalle), que siguen bajo GestionDeCatalogo —
+        // ambas ya cubiertas por PoliticasAlMenosTanEstrictasComoOperacionDePos de abajo.
+        "/api/proveedores"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —


### PR DESCRIPTION
## Resumen

Slice 4/6 de la etapa 8 — el lado del dinero de las compras: "la compra registra la mercadería; el gasto registra la plata".

- **Gasto ligado a compra**: `idComprobanteCompra` opcional en el gasto, validado bajo `FOR SHARE` sobre el header de la compra DENTRO de la transacción (orden turno→compra, sin ciclo posible — el confirm/anular de compras nunca toca turnos) — anulada → 409, borrador → 409, categoría ≠ Proveedor → 400 pre-DB, proveedor derivado de la compra (mismatch imposible estructuralmente). La carrera anulación×gasto-nuevo probada en ambos interleavings por rendezvous.
- **Saldo de proveedor derivado** (sin persistencia, "sin tabla extra" — doc 10 literal): Σ compras confirmadas − Σ gastos ligados, breakdown por compra pagada/parcial/impaga, O(1) en compras. El caso del **gasto colgante** (compra anulada después de pagada) pinneado con backstop: la plata pagada sigue contando — el saldo puede quedar negativo, que es el número honesto.
- Ruta `GET /api/proveedores/{id}/saldo` **top-level con su propia policy** — el test del Vendedor-lee-200 caza la regresión de composición AND si alguien la anida en el grupo Admin-only.
- El arqueo byte-intacto: prueba funcional de que el gasto ligado fluye por el término existente.

## Verificación

- Suites: Domain 378, Application 212, **Integration 691 (+27)**, vitest 322, contra Postgres real.
- Judgment-day: A CLEAN (matriz de locks verificada, el test AND-composition validado como genuino) + 1 nit de doc; B sin blockers + 1 MAJOR de cobertura (el caso colgante sin backstop — la regla de dinero más sutil del slice) + minors — todos aplicados test-only. El breakdown sin límite adjudicado como aceptación consciente (postura de aproximación derivada, precedente etapa 7). Ronda 2 verificada por el orquestador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)