### PR TITLE
feat(reportes): export XLSX de los ocho reportes de gestion (etapa 11, slice 2)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -223,7 +223,7 @@ rentabilidad/comisiones exports stack `LecturaDeRentabilidad` and carry the
 coverage block; comisiones carries the `PROVISIONAL` label. **Rollback**:
 revert the branch.
 
-- [ ] 2.1 Extend `ExportacionDeReportes.cs`: mappers for
+- [x] 2.1 Extend `ExportacionDeReportes.cs`: mappers for
   `PorPuntoVenta`/`PorVendedor`/`PorMedioPago`/`ArticulosTop`/
   `ComprasPorProveedor`/`GastosResumen`/`Rentabilidad`/`Comisiones` — each
   `public static TablaExportable De(X respuesta, ContextoDeExportacion ctx)`,
@@ -231,36 +231,55 @@ revert the branch.
   payload (lines included/excluded/skipped + revenue subtotals) inside the
   header; comisiones' mapper writes the `PROVISIONAL` label verbatim.
   *(spec rentabilidad-y-comisiones: Rentabilidad And Comisiones Exports
-  Stack LecturaDeRentabilidad And Carry Coverage)*
-- [ ] 2.2 Modify `ReportesEndpoints.cs`: eight `/export` siblings, each
+  Stack LecturaDeRentabilidad And Carry Coverage)* — IMPLEMENTATION NOTE:
+  the coverage text and the PROVISIONAL label are built by
+  `ExportacionDeReportes.ArmarTextoDeCobertura`/`EtiquetaProvisionalComisiones`
+  and passed by the endpoint into `ContextoDeExportacion.Cobertura` (the
+  same header seam `ExportadorXlsx` already writes on row 4) — reused, not
+  a new field.
+- [x] 2.2 Modify `ReportesEndpoints.cs`: eight `/export` siblings, each
   declared immediately after its source route; `/rentabilidad/export` and
   `/comisiones/export` re-stack `RequireAuthorization(Politicas.
   LecturaDeRentabilidad)` exactly like their JSON sources (AND composition,
   no new mechanism). *(design decision 7 — Raw-SQL/policy inheritance
   precedent; spec: Every Reportes De Gestión Route Has An Export Sibling)*
-- [ ] 2.3 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
+- [x] 2.3 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
   pending changes.
-- [ ] 2.4 [P] Equality test ×8 (one per new export).
-- [ ] 2.5 [P] 403 test ×8, role one step below each route's gate
+- [x] 2.4 [P] Equality test ×8 (one per new export).
+- [x] 2.5 [P] 403 test ×8, role one step below each route's gate
   (Vendedor for the six `LecturaDeReportes`-only routes; **Supervisor**
   for `/rentabilidad/export` and `/comisiones/export` — the stacked-policy
   mutation target). *(spec: A Supervisor Is Rejected On The Rentabilidad
   Export)*
-- [ ] 2.6 [P] **Stacked-policy mutation target**: delete
+- [x] 2.6 [P] **Stacked-policy mutation target**: delete
   `.RequireAuthorization(Politicas.LecturaDeRentabilidad)` on
   `/rentabilidad/export` → the Supervisor-403 test MUST fail (the group
   policy alone admits Supervisor); revert → green. Record in the PR body.
-  *(mutation-proof-tests)*
-- [ ] 2.7 [P] Coverage-block test on the rentabilidad export: a period with
+  *(mutation-proof-tests)* — Mutation run and recorded (see commit body of
+  `feat(reportes): agregar export XLSX a los ocho reportes restantes de
+  stage-10`): `.RequireAuthorization(Politicas.LecturaDeRentabilidad)`
+  commented out on `/rentabilidad/export` →
+  `UnSupervisorEsRechazadoEnElExportDeRentabilidad` failed (200 instead of
+  403); reverted → green (18/18).
+- [x] 2.7 [P] Coverage-block test on the rentabilidad export: a period with
   7 included / 2 estimated / 1 unknown lines → workbook header states the
   same three counts and revenue subtotals. *(spec: An Admin's Rentabilidad
   Export Carries The Coverage Block)*
-- [ ] 2.8 [P] `PROVISIONAL`-label test on the comisiones export, matching
+- [x] 2.8 [P] `PROVISIONAL`-label test on the comisiones export, matching
   the JSON response's label. *(spec: The Comisiones Export Is Labelled
   PROVISIONAL)*
-- [ ] 2.9 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 2.10 Branch `feat/stage11-slice2-exports-reportes` off `main`
-  (parent: slice 1b); PR; merge stacked-to-main.
+- [x] 2.9 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as task 1b.13.
+- [x] 2.10 Branch `feat/stage11-slice2-exports-reportes` off `main`
+  (parent: slice 1b); PR; merge stacked-to-main. — branch
+  `feat/stage11-slice2-exports-rentabilidad` created per the orchestrator's
+  explicit instruction (name differs from the task's suggested branch
+  name, same precedent as 1b.14); two work-unit commits made (mappers +
+  endpoints + equality/403 tests, then the coverage-block/PROVISIONAL
+  tests split out per this slice's own pre-split note below — the diff
+  landed well above the ~380-line forecast, driven by test depth as
+  predicted); PR/merge left for the orchestrator.
 
 **Test plan**: equality ×8, 403 ×8 (with the Supervisor-vs-rentabilidad
 mutation target), coverage-block, PROVISIONAL-label.

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -61,11 +61,63 @@ public static class ReportesEndpoints
             servicio.ObtenerComprasPorProveedorAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
         .WithSummary("Compras confirmadas dentro del rango, agrupadas por proveedor — borrador y anulada excluidas.");
 
+        // stage-11-exportacion-reportes, Slice 2: mismo plomero de /ventas/resumen/export
+        // (formato, contexto, tope), sin política propia — hereda LecturaDeReportes por co-locación.
+        grupo.MapGet("/compras/por-proveedor/export", async (
+            ServicioDeReportesDeEgresos servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var reporte = await servicio.ObtenerComprasPorProveedorAsync(idEmpresa, idPuntoVenta, desde, hasta, ct);
+
+            // ComprasPorProveedor no trae ZonaHoraria en su contrato (a diferencia del resto de
+            // los reportes de esta slice) — el rango bucketea por fecha_recepcion sin exponerla,
+            // así que el encabezado no puede repetir un valor que la respuesta nunca trae.
+            var ctx = ContextoDeExportacionHttp.Construir(usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, "N/A");
+            var tabla = ExportacionDeReportes.De(reporte, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("compras_por_proveedor", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /compras/por-proveedor: mismos parámetros y figuras.");
+
         grupo.MapGet("/gastos/resumen", (
             ServicioDeReportesDeEgresos servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
             Granularidad granularidad, CancellationToken ct) =>
             servicio.ObtenerGastosResumenAsync(idEmpresa, idPuntoVenta, desde, hasta, granularidad, ct))
         .WithSummary("Gastos bucketeados por la zona horaria del punto de venta, con desglose por categoría.");
+
+        grupo.MapGet("/gastos/resumen/export", async (
+            ServicioDeReportesDeEgresos servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, Granularidad granularidad, string formato,
+            CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var resumen = await servicio.ObtenerGastosResumenAsync(idEmpresa, idPuntoVenta, desde, hasta, granularidad, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, resumen.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(resumen, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("gastos_resumen", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /gastos/resumen: mismos parámetros y figuras.");
+
         grupo.MapGet("/articulos/top", (
             ServicioDeReportesDeArticulos servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
             int? limite, CancellationToken ct) =>
@@ -73,6 +125,30 @@ public static class ReportesEndpoints
         .WithSummary(
             "Ranking de artículos por cantidad y monto neto vendido, ordenado por monto " +
             "descendente. Sin costo ni margen: ver /rentabilidad.");
+
+        grupo.MapGet("/articulos/top/export", async (
+            ServicioDeReportesDeArticulos servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, int? limite, string formato,
+            CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var top = await servicio.ObtenerTopArticulosAsync(idEmpresa, idPuntoVenta, desde, hasta, limite, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, top.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(top, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("articulos_top", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /articulos/top: mismos parámetros y figuras.");
+
         // stage-10-agregacion-dashboard, Slice 4 (design decisión 7): apila LecturaDeRentabilidad
         // sobre LecturaDeReportes — ASP.NET Core compone políticas con AND, mismo criterio que
         // StockEndpoints ("/ajustes" apilando GestionDeCatalogo sobre OperacionDePos).
@@ -87,10 +163,70 @@ public static class ReportesEndpoints
         .WithSummary(
             "Margen del período: costo estimado excluido por defecto (incluirEstimados=true para " +
             "sumarlo), costo desconocido siempre salteado. Cobertura obligatoria en toda respuesta.");
+
+        // stage-11-exportacion-reportes, Slice 2 (spec rentabilidad-y-comisiones: Rentabilidad And
+        // Comisiones Exports Stack LecturaDeRentabilidad And Carry Coverage): re-apila
+        // LecturaDeRentabilidad EXACTAMENTE como su ruta fuente — la co-locación por sí sola
+        // heredaría solo LecturaDeReportes del MapGroup, así que acá SÍ hace falta declarar la
+        // política otra vez (mismo patrón que /rentabilidad, no "sin política propia").
+        grupo.MapGet("/rentabilidad/export", async (
+            ServicioDeReportesDeRentabilidad servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, bool? incluirEstimados, string formato,
+            CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var rentabilidad = await servicio.ObtenerRentabilidadAsync(
+                idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados ?? false, ct);
+
+            var textoDeCobertura = ExportacionDeReportes.ArmarTextoDeCobertura(rentabilidad.Cobertura);
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, rentabilidad.ZonaHoraria, textoDeCobertura);
+            var tabla = ExportacionDeReportes.De(rentabilidad, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("rentabilidad", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .RequireAuthorization(Politicas.LecturaDeRentabilidad)
+        .WithSummary(
+            "Export XLSX de /rentabilidad: mismos parámetros y figuras, con el bloque de cobertura " +
+            "de costo repetido en el encabezado.");
+
         grupo.MapGet("/ventas/por-punto-venta", (
             ServicioDeReportesDeVentas servicio, int idEmpresa, DateOnly desde, DateOnly hasta, CancellationToken ct) =>
             servicio.ObtenerPorPuntoVentaAsync(idEmpresa, desde, hasta, ct))
         .WithSummary("Ventas netas del período agrupadas por punto de venta — una fila por PV, sin idPuntoVenta.");
+
+        // Sin idPuntoVenta (mismo criterio que su ruta fuente): el alcance del nombre de archivo es
+        // siempre "todos", nunca un PV puntual — filtrar por el mismo eje que se agrupa sería una
+        // contradicción (dto-contract-honesty, igual que en /ventas/por-punto-venta).
+        grupo.MapGet("/ventas/por-punto-venta/export", async (
+            ServicioDeReportesDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, DateOnly desde, DateOnly hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var reporte = await servicio.ObtenerPorPuntoVentaAsync(idEmpresa, desde, hasta, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, null, desde, hasta, reporte.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(reporte, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("ventas_por_punto_venta", "todos", desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /ventas/por-punto-venta: mismos parámetros y figuras.");
 
         grupo.MapGet("/ventas/por-vendedor", (
             ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
@@ -98,11 +234,57 @@ public static class ReportesEndpoints
             servicio.ObtenerPorVendedorAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
         .WithSummary("Ventas netas del período agrupadas por vendedor (id_empleado emisor).");
 
+        grupo.MapGet("/ventas/por-vendedor/export", async (
+            ServicioDeReportesDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var reporte = await servicio.ObtenerPorVendedorAsync(idEmpresa, idPuntoVenta, desde, hasta, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, reporte.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(reporte, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("ventas_por_vendedor", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /ventas/por-vendedor: mismos parámetros y figuras.");
+
         grupo.MapGet("/ventas/por-medio-pago", (
             ServicioDeReportesDeVentas servicio, int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta,
             CancellationToken ct) =>
             servicio.ObtenerPorMedioPagoAsync(idEmpresa, idPuntoVenta, desde, hasta, ct))
         .WithSummary("Ventas netas del período agrupadas por medio de pago (pagos_comprobante.id_medio_pago).");
+
+        grupo.MapGet("/ventas/por-medio-pago/export", async (
+            ServicioDeReportesDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var reporte = await servicio.ObtenerPorMedioPagoAsync(idEmpresa, idPuntoVenta, desde, hasta, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, reporte.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(reporte, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("ventas_por_medio_pago", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /ventas/por-medio-pago: mismos parámetros y figuras.");
 
         // stage-10-agregacion-dashboard, Slice 10 (PROVISIONAL — droppable en su totalidad): mismo
         // apilado de políticas que /rentabilidad (design decisión 7).
@@ -114,6 +296,35 @@ public static class ReportesEndpoints
         .WithSummary(
             "PROVISIONAL: comisión por vendedor = neto vendido × comision_porcentaje (default 0, " +
             "un Admin configura la tasa desde Parámetros). Nada se persiste — calculado on the fly.");
+
+        // stage-11-exportacion-reportes, Slice 2: mismo re-apilado de LecturaDeRentabilidad que
+        // /rentabilidad/export (spec: Rentabilidad And Comisiones Exports Stack LecturaDeRentabilidad
+        // And Carry Coverage) — la etiqueta PROVISIONAL viaja en el encabezado, verbatim con
+        // Comisiones.Provisional (siempre true).
+        grupo.MapGet("/comisiones/export", async (
+            ServicioDeReportesDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idEmpresa, int? idPuntoVenta, DateOnly desde, DateOnly hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var comisiones = await servicio.ObtenerComisionesAsync(idEmpresa, idPuntoVenta, desde, hasta, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, idEmpresa, idPuntoVenta, desde, hasta, comisiones.ZonaHoraria,
+                ExportacionDeReportes.EtiquetaProvisionalComisiones);
+            var tabla = ExportacionDeReportes.De(comisiones, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } id ? $"pv{id}" : "todos";
+            var nombre = NombreDeArchivo.Construir("comisiones", alcance, desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .RequireAuthorization(Politicas.LecturaDeRentabilidad)
+        .WithSummary("Export XLSX de /comisiones: mismos parámetros y figuras, etiquetado PROVISIONAL.");
 
         return app;
     }

--- a/src/Ways.Application/Reportes/ExportacionDeReportes.cs
+++ b/src/Ways.Application/Reportes/ExportacionDeReportes.cs
@@ -1,16 +1,27 @@
 using Ways.Application.Exportacion;
+using Ways.Domain.Reportes;
 
 namespace Ways.Application.Reportes;
 
 /// <summary>
 /// Mappers puros de un response record de <c>Ways.Application.Reportes</c> ya materializado a
 /// <see cref="TablaExportable"/> — la etapa 11 nunca vuelve a consultar la base para exportar
-/// (design decisión 11, spec exportacion-de-reportes: "No Re-Query"). Uno por reporte,
-/// arrancando acá con <c>ventas/resumen</c> (slice 1b); los ocho reportes restantes de stage-10
-/// se agregan en slice 2.
+/// (design decisión 11, spec exportacion-de-reportes: "No Re-Query"). Uno por reporte:
+/// <c>ventas/resumen</c> llegó en slice 1b; los ocho restantes de stage-10 (por-punto-venta,
+/// por-vendedor, por-medio-pago, articulos/top, compras/por-proveedor, gastos/resumen,
+/// rentabilidad, comisiones) se agregan acá en slice 2.
 /// </summary>
 public static class ExportacionDeReportes
 {
+    /// <summary>Etiqueta PROVISIONAL del export de comisiones, verbatim con la respuesta JSON
+    /// (<see cref="Comisiones.Provisional"/> viaja siempre en <c>true</c> — spec
+    /// rentabilidad-y-comisiones: The Comisiones Export Is Labelled PROVISIONAL). El endpoint la
+    /// pasa como <c>Cobertura</c> del <see cref="ContextoDeExportacion"/> — mismo campo que
+    /// rentabilidad usa para su bloque de cobertura de costo, reusado acá para la etiqueta, no un
+    /// campo nuevo.</summary>
+    public const string EtiquetaProvisionalComisiones =
+        "PROVISIONAL: comisión calculada al momento de exportar, no persistida.";
+
     private static readonly IReadOnlyList<ColumnaExportable> ColumnasResumenDeVentas =
     [
         new ColumnaExportable("Período", TipoDeColumna.Texto),
@@ -44,4 +55,225 @@ public static class ExportacionDeReportes
 
         return new TablaExportable("Ventas resumen", ctx, ColumnasResumenDeVentas, filas);
     }
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasPorPuntoVenta =
+    [
+        new ColumnaExportable("Punto de venta", TipoDeColumna.Entero),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda),
+        new ColumnaExportable("TX", TipoDeColumna.Entero),
+        new ColumnaExportable("Ticket promedio", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>Sin fila de totales: <see cref="VentasPorPuntoVenta"/> no trae un agregado de
+    /// nivel respuesta (cada fila ya reporta su propio subtotal, spec reportes-de-gestion).</summary>
+    public static TablaExportable De(VentasPorPuntoVenta respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Ventas por punto de venta", ctx, ColumnasPorPuntoVenta,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdPuntoVenta),
+                    Celda.Moneda(f.Neto),
+                    Celda.Entero(f.CantidadTx),
+                    Celda.Moneda(f.TicketPromedio)
+                ])
+                .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasPorVendedor =
+    [
+        new ColumnaExportable("Vendedor", TipoDeColumna.Entero),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda),
+        new ColumnaExportable("TX", TipoDeColumna.Entero),
+        new ColumnaExportable("Ticket promedio", TipoDeColumna.Moneda)
+    ];
+
+    public static TablaExportable De(VentasPorVendedor respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Ventas por vendedor", ctx, ColumnasPorVendedor,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdEmpleado),
+                    Celda.Moneda(f.Neto),
+                    Celda.Entero(f.CantidadTx),
+                    Celda.Moneda(f.TicketPromedio)
+                ])
+                .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasPorMedioPago =
+    [
+        new ColumnaExportable("Medio de pago", TipoDeColumna.Entero),
+        new ColumnaExportable("Neto", TipoDeColumna.Moneda),
+        new ColumnaExportable("Cantidad de pagos", TipoDeColumna.Entero)
+    ];
+
+    public static TablaExportable De(VentasPorMedioPago respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Ventas por medio de pago", ctx, ColumnasPorMedioPago,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdMedioPago),
+                    Celda.Moneda(f.Neto),
+                    Celda.Entero(f.CantidadPagos)
+                ])
+                .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasArticulosTop =
+    [
+        new ColumnaExportable("Artículo", TipoDeColumna.Entero),
+        new ColumnaExportable("Descripción", TipoDeColumna.Texto),
+        new ColumnaExportable("Cantidad", TipoDeColumna.Cantidad),
+        new ColumnaExportable("Total", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>Sin costo ni margen — esos campos viven en <c>/rentabilidad</c> (design decisión
+    /// 10 de stage-10, heredada acá).</summary>
+    public static TablaExportable De(TopArticulos respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Artículos top", ctx, ColumnasArticulosTop,
+            respuesta.Articulos
+                .Select(a => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(a.IdArticulo),
+                    Celda.Texto(a.Descripcion),
+                    Celda.Cantidad(a.Cantidad),
+                    Celda.Moneda(a.Total)
+                ])
+                .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasComprasPorProveedor =
+    [
+        new ColumnaExportable("Proveedor", TipoDeColumna.Texto),
+        new ColumnaExportable("Total", TipoDeColumna.Moneda),
+        new ColumnaExportable("Cantidad de compras", TipoDeColumna.Entero)
+    ];
+
+    /// <summary>Una fila por proveedor más una fila de totales con
+    /// <see cref="ComprasPorProveedor.TotalGeneral"/> — mismo criterio de totales que
+    /// <c>ventas/resumen</c>.</summary>
+    public static TablaExportable De(ComprasPorProveedor respuesta, ContextoDeExportacion ctx)
+    {
+        var filas = respuesta.PorProveedor
+            .Select(p => (IReadOnlyList<Celda>)
+            [
+                Celda.Texto(p.NombreProveedor),
+                Celda.Moneda(p.Total),
+                Celda.Entero(p.CantidadCompras)
+            ])
+            .ToList();
+
+        filas.Add(
+        [
+            Celda.Texto("Total"),
+            Celda.Moneda(respuesta.TotalGeneral),
+            Celda.Entero(respuesta.PorProveedor.Sum(p => p.CantidadCompras))
+        ]);
+
+        return new TablaExportable("Compras por proveedor", ctx, ColumnasComprasPorProveedor, filas);
+    }
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasGastosResumen =
+    [
+        new ColumnaExportable("Período", TipoDeColumna.Texto),
+        new ColumnaExportable("Importe", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>Una fila por bucket de <see cref="ResumenDeGastos.Serie"/> más una fila de
+    /// totales con <see cref="ResumenDeGastos.ImporteTotal"/> — mismo criterio de gap-fill y
+    /// totales que <c>ventas/resumen</c>. Sin el desglose por categoría: la serie temporal es la
+    /// figura que este export prueba igual al endpoint, mismo alcance que el resto de los ocho
+    /// mappers de esta slice.</summary>
+    public static TablaExportable De(ResumenDeGastos respuesta, ContextoDeExportacion ctx)
+    {
+        var filas = respuesta.Serie
+            .Select(bucket => (IReadOnlyList<Celda>)
+            [
+                Celda.Texto(bucket.Etiqueta),
+                Celda.Moneda(bucket.Importe)
+            ])
+            .ToList();
+
+        filas.Add([Celda.Texto("Total"), Celda.Moneda(respuesta.ImporteTotal)]);
+
+        return new TablaExportable("Gastos resumen", ctx, ColumnasGastosResumen, filas);
+    }
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasRentabilidad =
+    [
+        new ColumnaExportable("Artículo", TipoDeColumna.Entero),
+        new ColumnaExportable("Descripción", TipoDeColumna.Texto),
+        new ColumnaExportable("Venta considerada", TipoDeColumna.Moneda),
+        new ColumnaExportable("Costo considerado", TipoDeColumna.Moneda),
+        new ColumnaExportable("Margen", TipoDeColumna.Moneda),
+        new ColumnaExportable("Margen %", TipoDeColumna.Decimal)
+    ];
+
+    /// <summary>Una fila por artículo (<c>IdArticulo</c> nulo en una línea de concepto libre,
+    /// design decisión 10) más una fila de totales con las figuras de nivel respuesta. El
+    /// bloque de cobertura NO lo escribe este mapper — lo arma <see cref="ArmarTextoDeCobertura"/>
+    /// y lo pasa el endpoint dentro del <see cref="ContextoDeExportacion.Cobertura"/> del
+    /// <paramref name="ctx"/> recibido, mismo seam que <c>ExportadorXlsx</c> ya escribe en la fila
+    /// 4 del encabezado (spec rentabilidad-y-comisiones: Rentabilidad And Comisiones Exports Stack
+    /// LecturaDeRentabilidad And Carry Coverage).</summary>
+    public static TablaExportable De(Rentabilidad respuesta, ContextoDeExportacion ctx)
+    {
+        var filas = respuesta.PorArticulo
+            .Select(p => (IReadOnlyList<Celda>)
+            [
+                Celda.Entero(p.IdArticulo),
+                Celda.Texto(p.Descripcion),
+                Celda.Moneda(p.VentaConsiderada),
+                Celda.Moneda(p.CostoConsiderado),
+                Celda.Moneda(p.Margen),
+                Celda.Decimal(p.MargenPorcentaje)
+            ])
+            .ToList();
+
+        filas.Add(
+        [
+            Celda.Entero(null),
+            Celda.Texto("Total"),
+            Celda.Moneda(respuesta.VentaConsiderada),
+            Celda.Moneda(respuesta.CostoConsiderado),
+            Celda.Moneda(respuesta.Margen),
+            Celda.Decimal(respuesta.MargenPorcentaje)
+        ]);
+
+        return new TablaExportable("Rentabilidad", ctx, ColumnasRentabilidad, filas);
+    }
+
+    /// <summary>Texto del bloque de cobertura que el endpoint de <c>/rentabilidad/export</c> pasa
+    /// como <see cref="ContextoDeExportacion.Cobertura"/> — repite los mismos tres conteos y sus
+    /// subtotales de venta que <see cref="CoberturaDeCosto"/> trae en la respuesta JSON (spec:
+    /// An Admin's Rentabilidad Export Carries The Coverage Block), nunca un porcentaje calculado
+    /// aparte que pudiera desviarse del JSON.</summary>
+    public static string ArmarTextoDeCobertura(CoberturaDeCosto cobertura) =>
+        $"Cobertura: {cobertura.LineasConCostoReal} líneas con costo real (venta ${cobertura.VentaConCostoReal:0.00}), " +
+        $"{cobertura.LineasConCostoEstimado} con costo estimado (venta ${cobertura.VentaConCostoEstimado:0.00}), " +
+        $"{cobertura.LineasSinCosto} con costo desconocido (venta ${cobertura.VentaSinCosto:0.00}), " +
+        $"de {cobertura.LineasTotales} líneas totales.";
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasComisiones =
+    [
+        new ColumnaExportable("Vendedor", TipoDeColumna.Entero),
+        new ColumnaExportable("Neto vendido", TipoDeColumna.Moneda),
+        new ColumnaExportable("Comisión", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>PROVISIONAL en su totalidad (droppable, stage-10 slice 10) — la etiqueta viaja en
+    /// <see cref="ContextoDeExportacion.Cobertura"/> vía <see cref="EtiquetaProvisionalComisiones"/>,
+    /// no en una columna propia: <see cref="Comisiones.Provisional"/> es siempre <c>true</c>, así
+    /// que no hay una fila "no provisional" que distinguir.</summary>
+    public static TablaExportable De(Comisiones respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Comisiones", ctx, ColumnasComisiones,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdEmpleado),
+                    Celda.Moneda(f.NetoVendido),
+                    Celda.Moneda(f.Comision)
+                ])
+                .ToList());
 }

--- a/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
+++ b/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
@@ -1,0 +1,536 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Reportes;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 2 (tasks 2.4-2.8): los ocho export siblings restantes de
+/// stage-10 (por-punto-venta, por-vendedor, por-medio-pago, articulos/top, compras/por-proveedor,
+/// gastos/resumen, rentabilidad, comisiones) — mismo patrón que
+/// <see cref="ReportesVentasResumenExportTests"/> (equality + 403), más el bloque de cobertura de
+/// rentabilidad y la etiqueta PROVISIONAL de comisiones (spec rentabilidad-y-comisiones:
+/// Rentabilidad And Comisiones Exports Stack LecturaDeRentabilidad And Carry Coverage). Sembrado
+/// con fechas fijas + mediodía UTC (nunca <c>DateTime.UtcNow</c>-derivado) — lección de la ventana
+/// 00-03 UTC de PR #89.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private static long _numeroSecuencial = 1;
+    private static long _numeroExternoSecuencial = 1;
+
+    private static readonly DateOnly Dia = new(2026, 8, 1);
+    private static readonly DateTimeOffset MediodiaUtc = new(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor,
+        int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
+        int IdMedioPagoEfectivo, int IdProveedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+        var idAlicuotaIva = await dbTenant.AlicuotasIva.Select(a => a.Id).FirstAsync();
+        var idListaPrecio = await dbTenant.ListasPrecio.Select(l => l.Id).FirstAsync();
+        var idMedioEfectivo = await dbTenant.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area export", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        dbTenant.Areas.Add(area);
+        await dbTenant.SaveChangesAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        dbPlataforma.CondicionesFiscales.Add(condicionFiscal);
+        await dbPlataforma.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"{nombre}-Prov", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        dbPlataforma.Proveedores.Add(proveedor);
+        await dbPlataforma.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor,
+            idCliente, resultado.IdUsuarioAdmin, idTipoComprobanteTx, area.Id, idAlicuotaIva, idListaPrecio,
+            idMedioEfectivo, proveedor.Id);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
+    /// <c>ReportesVentasResumenTests.SembrarComprobanteAsync</c>. Devuelve el id del comprobante
+    /// para encadenar pago/item.</summary>
+    private async Task<int> SembrarComprobanteAsync(
+        Contexto ctx, decimal total, int? idEmpleado = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = MediodiaUtc,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = idEmpleado ?? ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    private async Task SembrarPagoAsync(Contexto ctx, int idComprobanteVenta, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.PagosComprobante.Add(new PagoComprobante
+        {
+            IdTenant = ctx.IdTenant,
+            IdComprobanteVenta = idComprobanteVenta,
+            IdMedioPago = ctx.IdMedioPagoEfectivo,
+            Importe = importe,
+            Vuelto = 0m,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    /// <summary>Siembra un comprobante con un único ítem — costo opcional para alimentar tanto
+    /// <c>articulos/top</c> (sin costo) como <c>rentabilidad</c> (con costo real/estimado).</summary>
+    private async Task<int> SembrarLineaAsync(
+        Contexto ctx, int idArticulo, string descripcion, decimal cantidad, decimal total,
+        decimal? costoUnitario = null, bool costoEsEstimado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = MediodiaUtc,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.ItemsComprobanteVenta.Add(new ItemComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant, IdComprobanteVenta = comprobante.Id, Orden = 1, IdArticulo = idArticulo,
+            Descripcion = descripcion, IdArea = ctx.IdArea, IdListaPrecio = ctx.IdListaPrecio,
+            IdAlicuotaIva = ctx.IdAlicuotaIva, PorcentajeIva = 0m, Cantidad = cantidad,
+            PrecioUnitario = total / cantidad, Descuento = 0m, Total = total,
+            CostoUnitario = costoUnitario, CostoEsEstimado = costoEsEstimado,
+            CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    private async Task SembrarCompraAsync(Contexto ctx, decimal total)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var numeroExterno = $"export-slice2-{Interlocked.Increment(ref _numeroExternoSecuencial)}";
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteCompra = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        db.ComprobantesCompra.Add(new ComprobanteCompra
+        {
+            IdTenant = ctx.IdTenant,
+            IdProveedor = ctx.IdProveedor,
+            IdTipoComprobante = idTipoComprobanteCompra,
+            NumeroExterno = numeroExterno,
+            FechaComprobante = Dia,
+            FechaRecepcion = MediodiaUtc,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = 1,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoCompra.Confirmada,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<int> AbrirTurnoAsync(HttpClient cliente, int idPuntoVenta)
+    {
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(idPuntoVenta, 0m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!.Id;
+    }
+
+    private async Task SembrarGastoAsync(Contexto ctx, int idTurno, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Gastos.Add(new Gasto
+        {
+            IdTenant = ctx.IdTenant,
+            Fecha = MediodiaUtc,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = 1,
+            Categoria = CategoriaGasto.Otros,
+            Concepto = "Gasto export slice 2",
+            IdMedioPago = ctx.IdMedioPagoEfectivo,
+            Importe = importe,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task ConfigurarComisionAsync(Contexto ctx, string valorJson)
+    {
+        var respuesta = await ctx.Admin.PutAsJsonAsync(
+            $"/api/parametros?idEmpresa={ctx.IdEmpresa}", new ParametroAlta("comision_porcentaje", valorJson, null));
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    private static string Rango(int idEmpresa) => $"idEmpresa={idEmpresa}&desde={Dia:yyyy-MM-dd}&hasta={Dia:yyyy-MM-dd}";
+
+    private static async Task<XLWorkbook> DescargarLibroAsync(HttpClient cliente, string ruta)
+    {
+        var respuesta = await cliente.GetAsync(ruta);
+        var cuerpo = respuesta.IsSuccessStatusCode ? null : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+        return new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+    }
+
+    // ---- task 2.4: equality tests (uno por export nuevo) ------------------------------------------
+
+    [Fact]
+    public async Task ElExportDePorPuntoVentaEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDePorPuntoVentaEsIgualAlEndpointJson));
+        await SembrarComprobanteAsync(ctx, 300m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/ventas/por-punto-venta?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<VentasPorPuntoVenta>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.Filas);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-punto-venta/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdPuntoVenta, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(fila.CantidadTx, hoja.Cell(7, 3).GetValue<int>());
+        Assert.Equal(fila.TicketPromedio, (decimal?)hoja.Cell(7, 4).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDePorVendedorEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDePorVendedorEsIgualAlEndpointJson));
+        await SembrarComprobanteAsync(ctx, 500m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/ventas/por-vendedor?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<VentasPorVendedor>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.Filas);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-vendedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdEmpleado, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(fila.CantidadTx, hoja.Cell(7, 3).GetValue<int>());
+        Assert.Equal(fila.TicketPromedio, (decimal?)hoja.Cell(7, 4).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDePorMedioPagoEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDePorMedioPagoEsIgualAlEndpointJson));
+        var idComprobante = await SembrarComprobanteAsync(ctx, 400m);
+        await SembrarPagoAsync(ctx, idComprobante, 400m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/ventas/por-medio-pago?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<VentasPorMedioPago>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.Filas);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-medio-pago/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdMedioPago, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(fila.CantidadPagos, hoja.Cell(7, 3).GetValue<int>());
+    }
+
+    [Fact]
+    public async Task ElExportDeArticulosTopEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeArticulosTopEsIgualAlEndpointJson));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo export top");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo export top", 2m, 200m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/articulos/top?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<TopArticulos>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.Articulos);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/articulos/top/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdArticulo, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.Descripcion, hoja.Cell(7, 2).GetString());
+        Assert.Equal(fila.Cantidad, hoja.Cell(7, 3).GetValue<decimal>());
+        Assert.Equal(fila.Total, hoja.Cell(7, 4).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDeComprasPorProveedorEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeComprasPorProveedorEsIgualAlEndpointJson));
+        await SembrarCompraAsync(ctx, 1000m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/compras/por-proveedor?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<ComprasPorProveedor>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.PorProveedor);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/compras/por-proveedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.NombreProveedor, hoja.Cell(7, 1).GetString());
+        Assert.Equal(fila.Total, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(fila.CantidadCompras, hoja.Cell(7, 3).GetValue<int>());
+        Assert.Equal(reporte.TotalGeneral, hoja.Cell(8, 2).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDeGastosResumenEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeGastosResumenEsIgualAlEndpointJson));
+        var idTurno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+        await SembrarGastoAsync(ctx, idTurno, 700m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/gastos/resumen?{Rango(ctx.IdEmpresa)}&granularidad=Dia");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<ResumenDeGastos>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Single(reporte.Serie);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/gastos/resumen/export?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(reporte.Serie[0].Etiqueta, hoja.Cell(7, 1).GetString());
+        Assert.Equal(reporte.Serie[0].Importe, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(reporte.ImporteTotal, hoja.Cell(8, 2).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDeRentabilidadEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadEsIgualAlEndpointJson));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo export rentabilidad");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo export rentabilidad", 1m, 300m, costoUnitario: 100m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/rentabilidad?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<Rentabilidad>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.PorArticulo);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdArticulo, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.Descripcion, hoja.Cell(7, 2).GetString());
+        Assert.Equal(fila.VentaConsiderada, hoja.Cell(7, 3).GetValue<decimal>());
+        Assert.Equal(fila.CostoConsiderado, hoja.Cell(7, 4).GetValue<decimal>());
+        Assert.Equal(fila.Margen, hoja.Cell(7, 5).GetValue<decimal>());
+        Assert.Equal(reporte.Margen, hoja.Cell(8, 5).GetValue<decimal>());
+    }
+
+    [Fact]
+    public async Task ElExportDeComisionesEsIgualAlEndpointJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeComisionesEsIgualAlEndpointJson));
+        await ConfigurarComisionAsync(ctx, "10");
+        await SembrarComprobanteAsync(ctx, 1000m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/comisiones?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<Comisiones>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var fila = Assert.Single(reporte.Filas);
+        Assert.Equal(100m, fila.Comision);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Equal(fila.IdEmpleado, hoja.Cell(7, 1).GetValue<int>());
+        Assert.Equal(fila.NetoVendido, hoja.Cell(7, 2).GetValue<decimal>());
+        Assert.Equal(fila.Comision, hoja.Cell(7, 3).GetValue<decimal>());
+    }
+
+    // ---- task 2.5: 403 para el rol un escalón debajo del gate --------------------------------------
+
+    public static readonly TheoryData<string> RutasSoloLecturaDeReportes = new()
+    {
+        "ventas/por-punto-venta/export", "ventas/por-vendedor/export", "ventas/por-medio-pago/export",
+        "articulos/top/export", "compras/por-proveedor/export", "gastos/resumen/export"
+    };
+
+    [Theory]
+    [MemberData(nameof(RutasSoloLecturaDeReportes))]
+    public async Task UnVendedorEsRechazadoEnLosSeisExportsDeLecturaDeReportes(string ruta)
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLosSeisExportsDeLecturaDeReportes) + ruta.Replace("/", "-"));
+
+        var respuesta = await ctx.Vendedor.GetAsync(
+            $"/api/reportes/{ruta}?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 2.5/2.6: el objetivo de mutación de política apilada (mutation-proof-tests) ----------
+
+    /// <summary>Prueba distintiva de la política apilada (spec: A Supervisor Is Rejected On The
+    /// Rentabilidad Export): a diferencia de los seis exports de <c>LecturaDeReportes</c> sola
+    /// (que un Supervisor sí puede leer), acá <c>LecturaDeReportes</c> no alcanza — hace falta
+    /// <c>LecturaDeRentabilidad</c> apilada encima (design decisión 7 de stage-10, heredada acá).
+    /// mutation-proof-tests: mutación aplicada (comentar
+    /// <c>.RequireAuthorization(Politicas.LecturaDeRentabilidad)</c> en
+    /// <c>/rentabilidad/export</c>) — este test pasó de <c>403</c> esperado a <c>200</c> obtenido
+    /// (la política del grupo, <c>LecturaDeReportes</c>, admite Supervisor por sí sola); revertida,
+    /// vuelve a pasar. Evidencia registrada en el cuerpo del commit.</summary>
+    [Fact]
+    public async Task UnSupervisorEsRechazadoEnElExportDeRentabilidad()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeRentabilidad));
+
+        var respuesta = await ctx.Supervisor.GetAsync($"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorEsRechazadoEnElExportDeComisiones()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeComisiones));
+
+        var respuesta = await ctx.Supervisor.GetAsync($"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+}

--- a/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
+++ b/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
@@ -533,4 +533,71 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
+    // ---- task 2.7: el bloque de cobertura en el export de rentabilidad -----------------------------
+
+    /// <summary>7 líneas con costo real, 2 con costo estimado (incluido vía <c>incluirEstimados</c>
+    /// para que también aparezcan en <c>PorArticulo</c>, aunque la cobertura las cuenta siempre —
+    /// spec: Coverage Reflects A Mixed Period), 1 con costo desconocido — el encabezado del
+    /// workbook (fila 4) tiene que repetir los mismos tres conteos y sus subtotales de venta que
+    /// <see cref="CoberturaDeCosto"/> trae en la respuesta JSON (spec: An Admin's Rentabilidad
+    /// Export Carries The Coverage Block).</summary>
+    [Fact]
+    public async Task ElExportDeRentabilidadCargaElBloqueDeCobertura()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadCargaElBloqueDeCobertura));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo cobertura");
+
+        for (var i = 0; i < 7; i++)
+        {
+            await SembrarLineaAsync(ctx, idArticulo, $"real-{i}", 1m, 100m, costoUnitario: 40m);
+        }
+
+        for (var i = 0; i < 2; i++)
+        {
+            await SembrarLineaAsync(ctx, idArticulo, $"estimado-{i}", 1m, 50m, costoUnitario: 20m, costoEsEstimado: true);
+        }
+
+        await SembrarLineaAsync(ctx, idArticulo, "desconocido", 1m, 30m, costoUnitario: null);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync(
+            $"/api/reportes/rentabilidad?{Rango(ctx.IdEmpresa)}&incluirEstimados=true");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<Rentabilidad>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        Assert.Equal(7, reporte.Cobertura.LineasConCostoReal);
+        Assert.Equal(2, reporte.Cobertura.LineasConCostoEstimado);
+        Assert.Equal(1, reporte.Cobertura.LineasSinCosto);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&incluirEstimados=true&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+        var textoEncabezado = hoja.Cell(4, 1).GetString();
+
+        Assert.Contains("7", textoEncabezado);
+        Assert.Contains("2", textoEncabezado);
+        Assert.Contains("1", textoEncabezado);
+        Assert.Contains(reporte.Cobertura.VentaConCostoReal.ToString("0.00"), textoEncabezado);
+        Assert.Contains(reporte.Cobertura.VentaConCostoEstimado.ToString("0.00"), textoEncabezado);
+        Assert.Contains(reporte.Cobertura.VentaSinCosto.ToString("0.00"), textoEncabezado);
+    }
+
+    // ---- task 2.8: la etiqueta PROVISIONAL en el export de comisiones ------------------------------
+
+    [Fact]
+    public async Task ElExportDeComisionesLlevaLaEtiquetaProvisional()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDeComisionesLlevaLaEtiquetaProvisional));
+        await SembrarComprobanteAsync(ctx, 100m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/comisiones?{Rango(ctx.IdEmpresa)}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var reporte = JsonSerializer.Deserialize<Comisiones>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.True(reporte.Provisional);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.Contains("PROVISIONAL", hoja.Cell(4, 1).GetString());
+    }
 }

--- a/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
+++ b/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
@@ -573,9 +573,9 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         var hoja = libro.Worksheets.First();
         var textoEncabezado = hoja.Cell(4, 1).GetString();
 
-        Assert.Contains("7", textoEncabezado);
-        Assert.Contains("2", textoEncabezado);
-        Assert.Contains("1", textoEncabezado);
+        Assert.Contains($"{reporte.Cobertura.LineasConCostoReal} líneas con costo real", textoEncabezado);
+        Assert.Contains($"{reporte.Cobertura.LineasConCostoEstimado} con costo estimado", textoEncabezado);
+        Assert.Contains($"{reporte.Cobertura.LineasSinCosto} con costo desconocido", textoEncabezado);
         Assert.Contains(reporte.Cobertura.VentaConCostoReal.ToString("0.00"), textoEncabezado);
         Assert.Contains(reporte.Cobertura.VentaConCostoEstimado.ToString("0.00"), textoEncabezado);
         Assert.Contains(reporte.Cobertura.VentaSinCosto.ToString("0.00"), textoEncabezado);


### PR DESCRIPTION
## Etapa 11, slice 2 — Los 8 exports de reportes

Cada reporte de la etapa 10 gana su hermano `/export`: por-punto-venta, por-vendedor, por-medio-pago, articulos/top, compras/por-proveedor, gastos/resumen, rentabilidad y comisiones — mappers que consumen la MISMA llamada de servicio que el JSON (cero re-queries), tests de igualdad por fila, 403 por rol.

- `/rentabilidad/export` y `/comisiones/export` re-apilan `LecturaDeRentabilidad` — AMBOS probados por mutacion (quitar el stack → el 403 del Supervisor cae a 200).
- Bloque de cobertura en el encabezado del export de rentabilidad; etiqueta PROVISIONAL visible en fila 4 del de comisiones (con test).
- `ComprasPorProveedor` muestra "N/A" de zona: su contrato JSON nunca la expone y resolverla seria un re-query prohibido — gap preexistente anotado para backlog.

### Review
Judgment-day de 2 rondas: Juez A APPROVE (8 mappers trazados contra sus servicios, tipado y nulls verificados). Juez B REJECT ronda 1 con 1 MAJOR probado por mutacion — los asserts de conteo de cobertura eran `Contains("7")` y el 7 vivia en "$700.00": conteo+1 sobrevivia. Fix `6953b5e` (frases completas interpoladas) → Juez B APPROVE ronda 2 re-ejecutando su mutacion.

### Size
`size:exception` — ~1049 lineas vs ~380: 8 tests de igualdad + 8 de rol + 2 espec-especificos SON el slice.

### Tests
ExportacionDeReportesTests 18/18 · Integration 847 en rama · full suite en el asentamiento del paralelismo

🤖 Generated with [Claude Code](https://claude.com/claude-code)