### PR TITLE
test(reportes): eliminar la ventana de falla 00-03 UTC en los tests de exclusion

### DIFF
--- a/tests/Ways.IntegrationTests/ReportesComisionesTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesComisionesTests.cs
@@ -161,11 +161,12 @@ public class ReportesComisionesTests(WaysApiFixture fixture) : IClassFixture<Way
     {
         var ctx = await PrepararAsync(nameof(UnaVentaSoftDeletedNuncaApareceEnLasComisiones));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
         var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
         await ConfigurarComisionAsync(ctx, "10");
 
-        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
-        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 100m);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 100m);
 
         var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -179,11 +180,12 @@ public class ReportesComisionesTests(WaysApiFixture fixture) : IClassFixture<Way
     {
         var ctx = await PrepararAsync(nameof(UnaVentaAnuladaNuncaApareceEnLasComisiones));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
         var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
         await ConfigurarComisionAsync(ctx, "10");
 
-        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
-        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 250m);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 250m);
 
         var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -223,11 +225,12 @@ public class ReportesComisionesTests(WaysApiFixture fixture) : IClassFixture<Way
     {
         var ctx = await PrepararAsync(nameof(SinParametroConfiguradoLaTasaDefaultEsCeroYTodaComisionEsCero));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
         var idTipoTx = await IdTipoComprobanteTxAsync(ctx);
 
         // Sin ConfigurarComisionAsync: ninguna fila de `parametros` para esta clave — el default
         // declarado en ParametroConocido.ComisionPorcentaje ("0") es lo único que puede resolver.
-        await SembrarComprobanteAsync(ctx, idTipoTx, DateTimeOffset.UtcNow, 10_000m);
+        await SembrarComprobanteAsync(ctx, idTipoTx, mediodiaUtc, 10_000m);
 
         var comisiones = await ObtenerComisionesAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 

--- a/tests/Ways.IntegrationTests/ReportesEgresosTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesEgresosTests.cs
@@ -240,9 +240,10 @@ public class ReportesEgresosTests(WaysApiFixture fixture) : IClassFixture<WaysAp
     {
         var ctx = await PrepararAsync(nameof(UnaCompraSoftDeletedNuncaApareceEnElReporteDeCompras));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodia = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarCompraAsync(ctx, DateTimeOffset.UtcNow, 999_999m, EstadoCompra.Confirmada, eliminado: true);
-        await SembrarCompraAsync(ctx, DateTimeOffset.UtcNow, 100m, EstadoCompra.Confirmada);
+        await SembrarCompraAsync(ctx, mediodia, 999_999m, EstadoCompra.Confirmada, eliminado: true);
+        await SembrarCompraAsync(ctx, mediodia, 100m, EstadoCompra.Confirmada);
 
         var reporte = await ObtenerComprasAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -351,10 +352,11 @@ public class ReportesEgresosTests(WaysApiFixture fixture) : IClassFixture<WaysAp
     {
         var ctx = await PrepararAsync(nameof(UnGastoSoftDeletedNuncaApareceEnElResumenDeGastos));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodia = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
         var turno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
 
-        await SembrarGastoAsync(ctx, turno, DateTimeOffset.UtcNow, 5000m, CategoriaGasto.Otros, eliminado: true);
-        await SembrarGastoAsync(ctx, turno, DateTimeOffset.UtcNow, 100m, CategoriaGasto.Otros);
+        await SembrarGastoAsync(ctx, turno, mediodia, 5000m, CategoriaGasto.Otros, eliminado: true);
+        await SembrarGastoAsync(ctx, turno, mediodia, 100m, CategoriaGasto.Otros);
 
         var resumen = await ObtenerGastosAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 

--- a/tests/Ways.IntegrationTests/ReportesVentasPorDimensionTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasPorDimensionTests.cs
@@ -211,9 +211,10 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorPuntoVentaExcluyeUnaFilaSoftDeleted));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
 
         var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -226,9 +227,10 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorPuntoVentaExcluyeUnComprobanteAnulado));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 250m);
 
         var reporte = await ObtenerPorPuntoVentaAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -316,9 +318,10 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorVendedorExcluyeUnaFilaSoftDeleted));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
 
         var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -331,9 +334,10 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorVendedorExcluyeUnComprobanteAnulado));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 250m);
 
         var reporte = await ObtenerPorVendedorAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -419,11 +423,12 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorMedioPagoExcluyeUnPagoDeUnEncabezadoSoftDeleted));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        var idEliminado = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
+        var idEliminado = await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, eliminado: true);
         await SembrarPagoAsync(ctx, idEliminado, ctx.IdMedioPagoEfectivo, 999_999m);
 
-        var idVisible = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+        var idVisible = await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
         await SembrarPagoAsync(ctx, idVisible, ctx.IdMedioPagoEfectivo, 100m);
 
         var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
@@ -437,11 +442,12 @@ public class ReportesVentasPorDimensionTests(WaysApiFixture fixture) : IClassFix
     {
         var ctx = await PrepararAsync(nameof(PorMedioPagoExcluyeUnPagoDeUnComprobanteAnulado));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        var idAnulado = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
+        var idAnulado = await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, estado: EstadoComprobante.Anulado);
         await SembrarPagoAsync(ctx, idAnulado, ctx.IdMedioPagoEfectivo, 999_999m);
 
-        var idVisible = await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+        var idVisible = await SembrarComprobanteAsync(ctx, mediodiaUtc, 250m);
         await SembrarPagoAsync(ctx, idVisible, ctx.IdMedioPagoEfectivo, 250m);
 
         var reporte = await ObtenerPorMedioPagoAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenTests.cs
@@ -191,9 +191,10 @@ public class ReportesVentasResumenTests(WaysApiFixture fixture) : IClassFixture<
     {
         var ctx = await PrepararAsync(nameof(UnaFilaSoftDeletedNuncaApareceEnElResumen));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, eliminado: true);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 100m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, eliminado: true);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 100m);
 
         var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 
@@ -205,9 +206,10 @@ public class ReportesVentasResumenTests(WaysApiFixture fixture) : IClassFixture<
     {
         var ctx = await PrepararAsync(nameof(UnComprobanteAnuladoNuncaApareceEnElResumen));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var mediodiaUtc = new DateTimeOffset(hoy.Year, hoy.Month, hoy.Day, 12, 0, 0, TimeSpan.Zero);
 
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 999_999m, estado: EstadoComprobante.Anulado);
-        await SembrarComprobanteAsync(ctx, DateTimeOffset.UtcNow, 250m);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 999_999m, estado: EstadoComprobante.Anulado);
+        await SembrarComprobanteAsync(ctx, mediodiaUtc, 250m);
 
         var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdEmpresa, hoy, hoy);
 


### PR DESCRIPTION
## Fix de la bomba de tiempo horaria

12 tests de exclusion (anulado/soft-deleted) en 4 suites de reportes sembraban con `DateTimeOffset.UtcNow` y consultaban `hoy` en fecha UTC: entre las 00:00-03:00 UTC (21-24 ART) el instante sembrado bucketea al dia ART ANTERIOR y el reporte devuelve vacio → `Actual: 0`. Falla determinista dentro de la ventana, invisible fuera — explicaba las corridas rojas 'inexplicables' post-merge de #88.

**Produccion correcta**: es la semantica de zona de la etapa 10 funcionando exactamente como se diseño. Los tests eran los dependientes de la hora.

Fix: converger al patron `mediodiaUtc` que los tests hermanos de los mismos archivos ya usaban (12:00 UTC = mismo dia civil en ambas zonas). Cero cambios de asserts, cero produccion. Auditoria de patron latente en los otros 4 archivos de reportes: ya eran seguros.

### Evidencia (experimento natural — fix aplicado DENTRO de la ventana)
- 00:51 UTC pre-fix: `UnComprobanteAnuladoNuncaApareceEnElResumen` FAIL (`Actual: 0`)
- 00:53-00:55 UTC post-fix: las 4 suites afectadas + 4 auditadas = 113/113 verdes dentro de la ventana

🤖 Generated with [Claude Code](https://claude.com/claude-code)