### PR TITLE
feat(web): panel de rentabilidad admin-only con cobertura de costo (etapa 10, slice 9)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -559,20 +559,37 @@ DOM for non-Admin, present with a mandatory coverage banner for Admin.
   not rendered — out of scope per this task's copy (banner + figure only).
 - [x] 9.3 [P] Component tests: Supervisor session → no rentabilidad DOM
   node; Admin session with partial coverage → banner text asserted per
-  coverage state (100% / partial / all-unknown). — 7 tests added to
-  `Tablero.test.tsx`: Supervisor and Vendedor absence (+ zero fetches to
-  `/reportes/rentabilidad` for Supervisor), the 3 coverage-banner states
-  (100% / partial 15%+5% matching the spec's own example / all-unknown
-  100%), the `incluirEstimados` toggle refetch, and per-panel error
-  isolation (mirrors the slice-8 "panel that fails doesn't contaminate
-  siblings" pattern). Mutation evidence recorded (comments in
-  `Tablero.test.tsx`): (1) the Admin-visibility gate deleted → the
-  Supervisor test failed (DOM node appeared) → reverted → passes; (2) the
-  "estimado excluido" banner clause deleted → the partial-coverage test
-  failed → reverted → passes; (3) the `margenPorcentaje === null` check
-  replaced with `?? 0` → the null-margin test failed ("0.0%" instead of
-  "—") → reverted → passes.
-- [ ] 9.4 Run `judgment-day`; fix; re-judge until clean.
+  coverage state (100% / partial / all-unknown). — 9 tests in
+  `Tablero.test.tsx` (7 initial + 2 from judgment-day round 1): Supervisor
+  and Vendedor absence (+ zero fetches to `/reportes/rentabilidad` for
+  Supervisor), 4 coverage-banner states (100% real / partial 15%+5%
+  matching the spec's own example / all-unknown 100% / empty period "Sin
+  ventas en el período."), the `incluirEstimados` toggle refetch asserting
+  the SECOND response's figure+banner win (not just the query param), a
+  stale-response/generation test for this panel (mirrors the slice-8
+  pattern — the 5th consumer of the shared `usePanelDeReporte` hook), and
+  per-panel error isolation. Mutation evidence recorded (comments in
+  `Tablero.test.tsx`), each actually run (mutate → confirm fail → revert →
+  confirm pass): (1) the Admin-visibility gate deleted → Supervisor test
+  failed; (2) the "estimado excluido" banner clause deleted → partial-
+  coverage test failed; (3) the `margenPorcentaje === null` check replaced
+  with `?? 0` → null-margin test failed ("0.0%" instead of "—"); (4)
+  [judgment-day round 1] the incluido/excluido distinction in
+  `bannerDeCobertura` reverted to the pre-fix single-branch version → the
+  toggle test failed (showed the false "100% real" claim with
+  `incluyeEstimados=true` and 30% estimated); (5) [judgment-day round 1]
+  the `ventaTotal === 0` guard removed → the empty-period test failed
+  (fell through to the same false "100% real" claim via 0/0); (6)
+  [judgment-day round 1] the shared generation guard in `usePanelDeReporte`
+  removed → the new stale-response test for this panel failed.
+- [ ] 9.4 Run `judgment-day`; fix; re-judge until clean. — round 1: BOTH
+  judges REJECT (Judge A MAJOR: `bannerDeCobertura` falsely claimed "100%
+  real" when `incluyeEstimados=true` and part of the margin was estimated,
+  plus a minor on the `ventaTotal === 0` division-by-zero fallback; Judge B
+  MAJOR: missing stale-response test for `PanelDeRentabilidad`, MINOR: the
+  `incluirEstimados` toggle test only asserted the query param, not the
+  rendered figure). All three fixed in this same branch — see 9.1-9.3
+  notes above. Round 2 pending re-judge.
 - [ ] 9.5 Branch `feat/stage10-slice9-tablero-rentabilidad` off `main`
   (parent: slice 8); PR; merge stacked-to-main. — branch created off
   `main` (post slice-8 merge); PR creation/merge is out of scope for

--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -531,20 +531,52 @@ its own fetch and `cargando`. **Rollback**: revert the branch.
 DOM for non-Admin, present with a mandatory coverage banner for Admin.
 **Rollback**: revert the branch.
 
-- [ ] 9.1 Extend `reportes.ts` + `tipos.ts`: client + mirror for
-  `/rentabilidad` (`Rentabilidad`, `CoberturaDeCosto`).
-- [ ] 9.2 Extend `Tablero.tsx`: rentabilidad panel gated by `useAuth` role
+- [x] 9.1 Extend `reportes.ts` + `tipos.ts`: client + mirror for
+  `/rentabilidad` (`Rentabilidad`, `CoberturaDeCosto`). — `Rentabilidad`,
+  `CoberturaDeCosto`, `RentabilidadPorArticulo` mirrored field-for-field
+  against `Contratos.cs`/`CoberturaDeCosto.cs` (already shipped backend,
+  slice 4); `clienteDeReportes.rentabilidad` + `FiltrosDeRentabilidad`
+  reuse `construirQueryDeBreakdownConPv` and append `incluirEstimados` only
+  when `true` (`dto-contract-honesty`/existing `incluirInactivos` pattern —
+  absent in the query string ⇒ excluded by default). `puedeVerRentabilidad`
+  added to `tipos.ts` mirroring `Politicas.LecturaDeRentabilidad`
+  (Admin-only), next to `puedeVerReportes`.
+- [x] 9.2 Extend `Tablero.tsx`: rentabilidad panel gated by `useAuth` role
   check — **not rendered at all** for Supervisor/Vendedor (no
   `display:none`); for Admin, always render the coverage banner above the
   figure, and when any revenue is excluded/unknown state it explicitly (no
   bare percentage). *(spec tablero: Margin Panel Is Invisible, Not
-  Disabled, For Non-Admin)*
-- [ ] 9.3 [P] Component tests: Supervisor session → no rentabilidad DOM
+  Disabled, For Non-Admin)* — `PanelDeRentabilidad` follows the slice-8
+  `usePanelDeReporte` pattern (own generation/`cargando`/`error`); the
+  panel column itself is wrapped in `usuario && puedeVerRentabilidad(usuario.rolId)`
+  in `Tablero`, so a non-Admin never mounts the component — no fetch fires,
+  not just no DOM node. `bannerDeCobertura` always returns text (never
+  `null`): a confirmation line at 100% coverage, "N% estimado excluido"/"N%
+  de costo desconocido" otherwise — never a bare margin percentage. The
+  panel owns a local `incluirEstimados` opt-in toggle (checkbox) that
+  re-fetches with `incluirEstimados=true`. Per-article breakdown
+  (`porArticulo`) is mirrored in `tipos.ts` for contract completeness but
+  not rendered — out of scope per this task's copy (banner + figure only).
+- [x] 9.3 [P] Component tests: Supervisor session → no rentabilidad DOM
   node; Admin session with partial coverage → banner text asserted per
-  coverage state (100% / partial / all-unknown).
+  coverage state (100% / partial / all-unknown). — 7 tests added to
+  `Tablero.test.tsx`: Supervisor and Vendedor absence (+ zero fetches to
+  `/reportes/rentabilidad` for Supervisor), the 3 coverage-banner states
+  (100% / partial 15%+5% matching the spec's own example / all-unknown
+  100%), the `incluirEstimados` toggle refetch, and per-panel error
+  isolation (mirrors the slice-8 "panel that fails doesn't contaminate
+  siblings" pattern). Mutation evidence recorded (comments in
+  `Tablero.test.tsx`): (1) the Admin-visibility gate deleted → the
+  Supervisor test failed (DOM node appeared) → reverted → passes; (2) the
+  "estimado excluido" banner clause deleted → the partial-coverage test
+  failed → reverted → passes; (3) the `margenPorcentaje === null` check
+  replaced with `?? 0` → the null-margin test failed ("0.0%" instead of
+  "—") → reverted → passes.
 - [ ] 9.4 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 9.5 Branch `feat/stage10-slice9-tablero-rentabilidad` off `main`
-  (parent: slice 8); PR; merge stacked-to-main.
+  (parent: slice 8); PR; merge stacked-to-main. — branch created off
+  `main` (post slice-8 merge); PR creation/merge is out of scope for
+  `sdd-apply` per this run's boundaries (no push/PR).
 
 **Verify**: `npm run test -- Tablero`
 

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -8,6 +8,7 @@
 import { api } from './cliente'
 import type {
   Granularidad,
+  Rentabilidad,
   ResumenDeGastos,
   ResumenDeVentas,
   TopArticulos,
@@ -67,6 +68,12 @@ export function construirQueryDeBreakdownConPv(filtros: FiltrosDeBreakdownConPv)
  * (`ReportesEndpoints.cs`: `int? limite`). */
 export type FiltrosDeTopArticulos = FiltrosDeBreakdownConPv & { limite: number | null }
 
+/** `rentabilidad` reutiliza el shape de `FiltrosDeBreakdownConPv` y suma `incluirEstimados` —
+ * único parámetro propio de esta ruta (`ReportesEndpoints.cs`: `bool? incluirEstimados`, ausente
+ * en la query string ⇒ excluido por default, spec rentabilidad-y-comisiones: Margin Excludes
+ * Estimated Cost Lines By Default). */
+export type FiltrosDeRentabilidad = FiltrosDeBreakdownConPv & { incluirEstimados: boolean }
+
 export const clienteDeReportes = {
   ventasResumen: (filtros: FiltrosDeReporte) =>
     api.get<ResumenDeVentas>(`/reportes/ventas/resumen${construirQueryDeReporte(filtros)}`),
@@ -82,6 +89,11 @@ export const clienteDeReportes = {
     const query = construirQueryDeBreakdownConPv(filtros)
     const conLimite = filtros.limite === null ? query : `${query}&limite=${filtros.limite}`
     return api.get<TopArticulos>(`/reportes/articulos/top${conLimite}`)
+  },
+  rentabilidad: (filtros: FiltrosDeRentabilidad) => {
+    const query = construirQueryDeBreakdownConPv(filtros)
+    const conEstimados = filtros.incluirEstimados ? `${query}&incluirEstimados=true` : query
+    return api.get<Rentabilidad>(`/reportes/rentabilidad${conEstimados}`)
   },
 }
 

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -101,6 +101,15 @@ export function puedeVerReportes(rolId: number) {
   return rolId === ROL.Supervisor || rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.LecturaDeRentabilidad` (stage-10-agregacion-dashboard, Slice 9): solo
+ * admin ve el panel de rentabilidad — ni siquiera supervisor entra acá, el costo es el número más
+ * sensible del sistema y esta etapa no amplía quién lo ve (spec rentabilidad-y-comisiones:
+ * LecturaDeRentabilidad Policy Admits Admin Only). Puramente cosmético: el servidor vuelve a
+ * exigir la misma policy en `/api/reportes/rentabilidad`. */
+export function puedeVerRentabilidad(rolId: number) {
+  return rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -1187,4 +1196,48 @@ export type TopArticulos = {
   hasta: string
   zonaHoraria: string
   articulos: ArticuloTop[]
+}
+
+/** Cobertura del costo de un período de rentabilidad (stage-9-costo-congelado, tres estados:
+ * real / estimado / desconocido) — espejo de `CoberturaDeCosto`. Viaja SIEMPRE en la respuesta de
+ * `/rentabilidad` (spec rentabilidad-y-comisiones: NULL Cost Is Never Treated As Zero, And
+ * Coverage Is Mandatory); cada campo alimenta el banner obligatorio del panel (spec tablero:
+ * Margin Panel Is Invisible, Not Disabled, For Non-Admin). */
+export type CoberturaDeCosto = {
+  lineasTotales: number
+  lineasConCostoReal: number
+  lineasConCostoEstimado: number
+  lineasSinCosto: number
+  ventaTotal: number
+  ventaConCostoReal: number
+  ventaConCostoEstimado: number
+  ventaSinCosto: number
+  incluyeEstimados: boolean
+}
+
+/** Fila de margen por artículo dentro de `/rentabilidad`, agrupada por `id_articulo` — espejo de
+ * `RentabilidadPorArticulo`. `idArticulo` es `null` en una línea de concepto libre;
+ * `margenPorcentaje` es `null`, nunca `0`, mismo criterio que `ticketPromedio`. */
+export type RentabilidadPorArticulo = {
+  idArticulo: number | null
+  descripcion: string
+  ventaConsiderada: number
+  costoConsiderado: number
+  margen: number
+  margenPorcentaje: number | null
+}
+
+/** Respuesta de `GET /api/reportes/rentabilidad` — espejo de `Rentabilidad`. `margenPorcentaje`
+ * es `null`, nunca `0`, cuando `ventaConsiderada` es cero (denominador vacío, mismo criterio que
+ * `ResumenDeVentas.ticketPromedio`). */
+export type Rentabilidad = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  ventaConsiderada: number
+  costoConsiderado: number
+  margen: number
+  margenPorcentaje: number | null
+  cobertura: CoberturaDeCosto
+  porArticulo: RentabilidadPorArticulo[]
 }

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -782,13 +782,42 @@ describe('Tablero — Panel de rentabilidad (stage-10-agregacion-dashboard, Slic
     expect(screen.queryByText('0.0%')).not.toBeInTheDocument()
   })
 
-  it('el toggle "Incluir costos estimados" dispara un refetch con incluirEstimados=true', async () => {
+  // Judgment-day ronda 1 (Judge B, MINOR + Judge A, MAJOR): el test original solo afirmaba el
+  // query param — nunca que la figura/banner en pantalla cambiara. Ahora la segunda respuesta trae
+  // una cifra y una cobertura DISTINTAS (margen $700/70%, 30% del período con costo estimado ahora
+  // incluido) y el test asegura que la UI refleja esa respuesta, no la primera.
+  it('el toggle "Incluir costos estimados" dispara un refetch y refleja la cifra/banner de la nueva respuesta', async () => {
     usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
-    mockearRutasBase()
+    let llamadas = 0
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        llamadas += 1
+        if (llamadas === 1) return Promise.resolve(rentabilidadFixture())
+        return Promise.resolve(
+          rentabilidadFixture({
+            margen: 700,
+            margenPorcentaje: 70,
+            cobertura: {
+              lineasTotales: 10,
+              lineasConCostoReal: 7,
+              lineasConCostoEstimado: 3,
+              lineasSinCosto: 0,
+              ventaTotal: 1000,
+              ventaConCostoReal: 700,
+              ventaConCostoEstimado: 300,
+              ventaSinCosto: 0,
+              incluyeEstimados: true,
+            },
+          }),
+        )
+      }
+      return undefined
+    })
     renderTablero()
 
     await screen.findByText('Rentabilidad')
     expect(await screen.findByText('Cobertura de costo: 100% de la venta con costo real considerado.')).toBeInTheDocument()
+    expect(screen.getByText('$400,00')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Incluir costos estimados'))
 
@@ -796,6 +825,55 @@ describe('Tablero — Panel de rentabilidad (stage-10-agregacion-dashboard, Slic
       const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
       expect(rutas.some((r) => r.startsWith('/reportes/rentabilidad?') && r.includes('incluirEstimados=true'))).toBe(true)
     })
+
+    // Judgment-day ronda 1 (Judge A, MAJOR — `bannerDeCobertura`): con `incluyeEstimados=true` y
+    // `ventaConCostoEstimado > 0` el banner debe nombrar ese tramo como "incluido", nunca caer en
+    // la afirmación "100% real" (falsa acá: 30% del margen mostrado es estimado). Mutación
+    // aplicada — revertida la distinción incluido/excluido de `bannerDeCobertura` (vuelve a tratar
+    // cualquier `incluyeEstimados=true` como "nada que reportar") → este test falló mostrando
+    // "Cobertura de costo: 100% de la venta con costo real considerado." en vez de "30% con costo
+    // estimado incluido" → revertida la mutación → vuelve a pasar.
+    expect(await screen.findByText('30% con costo estimado incluido')).toBeInTheDocument()
+    expect(screen.queryByText('Cobertura de costo: 100% de la venta con costo real considerado.')).not.toBeInTheDocument()
+    expect(await screen.findByText('$700,00')).toBeInTheDocument()
+    expect(screen.getByText('70.0%')).toBeInTheDocument()
+    expect(screen.queryByText('$400,00')).not.toBeInTheDocument()
+  })
+
+  // Judgment-day ronda 1 (Judge A, minor): un período sin ventas no tiene cobertura real que
+  // afirmar — antes de la corrección, `ventaTotal === 0` producía una división 0/0 que caía en el
+  // mismo fallback "100% real", una afirmación sin sentido para un período vacío.
+  it('un Admin ve "Sin ventas en el período." cuando la venta total del período es cero', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        return Promise.resolve(
+          rentabilidadFixture({
+            ventaConsiderada: 0,
+            costoConsiderado: 0,
+            margen: 0,
+            margenPorcentaje: null,
+            cobertura: {
+              lineasTotales: 0,
+              lineasConCostoReal: 0,
+              lineasConCostoEstimado: 0,
+              lineasSinCosto: 0,
+              ventaTotal: 0,
+              ventaConCostoReal: 0,
+              ventaConCostoEstimado: 0,
+              ventaSinCosto: 0,
+              incluyeEstimados: false,
+            },
+          }),
+        )
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('Sin ventas en el período.')).toBeInTheDocument()
+    expect(screen.queryByText('Cobertura de costo: 100% de la venta con costo real considerado.')).not.toBeInTheDocument()
   })
 
   it('el panel de rentabilidad muestra su propio estado de error sin afectar a los paneles de desglose', async () => {
@@ -816,5 +894,42 @@ describe('Tablero — Panel de rentabilidad (stage-10-agregacion-dashboard, Slic
       expect(screen.getByText('Efectivo')).toBeInTheDocument()
       expect(screen.getByText('Producto Estrella')).toBeInTheDocument()
     })
+  })
+
+  // Judgment-day ronda 1 (Judge B, MAJOR): faltaba el test de generación del panel de rentabilidad
+  // — mismo patrón que los cuatro paneles de desglose (Slice 8), la única entidad que no lo tenía
+  // todavía. Mutación aplicada — quitada la guarda `if (generacionRef.current !== miGeneracion)
+  // return` del `.then` compartido en `usePanelDeReporte` → este test falló ($1,00 de la respuesta
+  // obsoleta pisó los $9.999,00 ya re-scopeados) → revertido → vuelve a pasar (misma mutación ya
+  // probada para los cuatro paneles hermanos; este panel es ahora el quinto consumidor del hook).
+  it('el panel de rentabilidad descarta una respuesta obsoleta cuando "Hasta" cambia antes de que resuelva', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    let resolverPrimera: (valor: Rentabilidad) => void = () => {}
+    const primera = new Promise<Rentabilidad>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        llamadas += 1
+        if (llamadas === 1) return primera
+        return Promise.resolve(rentabilidadFixture({ margen: 9999, margenPorcentaje: 99 }))
+      }
+      return undefined
+    })
+
+    renderTablero()
+    await screen.findByText('Rentabilidad')
+
+    fireEvent.change(screen.getByLabelText('Hasta'), { target: { value: '2026-08-20' } })
+
+    expect(await screen.findByText('$9.999,00')).toBeInTheDocument()
+
+    resolverPrimera(rentabilidadFixture({ margen: 1, margenPorcentaje: 1 }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(screen.queryByText('$1,00')).not.toBeInTheDocument()
+    expect(screen.getByText('$9.999,00')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -8,6 +8,7 @@ import type {
   EmpresaListado,
   MedioPagoListado,
   PuntoVentaListado,
+  Rentabilidad,
   ResumenDeGastos,
   ResumenDeVentas,
   TopArticulos,
@@ -178,6 +179,31 @@ function topArticulosFixture(sobrescribir: Partial<TopArticulos> = {}): TopArtic
   }
 }
 
+function rentabilidadFixture(sobrescribir: Partial<Rentabilidad> = {}): Rentabilidad {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    ventaConsiderada: 1000,
+    costoConsiderado: 600,
+    margen: 400,
+    margenPorcentaje: 40,
+    cobertura: {
+      lineasTotales: 10,
+      lineasConCostoReal: 10,
+      lineasConCostoEstimado: 0,
+      lineasSinCosto: 0,
+      ventaTotal: 1000,
+      ventaConCostoReal: 1000,
+      ventaConCostoEstimado: 0,
+      ventaSinCosto: 0,
+      incluyeEstimados: false,
+    },
+    porArticulo: [],
+    ...sobrescribir,
+  }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
@@ -191,6 +217,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     if (ruta.startsWith('/reportes/ventas/por-vendedor?')) return Promise.resolve(ventasPorVendedorFixture())
     if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) return Promise.resolve(ventasPorMedioPagoFixture())
     if (ruta.startsWith('/reportes/articulos/top?')) return Promise.resolve(topArticulosFixture())
+    if (ruta.startsWith('/reportes/rentabilidad?')) return Promise.resolve(rentabilidadFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -637,5 +664,157 @@ describe('Tablero — Paneles de desglose por dimensión (stage-10-agregacion-da
 
     const rutasPorPv = apiGetMock.mock.calls.map((llamada) => llamada[0] as string).filter((r) => r.startsWith('/reportes/ventas/por-punto-venta?'))
     expect(rutasPorPv.every((r) => !r.includes('idPuntoVenta'))).toBe(true)
+  })
+})
+
+describe('Tablero — Panel de rentabilidad (stage-10-agregacion-dashboard, Slice 9)', () => {
+  // Prueba el gate `usuario && puedeVerRentabilidad(usuario.rolId)` que envuelve `PanelDeRentabilidad`
+  // en `Tablero.tsx` (spec tablero: Margin Panel Is Invisible, Not Disabled, For Non-Admin — "not
+  // rendered-and-disabled... absent"; mutation-proof-tests): mutación aplicada — reemplazado el
+  // gate por `true` (el panel se monta siempre) → este test falló (apareció "Rentabilidad" en el
+  // DOM y se disparó un fetch a `/reportes/rentabilidad`) → revertido → vuelve a pasar. No solo el
+  // nodo está ausente: al no montarse el componente, su `useEffect` de `usePanelDeReporte` nunca
+  // corre, así que tampoco hay fetch — "no fetch fired for non-Admin" se prueba por construcción,
+  // no por una guarda adicional en runtime.
+  it('un Supervisor no ve el panel de rentabilidad ni dispara su fetch', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Supervisor, rol: 'Supervisor' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(4))
+
+    expect(screen.queryByText('Rentabilidad')).not.toBeInTheDocument()
+    const rutasDeRentabilidad = apiGetMock.mock.calls.map((llamada) => llamada[0] as string).filter((r) => r.startsWith('/reportes/rentabilidad'))
+    expect(rutasDeRentabilidad).toHaveLength(0)
+  })
+
+  it('un Vendedor tampoco ve el panel de rentabilidad', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(4))
+
+    expect(screen.queryByText('Rentabilidad')).not.toBeInTheDocument()
+  })
+
+  it('un Admin ve el panel de rentabilidad con cobertura 100%: banner de confirmación, sin excluir nada', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('Cobertura de costo: 100% de la venta con costo real considerado.')).toBeInTheDocument()
+    expect(screen.getByText('$400,00')).toBeInTheDocument()
+    expect(screen.getByText('40.0%')).toBeInTheDocument()
+  })
+
+  // Cobertura parcial: mismo ejemplo textual que el spec (80% incluido, 15% estimado, 5%
+  // desconocido) — spec tablero: "shows the margin figure together with a banner stating '15%
+  // estimado excluido, 5% de costo desconocido'".
+  it('un Admin ve el banner de cobertura parcial: "15% estimado excluido, 5% de costo desconocido"', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        return Promise.resolve(
+          rentabilidadFixture({
+            cobertura: {
+              lineasTotales: 20,
+              lineasConCostoReal: 16,
+              lineasConCostoEstimado: 3,
+              lineasSinCosto: 1,
+              ventaTotal: 1000,
+              ventaConCostoReal: 800,
+              ventaConCostoEstimado: 150,
+              ventaSinCosto: 50,
+              incluyeEstimados: false,
+            },
+          }),
+        )
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('15% estimado excluido, 5% de costo desconocido')).toBeInTheDocument()
+  })
+
+  // Todo desconocido: coverage 0% conocida, banner nombra el 100% desconocido — nunca "$0,00" ni
+  // un margen a secas sin banner (spec: "a bare margin percentage MUST NOT be shown alone").
+  it('un Admin ve el banner "100% de costo desconocido" cuando toda la venta es de costo desconocido', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        return Promise.resolve(
+          rentabilidadFixture({
+            ventaConsiderada: 0,
+            costoConsiderado: 0,
+            margen: 0,
+            margenPorcentaje: null,
+            cobertura: {
+              lineasTotales: 5,
+              lineasConCostoReal: 0,
+              lineasConCostoEstimado: 0,
+              lineasSinCosto: 5,
+              ventaTotal: 200,
+              ventaConCostoReal: 0,
+              ventaConCostoEstimado: 0,
+              ventaSinCosto: 200,
+              incluyeEstimados: false,
+            },
+          }),
+        )
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('100% de costo desconocido')).toBeInTheDocument()
+    // Prueba el `datos.margenPorcentaje === null ? '—' : ...` de `PanelDeRentabilidad`
+    // (mutation-proof-tests, mismo criterio que `ticketPromedio`): mutación aplicada — reemplazado
+    // por `${(datos.margenPorcentaje ?? 0).toFixed(1)}%` (null tratado como 0) → este test falló
+    // ("0.0%" en pantalla en vez de "—") → revertido → vuelve a pasar.
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.queryByText('0.0%')).not.toBeInTheDocument()
+  })
+
+  it('el toggle "Incluir costos estimados" dispara un refetch con incluirEstimados=true', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('Cobertura de costo: 100% de la venta con costo real considerado.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Incluir costos estimados'))
+
+    await waitFor(() => {
+      const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+      expect(rutas.some((r) => r.startsWith('/reportes/rentabilidad?') && r.includes('incluirEstimados=true'))).toBe(true)
+    })
+  })
+
+  it('el panel de rentabilidad muestra su propio estado de error sin afectar a los paneles de desglose', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/rentabilidad?')) {
+        return Promise.reject(new Error('boom'))
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    expect(await screen.findByText('No se pudo cargar la rentabilidad.')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Vendedor #9')).toBeInTheDocument()
+      expect(screen.getByText('Efectivo')).toBeInTheDocument()
+      expect(screen.getByText('Producto Estrella')).toBeInTheDocument()
+    })
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -310,17 +310,26 @@ function PanelTopArticulos({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanel
 /** Texto del banner obligatorio de cobertura del panel de rentabilidad (spec tablero: Margin
  * Panel Is Invisible, Not Disabled, For Non-Admin — "a bare margin percentage MUST NOT be shown
  * alone"; design: "always renders the coverage banner above the figure"). Devuelve SIEMPRE un
- * texto, nunca `null`: con cobertura 100% confirma que no hay nada excluido; si hay estimado
- * excluido y/o costo desconocido, los nombra explícitamente — nunca un porcentaje de margen a
- * secas. El costo estimado solo cuenta como "excluido" cuando `incluyeEstimados` es `false`: una
- * vez que el caller optó por incluirlo, esa porción pasa a estar considerada en el margen. */
+ * texto, nunca `null`: con cobertura 100% real confirma que no hay nada excluido ni estimado; si
+ * hay estimado excluido, incluido u costo desconocido, los nombra explícitamente — nunca un
+ * porcentaje de margen a secas. `incluyeEstimados` decide la etiqueta del tramo estimado: `false`
+ * ⇒ "excluido" (no contribuye al margen mostrado); `true` ⇒ "incluido" (sí contribuye) — la
+ * frase "100% de la venta con costo real" solo es honesta cuando NINGUNA porción es estimada,
+ * incluida o no (judgment-day ronda 1, Judge A MAJOR: con `incluyeEstimados=true` y estimado > 0
+ * caía acá y afirmaba "100% real" siendo falso). Un período sin ventas (`ventaTotal === 0`) no
+ * tiene cobertura que reportar — copia neutra en vez de una división por cero disfrazada de 100%
+ * (Judge A minor). */
 function bannerDeCobertura(cobertura: CoberturaDeCosto): string {
   const { ventaTotal, ventaConCostoEstimado, ventaSinCosto, incluyeEstimados } = cobertura
-  const pctEstimadoExcluido = incluyeEstimados || ventaTotal === 0 ? 0 : (ventaConCostoEstimado / ventaTotal) * 100
-  const pctDesconocido = ventaTotal === 0 ? 0 : (ventaSinCosto / ventaTotal) * 100
+  if (ventaTotal === 0) return 'Sin ventas en el período.'
+
+  const pctEstimadoExcluido = incluyeEstimados ? 0 : (ventaConCostoEstimado / ventaTotal) * 100
+  const pctEstimadoIncluido = incluyeEstimados ? (ventaConCostoEstimado / ventaTotal) * 100 : 0
+  const pctDesconocido = (ventaSinCosto / ventaTotal) * 100
 
   const partes: string[] = []
   if (pctEstimadoExcluido > 0) partes.push(`${pctEstimadoExcluido.toFixed(0)}% estimado excluido`)
+  if (pctEstimadoIncluido > 0) partes.push(`${pctEstimadoIncluido.toFixed(0)}% con costo estimado incluido`)
   if (pctDesconocido > 0) partes.push(`${pctDesconocido.toFixed(0)}% de costo desconocido`)
 
   return partes.length === 0 ? 'Cobertura de costo: 100% de la venta con costo real considerado.' : partes.join(', ')

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -4,11 +4,13 @@ import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rangoUltimosSieteDias } from '../api/reportes'
 import type {
+  CoberturaDeCosto,
   EmpresaListado,
   Granularidad,
   MedioPagoAlta,
   MedioPagoListado,
   PuntoVentaListado,
+  Rentabilidad,
   ResumenDeGastos,
   ResumenDeVentas,
   TopArticulos,
@@ -16,6 +18,8 @@ import type {
   VentasPorPuntoVenta,
   VentasPorVendedor,
 } from '../api/tipos'
+import { puedeVerRentabilidad } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 import { GraficoDeBarras } from '../componentes/graficos/GraficoDeBarras'
@@ -303,6 +307,85 @@ function PanelTopArticulos({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanel
   )
 }
 
+/** Texto del banner obligatorio de cobertura del panel de rentabilidad (spec tablero: Margin
+ * Panel Is Invisible, Not Disabled, For Non-Admin — "a bare margin percentage MUST NOT be shown
+ * alone"; design: "always renders the coverage banner above the figure"). Devuelve SIEMPRE un
+ * texto, nunca `null`: con cobertura 100% confirma que no hay nada excluido; si hay estimado
+ * excluido y/o costo desconocido, los nombra explícitamente — nunca un porcentaje de margen a
+ * secas. El costo estimado solo cuenta como "excluido" cuando `incluyeEstimados` es `false`: una
+ * vez que el caller optó por incluirlo, esa porción pasa a estar considerada en el margen. */
+function bannerDeCobertura(cobertura: CoberturaDeCosto): string {
+  const { ventaTotal, ventaConCostoEstimado, ventaSinCosto, incluyeEstimados } = cobertura
+  const pctEstimadoExcluido = incluyeEstimados || ventaTotal === 0 ? 0 : (ventaConCostoEstimado / ventaTotal) * 100
+  const pctDesconocido = ventaTotal === 0 ? 0 : (ventaSinCosto / ventaTotal) * 100
+
+  const partes: string[] = []
+  if (pctEstimadoExcluido > 0) partes.push(`${pctEstimadoExcluido.toFixed(0)}% estimado excluido`)
+  if (pctDesconocido > 0) partes.push(`${pctDesconocido.toFixed(0)}% de costo desconocido`)
+
+  return partes.length === 0 ? 'Cobertura de costo: 100% de la venta con costo real considerado.' : partes.join(', ')
+}
+
+type PropsPanelDeRentabilidad = { idEmpresa: number; desde: string; hasta: string; idPuntoVenta: number | null }
+
+/**
+ * Panel de rentabilidad (Slice 9) — el único panel de `Tablero` que NO se monta para un rol
+ * distinto de Admin (spec tablero: Margin Panel Is Invisible, Not Disabled, For Non-Admin): el
+ * gate de rol vive en el `Tablero` que decide si este componente se renderiza, así que un
+ * `Supervisor`/`Vendedor` nunca dispara el `useEffect` de `usePanelDeReporte` — sin fetch a
+ * `/rentabilidad`, no solo sin nodo en el DOM. `incluirEstimados` es un toggle propio del panel
+ * (opt-in, spec rentabilidad-y-comisiones: Margin Excludes Estimated Cost Lines By Default):
+ * cambiarlo arma una nueva `cargarDatos` y dispara un refetch gateado por la misma generación que
+ * el resto de los paneles de desglose.
+ */
+function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanelDeRentabilidad) {
+  const [incluirEstimados, setIncluirEstimados] = useState(false)
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.rentabilidad({ idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados }),
+    [idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<Rentabilidad>(
+    cargarDatos,
+    'No se pudo cargar la rentabilidad.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <h6>Rentabilidad</h6>
+      <div className="form-check form-switch mb-2">
+        <input
+          id="tablero-rentabilidad-incluir-estimados"
+          className="form-check-input"
+          type="checkbox"
+          checked={incluirEstimados}
+          disabled={cargando}
+          onChange={(e) => setIncluirEstimados(e.target.checked)}
+        />
+        <label className="form-check-label small" htmlFor="tablero-rentabilidad-incluir-estimados">
+          Incluir costos estimados
+        </label>
+      </div>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <div className="alert alert-info rounded-0 py-1 px-2 small mb-2">{bannerDeCobertura(datos.cobertura)}</div>
+          <div className="row g-3 text-center">
+            <div className="col-6">
+              <div className="text-muted small">Margen</div>
+              <div className="fs-4">{formatearMoneda(datos.margen)}</div>
+            </div>
+            <div className="col-6">
+              <div className="text-muted small">Margen %</div>
+              <div className="fs-4">{datos.margenPorcentaje === null ? '—' : `${datos.margenPorcentaje.toFixed(1)}%`}</div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 /**
  * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity; Slice 8 — filtro compartido +
  * paneles de desglose): serie de ventas, serie de gastos, netos y ticket promedio de los últimos
@@ -325,8 +408,15 @@ function PanelTopArticulos({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanel
  * desglose (Slice 8) es una entidad operable independiente y trae su PROPIA generación/`cargando`
  * (`usePanelDeReporte`) — no extiende este par compartido (deviation registrada en tasks.md antes
  * de la tarea 7.6, vinculante para esta slice).
+ *
+ * Slice 9 — el panel de rentabilidad se monta condicionado por `puedeVerRentabilidad(usuario.rolId)`:
+ * para Supervisor/Vendedor ni siquiera se instancia (spec tablero: Margin Panel Is Invisible, Not
+ * Disabled, For Non-Admin) — el rol Admin es el único que ve el costo, la política más estricta
+ * de todo el tablero (spec rentabilidad-y-comisiones: LecturaDeRentabilidad Policy Admits Admin
+ * Only).
  */
 export function Tablero() {
+  const { usuario } = useAuth()
   const [empresas, setEmpresas] = useState<EmpresaListado[] | null>(null)
   const [idEmpresa, setIdEmpresa] = useState<number | null>(null)
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[]>([])
@@ -571,6 +661,14 @@ export function Tablero() {
                 </div>
                 <div className="col-md-3">
                   <PanelTopArticulos idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
+                </div>
+              </div>
+            )}
+
+            {idEmpresa !== null && usuario && puedeVerRentabilidad(usuario.rolId) && (
+              <div className="row g-3 mt-1">
+                <div className="col-md-6">
+                  <PanelDeRentabilidad idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Etapa 10, slice 9 — Tablero Rentabilidad

El panel de margen en el Tablero, con la doble llave: SOLO Admin lo ve — para Supervisor/Vendedor no se monta, no fetchea y no deja placeholder (test con spy: cero llamadas).

- Margen y cobertura de costo del backend como verdad, sin recomputo cliente; `—` para margen desconocido, nunca $0.
- Banner de cobertura HONESTO: estimado excluido por defecto ("N% estimado excluido"), con opt-in muestra "N% con costo estimado incluido" — nunca reclama "100% real" con costo estimado presente en ningun modo; periodo vacio dice "Sin ventas en el periodo."
- Toggle `incluirEstimados` re-fetchea y el test aserta las cifras re-renderizadas de la segunda respuesta.

### Review
Judgment-day de 2 rondas, DOBLE REJECT en ronda 1: Juez A cazo un MAJOR de produccion (el banner afirmaba "100% real" con estimado incluido — falsa seguridad en el numero mas sensible del sistema) + edge de periodo vacio; Juez B dos gaps de tests (stale-response del panel nuevo faltante; toggle sin asertar cifras). Fix batch `2666a7f` con evidencia de mutacion por fix → ronda 2: Juez B APPROVE (re-mutando + mutacion asesina propia congelando el panel), Juez A APPROVE (trazado de branches del banner contra los estados alcanzables de ArmarCobertura).

### Tests
vitest 471/471 (462 + 9) · tsc -b limpio · build limpio · oxlint sin issues nuevos · ~430 lineas

🤖 Generated with [Claude Code](https://claude.com/claude-code)