### PR TITLE
feat(web): contener recharts detras de componentes/graficos (etapa 10, slice 6)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -278,28 +278,33 @@ route shipped so far. **Rollback**: revert the branch.
 **Finish**: `recharts` installed, containment wrappers exist, no page yet
 consumes them. **Rollback**: `npm uninstall recharts`; revert the branch.
 
-- [ ] 6.1 Modify `src/Ways.Web/package.json`: add `recharts`. **Verify at
+- [x] 6.1 Modify `src/Ways.Web/package.json`: add `recharts`. **Verify at
   install**: license is MIT, version is React-19-compatible (peer-dep
   check), no transitive canvas/d3 conflict with existing deps. *(design
   decision 4; proposal decision 4)*
-- [ ] 6.2 Create `src/Ways.Web/src/componentes/graficos/series.ts`: pure
+- [x] 6.2 Create `src/Ways.Web/src/componentes/graficos/series.ts`: pure
   mapping helpers (report bucket → chart-friendly series shape), no
   `recharts` import.
-- [ ] 6.3 Create `src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx`
+- [x] 6.3 Create `src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx`
   and `GraficoDeBarras.tsx`: thin wrappers over `recharts`'
   `ResponsiveContainer`/`LineChart`/`BarChart`, own props (`data`, `alto`,
   no raw `recharts` prop pass-through). `recharts` MUST NOT be imported
   anywhere outside this folder. *(design decision 11; spec tablero: Recharts
   Is Contained To componentes/graficos)*
-- [ ] 6.4 [P] Colocated unit tests for `series.ts` per `web-descriptor-tests`
+- [x] 6.4 [P] Colocated unit tests for `series.ts` per `web-descriptor-tests`
   — every pure mapping helper, no DOM.
-- [ ] 6.5 [P] Colocated component tests for both wrappers with
+- [x] 6.5 [P] Colocated component tests for both wrappers with
   `vi.mock('recharts')` stubbing each chart to a `data-testid` node that
   serializes its `data` prop — assertions target the wrapper's mapping,
   never the library render. *(design: Web Composition — Vitest)*
-- [ ] 6.6 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 6.6 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
+  sdd-apply — requires sub-agent delegation, out of the apply executor's
+  scope; orchestrator must run this before PR.)*
 - [ ] 6.7 Branch `feat/stage10-slice6-graficos` off `main`; PR; merge
-  stacked-to-main (independent of the API slices' merge order).
+  stacked-to-main (independent of the API slices' merge order). *(Branch
+  `feat/stage10-slice6-graficos` created off `main`, commits `d75bda7` +
+  `c981c50` applied on it. PR creation/merge explicitly out of scope per
+  apply boundaries — NOT done.)*
 
 **Verify**: `npm run test -- graficos`
 

--- a/src/Ways.Web/package-lock.json
+++ b/src/Ways.Web/package-lock.json
@@ -11,7 +11,8 @@
         "bootstrap": "^5.3.8",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router": "^8.3.0"
+        "react-router": "^8.3.0",
+        "recharts": "^3.10.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
@@ -704,6 +705,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -990,7 +1017,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
@@ -1116,6 +1148,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1144,7 +1239,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1159,6 +1254,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.4",
@@ -1383,6 +1484,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1421,8 +1531,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -1458,6 +1689,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -1508,6 +1745,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1517,6 +1765,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.4.0",
@@ -1574,6 +1828,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+      "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1582,6 +1846,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -1962,9 +2235,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2163,9 +2436,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "8.3.0",
@@ -2188,6 +2483,36 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2202,6 +2527,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2211,6 +2551,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
@@ -2314,6 +2660,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -2444,6 +2796,37 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.5",

--- a/src/Ways.Web/package.json
+++ b/src/Ways.Web/package.json
@@ -15,7 +15,8 @@
     "bootstrap": "^5.3.8",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router": "^8.3.0"
+    "react-router": "^8.3.0",
+    "recharts": "^3.10.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.test.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { PuntoDeGrafico } from './series'
+
+// Mismo criterio que `GraficoDeLineas.test.tsx`: `recharts` se stubea por completo,
+// la aserción vive sobre la prop `data` que el wrapper le pasa a `BarChart`.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children, height }: { children: ReactNode; height: number }) => (
+    <div data-testid="responsive-container" data-alto={height}>
+      {children}
+    </div>
+  ),
+  BarChart: ({ data, children }: { data: PuntoDeGrafico[]; children: ReactNode }) => (
+    <div data-testid="bar-chart" data-serie={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  CartesianGrid: () => null,
+}))
+
+const { GraficoDeBarras } = await import('./GraficoDeBarras')
+
+describe('GraficoDeBarras', () => {
+  it('pasa la data mapeada al BarChart sin alterarla', () => {
+    const data: PuntoDeGrafico[] = [
+      { etiqueta: 'PV Centro', valor: 1500 },
+      { etiqueta: 'PV Norte', valor: 900 },
+    ]
+
+    render(<GraficoDeBarras data={data} alto={240} />)
+
+    const chart = screen.getByTestId('bar-chart')
+    expect(JSON.parse(chart.dataset.serie ?? '[]')).toEqual(data)
+  })
+
+  it('propaga el alto explícito al contenedor responsive', () => {
+    render(<GraficoDeBarras data={[]} alto={160} />)
+
+    expect(screen.getByTestId('responsive-container')).toHaveAttribute('data-alto', '160')
+  })
+
+  it('renderiza sin datos sin crashear', () => {
+    render(<GraficoDeBarras data={[]} alto={200} />)
+
+    expect(JSON.parse(screen.getByTestId('bar-chart').dataset.serie ?? 'null')).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
@@ -19,7 +19,7 @@ export function GraficoDeBarras({ data, alto }: Props) {
         <XAxis dataKey="etiqueta" />
         <YAxis />
         <Tooltip />
-        <Bar dataKey="valor" fill="#2f6fed" />
+        <Bar dataKey="valor" fill="#0d6efd" />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
@@ -1,0 +1,26 @@
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import type { PuntoDeGrafico } from './series'
+
+type Props = {
+  data: readonly PuntoDeGrafico[]
+  alto: number
+}
+
+/**
+ * Único punto de entrada a `recharts` para breakdowns por dimensión (barras).
+ * Mismas reglas que `GraficoDeLineas`: solo `data` + `alto`, sin props
+ * crudas de `recharts` (decisión de diseño 11).
+ */
+export function GraficoDeBarras({ data, alto }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={alto}>
+      <BarChart data={data as PuntoDeGrafico[]}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="etiqueta" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="valor" fill="#2f6fed" />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.test.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { PuntoDeGrafico } from './series'
+
+// `recharts` se mockea por completo: bajo jsdom `ResponsiveContainer` mide 0 y no
+// renderiza nada, así que el test no puede depender de su layout real. El stub
+// serializa la prop `data` en un `data-testid` para que la aserción quede sobre el
+// mapeo del wrapper, nunca sobre el render de la librería (design.md, Web Composition).
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children, height }: { children: ReactNode; height: number }) => (
+    <div data-testid="responsive-container" data-alto={height}>
+      {children}
+    </div>
+  ),
+  LineChart: ({ data, children }: { data: PuntoDeGrafico[]; children: ReactNode }) => (
+    <div data-testid="line-chart" data-serie={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  CartesianGrid: () => null,
+}))
+
+const { GraficoDeLineas } = await import('./GraficoDeLineas')
+
+describe('GraficoDeLineas', () => {
+  it('pasa la data mapeada al LineChart sin alterarla', () => {
+    const data: PuntoDeGrafico[] = [
+      { etiqueta: 'lun', valor: 100 },
+      { etiqueta: 'mar', valor: 200 },
+    ]
+
+    render(<GraficoDeLineas data={data} alto={240} />)
+
+    const chart = screen.getByTestId('line-chart')
+    expect(JSON.parse(chart.dataset.serie ?? '[]')).toEqual(data)
+  })
+
+  it('propaga el alto explícito al contenedor responsive', () => {
+    render(<GraficoDeLineas data={[]} alto={180} />)
+
+    expect(screen.getByTestId('responsive-container')).toHaveAttribute('data-alto', '180')
+  })
+
+  it('renderiza sin datos sin crashear', () => {
+    render(<GraficoDeLineas data={[]} alto={200} />)
+
+    expect(JSON.parse(screen.getByTestId('line-chart').dataset.serie ?? 'null')).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
@@ -20,7 +20,7 @@ export function GraficoDeLineas({ data, alto }: Props) {
         <XAxis dataKey="etiqueta" />
         <YAxis />
         <Tooltip />
-        <Line type="monotone" dataKey="valor" stroke="#2f6fed" dot={false} />
+        <Line type="monotone" dataKey="valor" stroke="#0d6efd" dot={false} />
       </LineChart>
     </ResponsiveContainer>
   )

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
@@ -1,0 +1,27 @@
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import type { PuntoDeGrafico } from './series'
+
+type Props = {
+  data: readonly PuntoDeGrafico[]
+  alto: number
+}
+
+/**
+ * Único punto de entrada a `recharts` para series temporales de línea. No
+ * reexpone props crudas de `recharts` — solo `data` (ya mapeada por
+ * `series.ts`) y `alto` explícito, para que ningún consumidor dependa de la
+ * API de la librería subyacente (decisión de diseño 11).
+ */
+export function GraficoDeLineas({ data, alto }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={alto}>
+      <LineChart data={data as PuntoDeGrafico[]}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="etiqueta" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="valor" stroke="#2f6fed" dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/Ways.Web/src/componentes/graficos/series.test.ts
+++ b/src/Ways.Web/src/componentes/graficos/series.test.ts
@@ -30,6 +30,10 @@ describe('aSerieDeGrafico', () => {
     expect(aSerieDeGrafico([])).toEqual([])
   })
 
+  it('preserva los valores negativos tal cual (datos con NCX)', () => {
+    expect(aSerieDeGrafico([{ etiqueta: 'x', valor: -50 }])).toEqual([{ etiqueta: 'x', valor: -50 }]);
+  });
+
   it('preserva el orden de los buckets de entrada', () => {
     const serie = aSerieDeGrafico([
       { etiqueta: 'c', valor: 3 },

--- a/src/Ways.Web/src/componentes/graficos/series.test.ts
+++ b/src/Ways.Web/src/componentes/graficos/series.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { aSerieDeGrafico } from './series'
+
+describe('aSerieDeGrafico', () => {
+  it('pasa etiqueta y valor sin transformar cuando el valor no es null', () => {
+    const serie = aSerieDeGrafico([
+      { etiqueta: 'lun', valor: 100 },
+      { etiqueta: 'mar', valor: 250.5 },
+    ])
+
+    expect(serie).toEqual([
+      { etiqueta: 'lun', valor: 100 },
+      { etiqueta: 'mar', valor: 250.5 },
+    ])
+  })
+
+  it('mapea un valor null a 0 para el eje del gráfico', () => {
+    const serie = aSerieDeGrafico([{ etiqueta: 'mie', valor: null }])
+
+    expect(serie).toEqual([{ etiqueta: 'mie', valor: 0 }])
+  })
+
+  it('mapea un valor 0 real a 0 (no lo confunde con null)', () => {
+    const serie = aSerieDeGrafico([{ etiqueta: 'jue', valor: 0 }])
+
+    expect(serie).toEqual([{ etiqueta: 'jue', valor: 0 }])
+  })
+
+  it('devuelve un array vacío para una serie vacía', () => {
+    expect(aSerieDeGrafico([])).toEqual([])
+  })
+
+  it('preserva el orden de los buckets de entrada', () => {
+    const serie = aSerieDeGrafico([
+      { etiqueta: 'c', valor: 3 },
+      { etiqueta: 'a', valor: 1 },
+      { etiqueta: 'b', valor: 2 },
+    ])
+
+    expect(serie.map((punto) => punto.etiqueta)).toEqual(['c', 'a', 'b'])
+  })
+})

--- a/src/Ways.Web/src/componentes/graficos/series.ts
+++ b/src/Ways.Web/src/componentes/graficos/series.ts
@@ -1,0 +1,28 @@
+/**
+ * Forma mínima de un bucket de un reporte de series temporales del backend
+ * (p. ej. `BucketDeVentas`). Estructural a propósito: este archivo no importa
+ * los tipos de `src/api/` para no acoplar `componentes/graficos/` a un
+ * reporte puntual — cualquier bucket con `etiqueta` + un valor numérico
+ * (posiblemente `null`, como `ticketPromedio` sin denominador) encaja.
+ */
+export type BucketDeReporte = {
+  etiqueta: string
+  valor: number | null
+}
+
+/** Punto que consumen los wrappers de gráfico (`GraficoDeLineas`, `GraficoDeBarras`). */
+export type PuntoDeGrafico = {
+  etiqueta: string
+  valor: number
+}
+
+/**
+ * Convierte los buckets de un reporte a la forma que consumen los wrappers de
+ * gráfico. Un `valor` `null` (p. ej. ticket promedio sin ventas en el bucket)
+ * se mapea a `0` solo para el eje del gráfico — el dato crudo nunca debe
+ * mostrarse como cifra de texto sin pasar antes por su propio manejo de
+ * nulabilidad (ver `Rentabilidad`/`ResumenDeVentas`, campos nullable).
+ */
+export function aSerieDeGrafico(buckets: readonly BucketDeReporte[]): PuntoDeGrafico[] {
+  return buckets.map(({ etiqueta, valor }) => ({ etiqueta, valor: valor ?? 0 }))
+}


### PR DESCRIPTION
## Etapa 10, slice 6 — Contencion de Recharts

Instala `recharts@3.10.1` (MIT, peer React 19) y lo contiene detras de `componentes/graficos/`: `GraficoDeLineas`, `GraficoDeBarras` y el mapper `aSerieDeGrafico` con tipo estructural `BucketDeReporte`. Ninguna pagina lo consume todavia (Tablero = slices 7-10). `recharts` importado SOLO desde los dos wrappers (verificado por grep en todo src/).

### Review
Judgment-day: ronda limpia — 2/2 APPROVE. 3 MINORs especulativos: 2 corregidos en la rama (hex alineado a `#0d6efd`, test de valores negativos para datos con NCX), 1 diferido con registro (atributos a11y de los SVG → slice 7, cuando los graficos tengan contenido real).

### Tests
vitest 426/426 (414 baseline + 12 nuevos) · tsc -b limpio · build limpio · oxlint sin issues nuevos · npm audit 0 vulnerabilidades (bump patch de nanoid transitivo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)