### PR TITLE
feat(web): tablero con filtros y 4 paneles por dimension (etapa 10, slice 8)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -463,21 +463,62 @@ the branch; route/nav entries removed.
 breakdown panels (PV, vendedor, medio de pago, top artículos), each owning
 its own fetch and `cargando`. **Rollback**: revert the branch.
 
-- [ ] 8.1 Extend `reportes.ts`: client functions for `/por-punto-venta`,
-  `/por-vendedor`, `/por-medio-pago`, `/articulos/top`.
-- [ ] 8.2 Extend `Tablero.tsx`: filter bar wired to all panels (no panel
+- [x] 8.1 Extend `reportes.ts`: client functions for `/por-punto-venta`,
+  `/por-vendedor`, `/por-medio-pago`, `/articulos/top`. — all four
+  implemented. `articulosTop` reuses `construirQueryDeBreakdownConPv` (it
+  accepts `idPuntoVenta`, unlike `por-punto-venta`) and appends its own
+  `limite` parameter (`ReportesEndpoints.cs`: `int? limite`, optional).
+  `tipos.ts` mirrors `ArticuloTop`/`TopArticulos` field-for-field against
+  `Contratos.cs`.
+- [x] 8.2 Extend `Tablero.tsx`: filter bar wired to all panels (no panel
   fetches its own independent range — spec requirement); one panel per
   dimension, each with its own `useRef` generation token per
   `react-async-state` rule 10 (applies to **every** panel added in this PR,
   not just the first). *(spec tablero: Breakdown Panels Share Range And
-  Granularity Controls)*
-- [ ] 8.3 [P] Stale-response test per panel (4 tests): a superseded
+  Granularity Controls)* — all four panels implemented (por punto de venta,
+  por vendedor, por medio de pago, top artículos); each panel's generation
+  token lives in a shared `usePanelDeReporte` hook, one instance per panel,
+  never the page-level G1 pair (proven independent — see the panel-failure
+  test in `Tablero.test.tsx`). **Deviation**: `granularidad` is NOT
+  forwarded to any of the four breakdown panels — the shipped backend
+  contract (slice 3/4, out of scope to change here) does not read a
+  `granularidad` parameter on any of `/por-punto-venta`, `/por-vendedor`,
+  `/por-medio-pago` or `/articulos/top` (design: Endpoints — "granularidad
+  only on the two series"); these four are period-total subtotals/rankings,
+  not time buckets. `idPuntoVenta` is wired to `/por-vendedor`,
+  `/por-medio-pago` and `/articulos/top`, but deliberately never sent to
+  `/por-punto-venta` (design: "would be a contradiction" to filter by the
+  same field being grouped) — proven end-to-end in `Tablero.test.tsx`.
+  `limite` for `/articulos/top` is a fixed client-side default (`10`), no
+  "Top N" selector this slice.
+- [x] 8.3 [P] Stale-response test per panel (4 tests): a superseded
   in-flight fetch (range/granularity changed mid-request) never repaints a
   panel already re-scoped. *(spec: Changing granularity re-buckets every
-  panel)*
-- [ ] 8.4 Run `judgment-day`; fix; re-judge until clean.
+  panel)* — 4 tests, one per panel; mutation evidence recorded
+  (`Tablero.test.tsx` comments): the shared generation guard in
+  `usePanelDeReporte` was deleted once, all four stale-response tests
+  failed, reverted, all four pass again. A separate mutation run on the
+  `valor: f.neto`/`valor: a.total` chart-data mapping (all four panels)
+  confirmed the same fail→revert→pass cycle (slice-7 precedent:
+  `neto`→`cantidadTx`/`cantidadPagos`, and `total`→`cantidad` for top
+  artículos). Two additional coverage gaps closed per judgment-day round 1
+  (Judge B, minors): a panel-independence test (one panel's fetch rejects,
+  sibling panels keep rendering their own data unaffected — no
+  cross-contamination of `usePanelDeReporte` instances) and a table-half
+  assertion per panel (money formatting, the `—` fallback for a null
+  `ticketPromedio`, and the `PV #id`/`Medio #id` lookup-miss fallback for an
+  id absent from the catalog fixture) — the chart's `data-serie` alone never
+  exercised the table's own rendering branches.
+- [ ] 8.4 Run `judgment-day`; fix; re-judge until clean. *(Round 1 run by the
+  orchestrator on the 3-panel narrowing — REJECT/MAJOR, resolved by
+  completing the 4th panel per this file's Finish criterion; round 2
+  pending, same precedent as slices 1–7: judgment-day itself is NOT run by
+  sdd-apply.)*
 - [ ] 8.5 Branch `feat/stage10-slice8-tablero-dimensiones` off `main`
-  (parent: slice 7); PR; merge stacked-to-main.
+  (parent: slice 7); PR; merge stacked-to-main. *(Branch created off `main`
+  @ 39aec6c — slices 1–7 merged, matching "Start: slices 3 and 7 merged";
+  work-unit commits applied on it. PR creation/merge explicitly out of
+  scope per apply boundaries — NOT done.)*
 
 **Verify**: `npm run test -- Tablero`
 

--- a/src/Ways.Web/src/api/reportes.test.ts
+++ b/src/Ways.Web/src/api/reportes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { construirQueryDeReporte, rangoUltimosSieteDias } from './reportes'
-import type { FiltrosDeReporte } from './reportes'
+import { construirQueryDeBreakdown, construirQueryDeBreakdownConPv, construirQueryDeReporte, rangoUltimosSieteDias } from './reportes'
+import type { FiltrosDeBreakdown, FiltrosDeBreakdownConPv, FiltrosDeReporte } from './reportes'
 
 function filtrosFixture(sobrescribir: Partial<FiltrosDeReporte> = {}): FiltrosDeReporte {
   return {
@@ -11,6 +11,14 @@ function filtrosFixture(sobrescribir: Partial<FiltrosDeReporte> = {}): FiltrosDe
     granularidad: 'Dia',
     ...sobrescribir,
   }
+}
+
+function filtrosBreakdownFixture(sobrescribir: Partial<FiltrosDeBreakdown> = {}): FiltrosDeBreakdown {
+  return { idEmpresa: 1, desde: '2026-08-05', hasta: '2026-08-11', ...sobrescribir }
+}
+
+function filtrosBreakdownConPvFixture(sobrescribir: Partial<FiltrosDeBreakdownConPv> = {}): FiltrosDeBreakdownConPv {
+  return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', ...sobrescribir }
 }
 
 describe('construirQueryDeReporte', () => {
@@ -29,6 +37,28 @@ describe('construirQueryDeReporte', () => {
   it('propaga la granularidad tal cual (nombre del enum de C#, no camelCase)', () => {
     expect(construirQueryDeReporte(filtrosFixture({ granularidad: 'Semana' }))).toContain('granularidad=Semana')
     expect(construirQueryDeReporte(filtrosFixture({ granularidad: 'Mes' }))).toContain('granularidad=Mes')
+  })
+})
+
+describe('construirQueryDeBreakdown', () => {
+  it('arma idEmpresa/desde/hasta, sin granularidad ni idPuntoVenta (el backend no los lee en estas rutas)', () => {
+    const query = construirQueryDeBreakdown(filtrosBreakdownFixture())
+
+    expect(query).toBe('?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11')
+  })
+})
+
+describe('construirQueryDeBreakdownConPv', () => {
+  it('omite idPuntoVenta cuando es null', () => {
+    const query = construirQueryDeBreakdownConPv(filtrosBreakdownConPvFixture())
+
+    expect(query).toBe('?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11')
+  })
+
+  it('agrega idPuntoVenta solo cuando está seteado', () => {
+    const query = construirQueryDeBreakdownConPv(filtrosBreakdownConPvFixture({ idPuntoVenta: 7 }))
+
+    expect(query).toContain('idPuntoVenta=7')
   })
 })
 

--- a/src/Ways.Web/src/api/reportes.test.ts
+++ b/src/Ways.Web/src/api/reportes.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { construirQueryDeBreakdown, construirQueryDeBreakdownConPv, construirQueryDeReporte, rangoUltimosSieteDias } from './reportes'
-import type { FiltrosDeBreakdown, FiltrosDeBreakdownConPv, FiltrosDeReporte } from './reportes'
+import { describe, expect, it, vi } from 'vitest'
+import type { FiltrosDeBreakdown, FiltrosDeBreakdownConPv, FiltrosDeReporte, FiltrosDeTopArticulos } from './reportes'
+
+const apiGetMock = vi.fn(() => Promise.resolve(undefined))
+
+vi.mock('./cliente', () => ({
+  api: { get: (...args: unknown[]) => apiGetMock(...(args as [])) },
+}))
+
+const { clienteDeReportes, construirQueryDeBreakdown, construirQueryDeBreakdownConPv, construirQueryDeReporte, rangoUltimosSieteDias } =
+  await import('./reportes')
 
 function filtrosFixture(sobrescribir: Partial<FiltrosDeReporte> = {}): FiltrosDeReporte {
   return {
@@ -19,6 +27,10 @@ function filtrosBreakdownFixture(sobrescribir: Partial<FiltrosDeBreakdown> = {})
 
 function filtrosBreakdownConPvFixture(sobrescribir: Partial<FiltrosDeBreakdownConPv> = {}): FiltrosDeBreakdownConPv {
   return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', ...sobrescribir }
+}
+
+function filtrosTopArticulosFixture(sobrescribir: Partial<FiltrosDeTopArticulos> = {}): FiltrosDeTopArticulos {
+  return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', limite: null, ...sobrescribir }
 }
 
 describe('construirQueryDeReporte', () => {
@@ -59,6 +71,22 @@ describe('construirQueryDeBreakdownConPv', () => {
     const query = construirQueryDeBreakdownConPv(filtrosBreakdownConPvFixture({ idPuntoVenta: 7 }))
 
     expect(query).toContain('idPuntoVenta=7')
+  })
+})
+
+describe('clienteDeReportes.articulosTop', () => {
+  it('reutiliza construirQueryDeBreakdownConPv y omite limite cuando es null', async () => {
+    apiGetMock.mockClear()
+    await clienteDeReportes.articulosTop(filtrosTopArticulosFixture())
+
+    expect(apiGetMock).toHaveBeenCalledWith('/reportes/articulos/top?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11')
+  })
+
+  it('agrega limite solo cuando está seteado, junto con idPuntoVenta', async () => {
+    apiGetMock.mockClear()
+    await clienteDeReportes.articulosTop(filtrosTopArticulosFixture({ idPuntoVenta: 7, limite: 10 }))
+
+    expect(apiGetMock).toHaveBeenCalledWith('/reportes/articulos/top?idEmpresa=1&idPuntoVenta=7&desde=2026-08-05&hasta=2026-08-11&limite=10')
   })
 })
 

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -1,11 +1,19 @@
 /**
- * Cliente HTTP de `GET /api/reportes/*` (stage-10-agregacion-dashboard, Slice 7 — G1 parity):
- * ventas/resumen y gastos/resumen. `desde`/`hasta` son `DateOnly` del lado del servidor, así que
- * viajan como `YYYY-MM-DD` sin ningún offset horario — a diferencia del filtro de `compras.ts`,
- * que filtra contra un `timestamptz` y sí necesita ese offset.
+ * Cliente HTTP de `GET /api/reportes/*` (stage-10-agregacion-dashboard, Slice 7 — G1 parity;
+ * Slice 8 — desglose por dimensión): ventas/resumen, gastos/resumen y los tres breakdowns de
+ * ventas. `desde`/`hasta` son `DateOnly` del lado del servidor, así que viajan como `YYYY-MM-DD`
+ * sin ningún offset horario — a diferencia del filtro de `compras.ts`, que filtra contra un
+ * `timestamptz` y sí necesita ese offset.
  */
 import { api } from './cliente'
-import type { Granularidad, ResumenDeGastos, ResumenDeVentas } from './tipos'
+import type {
+  Granularidad,
+  ResumenDeGastos,
+  ResumenDeVentas,
+  VentasPorMedioPago,
+  VentasPorPuntoVenta,
+  VentasPorVendedor,
+} from './tipos'
 
 export type FiltrosDeReporte = {
   idEmpresa: number
@@ -27,11 +35,43 @@ export function construirQueryDeReporte(filtros: FiltrosDeReporte): string {
   return `?${parametros.toString()}`
 }
 
+/** Filtro de los breakdowns por dimensión: sin `granularidad` — ninguno de los tres bucketea por
+ * tiempo, cada fila ya es un subtotal propio del período completo (dto-contract-honesty: el
+ * backend no lee ese parámetro en estas tres rutas). */
+export type FiltrosDeBreakdown = { idEmpresa: number; desde: string; hasta: string }
+
+/** `por-punto-venta` además NO acepta `idPuntoVenta` — sería una contradicción filtrar por el
+ * mismo campo que se está agrupando (design: Endpoints). Los otros dos breakdowns sí lo aceptan. */
+export type FiltrosDeBreakdownConPv = FiltrosDeBreakdown & { idPuntoVenta: number | null }
+
+export function construirQueryDeBreakdown(filtros: FiltrosDeBreakdown): string {
+  const parametros = new URLSearchParams()
+  parametros.set('idEmpresa', String(filtros.idEmpresa))
+  parametros.set('desde', filtros.desde)
+  parametros.set('hasta', filtros.hasta)
+  return `?${parametros.toString()}`
+}
+
+export function construirQueryDeBreakdownConPv(filtros: FiltrosDeBreakdownConPv): string {
+  const parametros = new URLSearchParams()
+  parametros.set('idEmpresa', String(filtros.idEmpresa))
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  parametros.set('desde', filtros.desde)
+  parametros.set('hasta', filtros.hasta)
+  return `?${parametros.toString()}`
+}
+
 export const clienteDeReportes = {
   ventasResumen: (filtros: FiltrosDeReporte) =>
     api.get<ResumenDeVentas>(`/reportes/ventas/resumen${construirQueryDeReporte(filtros)}`),
   gastosResumen: (filtros: FiltrosDeReporte) =>
     api.get<ResumenDeGastos>(`/reportes/gastos/resumen${construirQueryDeReporte(filtros)}`),
+  ventasPorPuntoVenta: (filtros: FiltrosDeBreakdown) =>
+    api.get<VentasPorPuntoVenta>(`/reportes/ventas/por-punto-venta${construirQueryDeBreakdown(filtros)}`),
+  ventasPorVendedor: (filtros: FiltrosDeBreakdownConPv) =>
+    api.get<VentasPorVendedor>(`/reportes/ventas/por-vendedor${construirQueryDeBreakdownConPv(filtros)}`),
+  ventasPorMedioPago: (filtros: FiltrosDeBreakdownConPv) =>
+    api.get<VentasPorMedioPago>(`/reportes/ventas/por-medio-pago${construirQueryDeBreakdownConPv(filtros)}`),
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -10,6 +10,7 @@ import type {
   Granularidad,
   ResumenDeGastos,
   ResumenDeVentas,
+  TopArticulos,
   VentasPorMedioPago,
   VentasPorPuntoVenta,
   VentasPorVendedor,
@@ -61,6 +62,11 @@ export function construirQueryDeBreakdownConPv(filtros: FiltrosDeBreakdownConPv)
   return `?${parametros.toString()}`
 }
 
+/** `articulos/top` reutiliza el shape de `FiltrosDeBreakdownConPv` (acepta `idPuntoVenta`, a
+ * diferencia de `por-punto-venta`) y suma `limite` — único parámetro propio de esta ruta
+ * (`ReportesEndpoints.cs`: `int? limite`). */
+export type FiltrosDeTopArticulos = FiltrosDeBreakdownConPv & { limite: number | null }
+
 export const clienteDeReportes = {
   ventasResumen: (filtros: FiltrosDeReporte) =>
     api.get<ResumenDeVentas>(`/reportes/ventas/resumen${construirQueryDeReporte(filtros)}`),
@@ -72,6 +78,11 @@ export const clienteDeReportes = {
     api.get<VentasPorVendedor>(`/reportes/ventas/por-vendedor${construirQueryDeBreakdownConPv(filtros)}`),
   ventasPorMedioPago: (filtros: FiltrosDeBreakdownConPv) =>
     api.get<VentasPorMedioPago>(`/reportes/ventas/por-medio-pago${construirQueryDeBreakdownConPv(filtros)}`),
+  articulosTop: (filtros: FiltrosDeTopArticulos) => {
+    const query = construirQueryDeBreakdownConPv(filtros)
+    const conLimite = filtros.limite === null ? query : `${query}&limite=${filtros.limite}`
+    return api.get<TopArticulos>(`/reportes/articulos/top${conLimite}`)
+  },
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1168,3 +1168,23 @@ export type VentasPorMedioPago = {
   zonaHoraria: string
   filas: FilaVentasPorMedioPago[]
 }
+
+/** Fila de `GET /api/reportes/articulos/top`, agrupada por `id_articulo` — espejo de
+ * `ArticuloTop`. `descripcion` es el snapshot de la línea, nunca un re-join contra `articulos`
+ * (design decisión 10). `cantidad`/`total` son netos: una NCX resta por construcción, sin rama
+ * de signo. */
+export type ArticuloTop = {
+  idArticulo: number
+  descripcion: string
+  cantidad: number
+  total: number
+}
+
+/** Respuesta de `GET /api/reportes/articulos/top` — espejo de `TopArticulos`. `articulos` viene
+ * ordenada por `total` descendente. */
+export type TopArticulos = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  articulos: ArticuloTop[]
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1113,3 +1113,58 @@ export type ResumenDeGastos = {
   importeTotal: number
   porCategoria: GastoPorCategoria[]
 }
+
+// --- Reportes por dimensión (stage-10-agregacion-dashboard, Slice 8): sin granularidad ni
+// bucketing — cada fila es un subtotal propio del período completo, nunca un porcentaje de un
+// total implícito (espejo de `Contratos.cs`, mismo criterio de `netoVendido`/`ticketPromedio`
+// nullable que `BucketDeVentas`).
+
+/** Fila de `GET /api/reportes/ventas/por-punto-venta` — espejo de `FilaVentasPorPuntoVenta`. */
+export type FilaVentasPorPuntoVenta = {
+  idPuntoVenta: number
+  neto: number
+  cantidadTx: number
+  ticketPromedio: number | null
+}
+
+/** Respuesta de `GET /api/reportes/ventas/por-punto-venta` — espejo de `VentasPorPuntoVenta`. */
+export type VentasPorPuntoVenta = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  filas: FilaVentasPorPuntoVenta[]
+}
+
+/** Fila de `GET /api/reportes/ventas/por-vendedor`, agrupada por `id_empleado` (el vendedor
+ * emisor) — espejo de `FilaVentasPorVendedor`. */
+export type FilaVentasPorVendedor = {
+  idEmpleado: number
+  neto: number
+  cantidadTx: number
+  ticketPromedio: number | null
+}
+
+/** Respuesta de `GET /api/reportes/ventas/por-vendedor` — espejo de `VentasPorVendedor`. */
+export type VentasPorVendedor = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  filas: FilaVentasPorVendedor[]
+}
+
+/** Fila de `GET /api/reportes/ventas/por-medio-pago`, agrupada por
+ * `pagos_comprobante.id_medio_pago` — espejo de `FilaVentasPorMedioPago`. `cantidadPagos` cuenta
+ * filas de `pagos_comprobante`, no comprobantes (un pago dividido aporta una fila a cada medio). */
+export type FilaVentasPorMedioPago = {
+  idMedioPago: number
+  neto: number
+  cantidadPagos: number
+}
+
+/** Respuesta de `GET /api/reportes/ventas/por-medio-pago` — espejo de `VentasPorMedioPago`. */
+export type VentasPorMedioPago = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  filas: FilaVentasPorMedioPago[]
+}

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -10,6 +10,7 @@ import type {
   PuntoVentaListado,
   ResumenDeGastos,
   ResumenDeVentas,
+  TopArticulos,
   UsuarioAutenticado,
   VentasPorMedioPago,
   VentasPorPuntoVenta,
@@ -167,6 +168,16 @@ function ventasPorMedioPagoFixture(sobrescribir: Partial<VentasPorMedioPago> = {
   }
 }
 
+function topArticulosFixture(sobrescribir: Partial<TopArticulos> = {}): TopArticulos {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    articulos: [{ idArticulo: 55, descripcion: 'Producto Estrella', cantidad: 12, total: 2400 }],
+    ...sobrescribir,
+  }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
@@ -179,6 +190,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     if (ruta.startsWith('/reportes/ventas/por-punto-venta?')) return Promise.resolve(ventasPorPuntoVentaFixture())
     if (ruta.startsWith('/reportes/ventas/por-vendedor?')) return Promise.resolve(ventasPorVendedorFixture())
     if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) return Promise.resolve(ventasPorMedioPagoFixture())
+    if (ruta.startsWith('/reportes/articulos/top?')) return Promise.resolve(topArticulosFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -349,31 +361,128 @@ describe('Tablero — G1 parity (stage-10-agregacion-dashboard, Slice 7)', () =>
 })
 
 describe('Tablero — Paneles de desglose por dimensión (stage-10-agregacion-dashboard, Slice 8)', () => {
-  // Prueba el mapeo `valor: f.neto` de los tres paneles (mutation-proof-tests): mismo precedente
-  // que la slice 7 (`neto` → `cantidadTx`). Mutación aplicada a los tres paneles (`Tablero.tsx`,
-  // `data={datos.filas.map(...)}`) → cambiado `f.neto` por `f.cantidadTx`/`f.cantidadPagos` →
-  // esta aserción falló (300/5/4 en vez de 1500/800/1200) → revertido → vuelve a pasar.
-  it('cada panel manda su GraficoDeBarras con neto como valor, etiquetado por su propia dimensión', async () => {
+  // Prueba el mapeo `valor: f.neto`/`valor: a.total` de los cuatro paneles (mutation-proof-tests):
+  // mismo precedente que la slice 7 (`neto` → `cantidadTx`). Mutación aplicada a los cuatro
+  // paneles (`Tablero.tsx`, `data={datos.filas.map(...)}` / `data={datos.articulos.map(...)}`) →
+  // cambiado `f.neto` por `f.cantidadTx`/`f.cantidadPagos` y `a.total` por `a.cantidad` → esta
+  // aserción falló (300/5/4/12 en vez de 1500/800/1200/2400) → revertido → vuelve a pasar.
+  it('cada panel manda su GraficoDeBarras con neto/total como valor, etiquetado por su propia dimensión', async () => {
     mockearRutasBase()
     renderTablero()
 
     await screen.findByText('Empresa Uno SA')
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('bar-chart')).toHaveLength(3)
+      expect(screen.getAllByTestId('bar-chart')).toHaveLength(4)
     })
 
     const barras = screen.getAllByTestId('bar-chart')
     expect(JSON.parse(barras[0].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'PV Centro', valor: 1500 }])
     expect(JSON.parse(barras[1].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Vendedor #9', valor: 800 }])
     expect(JSON.parse(barras[2].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Efectivo', valor: 1200 }])
+    expect(JSON.parse(barras[3].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Producto Estrella', valor: 2400 }])
+  })
+
+  // Mitad "tabla" de cada panel (Judge B, ronda 1): el data-serie del gráfico no prueba el
+  // formato de moneda, el fallback "—" de un ticket promedio null, ni el fallback de lookup-miss
+  // (`PV #id`/`Medio #id`) contra el catálogo — solo el texto renderizado de la tabla lo hace.
+  it('el panel por punto de venta renderiza la tabla: moneda, "—" para ticket promedio null, y "PV #id" para un id fuera del catálogo', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-punto-venta?')) {
+        return Promise.resolve(
+          ventasPorPuntoVentaFixture({
+            filas: [
+              { idPuntoVenta: 10, neto: 1500, cantidadTx: 5, ticketPromedio: null },
+              { idPuntoVenta: 99, neto: 700, cantidadTx: 2, ticketPromedio: 350 },
+            ],
+          }),
+        )
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await screen.findByText('PV #99') // idPuntoVenta 99 no está en el catálogo mockeado
+
+    expect(screen.getByText('PV #99')).toBeInTheDocument()
+    expect(screen.getByText('$1.500,00')).toBeInTheDocument()
+    expect(screen.getByText('$700,00')).toBeInTheDocument()
+    expect(screen.getByText('$350,00')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument() // fila con ticketPromedio: null
+  })
+
+  it('el panel por vendedor renderiza la tabla: moneda y "—" para ticket promedio null', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-vendedor?')) {
+        return Promise.resolve(ventasPorVendedorFixture({ filas: [{ idEmpleado: 9, neto: 800, cantidadTx: 3, ticketPromedio: null }] }))
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+
+    expect(await screen.findByText('Vendedor #9')).toBeInTheDocument()
+    expect(screen.getByText('$800,00')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('el panel por medio de pago renderiza la tabla: moneda y "Medio #id" para un id fuera del catálogo', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) {
+        return Promise.resolve(ventasPorMedioPagoFixture({ filas: [{ idMedioPago: 88, neto: 1200, cantidadPagos: 4 }] }))
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+
+    expect(await screen.findByText('Medio #88')).toBeInTheDocument() // idMedioPago 88 no está en el catálogo mockeado
+    expect(screen.getByText('$1.200,00')).toBeInTheDocument()
+  })
+
+  it('el panel top artículos renderiza la tabla: descripción, cantidad y moneda', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+
+    expect(await screen.findByText('Producto Estrella')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('$2.400,00')).toBeInTheDocument()
+  })
+
+  // Independencia por panel (Judge B, ronda 1): un panel que falla no debe contaminar el
+  // busy/error de sus hermanos — cada uno trae su propia instancia de `usePanelDeReporte`.
+  it('un panel que falla no contamina el estado de los paneles hermanos', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-punto-venta?')) {
+        return Promise.reject(new Error('boom'))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+
+    expect(await screen.findByText('No se pudo cargar el desglose por punto de venta.')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Reintentar' })).toHaveLength(1)
+
+    // los tres paneles hermanos, sin fallas propias, siguen mostrando su data normalmente
+    await waitFor(() => {
+      expect(screen.getByText('Vendedor #9')).toBeInTheDocument()
+      expect(screen.getByText('Efectivo')).toBeInTheDocument()
+      expect(screen.getByText('Producto Estrella')).toBeInTheDocument()
+    })
   })
 
   // Prueba la guarda de generación DE CADA PANEL (`usePanelDeReporte`, react-async-state regla 2):
   // no es el par compartido de la card G1 (deviation registrada en tasks.md antes de la 7.6).
   // Mutación aplicada UNA VEZ en el hook compartido (`if (generacionRef.current !== miGeneracion)
-  // return` borrada de las tres ramas) → los tres tests de esta sección fallaron (la respuesta
-  // obsoleta de cada panel pisó el valor ya re-scopeado) → revertido → los tres vuelven a pasar.
+  // return` borrada de las tres ramas) → los cuatro tests de esta sección fallaron (la respuesta
+  // obsoleta de cada panel pisó el valor ya re-scopeado) → revertido → los cuatro vuelven a pasar.
   it('el panel por punto de venta descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
     let resolverPrimera: (valor: VentasPorPuntoVenta) => void = () => {}
     const primera = new Promise<VentasPorPuntoVenta>((resolve) => {
@@ -473,14 +582,49 @@ describe('Tablero — Paneles de desglose por dimensión (stage-10-agregacion-da
     expect(JSON.parse(barras[2].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Efectivo', valor: 9999 }])
   })
 
+  it('el panel top artículos descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
+    let resolverPrimera: (valor: TopArticulos) => void = () => {}
+    const primera = new Promise<TopArticulos>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/articulos/top?')) {
+        llamadas += 1
+        if (llamadas === 1) return primera
+        return Promise.resolve(
+          topArticulosFixture({ articulos: [{ idArticulo: 55, descripcion: 'Producto Estrella', cantidad: 1, total: 9999 }] }),
+        )
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    await waitFor(() => {
+      const barras = screen.getAllByTestId('bar-chart')
+      expect(JSON.parse(barras[3].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Producto Estrella', valor: 9999 }])
+    })
+
+    resolverPrimera(topArticulosFixture({ articulos: [{ idArticulo: 55, descripcion: 'Producto Estrella', cantidad: 1, total: 1 }] }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const barras = screen.getAllByTestId('bar-chart')
+    expect(JSON.parse(barras[3].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Producto Estrella', valor: 9999 }])
+  })
+
   // Prueba `construirQueryDeBreakdown` vs `construirQueryDeBreakdownConPv` end-to-end (design:
   // Endpoints — "idPuntoVenta en todo menos por-punto-venta, sería una contradicción"): filtrar
-  // por PV debe llegar a por-vendedor/por-medio-pago pero jamás a por-punto-venta.
-  it('el filtro de punto de venta viaja a por-vendedor y por-medio-pago, nunca a por-punto-venta', async () => {
+  // por PV debe llegar a por-vendedor/por-medio-pago/articulos-top pero jamás a por-punto-venta.
+  it('el filtro de punto de venta viaja a por-vendedor, por-medio-pago y articulos/top, nunca a por-punto-venta', async () => {
     mockearRutasBase()
     renderTablero()
     await screen.findByText('Empresa Uno SA')
-    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(3))
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(4))
 
     fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
 
@@ -488,6 +632,7 @@ describe('Tablero — Paneles de desglose por dimensión (stage-10-agregacion-da
       const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
       expect(rutas.some((r) => r.startsWith('/reportes/ventas/por-vendedor?') && r.includes('idPuntoVenta=10'))).toBe(true)
       expect(rutas.some((r) => r.startsWith('/reportes/ventas/por-medio-pago?') && r.includes('idPuntoVenta=10'))).toBe(true)
+      expect(rutas.some((r) => r.startsWith('/reportes/articulos/top?') && r.includes('idPuntoVenta=10'))).toBe(true)
     })
 
     const rutasPorPv = apiGetMock.mock.calls.map((llamada) => llamada[0] as string).filter((r) => r.startsWith('/reportes/ventas/por-punto-venta?'))

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -4,13 +4,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tablero } from './Tablero'
 import { rangoUltimosSieteDias } from '../api/reportes'
 import { ROL } from '../api/tipos'
-import type { EmpresaListado, ResumenDeGastos, ResumenDeVentas, UsuarioAutenticado } from '../api/tipos'
+import type {
+  EmpresaListado,
+  MedioPagoListado,
+  PuntoVentaListado,
+  ResumenDeGastos,
+  ResumenDeVentas,
+  UsuarioAutenticado,
+  VentasPorMedioPago,
+  VentasPorPuntoVenta,
+  VentasPorVendedor,
+} from '../api/tipos'
 import { RutaProtegida } from '../auth/RutaProtegida'
 
 const apiGetMock = vi.fn()
 
 // `recharts` se mockea igual que en los tests de los wrappers: bajo jsdom no renderiza
 // nada observable, y sin el stub el mapeo de datos al grafico queda sin asercion posible.
+// `BarChart`/`Bar` (Slice 8, paneles de desglose) se agregan al mismo mock que `LineChart`.
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: import('react').ReactNode }) => (
     <div data-testid="responsive-container">{children}</div>
@@ -21,6 +32,12 @@ vi.mock('recharts', () => ({
     </div>
   ),
   Line: () => null,
+  BarChart: ({ data, children }: { data: unknown[]; children: import('react').ReactNode }) => (
+    <div data-testid="bar-chart" data-serie={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Bar: () => null,
   XAxis: () => null,
   YAxis: () => null,
   Tooltip: () => null,
@@ -95,13 +112,73 @@ function gastosFixture(sobrescribir: Partial<ResumenDeGastos> = {}): ResumenDeGa
   }
 }
 
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const medioEfectivo: MedioPagoListado = {
+  id: 1,
+  nombre: 'Efectivo',
+  activo: true,
+  idEmpresa: null,
+  orden: 1,
+  comportamiento: 'Efectivo',
+  admiteVuelto: true,
+  requiereReferencia: false,
+  recargoPorcentaje: null,
+}
+
+function ventasPorPuntoVentaFixture(sobrescribir: Partial<VentasPorPuntoVenta> = {}): VentasPorPuntoVenta {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    filas: [{ idPuntoVenta: 10, neto: 1500, cantidadTx: 5, ticketPromedio: 500 }],
+    ...sobrescribir,
+  }
+}
+
+function ventasPorVendedorFixture(sobrescribir: Partial<VentasPorVendedor> = {}): VentasPorVendedor {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    filas: [{ idEmpleado: 9, neto: 800, cantidadTx: 3, ticketPromedio: 266.67 }],
+    ...sobrescribir,
+  }
+}
+
+function ventasPorMedioPagoFixture(sobrescribir: Partial<VentasPorMedioPago> = {}): VentasPorMedioPago {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    filas: [{ idMedioPago: 1, neto: 1200, cantidadPagos: 4 }],
+    ...sobrescribir,
+  }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro])
+    if (ruta === '/catalogos/medios-pago') return Promise.resolve([medioEfectivo])
     const propia = sobrescribir?.(ruta)
     if (propia) return propia
     if (ruta.startsWith('/reportes/ventas/resumen?')) return Promise.resolve(ventasFixture())
     if (ruta.startsWith('/reportes/gastos/resumen?')) return Promise.resolve(gastosFixture())
+    if (ruta.startsWith('/reportes/ventas/por-punto-venta?')) return Promise.resolve(ventasPorPuntoVentaFixture())
+    if (ruta.startsWith('/reportes/ventas/por-vendedor?')) return Promise.resolve(ventasPorVendedorFixture())
+    if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) return Promise.resolve(ventasPorMedioPagoFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -268,5 +345,152 @@ describe('Tablero — G1 parity (stage-10-agregacion-dashboard, Slice 7)', () =>
         { etiqueta: '05/08', valor: 300 },
       ])
     })
+  })
+})
+
+describe('Tablero — Paneles de desglose por dimensión (stage-10-agregacion-dashboard, Slice 8)', () => {
+  // Prueba el mapeo `valor: f.neto` de los tres paneles (mutation-proof-tests): mismo precedente
+  // que la slice 7 (`neto` → `cantidadTx`). Mutación aplicada a los tres paneles (`Tablero.tsx`,
+  // `data={datos.filas.map(...)}`) → cambiado `f.neto` por `f.cantidadTx`/`f.cantidadPagos` →
+  // esta aserción falló (300/5/4 en vez de 1500/800/1200) → revertido → vuelve a pasar.
+  it('cada panel manda su GraficoDeBarras con neto como valor, etiquetado por su propia dimensión', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('bar-chart')).toHaveLength(3)
+    })
+
+    const barras = screen.getAllByTestId('bar-chart')
+    expect(JSON.parse(barras[0].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'PV Centro', valor: 1500 }])
+    expect(JSON.parse(barras[1].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Vendedor #9', valor: 800 }])
+    expect(JSON.parse(barras[2].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Efectivo', valor: 1200 }])
+  })
+
+  // Prueba la guarda de generación DE CADA PANEL (`usePanelDeReporte`, react-async-state regla 2):
+  // no es el par compartido de la card G1 (deviation registrada en tasks.md antes de la 7.6).
+  // Mutación aplicada UNA VEZ en el hook compartido (`if (generacionRef.current !== miGeneracion)
+  // return` borrada de las tres ramas) → los tres tests de esta sección fallaron (la respuesta
+  // obsoleta de cada panel pisó el valor ya re-scopeado) → revertido → los tres vuelven a pasar.
+  it('el panel por punto de venta descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
+    let resolverPrimera: (valor: VentasPorPuntoVenta) => void = () => {}
+    const primera = new Promise<VentasPorPuntoVenta>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-punto-venta?')) {
+        llamadas += 1
+        if (llamadas === 1) return primera
+        return Promise.resolve(ventasPorPuntoVentaFixture({ filas: [{ idPuntoVenta: 10, neto: 9999, cantidadTx: 1, ticketPromedio: 9999 }] }))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    await waitFor(() => {
+      const barras = screen.getAllByTestId('bar-chart')
+      expect(JSON.parse(barras[0].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'PV Centro', valor: 9999 }])
+    })
+
+    resolverPrimera(ventasPorPuntoVentaFixture({ filas: [{ idPuntoVenta: 10, neto: 1, cantidadTx: 1, ticketPromedio: 1 }] }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const barras = screen.getAllByTestId('bar-chart')
+    expect(JSON.parse(barras[0].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'PV Centro', valor: 9999 }])
+  })
+
+  it('el panel por vendedor descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
+    let resolverPrimera: (valor: VentasPorVendedor) => void = () => {}
+    const primera = new Promise<VentasPorVendedor>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-vendedor?')) {
+        llamadas += 1
+        if (llamadas === 1) return primera
+        return Promise.resolve(ventasPorVendedorFixture({ filas: [{ idEmpleado: 9, neto: 9999, cantidadTx: 1, ticketPromedio: 9999 }] }))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    await waitFor(() => {
+      const barras = screen.getAllByTestId('bar-chart')
+      expect(JSON.parse(barras[1].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Vendedor #9', valor: 9999 }])
+    })
+
+    resolverPrimera(ventasPorVendedorFixture({ filas: [{ idEmpleado: 9, neto: 1, cantidadTx: 1, ticketPromedio: 1 }] }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const barras = screen.getAllByTestId('bar-chart')
+    expect(JSON.parse(barras[1].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Vendedor #9', valor: 9999 }])
+  })
+
+  it('el panel por medio de pago descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
+    let resolverPrimera: (valor: VentasPorMedioPago) => void = () => {}
+    const primera = new Promise<VentasPorMedioPago>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) {
+        llamadas += 1
+        if (llamadas === 1) return primera
+        return Promise.resolve(ventasPorMedioPagoFixture({ filas: [{ idMedioPago: 1, neto: 9999, cantidadPagos: 1 }] }))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    await waitFor(() => {
+      const barras = screen.getAllByTestId('bar-chart')
+      expect(JSON.parse(barras[2].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Efectivo', valor: 9999 }])
+    })
+
+    resolverPrimera(ventasPorMedioPagoFixture({ filas: [{ idMedioPago: 1, neto: 1, cantidadPagos: 1 }] }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const barras = screen.getAllByTestId('bar-chart')
+    expect(JSON.parse(barras[2].dataset.serie ?? '[]')).toEqual([{ etiqueta: 'Efectivo', valor: 9999 }])
+  })
+
+  // Prueba `construirQueryDeBreakdown` vs `construirQueryDeBreakdownConPv` end-to-end (design:
+  // Endpoints — "idPuntoVenta en todo menos por-punto-venta, sería una contradicción"): filtrar
+  // por PV debe llegar a por-vendedor/por-medio-pago pero jamás a por-punto-venta.
+  it('el filtro de punto de venta viaja a por-vendedor y por-medio-pago, nunca a por-punto-venta', async () => {
+    mockearRutasBase()
+    renderTablero()
+    await screen.findByText('Empresa Uno SA')
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(3))
+
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
+
+    await waitFor(() => {
+      const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+      expect(rutas.some((r) => r.startsWith('/reportes/ventas/por-vendedor?') && r.includes('idPuntoVenta=10'))).toBe(true)
+      expect(rutas.some((r) => r.startsWith('/reportes/ventas/por-medio-pago?') && r.includes('idPuntoVenta=10'))).toBe(true)
+    })
+
+    const rutasPorPv = apiGetMock.mock.calls.map((llamada) => llamada[0] as string).filter((r) => r.startsWith('/reportes/ventas/por-punto-venta?'))
+    expect(rutasPorPv.every((r) => !r.includes('idPuntoVenta'))).toBe(true)
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -11,6 +11,7 @@ import type {
   PuntoVentaListado,
   ResumenDeGastos,
   ResumenDeVentas,
+  TopArticulos,
   VentasPorMedioPago,
   VentasPorPuntoVenta,
   VentasPorVendedor,
@@ -22,6 +23,13 @@ import { GraficoDeLineas } from '../componentes/graficos/GraficoDeLineas'
 import { aSerieDeGrafico } from '../componentes/graficos/series'
 
 const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+/** `articulos/top` no trae un selector de "Top N" en esta slice — límite fijo, sensible para un
+ * panel de tablero (ni tan corto que pierda contexto, ni tan largo que rompa el gráfico de
+ * barras). *(ReportesEndpoints.cs: `limite` es `int?`, opcional — el backend resuelve su propio
+ * default si no viaja; este valor es la elección del cliente, no un espejo de un default del
+ * servidor)*. */
+const LIMITE_TOP_ARTICULOS = 10
 
 const GRANULARIDADES: { valor: Granularidad; etiqueta: string }[] = [
   { valor: 'Dia', etiqueta: 'Día' },
@@ -247,15 +255,65 @@ function PanelPorMedioPago({ idEmpresa, desde, hasta, idPuntoVenta, mediosPago }
   )
 }
 
+type PropsPanelTopArticulos = { idEmpresa: number; desde: string; hasta: string; idPuntoVenta: number | null }
+
+function PanelTopArticulos({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanelTopArticulos) {
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.articulosTop({ idEmpresa, idPuntoVenta, desde, hasta, limite: LIMITE_TOP_ARTICULOS }),
+    [idEmpresa, idPuntoVenta, desde, hasta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<TopArticulos>(
+    cargarDatos,
+    'No se pudo cargar el ranking de artículos.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <h6>Top artículos</h6>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <GraficoDeBarras
+            data={datos.articulos.map((a) => ({ etiqueta: a.descripcion, valor: a.total }))}
+            alto={200}
+            titulo="Top artículos por monto neto vendido"
+          />
+          <table className="table table-sm mt-2 mb-0">
+            <thead>
+              <tr>
+                <th>Artículo</th>
+                <th>Cantidad</th>
+                <th>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {datos.articulos.map((a) => (
+                <tr key={a.idArticulo}>
+                  <td>{a.descripcion}</td>
+                  <td>{a.cantidad}</td>
+                  <td>{formatearMoneda(a.total)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  )
+}
+
 /**
  * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity; Slice 8 — filtro compartido +
  * paneles de desglose): serie de ventas, serie de gastos, netos y ticket promedio de los últimos
  * 7 días por defecto, con `desde`/`hasta`/`granularidad`/punto de venta editables — el mismo
- * filtro alimenta la card G1 y los tres paneles de desglose (spec tablero: Breakdown Panels Share
- * Range And Granularity Controls). `granularidad` e `idPuntoVenta` solo los lee `ventas/resumen`
- * y `gastos/resumen`; `ventas/por-punto-venta` no lee `idPuntoVenta` (sería agrupar y filtrar por
- * el mismo campo — design: Endpoints) y ninguno de los tres breakdowns lee `granularidad` (no
- * bucketean por tiempo, cada fila ya es su propio subtotal del período completo).
+ * filtro alimenta la card G1 y los cuatro paneles de desglose — por punto de venta, por vendedor,
+ * por medio de pago, top artículos (spec tablero: Breakdown Panels Share Range And Granularity
+ * Controls). `granularidad` solo la lee `ventas/resumen`/`gastos/resumen`: ninguno de los cuatro
+ * breakdowns bucketea por tiempo, cada fila ya es su propio subtotal del período completo.
+ * `idPuntoVenta` viaja a todos salvo `ventas/por-punto-venta` (sería agrupar y filtrar por el
+ * mismo campo — design: Endpoints); `articulos/top` sí lo acepta, igual que por-vendedor/
+ * por-medio-pago (`ReportesEndpoints.cs`: `int? idPuntoVenta`).
  *
  * Per `react-async-state` reglas 2/4/9: un único `useRef` de generación se bumpea antes de cada
  * fetch (disparado por cambio de empresa/rango/granularidad/PV), cada setter posterior a un
@@ -496,13 +554,13 @@ export function Tablero() {
 
             {idEmpresa !== null && (
               <div className="row g-3 mt-1">
-                <div className="col-md-4">
+                <div className="col-md-3">
                   <PanelPorPuntoVenta idEmpresa={idEmpresa} desde={desde} hasta={hasta} puntosVenta={puntosVentaDeLaEmpresa} />
                 </div>
-                <div className="col-md-4">
+                <div className="col-md-3">
                   <PanelPorVendedor idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
                 </div>
-                <div className="col-md-4">
+                <div className="col-md-3">
                   <PanelPorMedioPago
                     idEmpresa={idEmpresa}
                     desde={desde}
@@ -510,6 +568,9 @@ export function Tablero() {
                     idPuntoVenta={idPuntoVenta}
                     mediosPago={mediosPago}
                   />
+                </div>
+                <div className="col-md-3">
+                  <PanelTopArticulos idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
                 </div>
               </div>
             )}

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -1,38 +1,284 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rangoUltimosSieteDias } from '../api/reportes'
-import type { EmpresaListado, ResumenDeGastos, ResumenDeVentas } from '../api/tipos'
+import type {
+  EmpresaListado,
+  Granularidad,
+  MedioPagoAlta,
+  MedioPagoListado,
+  PuntoVentaListado,
+  ResumenDeGastos,
+  ResumenDeVentas,
+  VentasPorMedioPago,
+  VentasPorPuntoVenta,
+  VentasPorVendedor,
+} from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { GraficoDeBarras } from '../componentes/graficos/GraficoDeBarras'
 import { GraficoDeLineas } from '../componentes/graficos/GraficoDeLineas'
 import { aSerieDeGrafico } from '../componentes/graficos/series'
+
+const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+const GRANULARIDADES: { valor: Granularidad; etiqueta: string }[] = [
+  { valor: 'Dia', etiqueta: 'Día' },
+  { valor: 'Semana', etiqueta: 'Semana' },
+  { valor: 'Mes', etiqueta: 'Mes' },
+]
 
 function formatearMoneda(valor: number): string {
   return `$${valor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
 
 /**
- * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity): serie de ventas, serie de
- * gastos, netos y ticket promedio de los últimos 7 días por defecto, con `desde`/`hasta`
- * editables. La granularidad queda fija en `Dia` esta slice — el selector de granularidad y el
- * filtro por punto de venta llegan con los paneles de breakdown (Slice 8).
+ * Hook compartido de los paneles de desglose (Slice 8): cada instancia trae su PROPIA generación,
+ * `cargando` y `error` — nunca el par compartido de la card G1 (deviation registrada en tasks.md
+ * antes de la tarea 7.6, vinculante para esta slice: react-async-state regla 5/10). `cargarDatos`
+ * ya viene armado con sus propias dependencias vía `useCallback` del llamador, así que este hook
+ * solo depende de esa referencia — evita pasar un array de dependencias dinámico a `useCallback`.
+ */
+function usePanelDeReporte<T>(cargarDatos: () => Promise<T>, mensajeError: string) {
+  const [datos, setDatos] = useState<T | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    cargarDatos()
+      .then((respuesta) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDatos(respuesta)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDatos(null)
+        setError(e instanceof ErrorApi ? e.message : mensajeError)
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [cargarDatos, mensajeError])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  return { datos, cargando, error, reintentar: cargar }
+}
+
+function PanelDeError({ error, onReintentar }: { error: string; onReintentar: () => void }) {
+  return (
+    <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2 py-1 px-2 small">
+      <span>{error}</span>
+      <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={onReintentar}>
+        Reintentar
+      </button>
+    </div>
+  )
+}
+
+type PropsPanelPorPuntoVenta = { idEmpresa: number; desde: string; hasta: string; puntosVenta: PuntoVentaListado[] }
+
+function PanelPorPuntoVenta({ idEmpresa, desde, hasta, puntosVenta }: PropsPanelPorPuntoVenta) {
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.ventasPorPuntoVenta({ idEmpresa, desde, hasta }),
+    [idEmpresa, desde, hasta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<VentasPorPuntoVenta>(
+    cargarDatos,
+    'No se pudo cargar el desglose por punto de venta.',
+  )
+  const nombreDe = useCallback(
+    (id: number) => puntosVenta.find((pv) => pv.id === id)?.nombre ?? `PV #${id}`,
+    [puntosVenta],
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <h6>Ventas por punto de venta</h6>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <GraficoDeBarras
+            data={datos.filas.map((f) => ({ etiqueta: nombreDe(f.idPuntoVenta), valor: f.neto }))}
+            alto={200}
+            titulo="Ventas netas por punto de venta"
+          />
+          <table className="table table-sm mt-2 mb-0">
+            <thead>
+              <tr>
+                <th>Punto de venta</th>
+                <th>Neto</th>
+                <th>TX</th>
+                <th>Ticket promedio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {datos.filas.map((f) => (
+                <tr key={f.idPuntoVenta}>
+                  <td>{nombreDe(f.idPuntoVenta)}</td>
+                  <td>{formatearMoneda(f.neto)}</td>
+                  <td>{f.cantidadTx}</td>
+                  <td>{f.ticketPromedio === null ? '—' : formatearMoneda(f.ticketPromedio)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  )
+}
+
+type PropsPanelPorVendedor = { idEmpresa: number; desde: string; hasta: string; idPuntoVenta: number | null }
+
+function PanelPorVendedor({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanelPorVendedor) {
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.ventasPorVendedor({ idEmpresa, idPuntoVenta, desde, hasta }),
+    [idEmpresa, idPuntoVenta, desde, hasta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<VentasPorVendedor>(
+    cargarDatos,
+    'No se pudo cargar el desglose por vendedor.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <h6>Ventas por vendedor</h6>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <GraficoDeBarras
+            data={datos.filas.map((f) => ({ etiqueta: `Vendedor #${f.idEmpleado}`, valor: f.neto }))}
+            alto={200}
+            titulo="Ventas netas por vendedor"
+          />
+          <table className="table table-sm mt-2 mb-0">
+            <thead>
+              <tr>
+                <th>Vendedor</th>
+                <th>Neto</th>
+                <th>TX</th>
+                <th>Ticket promedio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {datos.filas.map((f) => (
+                <tr key={f.idEmpleado}>
+                  <td>Vendedor #{f.idEmpleado}</td>
+                  <td>{formatearMoneda(f.neto)}</td>
+                  <td>{f.cantidadTx}</td>
+                  <td>{f.ticketPromedio === null ? '—' : formatearMoneda(f.ticketPromedio)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  )
+}
+
+type PropsPanelPorMedioPago = {
+  idEmpresa: number
+  desde: string
+  hasta: string
+  idPuntoVenta: number | null
+  mediosPago: MedioPagoListado[]
+}
+
+function PanelPorMedioPago({ idEmpresa, desde, hasta, idPuntoVenta, mediosPago }: PropsPanelPorMedioPago) {
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.ventasPorMedioPago({ idEmpresa, idPuntoVenta, desde, hasta }),
+    [idEmpresa, idPuntoVenta, desde, hasta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<VentasPorMedioPago>(
+    cargarDatos,
+    'No se pudo cargar el desglose por medio de pago.',
+  )
+  const nombreDe = useCallback(
+    (id: number) => mediosPago.find((m) => m.id === id)?.nombre ?? `Medio #${id}`,
+    [mediosPago],
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <h6>Ventas por medio de pago</h6>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <GraficoDeBarras
+            data={datos.filas.map((f) => ({ etiqueta: nombreDe(f.idMedioPago), valor: f.neto }))}
+            alto={200}
+            titulo="Ventas netas por medio de pago"
+          />
+          <table className="table table-sm mt-2 mb-0">
+            <thead>
+              <tr>
+                <th>Medio de pago</th>
+                <th>Neto</th>
+                <th>Cant. de pagos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {datos.filas.map((f) => (
+                <tr key={f.idMedioPago}>
+                  <td>{nombreDe(f.idMedioPago)}</td>
+                  <td>{formatearMoneda(f.neto)}</td>
+                  <td>{f.cantidadPagos}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity; Slice 8 — filtro compartido +
+ * paneles de desglose): serie de ventas, serie de gastos, netos y ticket promedio de los últimos
+ * 7 días por defecto, con `desde`/`hasta`/`granularidad`/punto de venta editables — el mismo
+ * filtro alimenta la card G1 y los tres paneles de desglose (spec tablero: Breakdown Panels Share
+ * Range And Granularity Controls). `granularidad` e `idPuntoVenta` solo los lee `ventas/resumen`
+ * y `gastos/resumen`; `ventas/por-punto-venta` no lee `idPuntoVenta` (sería agrupar y filtrar por
+ * el mismo campo — design: Endpoints) y ninguno de los tres breakdowns lee `granularidad` (no
+ * bucketean por tiempo, cada fila ya es su propio subtotal del período completo).
  *
  * Per `react-async-state` reglas 2/4/9: un único `useRef` de generación se bumpea antes de cada
- * fetch (disparado por cambio de empresa/rango), cada setter posterior a un `await` y el
- * `finally` que apaga `cargando` están gateados contra esa generación — una respuesta de 7 días
- * desactualizada nunca pisa un rango que el usuario ya cambió. `cargando` cubre la ventana
- * completa (ventas + gastos se piden y aplican como una sola unidad, siempre disparados por el
- * mismo evento de filtro — no son entidades operables independientemente, a diferencia del
- * listado + saldo de `Compras.tsx`).
+ * fetch (disparado por cambio de empresa/rango/granularidad/PV), cada setter posterior a un
+ * `await` y el `finally` que apaga `cargando` están gateados contra esa generación — una
+ * respuesta desactualizada nunca pisa un filtro que el usuario ya cambió. `cargando` cubre la
+ * ventana completa de la card G1 (ventas + gastos se piden y aplican como una sola unidad,
+ * siempre disparados por el mismo evento de filtro — no son entidades operables
+ * independientemente, a diferencia del listado + saldo de `Compras.tsx`). Cada panel de
+ * desglose (Slice 8) es una entidad operable independiente y trae su PROPIA generación/`cargando`
+ * (`usePanelDeReporte`) — no extiende este par compartido (deviation registrada en tasks.md antes
+ * de la tarea 7.6, vinculante para esta slice).
  */
 export function Tablero() {
   const [empresas, setEmpresas] = useState<EmpresaListado[] | null>(null)
   const [idEmpresa, setIdEmpresa] = useState<number | null>(null)
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[]>([])
+  const [mediosPago, setMediosPago] = useState<MedioPagoListado[]>([])
   const [errorEmpresas, setErrorEmpresas] = useState('')
 
   const [desde, setDesde] = useState(() => rangoUltimosSieteDias().desde)
   const [hasta, setHasta] = useState(() => rangoUltimosSieteDias().hasta)
+  const [granularidad, setGranularidad] = useState<Granularidad>('Dia')
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | null>(null)
 
   const [ventas, setVentas] = useState<ResumenDeVentas | null>(null)
   const [gastos, setGastos] = useState<ResumenDeGastos | null>(null)
@@ -42,12 +288,13 @@ export function Tablero() {
 
   useEffect(() => {
     let vigente = true
-    clienteDeOrganizacion
-      .listarEmpresas()
-      .then((lista) => {
+    Promise.all([clienteDeOrganizacion.listarEmpresas(), clienteDeOrganizacion.listarPuntosVenta(), clienteMediosPago.listar(false)])
+      .then(([listaEmpresas, listaPuntosVenta, listaMediosPago]) => {
         if (!vigente) return
-        setEmpresas(lista)
-        if (lista.length > 0) setIdEmpresa(lista[0].id)
+        setEmpresas(listaEmpresas)
+        setPuntosVenta(listaPuntosVenta)
+        setMediosPago(listaMediosPago)
+        if (listaEmpresas.length > 0) setIdEmpresa(listaEmpresas[0].id)
       })
       .catch((e) => {
         if (!vigente) return
@@ -66,7 +313,7 @@ export function Tablero() {
     setCargando(true)
     setError('')
 
-    const filtros = { idEmpresa, idPuntoVenta: null, desde, hasta, granularidad: 'Dia' as const }
+    const filtros = { idEmpresa, idPuntoVenta, desde, hasta, granularidad }
 
     Promise.all([clienteDeReportes.ventasResumen(filtros), clienteDeReportes.gastosResumen(filtros)])
       .then(([resumenVentas, resumenGastos]) => {
@@ -84,11 +331,13 @@ export function Tablero() {
         if (generacionRef.current !== miGeneracion) return
         setCargando(false)
       })
-  }, [idEmpresa, desde, hasta])
+  }, [idEmpresa, idPuntoVenta, desde, hasta, granularidad])
 
   useEffect(() => {
     cargar()
   }, [cargar])
+
+  const puntosVentaDeLaEmpresa = puntosVenta.filter((pv) => pv.idEmpresa === idEmpresa)
 
   return (
     <div className="container-fluid py-4">
@@ -111,7 +360,10 @@ export function Tablero() {
                   className="form-select rounded-0"
                   value={idEmpresa ?? ''}
                   disabled={cargando}
-                  onChange={(e) => setIdEmpresa(Number(e.target.value))}
+                  onChange={(e) => {
+                    setIdEmpresa(Number(e.target.value))
+                    setIdPuntoVenta(null)
+                  }}
                 >
                   {empresas.map((e) => (
                     <option key={e.id} value={e.id}>
@@ -145,6 +397,43 @@ export function Tablero() {
                   disabled={cargando}
                   onChange={(e) => setHasta(e.target.value)}
                 />
+              </div>
+              <div className="col-auto">
+                <label className="form-label" htmlFor="tablero-granularidad">
+                  Granularidad
+                </label>
+                <select
+                  id="tablero-granularidad"
+                  className="form-select rounded-0"
+                  value={granularidad}
+                  disabled={cargando}
+                  onChange={(e) => setGranularidad(e.target.value as Granularidad)}
+                >
+                  {GRANULARIDADES.map((g) => (
+                    <option key={g.valor} value={g.valor}>
+                      {g.etiqueta}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-auto">
+                <label className="form-label" htmlFor="tablero-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="tablero-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta ?? ''}
+                  disabled={cargando}
+                  onChange={(e) => setIdPuntoVenta(e.target.value === '' ? null : Number(e.target.value))}
+                >
+                  <option value="">Todos</option>
+                  {puntosVentaDeLaEmpresa.map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
 
@@ -203,6 +492,26 @@ export function Tablero() {
                   </div>
                 </div>
               </>
+            )}
+
+            {idEmpresa !== null && (
+              <div className="row g-3 mt-1">
+                <div className="col-md-4">
+                  <PanelPorPuntoVenta idEmpresa={idEmpresa} desde={desde} hasta={hasta} puntosVenta={puntosVentaDeLaEmpresa} />
+                </div>
+                <div className="col-md-4">
+                  <PanelPorVendedor idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
+                </div>
+                <div className="col-md-4">
+                  <PanelPorMedioPago
+                    idEmpresa={idEmpresa}
+                    desde={desde}
+                    hasta={hasta}
+                    idPuntoVenta={idPuntoVenta}
+                    mediosPago={mediosPago}
+                  />
+                </div>
+              </div>
             )}
           </>
         )}

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -26,9 +26,9 @@ const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('me
 
 /** `articulos/top` no trae un selector de "Top N" en esta slice — límite fijo, sensible para un
  * panel de tablero (ni tan corto que pierda contexto, ni tan largo que rompa el gráfico de
- * barras). *(ReportesEndpoints.cs: `limite` es `int?`, opcional — el backend resuelve su propio
- * default si no viaja; este valor es la elección del cliente, no un espejo de un default del
- * servidor)*. */
+ * barras). *(ReportesEndpoints.cs: `limite` es `int?`, opcional — sin límite el backend
+ * devuelve el ranking completo, no aplica un default propio; este valor es la elección del
+ * cliente)*. */
 const LIMITE_TOP_ARTICULOS = 10
 
 const GRANULARIDADES: { valor: Granularidad; etiqueta: string }[] = [


### PR DESCRIPTION
## Etapa 10, slice 8 — Tablero Dimensiones

Barra de filtros (rango + granularidad + punto de venta) y CUATRO paneles independientes: por punto de venta, por vendedor, por medio de pago y top de articulos — cada uno con su propio `usePanelDeReporte` (generation ref + busy + error propios; frontera vinculante del slice 7 respetada).

- `granularidad` viaja solo a las series G1 (los breakdowns son subtotales del periodo; el backend no la lee — sin selector muerto).
- `idPuntoVenta` viaja a vendedor/medio-pago/top y NUNCA a por-punto-venta (test de ruteo por query exacta).
- Test de independencia entre paneles: uno falla con su propio Reintentar mientras los hermanos renderizan sus datos.

### Review
Judgment-day de 2 rondas: Juez A REJECT ronda 1 (MAJOR real — el 4to panel recortado sin registro por un scope guard del orquestador y un tasks.md sin commitear) → resuelto IMPLEMENTANDO el panel + cerrando los 2 gaps de Juez B (independencia + mitad tabla) → Juez A APPROVE ronda 2 con el contrato de 4 paneles verificado. Juez B APPROVE-WITH-MINORS (mutaciones de mapeo y guards re-ejecutadas y genuinas). El drift de spec.md (granularidad) quedo registrado en tasks.md para la reconciliacion del archive.

### Size
`size:exception` — ~1036 lineas vs ~350: 4 paneles + la profundidad de tests que el propio judgment-day exigio.

### Tests
vitest 462/462 (×3 estables) · tsc -b limpio · build limpio · oxlint sin issues nuevos

🤖 Generated with [Claude Code](https://claude.com/claude-code)