### PR TITLE
feat(web): tablero con paridad G1 (etapa 10, slice 7)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -438,6 +438,10 @@ the branch; route/nav entries removed.
   null-ticket-promedio rendering test, and role-gating tests (Supervisor
   reaches `/tablero`; Vendedor and Root redirect to `/`) via `RutaProtegida`,
   same pattern as `Compras.test.tsx`'s `renderComprasProtegido`.
+- Recorded deviation (slice 7, judged): the Tablero uses ONE page-level cargando/generation
+  pair because ventas+gastos are always fetched atomically from the same filter event. BINDING
+  for slice 8: each new breakdown panel owns its OWN fetch state (own generation ref, own busy
+  flag) — do NOT extend the shared pair (react-async-state rule 5; Judge A boundary warning).
 - [ ] 7.6 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
   sdd-apply — requires sub-agent delegation, out of the apply executor's
   scope; orchestrator must run this before PR, same precedent as slices

--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -404,28 +404,49 @@ consumes them. **Rollback**: `npm uninstall recharts`; revert the branch.
 promedio; route and nav wired for Supervisor + Admin. **Rollback**: revert
 the branch; route/nav entries removed.
 
-- [ ] 7.1 Create `src/Ways.Web/src/api/tipos.ts` mirrors for
+- [x] 7.1 Create `src/Ways.Web/src/api/tipos.ts` mirrors for
   `ResumenDeVentas`/`BucketDeVentas` (and `PARAMETROS_CONOCIDOS` untouched —
-  already typed in slice 1).
-- [ ] 7.2 Create `src/Ways.Web/src/api/reportes.ts`: client function for
-  `GET /reportes/ventas/resumen` (and gastos resumen, sharing the shape).
-- [ ] 7.3 Create `src/Ways.Web/src/paginas/Tablero.tsx`: defaults to last 7
+  already typed in slice 1). — also mirrors `ResumenDeGastos`/`BucketDeGastos`/
+  `GastoPorCategoria`/`Granularidad` (needed for the gastos card in the same
+  slice) and adds `puedeVerReportes` (espejo de `Politicas.LecturaDeReportes`).
+- [x] 7.2 Create `src/Ways.Web/src/api/reportes.ts`: client function for
+  `GET /reportes/ventas/resumen` (and gastos resumen, sharing the shape). —
+  `construirQueryDeReporte` (shared query builder, colocated tests) and
+  `rangoUltimosSieteDias` (default-range helper, colocated tests, takes
+  `ahora` as a parameter for testability).
+- [x] 7.3 Create `src/Ways.Web/src/paginas/Tablero.tsx`: defaults to last 7
   days on load; ventas series card (`<GraficoDeLineas>`), gastos series
   card, net sales total, gastos total, ticket promedio. Per
   `react-async-state` rules 2/4/9: one `useRef` generation token bumped
   before any filter mutates state, every post-`await` setter and every
   `finally` clearing `cargando` gated on it. *(spec tablero: Tablero Covers
-  Legacy G1 Parity By Default; success criterion 6)*
-- [ ] 7.4 Modify `src/Ways.Web/src/App.tsx` and
+  Legacy G1 Parity By Default; success criterion 6)* — empresa selector
+  follows the `Parametros.tsx` precedent (`clienteDeOrganizacion.listarEmpresas`);
+  `desde`/`hasta` are editable `DateOnly` inputs, no offset needed (unlike
+  `compras.ts`'s `timestamptz` filter); granularidad fixed to `Dia` this
+  slice (selector deferred to Slice 8). Carried-over debt from slice 6
+  judges paid here: `GraficoDeLineas`/`GraficoDeBarras` now require a
+  `titulo` prop (`role="img"` + `aria-label`) since Tablero is their first
+  real consumer.
+- [x] 7.4 Modify `src/Ways.Web/src/App.tsx` and
   `src/Ways.Web/src/componentes/Layout.tsx`: add the `/tablero` route
-  (`ROL.Supervisor`, `ROL.Admin`) and nav entry.
-- [ ] 7.5 [P] `Tablero.test.tsx`: default-load renders 7-day range and both
+  (`ROL.Supervisor`, `ROL.Admin`) and nav entry. — nav item gated by the new
+  `puedeVerReportes` helper, same pattern as `puedeSupervisarCuentaCorriente`.
+- [x] 7.5 [P] `Tablero.test.tsx`: default-load renders 7-day range and both
   totals; generation-token gating verified with a delayed-then-superseded
-  fetch; error path (API 500) renders a retry state, not a crash.
-- [ ] 7.6 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 7.7 Branch `feat/stage10-slice7-tablero-g1` off `main` (parent: slice
+  fetch; error path (API 500) renders a retry state, not a crash. — plus a
+  null-ticket-promedio rendering test, and role-gating tests (Supervisor
+  reaches `/tablero`; Vendedor and Root redirect to `/`) via `RutaProtegida`,
+  same pattern as `Compras.test.tsx`'s `renderComprasProtegido`.
+- [ ] 7.6 Run `judgment-day`; fix; re-judge until clean. *(NOT run by
+  sdd-apply — requires sub-agent delegation, out of the apply executor's
+  scope; orchestrator must run this before PR, same precedent as slices
+  2/3/4/5/6.)*
+- [x] 7.7 Branch `feat/stage10-slice7-tablero-g1` off `main` (parent: slice
   2 for the endpoint, slice 6 for the wrappers — both already on `main`);
-  PR; merge stacked-to-main.
+  PR; merge stacked-to-main. *(Branch created off `main`; three work-unit
+  commits applied on it. PR creation/merge explicitly out of scope per
+  apply boundaries — NOT done.)*
 
 **Verify**: `npm run test -- Tablero`
 

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -23,6 +23,7 @@ import { Pos } from './paginas/Pos'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
+import { Tablero } from './paginas/Tablero'
 import { Tenants } from './paginas/Tenants'
 import { Transferencias } from './paginas/Transferencias'
 import { Usuarios } from './paginas/Usuarios'
@@ -45,6 +46,19 @@ export function App() {
             }
           >
             <Route path="/" element={<Inicio />} />
+
+            {/* stage-10-agregacion-dashboard (Slice 7, design: Web Composition, spec tablero):
+                G1 parity — ventas y gastos de los últimos 7 días por defecto, ticket promedio.
+                Politicas.LecturaDeReportes del lado del servidor: Supervisor + Admin, ni
+                Vendedor ni Root. */}
+            <Route
+              path="/tablero"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <Tablero />
+                </RutaProtegida>
+              }
+            />
 
             {/* stage-5-pos-ventas (Slice 6, design: POS Screen Composition): pantalla dedicada,
                 admite Vendedor + Supervisor + Admin (Politicas.OperacionDePos) — no solo Admin

--- a/src/Ways.Web/src/api/reportes.test.ts
+++ b/src/Ways.Web/src/api/reportes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { construirQueryDeReporte, rangoUltimosSieteDias } from './reportes'
+import type { FiltrosDeReporte } from './reportes'
+
+function filtrosFixture(sobrescribir: Partial<FiltrosDeReporte> = {}): FiltrosDeReporte {
+  return {
+    idEmpresa: 1,
+    idPuntoVenta: null,
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    granularidad: 'Dia',
+    ...sobrescribir,
+  }
+}
+
+describe('construirQueryDeReporte', () => {
+  it('arma idEmpresa/desde/hasta/granularidad sin idPuntoVenta cuando es null', () => {
+    const query = construirQueryDeReporte(filtrosFixture())
+
+    expect(query).toBe('?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11&granularidad=Dia')
+  })
+
+  it('agrega idPuntoVenta solo cuando está seteado', () => {
+    const query = construirQueryDeReporte(filtrosFixture({ idPuntoVenta: 7 }))
+
+    expect(query).toContain('idPuntoVenta=7')
+  })
+
+  it('propaga la granularidad tal cual (nombre del enum de C#, no camelCase)', () => {
+    expect(construirQueryDeReporte(filtrosFixture({ granularidad: 'Semana' }))).toContain('granularidad=Semana')
+    expect(construirQueryDeReporte(filtrosFixture({ granularidad: 'Mes' }))).toContain('granularidad=Mes')
+  })
+})
+
+describe('rangoUltimosSieteDias', () => {
+  it('devuelve [hoy - 6 días, hoy] — 7 días inclusive', () => {
+    const rango = rangoUltimosSieteDias(new Date(2026, 7, 11)) // 11 de agosto de 2026
+
+    expect(rango).toEqual({ desde: '2026-08-05', hasta: '2026-08-11' })
+  })
+
+  it('cruza el límite de mes correctamente', () => {
+    const rango = rangoUltimosSieteDias(new Date(2026, 7, 3)) // 3 de agosto de 2026
+
+    expect(rango).toEqual({ desde: '2026-07-28', hasta: '2026-08-03' })
+  })
+
+  it('usa la fecha local, no UTC (sin desfasaje de un día)', () => {
+    const rango = rangoUltimosSieteDias(new Date(2026, 0, 1, 0, 30)) // 1 de enero, 00:30 local
+
+    expect(rango.hasta).toBe('2026-01-01')
+  })
+})

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -1,0 +1,51 @@
+/**
+ * Cliente HTTP de `GET /api/reportes/*` (stage-10-agregacion-dashboard, Slice 7 — G1 parity):
+ * ventas/resumen y gastos/resumen. `desde`/`hasta` son `DateOnly` del lado del servidor, así que
+ * viajan como `YYYY-MM-DD` sin ningún offset horario — a diferencia del filtro de `compras.ts`,
+ * que filtra contra un `timestamptz` y sí necesita ese offset.
+ */
+import { api } from './cliente'
+import type { Granularidad, ResumenDeGastos, ResumenDeVentas } from './tipos'
+
+export type FiltrosDeReporte = {
+  idEmpresa: number
+  idPuntoVenta: number | null
+  desde: string
+  hasta: string
+  granularidad: Granularidad
+}
+
+/** Arma el query string compartido por todo `GET /api/reportes/*` que acepta este shape de
+ * filtro (`dto-contract-honesty`: cada parámetro solo se agrega si el backend lo lee). */
+export function construirQueryDeReporte(filtros: FiltrosDeReporte): string {
+  const parametros = new URLSearchParams()
+  parametros.set('idEmpresa', String(filtros.idEmpresa))
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  parametros.set('desde', filtros.desde)
+  parametros.set('hasta', filtros.hasta)
+  parametros.set('granularidad', filtros.granularidad)
+  return `?${parametros.toString()}`
+}
+
+export const clienteDeReportes = {
+  ventasResumen: (filtros: FiltrosDeReporte) =>
+    api.get<ResumenDeVentas>(`/reportes/ventas/resumen${construirQueryDeReporte(filtros)}`),
+  gastosResumen: (filtros: FiltrosDeReporte) =>
+    api.get<ResumenDeGastos>(`/reportes/gastos/resumen${construirQueryDeReporte(filtros)}`),
+}
+
+function aFechaIso(fecha: Date): string {
+  const anio = fecha.getFullYear()
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0')
+  const dia = String(fecha.getDate()).padStart(2, '0')
+  return `${anio}-${mes}-${dia}`
+}
+
+/** Rango por defecto de `Tablero` (spec tablero: "Default load shows the last 7 days") —
+ * `[hoy - 6 días, hoy]`, 7 días inclusive. Recibe `ahora` como parámetro (default `new Date()`)
+ * para quedar testeable sin mockear el reloj del sistema. */
+export function rangoUltimosSieteDias(ahora: Date = new Date()): { desde: string; hasta: string } {
+  const hace6Dias = new Date(ahora)
+  hace6Dias.setDate(hace6Dias.getDate() - 6)
+  return { desde: aFechaIso(hace6Dias), hasta: aFechaIso(ahora) }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -93,6 +93,14 @@ export function puedeSupervisarCuentaCorriente(rolId: number) {
   return rolId === ROL.Supervisor || rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.LecturaDeReportes` (stage-10-agregacion-dashboard, Slice 1): supervisor o
+ * admin ven `Tablero` — vendedor y root quedan afuera, mismo criterio que
+ * `puedeSupervisarCuentaCorriente`. Puramente cosmético: el servidor vuelve a exigir la misma
+ * policy en cada endpoint de `/api/reportes`. */
+export function puedeVerReportes(rolId: number) {
+  return rolId === ROL.Supervisor || rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -1053,3 +1061,55 @@ export type ResultadoTransferencia = {
  * delta (espejo de `SolicitudDeConteo`; spec: conteo-de-inventario / Conteo Input Is The Counted
  * Total, Never A Delta). */
 export type SolicitudDeConteo = { idPuntoVenta: number; idArticulo: number; contada: number; observaciones: string }
+
+// --- Reportes (stage-10-agregacion-dashboard, Slice 7): G1 parity — ventas/resumen y
+// gastos/resumen. Espejo de `Ways.Application.Reportes.Contratos` — mismos nombres de campo que
+// el backend serializa en camelCase, ningún dato de negocio recalculado en el cliente.
+
+/** Espejo del enum `Granularidad` (Ways.Domain.Reportes) — viaja como texto (`JsonStringEnumConverter`
+ * en `Program.cs`), nunca como ordinal. */
+export type Granularidad = 'Dia' | 'Semana' | 'Mes'
+
+/** Un bucket de la serie de ventas ya rellenada (sin huecos) — espejo de `BucketDeVentas`.
+ * `ticketPromedio` es `null`, nunca `0`, cuando el bucket no tuvo ningún TX. */
+export type BucketDeVentas = {
+  etiqueta: string
+  inicio: string
+  neto: number
+  cantidadTx: number
+  ticketPromedio: number | null
+}
+
+/** Respuesta de `GET /api/reportes/ventas/resumen` — espejo de `ResumenDeVentas`. `zonaHoraria`
+ * es la zona efectivamente resuelta y aplicada al bucketing (echo obligatorio, design decisión 5). */
+export type ResumenDeVentas = {
+  desde: string
+  hasta: string
+  granularidad: Granularidad
+  zonaHoraria: string
+  serie: BucketDeVentas[]
+  netoVendido: number
+  cantidadTx: number
+  ticketPromedio: number | null
+  cantidadNcx: number
+  netoNcx: number
+}
+
+/** Un bucket de la serie de gastos ya rellenada — espejo de `BucketDeGastos`, mismo criterio de
+ * gap-fill que `BucketDeVentas`. */
+export type BucketDeGastos = { etiqueta: string; inicio: string; importe: number }
+
+/** Desglose por categoría de `GET /api/reportes/gastos/resumen` — espejo de `GastoPorCategoria`. */
+export type GastoPorCategoria = { categoria: CategoriaGasto; importe: number; cantidadGastos: number }
+
+/** Respuesta de `GET /api/reportes/gastos/resumen` — espejo de `ResumenDeGastos`; sin NCX ni
+ * ticket promedio, `gastos` no tiene esa semántica. */
+export type ResumenDeGastos = {
+  desde: string
+  hasta: string
+  granularidad: Granularidad
+  zonaHoraria: string
+  serie: BucketDeGastos[]
+  importeTotal: number
+  porCategoria: GastoPorCategoria[]
+}

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -1,7 +1,14 @@
 import { NavLink, Outlet, useNavigate } from 'react-router'
 import { useAuth } from '../auth/useAuth'
 import { DESCRIPTORES_DE_CATALOGO } from '../api/catalogos'
-import { ROL, puedeAprovisionarTenants, puedeGestionarCatalogos, puedeGestionarUsuarios, puedeOperarPos } from '../api/tipos'
+import {
+  ROL,
+  puedeAprovisionarTenants,
+  puedeGestionarCatalogos,
+  puedeGestionarUsuarios,
+  puedeOperarPos,
+  puedeVerReportes,
+} from '../api/tipos'
 
 export function Layout() {
   const { usuario, cerrarSesion } = useAuth()
@@ -54,6 +61,16 @@ export function Layout() {
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/compras">
                       Compras
+                    </NavLink>
+                  </li>
+                )}
+                {/* stage-10-agregacion-dashboard (Slice 7, design: Web Composition): nav y ruta
+                    comparten Politicas.LecturaDeReportes — Supervisor + Admin, ni Vendedor ni
+                    Root. */}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/tablero">
+                      Tablero
                     </NavLink>
                   </li>
                 )}

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.test.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.test.tsx
@@ -32,21 +32,27 @@ describe('GraficoDeBarras', () => {
       { etiqueta: 'PV Norte', valor: 900 },
     ]
 
-    render(<GraficoDeBarras data={data} alto={240} />)
+    render(<GraficoDeBarras data={data} alto={240} titulo="Ventas por punto de venta" />)
 
     const chart = screen.getByTestId('bar-chart')
     expect(JSON.parse(chart.dataset.serie ?? '[]')).toEqual(data)
   })
 
   it('propaga el alto explícito al contenedor responsive', () => {
-    render(<GraficoDeBarras data={[]} alto={160} />)
+    render(<GraficoDeBarras data={[]} alto={160} titulo="Ventas por punto de venta" />)
 
     expect(screen.getByTestId('responsive-container')).toHaveAttribute('data-alto', '160')
   })
 
   it('renderiza sin datos sin crashear', () => {
-    render(<GraficoDeBarras data={[]} alto={200} />)
+    render(<GraficoDeBarras data={[]} alto={200} titulo="Ventas por punto de venta" />)
 
     expect(JSON.parse(screen.getByTestId('bar-chart').dataset.serie ?? 'null')).toEqual([])
+  })
+
+  it('expone un nombre accesible para lectores de pantalla', () => {
+    render(<GraficoDeBarras data={[]} alto={200} titulo="Ventas por punto de venta" />)
+
+    expect(screen.getByRole('img', { name: 'Ventas por punto de venta' })).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeBarras.tsx
@@ -4,6 +4,9 @@ import type { PuntoDeGrafico } from './series'
 type Props = {
   data: readonly PuntoDeGrafico[]
   alto: number
+  /** Nombre accesible del gráfico (`role="img"` + `aria-label`) — mismo criterio que
+   * `GraficoDeLineas`: el SVG de `recharts` no trae texto propio para un lector de pantalla. */
+  titulo: string
 }
 
 /**
@@ -11,16 +14,18 @@ type Props = {
  * Mismas reglas que `GraficoDeLineas`: solo `data` + `alto`, sin props
  * crudas de `recharts` (decisión de diseño 11).
  */
-export function GraficoDeBarras({ data, alto }: Props) {
+export function GraficoDeBarras({ data, alto, titulo }: Props) {
   return (
-    <ResponsiveContainer width="100%" height={alto}>
-      <BarChart data={data as PuntoDeGrafico[]}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="etiqueta" />
-        <YAxis />
-        <Tooltip />
-        <Bar dataKey="valor" fill="#0d6efd" />
-      </BarChart>
-    </ResponsiveContainer>
+    <div role="img" aria-label={titulo}>
+      <ResponsiveContainer width="100%" height={alto}>
+        <BarChart data={data as PuntoDeGrafico[]}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="etiqueta" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="valor" fill="#0d6efd" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   )
 }

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.test.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.test.tsx
@@ -34,21 +34,27 @@ describe('GraficoDeLineas', () => {
       { etiqueta: 'mar', valor: 200 },
     ]
 
-    render(<GraficoDeLineas data={data} alto={240} />)
+    render(<GraficoDeLineas data={data} alto={240} titulo="Ventas" />)
 
     const chart = screen.getByTestId('line-chart')
     expect(JSON.parse(chart.dataset.serie ?? '[]')).toEqual(data)
   })
 
   it('propaga el alto explícito al contenedor responsive', () => {
-    render(<GraficoDeLineas data={[]} alto={180} />)
+    render(<GraficoDeLineas data={[]} alto={180} titulo="Ventas" />)
 
     expect(screen.getByTestId('responsive-container')).toHaveAttribute('data-alto', '180')
   })
 
   it('renderiza sin datos sin crashear', () => {
-    render(<GraficoDeLineas data={[]} alto={200} />)
+    render(<GraficoDeLineas data={[]} alto={200} titulo="Ventas" />)
 
     expect(JSON.parse(screen.getByTestId('line-chart').dataset.serie ?? 'null')).toEqual([])
+  })
+
+  it('expone un nombre accesible para lectores de pantalla', () => {
+    render(<GraficoDeLineas data={[]} alto={200} titulo="Ventas de los últimos 7 días" />)
+
+    expect(screen.getByRole('img', { name: 'Ventas de los últimos 7 días' })).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
+++ b/src/Ways.Web/src/componentes/graficos/GraficoDeLineas.tsx
@@ -4,6 +4,9 @@ import type { PuntoDeGrafico } from './series'
 type Props = {
   data: readonly PuntoDeGrafico[]
   alto: number
+  /** Nombre accesible del gráfico (`role="img"` + `aria-label`) — el SVG de `recharts` no trae
+   * texto propio para un lector de pantalla, así que cada consumidor lo declara explícito. */
+  titulo: string
 }
 
 /**
@@ -12,16 +15,18 @@ type Props = {
  * `series.ts`) y `alto` explícito, para que ningún consumidor dependa de la
  * API de la librería subyacente (decisión de diseño 11).
  */
-export function GraficoDeLineas({ data, alto }: Props) {
+export function GraficoDeLineas({ data, alto, titulo }: Props) {
   return (
-    <ResponsiveContainer width="100%" height={alto}>
-      <LineChart data={data as PuntoDeGrafico[]}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="etiqueta" />
-        <YAxis />
-        <Tooltip />
-        <Line type="monotone" dataKey="valor" stroke="#0d6efd" dot={false} />
-      </LineChart>
-    </ResponsiveContainer>
+    <div role="img" aria-label={titulo}>
+      <ResponsiveContainer width="100%" height={alto}>
+        <LineChart data={data as PuntoDeGrafico[]}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="etiqueta" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="valor" stroke="#0d6efd" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
   )
 }

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -1,0 +1,234 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Tablero } from './Tablero'
+import { rangoUltimosSieteDias } from '../api/reportes'
+import { ROL } from '../api/tipos'
+import type { EmpresaListado, ResumenDeGastos, ResumenDeVentas, UsuarioAutenticado } from '../api/tipos'
+import { RutaProtegida } from '../auth/RutaProtegida'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const empresaUno: EmpresaListado = { id: 1, idTenant: 1, razonSocial: 'Empresa Uno SA', nombreFantasia: null, cuit: null }
+
+function ventasFixture(sobrescribir: Partial<ResumenDeVentas> = {}): ResumenDeVentas {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    granularidad: 'Dia',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    serie: [{ etiqueta: '05/08', inicio: '2026-08-05', neto: 1000, cantidadTx: 4, ticketPromedio: 250 }],
+    netoVendido: 1000,
+    cantidadTx: 4,
+    ticketPromedio: 250,
+    cantidadNcx: 0,
+    netoNcx: 0,
+    ...sobrescribir,
+  }
+}
+
+function gastosFixture(sobrescribir: Partial<ResumenDeGastos> = {}): ResumenDeGastos {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    granularidad: 'Dia',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    serie: [{ etiqueta: '05/08', inicio: '2026-08-05', importe: 300 }],
+    importeTotal: 300,
+    porCategoria: [],
+    ...sobrescribir,
+  }
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/empresas') return Promise.resolve([empresaUno])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/reportes/ventas/resumen?')) return Promise.resolve(ventasFixture())
+    if (ruta.startsWith('/reportes/gastos/resumen?')) return Promise.resolve(gastosFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderTablero() {
+  return render(<Tablero />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/tablero`
+ * (`Politicas.LecturaDeReportes`: Supervisor + Admin). */
+function renderTableroProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/tablero']}>
+      <Routes>
+        <Route
+          path="/tablero"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <Tablero />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+describe('Tablero — G1 parity (stage-10-agregacion-dashboard, Slice 7)', () => {
+  it('por defecto carga el rango de los últimos 7 días y muestra ventas, gastos y ticket promedio', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    const rangoEsperado = rangoUltimosSieteDias()
+    await screen.findByText('Empresa Uno SA')
+    expect(screen.getByLabelText('Desde')).toHaveValue(rangoEsperado.desde)
+    expect(screen.getByLabelText('Hasta')).toHaveValue(rangoEsperado.hasta)
+
+    expect(await screen.findByText('$1.000,00')).toBeInTheDocument() // ventas netas
+    expect(screen.getByText('$300,00')).toBeInTheDocument() // gastos
+    expect(screen.getByText('$250,00')).toBeInTheDocument() // ticket promedio
+    expect(screen.getByRole('img', { name: 'Serie de ventas netas por período' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Serie de gastos por período' })).toBeInTheDocument()
+  })
+
+  it('un ticket promedio null se muestra como "—", nunca como $0,00', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/resumen?')) {
+        return Promise.resolve(ventasFixture({ ticketPromedio: null, cantidadTx: 0 }))
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    expect(await screen.findByText('—')).toBeInTheDocument()
+    expect(screen.queryByText('$0,00')).not.toBeInTheDocument()
+  })
+
+  it('una respuesta desactualizada nunca pisa el rango ya cambiado (generación)', async () => {
+    let resolverPrimeraVentas: (valor: ResumenDeVentas) => void = () => {}
+    const primeraVentas = new Promise<ResumenDeVentas>((resolve) => {
+      resolverPrimeraVentas = resolve
+    })
+    let llamadasAVentas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/resumen?')) {
+        llamadasAVentas += 1
+        if (llamadasAVentas === 1) return primeraVentas
+        return Promise.resolve(ventasFixture({ netoVendido: 9999 }))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+    expect(screen.getByLabelText('Desde')).toBeInTheDocument()
+
+    // Cambia "Hasta" ANTES de que la primera consulta (rango de 7 días por defecto) resuelva.
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    expect(await screen.findByText('$9.999,00')).toBeInTheDocument()
+
+    // La primera respuesta, ahora obsoleta, resuelve tarde — no debe pisar el rango ya cambiado.
+    resolverPrimeraVentas(ventasFixture({ netoVendido: 1 }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(screen.queryByText('$1,00')).not.toBeInTheDocument()
+    expect(screen.getByText('$9.999,00')).toBeInTheDocument()
+  })
+
+  it('un error del servidor muestra un estado de reintento, no un crash', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/resumen?')) {
+        return Promise.reject(new (class extends Error {
+          estado = 500
+          codigo = 'error_interno'
+        })('No se pudo cargar el tablero.'))
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    expect(await screen.findByText('No se pudo cargar el tablero.')).toBeInTheDocument()
+    const botonReintentar = screen.getByRole('button', { name: 'Reintentar' })
+    expect(botonReintentar).toBeInTheDocument()
+
+    // El reintento vuelve a pedir el reporte — ya no debe quedar la pantalla rota.
+    mockearRutasBase()
+    fireEvent.click(botonReintentar)
+
+    expect(await screen.findByText('$1.000,00')).toBeInTheDocument()
+    expect(screen.queryByText('No se pudo cargar el tablero.')).not.toBeInTheDocument()
+  })
+
+  it('un Supervisor llega a la ruta protegida', async () => {
+    mockearRutasBase()
+    renderTableroProtegido()
+
+    expect(await screen.findByText('$1.000,00')).toBeInTheDocument()
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /tablero: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderTableroProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Empresa Uno SA')).not.toBeInTheDocument())
+  })
+
+  it('un Root nunca llega a /tablero: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 1, usuario: 'root', rolId: ROL.Root, rol: 'Root', idTenant: null })
+    mockearRutasBase()
+
+    renderTableroProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -148,6 +148,10 @@ describe('Tablero — G1 parity (stage-10-agregacion-dashboard, Slice 7)', () =>
     expect(screen.queryByText('$0,00')).not.toBeInTheDocument()
   })
 
+  // Prueba la guarda `if (generacionRef.current !== miGeneracion) return` del `.then` de
+  // `cargar` en Tablero.tsx (mutation-proof-tests): quitando esa línea este test falla
+  // (verificado — $1,00 de la respuesta obsoleta queda en pantalla en vez de $9.999,00),
+  // revertida vuelve a pasar.
   it('una respuesta desactualizada nunca pisa el rango ya cambiado (generación)', async () => {
     let resolverPrimeraVentas: (valor: ResumenDeVentas) => void = () => {}
     const primeraVentas = new Promise<ResumenDeVentas>((resolve) => {

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -9,6 +9,24 @@ import { RutaProtegida } from '../auth/RutaProtegida'
 
 const apiGetMock = vi.fn()
 
+// `recharts` se mockea igual que en los tests de los wrappers: bajo jsdom no renderiza
+// nada observable, y sin el stub el mapeo de datos al grafico queda sin asercion posible.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: import('react').ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ data, children }: { data: unknown[]; children: import('react').ReactNode }) => (
+    <div data-testid="line-chart" data-serie={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  CartesianGrid: () => null,
+}))
+
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
@@ -234,5 +252,21 @@ describe('Tablero — G1 parity (stage-10-agregacion-dashboard, Slice 7)', () =>
     renderTableroProtegido()
 
     expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+  })
+
+  it('mapea neto e importe como valor de las series de ventas y gastos', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await waitFor(() => {
+      const charts = screen.getAllByTestId('line-chart')
+      expect(charts).toHaveLength(2)
+      expect(JSON.parse(charts[0].dataset.serie ?? '[]')).toEqual([
+        { etiqueta: '05/08', valor: 1000 },
+      ])
+      expect(JSON.parse(charts[1].dataset.serie ?? '[]')).toEqual([
+        { etiqueta: '05/08', valor: 300 },
+      ])
+    })
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, rangoUltimosSieteDias } from '../api/reportes'
+import type { EmpresaListado, ResumenDeGastos, ResumenDeVentas } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+import { GraficoDeLineas } from '../componentes/graficos/GraficoDeLineas'
+import { aSerieDeGrafico } from '../componentes/graficos/series'
+
+function formatearMoneda(valor: number): string {
+  return `$${valor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+/**
+ * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity): serie de ventas, serie de
+ * gastos, netos y ticket promedio de los últimos 7 días por defecto, con `desde`/`hasta`
+ * editables. La granularidad queda fija en `Dia` esta slice — el selector de granularidad y el
+ * filtro por punto de venta llegan con los paneles de breakdown (Slice 8).
+ *
+ * Per `react-async-state` reglas 2/4/9: un único `useRef` de generación se bumpea antes de cada
+ * fetch (disparado por cambio de empresa/rango), cada setter posterior a un `await` y el
+ * `finally` que apaga `cargando` están gateados contra esa generación — una respuesta de 7 días
+ * desactualizada nunca pisa un rango que el usuario ya cambió. `cargando` cubre la ventana
+ * completa (ventas + gastos se piden y aplican como una sola unidad, siempre disparados por el
+ * mismo evento de filtro — no son entidades operables independientemente, a diferencia del
+ * listado + saldo de `Compras.tsx`).
+ */
+export function Tablero() {
+  const [empresas, setEmpresas] = useState<EmpresaListado[] | null>(null)
+  const [idEmpresa, setIdEmpresa] = useState<number | null>(null)
+  const [errorEmpresas, setErrorEmpresas] = useState('')
+
+  const [desde, setDesde] = useState(() => rangoUltimosSieteDias().desde)
+  const [hasta, setHasta] = useState(() => rangoUltimosSieteDias().hasta)
+
+  const [ventas, setVentas] = useState<ResumenDeVentas | null>(null)
+  const [gastos, setGastos] = useState<ResumenDeGastos | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarEmpresas()
+      .then((lista) => {
+        if (!vigente) return
+        setEmpresas(lista)
+        if (lista.length > 0) setIdEmpresa(lista[0].id)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setEmpresas([])
+        setErrorEmpresas(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las empresas.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    if (idEmpresa === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    const filtros = { idEmpresa, idPuntoVenta: null, desde, hasta, granularidad: 'Dia' as const }
+
+    Promise.all([clienteDeReportes.ventasResumen(filtros), clienteDeReportes.gastosResumen(filtros)])
+      .then(([resumenVentas, resumenGastos]) => {
+        if (generacionRef.current !== miGeneracion) return
+        setVentas(resumenVentas)
+        setGastos(resumenGastos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setVentas(null)
+        setGastos(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el tablero.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [idEmpresa, desde, hasta])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Tablero" variante="inverse">
+        {errorEmpresas && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorEmpresas}</div>}
+
+        {empresas === null ? (
+          <Cargando />
+        ) : empresas.length === 0 ? (
+          <p className="text-muted text-center py-4">No hay empresas visibles para mostrar el tablero.</p>
+        ) : (
+          <>
+            <div className="row g-3 align-items-end mb-4">
+              <div className="col-auto">
+                <label className="form-label" htmlFor="tablero-empresa">
+                  Empresa
+                </label>
+                <select
+                  id="tablero-empresa"
+                  className="form-select rounded-0"
+                  value={idEmpresa ?? ''}
+                  disabled={cargando}
+                  onChange={(e) => setIdEmpresa(Number(e.target.value))}
+                >
+                  {empresas.map((e) => (
+                    <option key={e.id} value={e.id}>
+                      {e.razonSocial}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-auto">
+                <label className="form-label" htmlFor="tablero-desde">
+                  Desde
+                </label>
+                <input
+                  id="tablero-desde"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={desde}
+                  disabled={cargando}
+                  onChange={(e) => setDesde(e.target.value)}
+                />
+              </div>
+              <div className="col-auto">
+                <label className="form-label" htmlFor="tablero-hasta">
+                  Hasta
+                </label>
+                <input
+                  id="tablero-hasta"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={hasta}
+                  disabled={cargando}
+                  onChange={(e) => setHasta(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {error && (
+              <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+                <span>{error}</span>
+                <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+                  Reintentar
+                </button>
+              </div>
+            )}
+
+            {cargando && !ventas && !gastos && <Cargando />}
+
+            {ventas && gastos && (
+              <>
+                <div className="row g-3 mb-4">
+                  <div className="col-md-3">
+                    <div className="border p-3 bg-white text-center">
+                      <div className="text-muted small">Ventas netas</div>
+                      <div className="fs-4">{formatearMoneda(ventas.netoVendido)}</div>
+                    </div>
+                  </div>
+                  <div className="col-md-3">
+                    <div className="border p-3 bg-white text-center">
+                      <div className="text-muted small">Gastos</div>
+                      <div className="fs-4">{formatearMoneda(gastos.importeTotal)}</div>
+                    </div>
+                  </div>
+                  <div className="col-md-3">
+                    <div className="border p-3 bg-white text-center">
+                      <div className="text-muted small">Ticket promedio</div>
+                      <div className="fs-4">{ventas.ticketPromedio === null ? '—' : formatearMoneda(ventas.ticketPromedio)}</div>
+                    </div>
+                  </div>
+                  <div className="col-md-3">
+                    <div className="border p-3 bg-white text-center">
+                      <div className="text-muted small">Transacciones</div>
+                      <div className="fs-4">{ventas.cantidadTx}</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="row g-3">
+                  <div className="col-md-6">
+                    <div className="border p-3 bg-white">
+                      <h6>Serie de ventas</h6>
+                      <GraficoDeLineas data={aSerieDeGrafico(ventas.serie.map((b) => ({ etiqueta: b.etiqueta, valor: b.neto })))} alto={240} titulo="Serie de ventas netas por período" />
+                    </div>
+                  </div>
+                  <div className="col-md-6">
+                    <div className="border p-3 bg-white">
+                      <h6>Serie de gastos</h6>
+                      <GraficoDeLineas data={aSerieDeGrafico(gastos.serie.map((b) => ({ etiqueta: b.etiqueta, valor: b.importe })))} alto={240} titulo="Serie de gastos por período" />
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}


### PR DESCRIPTION
## Etapa 10, slice 7 — Tablero G1

Primera pantalla de reportes: `/tablero` (Supervisor+Admin, espejo de `LecturaDeReportes`) con ventas netas, gastos, ticket promedio y las dos series de los ultimos 7 dias, consumiendo `/api/reportes/ventas/resumen` + `/gastos/resumen` a traves de los wrappers de graficos.

- Gating de generacion en cada setter post-await (evidencia de mutacion registrada); reintento re-gateado; ticket promedio null renderiza '—', nunca $0.
- Deuda a11y del slice 6 saldada: `titulo` requerido con `role=img`/aria-label en ambos wrappers.
- Deviation registrada y acotada: UN par cargando/generacion page-level porque ventas+gastos son atomicos al mismo evento de filtro — VINCULANTE para el slice 8: cada panel nuevo es dueño de su propio estado.

### Review
Judgment-day: ronda limpia — Juez A APPROVE-WITH-MINORS (read-only: compliance react-async-state, roles nav+ruta, fidelidad de DTOs contra Contratos.cs; nit documental corregido), Juez B APPROVE-WITH-MINORS (mutador: 3 mutaciones confirmaron guards de staleness/ruta/retry; 1 WARNING real — el mapeo de series sin asercion bajo jsdom — corregido en la rama con recharts mockeado + evidencia de mutacion propia: neto→cantidadTx mata el test nuevo).

### Size
`size:exception` — ~700 lineas vs ~300: profundidad de tests (8 escenarios) + retrofit a11y.

### Tests
vitest 446/446 (430 + 16) · tsc -b limpio · build limpio · oxlint sin issues nuevos

🤖 Generated with [Claude Code](https://claude.com/claude-code)