### PR TITLE
feat(reportes): resumen de ventas con series por zona horaria (etapa 10, slice 2)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -106,17 +106,17 @@ live behind `LecturaDeReportes`, business-day bucketing correct in the punto
 de venta's zone, ticket promedio excludes NCX on both sides. **Rollback**:
 revert the branch; no state to unwind.
 
-- [ ] 2.1 Create `src/Ways.Domain/Reportes/Granularidad.cs`: enum `Dia |
+- [x] 2.1 Create `src/Ways.Domain/Reportes/Granularidad.cs`: enum `Dia |
   Semana | Mes`.
-- [ ] 2.2 Create `src/Ways.Domain/Reportes/CoberturaDeCosto.cs`: the record
+- [x] 2.2 Create `src/Ways.Domain/Reportes/CoberturaDeCosto.cs`: the record
   from design *Interfaces / Contracts* (used by slice 4; created here so
   `Domain/Reportes/` ships as one unit per the design's file grouping).
-- [ ] 2.3 Create `src/Ways.Domain/Reportes/RangoDeReporte.cs`: DB-free type —
+- [x] 2.3 Create `src/Ways.Domain/Reportes/RangoDeReporte.cs`: DB-free type —
   `(DateOnly Desde, DateOnly Hasta, Granularidad, TimeZoneInfo)` →
   `DesdeUtc`, `HastaUtcExclusivo`, `Buckets()`; ISO week label via
   `ISOWeek.GetYear`/`GetWeekOfYear`; rejects `hasta < desde` and spans past
   366 days. *(design: Range resolution; Architecture Decision 4, 6)*
-- [ ] 2.4 Create `src/Ways.Application/Reportes/LectorDeSerieTemporal.cs`:
+- [x] 2.4 Create `src/Ways.Application/Reportes/LectorDeSerieTemporal.cs`:
   two `private const string` SQL bodies (ventas, gastos) copied structurally
   from `ServicioDeCategorias.cs:199-244`; one `EjecutarAsync` opened via
   `Db.Database.OpenConnectionAsync()` (never `GetDbConnection().OpenAsync()`);
@@ -124,43 +124,61 @@ revert the branch; no state to unwind.
   `id_tenant = $n`, `id_punto_venta = ANY($n)`; granularity inlined as a
   validated literal from a `switch` over `Granularidad`, zone bound as
   `$n`. *(design decisions 1–3, 8, 9; Timezone Mechanics SQL)*
-- [ ] 2.5 Create `src/Ways.Application/Reportes/Contratos.cs`:
+- [x] 2.5 Create `src/Ways.Application/Reportes/Contratos.cs`:
   `BucketDeVentas`, `ResumenDeVentas` records exactly as in design
   *Interfaces / Contracts* (`TicketPromedio` nullable, never `0`).
-- [ ] 2.6 Create `src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs`:
+- [x] 2.6 Create `src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs`:
   `ObtenerResumenAsync` — `Empresas.AnyAsync` → 404 (ADR-8);
   `PuntosVenta.Where(IdEmpresa)` → PV scope; resolve `zona_horaria` via
   `ServicioDeParametros`; build `RangoDeReporte`; call
   `LectorDeSerieTemporal`; left-join `Buckets()` against SQL rows in C# to
   fill gaps; compute `NetoVendido`/`CantidadTx`/`TicketPromedio`/
   `CantidadNcx`/`NetoNcx`. *(design decisions 4, 5; Data Flow)*
-- [ ] 2.7 Modify `src/Ways.Application/DependencyInjection.cs`: register
+- [x] 2.7 Modify `src/Ways.Application/DependencyInjection.cs`: register
   `ServicioDeReportesDeVentas` and `LectorDeSerieTemporal`.
-- [ ] 2.8 Create `src/Ways.Api/Endpoints/ReportesEndpoints.cs`:
+- [x] 2.8 Create `src/Ways.Api/Endpoints/ReportesEndpoints.cs`:
   `MapGroup("/api/reportes").RequireAuthorization(Politicas.LecturaDeReportes)`;
   `GET /ventas/resumen` (`idEmpresa`, `idPuntoVenta?`, `desde`, `hasta`,
   `granularidad`). *(design: Endpoints; dto-contract-honesty)*
-- [ ] 2.9 [P] Domain unit suite for `RangoDeReporte`: 22:30 ART sale buckets
+- [x] 2.9 [P] Domain unit suite for `RangoDeReporte`: 22:30 ART sale buckets
   to its own day (and to the next day under a UTC zone, proving the
   parameter is live); `hasta` inclusivity; ISO Monday-start with
   `2026-W01` year rollover; month boundaries; gap fill; invalid-range and
-  366-day guard. *(spec reportes-de-gestion: Business-Day Bucketing)*
-- [ ] 2.10 [P] Extend `WaysApiFixture` with a two-tenant report seeder
-  (comprobantes across tenants, estados, `deleted_at`).
-- [ ] 2.11 [P] `ReportesVentasResumenTests` — the 4-test pattern:
+  366-day guard. *(spec reportes-de-gestion: Business-Day Bucketing)* —
+  `RangoDeReporteTests.cs`, 10 tests.
+- [x] 2.10 [P] Two-tenant report seeder — implemented as a LOCAL helper
+  (`PrepararAsync`/`SembrarComprobanteAsync`) inside
+  `ReportesVentasResumenTests.cs` instead of extending `WaysApiFixture`:
+  every existing seeder in this test suite (`SaldoDeProveedorTests.
+  PrepararAsync`, `CajaResumenContenidoTests.PrepararAsync`) follows this
+  same per-file convention — `WaysApiFixture` itself has never carried
+  feature-specific seeding. Deviation recorded, not silent.
+- [x] 2.11 [P] `ReportesVentasResumenTests` — the 4-test pattern:
   cross-tenant absence, soft-delete absence, anulado absence, hand-computed
   fixture equality. *(spec reportes-de-gestion: Net Sales Has No Sign
   Branch; success criterion 1)*
-- [ ] 2.12 [P] `ReportesZonaHorariaTests`: same seed read with
-  `zona_horaria` = ART vs UTC returns different bucket assignment for a
-  22:30 sale. *(spec: A late-evening sale lands on its own business day)*
-- [ ] 2.13 [P] `ReportesSemanticaTests`: NCX reduces `NetoVendido` and leaves
+- [x] 2.12 [P] Timezone edge test: same seed read with `zona_horaria` = ART
+  vs UTC returns different bucket assignment for a 22:30 sale. *(spec: A
+  late-evening sale lands on its own business day)* — consolidated into
+  `ReportesVentasResumenTests.cs` (no separate `ReportesZonaHorariaTests`
+  file) to keep the slice's file count down under the review budget.
+- [x] 2.13 [P] NCX semantics test: NCX reduces `NetoVendido` and leaves
   `CantidadTx`/`TicketPromedio` untouched (600/3 = $200, not 550/4).
-  *(spec: Ticket Promedio Excludes NCX From Both Sides)*
-- [ ] 2.14 Gate guard: `dotnet ef migrations list` unchanged.
-- [ ] 2.15 Run `judgment-day`; fix; re-judge until clean.
+  *(spec: Ticket Promedio Excludes NCX From Both Sides)* — consolidated
+  into `ReportesVentasResumenTests.cs` (no separate `ReportesSemanticaTests`
+  file), same budget reasoning as 2.12. Role 403/200 matrix (Vendedor,
+  Root, Supervisor) and cross-tenant-empresa 404 added in the same file,
+  ahead of slice 4's `ReportesAutorizacionTests`.
+- [x] 2.14 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  "No changes have been made to the model since the last migration."
+- [ ] 2.15 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
+  sdd-apply — requires sub-agent delegation, out of the apply executor's
+  scope; orchestrator must run this before PR, same precedent as slice 6
+  task 6.6.)*
 - [ ] 2.16 Branch `feat/stage10-slice2-ventas-resumen` off `main` (parent:
-  slice 1's merged commit); PR; merge stacked-to-main.
+  slice 1's merged commit); PR; merge stacked-to-main. *(Branch created off
+  `main` @ 116a71b. PR creation/merge explicitly out of scope per apply
+  boundaries — NOT done.)*
 
 **Verify**: `dotnet test --filter FullyQualifiedName~RangoDeReporte|FullyQualifiedName~ReportesVentasResumen|FullyQualifiedName~ReportesZonaHoraria|FullyQualifiedName~ReportesSemantica`
 

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -1,0 +1,25 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Reportes;
+using Ways.Domain.Reportes;
+
+namespace Ways.Api.Endpoints;
+
+public static class ReportesEndpoints
+{
+    public static IEndpointRouteBuilder MapearReportes(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/reportes")
+            .WithTags("Reportes")
+            .RequireAuthorization(Politicas.LecturaDeReportes);
+
+        grupo.MapGet("/ventas/resumen", (
+            ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
+            Granularidad granularidad, CancellationToken ct) =>
+            servicio.ObtenerResumenAsync(idEmpresa, idPuntoVenta, desde, hasta, granularidad, ct))
+        .WithSummary(
+            "Ventas netas bucketeadas por la zona horaria del punto de venta: ticket promedio " +
+            "excluye NCX de numerador y denominador.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -174,6 +174,7 @@ app.MapearCaja();
 app.MapearGastos();
 app.MapearCuentaCorriente();
 app.MapearCompras();
+app.MapearReportes();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -12,6 +12,7 @@ using Ways.Application.Organizacion;
 using Ways.Application.Parametros;
 using Ways.Application.Precios;
 using Ways.Application.Proveedores;
+using Ways.Application.Reportes;
 using Ways.Application.Stock;
 using Ways.Application.Usuarios;
 using Ways.Application.Ventas;
@@ -79,6 +80,12 @@ public static class DependencyInjection
         // stage-8-compras-transferencias-inventario, Slice 4: el saldo derivado del proveedor
         // (design decisión 11) — dedicado, no extiende ServicioDeProveedores.
         services.AddScoped<ServicioDeSaldoDeProveedor>();
+
+        // stage-10-agregacion-dashboard, Slice 2: LectorDeSerieTemporal es la única superficie de
+        // SQL crudo de toda la etapa (design decisión 2) — ServicioDeReportesDeVentas es su
+        // primer consumidor.
+        services.AddScoped<LectorDeSerieTemporal>();
+        services.AddScoped<ServicioDeReportesDeVentas>();
 
         return services;
     }

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -1,0 +1,17 @@
+using Ways.Domain.Reportes;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>Un bucket de la serie de ventas ya rellenada (sin huecos, design decisión 4).
+/// <see cref="TicketPromedio"/> es <c>null</c>, nunca <c>0</c>, cuando el bucket no tuvo ningún
+/// TX — un denominador vacío no tiene respuesta.</summary>
+public sealed record BucketDeVentas(string Etiqueta, DateOnly Inicio, decimal Neto, int CantidadTx, decimal? TicketPromedio);
+
+/// <summary>Respuesta de <c>GET /api/reportes/ventas/resumen</c> (design: Interfaces /
+/// Contracts). <see cref="ZonaHoraria"/> es la zona efectivamente resuelta y aplicada al
+/// bucketing — echo obligatorio (design decisión 5): un número cuyo corte de día es invisible no
+/// es auditable.</summary>
+public sealed record ResumenDeVentas(
+    DateOnly Desde, DateOnly Hasta, Granularidad Granularidad, string ZonaHoraria,
+    IReadOnlyList<BucketDeVentas> Serie,
+    decimal NetoVendido, int CantidadTx, decimal? TicketPromedio, int CantidadNcx, decimal NetoNcx);

--- a/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
+++ b/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
@@ -1,0 +1,165 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Reportes;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>
+/// La ÚNICA superficie de SQL crudo de stage-10-agregacion-dashboard (design decisión 2: "one
+/// file is one review target and one grep target for the invariant checklist"). Dos cuerpos SQL
+/// constantes (ventas, gastos) y un ejecutor genérico compartido — mismo patrón que
+/// <c>ServicioDeCategorias</c>: la conexión se abre con <c>Db.Database.OpenConnectionAsync()</c>,
+/// NUNCA <c>GetDbConnection().OpenAsync()</c> crudo, porque solo el primero corre el pipeline de
+/// interceptores de EF que setea los GUCs de RLS (<c>InterceptorDeContextoDeTenant</c>) — saltarlo
+/// falla en silencio a 0 filas, no con una excepción.
+///
+/// La granularidad se inlinea como literal validado (design decisión 3): sale de un
+/// <c>switch</c> sobre <see cref="Granularidad"/>, nunca de texto de la request. La zona SÍ es
+/// dato de tenant y viaja como parámetro — <c>timezone(text, timestamptz)</c> en vez de la forma
+/// infix <c>AT TIME ZONE</c> porque la forma función no es ambigua con un parámetro posicional.
+/// </summary>
+public class LectorDeSerieTemporal(IWaysDbContext db)
+{
+    private const string SqlVentas =
+        """
+        SELECT date_trunc('{0}', timezone($1, cv.fecha))::date AS bucket,
+               SUM(cv.total) AS neto,
+               COUNT(*) FILTER (WHERE tc.signo > 0) AS cantidad_tx,
+               COALESCE(SUM(cv.total) FILTER (WHERE tc.signo > 0), 0) AS neto_tx,
+               COUNT(*) FILTER (WHERE tc.signo < 0) AS cantidad_ncx,
+               COALESCE(SUM(cv.total) FILTER (WHERE tc.signo < 0), 0) AS neto_ncx
+        FROM comprobantes_venta cv
+        JOIN tipos_comprobante tc ON tc.id_tipo_comprobante = cv.id_tipo_comprobante
+        WHERE cv.deleted_at IS NULL
+          AND cv.estado <> 'anulado'::estado_comprobante
+          AND tc.clase = 'venta'::clase_comprobante
+          AND cv.id_tenant = $2
+          AND cv.id_punto_venta = ANY($3)
+          AND cv.fecha >= $4
+          AND cv.fecha < $5
+        GROUP BY 1
+        ORDER BY 1
+        """;
+
+    /// <summary>Sin columna <c>estado</c> — <c>gastos</c> no tiene máquina de estados. Reusada tal
+    /// cual por <c>gastos/resumen</c> (stage-10 slice 5, design: Raw-SQL Invariant Checklist).</summary>
+    private const string SqlGastos =
+        """
+        SELECT date_trunc('{0}', timezone($1, g.fecha))::date AS bucket,
+               SUM(g.importe) AS importe
+        FROM gastos g
+        WHERE g.deleted_at IS NULL
+          AND g.id_tenant = $2
+          AND g.id_punto_venta = ANY($3)
+          AND g.fecha >= $4
+          AND g.fecha < $5
+        GROUP BY 1
+        ORDER BY 1
+        """;
+
+    public Task<IReadOnlyList<FilaSerieDeVentas>> EjecutarVentasAsync(
+        Granularidad granularidad, string zona, int idTenant, IReadOnlyCollection<int> idsPuntoVenta,
+        DateTimeOffset desdeUtc, DateTimeOffset hastaUtcExclusivo, CancellationToken ct = default) =>
+        EjecutarAsync(
+            SqlVentas, granularidad, zona, idTenant, idsPuntoVenta, desdeUtc, hastaUtcExclusivo,
+            ProyectarFilaDeVentas, ct);
+
+    /// <summary>Sin consumidor todavía en esta slice — stage-10 slice 5
+    /// (<c>ServicioDeReportesDeEgresos.ObtenerGastosResumenAsync</c>) es el primero. Declarado acá
+    /// porque design decisión 2 asigna TODO el raw-SQL de la etapa a este único archivo.</summary>
+    public Task<IReadOnlyList<FilaSerieDeGastos>> EjecutarGastosAsync(
+        Granularidad granularidad, string zona, int idTenant, IReadOnlyCollection<int> idsPuntoVenta,
+        DateTimeOffset desdeUtc, DateTimeOffset hastaUtcExclusivo, CancellationToken ct = default) =>
+        EjecutarAsync(
+            SqlGastos, granularidad, zona, idTenant, idsPuntoVenta, desdeUtc, hastaUtcExclusivo,
+            ProyectarFilaDeGastos, ct);
+
+    private async Task<IReadOnlyList<T>> EjecutarAsync<T>(
+        string sqlTemplate, Granularidad granularidad, string zona, int idTenant,
+        IReadOnlyCollection<int> idsPuntoVenta, DateTimeOffset desdeUtc, DateTimeOffset hastaUtcExclusivo,
+        Func<DbDataReader, T> proyectar, CancellationToken ct)
+    {
+        var laAbrimosAca = await AbrirSiHaceFaltaAsync(ct);
+
+        try
+        {
+            var conexion = db.Database.GetDbConnection();
+            await using var comando = conexion.CreateCommand();
+            comando.CommandText = string.Format(sqlTemplate, LiteralDeGranularidad(granularidad));
+
+            AgregarParametro(comando, zona);
+            AgregarParametro(comando, idTenant);
+            AgregarParametro(comando, idsPuntoVenta.ToArray());
+            AgregarParametro(comando, desdeUtc);
+            AgregarParametro(comando, hastaUtcExclusivo);
+
+            var filas = new List<T>();
+            await using var lector = await comando.ExecuteReaderAsync(ct);
+            while (await lector.ReadAsync(ct))
+            {
+                filas.Add(proyectar(lector));
+            }
+
+            return filas;
+        }
+        finally
+        {
+            if (laAbrimosAca)
+            {
+                await db.Database.CloseConnectionAsync();
+            }
+        }
+    }
+
+    private static FilaSerieDeVentas ProyectarFilaDeVentas(DbDataReader lector) => new(
+        lector.GetFieldValue<DateOnly>(0), lector.GetDecimal(1), Convert.ToInt32(lector.GetInt64(2)),
+        lector.GetDecimal(3), Convert.ToInt32(lector.GetInt64(4)), lector.GetDecimal(5));
+
+    private static FilaSerieDeGastos ProyectarFilaDeGastos(DbDataReader lector) => new(
+        lector.GetFieldValue<DateOnly>(0), lector.GetDecimal(1));
+
+    private static string LiteralDeGranularidad(Granularidad granularidad) => granularidad switch
+    {
+        Granularidad.Dia => "day",
+        Granularidad.Semana => "week",
+        Granularidad.Mes => "month",
+        _ => throw new ArgumentOutOfRangeException(nameof(granularidad))
+    };
+
+    /// <summary><c>Database.OpenConnectionAsync()</c>, no <c>GetDbConnection().OpenAsync()</c>
+    /// crudo — mismo motivo que <c>ServicioDeCategorias.AbrirSiHaceFaltaAsync</c>: solo el primero
+    /// corre el interceptor que setea los GUCs de RLS. Devuelve si esta llamada abrió la conexión,
+    /// para no interferir con una ya abierta por otra operación de EF en curso en el mismo
+    /// request.</summary>
+    private async Task<bool> AbrirSiHaceFaltaAsync(CancellationToken ct)
+    {
+        if (db.Database.GetDbConnection().State == ConnectionState.Open)
+        {
+            return false;
+        }
+
+        await db.Database.OpenConnectionAsync(ct);
+        return true;
+    }
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+}
+
+/// <summary>Una fila de la serie de ventas antes del gap-fill (<c>RangoDeReporte.Buckets()</c>
+/// hace el resto en C#, design decisión 4). <see cref="Neto"/> ya es neto de NCX por construcción
+/// (design decisión 9, <c>tipos_comprobante.signo</c> como discriminador — el total de un NCX ya
+/// llega negativo); <see cref="CantidadTx"/>/<see cref="NetoTx"/> cuentan solo <c>signo &gt;
+/// 0</c>.</summary>
+public sealed record FilaSerieDeVentas(
+    DateOnly Bucket, decimal Neto, int CantidadTx, decimal NetoTx, int CantidadNcx, decimal NetoNcx);
+
+/// <summary>Una fila de la serie de gastos — sin discriminador de signo, <c>gastos</c> no tiene
+/// noción de nota de crédito.</summary>
+public sealed record FilaSerieDeGastos(DateOnly Bucket, decimal Importe);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Parametros;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Reportes;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>
+/// El agregado de ventas de stage-10-agregacion-dashboard (design: Data Flow). Resuelve el
+/// alcance (empresa → puntos de venta), la zona horaria (<c>ServicioDeParametros</c>, misma
+/// precedencia punto de venta → empresa → default que cualquier otro parámetro), arma el
+/// <see cref="RangoDeReporte"/> puro y left-joinea sus buckets contra las filas crudas de
+/// <see cref="LectorDeSerieTemporal"/> — un bucket sin ventas queda en <c>0</c>, nunca
+/// desaparece (design decisión 4).
+/// </summary>
+public class ServicioDeReportesDeVentas(IWaysDbContext db, LectorDeSerieTemporal lector, ServicioDeParametros parametros)
+{
+    public async Task<ResumenDeVentas> ObtenerResumenAsync(
+        int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad,
+        CancellationToken ct = default)
+    {
+        var idTenant = await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, idPuntoVenta, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, idPuntoVenta, ct);
+
+        var rango = RangoDeReporte.Crear(desde, hasta, granularidad, zona);
+
+        IReadOnlyList<FilaSerieDeVentas> filas = idsPuntoVenta.Count == 0
+            ? Array.Empty<FilaSerieDeVentas>()
+            : await lector.EjecutarVentasAsync(
+                granularidad, zonaId, idTenant, idsPuntoVenta, rango.DesdeUtc, rango.HastaUtcExclusivo, ct);
+
+        var filaPorBucket = filas.ToDictionary(f => f.Bucket);
+
+        var serie = rango.Buckets()
+            .Select(bucket =>
+            {
+                filaPorBucket.TryGetValue(bucket.Inicio, out var fila);
+                var cantidadTx = fila?.CantidadTx ?? 0;
+                var ticketPromedioDelBucket = cantidadTx > 0 ? fila!.NetoTx / cantidadTx : (decimal?)null;
+                return new BucketDeVentas(bucket.Etiqueta, bucket.Inicio, fila?.Neto ?? 0m, cantidadTx, ticketPromedioDelBucket);
+            })
+            .ToList();
+
+        var netoVendido = filas.Sum(f => f.Neto);
+        var cantidadTxTotal = filas.Sum(f => f.CantidadTx);
+        var netoTxTotal = filas.Sum(f => f.NetoTx);
+        var ticketPromedio = cantidadTxTotal > 0 ? netoTxTotal / cantidadTxTotal : (decimal?)null;
+        var cantidadNcx = filas.Sum(f => f.CantidadNcx);
+        var netoNcx = filas.Sum(f => f.NetoNcx);
+
+        return new ResumenDeVentas(
+            desde, hasta, granularidad, zonaId, serie, netoVendido, cantidadTxTotal, ticketPromedio, cantidadNcx, netoNcx);
+    }
+
+    private async Task<int> ExigirEmpresaAsync(int idEmpresa, CancellationToken ct)
+    {
+        var idTenant = await db.Empresas
+            .Where(e => e.Id == idEmpresa)
+            .Select(e => (int?)e.IdTenant)
+            .FirstOrDefaultAsync(ct);
+
+        // ADR-8: mismo 404 para "no existe" y "es de otro tenant" — el filtro de EF/RLS ya deja
+        // invisible una empresa ajena, mismo criterio que el resto de los servicios de Application.
+        return idTenant ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {idEmpresa}.");
+    }
+
+    /// <summary>Sin <paramref name="idPuntoVenta"/>: todos los puntos de venta de la empresa
+    /// (empresa-wide, design decisión 5). Con él: la misma regla de pertenencia que
+    /// <c>ServicioDeParametros.ValidarPuntoVentaDeLaEmpresaAsync</c> — un punto de venta real pero
+    /// de otra empresa del mismo tenant no tiene FK que lo impida (nada en el esquema lo evita),
+    /// así que esta consulta, scopeada por tenant vía el filtro de EF, es quien lo valida.</summary>
+    private async Task<IReadOnlyList<int>> ResolverPuntosDeVentaAsync(int idEmpresa, int? idPuntoVenta, CancellationToken ct)
+    {
+        var puntosDeLaEmpresa = db.PuntosVenta.Where(pv => pv.IdEmpresa == idEmpresa);
+
+        if (idPuntoVenta is { } id)
+        {
+            var pertenece = await puntosDeLaEmpresa.AnyAsync(pv => pv.Id == id, ct);
+            if (!pertenece)
+            {
+                throw new ErrorDominio(
+                    "punto_venta_no_pertenece_a_la_empresa",
+                    "El punto de venta indicado no pertenece a la empresa declarada.",
+                    400);
+            }
+
+            return [id];
+        }
+
+        return await puntosDeLaEmpresa.Select(pv => pv.Id).ToListAsync(ct);
+    }
+
+    /// <summary>design decisión 5: la zona se resuelve UNA vez, al alcance que pidió el caller —
+    /// con <paramref name="idPuntoVenta"/>, PV → empresa → default; sin él, empresa → default,
+    /// ignorando cualquier override de punto de venta (mismo comportamiento que
+    /// <c>ServicioDeParametros.ResolverAsync</c> con <c>idPuntoVenta = null</c>, que solo mira las
+    /// filas de nivel empresa).</summary>
+    private async Task<(string ZonaId, TimeZoneInfo Zona)> ResolverZonaAsync(
+        int idEmpresa, int? idPuntoVenta, CancellationToken ct)
+    {
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, idPuntoVenta, ct);
+        var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
+        return (zonaId, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+    }
+}

--- a/src/Ways.Domain/Reportes/CoberturaDeCosto.cs
+++ b/src/Ways.Domain/Reportes/CoberturaDeCosto.cs
@@ -1,0 +1,13 @@
+namespace Ways.Domain.Reportes;
+
+/// <summary>
+/// Cobertura del costo de un período de rentabilidad (stage-9-costo-congelado, tres estados:
+/// real / estimado / desconocido). Cada campo lo consume el banner obligatorio de rentabilidad
+/// (stage-10 slice 4) — declarado acá, junto al resto de <c>Domain/Reportes/</c>, para que la
+/// carpeta aterrice como una sola unidad revisable (design: File Changes), aunque su primer
+/// consumidor real llega recién en esa slice.
+/// </summary>
+public sealed record CoberturaDeCosto(
+    int LineasTotales, int LineasConCostoReal, int LineasConCostoEstimado, int LineasSinCosto,
+    decimal VentaTotal, decimal VentaConCostoReal, decimal VentaConCostoEstimado, decimal VentaSinCosto,
+    bool IncluyeEstimados);

--- a/src/Ways.Domain/Reportes/Granularidad.cs
+++ b/src/Ways.Domain/Reportes/Granularidad.cs
@@ -1,0 +1,14 @@
+namespace Ways.Domain.Reportes;
+
+/// <summary>
+/// Granularidad de bucketing de los reportes de gestión (stage-10-agregacion-dashboard). El
+/// literal SQL que <c>LectorDeSerieTemporal</c> inlinea en el <c>date_trunc</c> sale de un
+/// <c>switch</c> sobre este enum, nunca de texto de la request (design decisión 3): el enum es
+/// cerrado y se parsea antes de armar la consulta, así que no hay vector de inyección.
+/// </summary>
+public enum Granularidad
+{
+    Dia,
+    Semana,
+    Mes
+}

--- a/src/Ways.Domain/Reportes/RangoDeReporte.cs
+++ b/src/Ways.Domain/Reportes/RangoDeReporte.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Reportes;
+
+/// <summary>
+/// Rango de fechas + granularidad + zona horaria de un reporte de gestión (stage-10), puro y
+/// DB-free como <c>PoliticaDeRoles</c> (design: Timezone Mechanics — "Range resolution"). Resuelve
+/// los límites UTC del rango sobre la zona del punto de venta y la lista completa de buckets del
+/// período — incluidos los que no tienen ninguna fila en <c>LectorDeSerieTemporal</c> — para que
+/// el servicio de aplicación pueda left-joinearlos en C# (design decisión 4: un día sin ventas
+/// tiene que renderizar <c>0</c>, no desaparecer del gráfico).
+/// </summary>
+public sealed class RangoDeReporte
+{
+    private const int SpanMaximoEnDias = 366;
+
+    public DateOnly Desde { get; }
+    public DateOnly Hasta { get; }
+    public Granularidad Granularidad { get; }
+    public TimeZoneInfo Zona { get; }
+
+    private RangoDeReporte(DateOnly desde, DateOnly hasta, Granularidad granularidad, TimeZoneInfo zona)
+    {
+        Desde = desde;
+        Hasta = hasta;
+        Granularidad = granularidad;
+        Zona = zona;
+    }
+
+    /// <summary>Rechaza <c>hasta &lt; desde</c> y un span mayor a <see cref="SpanMaximoEnDias"/>
+    /// días (agregado acotado ⇒ sin paginación, design: Range resolution).</summary>
+    public static RangoDeReporte Crear(DateOnly desde, DateOnly hasta, Granularidad granularidad, TimeZoneInfo zona)
+    {
+        if (hasta < desde)
+        {
+            throw new ErrorDominio(
+                "rango_invalido", "'hasta' no puede ser anterior a 'desde'.", 400);
+        }
+
+        if (hasta.DayNumber - desde.DayNumber > SpanMaximoEnDias)
+        {
+            throw new ErrorDominio(
+                "rango_demasiado_amplio", $"El rango no puede superar {SpanMaximoEnDias} días.", 400);
+        }
+
+        return new RangoDeReporte(desde, hasta, granularidad, zona);
+    }
+
+    /// <summary>Instante UTC de la medianoche local de <see cref="Desde"/> en <see cref="Zona"/>
+    /// — el límite inferior INCLUSIVO que <c>LectorDeSerieTemporal</c> liga a <c>fecha &gt;=</c>.</summary>
+    public DateTimeOffset DesdeUtc => InstanteLocal(Desde);
+
+    /// <summary>Límite superior EXCLUSIVO: medianoche local del día siguiente a
+    /// <see cref="Hasta"/> — <see cref="Hasta"/> es inclusivo en el rango de fechas del reporte.</summary>
+    public DateTimeOffset HastaUtcExclusivo => InstanteLocal(Hasta.AddDays(1));
+
+    private DateTimeOffset InstanteLocal(DateOnly fecha)
+    {
+        var local = fecha.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
+        var offset = Zona.GetUtcOffset(local);
+
+        // Npgsql solo acepta offset 0 para "timestamp with time zone" — el resultado sigue
+        // siendo el MISMO instante, normalizado a UTC (design: Timezone Mechanics).
+        return new DateTimeOffset(local, offset).ToUniversalTime();
+    }
+
+    /// <summary>Todos los buckets del período, tengan o no filas en el resultado SQL — el punto
+    /// de entrada del left-join en C# (design decisión 4).</summary>
+    public IReadOnlyList<(DateOnly Inicio, string Etiqueta)> Buckets() => Granularidad switch
+    {
+        Granularidad.Dia => BucketsPorDia(),
+        Granularidad.Semana => BucketsPorSemana(),
+        Granularidad.Mes => BucketsPorMes(),
+        _ => throw new ArgumentOutOfRangeException(nameof(Granularidad))
+    };
+
+    private List<(DateOnly, string)> BucketsPorDia()
+    {
+        var buckets = new List<(DateOnly, string)>();
+        for (var fecha = Desde; fecha <= Hasta; fecha = fecha.AddDays(1))
+        {
+            buckets.Add((fecha, fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+        }
+
+        return buckets;
+    }
+
+    /// <summary>Postgres <c>date_trunc('week', …)</c> es Monday-start por defecto — la etiqueta
+    /// ISO (<c>2026-W33</c>) sale de <see cref="ISOWeek"/> sobre el propio lunes del bucket, nunca
+    /// de <c>to_char</c> (design: Timezone Mechanics, "ISO week").</summary>
+    private List<(DateOnly, string)> BucketsPorSemana()
+    {
+        var buckets = new List<(DateOnly, string)>();
+        var lunes = LunesDeLaSemanaDe(Desde);
+        var ultimoLunes = LunesDeLaSemanaDe(Hasta);
+
+        while (lunes <= ultimoLunes)
+        {
+            var fechaDeReferencia = lunes.ToDateTime(TimeOnly.MinValue);
+            var etiqueta = $"{ISOWeek.GetYear(fechaDeReferencia)}-W{ISOWeek.GetWeekOfYear(fechaDeReferencia):D2}";
+            buckets.Add((lunes, etiqueta));
+            lunes = lunes.AddDays(7);
+        }
+
+        return buckets;
+    }
+
+    private List<(DateOnly, string)> BucketsPorMes()
+    {
+        var buckets = new List<(DateOnly, string)>();
+        var mes = new DateOnly(Desde.Year, Desde.Month, 1);
+        var ultimoMes = new DateOnly(Hasta.Year, Hasta.Month, 1);
+
+        while (mes <= ultimoMes)
+        {
+            buckets.Add((mes, mes.ToString("yyyy-MM", CultureInfo.InvariantCulture)));
+            mes = mes.AddMonths(1);
+        }
+
+        return buckets;
+    }
+
+    private static DateOnly LunesDeLaSemanaDe(DateOnly fecha)
+    {
+        var diferencia = ((int)fecha.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        return fecha.AddDays(-diferencia);
+    }
+}

--- a/tests/Ways.Domain.Tests/Reportes/RangoDeReporteTests.cs
+++ b/tests/Ways.Domain.Tests/Reportes/RangoDeReporteTests.cs
@@ -1,0 +1,139 @@
+using Ways.Domain.Common;
+using Ways.Domain.Reportes;
+
+namespace Ways.Domain.Tests.Reportes;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 2 (task 2.9, design: Timezone Mechanics / Range
+/// resolution; spec reportes-de-gestion: Business-Day Bucketing Resolved Through The Punto De
+/// Venta's Timezone) — pura, sin base de datos, mismo criterio que <c>PoliticaDeRoles</c>.
+/// </summary>
+public class RangoDeReporteTests
+{
+    private static readonly TimeZoneInfo ZonaArgentina = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
+    private static readonly TimeZoneInfo ZonaUtc = TimeZoneInfo.Utc;
+
+    // ---- 22:30 ART, "A late-evening sale lands on its own business day" -----------------------
+
+    [Fact]
+    public void UnaVentaDeLas2230EnArtQuedaDentroDelRangoDelMismoDiaLocal()
+    {
+        // 2026-08-05T22:30:00-03:00 == 2026-08-06T01:30:00Z.
+        var instante = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5), Granularidad.Dia, ZonaArgentina);
+
+        Assert.True(instante >= rango.DesdeUtc);
+        Assert.True(instante < rango.HastaUtcExclusivo);
+    }
+
+    [Fact]
+    public void LaMismaVentaBajoUnaZonaUtcQuedaFueraDelRangoDelDia5DemostrandoQueElParametroEstaVivo()
+    {
+        var instante = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5), Granularidad.Dia, ZonaUtc);
+
+        Assert.False(instante < rango.HastaUtcExclusivo);
+    }
+
+    // ---- hasta inclusivity ----------------------------------------------------------------------
+
+    [Fact]
+    public void HastaEsInclusivoElLimiteSuperiorEsLaMedianocheLocalDelDiaSiguiente()
+    {
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 5), Granularidad.Dia, ZonaArgentina);
+
+        var medianocheLocalDelSeis = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(medianocheLocalDelSeis, rango.HastaUtcExclusivo);
+    }
+
+    // ---- ISO Monday-start + year rollover ---------------------------------------------------------
+
+    [Fact]
+    public void LosBucketsSemanalesArrancanElLunes()
+    {
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 8, 9), new DateOnly(2026, 8, 10), Granularidad.Semana, ZonaArgentina);
+
+        var buckets = rango.Buckets();
+
+        // 2026-08-09 es domingo, 2026-08-10 es lunes — dos semanas ISO distintas.
+        Assert.Equal(2, buckets.Count);
+        Assert.Equal(new DateOnly(2026, 8, 3), buckets[0].Inicio);
+        Assert.Equal(new DateOnly(2026, 8, 10), buckets[1].Inicio);
+    }
+
+    [Fact]
+    public void LaEtiquetaIsoHaceElRolloverDeAnioEnLaSemana1()
+    {
+        // 2026-01-01 es jueves; su semana ISO pertenece a 2026-W01 (empieza el lunes 2025-12-29).
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 1), Granularidad.Semana, ZonaArgentina);
+
+        var bucket = Assert.Single(rango.Buckets());
+
+        Assert.Equal("2026-W01", bucket.Etiqueta);
+        Assert.Equal(new DateOnly(2025, 12, 29), bucket.Inicio);
+    }
+
+    // ---- month boundaries -------------------------------------------------------------------------
+
+    [Fact]
+    public void LosBucketsMensualesArrancanElPrimeroDeCadaMes()
+    {
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 1, 15), new DateOnly(2026, 3, 3), Granularidad.Mes, ZonaArgentina);
+
+        var buckets = rango.Buckets();
+
+        Assert.Equal(3, buckets.Count);
+        Assert.Equal(new DateOnly(2026, 1, 1), buckets[0].Inicio);
+        Assert.Equal("2026-01", buckets[0].Etiqueta);
+        Assert.Equal(new DateOnly(2026, 2, 1), buckets[1].Inicio);
+        Assert.Equal(new DateOnly(2026, 3, 1), buckets[2].Inicio);
+    }
+
+    // ---- gap fill: cada bucket del rango existe, tenga o no filas SQL -----------------------------
+
+    [Fact]
+    public void BucketsDevuelveUnaEntradaPorCadaDiaDelRangoSinImportarSiTuvoVentas()
+    {
+        var rango = RangoDeReporte.Crear(new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 5), Granularidad.Dia, ZonaArgentina);
+
+        var buckets = rango.Buckets();
+
+        Assert.Equal(5, buckets.Count);
+        Assert.Equal(new DateOnly(2026, 8, 1), buckets[0].Inicio);
+        Assert.Equal(new DateOnly(2026, 8, 5), buckets[^1].Inicio);
+    }
+
+    // ---- invalid range + 366-day guard --------------------------------------------------------------
+
+    [Fact]
+    public void HastaAnteriorADesdeSeRechaza()
+    {
+        var excepcion = Assert.Throws<ErrorDominio>(() =>
+            RangoDeReporte.Crear(new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 1), Granularidad.Dia, ZonaArgentina));
+
+        Assert.Equal("rango_invalido", excepcion.Codigo);
+        Assert.Equal(400, excepcion.EstadoHttp);
+    }
+
+    [Fact]
+    public void UnRangoDeExactamente366DiasEsValido()
+    {
+        var desde = new DateOnly(2026, 1, 1);
+        var hasta = desde.AddDays(366);
+
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, ZonaArgentina);
+
+        Assert.Equal(hasta, rango.Hasta);
+    }
+
+    [Fact]
+    public void UnRangoDeMasDe366DiasSeRechaza()
+    {
+        var desde = new DateOnly(2026, 1, 1);
+        var hasta = desde.AddDays(367);
+
+        var excepcion = Assert.Throws<ErrorDominio>(() => RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, ZonaArgentina));
+
+        Assert.Equal("rango_demasiado_amplio", excepcion.Codigo);
+    }
+}

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
@@ -158,6 +158,34 @@ public class ReportesVentasResumenTests(WaysApiFixture fixture) : IClassFixture<
         Assert.Equal(0m, resumen.NetoVendido);
     }
 
+    /// <summary>El test de arriba pasa igual aunque se borre <c>AND cv.id_tenant = $2</c> del SQL:
+    /// tanto RLS (GUC de conexión) como la lista de puntos de venta resuelta por
+    /// <c>ServicioDeReportesDeVentas.ResolverPuntosDeVentaAsync</c> (siempre acotada a la empresa,
+    /// por lo tanto al tenant) ya lo enmascaran. Este test ejercita <see cref="LectorDeSerieTemporal"/>
+    /// directo, con un <see cref="WaysDbContext"/> en modo <c>Plataforma</c> (RLS bypasseada por
+    /// <c>app_es_plataforma()</c>) y una <c>idsPuntoVenta</c> armada a mano que incluye el punto de
+    /// venta del tenant B — así el único filtro de tenant que puede aplicar es el predicado
+    /// <c>id_tenant = $2</c> del propio SQL.</summary>
+    [Fact]
+    public async Task ElPredicadoDeIdTenantDelSqlExcluyeFilasDeOtroTenant()
+    {
+        var ctxA = await PrepararAsync(nameof(ElPredicadoDeIdTenantDelSqlExcluyeFilasDeOtroTenant) + "-A");
+        var ctxB = await PrepararAsync(nameof(ElPredicadoDeIdTenantDelSqlExcluyeFilasDeOtroTenant) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var desdeUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 0, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctxB, mediodiaUtc, 999_999m);
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var lector = new LectorDeSerieTemporal(dbPlataforma);
+
+        var filas = await lector.EjecutarVentasAsync(
+            Granularidad.Dia, "UTC", ctxA.IdTenant, [ctxA.IdPuntoVenta, ctxB.IdPuntoVenta], desdeUtc, desdeUtc.AddDays(1));
+
+        Assert.Empty(filas);
+    }
+
     [Fact]
     public async Task UnaFilaSoftDeletedNuncaApareceEnElResumen()
     {
@@ -217,21 +245,35 @@ public class ReportesVentasResumenTests(WaysApiFixture fixture) : IClassFixture<
         var instante = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
         await SembrarComprobanteAsync(ctx, instante, 500m);
 
+        // Rango de 3 días: con un solo día en el rango, hay un único bucket posible y el test no
+        // distingue si el bucketing por zona en verdad corrió en el SQL (timezone($1, cv.fecha))
+        // o si el date_trunc truncó en la zona de sesión de Postgres sin más. Con 3 días, la venta
+        // tiene que caer en el bucket correcto SEGÚN LA ZONA, no en cualquiera del rango.
+        var desde = new DateOnly(2026, 8, 4);
+        var hasta = new DateOnly(2026, 8, 6);
+
         var configuracionArt = await ctx.Admin.PutAsJsonAsync(
             "/api/parametros?idEmpresa=" + ctx.IdEmpresa,
             new ParametroAlta("zona_horaria", "\"America/Argentina/Buenos_Aires\"", null));
         Assert.Equal(HttpStatusCode.OK, configuracionArt.StatusCode);
 
-        var resumenArt = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5));
+        var resumenArt = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, desde, hasta);
         Assert.Equal(500m, resumenArt.NetoVendido);
+        Assert.Equal(500m, BucketPor(resumenArt, "2026-08-05").Neto);
+        Assert.Equal(0m, BucketPor(resumenArt, "2026-08-06").Neto);
 
         var configuracionUtc = await ctx.Admin.PutAsJsonAsync(
             "/api/parametros?idEmpresa=" + ctx.IdEmpresa, new ParametroAlta("zona_horaria", "\"UTC\"", null));
         Assert.Equal(HttpStatusCode.OK, configuracionUtc.StatusCode);
 
-        var resumenUtc = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5));
-        Assert.Equal(0m, resumenUtc.NetoVendido);
+        var resumenUtc = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, desde, hasta);
+        Assert.Equal(500m, resumenUtc.NetoVendido);
+        Assert.Equal(0m, BucketPor(resumenUtc, "2026-08-05").Neto);
+        Assert.Equal(500m, BucketPor(resumenUtc, "2026-08-06").Neto);
     }
+
+    private static BucketDeVentas BucketPor(ResumenDeVentas resumen, string etiqueta) =>
+        resumen.Serie.Single(b => b.Etiqueta == etiqueta);
 
     // ---- task 2.13: NCX se excluye de numerador Y denominador del ticket promedio ----------------
 

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
@@ -1,0 +1,304 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Reportes;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 2 (tasks 2.11-2.13): <c>GET /api/reportes/ventas/resumen</c>
+/// punta a punta — el patrón de 4 pruebas no negociable por endpoint (spec reportes-de-gestion: Net
+/// Sales Has No Sign Branch, Raw SQL MUST Spell Out Soft-Delete And Estado Filters Explicitly,
+/// Tenant Isolation Holds On Raw SQL Via Connection-Level RLS), el corte de zona horaria (spec:
+/// Business-Day Bucketing) y la semántica NCX de ticket promedio (spec: Ticket Promedio Excludes
+/// NCX From Both Sides) — consolidado en un único archivo (en vez de tres) para no triplicar el
+/// boilerplate de <see cref="PrepararAsync"/> bajo el presupuesto de revisión de esta slice.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReportesVentasResumenTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        HttpClient Root, int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdTipoComprobanteNcx);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        // Sin "using": ctx.Root viaja en el Contexto devuelto y se usa después de que este
+        // método retorna — mismo criterio que ctx.Admin, nunca se dispone acá.
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+        var idTipoComprobanteNcx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "NCX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor, root,
+            idCliente, resultado.IdUsuarioAdmin, idTipoComprobanteTx, idTipoComprobanteNcx);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        // "usuario" tiene un máximo de 40 caracteres (ServicioDeUsuarios.CrearAsync) — los
+        // nombres de test son largos, así que el login usa un sufijo corto y único en vez del
+        // nombre completo del caso.
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> (que exige turno abierto) —
+    /// mismo criterio que <c>SaldoDeProveedorTests.SembrarPagoAsync</c>: la derivación del reporte
+    /// nunca toca <c>items_comprobante_venta</c>/<c>pagos_comprobante</c>.</summary>
+    private async Task SembrarComprobanteAsync(
+        Contexto ctx, DateTimeOffset fecha, decimal total, bool esNcx = false,
+        EstadoComprobante estado = EstadoComprobante.Emitido, bool eliminado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = esNcx ? ctx.IdTipoComprobanteNcx : ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora,
+            DeletedAt = eliminado ? ahora : null
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<HttpResponseMessage> LlamarResumenAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta, Granularidad granularidad = Granularidad.Dia,
+        int? idPuntoVenta = null)
+    {
+        var query =
+            $"/api/reportes/ventas/resumen?idEmpresa={idEmpresa}&desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}" +
+            $"&granularidad={granularidad}" + (idPuntoVenta is { } id ? $"&idPuntoVenta={id}" : string.Empty);
+        return await cliente.GetAsync(query);
+    }
+
+    private static async Task<ResumenDeVentas> ObtenerResumenAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta, Granularidad granularidad = Granularidad.Dia)
+    {
+        var respuesta = await LlamarResumenAsync(cliente, idEmpresa, desde, hasta, granularidad);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResumenDeVentas>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 2.11: el patrón de 4 pruebas ------------------------------------------------------
+
+    [Fact]
+    public async Task UnaFilaDeOtroTenantNuncaApareceEnElResumen()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaFilaDeOtroTenantNuncaApareceEnElResumen) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnaFilaDeOtroTenantNuncaApareceEnElResumen) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctxB, DateTimeOffset.UtcNow, 999_999m);
+
+        var resumen = await ObtenerResumenAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(0m, resumen.NetoVendido);
+    }
+
+    [Fact]
+    public async Task UnaFilaSoftDeletedNuncaApareceEnElResumen()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFilaSoftDeletedNuncaApareceEnElResumen));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(100m, resumen.NetoVendido);
+    }
+
+    [Fact]
+    public async Task UnComprobanteAnuladoNuncaApareceEnElResumen()
+    {
+        var ctx = await PrepararAsync(nameof(UnComprobanteAnuladoNuncaApareceEnElResumen));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(250m, resumen.NetoVendido);
+    }
+
+    [Fact]
+    public async Task ElResumenCoincideConElCalculoAMano()
+    {
+        var ctx = await PrepararAsync(nameof(ElResumenCoincideConElCalculoAMano));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 200m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, -50m, esNcx: true);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(550m, resumen.NetoVendido);
+        Assert.Equal(3, resumen.CantidadTx);
+        Assert.Equal(200m, resumen.TicketPromedio);
+        Assert.Equal(1, resumen.CantidadNcx);
+        Assert.Equal(-50m, resumen.NetoNcx);
+    }
+
+    // ---- task 2.12: el corte de día vive en la zona del punto de venta ---------------------------
+
+    [Fact]
+    public async Task UnaVentaALas2230ArtBucketeaEnDiasDistintosSegunLaZonaConfigurada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaALas2230ArtBucketeaEnDiasDistintosSegunLaZonaConfigurada));
+        // 2026-08-05T22:30:00-03:00 == 2026-08-06T01:30:00Z.
+        var instante = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+        await SembrarComprobanteAsync(ctx, instante, 500m);
+
+        var configuracionArt = await ctx.Admin.PutAsJsonAsync(
+            "/api/parametros?idEmpresa=" + ctx.IdEmpresa,
+            new ParametroAlta("zona_horaria", "\"America/Argentina/Buenos_Aires\"", null));
+        Assert.Equal(HttpStatusCode.OK, configuracionArt.StatusCode);
+
+        var resumenArt = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5));
+        Assert.Equal(500m, resumenArt.NetoVendido);
+
+        var configuracionUtc = await ctx.Admin.PutAsJsonAsync(
+            "/api/parametros?idEmpresa=" + ctx.IdEmpresa, new ParametroAlta("zona_horaria", "\"UTC\"", null));
+        Assert.Equal(HttpStatusCode.OK, configuracionUtc.StatusCode);
+
+        var resumenUtc = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, new DateOnly(2026, 8, 5), new DateOnly(2026, 8, 5));
+        Assert.Equal(0m, resumenUtc.NetoVendido);
+    }
+
+    // ---- task 2.13: NCX se excluye de numerador Y denominador del ticket promedio ----------------
+
+    [Fact]
+    public async Task UnaNcxReduceElNetoSinAlterarElTicketPromedioNiLaCantidadDeTx()
+    {
+        var ctx = await PrepararAsync(nameof(UnaNcxReduceElNetoSinAlterarElTicketPromedioNiLaCantidadDeTx));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 200m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, -50m, esNcx: true);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        // 600/3 = 200, nunca 550/4.
+        Assert.Equal(200m, resumen.TicketPromedio);
+        Assert.Equal(3, resumen.CantidadTx);
+        Assert.Equal(550m, resumen.NetoVendido);
+    }
+
+    // ---- matriz de roles: Vendedor y Root rechazados, Supervisor y Admin aceptados ----------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelReporteDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelReporteDeVentas));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarResumenAsync(ctx.Vendedor, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazadoDelReporteDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDelReporteDeVentas));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarResumenAsync(ctx.Root, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorLeeElReporteDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorLeeElReporteDeVentas));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarResumenAsync(ctx.Supervisor, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnEmpresaDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnEmpresaDeOtroTenantDevuelve404) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnEmpresaDeOtroTenantDevuelve404) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarResumenAsync(ctxA.Admin, ctxB.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}


### PR DESCRIPTION
## Etapa 10, slice 2 — Ventas resumen

Primer endpoint de agregacion del sistema: `GET /api/reportes/ventas/resumen` bajo `LecturaDeReportes`.

- `LectorDeSerieTemporal`: LA unica superficie de SQL crudo de la etapa — `OpenConnectionAsync` (dispara el interceptor RLS), zona bind-parametrizada, granularidad por switch cerrado, predicados `deleted_at`/`estado`/`id_tenant`/`id_punto_venta` alineados al indice compuesto.
- `RangoDeReporte`: bucketing dia/semana ISO/mes por zona del negocio, rango UTC half-open; fix real de Npgsql encontrado al implementar (offset local rechazado en timestamptz → ToUniversalTime).
- Ventas netas sin branch de signo (el total de la NCX ya es negativo); ticket promedio TX-only en numerador y denominador via `signo`, nunca `codigo`.
- Cero migraciones (gate sin-cambios-de-DB verificado).

### Review
Judgment-day: Juez A APPROVE ronda 1 (cero hallazgos — inyeccion, RLS, indices, bordes UTC verificados). Juez B REJECT ronda 1 con 2 MAJORs de honestidad de tests PROBADOS POR MUTACION (el test cross-tenant y el de zona pasaban con sus clausulas borradas — sobredeterminados por RLS y el rango C#). Fix test-only `c059d04` con evidencia de mutacion registrada (FAIL→revert→PASS por cada uno); Juez B APPROVE ronda 2 re-ejecutando sus propias mutaciones. Este incidente (3ra ocurrencia de la clase) creo la skill `mutation-proof-tests`.

### Size
`size:exception` — ~962 lineas vs ~390 previstas; el desborde es cobertura del patron de 4 tests + bordes de zona sobre la superficie RLS-sensible. Separar los tests del SQL que verifican seria peor.

### Tests
Domain 394/394 · Application 219/219 · Integration 727/727 (716 + 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)