### PR TITLE
feat(parametros): zona horaria y politicas de reportes (etapa 10, slice 1)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -54,40 +54,40 @@ deserialization and validates `zona_horaria` as a real IANA id,
 and `LecturaDeRentabilidad` policies exist and compose correctly. **Rollback**:
 revert the branch — additive only, no schema, no data required.
 
-- [ ] 1.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
+- [x] 1.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
   `ZonaHoraria` (`string`, default `"America/Argentina/Buenos_Aires"`,
   JSON-quoted) and `ComisionPorcentaje` (`decimal`, default `"0"`) to the
   registry array at `:30`. *(design: Timezone Mechanics; spec
   parametros-operativos: zona_horaria And comision_porcentaje Are Known Keys)*
-- [ ] 1.2 Modify `src/Ways.Application/Parametros/ServicioDeParametros.cs`:
+- [x] 1.2 Modify `src/Ways.Application/Parametros/ServicioDeParametros.cs`:
   harden `ValidarTipo` (`:110-123`) to reject a JSON `null` deserialization
   result instead of accepting it; add IANA validation for `zona_horaria` via
   `TimeZoneInfo.FindSystemTimeZoneById`, failing as 400 rather than letting a
   bad zone reach `date_trunc` as a Postgres 22023. *(design decision 12; spec
   parametros-operativos: First String-Typed Parametro Must Be Stored Quoted)*
-- [ ] 1.3 Modify `src/Ways.Api/Seguridad/Politicas.cs`: add
+- [x] 1.3 Modify `src/Ways.Api/Seguridad/Politicas.cs`: add
   `LecturaDeReportes` (`RequireClaim(RolId, Supervisor, Admin)`) and
   `LecturaDeRentabilidad` (`RequireClaim(RolId, Admin)`), same shape as
   `SupervisionDeCuentaCorriente` (`:57`). *(design decision 3, 7; spec
   reportes-de-gestion: LecturaDeReportes Policy; rentabilidad-y-comisiones:
   LecturaDeRentabilidad Policy Admits Admin Only)*
-- [ ] 1.4 Modify `src/Ways.Web/src/paginas/Parametros.tsx` (`:91,188-197`):
+- [x] 1.4 Modify `src/Ways.Web/src/paginas/Parametros.tsx` (`:91,188-197`):
   add `tipo: 'texto'` to `PARAMETROS_CONOCIDOS` for `zona_horaria`, render a
   `<select>` of offered IANA zones instead of the hardcoded
   `type="number"` + `JSON.stringify(Number(...))` path; keep
   `comision_porcentaje` on the existing numeric path. *(design decision 12)*
-- [ ] 1.5 [P] `ParametrosTests` (Application/Integration): quoted
+- [x] 1.5 [P] `ParametrosTests` (Application/Integration): quoted
   `zona_horaria` round-trips; unquoted value → 400; `null` deserialization →
   400; an invalid IANA id → 400. *(spec parametros-operativos, both
   requirements)*
-- [ ] 1.6 [P] Colocated `Parametros.test.tsx`: the zone `<select>` renders
+- [x] 1.6 [P] Colocated `Parametros.test.tsx`: the zone `<select>` renders
   and submits a quoted value; existing numeric-key flow unchanged. Per
   `web-descriptor-tests`.
-- [ ] 1.7 [P] `PoliticasTests` (or extend existing policy test file): claim
+- [x] 1.7 [P] `PoliticasTests` (or extend existing policy test file): claim
   matrix for `LecturaDeReportes` (Vendedor/Root rejected, Supervisor/Admin
   accepted) and `LecturaDeRentabilidad` (Admin only) at the policy level,
   independent of any endpoint.
-- [ ] 1.8 Gate guard: confirm `dotnet ef migrations list` is unchanged and
+- [x] 1.8 Gate guard: confirm `dotnet ef migrations list` is unchanged and
   the model snapshot has no diff.
 - [ ] 1.9 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge
   until clean.

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -56,6 +56,20 @@ public static class Politicas
     /// legacy de esta etapa (el legacy no tiene ningún gate de rol sobre cuenta corriente).</summary>
     public const string SupervisionDeCuentaCorriente = "supervision_cuenta_corriente";
 
+    /// <summary>Supervisor o admin — la puerta de los reportes de gestión operativos/de volumen
+    /// bajo <c>/api/reportes/*</c> (stage-10-agregacion-dashboard; spec reportes-de-gestion:
+    /// LecturaDeReportes Policy Gates The Volume/Operational Reports). Vendedor y Root quedan
+    /// afuera. <c>/rentabilidad</c> y <c>/comisiones</c> apilan
+    /// <see cref="LecturaDeRentabilidad"/> encima de esta — ASP.NET Core compone políticas con
+    /// AND, mismo criterio que <see cref="OperacionDePos"/> + <see cref="GestionDeCatalogo"/>.</summary>
+    public const string LecturaDeReportes = "lectura_reportes";
+
+    /// <summary>Solo admin — la puerta del margen y las comisiones (stage-10-agregacion-dashboard;
+    /// spec rentabilidad-y-comisiones: LecturaDeRentabilidad Policy Admits Admin Only). El costo
+    /// es el dato más sensible del sistema; esta etapa no amplía quién lo ve. Se apila sobre
+    /// <see cref="LecturaDeReportes"/> en <c>/rentabilidad</c> y <c>/comisiones</c>.</summary>
+    public const string LecturaDeRentabilidad = "lectura_rentabilidad";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -97,6 +111,15 @@ public static class Politicas
                         .RequireClaim(
                             ClaimsWays.RolId,
                             ((int)RolConocido.Supervisor).ToString(),
-                            ((int)RolConocido.Admin).ToString()));
+                            ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(LecturaDeReportes, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(
+                            ClaimsWays.RolId,
+                            ((int)RolConocido.Supervisor).ToString(),
+                            ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(LecturaDeRentabilidad, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Application/Parametros/ServicioDeParametros.cs
+++ b/src/Ways.Application/Parametros/ServicioDeParametros.cs
@@ -107,11 +107,19 @@ public class ServicioDeParametros(IWaysDbContext db, IRelojDelSistema reloj)
         }
     }
 
+    /// <summary>Valida el JSON contra el tipo CLR declarado (ADR-13) y, para
+    /// <c>zona_horaria</c>, además contra el catálogo IANA (design decisión 12): un
+    /// <c>null</c> deserializado (p.ej. <c>valorJson = "null"</c> para una clave string) se
+    /// rechaza acá en vez de guardarse — sin este chequeo, <c>JsonSerializer.Deserialize</c>
+    /// devuelve <c>null</c> sin tirar excepción y el valor inválido pasa. Una zona horaria
+    /// inválida se rechaza en la escritura (400) en vez de llegar a <c>date_trunc</c> en un
+    /// reporte y explotar como un 22023 de Postgres.</summary>
     private static void ValidarTipo(ParametroConocido conocido, string valorJson)
     {
+        object? valor;
         try
         {
-            JsonSerializer.Deserialize(valorJson, conocido.TipoClr);
+            valor = JsonSerializer.Deserialize(valorJson, conocido.TipoClr);
         }
         catch (JsonException)
         {
@@ -119,6 +127,30 @@ public class ServicioDeParametros(IWaysDbContext db, IRelojDelSistema reloj)
                 "parametro_tipo_invalido",
                 $"El valor de '{conocido.Clave}' tiene que ser un {conocido.TipoClr.Name} válido.",
                 400);
+        }
+
+        if (valor is null)
+        {
+            throw new ErrorDominio(
+                "parametro_tipo_invalido",
+                $"El valor de '{conocido.Clave}' tiene que ser un {conocido.TipoClr.Name} válido.",
+                400);
+        }
+
+        if (conocido.Clave == ParametroConocido.ZonaHoraria.Clave)
+        {
+            var zona = (string)valor;
+            try
+            {
+                TimeZoneInfo.FindSystemTimeZoneById(zona);
+            }
+            catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+            {
+                throw new ErrorDominio(
+                    "parametro_zona_horaria_invalida",
+                    $"'{zona}' no es un identificador de zona horaria IANA válido.",
+                    400);
+            }
         }
     }
 }

--- a/src/Ways.Application/Parametros/ServicioDeParametros.cs
+++ b/src/Ways.Application/Parametros/ServicioDeParametros.cs
@@ -142,7 +142,12 @@ public class ServicioDeParametros(IWaysDbContext db, IRelojDelSistema reloj)
             var zona = (string)valor;
             try
             {
-                TimeZoneInfo.FindSystemTimeZoneById(zona);
+                // HasIanaId frena los ids nativos de Windows ("Argentina Standard Time"),
+                // que FindSystemTimeZoneById resuelve en ambos OS pero Postgres no entiende.
+                if (!TimeZoneInfo.FindSystemTimeZoneById(zona).HasIanaId)
+                {
+                    throw new TimeZoneNotFoundException(zona);
+                }
             }
             catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
             {

--- a/src/Ways.Domain/Catalogos/ParametroConocido.cs
+++ b/src/Ways.Domain/Catalogos/ParametroConocido.cs
@@ -26,9 +26,26 @@ public sealed record ParametroConocido(string Clave, Type TipoClr, string ValorP
     public static readonly ParametroConocido SlotsTicketsEspera =
         new("slots_tickets_espera", typeof(int), "10");
 
+    /// <summary>Zona horaria IANA usada para el bucketing de los reportes de gestión
+    /// (stage-10): resuelve punto de venta → empresa → default como cualquier otro parámetro.
+    /// Es el primer parámetro string-tipado del registro — el default va entre comillas porque
+    /// <c>ResolucionDeParametros.Resolver</c> lo devuelve verbatim y los lectores lo
+    /// deserializan con <c>JsonSerializer.Deserialize&lt;string&gt;</c>.</summary>
+    public static readonly ParametroConocido ZonaHoraria =
+        new("zona_horaria", typeof(string), "\"America/Argentina/Buenos_Aires\"");
+
+    /// <summary>Porcentaje de comisión del reporte provisional de comisiones (stage-10):
+    /// default <c>0</c>, es decir comisiones calculadas pero siempre en cero hasta que un
+    /// Admin configure una tasa.</summary>
+    public static readonly ParametroConocido ComisionPorcentaje =
+        new("comision_porcentaje", typeof(decimal), "0");
+
     private static readonly IReadOnlyDictionary<string, ParametroConocido> PorClave =
-        new[] { ToleranciaPago, VueltoMaximo, ImporteAdicionalRecarga, SlotsTicketsEspera }
-            .ToDictionary(p => p.Clave, p => p, StringComparer.OrdinalIgnoreCase);
+        new[]
+        {
+            ToleranciaPago, VueltoMaximo, ImporteAdicionalRecarga, SlotsTicketsEspera,
+            ZonaHoraria, ComisionPorcentaje
+        }.ToDictionary(p => p.Clave, p => p, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Devuelve el registro de <paramref name="clave"/>, o rechaza con un error de
     /// dominio si no es una clave conocida (evita que un typo en el llamador se resuelva

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -188,11 +188,12 @@ export type ParametroAlta = { clave: string; valor: string; idPuntoVenta: number
 export type ParametroResuelto = { clave: string; valor: string }
 
 /** Espejo de `ParametroConocido` (Ways.Domain.Catalogos): clave, tipo declarado y default
- * documentado — el editor solo acepta estas claves, igual que el backend. */
+ * documentado — el editor solo acepta estas claves, igual que el backend. `zona_horaria` es
+ * el primer tipo `'texto'`: el backend lo guarda como string JSON-quoteado (stage-10). */
 export const PARAMETROS_CONOCIDOS: {
   clave: string
   etiqueta: string
-  tipo: 'entero' | 'decimal'
+  tipo: 'entero' | 'decimal' | 'texto'
   porDefecto: string
 }[] = [
   { clave: 'tolerancia_pago', etiqueta: 'Tolerancia de pago ($)', tipo: 'decimal', porDefecto: '10' },
@@ -204,6 +205,31 @@ export const PARAMETROS_CONOCIDOS: {
     porDefecto: '5',
   },
   { clave: 'slots_tickets_espera', etiqueta: 'Tickets en espera (cantidad)', tipo: 'entero', porDefecto: '10' },
+  {
+    clave: 'zona_horaria',
+    etiqueta: 'Zona horaria',
+    tipo: 'texto',
+    porDefecto: 'America/Argentina/Buenos_Aires',
+  },
+  { clave: 'comision_porcentaje', etiqueta: 'Comisión (%)', tipo: 'decimal', porDefecto: '0' },
+]
+
+/** Zonas IANA ofrecidas en el editor de `zona_horaria` (design decisión 12): un `<select>`
+ * cerrado en vez de texto libre, para que un identificador inválido no pueda ni tipearse. */
+export const ZONAS_HORARIAS_OFRECIDAS: { id: string; etiqueta: string }[] = [
+  { id: 'America/Argentina/Buenos_Aires', etiqueta: 'Buenos Aires' },
+  { id: 'America/Argentina/Catamarca', etiqueta: 'Catamarca' },
+  { id: 'America/Argentina/Cordoba', etiqueta: 'Córdoba' },
+  { id: 'America/Argentina/Jujuy', etiqueta: 'Jujuy' },
+  { id: 'America/Argentina/La_Rioja', etiqueta: 'La Rioja' },
+  { id: 'America/Argentina/Mendoza', etiqueta: 'Mendoza' },
+  { id: 'America/Argentina/Rio_Gallegos', etiqueta: 'Río Gallegos' },
+  { id: 'America/Argentina/Salta', etiqueta: 'Salta' },
+  { id: 'America/Argentina/San_Juan', etiqueta: 'San Juan' },
+  { id: 'America/Argentina/San_Luis', etiqueta: 'San Luis' },
+  { id: 'America/Argentina/Tucuman', etiqueta: 'Tucumán' },
+  { id: 'America/Argentina/Ushuaia', etiqueta: 'Ushuaia' },
+  { id: 'UTC', etiqueta: 'UTC' },
 ]
 
 // --- Organización: lectura/edición (ServicioDeOrganizacion) ---

--- a/src/Ways.Web/src/paginas/Parametros.test.tsx
+++ b/src/Ways.Web/src/paginas/Parametros.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Parametros } from './Parametros'
+import type { EmpresaListado, ParametroListado, PuntoVentaListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {},
+}))
+
+const empresaUno: EmpresaListado = {
+  id: 1,
+  idTenant: 1,
+  razonSocial: 'Empresa Uno SA',
+  nombreFantasia: null,
+  cuit: null,
+}
+
+const puntoVentaUno: PuntoVentaListado = {
+  id: 1,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'Local 1',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function mockearRutasBase(items: ParametroListado[] = []) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/empresas') return Promise.resolve([empresaUno])
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaUno])
+    if (ruta.startsWith('/parametros?idEmpresa=')) return Promise.resolve(items)
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPutMock.mockReset()
+  apiPutMock.mockResolvedValue({ id: 1, clave: 'x', valor: '"x"', idPuntoVenta: null })
+})
+
+describe('Parametros — clave zona_horaria (stage-10, design decisión 12)', () => {
+  it('renderiza un <select> de zonas ofrecidas y envía el valor JSON-quoteado', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'zona_horaria')
+
+    const selectorDeValor = screen.getByLabelText('Valor')
+    expect(selectorDeValor.tagName).toBe('SELECT')
+    expect(screen.getByRole('option', { name: 'Córdoba' })).toBeInTheDocument()
+
+    await usuario.selectOptions(selectorDeValor, 'America/Argentina/Cordoba')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.clave).toBe('zona_horaria')
+    expect(datos.valor).toBe('"America/Argentina/Cordoba"')
+  })
+
+  it('nunca permite un valor libre: no hay ningún <input> de texto para zona_horaria', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'zona_horaria')
+
+    expect(screen.queryByRole('spinbutton', { name: 'Valor' })).not.toBeInTheDocument()
+  })
+})
+
+describe('Parametros — claves numéricas existentes (flujo sin cambios)', () => {
+  it('sigue enviando tolerancia_pago como un número JSON, no un string', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    // tolerancia_pago es la clave por defecto: el input numérico ya está montado.
+    expect(screen.getByLabelText('Valor').tagName).toBe('INPUT')
+
+    await usuario.type(screen.getByLabelText('Valor'), '15')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.clave).toBe('tolerancia_pago')
+    expect(datos.valor).toBe('15')
+  })
+
+  it('slots_tickets_espera (entero) sigue truncando a un número entero JSON', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'slots_tickets_espera')
+    await usuario.type(screen.getByLabelText('Valor'), '12')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.valor).toBe('12')
+  })
+})

--- a/src/Ways.Web/src/paginas/Parametros.tsx
+++ b/src/Ways.Web/src/paginas/Parametros.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { api, ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
-import { PARAMETROS_CONOCIDOS } from '../api/tipos'
+import { PARAMETROS_CONOCIDOS, ZONAS_HORARIAS_OFRECIDAS } from '../api/tipos'
 import type { EmpresaListado, ParametroAlta, ParametroListado, ParametroResuelto, PuntoVentaListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -73,7 +73,16 @@ export function Parametros() {
     }
   }, [idEmpresa, cargarListado])
 
+  // Cambiar de clave resetea el valor tipeado: un `<select>` de zona horaria no puede arrancar
+  // en '' (no matchea ninguna opción), y un numérico arranca limpio para que el placeholder con
+  // el default declarado sea visible.
+  useEffect(() => {
+    const conocido = PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)
+    setValorTexto(conocido?.tipo === 'texto' ? ZONAS_HORARIAS_OFRECIDAS[0].id : '')
+  }, [clave])
+
   const puntosVentaDeLaEmpresa = puntosVenta.filter((p) => p.idEmpresa === idEmpresa)
+  const conocidoSeleccionado = PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)
 
   async function establecer(evento: FormEvent) {
     evento.preventDefault()
@@ -83,18 +92,23 @@ export function Parametros() {
     setError('')
     setAviso('')
 
-    const conocido = PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)
-
     try {
+      const valor =
+        conocidoSeleccionado?.tipo === 'texto'
+          ? JSON.stringify(valorTexto)
+          : JSON.stringify(
+              conocidoSeleccionado?.tipo === 'entero' ? Math.trunc(Number(valorTexto)) : Number(valorTexto),
+            )
+
       const datos: ParametroAlta = {
         clave,
-        valor: JSON.stringify(conocido?.tipo === 'entero' ? Math.trunc(Number(valorTexto)) : Number(valorTexto)),
+        valor,
         idPuntoVenta: idPuntoVenta === '' ? null : Number(idPuntoVenta),
       }
 
       await api.put(`/parametros?idEmpresa=${idEmpresa}`, datos)
       setAviso(`Se guardó "${clave}".`)
-      setValorTexto('')
+      setValorTexto(conocidoSeleccionado?.tipo === 'texto' ? ZONAS_HORARIAS_OFRECIDAS[0].id : '')
       await cargarListado(idEmpresa)
     } catch (e) {
       setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el parámetro.')
@@ -185,16 +199,32 @@ export function Parametros() {
                 <label className="form-label" htmlFor="p-valor">
                   Valor
                 </label>
-                <input
-                  id="p-valor"
-                  type="number"
-                  step={PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)?.tipo === 'entero' ? '1' : '0.01'}
-                  className="form-control rounded-0"
-                  placeholder={`Default: ${PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)?.porDefecto}`}
-                  value={valorTexto}
-                  onChange={(e) => setValorTexto(e.target.value)}
-                  required
-                />
+                {conocidoSeleccionado?.tipo === 'texto' ? (
+                  <select
+                    id="p-valor"
+                    className="form-select rounded-0"
+                    value={valorTexto}
+                    onChange={(e) => setValorTexto(e.target.value)}
+                    required
+                  >
+                    {ZONAS_HORARIAS_OFRECIDAS.map((z) => (
+                      <option key={z.id} value={z.id}>
+                        {z.etiqueta}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    id="p-valor"
+                    type="number"
+                    step={conocidoSeleccionado?.tipo === 'entero' ? '1' : '0.01'}
+                    className="form-control rounded-0"
+                    placeholder={`Default: ${conocidoSeleccionado?.porDefecto}`}
+                    value={valorTexto}
+                    onChange={(e) => setValorTexto(e.target.value)}
+                    required
+                  />
+                )}
               </div>
 
               <div className="col-md-3">

--- a/tests/Ways.Application.Tests/Parametros/ServicioDeParametrosTests.cs
+++ b/tests/Ways.Application.Tests/Parametros/ServicioDeParametrosTests.cs
@@ -94,4 +94,69 @@ public class ServicioDeParametrosTests
 
         Assert.Equal("punto_venta_no_pertenece_a_la_empresa", error.Codigo);
     }
+
+    /// <summary>Stage-10 (design decisión 12): <c>zona_horaria</c> es el primer parámetro
+    /// string-tipado, y su valor tiene que guardarse JSON-quoteado — un identificador sin
+    /// comillas no es JSON válido para un <c>string</c>.</summary>
+    [Fact]
+    public async Task EstablecerAsyncAceptaZonaHorariaQuoteadaYLaDevuelveVerbatim()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncAceptaZonaHorariaQuoteadaYLaDevuelveVerbatim);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var resultado = await servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "\"America/Argentina/Cordoba\"", null));
+
+        Assert.Equal("\"America/Argentina/Cordoba\"", resultado.Valor);
+    }
+
+    [Fact]
+    public async Task EstablecerAsyncRechazaZonaHorariaSinComillas()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncRechazaZonaHorariaSinComillas);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "America/Argentina/Cordoba", null)));
+
+        Assert.Equal("parametro_tipo_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    /// <summary>Judgment-day trap que este endurecimiento cierra: <c>JsonSerializer.Deserialize
+    /// ("null", typeof(string))</c> devuelve <c>null</c> sin tirar excepción, así que
+    /// <c>ValidarTipo</c> lo aceptaba antes de este endurecimiento.</summary>
+    [Fact]
+    public async Task EstablecerAsyncRechazaUnaDeserializacionNull()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncRechazaUnaDeserializacionNull);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "null", null)));
+
+        Assert.Equal("parametro_tipo_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task EstablecerAsyncRechazaUnaZonaHorariaQueNoEsUnIdIana()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncRechazaUnaZonaHorariaQueNoEsUnIdIana);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "\"No/Existe\"", null)));
+
+        Assert.Equal("parametro_zona_horaria_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
 }

--- a/tests/Ways.Application.Tests/Parametros/ServicioDeParametrosTests.cs
+++ b/tests/Ways.Application.Tests/Parametros/ServicioDeParametrosTests.cs
@@ -159,4 +159,48 @@ public class ServicioDeParametrosTests
         Assert.Equal("parametro_zona_horaria_invalida", error.Codigo);
         Assert.Equal(400, error.EstadoHttp);
     }
+
+    [Fact]
+    public async Task EstablecerAsyncRechazaUnIdDeZonaNativoDeWindows()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncRechazaUnIdDeZonaNativoDeWindows);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "\"Argentina Standard Time\"", null)));
+
+        Assert.Equal("parametro_zona_horaria_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task EstablecerAsyncAceptaUnaZonaIanaFueraDeLaListaCuradaDelFront()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncAceptaUnaZonaIanaFueraDeLaListaCuradaDelFront);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var parametro = await servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "\"America/Santiago\"", null));
+
+        Assert.Equal("\"America/Santiago\"", parametro.Valor);
+    }
+
+    [Fact]
+    public async Task EstablecerAsyncRechazaUnaZonaHorariaVacia()
+    {
+        var nombreDeBase = nameof(EstablecerAsyncRechazaUnaZonaHorariaVacia);
+        var (idEmpresaA, _, _, _) = await SembrarDosEmpresasConSuPuntoDeVentaAsync(nombreDeBase);
+
+        var servicio = new ServicioDeParametros(CrearContexto(nombreDeBase), new RelojFijo(Ahora));
+
+        var error = await Assert.ThrowsAsync<ErrorDominio>(() => servicio.EstablecerAsync(
+            idEmpresaA, new ParametroAlta("zona_horaria", "\"\"", null)));
+
+        Assert.Equal("parametro_zona_horaria_invalida", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
 }

--- a/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
+++ b/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
@@ -10,11 +10,27 @@ public class ParametroConocidoTests
     [InlineData("vuelto_maximo")]
     [InlineData("importe_adicional_recarga")]
     [InlineData("slots_tickets_espera")]
-    public void LasCuatroClavesDeDoc10EstanRegistradas(string clave)
+    [InlineData("zona_horaria")]
+    [InlineData("comision_porcentaje")]
+    public void LasSeisClavesConocidasEstanRegistradas(string clave)
     {
         var conocido = ParametroConocido.Buscar(clave);
 
         Assert.Equal(clave, conocido.Clave);
+    }
+
+    [Fact]
+    public void ZonaHorariaDeclaraElDefaultComoStringJsonQuoteado()
+    {
+        Assert.Equal(typeof(string), ParametroConocido.ZonaHoraria.TipoClr);
+        Assert.Equal("\"America/Argentina/Buenos_Aires\"", ParametroConocido.ZonaHoraria.ValorPorDefecto);
+    }
+
+    [Fact]
+    public void ComisionPorcentajeDeclaraElDefaultEnCero()
+    {
+        Assert.Equal(typeof(decimal), ParametroConocido.ComisionPorcentaje.TipoClr);
+        Assert.Equal("0", ParametroConocido.ComisionPorcentaje.ValorPorDefecto);
     }
 
     [Fact]

--- a/tests/Ways.Domain.Tests/Catalogos/ResolucionDeParametrosTests.cs
+++ b/tests/Ways.Domain.Tests/Catalogos/ResolucionDeParametrosTests.cs
@@ -62,4 +62,20 @@ public class ResolucionDeParametrosTests
         Assert.Equal("parametro_desconocido", error.Codigo);
         Assert.Equal(400, error.EstadoHttp);
     }
+
+    [Fact]
+    public void ZonaHorariaResuelveASuDefaultSinFilasConfiguradas()
+    {
+        var resuelto = ResolucionDeParametros.Resolver("zona_horaria", [], idPuntoVenta: 3);
+
+        Assert.Equal("\"America/Argentina/Buenos_Aires\"", resuelto);
+    }
+
+    [Fact]
+    public void ComisionPorcentajeResuelveACeroSinFilasConfiguradas()
+    {
+        var resuelto = ResolucionDeParametros.Resolver("comision_porcentaje", [], idPuntoVenta: 3);
+
+        Assert.Equal("0", resuelto);
+    }
 }

--- a/tests/Ways.IntegrationTests/PoliticasTests.cs
+++ b/tests/Ways.IntegrationTests/PoliticasTests.cs
@@ -1,0 +1,87 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Api.Seguridad;
+using Ways.Domain.Usuarios;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Matriz de claims a nivel policy, independiente de cualquier endpoint (stage-10, task 1.7):
+/// construye el mismo <see cref="AuthorizationBuilder"/> que <c>Program.cs</c> registra vía
+/// <see cref="Politicas.AgregarPoliticasWays"/> y evalúa <see cref="IAuthorizationService"/>
+/// contra un <see cref="ClaimsPrincipal"/> por rol, sin levantar la app ni Docker.
+/// </summary>
+public class PoliticasTests
+{
+    private static IAuthorizationService ConstruirServicioDeAutorizacion()
+    {
+        var servicios = new ServiceCollection();
+        servicios.AddLogging();
+        servicios.AddAuthorizationBuilder().AgregarPoliticasWays();
+        return servicios.BuildServiceProvider().GetRequiredService<IAuthorizationService>();
+    }
+
+    private static ClaimsPrincipal Usuario(RolConocido rol)
+    {
+        var identidad = new ClaimsIdentity(
+            [new Claim(ClaimsWays.RolId, ((int)rol).ToString())], "test");
+        return new ClaimsPrincipal(identidad);
+    }
+
+    [Theory]
+    [InlineData(RolConocido.Vendedor, false)]
+    [InlineData(RolConocido.Root, false)]
+    [InlineData(RolConocido.Supervisor, true)]
+    [InlineData(RolConocido.Admin, true)]
+    public async Task LecturaDeReportesAdmiteSupervisorYAdminUnicamente(RolConocido rol, bool admitido)
+    {
+        var servicio = ConstruirServicioDeAutorizacion();
+
+        var resultado = await servicio.AuthorizeAsync(Usuario(rol), Politicas.LecturaDeReportes);
+
+        Assert.Equal(admitido, resultado.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(RolConocido.Vendedor, false)]
+    [InlineData(RolConocido.Supervisor, false)]
+    [InlineData(RolConocido.Root, false)]
+    [InlineData(RolConocido.Admin, true)]
+    public async Task LecturaDeRentabilidadAdmiteSoloAdmin(RolConocido rol, bool admitido)
+    {
+        var servicio = ConstruirServicioDeAutorizacion();
+
+        var resultado = await servicio.AuthorizeAsync(Usuario(rol), Politicas.LecturaDeRentabilidad);
+
+        Assert.Equal(admitido, resultado.Succeeded);
+    }
+
+    /// <summary>Design decisión 7: ASP.NET Core compone metadata de autorización con AND, así
+    /// que apilar ambas policies (como hacen <c>/rentabilidad</c> y <c>/comisiones</c>) tiene
+    /// que dar Admin-only sin ningún mecanismo nuevo — lo prueba acá, a nivel policy, sin
+    /// depender de que un endpoint concreto exista.</summary>
+    [Theory]
+    [InlineData(RolConocido.Vendedor, false)]
+    [InlineData(RolConocido.Supervisor, false)]
+    [InlineData(RolConocido.Root, false)]
+    [InlineData(RolConocido.Admin, true)]
+    public async Task ApilarLecturaDeReportesConLecturaDeRentabilidadEquivaleAAdminOnly(
+        RolConocido rol, bool admitido)
+    {
+        var servicios = new ServiceCollection();
+        servicios.AddLogging();
+        servicios.AddAuthorizationBuilder().AgregarPoliticasWays();
+        var proveedor = servicios.BuildServiceProvider();
+        var opciones = proveedor.GetRequiredService<IAuthorizationPolicyProvider>();
+
+        var reportes = await opciones.GetPolicyAsync(Politicas.LecturaDeReportes);
+        var rentabilidad = await opciones.GetPolicyAsync(Politicas.LecturaDeRentabilidad);
+        var apilada = AuthorizationPolicy.Combine(reportes!, rentabilidad!);
+
+        var servicio = proveedor.GetRequiredService<IAuthorizationService>();
+        var resultado = await servicio.AuthorizeAsync(Usuario(rol), apilada);
+
+        Assert.Equal(admitido, resultado.Succeeded);
+    }
+}


### PR DESCRIPTION
## Etapa 10, slice 1 — Parametros y politicas

Base de la cadena API de reportes:
- `ParametroConocido` gana `zona_horaria` (string, quoted-JSON, default `America/Argentina/Buenos_Aires`) y `comision_porcentaje` (default 0 = apagado). Cero migraciones — el registro es codigo, gate sin-cambios-de-DB verificado.
- `ValidarTipo` endurecido: rechaza deserializacion null silenciosa (primer parametro string del sistema), valida id IANA, y rechaza ids nativos de Windows via `HasIanaId` (desde .NET 8 ambos OS los resuelven — Postgres no los entiende).
- Politicas `LecturaDeReportes` (Supervisor+Admin) y `LecturaDeRentabilidad` (solo Admin), espejo exacto del patron de casa, sin wiring prematuro de endpoints.
- Editor tipado en Parametros.tsx: `<select>` de zonas para `zona_horaria`; el path numerico queda byte-identico.
- Contrato pineado por test: la UI ofrece la lista curada argentina; el backend acepta cualquier IANA valida (`America/Santiago` incluido).

### Review
Judgment-day: ronda limpia — 2/2 APPROVE (Juez A con repro empirico de ICU/timezone en Windows; Juez B con mutation testing del hardening). 5 MINORs de triage aplicados en la rama con evidencia de mutacion (guarda HasIanaId: sin ella el test falla, con ella pasa).

### Tests
Domain 384/384 · Application 219/219 · Integration 716/716 · vitest 430/430 · tsc/build/oxlint limpios

🤖 Generated with [Claude Code](https://claude.com/claude-code)