### PR TITLE
feat(reportes): ventas por punto de venta, vendedor y medio de pago (etapa 10, slice 3)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -190,24 +190,44 @@ revert the branch; no state to unwind.
 `/por-medio-pago` live, LINQ-based, each row an independent subtotal.
 **Rollback**: revert the branch.
 
-- [ ] 3.1 Extend `ServicioDeReportesDeVentas.cs`: `ObtenerPorPuntoVentaAsync`,
+- [x] 3.1 Extend `ServicioDeReportesDeVentas.cs`: `ObtenerPorPuntoVentaAsync`,
   `ObtenerPorVendedorAsync` (group by `id_empleado`), `ObtenerPorMedioPagoAsync`
   (join `PagosComprobante` ⋈ `ComprobantesVenta`, group by `id_medio_pago`,
   header `Estado`/`deleted_at`). All plain LINQ — EF `Tenant`/`BajaLogica`
   filters apply automatically. *(design: Raw-SQL Invariant Checklist rows
-  3–4; spec: Ventas Breakdown Endpoints)*
-- [ ] 3.2 Extend `Contratos.cs` with the three response records (one row per
+  3–4; spec: Ventas Breakdown Endpoints)* — deviation recorded: the shared
+  `Join(...).GroupBy(x => x.SomeProperty)` pattern does not translate when
+  the join's result selector constructs a named record (EF
+  `InvalidOperationException`, "could not be translated"); anonymous-type
+  result selectors (same idiom as `LectorDeContenidoDeResumen`) do. Each
+  `Consultar*Async` builds its own anonymous projection instead of sharing
+  one typed helper record.
+- [x] 3.2 Extend `Contratos.cs` with the three response records (one row per
   dimension key, own subtotal — no implicit-whole percentage).
-- [ ] 3.3 Extend `ReportesEndpoints.cs`: three `GET` routes under the same
+- [x] 3.3 Extend `ReportesEndpoints.cs`: three `GET` routes under the same
   `LecturaDeReportes` group.
-- [ ] 3.4 [P] `ReportesVentasPorDimensionTests` — 4-test pattern ×3 (one per
+- [x] 3.4 [P] `ReportesVentasPorDimensionTests` — 4-test pattern ×3 (one per
   route) + NCX-sign check (an NCX reduces its vendedor's/PV's/medio's
   subtotal, no separate branch). *(spec: Grouping by vendedor sums each
-  empleado's TX independently)*
-- [ ] 3.5 Gate guard: `dotnet ef migrations list` unchanged.
-- [ ] 3.6 Run `judgment-day`; fix; re-judge until clean.
+  empleado's TX independently)* — 15 tests, all green. Mutation evidence
+  recorded for `por-medio-pago`'s `x.Importe * x.Signo` clause (the only
+  novel sign-application logic this slice adds — `pagos_comprobante.importe`
+  is never negative by CHECK, so the NCX sign has to come from the header's
+  `Signo`): mutated to `x.Importe` alone, the NCX test failed 350 vs
+  expected 250, reverted, green again. Cross-tenant checks for the three
+  routes are recorded as ordinary coverage, not mutation-proof — they reuse
+  `ResolverPuntosDeVentaAsync`'s scope (already proven by slice 2), with no
+  separate predicate of their own to isolate from that confound.
+- [x] 3.5 Gate guard: `dotnet ef migrations list` unchanged, no diff in the
+  model snapshot.
+- [ ] 3.6 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
+  sdd-apply — requires sub-agent delegation, out of the apply executor's
+  scope; orchestrator must run this before PR, same precedent as slices 2/6.)*
 - [ ] 3.7 Branch `feat/stage10-slice3-ventas-por-dimension` off `main`
-  (parent: slice 2); PR; merge stacked-to-main.
+  (parent: slice 2's merged commit); PR; merge stacked-to-main. *(Branch
+  created off the worktree's HEAD — slices 1/2/6 merged, matching "Start:
+  slice 2 merged" — commit `398c5f5` applied on it. PR creation/merge
+  explicitly out of scope per apply boundaries — NOT done.)*
 
 **Verify**: `dotnet test --filter FullyQualifiedName~ReportesVentasPorDimension`
 

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -52,6 +52,22 @@ public static class ReportesEndpoints
         .WithSummary(
             "Margen del período: costo estimado excluido por defecto (incluirEstimados=true para " +
             "sumarlo), costo desconocido siempre salteado. Cobertura obligatoria en toda respuesta.");
+        grupo.MapGet("/ventas/por-punto-venta", (
+            ServicioDeReportesDeVentas servicio, int idEmpresa, DateOnly desde, DateOnly hasta, CancellationToken ct) =>
+            servicio.ObtenerPorPuntoVentaAsync(idEmpresa, desde, hasta, ct))
+        .WithSummary("Ventas netas del período agrupadas por punto de venta — una fila por PV, sin idPuntoVenta.");
+
+        grupo.MapGet("/ventas/por-vendedor", (
+            ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
+            CancellationToken ct) =>
+            servicio.ObtenerPorVendedorAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
+        .WithSummary("Ventas netas del período agrupadas por vendedor (id_empleado emisor).");
+
+        grupo.MapGet("/ventas/por-medio-pago", (
+            ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
+            CancellationToken ct) =>
+            servicio.ObtenerPorMedioPagoAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
+        .WithSummary("Ventas netas del período agrupadas por medio de pago (pagos_comprobante.id_medio_pago).");
 
         return app;
     }

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -73,3 +73,36 @@ public sealed record Rentabilidad(
     DateOnly Desde, DateOnly Hasta, string ZonaHoraria,
     decimal VentaConsiderada, decimal CostoConsiderado, decimal Margen, decimal? MargenPorcentaje,
     CoberturaDeCosto Cobertura, IReadOnlyList<RentabilidadPorArticulo> PorArticulo);
+/// <summary>Una fila de <c>ventas/por-punto-venta</c> — mismo criterio de <see cref="Neto"/> y
+/// <see cref="TicketPromedio"/> que <see cref="BucketDeVentas"/> (design decisión 9: <c>Neto</c>
+/// ya viene neto de NCX por construcción; <see cref="TicketPromedio"/> es <c>null</c>, nunca
+/// <c>0</c>, sin ningún TX en el punto de venta).</summary>
+public sealed record FilaVentasPorPuntoVenta(int IdPuntoVenta, decimal Neto, int CantidadTx, decimal? TicketPromedio);
+
+/// <summary>Respuesta de <c>GET /api/reportes/ventas/por-punto-venta</c> (spec reportes-de-gestion:
+/// Ventas Breakdown Endpoints By Punto De Venta, Vendedor, Medio De Pago) — cada fila reporta su
+/// propio subtotal, nunca un porcentaje de un total implícito.</summary>
+public sealed record VentasPorPuntoVenta(
+    DateOnly Desde, DateOnly Hasta, string ZonaHoraria, IReadOnlyList<FilaVentasPorPuntoVenta> Filas);
+
+/// <summary>Una fila de <c>ventas/por-vendedor</c>, agrupada por <c>id_empleado</c> (el vendedor
+/// emisor, design decisión 11: hoy es <c>IContextoDeUsuario.UsuarioId</c> — no existe tabla
+/// <c>empleados</c> separada todavía).</summary>
+public sealed record FilaVentasPorVendedor(int IdEmpleado, decimal Neto, int CantidadTx, decimal? TicketPromedio);
+
+/// <summary>Respuesta de <c>GET /api/reportes/ventas/por-vendedor</c>.</summary>
+public sealed record VentasPorVendedor(
+    DateOnly Desde, DateOnly Hasta, string ZonaHoraria, IReadOnlyList<FilaVentasPorVendedor> Filas);
+
+/// <summary>Una fila de <c>ventas/por-medio-pago</c>, agrupada por <c>pagos_comprobante.id_medio_pago</c>.
+/// <see cref="Neto"/> es <c>Σ (importe × signo del tipo de comprobante del encabezado)</c>: el
+/// importe de un pago nunca es negativo (CHECK <c>ck_pagos_comprobante_importe_no_negativo</c>),
+/// así que el signo lo aporta el encabezado — mismo discriminador que <c>ventas/resumen</c>
+/// (design decisión 9), ninguna rama condicional. <see cref="CantidadPagos"/> cuenta filas de
+/// <c>pagos_comprobante</c>, no comprobantes — un TX con pago dividido entre dos medios aporta una
+/// fila a cada uno.</summary>
+public sealed record FilaVentasPorMedioPago(int IdMedioPago, decimal Neto, int CantidadPagos);
+
+/// <summary>Respuesta de <c>GET /api/reportes/ventas/por-medio-pago</c>.</summary>
+public sealed record VentasPorMedioPago(
+    DateOnly Desde, DateOnly Hasta, string ZonaHoraria, IReadOnlyList<FilaVentasPorMedioPago> Filas);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
@@ -5,6 +5,7 @@ using Ways.Application.Parametros;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Reportes;
+using Ways.Domain.Ventas;
 
 namespace Ways.Application.Reportes;
 
@@ -56,6 +57,48 @@ public class ServicioDeReportesDeVentas(IWaysDbContext db, LectorDeSerieTemporal
             desde, hasta, granularidad, zonaId, serie, netoVendido, cantidadTxTotal, ticketPromedio, cantidadNcx, netoNcx);
     }
 
+    /// <summary>Sin <c>idPuntoVenta</c> — sería una contradicción filtrar por el mismo eje que se
+    /// está agrupando (design: Interfaces / Contracts, dto-contract-honesty). Zona resuelta a
+    /// nivel empresa (spec: Ventas Breakdown Endpoints).</summary>
+    public async Task<VentasPorPuntoVenta> ObtenerPorPuntoVentaAsync(
+        int idEmpresa, DateOnly desde, DateOnly hasta, CancellationToken ct = default)
+    {
+        await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, null, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, null, ct);
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, zona);
+
+        var filas = await ConsultarPorPuntoVentaAsync(idsPuntoVenta, rango, ct);
+
+        return new VentasPorPuntoVenta(desde, hasta, zonaId, filas);
+    }
+
+    public async Task<VentasPorVendedor> ObtenerPorVendedorAsync(
+        int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, CancellationToken ct = default)
+    {
+        await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, idPuntoVenta, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, idPuntoVenta, ct);
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, zona);
+
+        var filas = await ConsultarPorVendedorAsync(idsPuntoVenta, rango, ct);
+
+        return new VentasPorVendedor(desde, hasta, zonaId, filas);
+    }
+
+    public async Task<VentasPorMedioPago> ObtenerPorMedioPagoAsync(
+        int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, CancellationToken ct = default)
+    {
+        await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, idPuntoVenta, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, idPuntoVenta, ct);
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, zona);
+
+        var filas = await ConsultarPorMedioPagoAsync(idsPuntoVenta, rango, ct);
+
+        return new VentasPorMedioPago(desde, hasta, zonaId, filas);
+    }
+
     private async Task<int> ExigirEmpresaAsync(int idEmpresa, CancellationToken ct)
     {
         var idTenant = await db.Empresas
@@ -105,5 +148,109 @@ public class ServicioDeReportesDeVentas(IWaysDbContext db, LectorDeSerieTemporal
         var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, idPuntoVenta, ct);
         var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
         return (zonaId, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+    }
+
+    /// <summary>LINQ plano (design: Raw-SQL Invariant Checklist filas 3-4) — <c>Tenant</c> y
+    /// <c>BajaLogica</c> los aplica EF automáticamente vía sus query filters globales; acá se
+    /// espeletrean explícitamente <c>Estado != Anulado</c>, igual que el SQL crudo de
+    /// <see cref="LectorDeSerieTemporal"/> los espeletrea a mano. Sin el <c>Join</c> a
+    /// <c>tipos_comprobante</c> todavía — cada consumidor lo arma con una proyección anónima
+    /// propia: EF no logra traducir un <c>GroupBy</c> sobre la propiedad de un record con nombre
+    /// construido en el mismo <c>Join</c> (probado — <c>InvalidOperationException</c> "could not
+    /// be translated"), pero sí sobre la de un tipo anónimo, mismo patrón que
+    /// <c>LectorDeContenidoDeResumen.LeerAsync</c> paso 4.</summary>
+    private IQueryable<ComprobanteVenta> ComprobantesVentaDelPeriodo(
+        IReadOnlyCollection<int> idsPuntoVenta, RangoDeReporte rango) =>
+        db.ComprobantesVenta
+            .Where(cv => idsPuntoVenta.Contains(cv.IdPuntoVenta))
+            .Where(cv => cv.Estado != EstadoComprobante.Anulado)
+            .Where(cv => cv.Fecha >= rango.DesdeUtc && cv.Fecha < rango.HastaUtcExclusivo);
+
+    private async Task<IReadOnlyList<FilaVentasPorPuntoVenta>> ConsultarPorPuntoVentaAsync(
+        IReadOnlyCollection<int> idsPuntoVenta, RangoDeReporte rango, CancellationToken ct)
+    {
+        if (idsPuntoVenta.Count == 0)
+        {
+            return [];
+        }
+
+        var agregados = await ComprobantesVentaDelPeriodo(idsPuntoVenta, rango)
+            .Join(
+                db.TiposComprobante.Where(t => t.Clase == ClaseComprobante.Venta),
+                cv => cv.IdTipoComprobante, t => t.Id, (cv, t) => new { cv.IdPuntoVenta, cv.Total, t.Signo })
+            .GroupBy(x => x.IdPuntoVenta)
+            .Select(g => new
+            {
+                Clave = g.Key,
+                Neto = g.Sum(x => x.Total),
+                CantidadTx = g.Count(x => x.Signo > 0),
+                NetoTx = g.Sum(x => x.Signo > 0 ? x.Total : 0m)
+            })
+            .ToListAsync(ct);
+
+        return agregados
+            .Select(a => new FilaVentasPorPuntoVenta(
+                a.Clave, a.Neto, a.CantidadTx, a.CantidadTx > 0 ? a.NetoTx / a.CantidadTx : (decimal?)null))
+            .OrderBy(f => f.IdPuntoVenta)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<FilaVentasPorVendedor>> ConsultarPorVendedorAsync(
+        IReadOnlyCollection<int> idsPuntoVenta, RangoDeReporte rango, CancellationToken ct)
+    {
+        if (idsPuntoVenta.Count == 0)
+        {
+            return [];
+        }
+
+        var agregados = await ComprobantesVentaDelPeriodo(idsPuntoVenta, rango)
+            .Join(
+                db.TiposComprobante.Where(t => t.Clase == ClaseComprobante.Venta),
+                cv => cv.IdTipoComprobante, t => t.Id, (cv, t) => new { cv.IdEmpleado, cv.Total, t.Signo })
+            .GroupBy(x => x.IdEmpleado)
+            .Select(g => new
+            {
+                Clave = g.Key,
+                Neto = g.Sum(x => x.Total),
+                CantidadTx = g.Count(x => x.Signo > 0),
+                NetoTx = g.Sum(x => x.Signo > 0 ? x.Total : 0m)
+            })
+            .ToListAsync(ct);
+
+        return agregados
+            .Select(a => new FilaVentasPorVendedor(
+                a.Clave, a.Neto, a.CantidadTx, a.CantidadTx > 0 ? a.NetoTx / a.CantidadTx : (decimal?)null))
+            .OrderBy(f => f.IdEmpleado)
+            .ToList();
+    }
+
+    /// <summary><c>pagos_comprobante.importe</c> nunca es negativo (CHECK
+    /// <c>ck_pagos_comprobante_importe_no_negativo</c>, <c>ValidadorDePagos</c> regla 0) — el
+    /// signo lo aporta el <c>Signo</c> del tipo de comprobante del encabezado, mismo discriminador
+    /// que las otras dos rutas, así que una NCX resta sin ninguna rama condicional (design
+    /// decisión 9).</summary>
+    private async Task<IReadOnlyList<FilaVentasPorMedioPago>> ConsultarPorMedioPagoAsync(
+        IReadOnlyCollection<int> idsPuntoVenta, RangoDeReporte rango, CancellationToken ct)
+    {
+        if (idsPuntoVenta.Count == 0)
+        {
+            return [];
+        }
+
+        var agregados = await ComprobantesVentaDelPeriodo(idsPuntoVenta, rango)
+            .Join(
+                db.TiposComprobante.Where(t => t.Clase == ClaseComprobante.Venta),
+                cv => cv.IdTipoComprobante, t => t.Id, (cv, t) => new { cv.Id, t.Signo })
+            .Join(db.PagosComprobante, cv => cv.Id, p => p.IdComprobanteVenta, (cv, p) => new { cv.Signo, p.IdMedioPago, p.Importe })
+            .GroupBy(x => x.IdMedioPago)
+            // mutation-proof-tests: la cláusula "x.Signo" es lo único que hace que una NCX reste
+            // acá (probado por PorMedioPagoUnaNcxReduceElSubtotalDelMedioSinRamaEspecial).
+            .Select(g => new { Clave = g.Key, Neto = g.Sum(x => x.Importe * x.Signo), CantidadPagos = g.Count() })
+            .ToListAsync(ct);
+
+        return agregados
+            .Select(a => new FilaVentasPorMedioPago(a.Clave, a.Neto, a.CantidadPagos))
+            .OrderBy(f => f.IdMedioPago)
+            .ToList();
     }
 }

--- a/tests/Ways.IntegrationTests/ReportesVentasPorDimensionTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasPorDimensionTests.cs
@@ -1,0 +1,503 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Reportes;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 3 (task 3.4): <c>GET /api/reportes/ventas/por-punto-venta</c>,
+/// <c>/por-vendedor</c> y <c>/por-medio-pago</c> punta a punta — el patrón de 4 pruebas por ruta
+/// (cross-tenant, soft-delete, anulado, cálculo a mano) más el chequeo de signo NCX por ruta (spec
+/// reportes-de-gestion: Ventas Breakdown Endpoints By Punto De Venta, Vendedor, Medio De Pago),
+/// consolidado en un único archivo — mismo criterio que <see cref="ReportesVentasResumenTests"/>.
+///
+/// El chequeo cross-tenant de estas tres rutas es cobertura ORDINARIA, no mutation-proof
+/// (mutation-proof-tests skill, Decision Gate: "cannot name the clause under test"): a diferencia
+/// de <see cref="LectorDeSerieTemporal"/> (que tiene un <c>id_tenant = $2</c> propio y separado del
+/// alcance por punto de venta), las tres rutas LINQ de esta slice NO agregan ningún predicado de
+/// tenant propio — reusan exactamente <c>ServicioDeReportesDeVentas.ResolverPuntosDeVentaAsync</c>,
+/// ya probado por <c>ReportesVentasResumenTests</c>. No hay una segunda cláusula que aislar del
+/// confound de <c>idEmpresa</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        HttpClient Root, int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdTipoComprobanteNcx,
+        int IdMedioPagoEfectivo, int IdMedioPagoTransferencia);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        // Sin "using": ctx.Root viaja en el Contexto devuelto y se usa después de que este
+        // método retorna — mismo criterio que ReportesVentasResumenTests.PrepararAsync.
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+        var idsMedioPago = await dbTenant.MediosPago.OrderBy(m => m.Orden).Select(m => m.Id).ToListAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+        var idTipoComprobanteNcx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "NCX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor, root,
+            idCliente, resultado.IdUsuarioAdmin, idTipoComprobanteTx, idTipoComprobanteNcx,
+            idsMedioPago[0], idsMedioPago[1]);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
+    /// <c>ReportesVentasResumenTests.SembrarComprobanteAsync</c>. Devuelve el id del comprobante
+    /// para que los tests de <c>por-medio-pago</c> puedan encadenar <see cref="SembrarPagoAsync"/>.</summary>
+    private async Task<int> SembrarComprobanteAsync(
+        Contexto ctx, DateTimeOffset fecha, decimal total, int? idPuntoVenta = null, int? idEmpleado = null,
+        bool esNcx = false, EstadoComprobante estado = EstadoComprobante.Emitido, bool eliminado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = esNcx ? ctx.IdTipoComprobanteNcx : ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = fecha,
+            IdPuntoVenta = idPuntoVenta ?? ctx.IdPuntoVenta,
+            IdEmpleado = idEmpleado ?? ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora,
+            DeletedAt = eliminado ? ahora : null
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    /// <summary><c>pagos_comprobante.importe</c> siempre no-negativo (CHECK
+    /// <c>ck_pagos_comprobante_importe_no_negativo</c>) — el signo de una NCX lo aporta el
+    /// <c>Signo</c> del tipo de comprobante del encabezado, nunca este importe.</summary>
+    private async Task SembrarPagoAsync(Contexto ctx, int idComprobanteVenta, int idMedioPago, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = idComprobanteVenta,
+            IdMedioPago = idMedioPago,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Sin endpoint de alta de puntos de venta (<c>OrganizacionEndpoints</c> solo lista/
+    /// edita) — sembrado directo, mismo criterio que el resto de este archivo.</summary>
+    private async Task<int> SembrarPuntoVentaAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdEmpresa = ctx.IdEmpresa,
+            Nombre = nombre,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+        return puntoVenta.Id;
+    }
+
+    private static string Rango(DateOnly desde, DateOnly hasta) =>
+        $"desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}";
+
+    // ------------------------------------------------------------------------------------------
+    // por-punto-venta
+    // ------------------------------------------------------------------------------------------
+
+    private static Task<HttpResponseMessage> LlamarPorPuntoVentaAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/reportes/ventas/por-punto-venta?idEmpresa={idEmpresa}&{Rango(desde, hasta)}");
+
+    private static async Task<VentasPorPuntoVenta> ObtenerPorPuntoVentaAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta)
+    {
+        var respuesta = await LlamarPorPuntoVentaAsync(cliente, idEmpresa, desde, hasta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<VentasPorPuntoVenta>(cuerpo, OpcionesJson)!;
+    }
+
+    [Fact]
+    public async Task PorPuntoVentaNuncaMuestraVentasDeOtroTenant()
+    {
+        var ctxA = await PrepararAsync(nameof(PorPuntoVentaNuncaMuestraVentasDeOtroTenant) + "-A");
+        var ctxB = await PrepararAsync(nameof(PorPuntoVentaNuncaMuestraVentasDeOtroTenant) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctxB, DateTimeOffset.UtcNow, 999_999m);
+
+        var reporte = await ObtenerPorPuntoVentaAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Empty(reporte.Filas);
+    }
+
+    [Fact]
+    public async Task PorPuntoVentaExcluyeUnaFilaSoftDeleted()
+    {
+        var ctx = await PrepararAsync(nameof(PorPuntoVentaExcluyeUnaFilaSoftDeleted));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+
+        var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(100m, fila.Neto);
+    }
+
+    [Fact]
+    public async Task PorPuntoVentaExcluyeUnComprobanteAnulado()
+    {
+        var ctx = await PrepararAsync(nameof(PorPuntoVentaExcluyeUnComprobanteAnulado));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+
+        var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+    }
+
+    [Fact]
+    public async Task PorPuntoVentaAgrupaCadaPuntoDeVentaConSuPropioSubtotal()
+    {
+        var ctx = await PrepararAsync(nameof(PorPuntoVentaAgrupaCadaPuntoDeVentaConSuPropioSubtotal));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var idPuntoVenta2 = await SembrarPuntoVentaAsync(ctx, "Sucursal 2");
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 200m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m, idPuntoVenta: idPuntoVenta2);
+
+        var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(2, reporte.Filas.Count);
+        var filaPv1 = Assert.Single(reporte.Filas, f => f.IdPuntoVenta == ctx.IdPuntoVenta);
+        Assert.Equal(300m, filaPv1.Neto);
+        Assert.Equal(2, filaPv1.CantidadTx);
+        Assert.Equal(150m, filaPv1.TicketPromedio);
+
+        var filaPv2 = Assert.Single(reporte.Filas, f => f.IdPuntoVenta == idPuntoVenta2);
+        Assert.Equal(300m, filaPv2.Neto);
+        Assert.Equal(1, filaPv2.CantidadTx);
+        Assert.Equal(300m, filaPv2.TicketPromedio);
+    }
+
+    [Fact]
+    public async Task PorPuntoVentaUnaNcxReduceElSubtotalDelPuntoDeVentaSinRamaEspecial()
+    {
+        var ctx = await PrepararAsync(nameof(PorPuntoVentaUnaNcxReduceElSubtotalDelPuntoDeVentaSinRamaEspecial));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, -50m, esNcx: true);
+
+        var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+        Assert.Equal(1, fila.CantidadTx);
+        Assert.Equal(300m, fila.TicketPromedio);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // por-vendedor
+    // ------------------------------------------------------------------------------------------
+
+    private static Task<HttpResponseMessage> LlamarPorVendedorAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/reportes/ventas/por-vendedor?idEmpresa={idEmpresa}&{Rango(desde, hasta)}");
+
+    private static async Task<VentasPorVendedor> ObtenerPorVendedorAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta)
+    {
+        var respuesta = await LlamarPorVendedorAsync(cliente, idEmpresa, desde, hasta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<VentasPorVendedor>(cuerpo, OpcionesJson)!;
+    }
+
+    [Fact]
+    public async Task PorVendedorNuncaMuestraVentasDeOtroTenant()
+    {
+        var ctxA = await PrepararAsync(nameof(PorVendedorNuncaMuestraVentasDeOtroTenant) + "-A");
+        var ctxB = await PrepararAsync(nameof(PorVendedorNuncaMuestraVentasDeOtroTenant) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctxB, DateTimeOffset.UtcNow, 999_999m);
+
+        var reporte = await ObtenerPorVendedorAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Empty(reporte.Filas);
+    }
+
+    [Fact]
+    public async Task PorVendedorExcluyeUnaFilaSoftDeleted()
+    {
+        var ctx = await PrepararAsync(nameof(PorVendedorExcluyeUnaFilaSoftDeleted));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+
+        var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(100m, fila.Neto);
+    }
+
+    [Fact]
+    public async Task PorVendedorExcluyeUnComprobanteAnulado()
+    {
+        var ctx = await PrepararAsync(nameof(PorVendedorExcluyeUnComprobanteAnulado));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+
+        var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+    }
+
+    /// <summary>spec reportes-de-gestion, Scenario "Grouping by vendedor sums each empleado's TX
+    /// independently": vendedor A emite $500, vendedor B emite $700, dos filas, sin fila de total
+    /// cruzado (satisfecho estructuralmente — <see cref="VentasPorVendedor"/> no tiene un campo de
+    /// total agregado).</summary>
+    [Fact]
+    public async Task PorVendedorSumaCadaEmpleadoDeFormaIndependiente()
+    {
+        var ctx = await PrepararAsync(nameof(PorVendedorSumaCadaEmpleadoDeFormaIndependiente));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var meSupervisor = await ctx.Supervisor.GetAsync("/api/auth/me");
+        var idEmpleadoSupervisor = (await meSupervisor.Content.ReadFromJsonAsync<UsuarioAutenticado>())!.Id;
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 500m, idEmpleado: ctx.IdEmpleadoAdmin);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 700m, idEmpleado: idEmpleadoSupervisor);
+
+        var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(2, reporte.Filas.Count);
+        Assert.Equal(500m, Assert.Single(reporte.Filas, f => f.IdEmpleado == ctx.IdEmpleadoAdmin).Neto);
+        Assert.Equal(700m, Assert.Single(reporte.Filas, f => f.IdEmpleado == idEmpleadoSupervisor).Neto);
+    }
+
+    [Fact]
+    public async Task PorVendedorUnaNcxReduceElSubtotalDelVendedorSinRamaEspecial()
+    {
+        var ctx = await PrepararAsync(nameof(PorVendedorUnaNcxReduceElSubtotalDelVendedorSinRamaEspecial));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, -50m, esNcx: true);
+
+        var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+        Assert.Equal(1, fila.CantidadTx);
+        Assert.Equal(300m, fila.TicketPromedio);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // por-medio-pago
+    // ------------------------------------------------------------------------------------------
+
+    private static Task<HttpResponseMessage> LlamarPorMedioPagoAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/reportes/ventas/por-medio-pago?idEmpresa={idEmpresa}&{Rango(desde, hasta)}");
+
+    private static async Task<VentasPorMedioPago> ObtenerPorMedioPagoAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta)
+    {
+        var respuesta = await LlamarPorMedioPagoAsync(cliente, idEmpresa, desde, hasta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<VentasPorMedioPago>(cuerpo, OpcionesJson)!;
+    }
+
+    [Fact]
+    public async Task PorMedioPagoNuncaMuestraVentasDeOtroTenant()
+    {
+        var ctxA = await PrepararAsync(nameof(PorMedioPagoNuncaMuestraVentasDeOtroTenant) + "-A");
+        var ctxB = await PrepararAsync(nameof(PorMedioPagoNuncaMuestraVentasDeOtroTenant) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var idComprobanteB = await SembrarComprobanteAsync(ctxB, DateTimeOffset.UtcNow, 999_999m);
+        await SembrarPagoAsync(ctxB, idComprobanteB, ctxB.IdMedioPagoEfectivo, 999_999m);
+
+        var reporte = await ObtenerPorMedioPagoAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Empty(reporte.Filas);
+    }
+
+    [Fact]
+    public async Task PorMedioPagoExcluyeUnPagoDeUnEncabezadoSoftDeleted()
+    {
+        var ctx = await PrepararAsync(nameof(PorMedioPagoExcluyeUnPagoDeUnEncabezadoSoftDeleted));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var idEliminado = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        await SembrarPagoAsync(ctx, idEliminado, ctx.IdMedioPagoEfectivo, 999_999m);
+
+        var idVisible = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+        await SembrarPagoAsync(ctx, idVisible, ctx.IdMedioPagoEfectivo, 100m);
+
+        var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(100m, fila.Neto);
+    }
+
+    [Fact]
+    public async Task PorMedioPagoExcluyeUnPagoDeUnComprobanteAnulado()
+    {
+        var ctx = await PrepararAsync(nameof(PorMedioPagoExcluyeUnPagoDeUnComprobanteAnulado));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var idAnulado = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarPagoAsync(ctx, idAnulado, ctx.IdMedioPagoEfectivo, 999_999m);
+
+        var idVisible = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+        await SembrarPagoAsync(ctx, idVisible, ctx.IdMedioPagoEfectivo, 250m);
+
+        var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+    }
+
+    [Fact]
+    public async Task PorMedioPagoAgrupaCadaMedioConSuPropioSubtotal()
+    {
+        var ctx = await PrepararAsync(nameof(PorMedioPagoAgrupaCadaMedioConSuPropioSubtotal));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        var idEfectivo = await SembrarComprobanteAsync(ctx, mediodiaUtc, 400m);
+        await SembrarPagoAsync(ctx, idEfectivo, ctx.IdMedioPagoEfectivo, 400m);
+
+        var idTransferencia = await SembrarComprobanteAsync(ctx, mediodiaUtc, 600m);
+        await SembrarPagoAsync(ctx, idTransferencia, ctx.IdMedioPagoTransferencia, 600m);
+
+        var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(2, reporte.Filas.Count);
+        var filaEfectivo = Assert.Single(reporte.Filas, f => f.IdMedioPago == ctx.IdMedioPagoEfectivo);
+        Assert.Equal(400m, filaEfectivo.Neto);
+        Assert.Equal(1, filaEfectivo.CantidadPagos);
+
+        var filaTransferencia = Assert.Single(reporte.Filas, f => f.IdMedioPago == ctx.IdMedioPagoTransferencia);
+        Assert.Equal(600m, filaTransferencia.Neto);
+        Assert.Equal(1, filaTransferencia.CantidadPagos);
+    }
+
+    /// <summary>Mutation-proof (skill mutation-proof-tests): la cláusula bajo prueba es
+    /// <c>x.Importe * x.Signo</c> en <c>ServicioDeReportesDeVentas.ConsultarPorMedioPagoAsync</c> —
+    /// el único lugar de esta etapa donde una NCX resta un importe que, por esquema, SIEMPRE llega
+    /// no-negativo (<c>ck_pagos_comprobante_importe_no_negativo</c>). Mutación aplicada: reemplazar
+    /// <c>x.Importe * x.Signo</c> por <c>x.Importe</c> (quitar el signo) → este test pasó de
+    /// <c>250m</c> a fallar con <c>350m</c> — confirmado, revertido.</summary>
+    [Fact]
+    public async Task PorMedioPagoUnaNcxReduceElSubtotalDelMedioSinRamaEspecial()
+    {
+        var ctx = await PrepararAsync(nameof(PorMedioPagoUnaNcxReduceElSubtotalDelMedioSinRamaEspecial));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        var idTx = await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarPagoAsync(ctx, idTx, ctx.IdMedioPagoEfectivo, 300m);
+
+        var idNcx = await SembrarComprobanteAsync(ctx, mediodiaUtc, -50m, esNcx: true);
+        await SembrarPagoAsync(ctx, idNcx, ctx.IdMedioPagoEfectivo, 50m);
+
+        var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(250m, fila.Neto);
+        Assert.Equal(2, fila.CantidadPagos);
+    }
+}


### PR DESCRIPTION
## Etapa 10, slice 3 — Ventas por Dimension

Cierra la capa API de la etapa: `GET /api/reportes/ventas/por-punto-venta`, `/por-vendedor` y `/por-medio-pago` bajo `LecturaDeReportes`.

- Semantica identica al resumen (estado, clase, signo sin branch) verificada byte-a-byte contra el SQL del lector.
- `por-medio-pago`: `Importe × Signo` — el importe es CHECK-non-negative, el signo viene del header (unica logica nueva, con evidencia de mutacion). Nota honesta del Juez A: el camino NCX-con-pagos es defensivamente correcto pero hoy inalcanzable en produccion (la NCX real no escribe pagos) — queda listo para cuando exista.
- Deviation documentada: proyecciones anonimas en vez de records nombrados (limite de traduccion de EF, precedente LectorDeContenidoDeResumen).

### Review
Judgment-day: ronda limpia — Juez A APPROVE (semantica de signo verificada contra el write path real; flakiness transitoria autoinfligida por su propia instrumentacion, 12 corridas limpias consecutivas despues), Juez B APPROVE-WITH-MINORS (mutacion del Signo reproducida exacta; corrio el mismo la mutacion del filtro de estado que faltaba documentar — 3 tests fallan sin confound). Filtro corrido 3× limpio post-rebase.

### Size
`size:exception` — ~701 lineas vs ~300 previstas, mismo patron: profundidad del archivo de tests consolidado (15 tests, fixtures multi-dimension).

### Tests
15/15 ×3 post-rebase · full suite en el merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)