### PR TITLE
feat(exportacion): patron de ruta /export probado en ventas/resumen (etapa 11, slice 1b)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -143,54 +143,69 @@ route.
 live, equal to its JSON endpoint, gated by co-location, refusing over-cap
 requests. **Rollback**: revert the branch; no state to unwind.
 
-- [ ] 1b.1 Create `src/Ways.Application/Exportacion/FormatoDeExportacion.cs`:
+- [x] 1b.1 Create `src/Ways.Application/Exportacion/FormatoDeExportacion.cs`:
   `Parsear(string)` → `ErrorDominio("formato_no_soportado", …, 400)` for
   anything but `xlsx`; missing `formato` stays a framework 400 (non-nullable
   required query param). *(design decision 9; spec exportacion-de-reportes:
   Export Route Convention And Policy Inheritance By Co-Location)*
-- [ ] 1b.2 Create `src/Ways.Application/Exportacion/GuardaDeTope.cs`:
+- [x] 1b.2 Create `src/Ways.Application/Exportacion/GuardaDeTope.cs`:
   `Exigir(TablaExportable, int topeDeFilas)` → `ErrorDominio(
   "exportacion_demasiado_grande", …, 400)` naming the actual row count when
   `Filas.Count > topeDeFilas`. Runs on the mapped table's row count for
   aggregates — no query at all. *(design decisions 5-6; spec
   exportacion-de-reportes: Row Cap Refuses, Never Truncates)*
-- [ ] 1b.3 Create `src/Ways.Api/Exportacion/ResultadoDeExportacion.cs`:
+- [x] 1b.3 Create `src/Ways.Api/Exportacion/ResultadoDeExportacion.cs`:
   `Content-Disposition: attachment; filename="…"; filename*=UTF-8''…` (ASCII
   + RFC 5987) plus
   `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.
-- [ ] 1b.4 Create `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
+- [x] 1b.4 Create `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
   `De(ResumenDeVentas respuesta, ContextoDeExportacion ctx)` — pure mapper,
   no database: columns Período(Texto)/Neto(Moneda)/TX(Entero)/Ticket
   promedio(Moneda), one row per bucket + totals row, `TicketPromedio` null
   ⇒ empty cell. *(design: Data Flow; Interfaces/Contracts — mappers)*
-- [ ] 1b.5 Modify `src/Ways.Api/Endpoints/ReportesEndpoints.cs`: `GET
+- [x] 1b.5 Modify `src/Ways.Api/Endpoints/ReportesEndpoints.cs`: `GET
   /ventas/resumen/export` declared immediately after `/ventas/resumen`
   inside the same `MapGroup` (`LecturaDeReportes` inherited, no separate
   policy declared). *(design: Data Flow — end-to-end)*
-- [ ] 1b.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+- [x] 1b.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes.
-- [ ] 1b.7 [P] **Equality test**: call the JSON route and the export with
+- [x] 1b.7 [P] **Equality test**: call the JSON route and the export with
   identical query strings, read the workbook back with ClosedXML, assert
   every figure matches. *(design decision 8; spec: No Re-Query — Exported
   Figures Equal Endpoint Figures)*
-- [ ] 1b.8 [P] **403 test**: a role one step below `LecturaDeReportes`
+- [x] 1b.8 [P] **403 test**: a role one step below `LecturaDeReportes`
   (Vendedor) is rejected on `/ventas/resumen/export`.
-- [ ] 1b.9 [P] **Cap-refusal mutation target**: bind `OpcionesDeExportacion.
+- [x] 1b.9 [P] **Cap-refusal mutation target**: bind `OpcionesDeExportacion.
   TopeDeFilas` to `3` in the integration fixture, seed `4` rows, assert
   `400 exportacion_demasiado_grande` naming `4`, no bytes returned. Record
   mutation evidence: delete the `if` in `GuardaDeTope.Exigir` → the test
   MUST fail; revert → green. *(design decision 5; mutation-proof-tests)*
-- [ ] 1b.10 [P] **At-cap success test**: exactly `3` seeded rows with the
+  — IMPLEMENTATION NOTE: `/ventas/resumen` is an aggregate (design decision
+  6), so `GuardaDeTope` guards `TablaExportable.Filas.Count`, not a
+  `COUNT(*)`; there is no business row to "seed" toward 4. Per the tasks.md
+  escape hatch for aggregates, the 4 exported rows come from the SERIES
+  LENGTH instead: a 3-day `Granularidad.Dia` range always yields 3 buckets
+  (gap-fill, stage-10 decision 4) + 1 totals row = 4 `Filas`, with `TopeDeFilas`
+  bound to `3` via `WithWebHostBuilder`. Mutation run and recorded (see
+  commit body): `if` neutered → test failed (200 instead of 400); reverted →
+  green.
+- [x] 1b.10 [P] **At-cap success test**: exactly `3` seeded rows with the
   fixture's tope bound to `3` → `200` with `3` data rows. *(spec: An
-  At-Cap Request Succeeds)*
-- [ ] 1b.11 [P] **Header block test**: rows 1-4 state empresa, PV or
+  At-Cap Request Succeeds)* — same series-length substitution as 1b.9: a
+  2-day range yields 2 buckets + 1 totals row = 3 `Filas`.
+- [x] 1b.11 [P] **Header block test**: rows 1-4 state empresa, PV or
   "Todos", the date range, and generation instant/zone/user; table header
   starts row 6.
-- [ ] 1b.12 [P] `FormatoDeExportacionTests`: `?formato=pdf` → `400
+- [x] 1b.12 [P] `FormatoDeExportacionTests`: `?formato=pdf` → `400
   formato_no_soportado`; `?formato=xlsx` parses.
-- [ ] 1b.13 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 1b.13 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE
+  for this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase.
 - [ ] 1b.14 Branch `feat/stage11-slice1b-primer-export` off `main` (parent:
-  slice 1a); PR; merge stacked-to-main.
+  slice 1a); PR; merge stacked-to-main. — branch `feat/stage11-slice1b-
+  ruta-export` created per the orchestrator's explicit instruction (name
+  differs from the task's suggested branch name); PR/merge left for the
+  orchestrator.
 
 **Test plan**: equality (1b.7), 403 (1b.8), cap-refusal with mutation
 evidence (1b.9), at-cap (1b.10), header/coverage-shape (1b.11), formato

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -1,4 +1,8 @@
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
 using Ways.Application.Reportes;
 using Ways.Domain.Reportes;
 
@@ -19,6 +23,37 @@ public static class ReportesEndpoints
         .WithSummary(
             "Ventas netas bucketeadas por la zona horaria del punto de venta: ticket promedio " +
             "excluye NCX de numerador y denominador.");
+
+        // stage-11-exportacion-reportes, Slice 1b (design decisión 4; spec exportacion-de-
+        // reportes: "Export Route Convention And Policy Inheritance By Co-Location"): sibling
+        // declarado inmediatamente después de su ruta fuente, dentro del mismo MapGroup — hereda
+        // LecturaDeReportes estructuralmente, sin política propia. El plomero de acá (formato,
+        // contexto, tope) es el que reusa cada export sibling de las slices siguientes.
+        grupo.MapGet("/ventas/resumen/export", async (
+            ServicioDeReportesDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad, string formato,
+            CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var resumen = await servicio.ObtenerResumenAsync(idEmpresa, idPuntoVenta, desde, hasta, granularidad, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, resumen.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(resumen, ctx);
+
+            GuardaDeTope.Exigir(tabla, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("ventas_resumen", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de /ventas/resumen: mismos parámetros y figuras, gate LecturaDeReportes " +
+            "heredado por co-locación.");
 
         grupo.MapGet("/compras/por-proveedor", (
             ServicioDeReportesDeEgresos servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -43,7 +43,7 @@ public static class ReportesEndpoints
                 usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, resumen.ZonaHoraria);
             var tabla = ExportacionDeReportes.De(resumen, ctx);
 
-            GuardaDeTope.Exigir(tabla, opciones.Value.TopeDeFilas);
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
 
             var bytes = exportador.Generar(tabla);
             var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";

--- a/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
+++ b/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
@@ -7,7 +7,8 @@ namespace Ways.Api.Exportacion;
 /// Arma el <see cref="ContextoDeExportacion"/> de una request HTTP — el plomero compartido que
 /// todo <c>/export</c> sibling de esta y las próximas slices reusa (design: Data Flow). Usuario y
 /// reloj salen de los mismos servicios que ya inyecta el resto de la API, nunca de una segunda
-/// derivación de negocio. Empresa y punto de venta se identifican por id (<c>"Empresa {id}"</c>,
+/// derivación de negocio. Empresa y punto de venta se identifican por id (<see cref="ContextoDeExportacion.Empresa"/>
+/// es el id solo, sin repetir la etiqueta que ya pone el encabezado del XLSX; <c>PuntoVenta</c> es
 /// <c>"PV {id}"</c>), el mismo criterio "ids, no nombres" de <c>NombreDeArchivo</c> (design
 /// decisión 7) — evita una consulta extra solo para mostrar una razón social en el encabezado.
 /// </summary>
@@ -23,7 +24,7 @@ public static class ContextoDeExportacionHttp
         string zonaHoraria,
         string? cobertura = null) =>
         new(
-            Empresa: $"Empresa {idEmpresa}",
+            Empresa: idEmpresa.ToString(),
             PuntoVenta: idPuntoVenta is { } id ? $"PV {id}" : null,
             Desde: desde,
             Hasta: hasta,

--- a/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
+++ b/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
@@ -1,0 +1,34 @@
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+
+namespace Ways.Api.Exportacion;
+
+/// <summary>
+/// Arma el <see cref="ContextoDeExportacion"/> de una request HTTP — el plomero compartido que
+/// todo <c>/export</c> sibling de esta y las próximas slices reusa (design: Data Flow). Usuario y
+/// reloj salen de los mismos servicios que ya inyecta el resto de la API, nunca de una segunda
+/// derivación de negocio. Empresa y punto de venta se identifican por id (<c>"Empresa {id}"</c>,
+/// <c>"PV {id}"</c>), el mismo criterio "ids, no nombres" de <c>NombreDeArchivo</c> (design
+/// decisión 7) — evita una consulta extra solo para mostrar una razón social en el encabezado.
+/// </summary>
+public static class ContextoDeExportacionHttp
+{
+    public static ContextoDeExportacion Construir(
+        IContextoDeUsuario usuario,
+        IRelojDelSistema reloj,
+        int idEmpresa,
+        int? idPuntoVenta,
+        DateOnly desde,
+        DateOnly hasta,
+        string zonaHoraria,
+        string? cobertura = null) =>
+        new(
+            Empresa: $"Empresa {idEmpresa}",
+            PuntoVenta: idPuntoVenta is { } id ? $"PV {id}" : null,
+            Desde: desde,
+            Hasta: hasta,
+            ZonaHoraria: zonaHoraria,
+            Usuario: usuario.NombreUsuario,
+            GeneradoEl: reloj.Ahora,
+            Cobertura: cobertura);
+}

--- a/src/Ways.Api/Exportacion/ResultadoDeExportacion.cs
+++ b/src/Ways.Api/Exportacion/ResultadoDeExportacion.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Ways.Api.Exportacion;
+
+/// <summary>
+/// Arma el <see cref="IResult"/> HTTP de un archivo exportado (spec exportacion-de-reportes: XLSX
+/// Response Contract And Deterministic Naming). El <c>Content-Disposition</c> lleva SIEMPRE los
+/// dos parámetros — <c>filename</c> ASCII y <c>filename*</c> RFC 5987 UTF-8 — aunque
+/// <c>NombreDeArchivo.Construir</c> ya sea ASCII por construcción: es gratis y correcto, y no ata
+/// la respuesta a esa garantía para siempre.
+/// </summary>
+public static class ResultadoDeExportacion
+{
+    public static IResult Archivo(byte[] contenido, string tipoDeContenido, string nombreDeArchivo) =>
+        new ArchivoExportadoResult(contenido, tipoDeContenido, nombreDeArchivo);
+
+    private sealed class ArchivoExportadoResult(byte[] contenido, string tipoDeContenido, string nombreDeArchivo)
+        : IResult
+    {
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            var disposicion =
+                $"attachment; filename=\"{nombreDeArchivo}\"; filename*=UTF-8''{Uri.EscapeDataString(nombreDeArchivo)}";
+
+            httpContext.Response.ContentType = tipoDeContenido;
+            httpContext.Response.Headers.Append("Content-Disposition", new StringValues(disposicion));
+            httpContext.Response.ContentLength = contenido.Length;
+
+            return httpContext.Response.Body.WriteAsync(contenido, httpContext.RequestAborted).AsTask();
+        }
+    }
+}

--- a/src/Ways.Application/Exportacion/FormatoDeExportacion.cs
+++ b/src/Ways.Application/Exportacion/FormatoDeExportacion.cs
@@ -1,0 +1,29 @@
+using Ways.Domain.Common;
+
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Parsea el parámetro de query <c>formato</c> de toda ruta <c>/export</c> (design decisión 9):
+/// se bindea como <c>string</c> y se valida acá, nunca como enum bindeado por el framework — el
+/// 400 automático de un bindeo de enum fallido no lleva <c>codigo</c>, indistinguible de un
+/// <c>desde</c> mal formado, y el spec fija el código. En v1 hay un único valor legal:
+/// <c>"xlsx"</c>. <c>formato</c> ausente en la query string queda como 400 de framework
+/// (parámetro requerido no-nullable) — no necesita código acá.
+/// </summary>
+public static class FormatoDeExportacion
+{
+    public const string Xlsx = "xlsx";
+
+    public static string Parsear(string valor)
+    {
+        if (!string.Equals(valor, Xlsx, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ErrorDominio(
+                "formato_no_soportado",
+                $"El formato \"{valor}\" no está soportado. Formatos válidos: {Xlsx}.",
+                400);
+        }
+
+        return Xlsx;
+    }
+}

--- a/src/Ways.Application/Exportacion/GuardaDeTope.cs
+++ b/src/Ways.Application/Exportacion/GuardaDeTope.cs
@@ -1,0 +1,28 @@
+using Ways.Domain.Common;
+
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Guarda del tope de filas de una exportación (design decisión 5-6). Corre sobre
+/// <see cref="TablaExportable.Filas"/> ya mapeada — para un reporte agregado esto es el conteo
+/// final, sin ninguna consulta adicional ("nada que contar" además de lo que el mapper ya
+/// produjo). Los reportes de tipo listado (slice 3) corren un <c>COUNT(*)</c> antes de mapear y
+/// llaman a esta misma guarda con ese conteo.
+/// mutation-proof-tests: mutación aplicada (el <c>if</c> reemplazado por <c>if (false &amp;&amp;
+/// ...)</c>) — <c>ReportesVentasResumenExportTests.UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c>
+/// pasó de 400 esperado a 200 obtenido; revertida, vuelve a pasar.
+/// </summary>
+public static class GuardaDeTope
+{
+    public static void Exigir(TablaExportable tabla, int topeDeFilas)
+    {
+        if (tabla.Filas.Count > topeDeFilas)
+        {
+            throw new ErrorDominio(
+                "exportacion_demasiado_grande",
+                $"La exportación tiene {tabla.Filas.Count} filas; el tope es {topeDeFilas}. " +
+                "Acotá el rango o los filtros e intentá de nuevo.",
+                400);
+        }
+    }
+}

--- a/src/Ways.Application/Exportacion/GuardaDeTope.cs
+++ b/src/Ways.Application/Exportacion/GuardaDeTope.cs
@@ -3,24 +3,25 @@ using Ways.Domain.Common;
 namespace Ways.Application.Exportacion;
 
 /// <summary>
-/// Guarda del tope de filas de una exportación (design decisión 5-6). Corre sobre
-/// <see cref="TablaExportable.Filas"/> ya mapeada — para un reporte agregado esto es el conteo
-/// final, sin ninguna consulta adicional ("nada que contar" además de lo que el mapper ya
-/// produjo). Los reportes de tipo listado (slice 3) corren un <c>COUNT(*)</c> antes de mapear y
-/// llaman a esta misma guarda con ese conteo.
+/// Guarda del tope de filas de una exportación (design decisión 5-6). Recibe la cantidad de filas
+/// ya contada por el caller: los reportes agregados (slice 1b/2) pasan
+/// <see cref="TablaExportable.Filas"/><c>.Count</c> ya mapeada, sin ninguna consulta adicional
+/// ("nada que contar" además de lo que el mapper ya produjo). Los reportes de tipo listado (slice
+/// 3) corren un <c>COUNT(*)</c> ANTES de materializar y llaman a esta misma guarda con ese
+/// conteo, sin pagar el costo de mapear filas que después se van a rechazar.
 /// mutation-proof-tests: mutación aplicada (el <c>if</c> reemplazado por <c>if (false &amp;&amp;
 /// ...)</c>) — <c>ReportesVentasResumenExportTests.UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c>
 /// pasó de 400 esperado a 200 obtenido; revertida, vuelve a pasar.
 /// </summary>
 public static class GuardaDeTope
 {
-    public static void Exigir(TablaExportable tabla, int topeDeFilas)
+    public static void Exigir(int cantidadDeFilas, int topeDeFilas)
     {
-        if (tabla.Filas.Count > topeDeFilas)
+        if (cantidadDeFilas > topeDeFilas)
         {
             throw new ErrorDominio(
                 "exportacion_demasiado_grande",
-                $"La exportación tiene {tabla.Filas.Count} filas; el tope es {topeDeFilas}. " +
+                $"La exportación tiene {cantidadDeFilas} filas; el tope es {topeDeFilas}. " +
                 "Acotá el rango o los filtros e intentá de nuevo.",
                 400);
         }

--- a/src/Ways.Application/Reportes/ExportacionDeReportes.cs
+++ b/src/Ways.Application/Reportes/ExportacionDeReportes.cs
@@ -1,0 +1,47 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>
+/// Mappers puros de un response record de <c>Ways.Application.Reportes</c> ya materializado a
+/// <see cref="TablaExportable"/> — la etapa 11 nunca vuelve a consultar la base para exportar
+/// (design decisión 11, spec exportacion-de-reportes: "No Re-Query"). Uno por reporte,
+/// arrancando acá con <c>ventas/resumen</c> (slice 1b); los ocho reportes restantes de stage-10
+/// se agregan en slice 2.
+/// </summary>
+public static class ExportacionDeReportes
+{
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasResumenDeVentas =
+    [
+        new ColumnaExportable("Período", TipoDeColumna.Texto),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda),
+        new ColumnaExportable("TX", TipoDeColumna.Entero),
+        new ColumnaExportable("Ticket promedio", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>Una fila por bucket de <see cref="ResumenDeVentas.Serie"/> más una fila de
+    /// totales — mismo criterio que la respuesta JSON: <c>TicketPromedio</c> nulo (bucket o
+    /// período sin ningún TX) queda como celda vacía, nunca <c>0</c>.</summary>
+    public static TablaExportable De(ResumenDeVentas respuesta, ContextoDeExportacion ctx)
+    {
+        var filas = respuesta.Serie
+            .Select(bucket => (IReadOnlyList<Celda>)
+            [
+                Celda.Texto(bucket.Etiqueta),
+                Celda.Moneda(bucket.Neto),
+                Celda.Entero(bucket.CantidadTx),
+                Celda.Moneda(bucket.TicketPromedio)
+            ])
+            .ToList();
+
+        filas.Add(
+        [
+            Celda.Texto("Total"),
+            Celda.Moneda(respuesta.NetoVendido),
+            Celda.Entero(respuesta.CantidadTx),
+            Celda.Moneda(respuesta.TicketPromedio)
+        ]);
+
+        return new TablaExportable("Ventas resumen", ctx, ColumnasResumenDeVentas, filas);
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/FormatoDeExportacionTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/FormatoDeExportacionTests.cs
@@ -1,0 +1,37 @@
+using Ways.Application.Exportacion;
+using Ways.Domain.Common;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1b (design decisión 9; spec exportacion-de-reportes: "Export Route Convention
+/// And Policy Inheritance By Co-Location") — único valor legal en v1 es <c>"xlsx"</c>, cualquier
+/// otro rechaza con el código de dominio que el spec fija.
+/// </summary>
+public class FormatoDeExportacionTests
+{
+    [Fact]
+    public void UnFormatoNoSoportadoRechazaConElCodigoDeDominio()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => FormatoDeExportacion.Parsear("pdf"));
+
+        Assert.Equal("formato_no_soportado", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void XlsxParseaSinLanzar()
+    {
+        var formato = FormatoDeExportacion.Parsear("xlsx");
+
+        Assert.Equal("xlsx", formato);
+    }
+
+    [Fact]
+    public void ElParseoEsInsensibleAMayusculas()
+    {
+        var formato = FormatoDeExportacion.Parsear("XLSX");
+
+        Assert.Equal("xlsx", formato);
+    }
+}

--- a/tests/Ways.Application.Tests/Exportacion/FormatoDeExportacionTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/FormatoDeExportacionTests.cs
@@ -10,10 +10,13 @@ namespace Ways.Application.Tests.Exportacion;
 /// </summary>
 public class FormatoDeExportacionTests
 {
-    [Fact]
-    public void UnFormatoNoSoportadoRechazaConElCodigoDeDominio()
+    [Theory]
+    [InlineData("pdf")]
+    [InlineData("csv")]
+    [InlineData("XLS")]
+    public void UnFormatoNoSoportadoRechazaConElCodigoDeDominio(string valor)
     {
-        var error = Assert.Throws<ErrorDominio>(() => FormatoDeExportacion.Parsear("pdf"));
+        var error = Assert.Throws<ErrorDominio>(() => FormatoDeExportacion.Parsear(valor));
 
         Assert.Equal("formato_no_soportado", error.Codigo);
         Assert.Equal(400, error.EstadoHttp);

--- a/tests/Ways.Application.Tests/Exportacion/GuardaDeTopeTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/GuardaDeTopeTests.cs
@@ -1,0 +1,39 @@
+using Ways.Application.Exportacion;
+using Ways.Domain.Common;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11, Slice 1b (design decisión 5-6) — <c>Exigir</c> toma la cantidad de filas ya contada
+/// por el caller, para que un reporte de listado (slice 3) pueda pasar un <c>COUNT(*)</c> sin
+/// materializar filas de más.
+/// </summary>
+public class GuardaDeTopeTests
+{
+    [Fact]
+    public void UnaCantidadPorEncimaDelTopeRechazaConElCodigoDeDominio()
+    {
+        var error = Assert.Throws<ErrorDominio>(() => GuardaDeTope.Exigir(cantidadDeFilas: 4, topeDeFilas: 3));
+
+        Assert.Equal("exportacion_demasiado_grande", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+        Assert.Contains("4", error.Message);
+        Assert.Contains("3", error.Message);
+    }
+
+    [Fact]
+    public void UnaCantidadExactamenteEnElTopeNoLanza()
+    {
+        var excepcion = Record.Exception(() => GuardaDeTope.Exigir(cantidadDeFilas: 3, topeDeFilas: 3));
+
+        Assert.Null(excepcion);
+    }
+
+    [Fact]
+    public void UnaCantidadPorDebajoDelTopeNoLanza()
+    {
+        var excepcion = Record.Exception(() => GuardaDeTope.Exigir(cantidadDeFilas: 1, topeDeFilas: 3));
+
+        Assert.Null(excepcion);
+    }
+}

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
@@ -1,0 +1,277 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Reportes;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 1b: <c>GET /api/reportes/ventas/resumen/export</c> — el
+/// primer export sibling, patrón que toda slice siguiente copia (spec exportacion-de-reportes;
+/// design: Data Flow). Archivo separado de <see cref="ReportesVentasResumenTests"/> (mismo
+/// criterio de <c>PoliticaDeRoles</c>-style split que el resto del repo): esta clase necesita su
+/// propio contenedor porque algunas de sus pruebas corren contra un host con
+/// <see cref="OpcionesDeExportacion.TopeDeFilas"/> pisado, y <c>WaysApiFixture</c> es sellada
+/// (no se puede heredar para exponer ese override) — <c>WithWebHostBuilder</c> arma un host
+/// adicional que comparte la MISMA base (mismo <c>ConnectionStrings__Ways</c> ya seteado por
+/// <see cref="WaysApiFixture.InitializeAsync"/>), sin tocar la fixture compartida.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx);
+
+    /// <summary>Igual que <c>ReportesVentasResumenTests.PrepararAsync</c>, parametrizado por
+    /// <paramref name="factory"/>: las pruebas de tope usan un <c>WithWebHostBuilder</c> propio
+    /// para ejercitar la mutación (task 1b.9/1b.10) sin afectar al resto de esta clase.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, factory, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, factory, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor,
+            idCliente, resultado.IdUsuarioAdmin, idTipoComprobanteTx);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> factory, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
+    /// <c>ReportesVentasResumenTests.SembrarComprobanteAsync</c>.</summary>
+    private async Task SembrarComprobanteAsync(Contexto ctx, DateTimeOffset fecha, decimal total)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.ComprobantesVenta.Add(new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static string ConstruirQuery(
+        int idEmpresa, int idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad, string? formato) =>
+        $"idEmpresa={idEmpresa}&idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}" +
+        $"&granularidad={granularidad}" + (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarResumenAsync(
+        HttpClient cliente, int idEmpresa, int idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad) =>
+        cliente.GetAsync($"/api/reportes/ventas/resumen?{ConstruirQuery(idEmpresa, idPuntoVenta, desde, hasta, granularidad, null)}");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, int idEmpresa, int idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad,
+        string formato = "xlsx") =>
+        cliente.GetAsync($"/api/reportes/ventas/resumen/export?{ConstruirQuery(idEmpresa, idPuntoVenta, desde, hasta, granularidad, formato)}");
+
+    // ---- task 1b.7: la exportación es igual al endpoint JSON para los mismos parámetros --------
+
+    [Fact]
+    public async Task ElExportEsIgualAlEndpointJsonParaLosMismosParametros()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlEndpointJsonParaLosMismosParametros), fixture);
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 200m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+
+        var jsonRespuesta = await LlamarResumenAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var resumen = JsonSerializer.Deserialize<ResumenDeVentas>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia);
+        Assert.Equal(HttpStatusCode.OK, exportRespuesta.StatusCode);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        var nombreEsperado = NombreDeArchivo.Construir("ventas_resumen", $"pv{ctx.IdPuntoVenta}", hoy, hoy);
+        var disposicion = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
+        Assert.Contains($"filename*=UTF-8''{nombreEsperado}", disposicion);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Rango de un día ⇒ un único bucket ⇒ la fila de totales es la fila 8 (fila 7 = el
+        // bucket, fila 6 = título de tabla). Se lee la fila de TOTALES, no la del bucket: es la
+        // que expone las mismas tres figuras (NetoVendido/CantidadTx/TicketPromedio) que el JSON
+        // reporta a nivel de respuesta.
+        var filaDeTotales = hoja.Row(8);
+        Assert.Equal(resumen.NetoVendido, filaDeTotales.Cell(2).GetValue<decimal>());
+        Assert.Equal(resumen.CantidadTx, filaDeTotales.Cell(3).GetValue<int>());
+        Assert.Equal(resumen.TicketPromedio, (decimal?)filaDeTotales.Cell(4).GetValue<decimal>());
+    }
+
+    // ---- task 1b.8: 403 para el rol un escalón debajo del gate -----------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelExportDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelExportDeVentas), fixture);
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 1b.11: el encabezado identifica alcance y generador --------------------------------
+
+    [Fact]
+    public async Task ElEncabezadoIdentificaElAlcanceYElGenerador()
+    {
+        var ctx = await PrepararAsync(nameof(ElEncabezadoIdentificaElAlcanceYElGenerador), fixture);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, desde, hasta, Granularidad.Dia);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        Assert.Contains($"Empresa {ctx.IdEmpresa}", hoja.Cell(1, 1).GetString());
+        Assert.Contains($"PV {ctx.IdPuntoVenta}", hoja.Cell(2, 1).GetString());
+        Assert.Contains("2026-08-01", hoja.Cell(3, 1).GetString());
+        Assert.Contains("admin", hoja.Cell(4, 1).GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.True(hoja.Cell(5, 1).Value.IsBlank);
+        Assert.Equal("Período", hoja.Cell(6, 1).GetString());
+    }
+
+    // ---- task 1b.9: rechazo por tope (mutation-proof-tests) --------------------------------------
+
+    /// <summary>Bindea <see cref="OpcionesDeExportacion.TopeDeFilas"/> a <c>3</c> en un host
+    /// propio de esta prueba. Este reporte es un AGREGADO (design decisión 6): la guarda corre
+    /// sobre <c>TablaExportable.Filas.Count</c>, no sobre un <c>COUNT(*)</c> — no hay ninguna fila
+    /// de negocio que "sembrar" para llegar a 4 filas exportadas. En su lugar se ejercita la
+    /// LONGITUD DE LA SERIE (spec: gap-fill, un bucket sin ventas nunca desaparece): un rango de 3
+    /// días en granularidad Día siempre produce 3 buckets + 1 fila de totales = 4 filas, sin
+    /// sembrar ningún comprobante — la escapatoria que las tasks.md de la slice autorizan
+    /// explícitamente para reportes agregados.
+    /// Mutación aplicada (comentar el <c>if</c> de <c>GuardaDeTope.Exigir</c>): esta prueba pasó
+    /// de FALLAR (200 en vez de 400) a pasar al revertir — evidencia registrada en el cuerpo del PR.</summary>
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 3);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, desde, hasta, Granularidad.Dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    // ---- task 1b.10: éxito exactamente en el tope -------------------------------------------------
+
+    [Fact]
+    public async Task UnaExportacionExactamenteEnElTopeSeAcepta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionExactamenteEnElTopeSeAcepta), factoryBajo);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, desde, hasta, Granularidad.Dia);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // 2 buckets + 1 fila de totales = 3 filas de datos, filas 7-9; la fila 10 tiene que estar
+        // vacía (nada más allá del tope).
+        Assert.False(hoja.Cell(7, 1).Value.IsBlank);
+        Assert.False(hoja.Cell(8, 1).Value.IsBlank);
+        Assert.False(hoja.Cell(9, 1).Value.IsBlank);
+        Assert.True(hoja.Cell(10, 1).Value.IsBlank);
+    }
+
+    // ---- task 1b.12 vive en FormatoDeExportacionTests (unitaria, sin fixture) --------------------
+}

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
@@ -139,26 +139,40 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
 
     // ---- task 1b.7: la exportación es igual al endpoint JSON para los mismos parámetros --------
 
+    /// <summary>Rango de 2 días ⇒ 2 buckets (granularidad Día): cada fila de bucket se compara
+    /// contra su entrada de <see cref="ResumenDeVentas.Serie"/> EN ORDEN (fila 7 = fila 6 = título
+    /// de tabla + serie[0], fila 8 = serie[1]), más la fila de totales (fila 9) contra las figuras
+    /// de nivel respuesta — un solo bucket comparado dejaba pasar mutaciones que solo afectan al
+    /// mapeo por-bucket (orden invertido, un valor corrido) porque la fila de totales las absorbe.
+    /// Mutación aplicada en <c>ExportacionDeReportes.De</c> (a) <c>.Reverse()</c> antes del
+    /// <c>Select</c>: esta prueba pasó de verde a rojo (bucket[0] esperado vs. bucket[1] real en
+    /// fila 7); revertida, vuelve a pasar. (b) <c>Celda.Moneda(bucket.Neto + 1m)</c>: mismo
+    /// resultado (Neto de fila 7/8 desviado en 1); revertida, vuelve a pasar.</summary>
     [Fact]
     public async Task ElExportEsIgualAlEndpointJsonParaLosMismosParametros()
     {
         var ctx = await PrepararAsync(nameof(ElExportEsIgualAlEndpointJsonParaLosMismosParametros), fixture);
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
-        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
+        var ayer = hoy.AddDays(-1);
+        var mediodiaAyerUtc = new DateTimeOffset(ayer.Year, ayer.Month, ayer.Day, 12, 0, 0, TimeSpan.Zero);
+        var mediodiaHoyUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
-        await SembrarComprobanteAsync(ctx, mediodiaUtc, 200m);
-        await SembrarComprobanteAsync(ctx, mediodiaUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaAyerUtc, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaAyerUtc, 50m);
+        await SembrarComprobanteAsync(ctx, mediodiaHoyUtc, 200m);
+        await SembrarComprobanteAsync(ctx, mediodiaHoyUtc, 300m);
+        await SembrarComprobanteAsync(ctx, mediodiaHoyUtc, 400m);
 
-        var jsonRespuesta = await LlamarResumenAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia);
+        var jsonRespuesta = await LlamarResumenAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, ayer, hoy, Granularidad.Dia);
         Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
         var resumen = JsonSerializer.Deserialize<ResumenDeVentas>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(2, resumen.Serie.Count);
 
-        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia);
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, ayer, hoy, Granularidad.Dia);
         Assert.Equal(HttpStatusCode.OK, exportRespuesta.StatusCode);
         Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
 
-        var nombreEsperado = NombreDeArchivo.Construir("ventas_resumen", $"pv{ctx.IdPuntoVenta}", hoy, hoy);
+        var nombreEsperado = NombreDeArchivo.Construir("ventas_resumen", $"pv{ctx.IdPuntoVenta}", ayer, hoy);
         var disposicion = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
         Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
         Assert.Contains($"filename*=UTF-8''{nombreEsperado}", disposicion);
@@ -166,11 +180,20 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
-        // Rango de un día ⇒ un único bucket ⇒ la fila de totales es la fila 8 (fila 7 = el
-        // bucket, fila 6 = título de tabla). Se lee la fila de TOTALES, no la del bucket: es la
-        // que expone las mismas tres figuras (NetoVendido/CantidadTx/TicketPromedio) que el JSON
-        // reporta a nivel de respuesta.
-        var filaDeTotales = hoja.Row(8);
+        // Primera fila de datos es la 7 (fila 6 = título de tabla) — una fila por bucket, EN
+        // ORDEN, seguida de la fila de totales.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < resumen.Serie.Count; i++)
+        {
+            var bucket = resumen.Serie[i];
+            var filaDeBucket = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(bucket.Etiqueta, filaDeBucket.Cell(1).GetString());
+            Assert.Equal(bucket.Neto, filaDeBucket.Cell(2).GetValue<decimal>());
+            Assert.Equal(bucket.CantidadTx, filaDeBucket.Cell(3).GetValue<int>());
+            Assert.Equal(bucket.TicketPromedio, (decimal?)filaDeBucket.Cell(4).GetValue<decimal>());
+        }
+
+        var filaDeTotales = hoja.Row(primeraFilaDeDatos + resumen.Serie.Count);
         Assert.Equal(resumen.NetoVendido, filaDeTotales.Cell(2).GetValue<decimal>());
         Assert.Equal(resumen.CantidadTx, filaDeTotales.Cell(3).GetValue<int>());
         Assert.Equal(resumen.TicketPromedio, (decimal?)filaDeTotales.Cell(4).GetValue<decimal>());
@@ -189,6 +212,25 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
+    /// <summary>Complementa <c>FormatoDeExportacionTests</c> (unitaria, sin fixture): un caso a
+    /// nivel HTTP que atraviesa el pipeline real (routing, binding, middleware de errores) y
+    /// confirma que <see cref="FormatoDeExportacion.Parsear"/> corta la request ANTES de tocar el
+    /// servicio de reportes, con el <c>codigo</c> de dominio propagado en el ProblemDetails.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsAtravesDelPipelineHttp()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsAtravesDelPipelineHttp), fixture);
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy, hoy, Granularidad.Dia, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
     // ---- task 1b.11: el encabezado identifica alcance y generador --------------------------------
 
     [Fact]
@@ -204,7 +246,7 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
         using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
-        Assert.Contains($"Empresa {ctx.IdEmpresa}", hoja.Cell(1, 1).GetString());
+        Assert.Contains($"Empresa: {ctx.IdEmpresa}", hoja.Cell(1, 1).GetString());
         Assert.Contains($"PV {ctx.IdPuntoVenta}", hoja.Cell(2, 1).GetString());
         Assert.Contains("2026-08-01", hoja.Cell(3, 1).GetString());
         Assert.Contains("admin", hoja.Cell(4, 1).GetString(), StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Etapa 11, slice 1b — El patron de ruta export

El primer `/export` real y la plomeria que TODOS los slices siguientes copian:

- `GET /ventas/resumen/export?formato=xlsx` co-locado en el MapGroup del reporte fuente — la politica se hereda ESTRUCTURALMENTE (mutacion: mover la ruta fuera del grupo rompe el test de 403).
- `GuardaDeTope.Exigir(int, int)` — por conteo, no por tabla materializada: los listados del slice 3 pasan el COUNT(*) ANTES de construir nada (fix de ronda 1 que evito que 10 slices copien la firma equivocada).
- `ResultadoDeExportacion` con Content-Disposition RFC 6266 (filename + filename* UTF-8), nombres deterministas.
- El test de igualdad fundacional: JSON vs XLSX re-leido, POR BUCKET y en orden + totales — tras el MAJOR de ronda 1 (solo comparaba totales; reordenar buckets o corromper una celda +1 sobrevivia).

### Review
Judgment-day de 2 rondas: Juez A APPROVE-WITH-MINORS (firma de la guarda, doble etiqueta del encabezado, test HTTP de formato), Juez B APPROVE-WITH-MINORS con 1 MAJOR probado por mutacion (igualdad ciega a buckets — 2 mutaciones supervivientes). Batch de 5 fixes `15678d7` con evidencia por fix → ronda 2: doble APPROVE, ambos supervivientes ahora mueren.

### Tests
Application 243/243 · ReportesVentasResumenExportTests 6/6 · gate cero migraciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)