### PR TITLE
feat(exportacion): seam de exportacion XLSX con ClosedXML auditado (etapa 11, slice 1a)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -67,7 +67,7 @@ its licence-audit fallback); DI registers it; no route yet consumes it.
 **Rollback**: revert the branch — one `PackageReference` and the
 `Exportacion/` folder, nothing downstream depends on it yet.
 
-- [ ] 1a.1 **Licence audit (binding, pinned command)**: run
+- [x] 1a.1 **Licence audit (binding, pinned command)**: run
   `dotnet list src/Ways.Infrastructure/Ways.Infrastructure.csproj package --include-transitive --format json`
   after adding the `ClosedXML` `PackageReference`; for each `(id, version)`
   read `<license>`/`<licenseUrl>` from
@@ -79,7 +79,7 @@ its licence-audit fallback); DI registers it; no route yet consumes it.
   swap in the PR body. *(proposal decision 1; design "Licence audit"; spec
   exportacion-de-reportes: Licence Audit Is Recorded Before The Exporter
   Ships)*
-- [ ] 1a.2 Create `src/Ways.Application/Exportacion/TablaExportable.cs` +
+- [x] 1a.2 Create `src/Ways.Application/Exportacion/TablaExportable.cs` +
   `Celda.cs` + `ColumnaExportable.cs` + `ContextoDeExportacion.cs`: typed
   cells (`TipoDeColumna { Texto, Entero, Decimal, Moneda, Cantidad, Fecha,
   FechaHora }`), `Celda` factories (`Celda.Moneda`, `Celda.Fecha`,
@@ -87,42 +87,42 @@ its licence-audit fallback); DI registers it; no route yet consumes it.
   zone-less `DateTime`), `TablaExportable`'s constructor validates every row
   has `Columnas.Count` cells and `fila[i].Tipo == Columnas[i].Tipo`, else
   throws. *(design decisions 1-3; Interfaces/Contracts)*
-- [ ] 1a.3 Create `src/Ways.Application/Exportacion/IExportadorDeTabla.cs`:
+- [x] 1a.3 Create `src/Ways.Application/Exportacion/IExportadorDeTabla.cs`:
   `TipoDeContenido { get; }` + `byte[] Generar(TablaExportable)`.
-- [ ] 1a.4 Create `src/Ways.Application/Exportacion/OpcionesDeExportacion.cs`:
+- [x] 1a.4 Create `src/Ways.Application/Exportacion/OpcionesDeExportacion.cs`:
   `TopeDeFilas` (default `25_000`), bound from configuration — **an option,
   not a `const`**, so the integration fixture can bind it low. *(design
   decision 5)*
-- [ ] 1a.5 Create `src/Ways.Application/Exportacion/NombreDeArchivo.cs`: pure
+- [x] 1a.5 Create `src/Ways.Application/Exportacion/NombreDeArchivo.cs`: pure
   static `Construir(reporte, alcance, desde, hasta)` — deterministic, ASCII
   by construction (ids, never names). *(design: Interfaces/Contracts; spec
   exportacion-de-reportes: XLSX Response Contract And Deterministic Naming)*
-- [ ] 1a.6 Create `src/Ways.Infrastructure/Exportacion/ExportadorXlsx.cs`:
+- [x] 1a.6 Create `src/Ways.Infrastructure/Exportacion/ExportadorXlsx.cs`:
   the only file naming the Excel library; sets a real numeric/date cell
   value plus a **column-level** number format (never a formatted string);
   writes the header block (rows 1-4, blank row 5, table header row 6).
   *(design decision 1; spec exportacion-de-reportes: In-Sheet Header Block)*
-- [ ] 1a.7 Modify `src/Ways.Infrastructure/Ways.Infrastructure.csproj` (one
+- [x] 1a.7 Modify `src/Ways.Infrastructure/Ways.Infrastructure.csproj` (one
   `PackageReference`, per 1a.1's outcome) and `DependencyInjection.cs`:
   `AddSingleton<IExportadorDeTabla, ExportadorXlsx>()` next to
   `HasheadorPbkdf2` (`:56`).
-- [ ] 1a.8 [P] `tests/Ways.Application.Tests/Exportacion/ContencionDelExportadorTests.cs`:
+- [x] 1a.8 [P] `tests/Ways.Application.Tests/Exportacion/ContencionDelExportadorTests.cs`:
   source-scan test walking `src/**/*.cs` from `ResolverRaizDelRepositorio()`,
   asserting exactly ONE file matches the adopted library's namespace and
   only `Ways.Infrastructure.csproj` carries its `PackageReference`. Scan
   root is `src/` only (test code reads workbooks back on purpose, decision
   8). *(design decision 4; spec exportacion-de-reportes: Excel Library
   Containment)*
-- [ ] 1a.9 [P] `TablaExportableTests`: hand-built rows with mismatched cell
+- [x] 1a.9 [P] `TablaExportableTests`: hand-built rows with mismatched cell
   count → throws; a `Texto`-typed cell holding a `Moneda` value at the wrong
   index → throws (proves "a mapper put a string in a money column" is a
   failing unit test, not a silent workbook cell); `null` cell values render
   as empty, never `0`/`"-"`. *(design decision 2)*
-- [ ] 1a.10 [P] `NombreDeArchivoTests`: determinism (two identical inputs →
+- [x] 1a.10 [P] `NombreDeArchivoTests`: determinism (two identical inputs →
   identical name), ASCII-only assertion, the `ventas_resumen_pv3_2026-08-01_
   2026-08-12.xlsx` example from the spec.
-- [ ] 1a.11 [P] `OpcionesDeExportacionTests`: production default is `25_000`.
-- [ ] 1a.12 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+- [x] 1a.11 [P] `OpcionesDeExportacionTests`: production default is `25_000`.
+- [x] 1a.12 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes; no migration files touched.
 - [ ] 1a.13 Run `judgment-day` on the slice diff; fix confirmed issues;
   re-judge until clean.

--- a/src/Ways.Application/Exportacion/Celda.cs
+++ b/src/Ways.Application/Exportacion/Celda.cs
@@ -1,0 +1,45 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>Tipo de dato de una columna exportable. Determina cómo <c>IExportadorDeTabla</c>
+/// escribe el valor (número/fecha reales, nunca texto pre-formateado) y qué formato de
+/// número aplica a nivel columna.</summary>
+public enum TipoDeColumna
+{
+    Texto,
+    Entero,
+    Decimal,
+    Moneda,
+    Cantidad,
+    Fecha,
+    FechaHora
+}
+
+/// <summary>
+/// Una celda tipada de <see cref="TablaExportable"/>. El valor viaja boxeado a propósito: el
+/// <see cref="TipoDeColumna"/> es la única fuente de verdad sobre cómo interpretarlo, así el
+/// adaptador que finalmente escribe el archivo (hoy <c>ExportadorXlsx</c>) nunca decide un
+/// formato por su cuenta — decisión 1 del design de la etapa 11 ("una columna de importe que
+/// Excel no puede sumar porque en realidad es texto" es la falla que este tipo evita).
+/// <c>Valor == null</c> siempre se traduce a celda vacía, nunca a <c>0</c> ni a <c>"-"</c>.
+/// </summary>
+public readonly record struct Celda(TipoDeColumna Tipo, object? Valor)
+{
+    public static Celda Texto(string? v) => new(TipoDeColumna.Texto, v);
+
+    public static Celda Entero(int? v) => new(TipoDeColumna.Entero, v);
+
+    public static Celda Decimal(decimal? v) => new(TipoDeColumna.Decimal, v);
+
+    public static Celda Moneda(decimal? v) => new(TipoDeColumna.Moneda, v);
+
+    public static Celda Cantidad(decimal? v) => new(TipoDeColumna.Cantidad, v);
+
+    public static Celda Fecha(DateOnly? v) => new(TipoDeColumna.Fecha, v);
+
+    /// <summary>Convierte el instante a la hora local de <paramref name="zona"/> y descarta el
+    /// offset antes de guardarlo — Excel no tiene noción de zona horaria; escribir el instante
+    /// crudo le daría al archivo una segunda oportunidad de correr el día que el servidor ya
+    /// fijó (ADR-6 de la etapa 10, aplicado acá a archivos).</summary>
+    public static Celda FechaHora(DateTimeOffset? v, TimeZoneInfo zona) =>
+        new(TipoDeColumna.FechaHora, v is null ? null : TimeZoneInfo.ConvertTime(v.Value, zona).DateTime);
+}

--- a/src/Ways.Application/Exportacion/ColumnaExportable.cs
+++ b/src/Ways.Application/Exportacion/ColumnaExportable.cs
@@ -1,0 +1,5 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>Encabezado de una columna de <see cref="TablaExportable"/>: el título visible y el
+/// <see cref="TipoDeColumna"/> que toda celda de esa columna debe respetar.</summary>
+public sealed record ColumnaExportable(string Titulo, TipoDeColumna Tipo);

--- a/src/Ways.Application/Exportacion/ContextoDeExportacion.cs
+++ b/src/Ways.Application/Exportacion/ContextoDeExportacion.cs
@@ -1,0 +1,15 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>Encabezado del archivo (proposal decisión 7): empresa, punto de venta o
+/// <c>"Todos"</c>, rango de fechas, y quién/cuándo lo generó junto con su zona horaria.
+/// <see cref="Cobertura"/> lleva el texto de la línea de cobertura de costo estimado
+/// (stage-10) cuando el reporte exportado la trae; queda <c>null</c> para el resto.</summary>
+public sealed record ContextoDeExportacion(
+    string Empresa,
+    string? PuntoVenta,
+    DateOnly Desde,
+    DateOnly Hasta,
+    string ZonaHoraria,
+    string Usuario,
+    DateTimeOffset GeneradoEl,
+    string? Cobertura);

--- a/src/Ways.Application/Exportacion/IExportadorDeTabla.cs
+++ b/src/Ways.Application/Exportacion/IExportadorDeTabla.cs
@@ -1,0 +1,15 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Puerto de exportación de <see cref="TablaExportable"/> a bytes de un formato de archivo
+/// concreto. Es el mismo seam que <c>IHasheadorDeContrasenas</c> → <c>HasheadorPbkdf2</c>: si el
+/// audit de licencias de la librería adoptada fallara, el swap es un archivo de Infrastructure y
+/// un <c>PackageReference</c>, sin tocar Application.
+/// </summary>
+public interface IExportadorDeTabla
+{
+    /// <summary>Content-Type de la respuesta HTTP para el archivo generado.</summary>
+    string TipoDeContenido { get; }
+
+    byte[] Generar(TablaExportable tabla);
+}

--- a/src/Ways.Application/Exportacion/NombreDeArchivo.cs
+++ b/src/Ways.Application/Exportacion/NombreDeArchivo.cs
@@ -1,0 +1,13 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Construye el nombre determinístico de un archivo exportado: mismos parámetros ⇒ mismo
+/// nombre, siempre, sin timestamp ni sufijo aleatorio. ASCII por construcción — <paramref
+/// name="reporte"/> y <paramref name="alcance"/> deben ser ids (p. ej. "ventas_resumen",
+/// "pv3"), nunca nombres libres ingresados por un usuario.
+/// </summary>
+public static class NombreDeArchivo
+{
+    public static string Construir(string reporte, string alcance, DateOnly desde, DateOnly hasta) =>
+        $"{reporte}_{alcance}_{desde:yyyy-MM-dd}_{hasta:yyyy-MM-dd}.xlsx";
+}

--- a/src/Ways.Application/Exportacion/OpcionesDeExportacion.cs
+++ b/src/Ways.Application/Exportacion/OpcionesDeExportacion.cs
@@ -1,0 +1,15 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Opciones de exportación a planillas. <see cref="TopeDeFilas"/> es una opción bindable desde
+/// configuración y NO una constante (decisión 5 del design de la etapa 11): un tope que solo se
+/// puede ejercitar sembrando 25.001 filas es un tope cuya guarda nunca se prueba de verdad —
+/// borrar el <c>if</c> que lo aplica dejaría todos los tests en verde. Con una opción, el fixture
+/// de integración la baja a un número chico y la mutación se observa en menos de un segundo.
+/// </summary>
+public sealed class OpcionesDeExportacion
+{
+    public const string Seccion = "Exportacion";
+
+    public int TopeDeFilas { get; set; } = 25_000;
+}

--- a/src/Ways.Application/Exportacion/TablaExportable.cs
+++ b/src/Ways.Application/Exportacion/TablaExportable.cs
@@ -1,0 +1,55 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Tabla neutra que todo mapper produce y todo <see cref="IExportadorDeTabla"/> consume — el
+/// puerto de exportación de la etapa 11. El constructor se auto-valida (decisión 2 del design):
+/// cada fila debe tener exactamente <see cref="Columnas"/>.Count celdas y el tipo de cada celda
+/// debe coincidir con el de su columna, o lanza. Así "un mapper puso un string en una columna de
+/// plata" es un test unitario que falla, no una celda silenciosa en un archivo que nadie vuelve
+/// a abrir.
+/// </summary>
+public sealed record TablaExportable
+{
+    public string NombreDeHoja { get; }
+
+    public ContextoDeExportacion Contexto { get; }
+
+    public IReadOnlyList<ColumnaExportable> Columnas { get; }
+
+    public IReadOnlyList<IReadOnlyList<Celda>> Filas { get; }
+
+    public TablaExportable(
+        string nombreDeHoja,
+        ContextoDeExportacion contexto,
+        IReadOnlyList<ColumnaExportable> columnas,
+        IReadOnlyList<IReadOnlyList<Celda>> filas)
+    {
+        for (var f = 0; f < filas.Count; f++)
+        {
+            var fila = filas[f];
+
+            if (fila.Count != columnas.Count)
+            {
+                throw new ArgumentException(
+                    $"La fila {f} tiene {fila.Count} celda(s); se esperaban {columnas.Count} (una por columna).",
+                    nameof(filas));
+            }
+
+            for (var c = 0; c < columnas.Count; c++)
+            {
+                if (fila[c].Tipo != columnas[c].Tipo)
+                {
+                    throw new ArgumentException(
+                        $"La celda [{f}][{c}] es de tipo {fila[c].Tipo}, pero la columna " +
+                        $"\"{columnas[c].Titulo}\" espera {columnas[c].Tipo}.",
+                        nameof(filas));
+                }
+            }
+        }
+
+        NombreDeHoja = nombreDeHoja;
+        Contexto = contexto;
+        Columnas = columnas;
+        Filas = filas;
+    }
+}

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -14,6 +14,8 @@ using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
 using Ways.Domain.Ventas;
+using Ways.Application.Exportacion;
+using Ways.Infrastructure.Exportacion;
 using Ways.Infrastructure.Multitenancy;
 using Ways.Infrastructure.Persistencia;
 using Ways.Infrastructure.Seguridad;
@@ -54,6 +56,7 @@ public static class DependencyInjection
 
         services.AddScoped<IWaysDbContext>(sp => sp.GetRequiredService<WaysDbContext>());
         services.AddSingleton<IHasheadorDeContrasenas, HasheadorPbkdf2>();
+        services.AddSingleton<IExportadorDeTabla, ExportadorXlsx>();
 
         // Migraciones y semilla (ADR-2, ADR-14): un WaysDbContext propio, atado a la
         // instancia inmutable TenantActualFijo.Plataforma — nunca a la sesión HTTP mutable
@@ -83,6 +86,7 @@ public static class DependencyInjection
             .PersistKeysToDbContext<WaysDbContext>();
 
         services.Configure<SemillaRoot>(configuration.GetSection(SemillaRoot.Seccion));
+        services.Configure<OpcionesDeExportacion>(configuration.GetSection(OpcionesDeExportacion.Seccion));
 
         return services;
     }

--- a/src/Ways.Infrastructure/Exportacion/ExportadorXlsx.cs
+++ b/src/Ways.Infrastructure/Exportacion/ExportadorXlsx.cs
@@ -1,0 +1,113 @@
+using ClosedXML.Excel;
+using Ways.Application.Exportacion;
+
+namespace Ways.Infrastructure.Exportacion;
+
+/// <summary>
+/// Único archivo de <c>src/</c> que referencia ClosedXML — contenido por
+/// <c>ContencionDelExportadorTests</c> (decisión 4 del design de la etapa 11). Escribe valores
+/// numéricos/de fecha reales más un formato de número a nivel COLUMNA, nunca un string
+/// pre-formateado por celda (decisión 1): una columna de importe que Excel no puede sumar porque
+/// en realidad es texto es la falla exacta que este adaptador evita. También escribe el bloque de
+/// encabezado en las filas 1-4, deja la fila 5 vacía y arranca la tabla en la fila 6.
+/// </summary>
+public sealed class ExportadorXlsx : IExportadorDeTabla
+{
+    private const int PrimeraFilaDeEncabezado = 1;
+    private const int FilaDeTituloDeTabla = 6;
+
+    public string TipoDeContenido =>
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    public byte[] Generar(TablaExportable tabla)
+    {
+        using var libro = new XLWorkbook();
+        var hoja = libro.Worksheets.Add(tabla.NombreDeHoja);
+
+        EscribirEncabezado(hoja, tabla.Contexto);
+        EscribirTabla(hoja, tabla);
+
+        using var memoria = new MemoryStream();
+        libro.SaveAs(memoria);
+        return memoria.ToArray();
+    }
+
+    private static void EscribirEncabezado(IXLWorksheet hoja, ContextoDeExportacion contexto)
+    {
+        var generadoPor =
+            $"Generado el {contexto.GeneradoEl:yyyy-MM-dd HH:mm} ({contexto.ZonaHoraria}) por {contexto.Usuario}";
+
+        hoja.Cell(PrimeraFilaDeEncabezado, 1).Value = $"Empresa: {contexto.Empresa}";
+        hoja.Cell(PrimeraFilaDeEncabezado + 1, 1).Value =
+            $"Punto de venta: {contexto.PuntoVenta ?? "Todos"}";
+        hoja.Cell(PrimeraFilaDeEncabezado + 2, 1).Value =
+            $"Período: {contexto.Desde:yyyy-MM-dd} a {contexto.Hasta:yyyy-MM-dd}";
+        hoja.Cell(PrimeraFilaDeEncabezado + 3, 1).Value = contexto.Cobertura is null
+            ? generadoPor
+            : $"{generadoPor} — {contexto.Cobertura}";
+
+        // La fila 5 queda vacía a propósito: separador visual antes del encabezado de tabla.
+    }
+
+    private static void EscribirTabla(IXLWorksheet hoja, TablaExportable tabla)
+    {
+        for (var c = 0; c < tabla.Columnas.Count; c++)
+        {
+            hoja.Cell(FilaDeTituloDeTabla, c + 1).Value = tabla.Columnas[c].Titulo;
+        }
+
+        var primeraFilaDeDatos = FilaDeTituloDeTabla + 1;
+
+        for (var f = 0; f < tabla.Filas.Count; f++)
+        {
+            var fila = tabla.Filas[f];
+
+            for (var c = 0; c < fila.Count; c++)
+            {
+                EscribirCelda(hoja.Cell(primeraFilaDeDatos + f, c + 1), fila[c]);
+            }
+        }
+
+        for (var c = 0; c < tabla.Columnas.Count; c++)
+        {
+            AplicarFormatoDeColumna(hoja.Column(c + 1), tabla.Columnas[c].Tipo);
+        }
+    }
+
+    private static void EscribirCelda(IXLCell celda, Celda valor)
+    {
+        if (valor.Valor is null)
+        {
+            // null siempre es celda vacía — nunca 0 ni "-" (decisión 2 del design).
+            return;
+        }
+
+        celda.Value = valor.Tipo switch
+        {
+            TipoDeColumna.Texto => (string)valor.Valor,
+            TipoDeColumna.Entero => (int)valor.Valor,
+            TipoDeColumna.Decimal or TipoDeColumna.Moneda or TipoDeColumna.Cantidad => (decimal)valor.Valor,
+            TipoDeColumna.Fecha => ((DateOnly)valor.Valor).ToDateTime(TimeOnly.MinValue),
+            TipoDeColumna.FechaHora => (DateTime)valor.Valor,
+            _ => throw new NotSupportedException($"Tipo de columna no soportado: {valor.Tipo}.")
+        };
+    }
+
+    private static void AplicarFormatoDeColumna(IXLColumn columna, TipoDeColumna tipo)
+    {
+        var formato = tipo switch
+        {
+            TipoDeColumna.Entero => "#,##0",
+            TipoDeColumna.Decimal or TipoDeColumna.Cantidad => "#,##0.00",
+            TipoDeColumna.Moneda => "$ #,##0.00",
+            TipoDeColumna.Fecha => "yyyy-mm-dd",
+            TipoDeColumna.FechaHora => "yyyy-mm-dd hh:mm",
+            _ => null
+        };
+
+        if (formato is not null)
+        {
+            columna.Style.NumberFormat.Format = formato;
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Ways.Infrastructure.csproj
+++ b/src/Ways.Infrastructure/Ways.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Ways.Application.Tests/Exportacion/ContencionDelExportadorTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/ContencionDelExportadorTests.cs
@@ -1,0 +1,60 @@
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1a (design decisión 4; spec exportacion-de-reportes: "Excel Library
+/// Containment"): la librería XLSX solo puede nombrarse desde
+/// <c>src/Ways.Infrastructure/Exportacion/ExportadorXlsx.cs</c>. Un scan de fuente, mismo idioma
+/// que <see cref="Ways.IntegrationTests.VentasCheckoutTests.NingunLiteralDeToleranciaOVueltoHardcodeadoEnElCaminoDeCheckout"/>
+/// — corre en la suite rápida sin DB porque el scan es sobre archivos, no sobre tipos cargados.
+/// El raíz del scan es <c>src/</c> solamente: el código de test SÍ lee workbooks con la
+/// librería, a propósito (decisión 8).
+/// </summary>
+public class ContencionDelExportadorTests
+{
+    private const string NombreDeLaLibreria = "ClosedXML";
+    private const string ArchivoAutorizado = "ExportadorXlsx.cs";
+    private const string ProyectoAutorizado = "Ways.Infrastructure.csproj";
+
+    [Fact]
+    public void SoloExportadorXlsxReferenciaLaLibreriaXlsxEnSrc()
+    {
+        var raiz = ResolverRaizDelRepositorio();
+        var srcDir = Path.Combine(raiz, "src");
+
+        var archivosQueNombranLaLibreria = Directory
+            .EnumerateFiles(srcDir, "*.cs", SearchOption.AllDirectories)
+            .Where(archivo => File.ReadAllText(archivo).Contains(NombreDeLaLibreria, StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.Equal([ArchivoAutorizado], archivosQueNombranLaLibreria);
+    }
+
+    [Fact]
+    public void SoloWaysInfrastructureCsprojReferenciaElPackageDeLaLibreria()
+    {
+        var raiz = ResolverRaizDelRepositorio();
+        var srcDir = Path.Combine(raiz, "src");
+
+        var csprojsQueReferencianElPackage = Directory
+            .EnumerateFiles(srcDir, "*.csproj", SearchOption.AllDirectories)
+            .Where(csproj => File.ReadAllText(csproj)
+                .Contains($"PackageReference Include=\"{NombreDeLaLibreria}\"", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.Equal([ProyectoAutorizado], csprojsQueReferencianElPackage);
+    }
+
+    private static string ResolverRaizDelRepositorio()
+    {
+        var directorio = AppContext.BaseDirectory;
+
+        while (directorio is not null && !File.Exists(Path.Combine(directorio, "Ways.slnx")))
+        {
+            directorio = Path.GetDirectoryName(directorio.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        return directorio ?? throw new InvalidOperationException("No se encontró la raíz del repositorio (Ways.slnx).");
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
@@ -106,6 +106,10 @@ public class ExportadorXlsxTests
 
         Assert.Contains("Empresa de prueba", hoja.Cell(1, 1).GetString());
         Assert.Contains("PV 3", hoja.Cell(2, 1).GetString());
+        Assert.Contains("2026-08-01", hoja.Cell(3, 1).GetString());
+        Assert.Contains("2026-08-12", hoja.Cell(3, 1).GetString());
+        Assert.Contains("usuario-de-prueba", hoja.Cell(4, 1).GetString());
+        Assert.Contains("America/Argentina/Buenos_Aires", hoja.Cell(4, 1).GetString());
         Assert.True(hoja.Cell(5, 1).Value.IsBlank);
         Assert.Equal("Período", hoja.Cell(6, 1).GetString());
     }

--- a/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
@@ -1,0 +1,112 @@
+using ClosedXML.Excel;
+using Ways.Application.Exportacion;
+using Ways.Infrastructure.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1a (design decisión 1; spec exportacion-de-reportes: "In-Sheet Header Block")
+/// — prueba de ida y vuelta: genera un workbook chico con <see cref="ExportadorXlsx"/> y lo
+/// vuelve a leer con la misma librería para probar que la plata quedó como número con formato
+/// (no como texto), la fecha quedó como fecha, y el texto quedó como texto. Es la prueba que un
+/// golden-file byte-a-byte no puede dar: prueba tipos, no bytes.
+/// </summary>
+public class ExportadorXlsxTests
+{
+    private static readonly ContextoDeExportacion ContextoDePrueba = new(
+        Empresa: "Empresa de prueba",
+        PuntoVenta: "PV 3",
+        Desde: new DateOnly(2026, 8, 1),
+        Hasta: new DateOnly(2026, 8, 12),
+        ZonaHoraria: "America/Argentina/Buenos_Aires",
+        Usuario: "usuario-de-prueba",
+        GeneradoEl: new DateTimeOffset(2026, 8, 12, 10, 0, 0, TimeSpan.FromHours(-3)),
+        Cobertura: null);
+
+    private static readonly IReadOnlyList<ColumnaExportable> Columnas =
+    [
+        new ColumnaExportable("Período", TipoDeColumna.Texto),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda),
+        new ColumnaExportable("Fecha", TipoDeColumna.Fecha)
+    ];
+
+    private static XLWorkbook GenerarYReabrir(TablaExportable tabla)
+    {
+        var exportador = new ExportadorXlsx();
+        var bytes = exportador.Generar(tabla);
+
+        using var memoria = new MemoryStream(bytes);
+        return new XLWorkbook(memoria);
+    }
+
+    [Fact]
+    public void LaPlataQuedaComoNumeroConFormatoNuncaComoTexto()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(700m), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var celdaDeNeto = libro.Worksheets.First().Cell(7, 2);
+
+        Assert.True(celdaDeNeto.Value.IsNumber);
+        Assert.Equal(700d, celdaDeNeto.Value.GetNumber());
+        Assert.NotEqual("General", celdaDeNeto.Style.NumberFormat.Format);
+    }
+
+    [Fact]
+    public void LaFechaQuedaComoFechaNuncaComoTexto()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(700m), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var celdaDeFecha = libro.Worksheets.First().Cell(7, 3);
+
+        Assert.True(celdaDeFecha.Value.IsDateTime);
+        Assert.Equal(new DateTime(2026, 8, 12), celdaDeFecha.Value.GetDateTime());
+    }
+
+    [Fact]
+    public void ElTextoQuedaComoTexto()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(700m), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var celdaDePeriodo = libro.Worksheets.First().Cell(7, 1);
+
+        Assert.True(celdaDePeriodo.Value.IsText);
+        Assert.Equal("2026-08", celdaDePeriodo.Value.GetText());
+    }
+
+    [Fact]
+    public void UnValorNuloQuedaComoCeldaVaciaNuncaComoCeroNiGuion()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(null), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var celdaDeNeto = libro.Worksheets.First().Cell(7, 2);
+
+        Assert.True(celdaDeNeto.Value.IsBlank);
+    }
+
+    [Fact]
+    public void ElEncabezadoOcupaLasFilas1A4YLaTablaArrancaEnLaFila6()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas = [[Celda.Texto("2026-08"), Celda.Moneda(700m), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var hoja = libro.Worksheets.First();
+
+        Assert.Contains("Empresa de prueba", hoja.Cell(1, 1).GetString());
+        Assert.Contains("PV 3", hoja.Cell(2, 1).GetString());
+        Assert.True(hoja.Cell(5, 1).Value.IsBlank);
+        Assert.Equal("Período", hoja.Cell(6, 1).GetString());
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/NombreDeArchivoTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/NombreDeArchivoTests.cs
@@ -1,0 +1,40 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1a (spec exportacion-de-reportes: "XLSX Response Contract And Deterministic
+/// Naming") — mismos parámetros ⇒ mismo nombre, siempre, y el nombre es ASCII por construcción.
+/// </summary>
+public class NombreDeArchivoTests
+{
+    [Fact]
+    public void DosLlamadosConLosMismosParametrosProducenElMismoNombre()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 12);
+
+        var primero = NombreDeArchivo.Construir("ventas_resumen", "pv3", desde, hasta);
+        var segundo = NombreDeArchivo.Construir("ventas_resumen", "pv3", desde, hasta);
+
+        Assert.Equal(primero, segundo);
+    }
+
+    [Fact]
+    public void ElNombreEsAsciiPuro()
+    {
+        var nombre = NombreDeArchivo.Construir(
+            "ventas_resumen", "pv3", new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 12));
+
+        Assert.All(nombre, caracter => Assert.True(caracter <= 127));
+    }
+
+    [Fact]
+    public void ElEjemploDelSpecProduceElNombreEsperado()
+    {
+        var nombre = NombreDeArchivo.Construir(
+            "ventas_resumen", "pv3", new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 12));
+
+        Assert.Equal("ventas_resumen_pv3_2026-08-01_2026-08-12.xlsx", nombre);
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/OpcionesDeExportacionTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/OpcionesDeExportacionTests.cs
@@ -1,0 +1,19 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1a (design decisión 5) — el valor por defecto de producción es 25.000; el
+/// fixture de integración de la slice 1b lo pisa con un valor bajo para ejercitar el rechazo por
+/// tope sin sembrar 25.001 filas.
+/// </summary>
+public class OpcionesDeExportacionTests
+{
+    [Fact]
+    public void ElTopeDeFilasPorDefectoEs25000()
+    {
+        var opciones = new OpcionesDeExportacion();
+
+        Assert.Equal(25_000, opciones.TopeDeFilas);
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/TablaExportableTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/TablaExportableTests.cs
@@ -1,0 +1,77 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1a (design decisión 2; spec exportacion-de-reportes) — el constructor de
+/// <see cref="TablaExportable"/> es la única barrera entre "un mapper puso un string en una
+/// columna de plata" y una celda silenciosa en un archivo que nadie vuelve a abrir. Cada test
+/// prueba una cláusula puntual del constructor: la mutación es borrar la comparación
+/// correspondiente y ver que el test que la nombra empieza a fallar.
+/// </summary>
+public class TablaExportableTests
+{
+    private static readonly ContextoDeExportacion ContextoDePrueba = new(
+        Empresa: "Empresa de prueba",
+        PuntoVenta: "PV 1",
+        Desde: new DateOnly(2026, 8, 1),
+        Hasta: new DateOnly(2026, 8, 12),
+        ZonaHoraria: "America/Argentina/Buenos_Aires",
+        Usuario: "usuario-de-prueba",
+        GeneradoEl: new DateTimeOffset(2026, 8, 12, 10, 0, 0, TimeSpan.FromHours(-3)),
+        Cobertura: null);
+
+    private static readonly IReadOnlyList<ColumnaExportable> DosColumnas =
+    [
+        new ColumnaExportable("Período", TipoDeColumna.Texto),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda)
+    ];
+
+    [Fact]
+    public void UnaFilaConMenosCeldasQueColumnasLanza()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas = [[Celda.Texto("2026-08")]];
+
+        var excepcion = Assert.Throws<ArgumentException>(() =>
+            new TablaExportable("Hoja", ContextoDePrueba, DosColumnas, filas));
+
+        Assert.Contains("1 celda", excepcion.Message);
+    }
+
+    [Fact]
+    public void UnaCeldaDeTextoEnUnaColumnaDeMonedaLanza()
+    {
+        // Prueba puntual: "el mapper puso un string en la columna de plata" tiene que ser un
+        // ArgumentException del constructor, no una celda de texto silenciosa en el workbook.
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Texto("setecientos")]];
+
+        var excepcion = Assert.Throws<ArgumentException>(() =>
+            new TablaExportable("Hoja", ContextoDePrueba, DosColumnas, filas));
+
+        Assert.Contains("Moneda", excepcion.Message);
+    }
+
+    [Fact]
+    public void UnaFilaConTiposCorrectosNoLanzaYPreservaElOrden()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(700m)]];
+
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, DosColumnas, filas);
+
+        Assert.Single(tabla.Filas);
+        Assert.Equal(700m, tabla.Filas[0][1].Valor);
+    }
+
+    [Fact]
+    public void UnValorNuloSePreservaComoNuloNuncaComoCeroNiGuion()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(null)]];
+
+        var tabla = new TablaExportable("Hoja", ContextoDePrueba, DosColumnas, filas);
+
+        Assert.Null(tabla.Filas[0][1].Valor);
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/TablaExportableTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/TablaExportableTests.cs
@@ -39,6 +39,16 @@ public class TablaExportableTests
     }
 
     [Fact]
+    public void UnaFilaConMasCeldasQueColumnasLanza()
+    {
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(1m), Celda.Moneda(2m)]];
+
+        Assert.Throws<ArgumentException>(() =>
+            new TablaExportable("Hoja", ContextoDePrueba, DosColumnas, filas));
+    }
+
+    [Fact]
     public void UnaCeldaDeTextoEnUnaColumnaDeMonedaLanza()
     {
         // Prueba puntual: "el mapper puso un string en la columna de plata" tiene que ser un


### PR DESCRIPTION
## Etapa 11, slice 1a — El seam de exportacion

La fundacion de toda la etapa: puerto `TablaExportable`/`IExportadorDeTabla` en Application (cero fuga de libreria), adapter `ExportadorXlsx` como UNICO archivo de src/ que nombra ClosedXML (test de contencion con el idioma de VentasCheckoutTests), `OpcionesDeExportacion.TopeDeFilas` bindeable (mutable por diseño para mutation-proof), constructor auto-validante (tipo y aridad de celdas — estados invalidos irrepresentables), celdas TIPADAS (numeros con formato de columna, nunca strings — null = celda vacia, jamas 0).

### Auditoria de licencias (gate duro de la etapa) — APROBADA
`ClosedXML 0.104.2` introduce exactamente 8 paquetes transitivos: 7 MIT + `SixLabors.Fonts 1.0.0` Apache-2.0 (verificado en nuspec — la version pineada es EXACTA, sin rango: un restore futuro no puede flotar a la 2.x de Split License sin bump explicito re-auditable). Sin fallback a MiniExcel. Re-verificada independientemente por el juez read-only desde los nuspecs.

### Review
Judgment-day: ronda limpia — Juez A APPROVE (auditoria re-derivada, pureza del puerto, celdas tipadas sin landmines de cultura), Juez B APPROVE-WITH-MINORS (mutaciones reclamadas + 3 propias: coercion de celda, determinismo del nombre — todas cazadas; 1 WARNING real: filas 3-4 del encabezado sin asertar — corregido en la rama con evidencia de mutacion, + test de aridad simetrica).

### Tests
Application 235/235 (219 + 16) · gate cero migraciones verificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)