### PR TITLE
fix(stock): exponer la verdad de escritura del conteo en la respuesta

### DIFF
--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -43,3 +43,15 @@ public sealed record LineaTransferida(int IdArticulo, decimal CantidadOrigen, de
 /// Total, Never A Delta): el servidor deriva el ajuste bajo el lock de la fila de <c>stock</c>.
 /// </summary>
 public sealed record SolicitudDeConteo(int IdPuntoVenta, int IdArticulo, decimal Contada, string Observaciones);
+
+/// <summary>
+/// Resultado de <c>POST /api/stock/conteos</c> (stage-8, judgment-day fix: la respuesta anterior
+/// (<see cref="StockActual"/>) era idéntica para el no-op de diferencia cero y para la rama que sí
+/// escribe un movimiento, así que el cliente no podía distinguir ambos casos sin volver a leer el
+/// stock — y esa segunda lectura puede correr después de una venta concurrente y mentir en
+/// cualquiera de las dos direcciones. Este contrato lleva la verdad tal como el servidor la
+/// escribió, bajo el mismo lock de fila que calculó <see cref="Delta"/>: nunca hace falta que el
+/// cliente adivine.
+/// </summary>
+public sealed record ResultadoConteo(
+    int IdPuntoVenta, int IdArticulo, decimal Cantidad, decimal CantidadAnterior, decimal Delta, bool MovimientoRegistrado);

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -183,7 +183,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
     /// se deriva del lado del servidor bajo el mismo lock de fila que <c>AjustarAsync</c> usa
     /// (el upsert no-op de <see cref="BloquearYCrearSiFaltaStockAsync"/>), así que un conteo
     /// nunca puede pisar una venta que corrió entre el conteo físico y el submit.</summary>
-    public async Task<StockActual> ContarAsync(SolicitudDeConteo solicitud, CancellationToken ct = default)
+    public async Task<ResultadoConteo> ContarAsync(SolicitudDeConteo solicitud, CancellationToken ct = default)
     {
         var idTenant = ExigirTenantDeLaSesion();
         var idEmpleado = contexto.UsuarioId;
@@ -200,7 +200,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
             await EjecutarConteoAsync(idTenant, idEmpleado, solicitud.IdPuntoVenta, solicitud.IdArticulo, contada, observaciones, momento, ct));
     }
 
-    private async Task<StockActual> EjecutarConteoAsync(
+    private async Task<ResultadoConteo> EjecutarConteoAsync(
         int idTenant, int idEmpleado, int idPuntoVenta, int idArticulo, decimal contada, string observaciones,
         DateTimeOffset momento, CancellationToken ct)
     {
@@ -217,7 +217,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
             // spec: "Zero-Difference Conteo Writes No Ledger Row" — commit sin escribir nada,
             // que además evita ck_movimientos_stock_cantidad_no_cero (nunca lo alcanza).
             await transaccion.CommitAsync(ct);
-            return new StockActual(idPuntoVenta, idArticulo, actual);
+            return new ResultadoConteo(idPuntoVenta, idArticulo, actual, actual, 0m, MovimientoRegistrado: false);
         }
 
         await InsertarMovimientoStockAsync(
@@ -237,7 +237,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         await transaccion.CommitAsync(ct);
 
-        return new StockActual(idPuntoVenta, idArticulo, final);
+        return new ResultadoConteo(idPuntoVenta, idArticulo, final, actual, delta, MovimientoRegistrado: delta != 0m);
     }
 
     /// <summary>Upsert no-op — <c>SET cantidad = stock.cantidad</c> — que crea la fila si falta

--- a/tests/Ways.IntegrationTests/TransferenciasYConteoDeInventarioTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciasYConteoDeInventarioTests.cs
@@ -611,8 +611,14 @@ public class TransferenciasYConteoDeInventarioTests(WaysApiFixture fixture) : IC
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
 
-        var actual = JsonSerializer.Deserialize<StockActual>(cuerpo, OpcionesJson)!;
+        var actual = JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
         Assert.Equal(45m, actual.Cantidad);
+
+        // judgment-day fix (stage-8 slice 6): la respuesta lleva la verdad de escritura del
+        // servidor, no una promesa que el cliente tenga que revalidar con una lectura aparte.
+        Assert.Equal(40m, actual.CantidadAnterior);
+        Assert.Equal(5m, actual.Delta);
+        Assert.True(actual.MovimientoRegistrado);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario);
@@ -632,8 +638,14 @@ public class TransferenciasYConteoDeInventarioTests(WaysApiFixture fixture) : IC
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
 
-        var actual = JsonSerializer.Deserialize<StockActual>(cuerpo, OpcionesJson)!;
+        var actual = JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
         Assert.Equal(33m, actual.Cantidad);
+
+        // judgment-day fix (stage-8 slice 6): mismo criterio que el conteo positivo — la
+        // dirección negativa del delta también tiene que salir tal cual del servidor.
+        Assert.Equal(40m, actual.CantidadAnterior);
+        Assert.Equal(-7m, actual.Delta);
+        Assert.True(actual.MovimientoRegistrado);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario);
@@ -668,8 +680,14 @@ public class TransferenciasYConteoDeInventarioTests(WaysApiFixture fixture) : IC
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
 
-        var actual = JsonSerializer.Deserialize<StockActual>(cuerpo, OpcionesJson)!;
+        var actual = JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
         Assert.Equal(40m, actual.Cantidad);
+
+        // judgment-day fix (stage-8 slice 6): un no-op de diferencia cero tiene que declararse
+        // como tal en la respuesta — nunca la misma forma que la rama que sí escribió.
+        Assert.Equal(40m, actual.CantidadAnterior);
+        Assert.Equal(0m, actual.Delta);
+        Assert.False(actual.MovimientoRegistrado);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
@@ -678,6 +696,25 @@ public class TransferenciasYConteoDeInventarioTests(WaysApiFixture fixture) : IC
             .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVentaOrigen)
             .Select(s => s.Cantidad).FirstAsync();
         Assert.Equal(40m, cantidad);
+
+        // judgment-day fix (stage-8 slice 6): un artículo que NUNCA tuvo una fila de stock
+        // también tiene que declarar cantidad_anterior = 0 tal cual la creación perezosa del
+        // upsert no-op de lock (BloquearYCrearSiFaltaStockAsync) — mismo criterio que
+        // StockActual.Cantidad para GET /api/stock, extendido acá al conteo.
+        var idArticuloNuncaStockeado = await SembrarArticuloConPrecioAsync(ctx, "articulo-conteo-nunca-stockeado", 10m);
+        var solicitudNuncaStockeado = new SolicitudDeConteo(
+            ctx.IdPuntoVentaOrigen, idArticuloNuncaStockeado, 0m, "Recuento de artículo sin stock previo");
+        var respuestaNuncaStockeado = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitudNuncaStockeado);
+        var cuerpoNuncaStockeado = await respuestaNuncaStockeado.Content.ReadAsStringAsync();
+        Assert.True(respuestaNuncaStockeado.StatusCode == HttpStatusCode.OK, cuerpoNuncaStockeado);
+
+        var actualNuncaStockeado = JsonSerializer.Deserialize<ResultadoConteo>(cuerpoNuncaStockeado, OpcionesJson)!;
+        Assert.Equal(0m, actualNuncaStockeado.Cantidad);
+        Assert.Equal(0m, actualNuncaStockeado.CantidadAnterior);
+        Assert.Equal(0m, actualNuncaStockeado.Delta);
+        Assert.False(actualNuncaStockeado.MovimientoRegistrado);
+
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticuloNuncaStockeado && m.Motivo == MotivoStock.Inventario));
     }
 
     // ---- task 3.10: observaciones obligatorias, motivo distinto de ajuste --------------------------


### PR DESCRIPTION
## Resumen

Micro-follow-up del hallazgo convergente de ambos jueces en la ronda del slice 6: el response del conteo (`StockActual` pelado) era idéntico en el no-op y en la escritura real — cualquier claim del cliente sobre "se registró / sin diferencia" era una adivinanza desde un snapshot viejo que podía invertirse en ambas direcciones bajo una venta concurrente.

- `ResultadoConteo(IdPuntoVenta, IdArticulo, Cantidad, CantidadAnterior, Delta, MovimientoRegistrado)` — la verdad calculada bajo el mismo lock de fila que el delta. El cliente nunca más adivina hechos del ledger.
- Cambio seguro: el único consumidor del shape anterior es el slice 6 web, aún sin mergear (lo lee en su lote de fixes).
- Tests extendidos en el lugar (nada debilitado), incluido el sub-caso never-stocked con `CantidadAnterior=0`.

## Verificación

Domain 378 / Application 212 / Integration 691, contra Postgres real; build 0 warnings; sin migración. Mutación: `MovimientoRegistrado` hardcodeado a false → la assertion nueva en rojo exacto → restaurado y re-confirmado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)