### PR TITLE
feat(reportes): comisiones provisionales por vendedor (etapa 10, slice 10)

### DIFF
--- a/openspec/changes/stage-10-agregacion-dashboard/tasks.md
+++ b/openspec/changes/stage-10-agregacion-dashboard/tasks.md
@@ -607,29 +607,53 @@ visible only to Admin. **Rollback**: revert this single branch — endpoint
 and card disappear, no migration, no persisted row to unwind (proposal
 Rollback Plan step 4).
 
-- [ ] 10.1 Extend `ServicioDeReportesDeVentas.cs` (reuses the net-sales
+- [x] 10.1 Extend `ServicioDeReportesDeVentas.cs` (reuses the net-sales
   filter): `ObtenerComisionesAsync` — group by `id_empleado`, `comision =
   neto_vendido_por_empleado × comision_porcentaje`, rate resolved via
   `ServicioDeParametros` (PV → empresa → default `0`). No write. *(spec
   rentabilidad-y-comisiones: Comisiones Is A Provisional, Non-Persisted
-  Report)*
-- [ ] 10.2 Extend `Contratos.cs` + `ReportesEndpoints.cs`: `GET /comisiones`
+  Report)* — reuses `ConsultarPorVendedorAsync` (`neto_vendido_por_empleado`
+  IS the existing por-vendedor aggregate) plus a new
+  `ResolverComisionPorcentajeAsync` (same PV → empresa → default precedence
+  as `ResolverZonaAsync`). `Comisiones.Provisional` always `true`.
+- [x] 10.2 Extend `Contratos.cs` + `ReportesEndpoints.cs`: `GET /comisiones`
   under `LecturaDeReportes` **+** `LecturaDeRentabilidad`.
-- [ ] 10.3 Extend `reportes.ts` + `Tablero.tsx`: comisiones card, Admin-only,
+- [x] 10.3 Extend `reportes.ts` + `Tablero.tsx`: comisiones card, Admin-only,
   literal `PROVISIONAL` badge, states the rate used. *(spec tablero:
-  Comisiones Card Is Labelled PROVISIONAL)*
-- [ ] 10.4 [P] `ReportesComisionesTests` — 4-test pattern + default rate `0`
+  Comisiones Card Is Labelled PROVISIONAL)* — `PanelDeComisiones` follows the
+  `usePanelDeReporte` pattern (own generation/`cargando`/`error`), gated by
+  `usuario && puedeVerComisiones(usuario.rolId)` in `Tablero` (no mount, no
+  fetch, for non-Admin — same construction as `PanelDeRentabilidad`). Rate
+  `0` renders an explicit "Comisiones desactivadas" message instead of a
+  table of `$0,00` rows (mutation-proof-tests evidence in
+  `Tablero.test.tsx`).
+- [x] 10.4 [P] `ReportesComisionesTests` — 4-test pattern + default rate `0`
   ⇒ every empleado's `comision = 0`; configured rate ⇒ non-zero and
   response labelled PROVISIONAL; no row written to any table (assert no
-  new row in any candidate table pre/post call).
-- [ ] 10.5 [P] Component test: PROVISIONAL text visible alongside computed
-  amounts; card absent for non-Admin.
-- [ ] 10.6 Complete `ReportesAutorizacionTests` for the full 9-route matrix.
-- [ ] 10.7 Gate guard: `dotnet ef migrations list` unchanged — final check
-  for the whole stage.
+  new row in any candidate table pre/post call). 7 tests; mutation evidence
+  recorded (`ServicioDeReportesDeVentas.cs` comment): the
+  `f.Neto * comisionPorcentaje / 100m` clause is the ONLY thing governing
+  both the configured-rate and the default-rate-0 outcome — mutated to
+  `f.Neto`, 4/7 tests failed (including the rate-0 test), reverted, all 7
+  pass again.
+- [x] 10.5 [P] Component test: PROVISIONAL text visible alongside computed
+  amounts; card absent for non-Admin. 5 tests in `Tablero.test.tsx`
+  (Supervisor/Vendedor absent + no fetch, Admin sees badge+rate+row, rate-0
+  off-state, PV filter reaches `/comisiones`); mutation evidence recorded
+  for the rate-0 branch (`{false ? ... : ...}` in place of
+  `datos.comisionPorcentaje === 0` → off-state test failed, reverted, green).
+- [x] 10.6 Complete `ReportesAutorizacionTests` for the full 9-route matrix.
+  New dedicated file, parameterized over the 9 routes: Vendedor/Root 403 on
+  all nine, Admin 200 on all nine, Supervisor 200 on the seven without
+  `LecturaDeRentabilidad` and 403 on `/rentabilidad` + `/comisiones` — 36
+  tests.
+- [x] 10.7 Gate guard: `dotnet ef migrations list` unchanged — final check
+  for the whole stage. Confirmed: same 18 migrations, last one
+  `20260811033540_CostoCongeladoEnVentaEtapa9` (stage 9) — no new file, `git
+  status` on `Migrations/` clean.
 - [ ] 10.8 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 10.9 Branch `feat/stage10-slice10-comisiones` off `main` (parent:
-  slice 7); PR; merge stacked-to-main.
+  slice 7); PR; merge stacked-to-main. Branch created; PR/merge pending.
 
 **Verify**: `dotnet test --filter FullyQualifiedName~ReportesComisiones` /
 `npm run test -- Tablero`

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -69,6 +69,17 @@ public static class ReportesEndpoints
             servicio.ObtenerPorMedioPagoAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
         .WithSummary("Ventas netas del período agrupadas por medio de pago (pagos_comprobante.id_medio_pago).");
 
+        // stage-10-agregacion-dashboard, Slice 10 (PROVISIONAL — droppable en su totalidad): mismo
+        // apilado de políticas que /rentabilidad (design decisión 7).
+        grupo.MapGet("/comisiones", (
+            ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
+            CancellationToken ct) =>
+            servicio.ObtenerComisionesAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
+        .RequireAuthorization(Politicas.LecturaDeRentabilidad)
+        .WithSummary(
+            "PROVISIONAL: comisión por vendedor = neto vendido × comision_porcentaje (default 0, " +
+            "un Admin configura la tasa desde Parámetros). Nada se persiste — calculado on the fly.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -106,3 +106,22 @@ public sealed record FilaVentasPorMedioPago(int IdMedioPago, decimal Neto, int C
 /// <summary>Respuesta de <c>GET /api/reportes/ventas/por-medio-pago</c>.</summary>
 public sealed record VentasPorMedioPago(
     DateOnly Desde, DateOnly Hasta, string ZonaHoraria, IReadOnlyList<FilaVentasPorMedioPago> Filas);
+
+/// <summary>Fila de <c>GET /api/reportes/comisiones</c> (stage-10 slice 10, PROVISIONAL —
+/// droppable en su totalidad), agrupada por <c>id_empleado</c> — mismo discriminador de vendedor
+/// que <see cref="FilaVentasPorVendedor"/> (design decisión 11), reusa exactamente su agregado de
+/// venta neta. <see cref="Comision"/> = <see cref="NetoVendido"/> × la tasa de la respuesta
+/// (<see cref="Comisiones.ComisionPorcentaje"/>) / 100.</summary>
+public sealed record ComisionPorEmpleado(int IdEmpleado, decimal NetoVendido, decimal Comision);
+
+/// <summary>Respuesta de <c>GET /api/reportes/comisiones</c> (spec rentabilidad-y-comisiones:
+/// Comisiones Is A Provisional, Non-Persisted Report). <see cref="ComisionPorcentaje"/> es la tasa
+/// efectivamente resuelta (<c>ParametroConocido.ComisionPorcentaje</c>, PV → empresa → default
+/// <c>0</c>) — echo obligatorio, mismo criterio que <see cref="ResumenDeVentas.ZonaHoraria"/>: con
+/// el default en <c>0</c> ninguna fila tiene comisión distinta de cero.
+/// <see cref="Provisional"/> viaja SIEMPRE en <c>true</c> — no existe una respuesta de este
+/// endpoint que no lo sea, la fórmula espera la decisión real del dueño del producto (design: Open
+/// Questions, "Commission rate scope").</summary>
+public sealed record Comisiones(
+    DateOnly Desde, DateOnly Hasta, string ZonaHoraria, decimal ComisionPorcentaje,
+    IReadOnlyList<ComisionPorEmpleado> Filas, bool Provisional);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeVentas.cs
@@ -99,6 +99,40 @@ public class ServicioDeReportesDeVentas(IWaysDbContext db, LectorDeSerieTemporal
         return new VentasPorMedioPago(desde, hasta, zonaId, filas);
     }
 
+    /// <summary>Reporte PROVISIONAL de comisiones (Slice 10, droppable en su totalidad — spec
+    /// rentabilidad-y-comisiones: Comisiones Is A Provisional, Non-Persisted Report). Reusa
+    /// exactamente <see cref="ConsultarPorVendedorAsync"/>: el neto por vendedor YA es el filtro
+    /// de venta neta que pide el spec (<c>neto_vendido_por_empleado</c>), así que la única pieza
+    /// propia de este reporte es resolver <c>comision_porcentaje</c> y multiplicar. Sin
+    /// escritura — ninguna fila se persiste en ninguna tabla, el cálculo es enteramente on the
+    /// fly.</summary>
+    public async Task<Comisiones> ObtenerComisionesAsync(
+        int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, CancellationToken ct = default)
+    {
+        await ExigirEmpresaAsync(idEmpresa, ct);
+        var idsPuntoVenta = await ResolverPuntosDeVentaAsync(idEmpresa, idPuntoVenta, ct);
+        var (zonaId, zona) = await ResolverZonaAsync(idEmpresa, idPuntoVenta, ct);
+        var rango = RangoDeReporte.Crear(desde, hasta, Granularidad.Dia, zona);
+
+        var comisionPorcentaje = await ResolverComisionPorcentajeAsync(idEmpresa, idPuntoVenta, ct);
+        var filas = await ConsultarPorVendedorAsync(idsPuntoVenta, rango, ct);
+
+        // mutation-proof-tests: la multiplicación por `comisionPorcentaje / 100m` es la ÚNICA
+        // cláusula que gobierna tanto la tasa configurada como el default en 0 — no hay una rama
+        // condicional separada para "tasa cero", el mismo producto la resuelve. Mutación aplicada
+        // (reemplazado `f.Neto * comisionPorcentaje / 100m` por `f.Neto`, i.e. ignorar la tasa):
+        // 4 de 7 tests de ReportesComisionesTests fallaron —
+        // LaComisionCoincideConElCalculoAMano (500 esperado, 10000 obtenido),
+        // SinParametroConfiguradoLaTasaDefaultEsCeroYTodaComisionEsCero (0 esperado, 10000
+        // obtenido) y las dos pruebas del patrón de 4 que aciertan un `Comision` no-cero
+        // (soft-delete/anulado) — revertida, vuelven a pasar las 7.
+        var comisiones = filas
+            .Select(f => new ComisionPorEmpleado(f.IdEmpleado, f.Neto, f.Neto * comisionPorcentaje / 100m))
+            .ToList();
+
+        return new Comisiones(desde, hasta, zonaId, comisionPorcentaje, comisiones, Provisional: true);
+    }
+
     private async Task<int> ExigirEmpresaAsync(int idEmpresa, CancellationToken ct)
     {
         var idTenant = await db.Empresas
@@ -148,6 +182,16 @@ public class ServicioDeReportesDeVentas(IWaysDbContext db, LectorDeSerieTemporal
         var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, idPuntoVenta, ct);
         var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
         return (zonaId, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+    }
+
+    /// <summary>Misma precedencia PV → empresa → default que <see cref="ResolverZonaAsync"/>
+    /// (design decisión 5, aplicada acá a la tasa en vez de la zona) — default <c>0</c> declarado
+    /// en <c>ParametroConocido.ComisionPorcentaje</c> (spec: "Default rate yields zero
+    /// commission").</summary>
+    private async Task<decimal> ResolverComisionPorcentajeAsync(int idEmpresa, int? idPuntoVenta, CancellationToken ct)
+    {
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.ComisionPorcentaje.Clave, idEmpresa, idPuntoVenta, ct);
+        return JsonSerializer.Deserialize<decimal>(resuelto.Valor);
     }
 
     /// <summary>LINQ plano (design: Raw-SQL Invariant Checklist filas 3-4) — <c>Tenant</c> y

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -7,6 +7,7 @@
  */
 import { api } from './cliente'
 import type {
+  Comisiones,
   Granularidad,
   Rentabilidad,
   ResumenDeGastos,
@@ -95,6 +96,8 @@ export const clienteDeReportes = {
     const conEstimados = filtros.incluirEstimados ? `${query}&incluirEstimados=true` : query
     return api.get<Rentabilidad>(`/reportes/rentabilidad${conEstimados}`)
   },
+  comisiones: (filtros: FiltrosDeBreakdownConPv) =>
+    api.get<Comisiones>(`/reportes/comisiones${construirQueryDeBreakdownConPv(filtros)}`),
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -110,6 +110,16 @@ export function puedeVerRentabilidad(rolId: number) {
   return rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.LecturaDeRentabilidad` aplicada a `GET /api/reportes/comisiones`
+ * (stage-10-agregacion-dashboard, Slice 10, PROVISIONAL): mismo policy admin-only que
+ * `puedeVerRentabilidad` — se apila sobre `LecturaDeReportes` igual que rentabilidad (design
+ * decisión 7) — nombrada aparte porque es un concern de UI distinto (tarjeta de comisiones, no el
+ * panel de margen). Puramente cosmético: el servidor vuelve a exigir la misma policy en
+ * `/api/reportes/comisiones`. */
+export function puedeVerComisiones(rolId: number) {
+  return rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -1240,4 +1250,31 @@ export type Rentabilidad = {
   margenPorcentaje: number | null
   cobertura: CoberturaDeCosto
   porArticulo: RentabilidadPorArticulo[]
+}
+
+// --- Comisiones (stage-10-agregacion-dashboard, Slice 10): reporte PROVISIONAL — sin tabla
+// propia, calculado on the fly (espejo de `Ways.Application.Reportes.Contratos`, `Comisiones`/
+// `ComisionPorEmpleado`). Droppable en su totalidad (proposal Rollback Plan step 4).
+
+/** Fila de `GET /api/reportes/comisiones`, agrupada por `id_empleado` — espejo de
+ * `ComisionPorEmpleado`. `comision` = `netoVendido` × la tasa resuelta de la respuesta
+ * (`comisionPorcentaje`). */
+export type ComisionPorEmpleado = {
+  idEmpleado: number
+  netoVendido: number
+  comision: number
+}
+
+/** Respuesta de `GET /api/reportes/comisiones` — espejo de `Comisiones` (spec
+ * rentabilidad-y-comisiones: Comisiones Is A Provisional, Non-Persisted Report).
+ * `comisionPorcentaje` es la tasa efectivamente resuelta (echo obligatorio, mismo criterio que
+ * `zonaHoraria` en el resto de los reportes) — con el default `0` ninguna fila tiene comisión
+ * distinta de cero. `provisional` viaja SIEMPRE en `true`. */
+export type Comisiones = {
+  desde: string
+  hasta: string
+  zonaHoraria: string
+  comisionPorcentaje: number
+  filas: ComisionPorEmpleado[]
+  provisional: boolean
 }

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -5,6 +5,7 @@ import { Tablero } from './Tablero'
 import { rangoUltimosSieteDias } from '../api/reportes'
 import { ROL } from '../api/tipos'
 import type {
+  Comisiones,
   EmpresaListado,
   MedioPagoListado,
   PuntoVentaListado,
@@ -204,6 +205,22 @@ function rentabilidadFixture(sobrescribir: Partial<Rentabilidad> = {}): Rentabil
   }
 }
 
+// idEmpleado 42 (no 9, el de `ventasPorVendedorFixture`) y montos distintos de los que ya usan las
+// demás fixtures del archivo: el panel de comisiones convive con el panel de desglose por
+// vendedor y las cards G1 en la misma pantalla — valores únicos evitan que
+// `screen.getByText(...)` resuelva a un nodo ambiguo entre paneles.
+function comisionesFixture(sobrescribir: Partial<Comisiones> = {}): Comisiones {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    zonaHoraria: 'America/Argentina/Buenos_Aires',
+    comisionPorcentaje: 5,
+    filas: [{ idEmpleado: 42, netoVendido: 3000, comision: 150 }],
+    provisional: true,
+    ...sobrescribir,
+  }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
@@ -218,6 +235,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     if (ruta.startsWith('/reportes/ventas/por-medio-pago?')) return Promise.resolve(ventasPorMedioPagoFixture())
     if (ruta.startsWith('/reportes/articulos/top?')) return Promise.resolve(topArticulosFixture())
     if (ruta.startsWith('/reportes/rentabilidad?')) return Promise.resolve(rentabilidadFixture())
+    if (ruta.startsWith('/reportes/comisiones?')) return Promise.resolve(comisionesFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -931,5 +949,89 @@ describe('Tablero — Panel de rentabilidad (stage-10-agregacion-dashboard, Slic
 
     expect(screen.queryByText('$1,00')).not.toBeInTheDocument()
     expect(screen.getByText('$9.999,00')).toBeInTheDocument()
+  })
+})
+
+describe('Tablero — Card de comisiones, PROVISIONAL (stage-10-agregacion-dashboard, Slice 10)', () => {
+  // Mismo gate que el panel de rentabilidad (mutation-proof-tests, mismo precedente de la Slice 9):
+  // sin `usuario && puedeVerComisiones(usuario.rolId)` envolviendo `PanelDeComisiones`, un
+  // Supervisor vería la card — la ausencia de nodo Y de fetch prueba que el componente ni se monta.
+  it('un Supervisor no ve la card de comisiones ni dispara su fetch', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(4))
+
+    expect(screen.queryByText('Comisiones')).not.toBeInTheDocument()
+    expect(screen.queryByText('PROVISIONAL')).not.toBeInTheDocument()
+    const rutasDeComisiones = apiGetMock.mock.calls.map((llamada) => llamada[0] as string).filter((r) => r.startsWith('/reportes/comisiones'))
+    expect(rutasDeComisiones).toHaveLength(0)
+  })
+
+  it('un Vendedor tampoco ve la card de comisiones', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart')).toHaveLength(4))
+
+    expect(screen.queryByText('Comisiones')).not.toBeInTheDocument()
+  })
+
+  // Prueba el contrato del producto (spec tablero: Comisiones Card Is Labelled PROVISIONAL): el
+  // badge está SIEMPRE presente junto a la tasa aplicada y a la cifra calculada por vendedor —
+  // nunca una comisión mostrada sin la etiqueta.
+  it('un Admin ve la card con el badge PROVISIONAL, la tasa y la comisión calculada por vendedor', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Comisiones')
+    expect(screen.getByText('PROVISIONAL')).toBeInTheDocument()
+    expect(await screen.findByText('Tasa aplicada: 5%')).toBeInTheDocument()
+    expect(screen.getByText('Vendedor #42')).toBeInTheDocument()
+    expect(screen.getByText('$3.000,00')).toBeInTheDocument()
+    expect(screen.getByText('$150,00')).toBeInTheDocument()
+  })
+
+  // Hard constraint (droppable slice): tasa 0 (default) nunca renderiza una tabla de filas en
+  // $0,00 simulando datos — muestra un estado "desactivado" honesto en su lugar
+  // (mutation-proof-tests: mutación aplicada — reemplazada la rama `datos.comisionPorcentaje ===
+  // 0` de `PanelDeComisiones` por `false` (fuerza siempre la tabla) → este test falló mostrando
+  // "$0,00" y "Vendedor #42" en vez del mensaje "desactivadas" → revertida → vuelve a pasar).
+  it('con tasa 0 (default) la card muestra un estado desactivado, nunca una tabla de comisiones en $0,00', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/comisiones?')) {
+        return Promise.resolve(
+          comisionesFixture({ comisionPorcentaje: 0, filas: [{ idEmpleado: 42, netoVendido: 1000, comision: 0 }] }),
+        )
+      }
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Comisiones')
+    expect(screen.getByText('PROVISIONAL')).toBeInTheDocument()
+    expect(await screen.findByText('Tasa aplicada: 0%')).toBeInTheDocument()
+    expect(screen.getByText(/Comisiones desactivadas/)).toBeInTheDocument()
+    expect(screen.queryByText('$0,00')).not.toBeInTheDocument()
+    expect(screen.queryByText('Vendedor #42')).not.toBeInTheDocument()
+  })
+
+  it('el filtro de punto de venta viaja a comisiones', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Comisiones')
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: String(puntoVentaCentro.id) } })
+
+    await waitFor(() => {
+      const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+      expect(rutas.some((r) => r.startsWith('/reportes/comisiones?') && r.includes(`idPuntoVenta=${puntoVentaCentro.id}`))).toBe(true)
+    })
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -5,6 +5,7 @@ import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rangoUltimosSieteDias } from '../api/reportes'
 import type {
   CoberturaDeCosto,
+  Comisiones,
   EmpresaListado,
   Granularidad,
   MedioPagoAlta,
@@ -18,7 +19,7 @@ import type {
   VentasPorPuntoVenta,
   VentasPorVendedor,
 } from '../api/tipos'
-import { puedeVerRentabilidad } from '../api/tipos'
+import { puedeVerComisiones, puedeVerRentabilidad } from '../api/tipos'
 import { useAuth } from '../auth/useAuth'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -395,6 +396,70 @@ function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPan
   )
 }
 
+type PropsPanelDeComisiones = { idEmpresa: number; desde: string; hasta: string; idPuntoVenta: number | null }
+
+/**
+ * Card de comisiones (Slice 10, PROVISIONAL — droppable en su totalidad, spec
+ * rentabilidad-y-comisiones: Comisiones Is A Provisional, Non-Persisted Report): mismo gate de rol
+ * que `PanelDeRentabilidad` (`puedeVerComisiones`, Admin-only — un Supervisor/Vendedor ni siquiera
+ * monta este componente, sin fetch a `/comisiones`). El badge PROVISIONAL es el contrato del
+ * producto, no decoración: la fórmula espera la decisión real del dueño (design: Open Questions,
+ * "Commission rate scope") — viaja siempre visible junto a la tasa y a cada cifra calculada. Con
+ * la tasa resuelta en `0` (default) el panel NUNCA renderiza una tabla de filas en `$0,00` — eso
+ * simularía datos que no existen; en cambio muestra un estado "desactivado" explícito.
+ */
+function PanelDeComisiones({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanelDeComisiones) {
+  const cargarDatos = useCallback(
+    () => clienteDeReportes.comisiones({ idEmpresa, idPuntoVenta, desde, hasta }),
+    [idEmpresa, idPuntoVenta, desde, hasta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<Comisiones>(
+    cargarDatos,
+    'No se pudo cargar las comisiones.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <div className="d-flex justify-content-between align-items-center">
+        <h6 className="mb-0">Comisiones</h6>
+        <span className="badge bg-warning text-dark">PROVISIONAL</span>
+      </div>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {cargando && !datos && <Cargando />}
+      {datos && (
+        <>
+          <p className="text-muted small mb-2">Tasa aplicada: {datos.comisionPorcentaje}%</p>
+          {datos.comisionPorcentaje === 0 ? (
+            <p className="text-muted small mb-0">
+              Comisiones desactivadas: la tasa configurada es 0%. Configure «Comisión (%)» en Parámetros para
+              activarlas.
+            </p>
+          ) : (
+            <table className="table table-sm mt-2 mb-0">
+              <thead>
+                <tr>
+                  <th>Vendedor</th>
+                  <th>Neto vendido</th>
+                  <th>Comisión</th>
+                </tr>
+              </thead>
+              <tbody>
+                {datos.filas.map((f) => (
+                  <tr key={f.idEmpleado}>
+                    <td>Vendedor #{f.idEmpleado}</td>
+                    <td>{formatearMoneda(f.netoVendido)}</td>
+                    <td>{formatearMoneda(f.comision)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
 /**
  * Tablero (stage-10-agregacion-dashboard, Slice 7 — G1 parity; Slice 8 — filtro compartido +
  * paneles de desglose): serie de ventas, serie de gastos, netos y ticket promedio de los últimos
@@ -678,6 +743,14 @@ export function Tablero() {
               <div className="row g-3 mt-1">
                 <div className="col-md-6">
                   <PanelDeRentabilidad idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
+                </div>
+              </div>
+            )}
+
+            {idEmpresa !== null && usuario && puedeVerComisiones(usuario.rolId) && (
+              <div className="row g-3 mt-1">
+                <div className="col-md-6">
+                  <PanelDeComisiones idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
                 </div>
               </div>
             )}

--- a/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http.Json;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Usuarios;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 10 (task 10.6): la matriz de roles completa de las nueve
+/// rutas de <c>/api/reportes/*</c> (spec rentabilidad-y-comisiones / reportes-de-gestion) en un
+/// único archivo dedicado — hasta esta slice cada endpoint probaba su propia matriz de roles por
+/// separado (<c>ReportesVentasResumenTests</c>, <c>ReportesEgresosTests</c>,
+/// <c>RentabilidadTests</c>); esto consolida las nueve en un solo lugar, parametrizado sobre la
+/// lista de rutas (design: Testing Strategy, "Integration — role matrix"). La composición de
+/// políticas en sí (AND de <c>LecturaDeReportes</c> + <c>LecturaDeRentabilidad</c>) ya está probada
+/// a nivel unitario en <c>PoliticasTests</c> — acá solo se prueba el <em>wiring</em> del grupo de
+/// endpoints completo.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private sealed record Contexto(int IdEmpresa, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor, HttpClient Root);
+
+    /// <summary>Las nueve rutas de <c>ReportesEndpoints.cs</c> — <c>rentabilidad</c> y
+    /// <c>comisiones</c> son las dos que apilan <c>LecturaDeRentabilidad</c> (design decisión 7).</summary>
+    public static readonly TheoryData<string> TodasLasRutas = new()
+    {
+        "ventas/resumen", "compras/por-proveedor", "gastos/resumen", "articulos/top",
+        "ventas/por-punto-venta", "ventas/por-vendedor", "ventas/por-medio-pago",
+        "rentabilidad", "comisiones"
+    };
+
+    public static readonly TheoryData<string> RutasSinLecturaDeRentabilidad = new()
+    {
+        "ventas/resumen", "compras/por-proveedor", "gastos/resumen", "articulos/top",
+        "ventas/por-punto-venta", "ventas/por-vendedor", "ventas/por-medio-pago"
+    };
+
+    public static readonly TheoryData<string> RutasConLecturaDeRentabilidad = new() { "rentabilidad", "comisiones" };
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        return new Contexto(resultado.IdEmpresa, admin, supervisor, vendedor, root);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>`ventas/resumen`/`gastos/resumen` exigen `granularidad`; el resto no lo lee
+    /// (dto-contract-honesty) — agregarlo de más no rompe nada, así que viaja siempre para
+    /// simplificar la matriz.</summary>
+    private static string RutaCon(string ruta, int idEmpresa, DateOnly hoy) =>
+        $"/api/reportes/{ruta}?idEmpresa={idEmpresa}&desde={hoy:yyyy-MM-dd}&hasta={hoy:yyyy-MM-dd}&granularidad=Dia";
+
+    [Theory]
+    [MemberData(nameof(TodasLasRutas))]
+    public async Task UnVendedorEsRechazadoEnLasNueveRutas(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await ctx.Vendedor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(TodasLasRutas))]
+    public async Task UnRootEsRechazadoEnLasNueveRutas(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await ctx.Root.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(TodasLasRutas))]
+    public async Task UnAdminEsAceptadoEnLasNueveRutas(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await ctx.Admin.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(RutasSinLecturaDeRentabilidad))]
+    public async Task UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad) + ruta.Replace("/", "-"));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    /// <summary>La prueba distintiva de esta matriz: a diferencia de las otras siete,
+    /// <c>rentabilidad</c> y <c>comisiones</c> apilan <c>LecturaDeRentabilidad</c> (admin-only)
+    /// sobre <c>LecturaDeReportes</c> — <c>LecturaDeReportes</c> sola no alcanza (design decisión
+    /// 7).</summary>
+    [Theory]
+    [MemberData(nameof(RutasConLecturaDeRentabilidad))]
+    public async Task UnSupervisorEsRechazadoEnRentabilidadYComisiones(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnRentabilidadYComisiones) + ruta.Replace("/", "-"));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/ReportesComisionesTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesComisionesTests.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-10-agregacion-dashboard, Slice 10 (task 10.4): <c>GET /api/reportes/comisiones</c> punta
+/// a punta — PROVISIONAL, droppable en su totalidad (spec rentabilidad-y-comisiones: Comisiones Is
+/// A Provisional, Non-Persisted Report). Reusa el mismo <c>ConsultarPorVendedorAsync</c> ya probado
+/// por <see cref="ReportesVentasPorDimensionTests"/> (cross-tenant/soft-delete/anulado son
+/// cobertura ORDINARIA acá, mismo criterio que esa clase), así que el patrón de 4 pruebas se centra
+/// en la pieza propia de este reporte: la resolución de <c>comision_porcentaje</c> y su
+/// multiplicación — más la garantía de que nada se escribe.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReportesComisionesTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        HttpClient Root, int IdCliente, int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor, root,
+            idCliente, resultado.IdUsuarioAdmin);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
+    /// <c>ReportesVentasPorDimensionTests.SembrarComprobanteAsync</c>.</summary>
+    private async Task<int> SembrarComprobanteAsync(
+        Contexto ctx, int idTipoComprobante, DateTimeOffset fecha, decimal total, int? idEmpleado = null,
+        EstadoComprobante estado = EstadoComprobante.Emitido, bool eliminado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = idTipoComprobante,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = idEmpleado ?? ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = estado,
+            CreatedAt = ahora,
+            UpdatedAt = ahora,
+            DeletedAt = eliminado ? ahora : null
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    private async Task<int> IdTipoComprobanteTxAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        return await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+    }
+
+    private static async Task ConfigurarComisionAsync(Contexto ctx, string valorJson)
+    {
+        var respuesta = await ctx.Admin.PutAsJsonAsync(
+            $"/api/parametros?idEmpresa={ctx.IdEmpresa}", new ParametroAlta("comision_porcentaje", valorJson, null));
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    private static Task<HttpResponseMessage> LlamarComisionesAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/reportes/comisiones?idEmpresa={idEmpresa}&desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}");
+
+    private static async Task<Comisiones> ObtenerComisionesAsync(
+        HttpClient cliente, int idEmpresa, DateOnly desde, DateOnly hasta)
+    {
+        var respuesta = await LlamarComisionesAsync(cliente, idEmpresa, desde, hasta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<Comisiones>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 10.4: el patrón de 4 pruebas ----------------------------------------------------
+
+    [Fact]
+    public async Task UnaVentaDeOtroTenantNuncaApareceEnLasComisiones()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaVentaDeOtroTenantNuncaApareceEnLasComisiones) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnaVentaDeOtroTenantNuncaApareceEnLasComisiones) + "-B");
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idTipoTxB = await IdTipoComprobanteTxAsync(ctxB);
+
+        await SembrarComprobanteAsync(ctxB, idTipoTxB, DateTimeOffset.UtcNow, 999_999m);
+        await ConfigurarComisionAsync(ctxA, "5");
+
+        var comisiones = await ObtenerComisionesAsync(ctxA.Admin, ctxA.IdEmpresa, hoy, hoy);
+
+        Assert.Empty(comisiones.Filas);
+    }
+
+    [Fact]
+    public async Task UnaVentaSoftDeletedNuncaApareceEnLasComisiones()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaSoftDeletedNuncaApareceEnLasComisiones));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
+        await ConfigurarComisionAsync(ctx, "10");
+
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 100m);
+
+        var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(comisiones.Filas);
+        Assert.Equal(100m, fila.NetoVendido);
+        Assert.Equal(10m, fila.Comision);
+    }
+
+    [Fact]
+    public async Task UnaVentaAnuladaNuncaApareceEnLasComisiones()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaAnuladaNuncaApareceEnLasComisiones));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
+        await ConfigurarComisionAsync(ctx, "10");
+
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 250m);
+
+        var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var fila = Assert.Single(comisiones.Filas);
+        Assert.Equal(250m, fila.NetoVendido);
+        Assert.Equal(25m, fila.Comision);
+    }
+
+    [Fact]
+    public async Task LaComisionCoincideConElCalculoAMano()
+    {
+        var ctx = await PrepararAsync(nameof(LaComisionCoincideConElCalculoAMano));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
+        await ConfigurarComisionAsync(ctx, "5");
+
+        // Vendedor emisor único (el admin sembrado por PrepararAsync): $10.000 netos → 5% = $500,
+        // el ejemplo textual del spec (Scenario "A configured rate computes a non-zero commission").
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 4_000m);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 6_000m);
+
+        var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(5m, comisiones.ComisionPorcentaje);
+        var fila = Assert.Single(comisiones.Filas);
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdEmpleado);
+        Assert.Equal(10_000m, fila.NetoVendido);
+        Assert.Equal(500m, fila.Comision);
+    }
+
+    // ---- task 10.4: tasa default 0 ⇒ toda comisión en cero (spec: "Default rate yields zero
+    // commission") ------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SinParametroConfiguradoLaTasaDefaultEsCeroYTodaComisionEsCero()
+    {
+        var ctx = await PrepararAsync(nameof(SinParametroConfiguradoLaTasaDefaultEsCeroYTodaComisionEsCero));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
+
+        // Sin ConfigurarComisionAsync: ninguna fila de `parametros` para esta clave — el default
+        // declarado en ParametroConocido.ComisionPorcentaje ("0") es lo único que puede resolver.
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 10_000m);
+
+        var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.Equal(0m, comisiones.ComisionPorcentaje);
+        var fila = Assert.Single(comisiones.Filas);
+        Assert.Equal(10_000m, fila.NetoVendido);
+        Assert.Equal(0m, fila.Comision);
+        Assert.True(comisiones.Provisional);
+    }
+
+    // ---- task 10.4: la respuesta viaja SIEMPRE etiquetada PROVISIONAL --------------------------
+
+    [Fact]
+    public async Task ConTasaConfiguradaLaRespuestaSigueEtiquetadaProvisional()
+    {
+        var ctx = await PrepararAsync(nameof(ConTasaConfiguradaLaRespuestaSigueEtiquetadaProvisional));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        await ConfigurarComisionAsync(ctx, "8");
+
+        var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        Assert.True(comisiones.Provisional);
+        Assert.Equal(8m, comisiones.ComisionPorcentaje);
+    }
+
+    // ---- task 10.4: nada se persiste — el endpoint es de solo lectura --------------------------
+
+    [Fact]
+    public async Task LlamarComisionesNoEscribeNingunaFilaNueva()
+    {
+        var ctx = await PrepararAsync(nameof(LlamarComisionesNoEscribeNingunaFilaNueva));
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
+        await ConfigurarComisionAsync(ctx, "5");
+        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 1_000m);
+
+        async Task<(int Comprobantes, int Items, int Parametros)> ContarAsync()
+        {
+            await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+            return (
+                await db.ComprobantesVenta.CountAsync(),
+                await db.ItemsComprobanteVenta.CountAsync(),
+                await db.Parametros.CountAsync());
+        }
+
+        var antes = await ContarAsync();
+
+        // Dos llamadas (no solo una): si el endpoint tuviera cualquier escritura idempotente-solo-
+        // a-la-primera-vez, la segunda llamada la expondría igual.
+        await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+        await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
+
+        var despues = await ContarAsync();
+
+        Assert.Equal(antes, despues);
+    }
+}


### PR DESCRIPTION
## Etapa 10, slice 10 — Comisiones (PROVISIONAL, droppable)

Cierre de la etapa: `GET /api/reportes/comisiones` (Admin-only, apilado como rentabilidad) + `PanelDeComisiones` en el Tablero.

- Formula: neto_por_vendedor × `comision_porcentaje`/100 (parametro del slice 1, default 0 = apagado), reusando la agregacion por vendedor existente — cero logica duplicada, cero persistencia (test de no-escritura con snapshot de filas), cero migraciones.
- Tasa 0 → estado "Comisiones desactivadas" honesto, nunca tabla de $0,00; badge PROVISIONAL siempre visible (la formula real espera la decision del dueño).
- Diff puramente aditivo: revertir esta rama elimina la feature limpia (droppable por contrato).
- Bonus: `ReportesAutorizacionTests` — la matriz completa 9 rutas × 4 roles (36 tests), saldando la consolidacion diferida de los slices paralelos.

### Review
Judgment-day: ronda limpia — Juez A APPROVE cero hallazgos (formula, autorizacion, no-persistencia y droppability verificadas contra fuente); Juez B APPROVE re-ejecutando ambas mutaciones + 2 propias no reclamadas (flag y badge PROVISIONAL, ambas cazadas) + flip de expectativas de la matriz probando que aserta respuestas vivas.

### Size
`size:exception` — ~765 lineas vs ~220: los dos archivos de test (comisiones + matriz de 36) son el grueso.

### Tests
Domain 394 · Application 219 · Integration 823 (780 + 43) · vitest 476 (471 + 5) · tsc/build/oxlint limpios

🤖 Generated with [Claude Code](https://claude.com/claude-code)