### PR TITLE
feat(compras): pantallas web de compras (etapa 8, slice 5)

### DIFF
--- a/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
+++ b/openspec/changes/stage-8-compras-transferencias-inventario/tasks.md
@@ -423,33 +423,62 @@ endpoint). **Start**: PR 4 merged/branch. **Finish**: the compras list and
 borrador editor (confirmar/anular/apply-price) work end to end for Admin,
 double-submit-proof. **Rollback**: new route + entry point only.
 
-- [ ] 5.1 [P] Add `src/Ways.Web/src/api/compras.ts`: pure request/response
+- [x] 5.1 [P] Add `src/Ways.Web/src/api/compras.ts`: pure request/response
   mappers, a **non-authoritative** totals mirror mirroring
   `CalculadorDeCompra` — server numbers always win (`dto-contract-honesty`).
   *(design: Web Composition)*
-- [ ] 5.2 Add `src/Ways.Web/src/paginas/Compras.tsx`: list + proveedor/
+- [x] 5.2 Add `src/Ways.Web/src/paginas/Compras.tsx`: list + proveedor/
   estado/fecha filters + payment status + entry point to the editor.
-  *(design: Web Composition)*
-- [ ] 5.3 Add `src/Ways.Web/src/paginas/CompraEditor.tsx` (`/compras/:id`):
-  header form + item grid (unidades/bultos/costoUnitario/descuento/
-  alícuota), the totals mirror, confirmar/anular actions, the
+  *(design: Web Composition)* **Deviation**: payment status per row is
+  populated only while the list is filtered by a single proveedor (fetches
+  that proveedor's `GET /api/proveedores/{id}/saldo`) — there is no bulk
+  saldo-by-page endpoint; an unfiltered list shows `—` in that column. The
+  full per-proveedor saldo panel is Slice 6's `Proveedores.tsx` scope.
+- [x] 5.3 Add `src/Ways.Web/src/paginas/CompraEditor.tsx` (`/compras/nueva`,
+  `/compras/:id`): header form + item grid (unidades/bultos/costoUnitario/
+  descuento/alícuota), the totals mirror, confirmar/anular actions (inline
+  irreversibility-confirm panels, `CierreDeCaja` precedent), the
   `precio_sugerido` panel + apply action. `react-async-state` rule 8
-  (`key={idCompra}`), rule 9 (first-line re-entrancy guard + full-window
-  disable on confirmar/anular/apply — all irreversible), rule 3 (generation
-  bumped before every write), rule 6 (a 2xx confirm is never reported as
-  failure), rule 7 (proveedores/tipos/alícuotas load failure ⇒ visible aviso
-  + genuinely disabled submit). *(design: Web Composition, obligations 3, 6,
-  7, 8, 9)*
-- [ ] 5.4 Wire the route in `App.tsx` under `GestionDeCatalogo` (Admin-only
-  nav, per decision 11's consistency note — no stage-7 nav/policy mismatch).
-  *(design: File Changes)*
-- [ ] 5.5 [P] Unit: `compras.ts` mappers + totals mirror asserted against the
-  `CalculadorDeCompra` formulas. *(web-descriptor-tests)*
-- [ ] 5.6 Component: double-click on "Confirmar" and on "Anular" each issue
+  (`key={idCompra ?? 'nuevo'}`), rule 9 (first-line re-entrancy guard +
+  full-window disable on confirmar/anular/apply — all irreversible), rule 3
+  (generation bumped before every write), rule 6 (a 2xx confirm/anular/apply
+  is never reported as failure), rule 7 (proveedores/tipos/alícuotas/puntos
+  de venta load failure ⇒ visible aviso + genuinely disabled submit; listas
+  de precio failure is non-blocking, only the apply-precio panel needs it).
+  *(design: Web Composition, obligations 3, 6, 7, 8, 9)*
+- [x] 5.4 Wire the route in `App.tsx` under `GestionDeCatalogo` (Admin-only
+  route AND nav — `rolesPermitidos={[ROL.Admin]}` on both `/compras` and
+  `/compras/:id`, not `OperacionDePos`, per decision 11's consistency note:
+  no stage-7 nav/policy mismatch where the backend read policy allowed a
+  role the web never gave an entry point to). *(design: File Changes)*
+- [x] 5.5 [P] Unit: `compras.ts` mappers + totals mirror asserted against the
+  `CalculadorDeCompra` formulas (`compras.test.ts`, 47 tests: cantidad from
+  unidades/bultos, both IVA regimes, ivaTotal NULL when not discriminating,
+  costoEfectivo with/without IVA, bonificación line, empty set, division by
+  zero guard, descuento > bruto rejection, request mapper trimming/filtering,
+  offset-aware `desde`/`hasta` query building). *(web-descriptor-tests)*
+- [x] 5.6 Component: double-click on "Confirmar" and on "Anular" each issue
   exactly one POST; an empty compras list renders an empty state, never a
   re-query; proveedores/tipos/alícuotas failing to load shows an aviso and
-  an actually-disabled submit. RTL + `user-event`, `vi.mock('../api/compras')`.
+  an actually-disabled submit; role gating (Vendedor hides every write
+  action, inputs disabled); numero_externo dedupe (`compra_duplicada`) and
+  stock-refusal (`compra_anulacion_stock_negativo`) errors rendered
+  verbatim; borrador replace-set PUT body shape asserted; list generation
+  gating (a stale response never overwrites a fresher one). RTL +
+  `user-event`. **Deviation**: mocks `../api/cliente` (`api.get/post/put`)
+  rather than `vi.mock('../api/compras')` — matches the project's
+  established convention (every existing page test mocks at that layer,
+  verified via grep; zero precedent for module-level API-client mocks) and
+  additionally exercises the real route strings built by `compras.ts`.
   *(design: Testing Strategy — Component Web)*
+- [x] 5.7 Regression: `npx vitest run` 322 → 371 (+49, all this slice's:
+  Compras.tsx/CompraEditor.tsx/compras.ts tests); `npx tsc -b` clean;
+  `npx oxlint` clean (0 new — the one pre-existing `AuthContext.tsx`
+  fast-refresh warning is untouched by this slice); `npx vite build` clean.
+  **Not run by this apply batch**: judgment-day (requires two independent
+  blind review agents, an orchestration action outside an executor's scope,
+  same posture as Slice 2 task 2.16) — recommend the orchestrator run it
+  next, before opening PR 5.
 
 **Verify**: `npx vitest run src/paginas/Compras.test.tsx src/paginas/CompraEditor.test.tsx src/api/compras.test.ts`
 

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -131,15 +131,17 @@ export function App() {
               }
             />
 
-            {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web Composition):
-                árbol propio, no la máquina genérica de catálogos — mismo criterio que
-                /proveedores/-articulos. Admin-only END TO END (route + nav), la lectura del
-                backend admite Vendedor (Politicas.OperacionDePos) pero esta web no expone
-                ninguna entrada para ese rol, evitando el gap de nav/policy de stage-7. */}
+            {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web Composition,
+                decisión 11): árbol propio, no la máquina genérica de catálogos — mismo criterio
+                que /proveedores/-articulos. La lectura (listado + detalle) sigue
+                Politicas.OperacionDePos, igual que /clientes/:id/cuenta-corriente — solo la
+                escritura (borrador/confirmar/anular/aplicar precio) es Admin-only, cosmético acá
+                y real en `GestionDeCatalogo` del lado del servidor (`puedeEscribir` en cada
+                pantalla oculta esas acciones para el resto de los roles). */}
             <Route
               path="/compras"
               element={
-                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <Compras />
                 </RutaProtegida>
               }
@@ -147,7 +149,7 @@ export function App() {
             <Route
               path="/compras/:id"
               element={
-                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <CompraEditor />
                 </RutaProtegida>
               }

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -8,6 +8,8 @@ import { CierreDeCaja } from './paginas/CierreDeCaja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
 import { Clientes } from './paginas/Clientes'
+import { Compras } from './paginas/Compras'
+import { CompraEditor } from './paginas/CompraEditor'
 import { CuentaCorriente } from './paginas/CuentaCorriente'
 import { Empresas } from './paginas/Empresas'
 import { Inicio } from './paginas/Inicio'
@@ -125,6 +127,28 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Admin]}>
                   <Articulos />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web Composition):
+                árbol propio, no la máquina genérica de catálogos — mismo criterio que
+                /proveedores/-articulos. Admin-only END TO END (route + nav), la lectura del
+                backend admite Vendedor (Politicas.OperacionDePos) pero esta web no expone
+                ninguna entrada para ese rol, evitando el gap de nav/policy de stage-7. */}
+            <Route
+              path="/compras"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                  <Compras />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/compras/:id"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                  <CompraEditor />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/compras.test.ts
+++ b/src/Ways.Web/src/api/compras.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  aLineaSolicitada,
+  aSolicitudDeCompra,
+  calcularTotalesDeCompra,
+  construirQueryDeCompras,
+  etiquetaDeEstadoCompra,
+  filtrosDeComprasVacios,
+  itemAFormulario,
+  lineaCompletaParaEnvio,
+  lineaConDescuentoInvalido,
+  lineaDeCompraVacia,
+  lineaFormularioACalculo,
+  type LineaDeCalculo,
+  type LineaDeCompraFormulario,
+} from './compras'
+import type { ItemDeCompra } from './tipos'
+
+function lineaFixture(sobrescribir: Partial<LineaDeCompraFormulario> = {}): LineaDeCompraFormulario {
+  return {
+    clave: 1,
+    idArticulo: 10,
+    descripcion: 'Fideos 500g',
+    unidades: '10',
+    bultos: '',
+    unidadesPorBulto: '',
+    costoUnitario: '100',
+    descuento: '50',
+    idAlicuotaIva: 3,
+    actualizaCosto: true,
+    ...sobrescribir,
+  }
+}
+
+function itemFixture(sobrescribir: Partial<ItemDeCompra> = {}): ItemDeCompra {
+  return {
+    orden: 1,
+    idArticulo: 10,
+    descripcion: 'Fideos 500g',
+    cantidad: 10,
+    bultos: null,
+    unidadesPorBulto: null,
+    costoUnitario: 100,
+    descuento: 50,
+    idAlicuotaIva: 3,
+    porcentajeIva: 21,
+    total: 950,
+    actualizaCosto: true,
+    precioSugerido: 114.95,
+    ...sobrescribir,
+  }
+}
+
+describe('etiquetaDeEstadoCompra', () => {
+  it('devuelve una etiqueta legible por cada estado', () => {
+    expect(etiquetaDeEstadoCompra('Borrador')).toBe('Borrador')
+    expect(etiquetaDeEstadoCompra('Confirmada')).toBe('Confirmada')
+    expect(etiquetaDeEstadoCompra('Anulada')).toBe('Anulada')
+  })
+})
+
+describe('lineaDeCompraVacia / itemAFormulario', () => {
+  it('lineaDeCompraVacia arranca sin artículo ni alícuota elegidos, actualizaCosto en true', () => {
+    const linea = lineaDeCompraVacia(7)
+    expect(linea).toEqual({
+      clave: 7,
+      idArticulo: '',
+      descripcion: '',
+      unidades: '',
+      bultos: '',
+      unidadesPorBulto: '',
+      costoUnitario: '',
+      descuento: '',
+      idAlicuotaIva: '',
+      actualizaCosto: true,
+    })
+  })
+
+  it('itemAFormulario sin bultos deriva unidades = cantidad tal cual', () => {
+    const linea = itemAFormulario(1, itemFixture({ cantidad: 10, bultos: null, unidadesPorBulto: null }))
+    expect(linea.unidades).toBe('10')
+    expect(linea.bultos).toBe('')
+    expect(linea.unidadesPorBulto).toBe('')
+  })
+
+  it('itemAFormulario con bultos reconstruye unidades restando bultos × unidadesPorBulto de la cantidad persistida', () => {
+    // cantidad = unidades + bultos*unidadesPorBulto = unidades + 3*6 => unidades = cantidad - 18
+    const linea = itemAFormulario(1, itemFixture({ cantidad: 20, bultos: 3, unidadesPorBulto: 6 }))
+    expect(linea.unidades).toBe('2')
+    expect(linea.bultos).toBe('3')
+    expect(linea.unidadesPorBulto).toBe('6')
+  })
+})
+
+describe('lineaCompletaParaEnvio', () => {
+  it('una línea con artículo, alícuota, unidades y costo está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture())).toBe(true)
+  })
+
+  it('sin artículo elegido no está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ idArticulo: '' }))).toBe(false)
+  })
+
+  it('sin alícuota elegida no está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ idAlicuotaIva: '' }))).toBe(false)
+  })
+
+  it('sin unidades tipeadas no está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ unidades: '' }))).toBe(false)
+  })
+
+  it('sin costo unitario tipeado no está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ costoUnitario: '' }))).toBe(false)
+  })
+})
+
+describe('aLineaSolicitada', () => {
+  it('mapea los campos numéricos y recorta bultos/unidadesPorBulto vacíos a null', () => {
+    expect(aLineaSolicitada(lineaFixture())).toEqual({
+      idArticulo: 10,
+      descripcion: 'Fideos 500g',
+      unidades: 10,
+      bultos: null,
+      unidadesPorBulto: null,
+      costoUnitario: 100,
+      descuento: 50,
+      idAlicuotaIva: 3,
+      actualizaCosto: true,
+    })
+  })
+
+  it('un descuento vacío se envía como 0, nunca NaN', () => {
+    expect(aLineaSolicitada(lineaFixture({ descuento: '' })).descuento).toBe(0)
+  })
+
+  it('bultos/unidadesPorBulto tipeados viajan como número', () => {
+    const linea = aLineaSolicitada(lineaFixture({ bultos: '3', unidadesPorBulto: '6' }))
+    expect(linea.bultos).toBe(3)
+    expect(linea.unidadesPorBulto).toBe(6)
+  })
+})
+
+describe('aSolicitudDeCompra', () => {
+  it('recorta numeroExterno/observaciones vacíos a null y fechaComprobante vacía a null', () => {
+    const solicitud = aSolicitudDeCompra(
+      {
+        idProveedor: 1,
+        idTipoComprobante: 5,
+        idPuntoVenta: 2,
+        numeroExterno: '   ',
+        fechaComprobante: '',
+        observaciones: '  ',
+      },
+      [],
+    )
+    expect(solicitud.numeroExterno).toBeNull()
+    expect(solicitud.fechaComprobante).toBeNull()
+    expect(solicitud.observaciones).toBeNull()
+  })
+
+  it('fechaComprobante viaja tal cual (DateOnly, sin offset horario)', () => {
+    const solicitud = aSolicitudDeCompra(
+      {
+        idProveedor: 1,
+        idTipoComprobante: 5,
+        idPuntoVenta: 2,
+        numeroExterno: '0003-00012345',
+        fechaComprobante: '2026-08-05',
+        observaciones: '',
+      },
+      [],
+    )
+    expect(solicitud.fechaComprobante).toBe('2026-08-05')
+  })
+
+  it('filtra las líneas incompletas — nunca viajan a medio llenar', () => {
+    const solicitud = aSolicitudDeCompra(
+      {
+        idProveedor: 1,
+        idTipoComprobante: 5,
+        idPuntoVenta: 2,
+        numeroExterno: '',
+        fechaComprobante: '',
+        observaciones: '',
+      },
+      [lineaFixture({ clave: 1 }), lineaFixture({ clave: 2, idArticulo: '' })],
+    )
+    expect(solicitud.items).toHaveLength(1)
+  })
+})
+
+describe('lineaFormularioACalculo', () => {
+  it('resuelve porcentajeIva desde el catálogo de alícuotas, nunca desde el formulario', () => {
+    const calculo = lineaFormularioACalculo(lineaFixture({ idAlicuotaIva: 3 }), { 3: 21 })
+    expect(calculo.porcentajeIva).toBe(21)
+  })
+
+  it('una alícuota sin elegir resuelve porcentajeIva = 0', () => {
+    const calculo = lineaFormularioACalculo(lineaFixture({ idAlicuotaIva: '' }), { 3: 21 })
+    expect(calculo.porcentajeIva).toBe(0)
+  })
+})
+
+// ---- calcularTotalesDeCompra: espejo de CalculadorDeCompra (design: "Compra Arithmetic") -----
+
+function lineaDeCalculoFixture(sobrescribir: Partial<LineaDeCalculo> = {}): LineaDeCalculo {
+  return { unidades: 10, bultos: 0, unidadesPorBulto: 0, costoUnitario: 100, descuento: 50, porcentajeIva: 21, ...sobrescribir }
+}
+
+describe('calcularTotalesDeCompra', () => {
+  it('cantidad = unidades + bultos × unidadesPorBulto', () => {
+    const { items } = calcularTotalesDeCompra([lineaDeCalculoFixture({ unidades: 2, bultos: 3, unidadesPorBulto: 6 })], false)
+    expect(items[0].cantidad).toBe(20)
+  })
+
+  it('discrimina_iva = true: iva_total por línea, total = subtotal − descuento + iva, costoEfectivo incluye IVA', () => {
+    const totales = calcularTotalesDeCompra([lineaDeCalculoFixture()], true)
+    expect(totales.subtotal).toBe(1000) // 10 × 100
+    expect(totales.descuentoTotal).toBe(50)
+    expect(totales.items[0].total).toBe(950) // 1000 − 50
+    expect(totales.ivaTotal).toBe(199.5) // round(950 × 21/100, 2)
+    expect(totales.total).toBe(1149.5) // 1000 − 50 + 199.5
+    expect(totales.items[0].costoEfectivo).toBe(114.95) // round(950 × 1.21 / 10, 2)
+  })
+
+  it('discrimina_iva = false: ivaTotal es NULL, total no suma IVA, costoEfectivo no lo incluye', () => {
+    const totales = calcularTotalesDeCompra([lineaDeCalculoFixture()], false)
+    expect(totales.ivaTotal).toBeNull()
+    expect(totales.total).toBe(950) // 1000 − 50
+    expect(totales.items[0].costoEfectivo).toBe(95) // round(950 / 10, 2)
+  })
+
+  it('una línea de bonificación (costo 0) no aporta bruto ni costoEfectivo negativo', () => {
+    const totales = calcularTotalesDeCompra([lineaDeCalculoFixture({ costoUnitario: 0, descuento: 0 })], false)
+    expect(totales.items[0].bruto).toBe(0)
+    expect(totales.items[0].costoEfectivo).toBe(0)
+  })
+
+  it('un set vacío de líneas da totales en cero, iva NULL cuando no discrimina', () => {
+    const totales = calcularTotalesDeCompra([], false)
+    expect(totales).toEqual({ items: [], subtotal: 0, descuentoTotal: 0, ivaTotal: null, total: 0 })
+  })
+
+  it('cantidad 0 no divide por cero — costoEfectivo es null', () => {
+    const totales = calcularTotalesDeCompra([lineaDeCalculoFixture({ unidades: 0, bultos: 0, unidadesPorBulto: 0 })], true)
+    expect(totales.items[0].costoEfectivo).toBeNull()
+  })
+
+  it('dos líneas suman sus brutos/descuentos/iva independientemente', () => {
+    const totales = calcularTotalesDeCompra(
+      [lineaDeCalculoFixture(), lineaDeCalculoFixture({ unidades: 5, costoUnitario: 40, descuento: 0, porcentajeIva: 10.5 })],
+      true,
+    )
+    // línea 2: cantidad 5, bruto 200, total 200, iva round(200×10.5/100,2)=21
+    expect(totales.subtotal).toBe(1200) // 1000 + 200
+    expect(totales.descuentoTotal).toBe(50) // 50 + 0
+    expect(totales.ivaTotal).toBe(220.5) // 199.5 + 21
+  })
+})
+
+describe('lineaConDescuentoInvalido', () => {
+  it('un descuento mayor al bruto es inválido', () => {
+    expect(lineaConDescuentoInvalido(lineaDeCalculoFixture({ descuento: 1500 }))).toBe(true)
+  })
+
+  it('un descuento igual o menor al bruto es válido', () => {
+    expect(lineaConDescuentoInvalido(lineaDeCalculoFixture({ descuento: 1000 }))).toBe(false)
+    expect(lineaConDescuentoInvalido(lineaDeCalculoFixture({ descuento: 50 }))).toBe(false)
+  })
+})
+
+// ---- construirQueryDeCompras: mismo patrón de offset explícito que cuentaCorriente.ts --------
+
+function offsetEsperado(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+describe('construirQueryDeCompras', () => {
+  it('sin filtros manda solo pagina/tamanio', () => {
+    expect(construirQueryDeCompras(filtrosDeComprasVacios())).toBe('?pagina=1&tamanio=25')
+  })
+
+  it('idProveedor y estado viajan tal cual', () => {
+    const query = construirQueryDeCompras({ ...filtrosDeComprasVacios(), idProveedor: 8, estado: 'Confirmada' })
+    expect(query).toContain('idProveedor=8')
+    expect(query).toContain('estado=Confirmada')
+  })
+
+  it('desde/hasta expanden a los bordes del día con el offset horario local', () => {
+    const offsetDesde = offsetEsperado(2026, 7, 1)
+    const offsetHasta = offsetEsperado(2026, 7, 31)
+    const query = decodeURIComponent(
+      construirQueryDeCompras({ ...filtrosDeComprasVacios(), desde: '2026-07-01', hasta: '2026-07-31' }),
+    )
+    expect(query).toContain(`desde=2026-07-01T00:00:00${offsetDesde}`)
+    expect(query).toContain(`hasta=2026-07-31T23:59:59.999${offsetHasta}`)
+  })
+})
+
+describe('construirQueryDeCompras — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+    const query = decodeURIComponent(construirQueryDeCompras({ ...filtrosDeComprasVacios(), desde: '2026-07-01' }))
+    expect(query).toContain('desde=2026-07-01T00:00:00-03:00')
+  })
+})

--- a/src/Ways.Web/src/api/compras.ts
+++ b/src/Ways.Web/src/api/compras.ts
@@ -1,0 +1,287 @@
+/**
+ * Cliente HTTP + reglas puras de compras (stage-8-compras-transferencias-inventario, Slice 5):
+ * CRUD de borrador, confirmar/anular/aplicar precio sugerido, y un mirror **no autoritativo** de
+ * `CalculadorDeCompra` (Ways.Domain.Compras) para feedback instantáneo en pantalla — el servidor
+ * vuelve a derivar todo (`dto-contract-honesty`): ningún endpoint acepta `cantidad`, un total de
+ * línea ni un total de header, solo los inputs (`unidades`/`bultos`/`unidadesPorBulto`/
+ * `costoUnitario`/`descuento`/`idAlicuotaIva`).
+ */
+import { api } from './cliente'
+import type {
+  CompraDetalle,
+  EstadoCompra,
+  ItemDeCompra,
+  LineaDeCompraSolicitada,
+  PaginaDeCompras,
+  ResultadoAnulacion,
+  ResultadoAplicarPrecio,
+  SaldoDeProveedor,
+  SolicitudDeAplicarPrecios,
+  SolicitudDeCompra,
+} from './tipos'
+
+function redondear(valor: number, decimales: number): number {
+  const factor = 10 ** decimales
+  return Math.round((valor + Number.EPSILON) * factor) / factor
+}
+
+// ---- Offset local para el filtro desde/hasta (mismo criterio que cuentaCorriente.ts: el
+// servidor corre en UTC, `fecha_recepcion` es `timestamptz` y un `<input type="date">` sin
+// offset se interpretaría como UTC, perdiendo actividad nocturna en ART). Duplicado a propósito
+// (sibling helper, mismo criterio que los statements crudos de `ServicioDeCompras`): no hay un
+// módulo compartido de utilidades de fecha en esta web todavía. -----------------------------
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+export type FiltrosDeCompras = {
+  idProveedor: number | null
+  estado: EstadoCompra | null
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+export function filtrosDeComprasVacios(): FiltrosDeCompras {
+  return { idProveedor: null, estado: null, desde: '', hasta: '', pagina: 1, tamanio: 25 }
+}
+
+/** Arma el query string de `GET /api/compras` — `desde`/`hasta` filtran por `fecha_recepcion`
+ * (`ServicioDeCompras.ListarAsync`), nunca por `fecha_comprobante`, así que llevan el mismo
+ * offset horario explícito que el resto de la web. */
+export function construirQueryDeCompras(filtros: FiltrosDeCompras): string {
+  const parametros = new URLSearchParams()
+  if (filtros.idProveedor !== null) parametros.set('idProveedor', String(filtros.idProveedor))
+  if (filtros.estado !== null) parametros.set('estado', filtros.estado)
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+export const clienteDeCompras = {
+  listar: (filtros: FiltrosDeCompras) => api.get<PaginaDeCompras>(`/compras${construirQueryDeCompras(filtros)}`),
+  obtener: (id: number) => api.get<CompraDetalle>(`/compras/${id}`),
+  crear: (solicitud: SolicitudDeCompra) => api.post<CompraDetalle>('/compras', solicitud),
+  actualizar: (id: number, solicitud: SolicitudDeCompra) => api.put<CompraDetalle>(`/compras/${id}`, solicitud),
+  confirmar: (id: number) => api.post<CompraDetalle>(`/compras/${id}/confirmar`),
+  anular: (id: number) => api.post<ResultadoAnulacion>(`/compras/${id}/anular`),
+  aplicarPrecios: (id: number, solicitud: SolicitudDeAplicarPrecios) =>
+    api.post<ResultadoAplicarPrecio[]>(`/compras/${id}/precios`, solicitud),
+  /** `GET /api/proveedores/{id}/saldo` — top-level, no dentro de `/api/proveedores` (design: API
+   * Surface). Usado acá solo para la columna de estado de pago cuando el listado está filtrado
+   * por un proveedor puntual; el panel completo lo construye `Proveedores.tsx` en la Slice 6. */
+  obtenerSaldoDeProveedor: (idProveedor: number) => api.get<SaldoDeProveedor>(`/proveedores/${idProveedor}/saldo`),
+}
+
+export function etiquetaDeEstadoCompra(estado: EstadoCompra): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'Borrador'
+    case 'Confirmada':
+      return 'Confirmada'
+    case 'Anulada':
+      return 'Anulada'
+  }
+}
+
+// ---- Formulario del editor: una línea por fila de la grilla ---------------------------------
+
+export type LineaDeCompraFormulario = {
+  /** Clave solo de React — el `PUT` es un replace-set completo (design decisión 2), ningún id de
+   * línea persistido viaja en el request ni sobrevive entre saves. */
+  clave: number
+  idArticulo: number | ''
+  descripcion: string
+  unidades: string
+  bultos: string
+  unidadesPorBulto: string
+  costoUnitario: string
+  descuento: string
+  idAlicuotaIva: number | ''
+  actualizaCosto: boolean
+}
+
+export function lineaDeCompraVacia(clave: number): LineaDeCompraFormulario {
+  return {
+    clave,
+    idArticulo: '',
+    descripcion: '',
+    unidades: '',
+    bultos: '',
+    unidadesPorBulto: '',
+    costoUnitario: '',
+    descuento: '',
+    idAlicuotaIva: '',
+    actualizaCosto: true,
+  }
+}
+
+/** Un item ya persistido → fila de formulario, para reabrir un borrador existente. */
+export function itemAFormulario(clave: number, item: ItemDeCompra): LineaDeCompraFormulario {
+  return {
+    clave,
+    idArticulo: item.idArticulo,
+    descripcion: item.descripcion,
+    unidades:
+      item.bultos !== null && item.unidadesPorBulto !== null
+        ? String(redondear(item.cantidad - item.bultos * item.unidadesPorBulto, 3))
+        : String(item.cantidad),
+    bultos: item.bultos === null ? '' : String(item.bultos),
+    unidadesPorBulto: item.unidadesPorBulto === null ? '' : String(item.unidadesPorBulto),
+    costoUnitario: String(item.costoUnitario),
+    descuento: String(item.descuento),
+    idAlicuotaIva: item.idAlicuotaIva,
+    actualizaCosto: item.actualizaCosto,
+  }
+}
+
+function numero(valor: string): number {
+  const n = Number(valor)
+  return valor.trim() === '' || !Number.isFinite(n) ? 0 : n
+}
+
+function numeroONulo(valor: string): number | null {
+  return valor.trim() === '' ? null : Number(valor)
+}
+
+export function lineaCompletaParaEnvio(l: LineaDeCompraFormulario): boolean {
+  return l.idArticulo !== '' && l.idAlicuotaIva !== '' && l.unidades.trim() !== '' && l.costoUnitario.trim() !== ''
+}
+
+/** Fila de formulario → `LineaDeCompraSolicitada` — solo se envían las filas completas
+ * (`lineaCompletaParaEnvio`), una fila a medio llenar nunca viaja al servidor. */
+export function aLineaSolicitada(l: LineaDeCompraFormulario): LineaDeCompraSolicitada {
+  return {
+    idArticulo: Number(l.idArticulo),
+    descripcion: l.descripcion.trim(),
+    unidades: numero(l.unidades),
+    bultos: numeroONulo(l.bultos),
+    unidadesPorBulto: numeroONulo(l.unidadesPorBulto),
+    costoUnitario: numero(l.costoUnitario),
+    descuento: l.descuento.trim() === '' ? 0 : numero(l.descuento),
+    idAlicuotaIva: Number(l.idAlicuotaIva),
+    actualizaCosto: l.actualizaCosto,
+  }
+}
+
+export type EncabezadoDeCompraFormulario = {
+  idProveedor: number | ''
+  idTipoComprobante: number | ''
+  idPuntoVenta: number | ''
+  numeroExterno: string
+  fechaComprobante: string
+  observaciones: string
+}
+
+/** `fechaComprobante` es `date` (`DateOnly`), no `timestamptz` — viaja tal cual el
+ * `<input type="date">` la entrega (`YYYY-MM-DD`), sin ningún offset horario (a diferencia de
+ * `desde`/`hasta` del listado, que sí filtran contra un `timestamptz`). */
+export function aSolicitudDeCompra(
+  encabezado: EncabezadoDeCompraFormulario,
+  lineas: LineaDeCompraFormulario[],
+): SolicitudDeCompra {
+  return {
+    idProveedor: encabezado.idProveedor === '' ? 0 : encabezado.idProveedor,
+    idTipoComprobante: encabezado.idTipoComprobante === '' ? 0 : encabezado.idTipoComprobante,
+    idPuntoVenta: encabezado.idPuntoVenta === '' ? 0 : encabezado.idPuntoVenta,
+    numeroExterno: encabezado.numeroExterno.trim() === '' ? null : encabezado.numeroExterno.trim(),
+    fechaComprobante: encabezado.fechaComprobante === '' ? null : encabezado.fechaComprobante,
+    observaciones: encabezado.observaciones.trim() === '' ? null : encabezado.observaciones.trim(),
+    items: lineas.filter(lineaCompletaParaEnvio).map(aLineaSolicitada),
+  }
+}
+
+// ---- Mirror no autoritativo de CalculadorDeCompra (design: "Compra Arithmetic") --------------
+
+export type LineaDeCalculo = {
+  unidades: number
+  bultos: number
+  unidadesPorBulto: number
+  costoUnitario: number
+  descuento: number
+  porcentajeIva: number
+}
+
+export type ItemCalculado = { cantidad: number; bruto: number; total: number; costoEfectivo: number | null }
+
+export type TotalesDeCompra = {
+  items: ItemCalculado[]
+  subtotal: number
+  descuentoTotal: number
+  ivaTotal: number | null
+  total: number
+}
+
+/** Fila de formulario → `LineaDeCalculo`, resolviendo `porcentajeIva` desde el catálogo de
+ * alícuotas (el formulario solo guarda el id, nunca el porcentaje). */
+export function lineaFormularioACalculo(
+  l: LineaDeCompraFormulario,
+  porcentajePorAlicuota: Record<number, number>,
+): LineaDeCalculo {
+  return {
+    unidades: numero(l.unidades),
+    bultos: numero(l.bultos),
+    unidadesPorBulto: numero(l.unidadesPorBulto),
+    costoUnitario: numero(l.costoUnitario),
+    descuento: numero(l.descuento),
+    porcentajeIva: l.idAlicuotaIva === '' ? 0 : (porcentajePorAlicuota[l.idAlicuotaIva] ?? 0),
+  }
+}
+
+function calcularItem(l: LineaDeCalculo, discriminaIva: boolean): ItemCalculado {
+  const cantidad = redondear(l.unidades + l.bultos * l.unidadesPorBulto, 3)
+  const bruto = redondear(cantidad * l.costoUnitario, 2)
+  const total = redondear(bruto - l.descuento, 2)
+  const costoEfectivo =
+    cantidad <= 0
+      ? null
+      : discriminaIva
+        ? redondear((total * (1 + l.porcentajeIva / 100)) / cantidad, 2)
+        : redondear(total / cantidad, 2)
+  return { cantidad, bruto, total, costoEfectivo }
+}
+
+/** Espejo de `CalculadorDeCompra.Calcular` (design: "Compra Arithmetic") — puramente informativo,
+ * el servidor recalcula todo desde cero al guardar (`dto-contract-honesty`). */
+export function calcularTotalesDeCompra(lineas: LineaDeCalculo[], discriminaIva: boolean): TotalesDeCompra {
+  const items = lineas.map((l) => calcularItem(l, discriminaIva))
+  const subtotal = redondear(
+    items.reduce((acumulado, i) => acumulado + i.bruto, 0),
+    2,
+  )
+  const descuentoTotal = redondear(
+    lineas.reduce((acumulado, l) => acumulado + l.descuento, 0),
+    2,
+  )
+
+  if (!discriminaIva) {
+    return { items, subtotal, descuentoTotal, ivaTotal: null, total: redondear(subtotal - descuentoTotal, 2) }
+  }
+
+  const ivaTotal = redondear(
+    items.reduce((acumulado, item, indice) => acumulado + redondear((item.total * lineas[indice].porcentajeIva) / 100, 2), 0),
+    2,
+  )
+  return { items, subtotal, descuentoTotal, ivaTotal, total: redondear(subtotal - descuentoTotal + ivaTotal, 2) }
+}
+
+/** Espejo de la regla `descuento(i) > bruto(i) ⇒ 400 descuento_de_item_invalido` — feedback
+ * instantáneo, nunca autoritativo (el servidor la vuelve a validar). */
+export function lineaConDescuentoInvalido(l: LineaDeCalculo): boolean {
+  const cantidad = redondear(l.unidades + l.bultos * l.unidadesPorBulto, 3)
+  const bruto = redondear(cantidad * l.costoUnitario, 2)
+  return l.descuento > bruto
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -864,3 +864,112 @@ export type ResultadoDeReliquidacion = {
   detalle: DetalleDeConsumo[]
   hayMas: boolean
 }
+
+// --- Compras (stage-8-compras-transferencias-inventario, Slice 5) --------------------------
+// Espejo de `Ways.Application.Compras.Contratos` — ningún request lleva `cantidad`, `total` ni
+// `delta` (design decisión 3): `CalculadorDeCompra` deriva todo eso server-side, el mirror de
+// `compras.ts` es puramente informativo (dto-contract-honesty: el servidor siempre gana).
+
+export type EstadoCompra = 'Borrador' | 'Confirmada' | 'Anulada'
+
+/** Una línea del cuerpo de `POST`/`PUT /api/compras` (espejo de `LineaDeCompraSolicitada`). */
+export type LineaDeCompraSolicitada = {
+  idArticulo: number
+  descripcion: string
+  unidades: number
+  bultos: number | null
+  unidadesPorBulto: number | null
+  costoUnitario: number
+  descuento: number
+  idAlicuotaIva: number
+  actualizaCosto: boolean
+}
+
+/** Cuerpo de `POST /api/compras` (crea un borrador) y `PUT /api/compras/{id}` (replace-set
+ * completo del header + los items — espejo de `SolicitudDeCompra`). */
+export type SolicitudDeCompra = {
+  idProveedor: number
+  idTipoComprobante: number
+  idPuntoVenta: number
+  numeroExterno: string | null
+  fechaComprobante: string | null
+  observaciones: string | null
+  items: LineaDeCompraSolicitada[]
+}
+
+/** Un item ya persistido, con su `precioSugerido` (espejo de `ItemDeCompra`). */
+export type ItemDeCompra = {
+  orden: number
+  idArticulo: number
+  descripcion: string
+  cantidad: number
+  bultos: number | null
+  unidadesPorBulto: number | null
+  costoUnitario: number
+  descuento: number
+  idAlicuotaIva: number
+  porcentajeIva: number
+  total: number
+  actualizaCosto: boolean
+  precioSugerido: number | null
+}
+
+/** Detalle completo de una compra (espejo de `CompraDetalle`). */
+export type CompraDetalle = {
+  id: number
+  idProveedor: number
+  idTipoComprobante: number
+  idPuntoVenta: number
+  numeroExterno: string | null
+  fechaComprobante: string | null
+  fechaRecepcion: string | null
+  subtotal: number
+  descuentoTotal: number
+  ivaTotal: number | null
+  total: number
+  observaciones: string | null
+  estado: EstadoCompra
+  items: ItemDeCompra[]
+}
+
+/** Fila de `GET /api/compras` — shape reducido (espejo de `CompraListada`). */
+export type CompraListada = {
+  id: number
+  idProveedor: number
+  idTipoComprobante: number
+  numeroExterno: string | null
+  estado: EstadoCompra
+  fechaRecepcion: string | null
+  total: number
+}
+
+/** Página de resultados de `GET /api/compras` (espejo de `PaginaDeCompras`). */
+export type PaginaDeCompras = { items: CompraListada[]; total: number; pagina: number; tamanio: number }
+
+/** Respuesta de `POST /api/compras/{id}/anular` — `gastosLigados` es la regla invertida
+ * (design decisión 6): la anulación NUNCA bloquea por gastos ligados, solo REPORTA cuántos pagos
+ * quedaron colgados de la compra anulada (espejo de `ResultadoAnulacion`). */
+export type ResultadoAnulacion = { compra: CompraDetalle; gastosLigados: number }
+
+/** Cuerpo de `POST /api/compras/{id}/precios` (espejo de `SolicitudDeAplicarPrecios`). */
+export type SolicitudDeAplicarPrecios = { idListaPrecio: number; confirmarReemplazo: boolean }
+
+/** Resultado por línea de aplicar `precioSugerido` — partial success es el contrato honesto
+ * (espejo de `ResultadoAplicarPrecio`). */
+export type ResultadoAplicarPrecio = { idArticulo: number; aplicado: boolean; precio: number | null; error: string | null }
+
+// --- Saldo de proveedor (stage-8, Slice 4 backend / Slice 5 web) ----------------------------
+// `GET /api/proveedores/{id}/saldo` — mapeado top-level, no dentro de `/api/proveedores`
+// (design: API Surface, "the AND-composition trap"). Espejo de `ServicioDeSaldoDeProveedor`.
+
+export type EstadoPago = 'Pagada' | 'Parcial' | 'Impaga'
+
+export type CompraConEstadoPago = {
+  idComprobanteCompra: number
+  numeroExterno: string | null
+  total: number
+  pagado: number
+  estadoPago: EstadoPago
+}
+
+export type SaldoDeProveedor = { idProveedor: number; saldo: number; compras: CompraConEstadoPago[] }

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -70,6 +70,14 @@ export function Layout() {
                         Artículos
                       </NavLink>
                     </li>
+                    {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web
+                        Composition): Admin-only end to end — nav y ruta comparten la misma
+                        política (no repite el gap de nav/policy de stage-7). */}
+                    <li className="nav-item">
+                      <NavLink className="nav-link" to="/compras">
+                        Compras
+                      </NavLink>
+                    </li>
                     <li className="nav-item">
                       <NavLink className="nav-link" to="/listas-precio">
                         Listas de precio

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -46,6 +46,17 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web Composition,
+                    decisión 11): la lectura sigue Politicas.OperacionDePos, igual que la ruta —
+                    nav y ruta comparten la misma política de lectura; la escritura queda oculta
+                    dentro de la pantalla vía `puedeEscribir` (Admin-only, cosmético). */}
+                {usuario && puedeOperarPos(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/compras">
+                      Compras
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">
@@ -68,14 +79,6 @@ export function Layout() {
                     <li className="nav-item">
                       <NavLink className="nav-link" to="/articulos">
                         Artículos
-                      </NavLink>
-                    </li>
-                    {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web
-                        Composition): Admin-only end to end — nav y ruta comparten la misma
-                        política (no repite el gap de nav/policy de stage-7). */}
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/compras">
-                        Compras
                       </NavLink>
                     </li>
                     <li className="nav-item">

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CompraEditor } from './CompraEditor'
+import { RutaProtegida } from '../auth/RutaProtegida'
 import { ErrorApi } from '../api/cliente'
 import { ROL } from '../api/tipos'
 import type {
@@ -181,6 +182,27 @@ function renderEditor(idCompra: string | number = 1) {
   )
 }
 
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/compras/:id` (decisión 11: la
+ * lectura sigue `Politicas.OperacionDePos`) — a diferencia de `renderEditor`, esto prueba que el
+ * rol realmente llega a la pantalla en vez de asumirlo. */
+function renderEditorProtegido(idCompra: string | number = 1) {
+  return render(
+    <MemoryRouter initialEntries={[`/compras/${idCompra}`]}>
+      <Routes>
+        <Route
+          path="/compras/:id"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+              <CompraEditor />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
 /** Rutas de referencia compartidas por casi todos los tests — cada test suma encima las rutas de
  * compra que le hacen falta. */
 function mockearReferencia(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
@@ -336,6 +358,9 @@ describe('CompraEditor — compra confirmada', () => {
     await usuario.click(botonAnularFinal)
     await usuario.click(botonAnularFinal)
 
+    // regla 9, gate simétrico: anulando bloquea aplicar-precios mientras la anulación está en vuelo.
+    expect(screen.getByRole('button', { name: 'Aplicar' })).toBeDisabled()
+
     resolverAnular({ compra: compraFixture({ estado: 'Anulada' }), gastosLigados: 2 })
     expect(await screen.findByText(/Quedan 2 gasto\(s\) ligado\(s\)/)).toBeInTheDocument()
 
@@ -384,6 +409,26 @@ describe('CompraEditor — compra confirmada', () => {
     const [, cuerpo] = apiPostMock.mock.calls.find((call: unknown[]) => call[0] === '/compras/1/precios') as [string, Record<string, unknown>]
     expect(cuerpo).toEqual({ idListaPrecio: 1, confirmarReemplazo: false })
   })
+
+  it('aplicar precio sugerido en vuelo bloquea "Anular compra" (regla 9, gate simétrico con anulando)', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    let resolverAplicar: (valor: ResultadoAplicarPrecio[]) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/precios') return new Promise((resolve) => (resolverAplicar = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByLabelText('Lista de precios')
+    await usuario.selectOptions(screen.getByLabelText('Lista de precios'), '1')
+    await usuario.click(screen.getByRole('button', { name: 'Aplicar' }))
+
+    expect(screen.getByRole('button', { name: 'Anular compra' })).toBeDisabled()
+
+    resolverAplicar([{ idArticulo: 10, aplicado: true, precio: 114.95, error: null }])
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Anular compra' })).toBeEnabled())
+  })
 })
 
 describe('CompraEditor — compra nueva', () => {
@@ -430,18 +475,52 @@ describe('CompraEditor — compra nueva', () => {
   })
 })
 
-describe('CompraEditor — role gating', () => {
-  it('un Vendedor ve el borrador de solo lectura, sin acciones de escritura', async () => {
-    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+describe('CompraEditor — líneas incompletas', () => {
+  it('una línea incompleta no entra en el total mostrado, y se avisa con un contador', async () => {
     mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    const usuario = userEvent.setup()
 
     renderEditor()
     await screen.findByDisplayValue('0003-00012345')
+    expect(screen.getByText('$1.149,50')).toBeInTheDocument()
 
+    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
+
+    // la línea nueva no tiene artículo ni alícuota elegidos — queda incompleta a propósito, pero
+    // se le cargan unidades/costo para que, si el mirror la sumara, el total cambiaría.
+    const unidades = screen.getAllByLabelText('Unidades')
+    await usuario.type(unidades[1], '5')
+    const costo = screen.getAllByLabelText('Costo unitario')
+    await usuario.type(costo[1], '20')
+
+    expect(await screen.findByText('1 línea(s) incompleta(s) — no se van a guardar.')).toBeInTheDocument()
+    expect(screen.getByText('$1.149,50')).toBeInTheDocument()
+  })
+})
+
+describe('CompraEditor — role gating', () => {
+  it('un Vendedor llega a la ruta (decisión 11) y ve el borrador de solo lectura, sin acciones de escritura', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+
+    renderEditorProtegido()
+    await screen.findByDisplayValue('0003-00012345')
+
+    // el gate de rol de la ruta lo dejó pasar — no lo mandó a "/".
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Guardar borrador' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Confirmar compra' })).not.toBeInTheDocument()
     expect(screen.getByLabelText('Proveedor')).toBeDisabled()
     expect(screen.getByLabelText('Costo unitario')).toBeDisabled()
+  })
+
+  it('un rol fuera de la lista (Root) es redirigido a "/" antes de llegar a la pantalla', async () => {
+    usuarioActual = usuarioFixture({ id: 99, usuario: 'root', mail: 'root@ways.test', rolId: ROL.Root, rol: 'Root', idTenant: null })
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+
+    renderEditorProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -429,6 +429,35 @@ describe('CompraEditor — compra confirmada', () => {
     resolverAplicar([{ idArticulo: 10, aplicado: true, precio: 114.95, error: null }])
     await waitFor(() => expect(screen.getByRole('button', { name: 'Anular compra' })).toBeEnabled())
   })
+
+  it('con el panel de anular ya abierto y tildado, aplicar precio sugerido en vuelo bloquea el botón interno Anular (regla 9)', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    let resolverAplicar: (valor: ResultadoAplicarPrecio[]) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/precios') return new Promise((resolve) => (resolverAplicar = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByRole('button', { name: 'Anular compra' })
+    await usuario.click(screen.getByRole('button', { name: 'Anular compra' }))
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero anular esta compra/))
+
+    const botonAnularFinal = screen.getByRole('button', { name: 'Anular' })
+    expect(botonAnularFinal).toBeEnabled()
+
+    await usuario.selectOptions(screen.getByLabelText('Lista de precios'), '1')
+    await usuario.click(screen.getByRole('button', { name: 'Aplicar' }))
+
+    expect(botonAnularFinal).toBeDisabled()
+
+    resolverAplicar([{ idArticulo: 10, aplicado: true, precio: 114.95, error: null }])
+    await waitFor(() => expect(botonAnularFinal).toBeEnabled())
+
+    const llamadasAnular = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/compras/1/anular')
+    expect(llamadasAnular).toHaveLength(0)
+  })
 })
 
 describe('CompraEditor — compra nueva', () => {

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -1,0 +1,483 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CompraEditor } from './CompraEditor'
+import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type {
+  AlicuotaIvaListado,
+  CompraDetalle,
+  ItemDeCompra,
+  ListaPrecioListado,
+  ProveedorListado,
+  PuntoVentaListado,
+  ResultadoAnulacion,
+  ResultadoAplicarPrecio,
+  TipoComprobanteListado,
+  UsuarioAutenticado,
+} from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown?])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 1,
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 1,
+    razonSocial: 'Proveedor Uno SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+function tipoFixture(sobrescribir: Partial<TipoComprobanteListado> = {}): TipoComprobanteListado {
+  return {
+    id: 5,
+    clase: 'Compra',
+    codigo: 'C-FA',
+    nombre: 'Factura A de compra',
+    letra: 'A',
+    signo: 1,
+    discriminaIva: true,
+    esFiscal: false,
+    afectaStock: true,
+    codigoAfip: null,
+    activo: true,
+    ...sobrescribir,
+  }
+}
+
+function alicuotaFixture(sobrescribir: Partial<AlicuotaIvaListado> = {}): AlicuotaIvaListado {
+  return { id: 3, nombre: '21%', porcentaje: 21, codigoAfip: null, activo: true, ...sobrescribir }
+}
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 2,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Casa Central',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function listaPrecioFixture(sobrescribir: Partial<ListaPrecioListado> = {}): ListaPrecioListado {
+  return {
+    id: 1,
+    nombre: 'Lista General',
+    activo: true,
+    idEmpresa: null,
+    esDefault: true,
+    modo: 'Fija',
+    idListaBase: null,
+    porcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function itemFixture(sobrescribir: Partial<ItemDeCompra> = {}): ItemDeCompra {
+  return {
+    orden: 1,
+    idArticulo: 10,
+    descripcion: 'Fideos 500g',
+    cantidad: 10,
+    bultos: null,
+    unidadesPorBulto: null,
+    costoUnitario: 100,
+    descuento: 50,
+    idAlicuotaIva: 3,
+    porcentajeIva: 21,
+    total: 950,
+    actualizaCosto: true,
+    precioSugerido: 114.95,
+    ...sobrescribir,
+  }
+}
+
+function compraFixture(sobrescribir: Partial<CompraDetalle> = {}): CompraDetalle {
+  return {
+    id: 1,
+    idProveedor: 1,
+    idTipoComprobante: 5,
+    idPuntoVenta: 2,
+    numeroExterno: '0003-00012345',
+    fechaComprobante: '2026-08-01',
+    fechaRecepcion: null,
+    subtotal: 1000,
+    descuentoTotal: 50,
+    ivaTotal: 199.5,
+    total: 1149.5,
+    observaciones: null,
+    estado: 'Borrador',
+    items: [itemFixture()],
+    ...sobrescribir,
+  }
+}
+
+function renderEditor(idCompra: string | number = 1) {
+  return render(
+    <MemoryRouter initialEntries={[`/compras/${idCompra}`]}>
+      <Routes>
+        <Route path="/compras/:id" element={<CompraEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** Rutas de referencia compartidas por casi todos los tests — cada test suma encima las rutas de
+ * compra que le hacen falta. */
+function mockearReferencia(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta.startsWith('/proveedores')) return Promise.resolve({ items: [proveedorFixture()], total: 1, pagina: 1, tamanio: 200 })
+    if (ruta === '/catalogos-fiscales/tipos-comprobante') return Promise.resolve([tipoFixture()])
+    if (ruta === '/catalogos-fiscales/alicuotas-iva') return Promise.resolve([alicuotaFixture()])
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/catalogos/listas-precio') return Promise.resolve([listaPrecioFixture()])
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiPutMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+describe('CompraEditor — borrador existente', () => {
+  it('carga el header y los items del borrador', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    renderEditor()
+
+    expect(await screen.findByDisplayValue('0003-00012345')).toBeInTheDocument()
+    expect(screen.getByText('Elegido: Fideos 500g')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Guardar borrador' })).toBeInTheDocument()
+  })
+
+  it('guardar borrador manda un PUT con el replace-set completo (header + items editados)', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    apiPutMock.mockResolvedValue(compraFixture({ observaciones: 'Actualizado' }))
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+
+    const costo = screen.getByLabelText('Costo unitario')
+    await usuario.clear(costo)
+    await usuario.type(costo, '120')
+
+    await usuario.type(screen.getByLabelText('Observaciones'), 'Actualizado')
+
+    await usuario.click(screen.getByRole('button', { name: 'Guardar borrador' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [ruta, cuerpo] = apiPutMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(ruta).toBe('/compras/1')
+    expect(cuerpo.observaciones).toBe('Actualizado')
+    expect(cuerpo.items).toHaveLength(1)
+    expect((cuerpo.items as Record<string, unknown>[])[0].costoUnitario).toBe(120)
+    // replace-set: el header viaja completo, no solo el campo tocado.
+    expect(cuerpo.idProveedor).toBe(1)
+    expect(cuerpo.idTipoComprobante).toBe(5)
+    expect(cuerpo.idPuntoVenta).toBe(2)
+
+    expect(await screen.findByText('Borrador guardado.')).toBeInTheDocument()
+  })
+
+  it('un 409 compra_duplicada al guardar se muestra tal cual, sin envolver el mensaje', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    apiPutMock.mockRejectedValue(new ErrorApi(409, 'compra_duplicada', 'Ya existe una compra confirmada con ese número.'))
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar borrador' }))
+
+    expect(await screen.findByText('Ya existe una compra confirmada con ese número.')).toBeInTheDocument()
+  })
+
+  it('confirmar: el checkbox de irreversibilidad bloquea el botón hasta tildarlo, y un doble click manda un solo POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    let resolverConfirmar: (valor: CompraDetalle) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/confirmar') return new Promise((resolve) => (resolverConfirmar = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar compra' }))
+
+    const botonConfirmarFinal = screen.getByRole('button', { name: 'Confirmar' })
+    expect(botonConfirmarFinal).toBeDisabled()
+
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero confirmar esta compra/))
+    expect(botonConfirmarFinal).toBeEnabled()
+
+    // Doble click rápido — el guard de reentrancia de primera línea evita un segundo POST.
+    await usuario.click(botonConfirmarFinal)
+    await usuario.click(botonConfirmarFinal)
+
+    resolverConfirmar(compraFixture({ estado: 'Confirmada', fechaRecepcion: '2026-08-05T12:00:00Z' }))
+    await screen.findByText('Compra confirmada: el stock y el costo ya se actualizaron.')
+
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/compras/1/confirmar')
+    expect(llamadas).toHaveLength(1)
+  })
+
+  it('un 400 compra_incompleta_para_confirmar se renderiza de forma accionable en el panel', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/confirmar') {
+        return Promise.reject(
+          new ErrorApi(400, 'compra_incompleta_para_confirmar', 'La compra necesita número de comprobante y fecha para confirmarse.'),
+        )
+      }
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar compra' }))
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero confirmar esta compra/))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar' }))
+
+    expect(await screen.findByText('La compra necesita número de comprobante y fecha para confirmarse.')).toBeInTheDocument()
+  })
+})
+
+describe('CompraEditor — compra confirmada', () => {
+  it('muestra los items de solo lectura con el precio sugerido, sin grilla editable', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    renderEditor()
+
+    await screen.findByText('Fideos 500g')
+    expect(screen.queryByLabelText('Costo unitario')).not.toBeInTheDocument()
+    expect(screen.getByText('$114,95')).toBeInTheDocument() // precio sugerido
+    expect(screen.getByRole('button', { name: 'Anular compra' })).toBeInTheDocument()
+  })
+
+  it('anular: reporta honestamente los gastos ligados colgados, y un doble click manda un solo POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    let resolverAnular: (valor: ResultadoAnulacion) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/anular') return new Promise((resolve) => (resolverAnular = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByRole('button', { name: 'Anular compra' })
+    await usuario.click(screen.getByRole('button', { name: 'Anular compra' }))
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero anular esta compra/))
+
+    const botonAnularFinal = screen.getByRole('button', { name: 'Anular' })
+    await usuario.click(botonAnularFinal)
+    await usuario.click(botonAnularFinal)
+
+    resolverAnular({ compra: compraFixture({ estado: 'Anulada' }), gastosLigados: 2 })
+    expect(await screen.findByText(/Quedan 2 gasto\(s\) ligado\(s\)/)).toBeInTheDocument()
+
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/compras/1/anular')
+    expect(llamadas).toHaveLength(1)
+  })
+
+  it('el refusal por stock negativo (409 compra_anulacion_stock_negativo) se muestra claro, nombrando el artículo', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/anular') {
+        return Promise.reject(
+          new ErrorApi(409, 'compra_anulacion_stock_negativo', 'El artículo 10 quedaría con stock negativo al anular esta compra.'),
+        )
+      }
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByRole('button', { name: 'Anular compra' })
+    await usuario.click(screen.getByRole('button', { name: 'Anular compra' }))
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero anular esta compra/))
+    await usuario.click(screen.getByRole('button', { name: 'Anular' }))
+
+    expect(await screen.findByText('El artículo 10 quedaría con stock negativo al anular esta compra.')).toBeInTheDocument()
+  })
+
+  it('aplicar precio sugerido: éxito parcial por línea, un 2xx nunca se reporta como fallo', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture({ estado: 'Confirmada' })) : undefined))
+    const resultados: ResultadoAplicarPrecio[] = [{ idArticulo: 10, aplicado: true, precio: 114.95, error: null }]
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras/1/precios') return Promise.resolve(resultados)
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByLabelText('Lista de precios')
+    await usuario.selectOptions(screen.getByLabelText('Lista de precios'), '1')
+    await usuario.click(screen.getByRole('button', { name: 'Aplicar' }))
+
+    expect(await screen.findByText('Precios aplicados — revisá el detalle por línea abajo.')).toBeInTheDocument()
+    expect(screen.getByText('Aplicado')).toBeInTheDocument()
+
+    const [, cuerpo] = apiPostMock.mock.calls.find((call: unknown[]) => call[0] === '/compras/1/precios') as [string, Record<string, unknown>]
+    expect(cuerpo).toEqual({ idListaPrecio: 1, confirmarReemplazo: false })
+  })
+})
+
+describe('CompraEditor — compra nueva', () => {
+  it('crear borrador manda un POST con el header completo y los items completos únicamente', async () => {
+    mockearReferencia()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras') return Promise.resolve(compraFixture({ id: 99 }))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor('nueva')
+    await screen.findByLabelText('Proveedor')
+
+    await usuario.selectOptions(screen.getByLabelText('Proveedor'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Tipo'), '5')
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '2')
+
+    await usuario.click(screen.getByRole('button', { name: 'Crear borrador' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledTimes(1))
+    const [ruta, cuerpo] = apiPostMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(ruta).toBe('/compras')
+    expect(cuerpo).toMatchObject({ idProveedor: 1, idTipoComprobante: 5, idPuntoVenta: 2, items: [] })
+  })
+
+  it('un 409 compra_duplicada al crear se muestra sin navegar (sigue en modo nuevo)', async () => {
+    mockearReferencia()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/compras') return Promise.reject(new ErrorApi(409, 'compra_duplicada', 'Ya existe una compra con ese número.'))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor('nueva')
+    await screen.findByLabelText('Proveedor')
+    await usuario.selectOptions(screen.getByLabelText('Proveedor'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Tipo'), '5')
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '2')
+    await usuario.click(screen.getByRole('button', { name: 'Crear borrador' }))
+
+    expect(await screen.findByText('Ya existe una compra con ese número.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Crear borrador' })).toBeInTheDocument()
+  })
+})
+
+describe('CompraEditor — role gating', () => {
+  it('un Vendedor ve el borrador de solo lectura, sin acciones de escritura', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+
+    expect(screen.queryByRole('button', { name: 'Guardar borrador' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Confirmar compra' })).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Proveedor')).toBeDisabled()
+    expect(screen.getByLabelText('Costo unitario')).toBeDisabled()
+  })
+})
+
+describe('CompraEditor — referencia fallida', () => {
+  it('un fallo al cargar proveedores/tipos/alícuotas/puntos de venta muestra un aviso y bloquea el guardado', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta.startsWith('/proveedores')) return Promise.reject(new Error('caído'))
+      if (ruta === '/catalogos-fiscales/tipos-comprobante') return Promise.resolve([tipoFixture()])
+      if (ruta === '/catalogos-fiscales/alicuotas-iva') return Promise.resolve([alicuotaFixture()])
+      if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+      if (ruta === '/catalogos/listas-precio') return Promise.resolve([listaPrecioFixture()])
+      if (ruta === '/compras/1') return Promise.resolve(compraFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+
+    renderEditor()
+
+    expect(await screen.findByText(/No se pudieron cargar los proveedores\./)).toBeInTheDocument()
+    await screen.findByDisplayValue('0003-00012345')
+    expect(screen.getByRole('button', { name: 'Guardar borrador' })).toBeDisabled()
+  })
+})
+
+describe('CompraEditor — carga inicial', () => {
+  it('muestra el spinner mientras el detalle está en vuelo y lo reemplaza por el formulario al resolver', async () => {
+    let resolverGet: (valor: CompraDetalle) => void = () => {}
+    mockearReferencia((ruta) => {
+      if (ruta === '/compras/1') return new Promise((resolve) => (resolverGet = resolve))
+      return undefined
+    })
+
+    renderEditor()
+    await screen.findByText('Cargando…')
+
+    resolverGet(compraFixture())
+    await waitFor(() => expect(screen.queryByText('Cargando…')).not.toBeInTheDocument())
+    expect(await screen.findByDisplayValue('0003-00012345')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -6,6 +6,7 @@ import {
   clienteDeCompras,
   etiquetaDeEstadoCompra,
   itemAFormulario,
+  lineaCompletaParaEnvio,
   lineaDeCompraVacia,
   lineaFormularioACalculo,
   lineaConDescuentoInvalido,
@@ -155,15 +156,17 @@ function FilaDeItem({ linea, alicuotas, disabled, discriminaIva, porcentajePorAl
   const calculo = lineaFormularioACalculo(linea, porcentajePorAlicuota)
   const item = calcularTotalesDeCompra([calculo], discriminaIva).items[0]
   const descuentoInvalido = lineaConDescuentoInvalido(calculo)
+  const incompleta = !lineaCompletaParaEnvio(linea)
 
   return (
-    <tr>
+    <tr className={incompleta ? 'table-warning text-muted' : undefined}>
       <td style={{ minWidth: 220 }}>
         <SelectorDeArticulo
           descripcion={linea.descripcion}
           disabled={disabled}
           onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
         />
+        {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
       </td>
       <td style={{ width: 90 }}>
         <input
@@ -319,9 +322,10 @@ type PropsPanelAplicarPrecios = {
   disabled: boolean
   onAntesDeEscribir: () => void
   onAplicado: (resultados: ResultadoAplicarPrecio[]) => void
+  onError: () => void
 }
 
-function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, onAplicado }: PropsPanelAplicarPrecios) {
+function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, onAplicado, onError }: PropsPanelAplicarPrecios) {
   const [idListaPrecio, setIdListaPrecio] = useState<number | ''>(listas[0]?.id ?? '')
   const [confirmarReemplazo, setConfirmarReemplazo] = useState(false)
   const [aplicando, setAplicando] = useState(false)
@@ -340,6 +344,9 @@ function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, on
     aplicandoRef.current = true
     setAplicando(true)
     setError('')
+    // El flag de "en vuelo" también se levanta en el padre (`aplicandoPrecios`, plegado en
+    // `ocupado`): mientras esta escritura está en curso, anular (y cualquier otra acción que la
+    // pudiera supersedear) queda bloqueado — regla 9, gate simétrico con anulando.
     onAntesDeEscribir()
 
     try {
@@ -355,6 +362,7 @@ function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, on
       aplicandoRef.current = false
       setAplicando(false)
       setError(e instanceof ErrorApi ? e.message : 'No se pudo aplicar el precio sugerido.')
+      onError()
     }
   }
 
@@ -558,9 +566,14 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
   const tipoSeleccionado = (tipos ?? []).find((t) => t.id === encabezado.idTipoComprobante) ?? null
   const discriminaIva = tipoSeleccionado?.discriminaIva ?? false
 
+  // El mirror de totales se calcula SOLO sobre las líneas completas (`lineaCompletaParaEnvio`):
+  // es la misma fuente de verdad que decide qué líneas viajan en `aSolicitudDeCompra` — una fila a
+  // medio llenar nunca debe sumar al Subtotal en pantalla, porque tampoco se va a guardar.
+  const lineasCompletas = useMemo(() => lineas.filter(lineaCompletaParaEnvio), [lineas])
+  const lineasIncompletas = lineas.length - lineasCompletas.length
   const calculo = useMemo(
-    () => lineas.map((l) => lineaFormularioACalculo(l, porcentajePorAlicuota)),
-    [lineas, porcentajePorAlicuota],
+    () => lineasCompletas.map((l) => lineaFormularioACalculo(l, porcentajePorAlicuota)),
+    [lineasCompletas, porcentajePorAlicuota],
   )
   const totales = useMemo(() => calcularTotalesDeCompra(calculo, discriminaIva), [calculo, discriminaIva])
 
@@ -582,7 +595,12 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
   const [errorAnular, setErrorAnular] = useState('')
   const [resultadoAnulacion, setResultadoAnulacion] = useState<ResultadoAnulacion | null>(null)
 
-  const ocupado = guardando || confirmando || anulando
+  // El panel de aplicar precio sugerido es local a `PanelAplicarPrecios`, pero su "en vuelo" se
+  // levanta acá (regla 9): sin esto, `ocupado` no lo ve y anular puede dispararse con un aplicar
+  // todavía en curso — el gate queda asimétrico.
+  const [aplicandoPrecios, setAplicandoPrecios] = useState(false)
+
+  const ocupado = guardando || confirmando || anulando || aplicandoPrecios
 
   function cambiarLinea(clave: number, cambios: Partial<LineaDeCompraFormulario>) {
     if (ocupado) return
@@ -920,6 +938,12 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
               </div>
             </div>
 
+            {lineasIncompletas > 0 && (
+              <div className="alert alert-warning rounded-0 py-1 px-2 small mb-3">
+                {lineasIncompletas} línea(s) incompleta(s) — no se van a guardar.
+              </div>
+            )}
+
             <div className="d-flex gap-2 mb-3">
               {puedeEscribir && (
                 <button type="button" className="btn btn-primary rounded-0" disabled={!puedeGuardar} onClick={guardarBorrador}>
@@ -1069,10 +1093,13 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
                       disabled={ocupado}
                       onAntesDeEscribir={() => {
                         generacionRef.current += 1
+                        setAplicandoPrecios(true)
                       }}
                       onAplicado={() => {
+                        setAplicandoPrecios(false)
                         setAviso('Precios aplicados — revisá el detalle por línea abajo.')
                       }}
+                      onError={() => setAplicandoPrecios(false)}
                     />
                   )}
                 </>
@@ -1088,8 +1115,10 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
 /**
  * Editor de un comprobante de compra (stage-8-compras-transferencias-inventario, Slice 5, design:
  * Web Composition): `/compras/nueva` crea un borrador desde cero; `/compras/:id` lo edita
- * (borrador), lo confirma/anula (confirmada) o solo lo muestra (anulada). Ruta Admin-only end to
- * end (design: "no stage-7 nav/policy mismatch") — `GestionDeCatalogo` es la autoridad real.
+ * (borrador), lo confirma/anula (confirmada) o solo lo muestra (anulada). La ruta sigue
+ * `Politicas.OperacionDePos` (decisión 11: la lectura queda abierta a Vendedor/Supervisor/Admin,
+ * igual que `/clientes/:id/cuenta-corriente`) — `puedeEscribir` oculta las acciones de escritura,
+ * `GestionDeCatalogo` es la autoridad real del lado del servidor.
  */
 export function CompraEditor() {
   const { id } = useParams<{ id: string }>()

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -685,6 +685,7 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
 
   async function anular() {
     // regla 9: guard de reentrancia de primera línea.
+    if (ocupado) return
     if (anulandoRef.current) return
     if (!confirmadoParaAnular || idCompra === null) return
 
@@ -1077,7 +1078,7 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
                         <button
                           type="button"
                           className="btn btn-danger rounded-0"
-                          disabled={!confirmadoParaAnular || anulando}
+                          disabled={!confirmadoParaAnular || ocupado}
                           onClick={anular}
                         >
                           {anulando ? 'Anulando…' : 'Anular'}

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -1,0 +1,1114 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import {
+  aSolicitudDeCompra,
+  calcularTotalesDeCompra,
+  clienteDeCompras,
+  etiquetaDeEstadoCompra,
+  itemAFormulario,
+  lineaDeCompraVacia,
+  lineaFormularioACalculo,
+  lineaConDescuentoInvalido,
+  type EncabezadoDeCompraFormulario,
+  type LineaDeCompraFormulario,
+} from '../api/compras'
+import { clienteDeArticulos } from '../api/articulos'
+import { clienteDeCatalogosFiscales } from '../api/catalogos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDePrecios } from '../api/precios'
+import { ROL } from '../api/tipos'
+import type {
+  AlicuotaIvaListado,
+  ArticuloListado,
+  CompraDetalle,
+  ListaPrecioListado,
+  PaginaDe,
+  ProveedorListado,
+  PuntoVentaListado,
+  ResultadoAnulacion,
+  ResultadoAplicarPrecio,
+  TipoComprobanteListado,
+} from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleString('es-AR') : '—'
+}
+
+function encabezadoVacio(): EncabezadoDeCompraFormulario {
+  return { idProveedor: '', idTipoComprobante: '', idPuntoVenta: '', numeroExterno: '', fechaComprobante: '', observaciones: '' }
+}
+
+function encabezadoDesdeDetalle(c: CompraDetalle): EncabezadoDeCompraFormulario {
+  return {
+    idProveedor: c.idProveedor,
+    idTipoComprobante: c.idTipoComprobante,
+    idPuntoVenta: c.idPuntoVenta,
+    numeroExterno: c.numeroExterno ?? '',
+    fechaComprobante: c.fechaComprobante ?? '',
+    observaciones: c.observaciones ?? '',
+  }
+}
+
+// ---- Selector de artículo por búsqueda (search-as-you-type, propio de cada fila) --------------
+
+type PropsSelectorDeArticulo = {
+  descripcion: string
+  disabled: boolean
+  onElegir: (articulo: ArticuloListado) => void
+}
+
+function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDeArticulo) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (termino.trim().length < 2) {
+      setResultados([])
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setBuscando(true)
+
+    const temporizador = setTimeout(() => {
+      clienteDeArticulos
+        .listar(termino, false)
+        .then((pagina) => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados(pagina.items)
+        })
+        .catch(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados([])
+        })
+        .finally(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setBuscando(false)
+        })
+    }, 300)
+
+    return () => {
+      vigente = false
+      clearTimeout(temporizador)
+    }
+  }, [termino])
+
+  return (
+    <div className="position-relative">
+      <input
+        type="text"
+        className="form-control form-control-sm rounded-0"
+        placeholder="Buscar artículo…"
+        value={termino}
+        disabled={disabled}
+        onChange={(e) => setTermino(e.target.value)}
+      />
+      {descripcion && <div className="small text-muted">Elegido: {descripcion}</div>}
+      {buscando && <div className="small text-muted">Buscando…</div>}
+      {!buscando && resultados.length > 0 && (
+        <div className="list-group position-absolute w-100" style={{ zIndex: 10 }}>
+          {resultados.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="list-group-item list-group-item-action py-1 px-2 small"
+              onClick={() => {
+                onElegir(a)
+                setTermino('')
+                setResultados([])
+              }}
+            >
+              {a.codigoInterno} — {a.nombre}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Fila editable del grid de items -----------------------------------------------------------
+
+type PropsFilaDeItem = {
+  linea: LineaDeCompraFormulario
+  alicuotas: AlicuotaIvaListado[]
+  disabled: boolean
+  discriminaIva: boolean
+  porcentajePorAlicuota: Record<number, number>
+  onCambio: (clave: number, cambios: Partial<LineaDeCompraFormulario>) => void
+  onQuitar: (clave: number) => void
+}
+
+function FilaDeItem({ linea, alicuotas, disabled, discriminaIva, porcentajePorAlicuota, onCambio, onQuitar }: PropsFilaDeItem) {
+  const calculo = lineaFormularioACalculo(linea, porcentajePorAlicuota)
+  const item = calcularTotalesDeCompra([calculo], discriminaIva).items[0]
+  const descuentoInvalido = lineaConDescuentoInvalido(calculo)
+
+  return (
+    <tr>
+      <td style={{ minWidth: 220 }}>
+        <SelectorDeArticulo
+          descripcion={linea.descripcion}
+          disabled={disabled}
+          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
+        />
+      </td>
+      <td style={{ width: 90 }}>
+        <input
+          type="number"
+          step="0.001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Unidades"
+          value={linea.unidades}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { unidades: e.target.value })}
+        />
+      </td>
+      <td style={{ width: 80 }}>
+        <input
+          type="number"
+          step="1"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Bultos"
+          value={linea.bultos}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { bultos: e.target.value })}
+        />
+      </td>
+      <td style={{ width: 100 }}>
+        <input
+          type="number"
+          step="0.001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Unidades por bulto"
+          value={linea.unidadesPorBulto}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { unidadesPorBulto: e.target.value })}
+        />
+      </td>
+      <td style={{ width: 110 }}>
+        <input
+          type="number"
+          step="0.0001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Costo unitario"
+          value={linea.costoUnitario}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { costoUnitario: e.target.value })}
+        />
+      </td>
+      <td style={{ width: 100 }}>
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          className={`form-control form-control-sm rounded-0 ${descuentoInvalido ? 'is-invalid' : ''}`}
+          aria-label="Descuento"
+          value={linea.descuento}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { descuento: e.target.value })}
+        />
+        {descuentoInvalido && <div className="invalid-feedback">Mayor al bruto de la línea.</div>}
+      </td>
+      <td style={{ width: 100 }}>
+        <select
+          className="form-select form-select-sm rounded-0"
+          aria-label="Alícuota de IVA"
+          value={linea.idAlicuotaIva}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { idAlicuotaIva: e.target.value === '' ? '' : Number(e.target.value) })}
+        >
+          <option value="">Elegir…</option>
+          {alicuotas.map((al) => (
+            <option key={al.id} value={al.id}>
+              {al.nombre}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="text-center" style={{ width: 60 }}>
+        <input
+          type="checkbox"
+          className="form-check-input rounded-0"
+          aria-label="Actualiza costo"
+          checked={linea.actualizaCosto}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { actualizaCosto: e.target.checked })}
+        />
+      </td>
+      <td className="text-end">{formatearMoneda(item.total)}</td>
+      <td>
+        <button
+          type="button"
+          className="btn btn-outline-danger btn-sm rounded-0"
+          disabled={disabled}
+          onClick={() => onQuitar(linea.clave)}
+        >
+          Quitar
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+// ---- Tabla de items de solo lectura (compra confirmada/anulada) -------------------------------
+
+function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
+  return (
+    <div className="table-responsive">
+      <table className="table table-sm table-striped table-bordered align-middle">
+        <thead>
+          <tr>
+            <th>Artículo</th>
+            <th className="text-end">Cantidad</th>
+            <th className="text-end">Costo unitario</th>
+            <th className="text-end">Descuento</th>
+            <th className="text-end">IVA %</th>
+            <th className="text-end">Total</th>
+            <th>Actualiza costo</th>
+            <th className="text-end">Precio sugerido</th>
+          </tr>
+        </thead>
+        <tbody>
+          {compra.items.map((item) => (
+            <tr key={item.orden}>
+              <td>{item.descripcion}</td>
+              <td className="text-end">{item.cantidad}</td>
+              <td className="text-end">{formatearMoneda(item.costoUnitario)}</td>
+              <td className="text-end">{formatearMoneda(item.descuento)}</td>
+              <td className="text-end">{item.porcentajeIva}%</td>
+              <td className="text-end">{formatearMoneda(item.total)}</td>
+              <td>{item.actualizaCosto ? 'Sí' : 'No'}</td>
+              <td className="text-end">{item.precioSugerido === null ? '—' : formatearMoneda(item.precioSugerido)}</td>
+            </tr>
+          ))}
+          {compra.items.length === 0 && (
+            <tr>
+              <td colSpan={8} className="text-center text-muted py-3">
+                Esta compra no tiene items.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ---- Panel de aplicar precio sugerido ----------------------------------------------------------
+
+type PropsPanelAplicarPrecios = {
+  idCompra: number
+  listas: ListaPrecioListado[]
+  disabled: boolean
+  onAntesDeEscribir: () => void
+  onAplicado: (resultados: ResultadoAplicarPrecio[]) => void
+}
+
+function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, onAplicado }: PropsPanelAplicarPrecios) {
+  const [idListaPrecio, setIdListaPrecio] = useState<number | ''>(listas[0]?.id ?? '')
+  const [confirmarReemplazo, setConfirmarReemplazo] = useState(false)
+  const [aplicando, setAplicando] = useState(false)
+  const aplicandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [resultados, setResultados] = useState<ResultadoAplicarPrecio[] | null>(null)
+
+  async function aplicar() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (aplicandoRef.current) return
+    if (idListaPrecio === '') {
+      setError('Elegí una lista de precios.')
+      return
+    }
+
+    aplicandoRef.current = true
+    setAplicando(true)
+    setError('')
+    onAntesDeEscribir()
+
+    try {
+      const resultado = await clienteDeCompras.aplicarPrecios(idCompra, { idListaPrecio, confirmarReemplazo })
+      aplicandoRef.current = false
+      setAplicando(false)
+      setResultados(resultado)
+      // regla 6: un 2xx nunca se reporta como fallo — incluso si alguna línea individual vino con
+      // `aplicado: false`, la respuesta 2xx en sí es un éxito de la operación (partial success es
+      // el contrato honesto, design decisión 8).
+      onAplicado(resultado)
+    } catch (e) {
+      aplicandoRef.current = false
+      setAplicando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo aplicar el precio sugerido.')
+    }
+  }
+
+  return (
+    <div className="border p-3 mt-3">
+      <strong>Aplicar precio sugerido</strong>
+      {error && <div className="alert alert-danger rounded-0 py-1 px-2 small mt-2">{error}</div>}
+      <div className="row g-2 align-items-end mt-1">
+        <div className="col-md-4">
+          <label className="form-label" htmlFor="compra-lista-precio">
+            Lista de precios
+          </label>
+          <select
+            id="compra-lista-precio"
+            className="form-select rounded-0"
+            value={idListaPrecio}
+            disabled={disabled || aplicando}
+            onChange={(e) => setIdListaPrecio(e.target.value === '' ? '' : Number(e.target.value))}
+          >
+            <option value="">Elegir…</option>
+            {listas.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.nombre}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="col-md-5">
+          <div className="form-check">
+            <input
+              id="compra-confirmar-reemplazo"
+              type="checkbox"
+              className="form-check-input rounded-0"
+              checked={confirmarReemplazo}
+              disabled={disabled || aplicando}
+              onChange={(e) => setConfirmarReemplazo(e.target.checked)}
+            />
+            <label className="form-check-label" htmlFor="compra-confirmar-reemplazo">
+              Confirmar reemplazo de un precio pendiente existente
+            </label>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <button type="button" className="btn btn-primary rounded-0 w-100" disabled={disabled || aplicando} onClick={aplicar}>
+            {aplicando ? 'Aplicando…' : 'Aplicar'}
+          </button>
+        </div>
+      </div>
+
+      {resultados && (
+        <table className="table table-sm table-bordered mt-3 mb-0">
+          <thead>
+            <tr>
+              <th>Artículo</th>
+              <th>Resultado</th>
+              <th className="text-end">Precio</th>
+            </tr>
+          </thead>
+          <tbody>
+            {resultados.map((r) => (
+              <tr key={r.idArticulo}>
+                <td>#{r.idArticulo}</td>
+                <td>{r.aplicado ? 'Aplicado' : (r.error ?? 'No aplicado')}</td>
+                <td className="text-end">{r.precio === null ? '—' : formatearMoneda(r.precio)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+// ---- Pantalla principal -------------------------------------------------------------------------
+
+type PropsPantalla = { idCompra: number | null }
+
+/** Remontada por `key={idCompra ?? 'nuevo'}` (react-async-state regla 8) — ningún estado de acá
+ * (borrador en edición, paneles de confirmar/anular) sobrevive a un cambio de compra. */
+function PantallaCompraEditor({ idCompra }: PropsPantalla) {
+  const navigate = useNavigate()
+  const { usuario } = useAuth()
+  const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
+
+  const esNuevo = idCompra === null
+
+  // ---- referencia (proveedores/tipos/alícuotas/puntos de venta/listas) ------------------------
+  const [proveedores, setProveedores] = useState<ProveedorListado[] | null>(null)
+  const [tipos, setTipos] = useState<TipoComprobanteListado[] | null>(null)
+  const [alicuotas, setAlicuotas] = useState<AlicuotaIvaListado[] | null>(null)
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [listasPrecio, setListasPrecio] = useState<ListaPrecioListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    const marcarError = (mensaje: string) => {
+      if (vigente) setErrorReferencia((prev) => (prev ? `${prev} ${mensaje}` : mensaje))
+    }
+
+    api
+      .get<PaginaDe<ProveedorListado>>('/proveedores?tamanio=200')
+      .then((p) => vigente && setProveedores(p.items))
+      .catch(() => {
+        setProveedores([])
+        marcarError('No se pudieron cargar los proveedores.')
+      })
+
+    clienteDeCatalogosFiscales
+      .tiposComprobante()
+      .then((lista) => vigente && setTipos(lista.filter((t) => t.clase === 'Compra' && t.activo)))
+      .catch(() => {
+        setTipos([])
+        marcarError('No se pudieron cargar los tipos de comprobante.')
+      })
+
+    clienteDeCatalogosFiscales
+      .alicuotasIva()
+      .then((lista) => vigente && setAlicuotas(lista))
+      .catch(() => {
+        setAlicuotas([])
+        marcarError('No se pudieron cargar las alícuotas de IVA.')
+      })
+
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => vigente && setPuntosVenta(lista))
+      .catch(() => {
+        setPuntosVenta([])
+        marcarError('No se pudieron cargar los puntos de venta.')
+      })
+
+    clienteDePrecios
+      .listasDePrecio()
+      .then((lista) => vigente && setListasPrecio(lista.filter((l) => l.activo)))
+      .catch(() => {
+        setListasPrecio([])
+        // La lista de precios solo hace falta para "aplicar precio sugerido" — no bloquea el
+        // resto de la pantalla, a diferencia de proveedores/tipos/alícuotas/puntos de venta.
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const referenciaLista = proveedores !== null && tipos !== null && alicuotas !== null && puntosVenta !== null
+  const referenciaOk = referenciaLista && errorReferencia === ''
+
+  const porcentajePorAlicuota = useMemo(() => {
+    const indice: Record<number, number> = {}
+    for (const a of alicuotas ?? []) indice[a.id] = a.porcentaje
+    return indice
+  }, [alicuotas])
+
+  // ---- carga de la compra existente (edición) --------------------------------------------------
+  const [compra, setCompra] = useState<CompraDetalle | null>(null)
+  const [cargandoCompra, setCargandoCompra] = useState(!esNuevo)
+  const [errorCompra, setErrorCompra] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (esNuevo || idCompra === null) return
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setCargandoCompra(true)
+    setErrorCompra('')
+
+    clienteDeCompras
+      .obtener(idCompra)
+      .then((detalle) => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setCompra(detalle)
+      })
+      .catch((e) => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setCompra(null)
+        setErrorCompra(e instanceof ErrorApi ? e.message : 'No se pudo cargar la compra.')
+      })
+      .finally(() => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setCargandoCompra(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [esNuevo, idCompra])
+
+  // ---- formulario editable (nuevo o borrador existente) ------------------------------------------
+  const [encabezado, setEncabezado] = useState<EncabezadoDeCompraFormulario>(encabezadoVacio())
+  const proximaClaveRef = useRef(1)
+  const [lineas, setLineas] = useState<LineaDeCompraFormulario[]>([])
+
+  useEffect(() => {
+    if (compra === null) return
+    setEncabezado(encabezadoDesdeDetalle(compra))
+    setLineas(compra.items.map((item) => itemAFormulario(proximaClaveRef.current++, item)))
+  }, [compra])
+
+  const tipoSeleccionado = (tipos ?? []).find((t) => t.id === encabezado.idTipoComprobante) ?? null
+  const discriminaIva = tipoSeleccionado?.discriminaIva ?? false
+
+  const calculo = useMemo(
+    () => lineas.map((l) => lineaFormularioACalculo(l, porcentajePorAlicuota)),
+    [lineas, porcentajePorAlicuota],
+  )
+  const totales = useMemo(() => calcularTotalesDeCompra(calculo, discriminaIva), [calculo, discriminaIva])
+
+  const [guardando, setGuardando] = useState(false)
+  const guardandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [aviso, setAviso] = useState('')
+
+  const [confirmando, setConfirmando] = useState(false)
+  const confirmandoRef = useRef(false)
+  const [panelConfirmarAbierto, setPanelConfirmarAbierto] = useState(false)
+  const [confirmadoParaConfirmar, setConfirmadoParaConfirmar] = useState(false)
+  const [errorConfirmar, setErrorConfirmar] = useState('')
+
+  const [anulando, setAnulando] = useState(false)
+  const anulandoRef = useRef(false)
+  const [panelAnularAbierto, setPanelAnularAbierto] = useState(false)
+  const [confirmadoParaAnular, setConfirmadoParaAnular] = useState(false)
+  const [errorAnular, setErrorAnular] = useState('')
+  const [resultadoAnulacion, setResultadoAnulacion] = useState<ResultadoAnulacion | null>(null)
+
+  const ocupado = guardando || confirmando || anulando
+
+  function cambiarLinea(clave: number, cambios: Partial<LineaDeCompraFormulario>) {
+    if (ocupado) return
+    // regla 1: updater funcional, nunca lee `lineas` del cierre.
+    setLineas((prev) => prev.map((l) => (l.clave === clave ? { ...l, ...cambios } : l)))
+  }
+
+  function agregarLinea() {
+    if (ocupado) return
+    setLineas((prev) => [...prev, lineaDeCompraVacia(proximaClaveRef.current++)])
+  }
+
+  function quitarLinea(clave: number) {
+    if (ocupado) return
+    setLineas((prev) => prev.filter((l) => l.clave !== clave))
+  }
+
+  const encabezadoCompleto = encabezado.idProveedor !== '' && encabezado.idTipoComprobante !== '' && encabezado.idPuntoVenta !== ''
+  const puedeGuardar = referenciaOk && puedeEscribir && encabezadoCompleto && !ocupado
+
+  async function guardarBorrador() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (guardandoRef.current) return
+    if (!puedeGuardar) return
+
+    guardandoRef.current = true
+    setGuardando(true)
+    setError('')
+    setAviso('')
+    // regla 3: bumpear la generación de carga ANTES de la escritura — invalida cualquier GET en
+    // vuelo de la compra que este guardado está a punto de reemplazar.
+    generacionRef.current += 1
+
+    try {
+      const solicitud = aSolicitudDeCompra(encabezado, lineas)
+      if (esNuevo) {
+        const creada = await clienteDeCompras.crear(solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        // Remontaje completo vía cambio de `key` (regla 8): navega a la ruta real de la compra
+        // recién creada, nunca reutiliza este estado de "nuevo" para simular la edición.
+        navigate(`/compras/${creada.id}`, { replace: true })
+      } else if (idCompra !== null) {
+        const actualizada = await clienteDeCompras.actualizar(idCompra, solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        setCompra(actualizada)
+        setAviso('Borrador guardado.')
+      }
+    } catch (e) {
+      guardandoRef.current = false
+      setGuardando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el borrador.')
+    }
+  }
+
+  async function confirmar() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (confirmandoRef.current) return
+    if (!confirmadoParaConfirmar || idCompra === null) return
+
+    confirmandoRef.current = true
+    setConfirmando(true)
+    setErrorConfirmar('')
+    generacionRef.current += 1
+
+    try {
+      const confirmada = await clienteDeCompras.confirmar(idCompra)
+      confirmandoRef.current = false
+      setConfirmando(false)
+      // regla 6: un 2xx de confirmar nunca se reporta como fallo — la respuesta ES el resultado.
+      setCompra(confirmada)
+      setPanelConfirmarAbierto(false)
+      setConfirmadoParaConfirmar(false)
+      setAviso('Compra confirmada: el stock y el costo ya se actualizaron.')
+    } catch (e) {
+      confirmandoRef.current = false
+      setConfirmando(false)
+      setErrorConfirmar(e instanceof ErrorApi ? e.message : 'No se pudo confirmar la compra.')
+    }
+  }
+
+  async function anular() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (anulandoRef.current) return
+    if (!confirmadoParaAnular || idCompra === null) return
+
+    anulandoRef.current = true
+    setAnulando(true)
+    setErrorAnular('')
+    generacionRef.current += 1
+
+    try {
+      const resultado = await clienteDeCompras.anular(idCompra)
+      anulandoRef.current = false
+      setAnulando(false)
+      // regla 6: un 2xx de anular nunca se reporta como fallo. El stock refusal (409
+      // compra_anulacion_stock_negativo) cae en el catch de abajo, nunca acá.
+      setCompra(resultado.compra)
+      setResultadoAnulacion(resultado)
+      setPanelAnularAbierto(false)
+      setConfirmadoParaAnular(false)
+    } catch (e) {
+      anulandoRef.current = false
+      setAnulando(false)
+      // El refusal por stock negativo (compra_anulacion_stock_negativo) nombra el artículo
+      // ofensivo en `e.message` — se muestra tal cual, sin envolver el mensaje del servidor.
+      setErrorAnular(e instanceof ErrorApi ? e.message : 'No se pudo anular la compra.')
+    }
+  }
+
+  if (!esNuevo && cargandoCompra) {
+    return (
+      <div className="container-fluid py-4">
+        <Cargando />
+      </div>
+    )
+  }
+
+  if (!esNuevo && errorCompra) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Compra" variante="danger">
+          <p className="text-muted">{errorCompra}</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/compras">
+            Volver a compras
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  const esBorrador = esNuevo || compra?.estado === 'Borrador'
+  const esConfirmada = compra?.estado === 'Confirmada'
+  const tienePreciosSugeridos = compra?.items.some((i) => i.precioSugerido !== null) ?? false
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={esNuevo ? 'Nueva compra' : `Compra ${compra?.numeroExterno ?? `#${idCompra}`}`}
+        variante="inverse"
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/compras">
+            Volver a compras
+          </Link>
+        }
+      >
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorReferencia} No se pueden registrar operaciones de compra hasta que esto se resuelva.
+          </div>
+        )}
+
+        {!esNuevo && compra && (
+          <div className="mb-3">
+            <span className={`badge rounded-0 me-2 ${esBorrador ? 'text-bg-secondary' : esConfirmada ? 'text-bg-success' : 'text-bg-danger'}`}>
+              {etiquetaDeEstadoCompra(compra.estado)}
+            </span>
+            {compra.fechaRecepcion && <span className="small text-muted">Recibida: {formatearFechaHora(compra.fechaRecepcion)}</span>}
+          </div>
+        )}
+
+        <div className="row g-2 mb-3">
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="compra-proveedor">
+              Proveedor
+            </label>
+            <select
+              id="compra-proveedor"
+              className="form-select rounded-0"
+              value={encabezado.idProveedor}
+              disabled={!esBorrador || ocupado || !referenciaOk || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idProveedor: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(proveedores ?? []).map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.razonSocial}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compra-tipo">
+              Tipo
+            </label>
+            <select
+              id="compra-tipo"
+              className="form-select rounded-0"
+              value={encabezado.idTipoComprobante}
+              disabled={!esBorrador || ocupado || !referenciaOk || !puedeEscribir}
+              onChange={(e) =>
+                setEncabezado((prev) => ({ ...prev, idTipoComprobante: e.target.value === '' ? '' : Number(e.target.value) }))
+              }
+            >
+              <option value="">Elegir…</option>
+              {(tipos ?? []).map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.codigo}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="compra-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="compra-punto-venta"
+              className="form-select rounded-0"
+              value={encabezado.idPuntoVenta}
+              disabled={!esBorrador || ocupado || !referenciaOk || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idPuntoVenta: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compra-numero-externo">
+              Número de comprobante
+            </label>
+            <input
+              id="compra-numero-externo"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.numeroExterno}
+              disabled={!esBorrador || ocupado || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, numeroExterno: e.target.value }))}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compra-fecha-comprobante">
+              Fecha del comprobante
+            </label>
+            <input
+              id="compra-fecha-comprobante"
+              type="date"
+              className="form-control rounded-0"
+              value={encabezado.fechaComprobante}
+              disabled={!esBorrador || ocupado || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, fechaComprobante: e.target.value }))}
+            />
+          </div>
+          <div className="col-12">
+            <label className="form-label" htmlFor="compra-observaciones">
+              Observaciones
+            </label>
+            <input
+              id="compra-observaciones"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.observaciones}
+              disabled={!esBorrador || ocupado || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, observaciones: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        {esBorrador ? (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Artículo</th>
+                    <th>Unidades</th>
+                    <th>Bultos</th>
+                    <th>Un./bulto</th>
+                    <th>Costo unitario</th>
+                    <th>Descuento</th>
+                    <th>IVA</th>
+                    <th>Act. costo</th>
+                    <th className="text-end">Total</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lineas.map((l) => (
+                    <FilaDeItem
+                      key={l.clave}
+                      linea={l}
+                      alicuotas={alicuotas ?? []}
+                      disabled={ocupado || !referenciaOk || !puedeEscribir}
+                      discriminaIva={discriminaIva}
+                      porcentajePorAlicuota={porcentajePorAlicuota}
+                      onCambio={cambiarLinea}
+                      onQuitar={quitarLinea}
+                    />
+                  ))}
+                  {lineas.length === 0 && (
+                    <tr>
+                      <td colSpan={10} className="text-center text-muted py-3">
+                        Todavía no hay items cargados.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {puedeEscribir && (
+              <button
+                type="button"
+                className="btn btn-outline-secondary btn-sm rounded-0 mb-3"
+                disabled={ocupado || !referenciaOk}
+                onClick={agregarLinea}
+              >
+                + Agregar línea
+              </button>
+            )}
+
+            <div className="row g-3 mb-3">
+              <div className="col-md-3">
+                <div className="small text-muted">Subtotal (mirror, no autoritativo)</div>
+                <div>{formatearMoneda(totales.subtotal)}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="small text-muted">Descuento</div>
+                <div>{formatearMoneda(totales.descuentoTotal)}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="small text-muted">IVA</div>
+                <div>{totales.ivaTotal === null ? '—' : formatearMoneda(totales.ivaTotal)}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="small text-muted">Total</div>
+                <div className="fs-6">{formatearMoneda(totales.total)}</div>
+              </div>
+            </div>
+
+            <div className="d-flex gap-2 mb-3">
+              {puedeEscribir && (
+                <button type="button" className="btn btn-primary rounded-0" disabled={!puedeGuardar} onClick={guardarBorrador}>
+                  {guardando ? 'Guardando…' : esNuevo ? 'Crear borrador' : 'Guardar borrador'}
+                </button>
+              )}
+              {!esNuevo && puedeEscribir && (
+                <button
+                  type="button"
+                  className="btn btn-success rounded-0"
+                  disabled={ocupado || !referenciaOk}
+                  onClick={() => setPanelConfirmarAbierto(true)}
+                >
+                  Confirmar compra
+                </button>
+              )}
+            </div>
+
+            {panelConfirmarAbierto && (
+              <div className="border p-3 mb-3">
+                <strong>Confirmar compra</strong>
+                {errorConfirmar && <div className="alert alert-danger rounded-0 py-1 px-2 small mt-2">{errorConfirmar}</div>}
+                <div className="form-check my-2">
+                  <input
+                    id="compra-confirmacion-confirmar"
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={confirmadoParaConfirmar}
+                    disabled={confirmando}
+                    onChange={(e) => setConfirmadoParaConfirmar(e.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="compra-confirmacion-confirmar">
+                    Confirmo que quiero confirmar esta compra. Es irreversible: el stock entra, el costo del artículo
+                    se actualiza y no se puede volver a borrador.
+                  </label>
+                </div>
+                <div className="d-flex gap-2">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary rounded-0"
+                    disabled={confirmando}
+                    onClick={() => {
+                      setPanelConfirmarAbierto(false)
+                      setConfirmadoParaConfirmar(false)
+                    }}
+                  >
+                    Cancelar
+                  </button>
+                  <button type="button" className="btn btn-success rounded-0" disabled={!confirmadoParaConfirmar || confirmando} onClick={confirmar}>
+                    {confirmando ? 'Confirmando…' : 'Confirmar'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          compra && (
+            <>
+              <TablaDeItemsDeSoloLectura compra={compra} />
+
+              <div className="row g-3 my-3">
+                <div className="col-md-3">
+                  <div className="small text-muted">Subtotal</div>
+                  <div>{formatearMoneda(compra.subtotal)}</div>
+                </div>
+                <div className="col-md-3">
+                  <div className="small text-muted">Descuento</div>
+                  <div>{formatearMoneda(compra.descuentoTotal)}</div>
+                </div>
+                <div className="col-md-3">
+                  <div className="small text-muted">IVA</div>
+                  <div>{compra.ivaTotal === null ? '—' : formatearMoneda(compra.ivaTotal)}</div>
+                </div>
+                <div className="col-md-3">
+                  <div className="small text-muted">Total</div>
+                  <div className="fs-6">{formatearMoneda(compra.total)}</div>
+                </div>
+              </div>
+
+              {resultadoAnulacion && (
+                <div className="alert alert-warning rounded-0">
+                  Compra anulada. {resultadoAnulacion.gastosLigados > 0
+                    ? `Quedan ${resultadoAnulacion.gastosLigados} gasto(s) ligado(s) a esta compra sin desvincular — la anulación no los revierte, quedan como historial de un pago ya realizado.`
+                    : 'No había ningún gasto ligado a esta compra.'}
+                </div>
+              )}
+
+              {esConfirmada && puedeEscribir && (
+                <>
+                  <div className="d-flex gap-2 mb-3">
+                    <button
+                      type="button"
+                      className="btn btn-danger rounded-0"
+                      disabled={ocupado}
+                      onClick={() => setPanelAnularAbierto(true)}
+                    >
+                      Anular compra
+                    </button>
+                  </div>
+
+                  {panelAnularAbierto && (
+                    <div className="border p-3 mb-3">
+                      <strong>Anular compra</strong>
+                      {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small mt-2">{errorAnular}</div>}
+                      <div className="form-check my-2">
+                        <input
+                          id="compra-confirmacion-anular"
+                          type="checkbox"
+                          className="form-check-input rounded-0"
+                          checked={confirmadoParaAnular}
+                          disabled={anulando}
+                          onChange={(e) => setConfirmadoParaAnular(e.target.checked)}
+                        />
+                        <label className="form-check-label" htmlFor="compra-confirmacion-anular">
+                          Confirmo que quiero anular esta compra. Es irreversible: se revierte el stock que entró, el
+                          costo del artículo NO se corrige solo (se edita aparte).
+                        </label>
+                      </div>
+                      <div className="d-flex gap-2">
+                        <button
+                          type="button"
+                          className="btn btn-outline-secondary rounded-0"
+                          disabled={anulando}
+                          onClick={() => {
+                            setPanelAnularAbierto(false)
+                            setConfirmadoParaAnular(false)
+                          }}
+                        >
+                          Cancelar
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-danger rounded-0"
+                          disabled={!confirmadoParaAnular || anulando}
+                          onClick={anular}
+                        >
+                          {anulando ? 'Anulando…' : 'Anular'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {tienePreciosSugeridos && listasPrecio && listasPrecio.length > 0 && (
+                    <PanelAplicarPrecios
+                      idCompra={compra.id}
+                      listas={listasPrecio}
+                      disabled={ocupado}
+                      onAntesDeEscribir={() => {
+                        generacionRef.current += 1
+                      }}
+                      onAplicado={() => {
+                        setAviso('Precios aplicados — revisá el detalle por línea abajo.')
+                      }}
+                    />
+                  )}
+                </>
+              )}
+            </>
+          )
+        )}
+      </Box>
+    </div>
+  )
+}
+
+/**
+ * Editor de un comprobante de compra (stage-8-compras-transferencias-inventario, Slice 5, design:
+ * Web Composition): `/compras/nueva` crea un borrador desde cero; `/compras/:id` lo edita
+ * (borrador), lo confirma/anula (confirmada) o solo lo muestra (anulada). Ruta Admin-only end to
+ * end (design: "no stage-7 nav/policy mismatch") — `GestionDeCatalogo` es la autoridad real.
+ */
+export function CompraEditor() {
+  const { id } = useParams<{ id: string }>()
+  const esNuevo = id === undefined || id === 'nueva'
+  const idNumerico = esNuevo ? null : Number(id)
+  const idValido = esNuevo || Number.isFinite(idNumerico)
+
+  if (!idValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Compra" variante="warning">
+          <p className="text-muted">No se especificó una compra válida.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/compras">
+            Volver a compras
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return <PantallaCompraEditor key={idNumerico ?? 'nuevo'} idCompra={idNumerico} />
+}

--- a/src/Ways.Web/src/paginas/Compras.test.tsx
+++ b/src/Ways.Web/src/paginas/Compras.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Compras } from './Compras'
+import { RutaProtegida } from '../auth/RutaProtegida'
 import { ROL } from '../api/tipos'
 import type { CompraListada, PaginaDeCompras, ProveedorListado, SaldoDeProveedor, TipoComprobanteListado, UsuarioAutenticado } from '../api/tipos'
 
@@ -105,6 +106,26 @@ function renderCompras() {
   return render(<Compras />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
 }
 
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/compras` (decisión 11: la lectura
+ * sigue `Politicas.OperacionDePos`) — prueba que el rol realmente llega a la pantalla. */
+function renderComprasProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/compras']}>
+      <Routes>
+        <Route
+          path="/compras"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+              <Compras />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta.startsWith('/proveedores?')) return Promise.resolve({ items: [proveedorFixture()], total: 1, pagina: 1, tamanio: 200 })
@@ -154,6 +175,16 @@ describe('Compras — listado', () => {
     usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
     rerender(<Compras />)
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Nueva compra' })).not.toBeInTheDocument())
+  })
+
+  it('un Vendedor llega a la ruta del listado (decisión 11); un Root queda afuera', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderComprasProtegido()
+
+    expect(await screen.findByText('No hay compras que coincidan con los filtros.')).toBeInTheDocument()
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
   })
 
   it('filtrar por proveedor carga su saldo y muestra el estado de pago por fila', async () => {

--- a/src/Ways.Web/src/paginas/Compras.test.tsx
+++ b/src/Ways.Web/src/paginas/Compras.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Compras } from './Compras'
+import { ROL } from '../api/tipos'
+import type { CompraListada, PaginaDeCompras, ProveedorListado, SaldoDeProveedor, TipoComprobanteListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 1,
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 1,
+    razonSocial: 'Proveedor Uno SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+function tipoFixture(sobrescribir: Partial<TipoComprobanteListado> = {}): TipoComprobanteListado {
+  return {
+    id: 5,
+    clase: 'Compra',
+    codigo: 'C-FA',
+    nombre: 'Factura A de compra',
+    letra: 'A',
+    signo: 1,
+    discriminaIva: true,
+    esFiscal: false,
+    afectaStock: true,
+    codigoAfip: null,
+    activo: true,
+    ...sobrescribir,
+  }
+}
+
+function compraListadaFixture(sobrescribir: Partial<CompraListada> = {}): CompraListada {
+  return {
+    id: 1,
+    idProveedor: 1,
+    idTipoComprobante: 5,
+    numeroExterno: '0003-00012345',
+    estado: 'Confirmada',
+    fechaRecepcion: '2026-08-05T12:00:00Z',
+    total: 1149.5,
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(items: CompraListada[], sobrescribir: Partial<PaginaDeCompras> = {}): PaginaDeCompras {
+  return { items, total: items.length, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function renderCompras() {
+  return render(<Compras />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta.startsWith('/proveedores?')) return Promise.resolve({ items: [proveedorFixture()], total: 1, pagina: 1, tamanio: 200 })
+    if (ruta === '/catalogos-fiscales/tipos-comprobante') return Promise.resolve([tipoFixture()])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/compras?')) return Promise.resolve(paginaFixture([]))
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+describe('Compras — listado', () => {
+  it('un listado vacío muestra un estado vacío, no un re-query', async () => {
+    mockearRutasBase()
+    renderCompras()
+
+    expect(await screen.findByText('No hay compras que coincidan con los filtros.')).toBeInTheDocument()
+    const llamadasAlListado = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/compras?'))
+    expect(llamadasAlListado).toHaveLength(1)
+  })
+
+  it('renderiza las filas del listado con proveedor y tipo resueltos', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/compras?')) return Promise.resolve(paginaFixture([compraListadaFixture()]))
+      return undefined
+    })
+    renderCompras()
+
+    expect(await screen.findByText('0003-00012345')).toBeInTheDocument()
+    const fila = screen.getByRole('row', { name: /0003-00012345/ })
+    expect(within(fila).getByText('Proveedor Uno SA')).toBeInTheDocument()
+    expect(within(fila).getByText('C-FA')).toBeInTheDocument()
+    expect(within(fila).getByText('Confirmada')).toBeInTheDocument()
+  })
+
+  it('Admin ve el botón "Nueva compra"; Vendedor no', async () => {
+    mockearRutasBase()
+    const { rerender } = renderCompras()
+    await screen.findByText('No hay compras que coincidan con los filtros.')
+    expect(screen.getByRole('button', { name: 'Nueva compra' })).toBeInTheDocument()
+
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    rerender(<Compras />)
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Nueva compra' })).not.toBeInTheDocument())
+  })
+
+  it('filtrar por proveedor carga su saldo y muestra el estado de pago por fila', async () => {
+    const saldo: SaldoDeProveedor = {
+      idProveedor: 1,
+      saldo: 500,
+      compras: [{ idComprobanteCompra: 1, numeroExterno: '0003-00012345', total: 1149.5, pagado: 649.5, estadoPago: 'Parcial' }],
+    }
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/compras?')) return Promise.resolve(paginaFixture([compraListadaFixture()]))
+      if (ruta === '/proveedores/1/saldo') return Promise.resolve(saldo)
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderCompras()
+
+    await screen.findByText('0003-00012345')
+    expect(screen.getAllByText('—')[0]).toBeInTheDocument() // sin filtro de proveedor, sin estado de pago todavía
+
+    await usuario.selectOptions(screen.getByLabelText('Proveedor'), '1')
+
+    expect(await screen.findByText('Parcial')).toBeInTheDocument()
+  })
+
+  it('una respuesta de listado desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: PaginaDeCompras) => void = () => {}
+    const primera = new Promise<PaginaDeCompras>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/compras?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(paginaFixture([compraListadaFixture({ id: 2, numeroExterno: 'segunda-respuesta' })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderCompras()
+    await screen.findByLabelText('Estado')
+
+    // Dispara una segunda consulta (estado=Borrador) ANTES de que la primera (sin filtro) resuelva.
+    await usuario.selectOptions(screen.getByLabelText('Estado'), 'Borrador')
+    expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
+
+    // La primera respuesta, ahora obsoleta, resuelve tarde — no debe reemplazar la tabla.
+    resolverPrimera(paginaFixture([compraListadaFixture({ id: 1, numeroExterno: 'primera-respuesta-vieja' })]))
+    await waitFor(() => expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument())
+    expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Compras.tsx
+++ b/src/Ways.Web/src/paginas/Compras.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { clienteDeCompras, etiquetaDeEstadoCompra, filtrosDeComprasVacios, type FiltrosDeCompras } from '../api/compras'
+import { clienteDeCatalogosFiscales } from '../api/catalogos'
+import { api, ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type { CompraListada, EstadoCompra, EstadoPago, PaginaDe, PaginaDeCompras, ProveedorListado, TipoComprobanteListado } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const OPCIONES_ESTADO: { valor: EstadoCompra | ''; etiqueta: string }[] = [
+  { valor: '', etiqueta: 'Todos' },
+  { valor: 'Borrador', etiqueta: 'Borrador' },
+  { valor: 'Confirmada', etiqueta: 'Confirmada' },
+  { valor: 'Anulada', etiqueta: 'Anulada' },
+]
+
+function formatearMoneda(valor: number): string {
+  return `$${valor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFecha(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleDateString('es-AR') : '—'
+}
+
+function etiquetaDeEstadoPago(estado: EstadoPago): string {
+  switch (estado) {
+    case 'Pagada':
+      return 'Pagada'
+    case 'Parcial':
+      return 'Parcial'
+    case 'Impaga':
+      return 'Impaga'
+  }
+}
+
+function claseDeBadgeDeEstado(estado: EstadoCompra): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'text-bg-secondary'
+    case 'Confirmada':
+      return 'text-bg-success'
+    case 'Anulada':
+      return 'text-bg-danger'
+  }
+}
+
+/**
+ * Listado de comprobantes de compra (stage-8-compras-transferencias-inventario, Slice 5, design:
+ * Web Composition): filtros proveedor/estado/fecha, estado de pago por fila (solo cuando el
+ * listado está filtrado por un proveedor puntual — el endpoint de saldo es por-proveedor, el
+ * panel completo con su propio estado lo construye `Proveedores.tsx` en la Slice 6) y entrada al
+ * editor de borrador. Ruta Admin-only end to end (design: "no stage-7 nav/policy mismatch") —
+ * `puedeEscribir` queda como defensa en profundidad cosmética, la política real es
+ * `GestionDeCatalogo` del lado del servidor.
+ */
+export function Compras() {
+  const { usuario } = useAuth()
+  const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
+  const navigate = useNavigate()
+
+  const [proveedores, setProveedores] = useState<ProveedorListado[] | null>(null)
+  const [errorProveedores, setErrorProveedores] = useState('')
+
+  const [tipos, setTipos] = useState<TipoComprobanteListado[] | null>(null)
+
+  const [filtros, setFiltros] = useState<FiltrosDeCompras>(filtrosDeComprasVacios())
+
+  const [pagina, setPagina] = useState<PaginaDeCompras | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  const [estadosPago, setEstadosPago] = useState<Record<number, EstadoPago>>({})
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PaginaDe<ProveedorListado>>('/proveedores?tamanio=200')
+      .then((p) => {
+        if (!vigente) return
+        setProveedores(p.items)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setProveedores([])
+        setErrorProveedores(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los proveedores.')
+      })
+
+    clienteDeCatalogosFiscales
+      .tiposComprobante()
+      .then((lista) => {
+        if (!vigente) return
+        setTipos(lista.filter((t) => t.clase === 'Compra'))
+      })
+      .catch(() => {
+        if (vigente) setTipos([])
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // regla 2: cada cambio de filtro dispara una nueva consulta — una respuesta desactualizada
+  // nunca puede pisar la más reciente.
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeCompras
+      .listar(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las compras.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  useEffect(() => {
+    setEstadosPago({})
+    if (filtros.idProveedor === null) return
+
+    let vigente = true
+    clienteDeCompras
+      .obtenerSaldoDeProveedor(filtros.idProveedor)
+      .then((saldo) => {
+        if (!vigente) return
+        const indice: Record<number, EstadoPago> = {}
+        for (const c of saldo.compras) indice[c.idComprobanteCompra] = c.estadoPago
+        setEstadosPago(indice)
+      })
+      .catch(() => {
+        // El estado de pago es un enriquecimiento, no un dato crítico del listado — una falla acá
+        // no bloquea la tabla, la columna simplemente queda vacía para esas filas.
+        if (vigente) setEstadosPago({})
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [filtros.idProveedor])
+
+  const proveedorPorId = useMemo(() => {
+    const indice: Record<number, ProveedorListado> = {}
+    for (const p of proveedores ?? []) indice[p.id] = p
+    return indice
+  }, [proveedores])
+
+  const tipoPorId = useMemo(() => {
+    const indice: Record<number, TipoComprobanteListado> = {}
+    for (const t of tipos ?? []) indice[t.id] = t
+    return indice
+  }, [tipos])
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeCompras, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  function crearBorrador() {
+    navigate('/compras/nueva')
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  const herramientas = puedeEscribir ? (
+    <nav className="p-2 d-flex gap-2">
+      <button type="button" className="btn btn-sm btn-success rounded-0 text-nowrap" onClick={crearBorrador}>
+        Nueva compra
+      </button>
+    </nav>
+  ) : undefined
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Compras" variante="inverse" herramientas={herramientas}>
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorProveedores && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorProveedores}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="compras-filtro-proveedor">
+              Proveedor
+            </label>
+            <select
+              id="compras-filtro-proveedor"
+              className="form-select rounded-0"
+              value={filtros.idProveedor ?? ''}
+              onChange={(e) => cambiarFiltro({ idProveedor: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(proveedores ?? []).map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.razonSocial}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compras-filtro-estado">
+              Estado
+            </label>
+            <select
+              id="compras-filtro-estado"
+              className="form-select rounded-0"
+              value={filtros.estado ?? ''}
+              onChange={(e) => cambiarFiltro({ estado: e.target.value === '' ? null : (e.target.value as EstadoCompra) })}
+            >
+              {OPCIONES_ESTADO.map((o) => (
+                <option key={o.valor} value={o.valor}>
+                  {o.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compras-filtro-desde">
+              Desde
+            </label>
+            <input
+              id="compras-filtro-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="compras-filtro-hasta">
+              Hasta
+            </label>
+            <input
+              id="compras-filtro-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+        </div>
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Número</th>
+                    <th>Proveedor</th>
+                    <th>Tipo</th>
+                    <th>Estado</th>
+                    <th>Estado de pago</th>
+                    <th>Fecha de recepción</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((c: CompraListada) => (
+                    <tr key={c.id}>
+                      <td>
+                        <Link className="link-underline-opacity-0" to={`/compras/${c.id}`}>
+                          {c.numeroExterno ?? `#${c.id}`}
+                        </Link>
+                      </td>
+                      <td>{proveedorPorId[c.idProveedor]?.razonSocial ?? `Proveedor #${c.idProveedor}`}</td>
+                      <td>{tipoPorId[c.idTipoComprobante]?.codigo ?? `#${c.idTipoComprobante}`}</td>
+                      <td>
+                        <span className={`badge rounded-0 ${claseDeBadgeDeEstado(c.estado)}`}>{etiquetaDeEstadoCompra(c.estado)}</span>
+                      </td>
+                      <td>{estadosPago[c.id] ? etiquetaDeEstadoPago(estadosPago[c.id]) : '—'}</td>
+                      <td>{formatearFecha(c.fechaRecepcion)}</td>
+                      <td className="text-end">{formatearMoneda(c.total)}</td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="text-center text-muted py-4">
+                        No hay compras que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} compra(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/Compras.tsx
+++ b/src/Ways.Web/src/paginas/Compras.tsx
@@ -51,9 +51,10 @@ function claseDeBadgeDeEstado(estado: EstadoCompra): string {
  * Web Composition): filtros proveedor/estado/fecha, estado de pago por fila (solo cuando el
  * listado está filtrado por un proveedor puntual — el endpoint de saldo es por-proveedor, el
  * panel completo con su propio estado lo construye `Proveedores.tsx` en la Slice 6) y entrada al
- * editor de borrador. Ruta Admin-only end to end (design: "no stage-7 nav/policy mismatch") —
- * `puedeEscribir` queda como defensa en profundidad cosmética, la política real es
- * `GestionDeCatalogo` del lado del servidor.
+ * editor de borrador. La ruta sigue `Politicas.OperacionDePos` (decisión 11: la lectura queda
+ * abierta a Vendedor/Supervisor/Admin) — `puedeEscribir` oculta el botón "Nueva compra" como
+ * defensa en profundidad cosmética, la política de escritura real es `GestionDeCatalogo` del
+ * lado del servidor.
  */
 export function Compras() {
   const { usuario } = useAuth()


### PR DESCRIPTION
## Resumen

Slice 5/6 de la etapa 8: las compras llegan a la pantalla — listado con estado de pago y el editor de borrador como máquina de estados completa. `size:exception` reconocido (~2.900 líneas: el editor CRUD con sus cuatro acciones y 483 líneas de tests).

- **Editor de borrador**: replace-set fiel al backend, costo a 4 decimales, flag `actualiza_costo` por línea, y los **totales honestos** — solo cuentan las líneas que el guardado va a persistir (mismo predicado, una fuente de verdad), con filas incompletas marcadas visualmente y contador "N línea(s) incompleta(s) — no se van a guardar" antes de las acciones.
- **Confirmar/anular** con confirmación de irreversibilidad, doble-click imposible, el reporte de gastos colgantes prominente y el 409 de stock renderizado con el artículo; **matriz de supersede simétrica completa** entre las cuatro acciones — incluido el botón interno del panel ya abierto.
- **Aplicar precios**: acción explícita separada con su tabla de resultados por línea.
- Rutas y nav alineadas al spec: lectura para Vendedor/Supervisor/Admin (precedente CuentaCorriente), escrituras Admin cosmético sobre server autoritativo. `fecha_comprobante` viaja como string DateOnly puro — sin gimnasia de offset donde no corresponde.

## Verificación

- vitest **376/376 (x2)**, tsc/oxlint/vite build limpios. Cero archivos backend.
- Judgment-day — 3 rondas: ronda 1 (2 BLOCKERs: el espejo de totales que mentía sobre líneas descartadas [caso de silla de operador]; aplicar-precios sin bloquear anular; + el MAJOR de la ruta Admin-only contradiciendo el spec y recreando el mismatch de la etapa 7), ronda 2 (B CLEAN; A cazó el residual: el botón INTERNO del panel ya abierto seguía sin gate), ronda 3 (el fix de dos líneas prescripto con mutación — vacío≠incompleto, paneles mutuamente excluyentes fuera del alcance). Triple evidencia de mutación acumulada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)