### PR TITLE
feat(reportes): rentabilidad con cobertura de costo (etapa 10, slice rentabilidad)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -226,35 +226,61 @@ branch.
   `ObtenerTopArticulosAsync` — join `ItemsComprobanteVenta` ⋈ header, net-sales
   filter, group by `id_articulo`, sum `cantidad`/`total`, label from the
   line's `descripcion` snapshot (never re-join `articulos`). *(design
-  decision 10; spec: Top Artículos Ranks By Net Quantity And Revenue)*
-- [ ] 4.2 Same file: `ObtenerRentabilidadAsync` — `SUM(total -
+  decision 10; spec: Top Artículos Ranks By Net Quantity And Revenue)* —
+  **NOT done in this batch**: the orchestrator narrowed this apply batch to
+  `/rentabilidad` only (parallel worktree scope split, three slices merging
+  the same night); `/articulos/top` remains open.
+- [x] 4.2 Same file: `ObtenerRentabilidadAsync` — `SUM(total -
   costo_unitario * cantidad)`, IVA-included both sides; `costo_es_estimado`
   lines excluded unless `incluirEstimados`; `costo_unitario IS NULL` lines
   skipped, never zeroed; build `CoberturaDeCosto` (lines/revenue included,
   excluded-as-estimated, skipped-as-unknown). *(design: Interfaces/Contracts
   `Rentabilidad`; spec rentabilidad-y-comisiones: Margin Excludes Estimated
-  Cost Lines By Default; NULL Cost Is Never Treated As Zero)*
-- [ ] 4.3 Extend `Contratos.cs`: `RentabilidadPorArticulo`, `Rentabilidad`
+  Cost Lines By Default; NULL Cost Is Never Treated As Zero)* — done; the
+  file created carries only `ObtenerRentabilidadAsync` (task 4.1's
+  `ObtenerTopArticulosAsync` out of scope, see above).
+- [x] 4.3 Extend `Contratos.cs`: `RentabilidadPorArticulo`, `Rentabilidad`
   records exactly as in design (`MargenPorcentaje` nullable, never `0`).
-- [ ] 4.4 Extend `ReportesEndpoints.cs`: `GET /articulos/top` (`limite`) under
+- [x] 4.4 Extend `ReportesEndpoints.cs`: `GET /articulos/top` (`limite`) under
   `LecturaDeReportes`; `GET /rentabilidad` (`incluirEstimados`) under
   `LecturaDeReportes` **+** `LecturaDeRentabilidad` (design decision 7 — AND
-  composition, no new mechanism).
+  composition, no new mechanism). — `GET /rentabilidad` only, wired and
+  tested; `GET /articulos/top` out of scope (see 4.1).
 - [ ] 4.5 [P] `ReportesArticulosTopTests` — 4-test pattern + NCX-reduces-ranking
-  check.
-- [ ] 4.6 [P] `RentabilidadTests`: four seeded lines (real cost / estimated /
+  check. — **NOT done**: depends on 4.1 (out of scope).
+- [x] 4.6 [P] `RentabilidadTests`: four seeded lines (real cost / estimated /
   `NULL` / cost `0`) — estimated excluded by default, included with the
   flag; `NULL` never counted as `0`; every coverage count/revenue field
   asserted for a 10-line mixed period (7 real / 2 estimated / 1 unknown).
-  *(spec: Coverage Reflects A Mixed Period)*
-- [ ] 4.7 [P] Extend `ReportesAutorizacionTests` (parameterized over the
+  *(spec: Coverage Reflects A Mixed Period)* — done, 12 tests, mutation
+  evidence recorded for the `costo_es_estimado` exclusion clause and the
+  `CostoUnitario IS NULL` guard (see apply-progress notes).
+- [x] 4.7 [P] Extend `ReportesAutorizacionTests` (parameterized over the
   route list, created here and grown in later slices): Vendedor → 403 on
   all current routes; Supervisor → 200 on volume routes, 403 on
-  `/rentabilidad`; Admin → 200 on all; Root → 403 on all.
-- [ ] 4.8 Gate guard: `dotnet ef migrations list` unchanged.
-- [ ] 4.9 Run `judgment-day`; fix; re-judge until clean.
+  `/rentabilidad`; Admin → 200 on all; Root → 403 on all. — **Deviation**:
+  no shared `ReportesAutorizacionTests` file created (would collide with the
+  sibling worktrees implementing slices 3/5 the same night). The
+  `/rentabilidad`-only role matrix (Vendedor/Root/Supervisor → 403, Admin →
+  200) is consolidated into `RentabilidadTests.cs` instead, same precedent
+  as slice 2's consolidation of its role tests into
+  `ReportesVentasResumenTests.cs`. A future slice must still create the
+  shared parameterized file once all routes are known.
+- [x] 4.8 Gate guard: `dotnet ef migrations list` unchanged. — confirmed via
+  `dotnet ef migrations has-pending-model-changes` (Infrastructure as
+  startup project): "No changes have been made to the model since the last
+  migration."
+- [ ] 4.9 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
+  sdd-apply — requires sub-agent delegation, out of the apply executor's
+  scope; orchestrator must run this before PR, same precedent as slices
+  2/6.)*
 - [ ] 4.10 Branch `feat/stage10-slice4-articulos-y-margen` off `main`
-  (parent: slice 2, independent of slice 3); PR; merge stacked-to-main.
+  (parent: slice 2, independent of slice 3); PR; merge stacked-to-main. —
+  Branch `feat/stage10-slice4-rentabilidad` created off `main` @ 46ce29f
+  instead (orchestrator-assigned name for the rentabilidad-only scope split
+  — `articulos-y-margen`'s `/articulos/top` half remains a separate open
+  work unit). PR creation/merge explicitly out of scope per apply
+  boundaries — NOT done.
 
 **Verify**: `dotnet test --filter FullyQualifiedName~ReportesArticulosTop|FullyQualifiedName~Rentabilidad|FullyQualifiedName~ReportesAutorizacion`
 

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -38,6 +38,20 @@ public static class ReportesEndpoints
         .WithSummary(
             "Ranking de artículos por cantidad y monto neto vendido, ordenado por monto " +
             "descendente. Sin costo ni margen: ver /rentabilidad.");
+        // stage-10-agregacion-dashboard, Slice 4 (design decisión 7): apila LecturaDeRentabilidad
+        // sobre LecturaDeReportes — ASP.NET Core compone políticas con AND, mismo criterio que
+        // StockEndpoints ("/ajustes" apilando GestionDeCatalogo sobre OperacionDePos).
+        grupo.MapGet("/rentabilidad", (
+            ServicioDeReportesDeRentabilidad servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
+            bool? incluirEstimados, CancellationToken ct) =>
+            // bool? (mismo criterio que incluirEliminados/incluirInactivos en el resto de la API):
+            // ausente en la query string ⇒ null ⇒ excluido por default (spec: Margin Excludes
+            // Estimated Cost Lines By Default), nunca un 400 por parámetro faltante.
+            servicio.ObtenerRentabilidadAsync(idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados ?? false, ct))
+        .RequireAuthorization(Politicas.LecturaDeRentabilidad)
+        .WithSummary(
+            "Margen del período: costo estimado excluido por defecto (incluirEstimados=true para " +
+            "sumarlo), costo desconocido siempre salteado. Cobertura obligatoria en toda respuesta.");
 
         return app;
     }

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -93,6 +93,9 @@ public static class DependencyInjection
         // stage-10-agregacion-dashboard, Slice 5: top artículos — LINQ puro, sin costo/margen
         // (eso vive en ServicioDeReportesDeRentabilidad, slice 4, bajo LecturaDeRentabilidad).
         services.AddScoped<ServicioDeReportesDeArticulos>();
+        // stage-10-agregacion-dashboard, Slice 4: el margen — LINQ propio, sin dependencia de
+        // LectorDeSerieTemporal (no bucketea, design: Interfaces / Contracts Rentabilidad).
+        services.AddScoped<ServicioDeReportesDeRentabilidad>();
 
         return services;
     }

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -56,3 +56,20 @@ public sealed record ArticuloTop(int IdArticulo, string Descripcion, decimal Can
 /// <c>/rentabilidad</c>, bajo <c>LecturaDeRentabilidad</c>.</summary>
 public sealed record TopArticulos(
     DateOnly Desde, DateOnly Hasta, string ZonaHoraria, IReadOnlyList<ArticuloTop> Articulos);
+/// <summary>Desglose de margen por artículo dentro de un período de rentabilidad (stage-10 slice
+/// 4). Agrupa por <c>id_articulo</c> pero etiqueta con la <see cref="Descripcion"/> snapshot de la
+/// línea (design decisión 10: nunca re-join contra <c>articulos</c>) — <c>IdArticulo</c> es
+/// <c>null</c> en una línea de concepto libre. Solo incluye líneas efectivamente consideradas en el
+/// margen (design: Interfaces / Contracts); <see cref="MargenPorcentaje"/> es nullable, nunca
+/// <c>0</c>, con el mismo criterio que <see cref="ResumenDeVentas.TicketPromedio"/>.</summary>
+public sealed record RentabilidadPorArticulo(
+    int? IdArticulo, string Descripcion, decimal VentaConsiderada, decimal CostoConsiderado,
+    decimal Margen, decimal? MargenPorcentaje);
+
+/// <summary>Respuesta de <c>GET /api/reportes/rentabilidad</c> (design: Interfaces / Contracts).
+/// <see cref="Cobertura"/> viaja SIEMPRE (spec rentabilidad-y-comisiones: NULL Cost Is Never Treated
+/// As Zero, And Coverage Is Mandatory) — no existe una respuesta sin ella.</summary>
+public sealed record Rentabilidad(
+    DateOnly Desde, DateOnly Hasta, string ZonaHoraria,
+    decimal VentaConsiderada, decimal CostoConsiderado, decimal Margen, decimal? MargenPorcentaje,
+    CoberturaDeCosto Cobertura, IReadOnlyList<RentabilidadPorArticulo> PorArticulo);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeRentabilidad.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeRentabilidad.cs
@@ -95,6 +95,9 @@ public class ServicioDeReportesDeRentabilidad(IWaysDbContext db, ServicioDeParam
     /// nunca re-join contra <c>articulos</c> (design decisión 10).</summary>
     private static IReadOnlyList<RentabilidadPorArticulo> ArmarPorArticulo(IReadOnlyList<LineaDeCosto> consideradas) =>
         consideradas
+            // Lineas de concepto libre (IdArticulo null) se agruparian juntas bajo una sola
+            // etiqueta; hoy ningun camino de escritura las produce — si la etapa que las
+            // habilite llega, agrupar por (IdArticulo, Descripcion) o excluirlas de PorArticulo.
             .GroupBy(l => l.IdArticulo)
             .Select(grupo =>
             {

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeRentabilidad.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeRentabilidad.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Parametros;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Reportes;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>
+/// El margen de stage-10-agregacion-dashboard, Slice 4 (design: Interfaces / Contracts —
+/// <c>Rentabilidad</c>; spec rentabilidad-y-comisiones). LINQ puro sobre
+/// <c>items_comprobante_venta</c> ⋈ <c>comprobantes_venta</c> ⋈ <c>tipos_comprobante</c> — los
+/// filtros de <c>deleted_at</c>/<c>id_tenant</c> los aportan los query filters de EF (design
+/// decisión 1: "carries the BajaLogica and Tenant query filters for free"), el resto (estado,
+/// clase, alcance de punto de venta, rango de fecha) es explícito, mismo criterio que
+/// <see cref="ServicioDeReportesDeVentas"/> (design: Raw-SQL Invariant Checklist, fila
+/// <c>articulos/top, rentabilidad</c>).
+///
+/// Costo en tres estados (stage-9-costo-congelado): real (<c>costo_unitario</c> no nulo,
+/// <c>costo_es_estimado = false</c>), estimado (<c>costo_es_estimado = true</c>, excluido del
+/// margen salvo <c>incluirEstimados</c>) y desconocido (<c>costo_unitario IS NULL</c>, jamás
+/// tratado como cero — se salta del margen y se reporta aparte en <see cref="CoberturaDeCosto"/>,
+/// spec: NULL Cost Is Never Treated As Zero, And Coverage Is Mandatory).
+/// </summary>
+public class ServicioDeReportesDeRentabilidad(IWaysDbContext db, ServicioDeParametros parametros)
+{
+    public async Task<Rentabilidad> ObtenerRentabilidadAsync(
+        int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, bool incluirEstimados,
+        CancellationToken ct = default)
+    {
+        await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, idPuntoVenta, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, idPuntoVenta, ct);
+
+        // Granularidad.Dia es un placeholder: Rentabilidad no bucketea (sin Serie/Granularidad en
+        // el contrato), solo necesita DesdeUtc/HastaUtcExclusivo — Buckets() nunca se invoca acá.
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, zona);
+
+        var lineas = idsPuntoVenta.Count == 0
+            ? []
+            : await (
+                from item in db.ItemsComprobanteVenta
+                join header in db.ComprobantesVenta on item.IdComprobanteVenta equals header.Id
+                join tipo in db.TiposComprobante on header.IdTipoComprobante equals tipo.Id
+                where header.Estado != EstadoComprobante.Anulado
+                   && tipo.Clase == ClaseComprobante.Venta
+                   && idsPuntoVenta.Contains(header.IdPuntoVenta)
+                   && header.Fecha >= rango.DesdeUtc
+                   && header.Fecha < rango.HastaUtcExclusivo
+                orderby item.Id
+                select new LineaDeCosto(
+                    item.IdArticulo, item.Descripcion, item.Total, item.Cantidad, item.CostoUnitario, item.CostoEsEstimado))
+                .ToListAsync(ct);
+
+        var cobertura = ArmarCobertura(lineas, incluirEstimados);
+        var consideradas = lineas.Where(l => EsConsiderada(l, incluirEstimados)).ToList();
+
+        var ventaConsiderada = consideradas.Sum(l => l.Total);
+        var costoConsiderado = consideradas.Sum(l => l.CostoUnitario!.Value * l.Cantidad);
+        var margen = ventaConsiderada - costoConsiderado;
+        var margenPorcentaje = ventaConsiderada != 0 ? margen / ventaConsiderada * 100m : (decimal?)null;
+
+        var porArticulo = ArmarPorArticulo(consideradas);
+
+        return new Rentabilidad(
+            desde, hasta, zonaId, ventaConsiderada, costoConsiderado, margen, margenPorcentaje, cobertura, porArticulo);
+    }
+
+    /// <summary>Real, o estimada con el opt-in prendido — nunca una línea con
+    /// <c>CostoUnitario IS NULL</c> (spec: NULL Cost Is Never Treated As Zero).</summary>
+    private static bool EsConsiderada(LineaDeCosto linea, bool incluirEstimados) =>
+        linea.CostoUnitario is not null && (!linea.CostoEsEstimado || incluirEstimados);
+
+    /// <summary>Cobertura sobre TODAS las líneas del período, independiente de
+    /// <paramref name="incluirEstimados"/> — el banner tiene que poder mostrar cuánto quedó
+    /// afuera aunque el caller no haya pedido incluirlo (spec: Coverage Reflects A Mixed
+    /// Period).</summary>
+    private static CoberturaDeCosto ArmarCobertura(IReadOnlyList<LineaDeCosto> lineas, bool incluirEstimados)
+    {
+        var reales = lineas.Where(l => l.CostoUnitario is not null && !l.CostoEsEstimado).ToList();
+        var estimadas = lineas.Where(l => l.CostoEsEstimado).ToList();
+        var desconocidas = lineas.Where(l => l.CostoUnitario is null).ToList();
+
+        return new CoberturaDeCosto(
+            lineas.Count, reales.Count, estimadas.Count, desconocidas.Count,
+            lineas.Sum(l => l.Total), reales.Sum(l => l.Total), estimadas.Sum(l => l.Total), desconocidas.Sum(l => l.Total),
+            incluirEstimados);
+    }
+
+    /// <summary>Agrupa las líneas ya consideradas por <c>id_articulo</c>, etiqueta con la
+    /// descripción de la primera línea del grupo (orden estable por <c>item.Id</c> en la query) —
+    /// nunca re-join contra <c>articulos</c> (design decisión 10).</summary>
+    private static IReadOnlyList<RentabilidadPorArticulo> ArmarPorArticulo(IReadOnlyList<LineaDeCosto> consideradas) =>
+        consideradas
+            .GroupBy(l => l.IdArticulo)
+            .Select(grupo =>
+            {
+                var venta = grupo.Sum(l => l.Total);
+                var costo = grupo.Sum(l => l.CostoUnitario!.Value * l.Cantidad);
+                var margenDelGrupo = venta - costo;
+                return new RentabilidadPorArticulo(
+                    grupo.Key, grupo.First().Descripcion, venta, costo, margenDelGrupo,
+                    venta != 0 ? margenDelGrupo / venta * 100m : (decimal?)null);
+            })
+            .OrderByDescending(p => p.Margen)
+            .ToList();
+
+    // ---- alcance: idéntico a ServicioDeReportesDeVentas — duplicado a propósito, sin base
+    // compartida (design: File Changes asigna un archivo de orquestación propio por reporte) -----
+
+    private async Task<int> ExigirEmpresaAsync(int idEmpresa, CancellationToken ct)
+    {
+        var idTenant = await db.Empresas
+            .Where(e => e.Id == idEmpresa)
+            .Select(e => (int?)e.IdTenant)
+            .FirstOrDefaultAsync(ct);
+
+        // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+        return idTenant ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {idEmpresa}.");
+    }
+
+    private async Task<IReadOnlyList<int>> ResolverPuntosDeVentaAsync(int idEmpresa, int? idPuntoVenta, CancellationToken ct)
+    {
+        var puntosDeLaEmpresa = db.PuntosVenta.Where(pv => pv.IdEmpresa == idEmpresa);
+
+        if (idPuntoVenta is { } id)
+        {
+            var pertenece = await puntosDeLaEmpresa.AnyAsync(pv => pv.Id == id, ct);
+            if (!pertenece)
+            {
+                throw new ErrorDominio(
+                    "punto_venta_no_pertenece_a_la_empresa",
+                    "El punto de venta indicado no pertenece a la empresa declarada.",
+                    400);
+            }
+
+            return [id];
+        }
+
+        return await puntosDeLaEmpresa.Select(pv => pv.Id).ToListAsync(ct);
+    }
+
+    /// <summary>Misma precedencia PV → empresa → default que cualquier otro parámetro (design
+    /// decisión 5) — la zona se resuelve una única vez, al alcance que pidió el caller.</summary>
+    private async Task<(string ZonaId, TimeZoneInfo Zona)> ResolverZonaAsync(int idEmpresa, int? idPuntoVenta, CancellationToken ct)
+    {
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, idPuntoVenta, ct);
+        var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
+        return (zonaId, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+    }
+
+    private sealed record LineaDeCosto(
+        int? IdArticulo, string Descripcion, decimal Total, decimal Cantidad, decimal? CostoUnitario, bool CostoEsEstimado);
+}

--- a/tests/Ways.IntegrationTests/RentabilidadTests.cs
+++ b/tests/Ways.IntegrationTests/RentabilidadTests.cs
@@ -1,0 +1,426 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 4 (tasks 4.6-4.7): <c>GET /api/reportes/rentabilidad</c>
+/// punta a punta — el patrón de 4 pruebas no negociable (spec rentabilidad-y-comisiones: LecturaDe
+/// Rentabilidad Policy Admits Admin Only, Margin Excludes Estimated Cost Lines By Default, NULL Cost
+/// Is Never Treated As Zero And Coverage Is Mandatory), la matriz de roles (Supervisor 403 es la
+/// prueba distintiva de esta slice: a diferencia de <c>/ventas/resumen</c>, acá NO alcanza con
+/// <c>LecturaDeReportes</c>) y la cobertura de costo obligatoria. Consolidado en un único archivo
+/// (mismo criterio que <c>ReportesVentasResumenTests</c>, slice 2) — la composición de políticas ya
+/// quedó probada a nivel unitario en <c>PoliticasTests</c> (slice 1); acá solo se prueba el
+/// <em>wiring</em> del endpoint.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class RentabilidadTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        HttpClient Root, int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdTipoComprobanteNcx,
+        int IdArea, int IdAlicuotaIva, int IdListaPrecio);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Rentabilidad-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        dbTenant.Areas.Add(area);
+        await dbTenant.SaveChangesAsync();
+
+        var idAlicuotaIva = await dbTenant.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Rentabilidad", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        dbTenant.ListasPrecio.Add(lista);
+        await dbTenant.SaveChangesAsync();
+
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+        var idTipoComprobanteNcx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "NCX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor, root,
+            idCliente, resultado.IdUsuarioAdmin, idTipoComprobanteTx, idTipoComprobanteNcx, area.Id, idAlicuotaIva, lista.Id);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> (que exige turno abierto) —
+    /// mismo criterio que <c>ReportesVentasResumenTests.SembrarComprobanteAsync</c>. Una sola línea
+    /// por comprobante alcanza para el reporte de rentabilidad.</summary>
+    private async Task<int> SembrarLineaAsync(
+        Contexto ctx, DateTimeOffset fecha, decimal total, decimal cantidad, decimal? costoUnitario,
+        bool costoEsEstimado = false, int? idArticulo = null, bool esNcx = false,
+        EstadoComprobante estado = EstadoComprobante.Emitido, bool eliminado = false, string descripcion = "linea-rentabilidad")
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = esNcx ? ctx.IdTipoComprobanteNcx : ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora,
+            DeletedAt = eliminado ? ahora : null
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.ItemsComprobanteVenta.Add(new ItemComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = comprobante.Id,
+            Orden = 1,
+            IdArticulo = idArticulo,
+            Descripcion = descripcion,
+            IdArea = ctx.IdArea,
+            IdListaPrecio = ctx.IdListaPrecio,
+            IdAlicuotaIva = ctx.IdAlicuotaIva,
+            PorcentajeIva = 0m,
+            Cantidad = cantidad,
+            PrecioUnitario = cantidad != 0 ? total / cantidad : 0m,
+            Descuento = 0m,
+            Total = total,
+            CostoUnitario = costoUnitario,
+            CostoEsEstimado = costoEsEstimado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return comprobante.Id;
+    }
+
+    /// <summary>Solo para <see cref="ElMargenCoincideConElCalculoAManoYUnaNcxLoRevierte"/>:
+    /// <c>id_articulo</c> tiene FK real contra <c>articulos</c>, así que <see cref="RentabilidadPorArticulo"/>
+    /// necesita un artículo genuino para agrupar, no un id inventado.</summary>
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private static async Task<HttpResponseMessage> LlamarRentabilidadAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta, bool? incluirEstimados = null,
+        int? idPuntoVenta = null)
+    {
+        var query =
+            $"/api/reportes/rentabilidad?idEmpresa={idEmpresa}&desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}"
+            + (incluirEstimados is { } flag ? $"&incluirEstimados={flag}" : string.Empty)
+            + (idPuntoVenta is { } id ? $"&idPuntoVenta={id}" : string.Empty);
+        return await cliente.GetAsync(query);
+    }
+
+    private static async Task<Rentabilidad> ObtenerRentabilidadAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta, bool? incluirEstimados = null)
+    {
+        var respuesta = await LlamarRentabilidadAsync(cliente, idEmpresa, desde, hasta, incluirEstimados);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<Rentabilidad>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 4.6: el patrón de 4 pruebas ---------------------------------------------------------
+
+    [Fact]
+    public async Task UnaLineaDeOtroTenantNuncaApareceEnLaRentabilidad()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaLineaDeOtroTenantNuncaApareceEnLaRentabilidad) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnaLineaDeOtroTenantNuncaApareceEnLaRentabilidad) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarLineaAsync(ctxB, mediodiaUtc, total: 999_999m, cantidad: 1m, costoUnitario: 1m);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(0m, rentabilidad.VentaConsiderada);
+        Assert.Equal(0, rentabilidad.Cobertura.LineasTotales);
+    }
+
+    [Fact]
+    public async Task UnaLineaSoftDeletedNuncaApareceEnLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaSoftDeletedNuncaApareceEnLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 999_999m, cantidad: 1m, costoUnitario: 1m, eliminado: true);
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 100m, cantidad: 1m, costoUnitario: 40m);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(60m, rentabilidad.Margen);
+        Assert.Equal(1, rentabilidad.Cobertura.LineasTotales);
+    }
+
+    [Fact]
+    public async Task UnaLineaDeComprobanteAnuladoNuncaApareceEnLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaDeComprobanteAnuladoNuncaApareceEnLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 999_999m, cantidad: 1m, costoUnitario: 1m, estado: EstadoComprobante.Anulado);
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 250m, cantidad: 1m, costoUnitario: 100m);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(150m, rentabilidad.Margen);
+        Assert.Equal(1, rentabilidad.Cobertura.LineasTotales);
+    }
+
+    [Fact]
+    public async Task ElMargenCoincideConElCalculoAManoYUnaNcxLoRevierte()
+    {
+        var ctx = await PrepararAsync(nameof(ElMargenCoincideConElCalculoAManoYUnaNcxLoRevierte));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-rentabilidad");
+
+        // TX real: venta 300, costo unitario 100 × cantidad 1 → margen de línea 200.
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 300m, cantidad: 1m, costoUnitario: 100m, idArticulo: idArticulo);
+        // NCX real sobre el mismo artículo: cantidad y total negativos, costo SIN signo (design
+        // decisión 4/9) → costo×cantidad también negativo, la línea resta 50 al margen total.
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: -150m, cantidad: -1m, costoUnitario: 100m, esNcx: true, idArticulo: idArticulo);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(150m, rentabilidad.VentaConsiderada);
+        Assert.Equal(0m, rentabilidad.CostoConsiderado);
+        Assert.Equal(150m, rentabilidad.Margen);
+        Assert.Equal(100m, rentabilidad.MargenPorcentaje);
+
+        var porArticulo = Assert.Single(rentabilidad.PorArticulo);
+        Assert.Equal(idArticulo, porArticulo.IdArticulo);
+        Assert.Equal(150m, porArticulo.Margen);
+    }
+
+    // ---- task 4.6: opt-in explícito de líneas estimadas (spec: Margin Excludes Estimated Cost
+    // Lines By Default) -----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaLineaEstimadaSeExcluyePorDefectoYSeIncluyeSoloConElOptInExplicito()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaEstimadaSeExcluyePorDefectoYSeIncluyeSoloConElOptInExplicito));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        // total 150, costo_unitario 100, costo_es_estimado true → $50 de margen en juego.
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 150m, cantidad: 1m, costoUnitario: 100m, costoEsEstimado: true);
+
+        var sinOptIn = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+        Assert.Equal(0m, sinOptIn.VentaConsiderada);
+        Assert.Equal(0m, sinOptIn.Margen);
+        Assert.Equal(1, sinOptIn.Cobertura.LineasConCostoEstimado);
+        Assert.Equal(150m, sinOptIn.Cobertura.VentaConCostoEstimado);
+        Assert.False(sinOptIn.Cobertura.IncluyeEstimados);
+
+        var conOptIn = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy, incluirEstimados: true);
+        Assert.Equal(150m, conOptIn.VentaConsiderada);
+        Assert.Equal(50m, conOptIn.Margen);
+        Assert.True(conOptIn.Cobertura.IncluyeEstimados);
+    }
+
+    // ---- task 4.6: costo desconocido nunca se trata como cero (spec: NULL Cost Is Never Treated As
+    // Zero) -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaLineaDeCostoDesconocidoSeSalteaDelMargenYSeReportaAparteNuncaComoCero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaDeCostoDesconocidoSeSalteaDelMargenYSeReportaAparteNuncaComoCero));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 200m, cantidad: 1m, costoUnitario: null);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        // Si costo_unitario NULL se tratara como 0, margen == venta (200) — nunca debe pasar: la
+        // línea queda totalmente afuera del margen (0/0, no 200/0).
+        Assert.Equal(0m, rentabilidad.VentaConsiderada);
+        Assert.Equal(0m, rentabilidad.CostoConsiderado);
+        Assert.Equal(0m, rentabilidad.Margen);
+        Assert.Null(rentabilidad.MargenPorcentaje);
+        Assert.Equal(1, rentabilidad.Cobertura.LineasSinCosto);
+        Assert.Equal(200m, rentabilidad.Cobertura.VentaSinCosto);
+        Assert.Empty(rentabilidad.PorArticulo);
+    }
+
+    // ---- task 4.6: la cobertura refleja un período mixto (spec: Coverage Reflects A Mixed Period) --
+
+    [Fact]
+    public async Task LaCoberturaReflejaUnPeriodoMixtoDeCostoRealEstimadoYDesconocido()
+    {
+        var ctx = await PrepararAsync(nameof(LaCoberturaReflejaUnPeriodoMixtoDeCostoRealEstimadoYDesconocido));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        // 7 líneas con costo real ($100 c/u, costo $60 c/u).
+        for (var i = 0; i < 7; i++)
+        {
+            await SembrarLineaAsync(ctx, mediodiaUtc, total: 100m, cantidad: 1m, costoUnitario: 60m);
+        }
+
+        // 2 líneas estimadas ($50 c/u, costo $30 c/u).
+        for (var i = 0; i < 2; i++)
+        {
+            await SembrarLineaAsync(ctx, mediodiaUtc, total: 50m, cantidad: 1m, costoUnitario: 30m, costoEsEstimado: true);
+        }
+
+        // 1 línea de costo desconocido ($40).
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: 40m, cantidad: 1m, costoUnitario: null);
+
+        var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(10, rentabilidad.Cobertura.LineasTotales);
+        Assert.Equal(7, rentabilidad.Cobertura.LineasConCostoReal);
+        Assert.Equal(700m, rentabilidad.Cobertura.VentaConCostoReal);
+        Assert.Equal(2, rentabilidad.Cobertura.LineasConCostoEstimado);
+        Assert.Equal(100m, rentabilidad.Cobertura.VentaConCostoEstimado);
+        Assert.Equal(1, rentabilidad.Cobertura.LineasSinCosto);
+        Assert.Equal(40m, rentabilidad.Cobertura.VentaSinCosto);
+
+        // Por defecto solo las 7 reales entran al margen: venta 700, costo 420, margen 280.
+        Assert.Equal(700m, rentabilidad.VentaConsiderada);
+        Assert.Equal(420m, rentabilidad.CostoConsiderado);
+        Assert.Equal(280m, rentabilidad.Margen);
+    }
+
+    // ---- matriz de roles: Supervisor rechazado ES la prueba distintiva de esta slice (a diferencia
+    // de /ventas/resumen, LecturaDeReportes solo no alcanza acá) -------------------------------------
+
+    [Fact]
+    public async Task UnSupervisorEsRechazadoDeLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoDeLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarRentabilidadAsync(ctx.Supervisor, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDeLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDeLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarRentabilidadAsync(ctx.Vendedor, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazadoDeLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDeLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarRentabilidadAsync(ctx.Root, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminLeeLaRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminLeeLaRentabilidad));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnaEmpresaDeOtroTenantDevuelve404EnRentabilidad()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaEmpresaDeOtroTenantDevuelve404EnRentabilidad) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnaEmpresaDeOtroTenantDevuelve404EnRentabilidad) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarRentabilidadAsync(ctxA.Admin, ctxB.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/RentabilidadTests.cs
+++ b/tests/Ways.IntegrationTests/RentabilidadTests.cs
@@ -260,18 +260,19 @@ public class RentabilidadTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
         await SembrarLineaAsync(ctx, mediodiaUtc, total: 300m, cantidad: 1m, costoUnitario: 100m, idArticulo: idArticulo);
         // NCX real sobre el mismo artículo: cantidad y total negativos, costo SIN signo (design
         // decisión 4/9) → costo×cantidad también negativo, la línea resta 50 al margen total.
-        await SembrarLineaAsync(ctx, mediodiaUtc, total: -150m, cantidad: -1m, costoUnitario: 100m, esNcx: true, idArticulo: idArticulo);
+        // Costo distinto al de la TX: cada línea usa SU costo congelado (etapa 9), y con
+        // valores iguales este test no distinguiría un bug que acople la NCX a la TX.
+        await SembrarLineaAsync(ctx, mediodiaUtc, total: -150m, cantidad: -1m, costoUnitario: 120m, esNcx: true, idArticulo: idArticulo);
 
         var rentabilidad = await ObtenerRentabilidadAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
         Assert.Equal(150m, rentabilidad.VentaConsiderada);
-        Assert.Equal(0m, rentabilidad.CostoConsiderado);
-        Assert.Equal(150m, rentabilidad.Margen);
-        Assert.Equal(100m, rentabilidad.MargenPorcentaje);
+        Assert.Equal(-20m, rentabilidad.CostoConsiderado);
+        Assert.Equal(170m, rentabilidad.Margen);
 
         var porArticulo = Assert.Single(rentabilidad.PorArticulo);
         Assert.Equal(idArticulo, porArticulo.IdArticulo);
-        Assert.Equal(150m, porArticulo.Margen);
+        Assert.Equal(170m, porArticulo.Margen);
     }
 
     // ---- task 4.6: opt-in explícito de líneas estimadas (spec: Margin Excludes Estimated Cost
@@ -298,6 +299,9 @@ public class RentabilidadTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
         Assert.Equal(150m, conOptIn.VentaConsiderada);
         Assert.Equal(50m, conOptIn.Margen);
         Assert.True(conOptIn.Cobertura.IncluyeEstimados);
+        // El opt-in incluye la línea en el margen pero NUNCA la convierte en real.
+        Assert.Equal(1, conOptIn.Cobertura.LineasConCostoEstimado);
+        Assert.Equal(150m, conOptIn.Cobertura.VentaConCostoEstimado);
     }
 
     // ---- task 4.6: costo desconocido nunca se trata como cero (spec: NULL Cost Is Never Treated As


### PR DESCRIPTION
## Etapa 10 — mitad rentabilidad del Slice 4 real

`GET /api/reportes/rentabilidad` — SOLO Admin (`LecturaDeRentabilidad` apilada sobre `LecturaDeReportes` del grupo; el 403 del Supervisor es el test distintivo del slice).

- Margen = total − costo_unitario × cantidad, IVA incluido ambos lados (contrato vinculante de la etapa 9); reversion NCX automatica por cantidad negativa, cada linea con SU costo congelado.
- Tres estados honestos: estimadas EXCLUIDAS por defecto con opt-in explicito; NULL nunca es 0; payload de cobertura obligatorio por tipo (no-nullable — garantia de compilacion).
- Cobertura particionada real+estimada+desconocida = total, respaldada por el CHECK de la etapa 9 que hace irrepresentable el solapamiento.

### Review
Judgment-day: ronda limpia — Juez A APPROVE-WITH-MINORS (formula, cobertura y autorizacion verificadas contra Postgres real; 1 MINOR dormante: agrupacion de concepto libre, comentado en el codigo), Juez B APPROVE-WITH-MINORS re-ejecutando ambas mutaciones (exclusion de estimados y guard de NULL). 2 WARNINGs de rigor de test aplicados en la rama: costo NCX distinto (120 vs 100 — con valores iguales el test no distinguia el acople) y asserts de cobertura bajo opt-in (la linea sigue reportandose estimada).

### Tests
RentabilidadTests 12/12 post-rebase · full suite en el merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)