### PR TITLE
feat(exportacion): exports XLSX de listados con tope por conteo previo (etapa 11, slice 3)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -276,36 +276,82 @@ listing exports run `Contar → refuse → single read with .Take(tope+1)`
 through an extracted `ConstruirQuery`, never re-declaring the predicate
 chain. **Rollback**: revert the branch.
 
-- [ ] 3.1 Modify `src/Ways.Application/Ventas/Servicio*.cs`,
+- [x] 3.1 Modify `src/Ways.Application/Ventas/Servicio*.cs`,
   `Compras/Servicio*.cs`, `CuentaCorriente/Servicio*.cs`: extract each
   service's filter chain into a private `ConstruirQuery(filtros)`, shared
   by the existing `ListarAsync` and a new `ListarParaExportacionAsync`
   (`Contar → refuse if over tope → single read with `.Take(tope + 1)`,
-  never paged). *(design decision 7)*
-- [ ] 3.2 Create `src/Ways.Application/Exportacion/ExportacionDeListados.cs`:
+  never paged). *(design decision 7)* — IMPLEMENTATION NOTE: `CuentaCorriente`
+  has no `ListarAsync` (its JSON source is `ObtenerEstadoDeCuentaAsync`,
+  single-cliente header + ledger, not a paginated multi-entity listing); the
+  extracted `ConstruirQuery(idCliente, desde, hasta)` is shared by that
+  method and the new `ObtenerEstadoDeCuentaParaExportacionAsync`, which
+  drops `histórico` (an export is by definition a bounded range) and
+  requires `desde`/`hasta` explicit.
+- [x] 3.2 Create `src/Ways.Application/Exportacion/ExportacionDeListados.cs`:
   mappers for ventas listado, compras listado, estado de cuenta — pure,
   consume the already-materialised export-query result.
-- [ ] 3.3 Modify `src/Ways.Api/Endpoints/{Ventas,Compras,
+- [x] 3.3 Modify `src/Ways.Api/Endpoints/{Ventas,Compras,
   CuentaCorriente}Endpoints.cs`: one `/export` sibling each, under their
   existing `OperacionDePos`/relevant groups (pagination bypassed under the
-  cap).
-- [ ] 3.4 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
-  pending changes.
-- [ ] 3.5 [P] Equality test ×3.
-- [ ] 3.6 [P] 403 test ×3 (role one step below each route's existing gate).
-- [ ] 3.7 [P] Cap-refusal test ×3, tope bound low via
+  cap). — IMPLEMENTATION NOTE: none of these three JSON listing routes
+  carries `idEmpresa` (unlike the reportes-de-gestión routes), so the header
+  block's Empresa/zona resolution needed its own plumbing — added
+  `src/Ways.Api/Exportacion/AlcanceDeListadoHttp.cs` (PV → empresa → default
+  when `idPuntoVenta` is present, the system default zone otherwise, no new
+  query) and a generic `ContextoDeExportacionHttp.Construir(... string
+  empresa, string? puntoVenta ...)` overload (the existing `int idEmpresa`
+  overload now delegates to it). `desde`/`hasta` are REQUIRED on all three
+  export routes (unlike their optional-filter JSON siblings) — a
+  deterministic filename needs a bounded range, and an export is exactly
+  the case the row cap exists for; `CuentaCorriente`'s export additionally
+  drops `historico` for the same reason (see 3.1 note).
+- [x] 3.4 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
+  pending changes. — `dotnet ef` tooling unavailable in this environment
+  (missing `Microsoft.EntityFrameworkCore.Design` wiring for the CLI tool);
+  verified equivalently via `git diff --stat`, confirming zero touched
+  files under any `Migrations/` folder, `WaysDbContext`, or `Configuraciones/`
+  — only `Ways.Application`/`Ways.Api` service and endpoint files changed.
+- [x] 3.5 [P] Equality test ×3.
+- [x] 3.6 [P] 403 test ×3 (role one step below each route's existing gate).
+  — IMPLEMENTATION NOTE: all three routes are gated `OperacionDePos`
+  (Vendedor/Supervisor/Admin), the widest tenant-role gate in the system —
+  there is no tenant role below Vendedor to use as "one step below". Used
+  Root instead, the role structurally EXCLUDED from `OperacionDePos` by
+  design ("root administra tenants, no opera ninguno", `Politicas.cs`):
+  `RequireClaim(RolId, 2,3,4)` rejects Root's claim (`RolId=1`) with a real
+  403, same mechanism as every other role-gate test in the repo.
+- [x] 3.7 [P] Cap-refusal test ×3, tope bound low via
   `OpcionesDeExportacion`, seeded one row over.
-- [ ] 3.8 [P] **`+1` race backstop / no-re-query invariant**: seed exactly
+- [x] 3.8 [P] **`+1` race backstop / no-re-query invariant**: seed exactly
   `tope + 1` rows so the count and the `.Take(tope + 1)` read disagree by
   construction (simulating a concurrent insert between count and read) —
   assert the export still refuses rather than silently returning `tope`
   rows. Record mutation evidence: replace `.Take(tope + 1)` with
   `.Take(tope)` → the backstop test MUST fail (a truncated file would
   escape undetected); revert → green. *(design decision 7 — "no truncated
-  file can escape even in that window"; mutation-proof-tests)*
-- [ ] 3.9 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 3.10 Branch `feat/stage11-slice3-exports-listados` off `main`
-  (parent: slice 1b); PR; merge stacked-to-main.
+  file can escape even in that window"; mutation-proof-tests)* —
+  IMPLEMENTATION NOTE: a real 2-request race can't be timed deterministically
+  from a test; `VentasListadoExportTests.UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion`
+  routes below the confound instead — a single-participant
+  `DbCommandInterceptor` (`InterceptorDeCarreraDeExportacion`, same
+  rendezvous family as `ParametrosTests.InterceptorDeRendezVous`) intercepts
+  the SECOND query touching `comprobantes_venta` (the `.Take(tope+1)` read;
+  the first is the `COUNT(*)`) and inserts the extra row synchronously right
+  before letting it run, deterministically reproducing "a row landed between
+  count and read" every run. Mutation run and recorded: `.Take(topeDeFilas +
+  1)` → `.Take(topeDeFilas)` in `ServicioDeVentas.ListarParaExportacionAsync`
+  — the test failed (`200` with the extra row silently dropped, instead of
+  the expected `400`); reverted → green. Per the tasks.md decision 5 note,
+  this single mutation covers the invariant for the whole slice (Compras/
+  Estado-de-cuenta share the identical `Contar → refuse → Take(tope+1) →
+  refuse` shape, proven once here).
+- [ ] 3.9 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase.
+- [ ] 3.10 Branch `feat/stage11-slice3-exports-listados` off `main` (parent:
+  slice 1b); PR; merge stacked-to-main. — branch created exactly as named;
+  PR/merge left for the orchestrator.
 
 **Test plan**: equality ×3, 403 ×3, cap ×3, `+1` race backstop with
 mutation evidence.

--- a/src/Ways.Api/Endpoints/ComprasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ComprasEndpoints.cs
@@ -1,5 +1,9 @@
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
 using Ways.Application.Compras;
+using Ways.Application.Exportacion;
 using Ways.Domain.Compras;
 
 namespace Ways.Api.Endpoints;
@@ -28,6 +32,38 @@ public static class ComprasEndpoints
             CancellationToken ct) =>
             servicio.ListarAsync(idProveedor, estado, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
         .WithSummary("Lista comprobantes de compra con filtros y paginado.");
+
+        // stage-11-exportacion-reportes (Slice 3, design decisión 7): sibling declarado
+        // inmediatamente después de su ruta fuente — hereda OperacionDePos por co-locación.
+        // Sin idPuntoVenta (el listado JSON tampoco lo tiene): Empresa/zona usan el default de
+        // AlcanceDeListadoHttp, no una consulta nueva.
+        grupo.MapGet("/export", async (
+            ServicioDeCompras servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int? idProveedor, EstadoCompra? estado, DateTimeOffset desde, DateTimeOffset hasta, string formato,
+            CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var filas = await servicio.ListarParaExportacionAsync(
+                idProveedor, estado, desde, hasta, opciones.Value.TopeDeFilas, ct);
+
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(AlcanceDeListadoHttp.ZonaPorDefecto);
+            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
+            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, "Todas", puntoVenta: null, desdeFecha, hastaFecha, AlcanceDeListadoHttp.ZonaPorDefecto);
+            var tabla = ExportacionDeListados.De(filas, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("compras_listado", "todas", desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de GET /api/compras: mismo filtro, sin paginado bajo el tope, gate " +
+            "OperacionDePos heredado por co-locación.");
 
         grupo.MapGet("/{id:int}", (ServicioDeCompras servicio, int id, CancellationToken ct) =>
             servicio.ObtenerAsync(id, ct))

--- a/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
@@ -1,5 +1,9 @@
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
 using Ways.Application.CuentaCorriente;
+using Ways.Application.Exportacion;
 
 namespace Ways.Api.Endpoints;
 
@@ -61,6 +65,39 @@ public static class CuentaCorrienteEndpoints
             bool? historico, CancellationToken ct) =>
             Results.Ok(await servicio.ObtenerEstadoDeCuentaAsync(idCliente, desde, hasta, historico ?? false, ct)))
         .WithSummary("Estado de cuenta: header (saldo/acuerdo/disponibilidad) + movimientos con saldo corrido.");
+
+        // stage-11-exportacion-reportes (Slice 3, design decisión 7): sibling declarado
+        // inmediatamente después de su ruta fuente — hereda OperacionDePos por co-locación.
+        // `desde`/`hasta` OBLIGATORIOS y sin `historico` (design: un export es por definición
+        // un rango acotado, exactamente lo que histórico evita) — mismo criterio que
+        // /api/ventas/export.
+        grupo.MapGet("/export", async (
+            ServicioDeCuentaCorriente servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj,
+            int idCliente, DateTimeOffset desde, DateTimeOffset hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var estado = await servicio.ObtenerEstadoDeCuentaParaExportacionAsync(
+                idCliente, desde, hasta, opciones.Value.TopeDeFilas, ct);
+
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(AlcanceDeListadoHttp.ZonaPorDefecto);
+            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
+            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, $"Cliente {idCliente}", puntoVenta: null, desdeFecha, hastaFecha,
+                AlcanceDeListadoHttp.ZonaPorDefecto);
+            var tabla = ExportacionDeListados.De(estado.Movimientos, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("estado_de_cuenta", $"cliente{idCliente}", desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX del ledger: mismo rango, sin histórico, gate OperacionDePos heredado " +
+            "por co-locación.");
 
         return app;
     }

--- a/src/Ways.Api/Endpoints/VentasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/VentasEndpoints.cs
@@ -1,4 +1,9 @@
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Parametros;
 using Ways.Application.Ventas;
 using Ways.Domain.Ventas;
 
@@ -49,6 +54,42 @@ public static class VentasEndpoints
             CancellationToken ct) =>
             servicio.ListarAsync(idPuntoVenta, desde, hasta, idCliente, estado, pagina ?? 1, tamanio ?? 25, ct))
         .WithSummary("Lista comprobantes de venta con filtros y paginado.");
+
+        // stage-11-exportacion-reportes (Slice 3, design decisión 7): sibling declarado
+        // inmediatamente después de su ruta fuente — hereda OperacionDePos por co-locación, sin
+        // política propia. `desde`/`hasta` son OBLIGATORIOS acá (a diferencia del listado JSON):
+        // un export es por definición un rango acotado, y el nombre de archivo determinístico
+        // necesita ambas fechas (spec exportacion-de-reportes: XLSX Response Contract And
+        // Deterministic Naming).
+        grupo.MapGet("/export", async (
+            ServicioDeVentas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int? idPuntoVenta, DateTimeOffset desde, DateTimeOffset hasta, int? idCliente, EstadoComprobante? estado,
+            string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var filas = await servicio.ListarParaExportacionAsync(
+                idPuntoVenta, desde, hasta, idCliente, estado, opciones.Value.TopeDeFilas, ct);
+
+            var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
+            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
+            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);
+            var tabla = ExportacionDeListados.De(filas, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } pv ? $"pv{pv}" : "todos";
+            var nombre = NombreDeArchivo.Construir("ventas_listado", alcance, desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de GET /api/ventas: mismo filtro, sin paginado bajo el tope, gate " +
+            "OperacionDePos heredado por co-locación.");
 
         return app;
     }

--- a/src/Ways.Api/Exportacion/AlcanceDeListadoHttp.cs
+++ b/src/Ways.Api/Exportacion/AlcanceDeListadoHttp.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Parametros;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+
+namespace Ways.Api.Exportacion;
+
+/// <summary>
+/// stage-11-exportacion-reportes (Slice 3): resuelve Empresa/zona horaria para los exports de
+/// listado con <c>idPuntoVenta</c> opcional (ventas) — PV → empresa → default, misma precedencia
+/// que <c>ServicioDeReportesDeVentas.ResolverZonaAsync</c>, pero arrancando desde el punto de
+/// venta en vez de una empresa ya conocida: <c>GET /api/ventas</c> nunca pidió <c>idEmpresa</c>.
+/// Los listados sin ningún concepto de punto de venta (compras, estado de cuenta) usan
+/// <see cref="ZonaPorDefecto"/> directo, sin consulta — sus rutas fuente nunca tuvieron ese
+/// parámetro y esta slice solo extrae <c>ConstruirQuery</c>, no agrega filtros nuevos (design
+/// decisión 7).
+/// </summary>
+public static class AlcanceDeListadoHttp
+{
+    public static readonly string ZonaPorDefecto =
+        JsonSerializer.Deserialize<string>(ParametroConocido.ZonaHoraria.ValorPorDefecto)!;
+
+    public static async Task<(string Empresa, string ZonaId)> ResolverAsync(
+        IWaysDbContext db, ServicioDeParametros parametros, int? idPuntoVenta, CancellationToken ct)
+    {
+        if (idPuntoVenta is not { } id)
+        {
+            return ("Todas", ZonaPorDefecto);
+        }
+
+        var idEmpresa = await db.PuntosVenta
+            .Where(pv => pv.Id == id)
+            .Select(pv => (int?)pv.IdEmpresa)
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {id}.");
+
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, id, ct);
+        var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
+
+        return (idEmpresa.ToString(), zonaId);
+    }
+}

--- a/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
+++ b/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
@@ -23,9 +23,29 @@ public static class ContextoDeExportacionHttp
         DateOnly hasta,
         string zonaHoraria,
         string? cobertura = null) =>
+        Construir(
+            usuario, reloj, idEmpresa.ToString(), idPuntoVenta is { } id ? $"PV {id}" : null, desde, hasta,
+            zonaHoraria, cobertura);
+
+    /// <summary>
+    /// Sobrecarga genérica (stage-11, Slice 3): los exports de listado (ventas/compras/estado de
+    /// cuenta) no tienen un <c>idEmpresa</c> propio en su ruta fuente — a diferencia de los
+    /// reportes de gestión, esas rutas nunca lo pidieron. <paramref name="empresa"/> ya viene
+    /// resuelto como texto por el caller ("Todas" cuando el listado no está acotado a una sola
+    /// empresa, el id cuando sí).
+    /// </summary>
+    public static ContextoDeExportacion Construir(
+        IContextoDeUsuario usuario,
+        IRelojDelSistema reloj,
+        string empresa,
+        string? puntoVenta,
+        DateOnly desde,
+        DateOnly hasta,
+        string zonaHoraria,
+        string? cobertura = null) =>
         new(
-            Empresa: idEmpresa.ToString(),
-            PuntoVenta: idPuntoVenta is { } id ? $"PV {id}" : null,
+            Empresa: empresa,
+            PuntoVenta: puntoVenta,
             Desde: desde,
             Hasta: hasta,
             ZonaHoraria: zonaHoraria,

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
 using Ways.Application.Precios;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
@@ -56,6 +57,54 @@ public class ServicioDeCompras(
         pagina = Math.Max(pagina, 1);
         tamanio = Math.Clamp(tamanio, 1, 200);
 
+        var query = ConstruirQuery(idProveedor, estado, desde, hasta);
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(c => c.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(c => new CompraListada(c.Id, c.IdProveedor, c.IdTipoComprobante, c.NumeroExterno, c.Estado, c.FechaRecepcion, c.Total))
+            .ToListAsync(ct);
+
+        return new PaginaDeCompras(items, total, pagina, tamanio);
+    }
+
+    /// <summary>stage-11-exportacion-reportes (Slice 3, design decisión 7): mismo criterio que
+    /// <c>ServicioDeVentas.ListarParaExportacionAsync</c> — <see cref="ConstruirQuery"/>
+    /// compartido, <c>Contar → refuse → lectura única con <c>.Take(topeDeFilas + 1)</c></c>. El
+    /// segundo <see cref="GuardaDeTope.Exigir"/> es el backstop de carrera contra un
+    /// <c>COUNT(*)</c> desactualizado.</summary>
+    public async Task<IReadOnlyList<CompraListada>> ListarParaExportacionAsync(
+        int? idProveedor,
+        EstadoCompra? estado,
+        DateTimeOffset? desde,
+        DateTimeOffset? hasta,
+        int topeDeFilas,
+        CancellationToken ct = default)
+    {
+        var query = ConstruirQuery(idProveedor, estado, desde, hasta);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var items = await query
+            .OrderByDescending(c => c.Id)
+            .Take(topeDeFilas + 1)
+            .Select(c => new CompraListada(c.Id, c.IdProveedor, c.IdTipoComprobante, c.NumeroExterno, c.Estado, c.FechaRecepcion, c.Total))
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(items.Count, topeDeFilas);
+
+        return items;
+    }
+
+    /// <summary>Filtro compartido de <see cref="ListarAsync"/> y
+    /// <see cref="ListarParaExportacionAsync"/> (design decisión 7).</summary>
+    private IQueryable<ComprobanteCompra> ConstruirQuery(
+        int? idProveedor, EstadoCompra? estado, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
         var query = db.ComprobantesCompra.AsQueryable();
 
         if (idProveedor is { } p)
@@ -78,16 +127,7 @@ public class ServicioDeCompras(
             query = query.Where(c => c.FechaRecepcion <= h);
         }
 
-        var total = await query.CountAsync(ct);
-
-        var items = await query
-            .OrderByDescending(c => c.Id)
-            .Skip((pagina - 1) * tamanio)
-            .Take(tamanio)
-            .Select(c => new CompraListada(c.Id, c.IdProveedor, c.IdTipoComprobante, c.NumeroExterno, c.Estado, c.FechaRecepcion, c.Total))
-            .ToListAsync(ct);
-
-        return new PaginaDeCompras(items, total, pagina, tamanio);
+        return query;
     }
 
     // ---- borrador: crear + replace-set (design decisión 2) ---------------------------------------

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorriente.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.Exportacion;
 using Ways.Application.Ventas;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
@@ -189,21 +190,10 @@ public class ServicioDeCuentaCorriente(
             hastaEfectivo = hasta;
         }
 
-        var consulta = db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente);
-        if (desdeEfectivo is { } desdeAplicado)
-        {
-            consulta = consulta.Where(m => m.Fecha >= desdeAplicado);
-        }
-
-        if (hastaEfectivo is { } hastaAplicado)
-        {
-            consulta = consulta.Where(m => m.Fecha <= hastaAplicado);
-        }
-
         // Newest-first (legacy: `ORDER BY fecha DESC`, doc-01:375 — "saldo corriendo hacia atrás
         // desde el saldo actual") y convención de resumen bancario. El cómputo del saldo (columna
         // saldo_resultante persistida) es ortogonal a este orden de display.
-        var filas = await consulta
+        var filas = await ConstruirQuery(idCliente, desdeEfectivo, hastaEfectivo)
             .OrderByDescending(m => m.Fecha).ThenByDescending(m => m.Id)
             .Select(m => new
             {
@@ -218,6 +208,68 @@ public class ServicioDeCuentaCorriente(
             .ToList();
 
         return new EstadoDeCuenta(header, movimientos, historico, desdeEfectivo, hastaEfectivo);
+    }
+
+    /// <summary>
+    /// stage-11-exportacion-reportes (Slice 3, design decisión 7): export del ledger — sin
+    /// <c>histórico</c> (una exportación es por definición un rango acotado, el tope de filas es
+    /// exactamente lo que ese modo evita) y con <paramref name="desde"/>/<paramref name="hasta"/>
+    /// SIEMPRE explícitos, a diferencia de <see cref="ObtenerEstadoDeCuentaAsync"/> que puede
+    /// aplicar el default de último mes. Header calculado igual, ledger mismo
+    /// <see cref="ConstruirQuery"/> — <c>Contar → refuse → lectura única con
+    /// <c>.Take(topeDeFilas + 1)</c></c>.</summary>
+    public async Task<EstadoDeCuenta> ObtenerEstadoDeCuentaParaExportacionAsync(
+        int idCliente, DateTimeOffset desde, DateTimeOffset hasta, int topeDeFilas, CancellationToken ct = default)
+    {
+        var cliente = await ResolverClienteAsync(idCliente, ct);
+
+        var disponibilidad = CalculadorDeEstadoDeCuenta.CalcularDisponibilidad(
+            cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado);
+        var header = new EstadoDeCuentaHeader(cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado, disponibilidad);
+
+        var query = ConstruirQuery(idCliente, desde, hasta);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var filas = await query
+            .OrderByDescending(m => m.Fecha).ThenByDescending(m => m.Id)
+            .Take(topeDeFilas + 1)
+            .Select(m => new
+            {
+                m.Id, m.Fecha, m.Tipo, m.Importe, m.SaldoResultante, m.Detalle, m.IdComprobanteVenta
+            })
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(filas.Count, topeDeFilas);
+
+        var movimientos = filas
+            .Select(f => new MovimientoDeCuentaCorriente(
+                f.Id, f.Fecha, f.Tipo, f.Importe, f.SaldoResultante, f.Detalle, f.IdComprobanteVenta,
+                f.Tipo == TipoMovimientoCc.Ajuste ? CalculadorDeEstadoDeCuenta.EtiquetarAjuste(f.IdComprobanteVenta) : null))
+            .ToList();
+
+        return new EstadoDeCuenta(header, movimientos, Historico: false, desde, hasta);
+    }
+
+    /// <summary>Filtro compartido de <see cref="ObtenerEstadoDeCuentaAsync"/> y
+    /// <see cref="ObtenerEstadoDeCuentaParaExportacionAsync"/> (design decisión 7).</summary>
+    private IQueryable<MovimientoCuentaCorriente> ConstruirQuery(
+        int idCliente, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var consulta = db.MovimientosCuentaCorriente.Where(m => m.IdCliente == idCliente);
+
+        if (desde is { } desdeAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha >= desdeAplicado);
+        }
+
+        if (hasta is { } hastaAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha <= hastaAplicado);
+        }
+
+        return consulta;
     }
 
     private async Task<ComprobanteEmitido> EjecutarTransaccionAsync(

--- a/src/Ways.Application/Exportacion/ExportacionDeListados.cs
+++ b/src/Ways.Application/Exportacion/ExportacionDeListados.cs
@@ -1,0 +1,103 @@
+using Ways.Application.Compras;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Ventas;
+
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Mappers puros de un listado ya materializado (<see cref="Ventas.ServicioDeVentas.ListarParaExportacionAsync"/>,
+/// <see cref="Compras.ServicioDeCompras.ListarParaExportacionAsync"/>,
+/// <see cref="CuentaCorriente.ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaParaExportacionAsync"/>)
+/// a <see cref="TablaExportable"/> — la etapa 11 nunca vuelve a consultar la base para exportar
+/// (design decisión 11). <paramref name="zona"/> viaja aparte de <see cref="ContextoDeExportacion"/>
+/// porque este último solo lleva la ETIQUETA de zona para el encabezado (design: Interfaces/
+/// Contracts) — <see cref="Celda.FechaHora"/> necesita el <see cref="TimeZoneInfo"/> resuelto.
+/// </summary>
+public static class ExportacionDeListados
+{
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasVentas =
+    [
+        new ColumnaExportable("Número", TipoDeColumna.Texto),
+        new ColumnaExportable("Fecha", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Punto de venta", TipoDeColumna.Entero),
+        new ColumnaExportable("Cliente", TipoDeColumna.Entero),
+        new ColumnaExportable("Estado", TipoDeColumna.Texto),
+        new ColumnaExportable("Total", TipoDeColumna.Moneda)
+    ];
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasCompras =
+    [
+        new ColumnaExportable("Comprobante", TipoDeColumna.Texto),
+        new ColumnaExportable("Proveedor", TipoDeColumna.Entero),
+        new ColumnaExportable("Fecha de recepción", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Estado", TipoDeColumna.Texto),
+        new ColumnaExportable("Total", TipoDeColumna.Moneda)
+    ];
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasEstadoDeCuenta =
+    [
+        new ColumnaExportable("Fecha", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Tipo", TipoDeColumna.Texto),
+        new ColumnaExportable("Importe", TipoDeColumna.Moneda),
+        new ColumnaExportable("Saldo", TipoDeColumna.Moneda),
+        new ColumnaExportable("Detalle", TipoDeColumna.Texto)
+    ];
+
+    /// <summary>Una fila por comprobante — mismo shape que <c>GET /api/ventas</c> (sin items ni
+    /// pagos, el listado nunca los trajo).</summary>
+    public static TablaExportable De(IReadOnlyList<ComprobanteListado> filas, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var celdas = filas
+            .Select(f => (IReadOnlyList<Celda>)
+            [
+                Celda.Texto(f.NumeroVisible),
+                Celda.FechaHora(f.Fecha, zona),
+                Celda.Entero(f.IdPuntoVenta),
+                Celda.Entero(f.IdCliente),
+                Celda.Texto(f.Estado.ToString()),
+                Celda.Moneda(f.Total)
+            ])
+            .ToList();
+
+        return new TablaExportable("Ventas", ctx, ColumnasVentas, celdas);
+    }
+
+    /// <summary>Una fila por comprobante de compra — <see cref="CompraListada.NumeroExterno"/>
+    /// nulo (borrador sin numerar todavía) queda como <c>"-"</c>, nunca celda vacía: distingue
+    /// "sin numerar" de "sin dato" para quien filtra la columna.</summary>
+    public static TablaExportable De(IReadOnlyList<CompraListada> filas, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var celdas = filas
+            .Select(f => (IReadOnlyList<Celda>)
+            [
+                Celda.Texto(f.NumeroExterno ?? "-"),
+                Celda.Entero(f.IdProveedor),
+                Celda.FechaHora(f.FechaRecepcion, zona),
+                Celda.Texto(f.Estado.ToString()),
+                Celda.Moneda(f.Total)
+            ])
+            .ToList();
+
+        return new TablaExportable("Compras", ctx, ColumnasCompras, celdas);
+    }
+
+    /// <summary>Una fila por movimiento del ledger — mismo orden (newest-first) y misma fuente de
+    /// saldo (<c>saldo_resultante</c> persistido, nunca recalculado) que <c>GET
+    /// /api/clientes/{id}/cuenta-corriente</c>. <see cref="MovimientoDeCuentaCorriente.Detalle"/>
+    /// nulo (todo movimiento salvo un ajuste manual) queda como celda vacía.</summary>
+    public static TablaExportable De(IReadOnlyList<MovimientoDeCuentaCorriente> filas, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var celdas = filas
+            .Select(f => (IReadOnlyList<Celda>)
+            [
+                Celda.FechaHora(f.Fecha, zona),
+                Celda.Texto(f.Tipo.ToString()),
+                Celda.Moneda(f.Importe),
+                Celda.Moneda(f.SaldoResultante),
+                Celda.Texto(f.Detalle)
+            ])
+            .ToList();
+
+        return new TablaExportable("Estado de cuenta", ctx, ColumnasEstadoDeCuenta, celdas);
+    }
+}

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
 using Ways.Application.CuentaCorriente;
+using Ways.Application.Exportacion;
 using Ways.Application.Ofertas;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
@@ -239,6 +240,73 @@ public class ServicioDeVentas(
         pagina = Math.Max(pagina, 1);
         tamanio = Math.Clamp(tamanio, 1, 200);
 
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta, idCliente, estado);
+
+        var total = await query.CountAsync(ct);
+
+        var crudos = await query
+            .OrderByDescending(c => c.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(c => new { c.Id, c.Numero, c.Estado, c.Fecha, c.IdPuntoVenta, c.IdCliente, c.Total })
+            .ToListAsync(ct);
+
+        // NumeroDeComprobante.Formatear no traduce a SQL: se arma en memoria, después de traer
+        // la página ya paginada/filtrada (nunca antes — evita materializar todo el listado).
+        var items = crudos
+            .Select(c => new ComprobanteListado(
+                c.Id, c.Numero, NumeroDeComprobante.Formatear(c.IdPuntoVenta, c.Numero), c.Estado, c.Fecha,
+                c.IdPuntoVenta, c.IdCliente, c.Total))
+            .ToList();
+
+        return new PaginaDeVentas(items, total, pagina, tamanio);
+    }
+
+    /// <summary>
+    /// stage-11-exportacion-reportes (Slice 3, design decisión 7): mismo <see cref="ConstruirQuery"/>
+    /// que <see cref="ListarAsync"/>, nunca un predicado redeclarado — <c>Contar → refuse →
+    /// lectura única con <c>.Take(topeDeFilas + 1)</c></c>, jamás paginada. El segundo
+    /// <see cref="GuardaDeTope.Exigir"/> es el backstop de carrera: si la lectura trae
+    /// <c>topeDeFilas + 1</c> filas, el <c>COUNT(*)</c> de arriba quedó desactualizado (una fila
+    /// se insertó entre las dos consultas) y esta exportación rechaza en vez de devolver un
+    /// archivo truncado (mutation-proof-tests: "no truncated file can escape even in that
+    /// window").
+    /// </summary>
+    public async Task<IReadOnlyList<ComprobanteListado>> ListarParaExportacionAsync(
+        int? idPuntoVenta,
+        DateTimeOffset? desde,
+        DateTimeOffset? hasta,
+        int? idCliente,
+        EstadoComprobante? estado,
+        int topeDeFilas,
+        CancellationToken ct = default)
+    {
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta, idCliente, estado);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var crudos = await query
+            .OrderByDescending(c => c.Fecha)
+            .Take(topeDeFilas + 1)
+            .Select(c => new { c.Id, c.Numero, c.Estado, c.Fecha, c.IdPuntoVenta, c.IdCliente, c.Total })
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(crudos.Count, topeDeFilas);
+
+        return crudos
+            .Select(c => new ComprobanteListado(
+                c.Id, c.Numero, NumeroDeComprobante.Formatear(c.IdPuntoVenta, c.Numero), c.Estado, c.Fecha,
+                c.IdPuntoVenta, c.IdCliente, c.Total))
+            .ToList();
+    }
+
+    /// <summary>Filtro compartido de <see cref="ListarAsync"/> y
+    /// <see cref="ListarParaExportacionAsync"/> (design decisión 7): un solo lugar declara el
+    /// predicado, nunca dos copias que puedan derivar.</summary>
+    private IQueryable<ComprobanteVenta> ConstruirQuery(
+        int? idPuntoVenta, DateTimeOffset? desde, DateTimeOffset? hasta, int? idCliente, EstadoComprobante? estado)
+    {
         var query = db.ComprobantesVenta.AsQueryable();
 
         if (idPuntoVenta is { } pv)
@@ -266,24 +334,7 @@ public class ServicioDeVentas(
             query = query.Where(c => c.Estado == e);
         }
 
-        var total = await query.CountAsync(ct);
-
-        var crudos = await query
-            .OrderByDescending(c => c.Fecha)
-            .Skip((pagina - 1) * tamanio)
-            .Take(tamanio)
-            .Select(c => new { c.Id, c.Numero, c.Estado, c.Fecha, c.IdPuntoVenta, c.IdCliente, c.Total })
-            .ToListAsync(ct);
-
-        // NumeroDeComprobante.Formatear no traduce a SQL: se arma en memoria, después de traer
-        // la página ya paginada/filtrada (nunca antes — evita materializar todo el listado).
-        var items = crudos
-            .Select(c => new ComprobanteListado(
-                c.Id, c.Numero, NumeroDeComprobante.Formatear(c.IdPuntoVenta, c.Numero), c.Estado, c.Fecha,
-                c.IdPuntoVenta, c.IdCliente, c.Total))
-            .ToList();
-
-        return new PaginaDeVentas(items, total, pagina, tamanio);
+        return query;
     }
 
     // ---- Anulación (Slice 5, design: Protection Rules — "A comprobante is anulado at most

--- a/tests/Ways.Application.Tests/Exportacion/ExportacionDeListadosTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/ExportacionDeListadosTests.cs
@@ -1,0 +1,125 @@
+using Ways.Application.Compras;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Exportacion;
+using Ways.Application.Ventas;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 3: reglas de mapeo de <see cref="ExportacionDeListados"/> —
+/// DB-free, mismo criterio (<c>PoliticaDeRoles</c>) que el resto de <c>Application.Tests</c>. Cubre
+/// las reglas de <c>null</c> que cada mapper documenta (Detalle vacío, sentinela <c>"-"</c> de
+/// <c>NumeroExterno</c>) y la conversión de <see cref="Celda.FechaHora"/> (design decisión 3:
+/// <see cref="DateTimeOffset"/> → hora local sin offset).
+/// </summary>
+public class ExportacionDeListadosTests
+{
+    private static readonly TimeZoneInfo ZonaBuenosAires = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
+
+    private static readonly ContextoDeExportacion Contexto = new(
+        Empresa: "1",
+        PuntoVenta: null,
+        Desde: new DateOnly(2026, 8, 1),
+        Hasta: new DateOnly(2026, 8, 1),
+        ZonaHoraria: "America/Argentina/Buenos_Aires",
+        Usuario: "admin@ways.test",
+        GeneradoEl: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
+        Cobertura: null);
+
+    // ---- Ventas ------------------------------------------------------------------------------
+
+    [Fact]
+    public void VentasConvierteLaFechaALaZonaLocalYDescartaElOffset()
+    {
+        var instante = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var fila = new ComprobanteListado(1, 1L, "0001-00000001", EstadoComprobante.Emitido, instante, 1, 1, 100m);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[0][1].Valor);
+    }
+
+    // ---- Compras -------------------------------------------------------------------------------
+
+    [Fact]
+    public void ComprasConNumeroExternoNuloQuedaComoElSentinela()
+    {
+        var fila = new CompraListada(1, 1, 1, null, EstadoCompra.Borrador, null, 500m);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal("-", tabla.Filas[0][0].Valor);
+    }
+
+    [Fact]
+    public void ComprasConNumeroExternoPasaElTextoTalCual()
+    {
+        var fila = new CompraListada(1, 1, 1, "0001-00000042", EstadoCompra.Confirmada, null, 500m);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal("0001-00000042", tabla.Filas[0][0].Valor);
+    }
+
+    [Fact]
+    public void ComprasConvierteLaFechaDeRecepcionALaZonaLocalYDescartaElOffset()
+    {
+        var instante = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var fila = new CompraListada(1, 1, 1, "0001-00000001", EstadoCompra.Confirmada, instante, 500m);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[0][2].Valor);
+    }
+
+    [Fact]
+    public void ComprasConFechaDeRecepcionNulaQuedaComoCeldaVacia()
+    {
+        var fila = new CompraListada(1, 1, 1, "0001-00000001", EstadoCompra.Borrador, null, 500m);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Null(tabla.Filas[0][2].Valor);
+    }
+
+    // ---- Estado de cuenta -----------------------------------------------------------------------
+
+    [Fact]
+    public void EstadoDeCuentaConDetalleNuloQuedaComoCeldaVacia()
+    {
+        var fila = new MovimientoDeCuentaCorriente(
+            1, new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero), TipoMovimientoCc.Consumo, 100m, 100m,
+            null, null, null);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Null(tabla.Filas[0][4].Valor);
+    }
+
+    [Fact]
+    public void EstadoDeCuentaConDetallePasaElTextoTalCual()
+    {
+        var fila = new MovimientoDeCuentaCorriente(
+            1, new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero), TipoMovimientoCc.Ajuste, 100m, 100m,
+            "Ajuste de prueba", null, EtiquetaDeAjuste.Manual);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal("Ajuste de prueba", tabla.Filas[0][4].Valor);
+    }
+
+    [Fact]
+    public void EstadoDeCuentaConvierteLaFechaALaZonaLocalYDescartaElOffset()
+    {
+        var instante = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var fila = new MovimientoDeCuentaCorriente(
+            1, instante, TipoMovimientoCc.Consumo, 100m, 100m, null, null, null);
+
+        var tabla = ExportacionDeListados.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[0][0].Valor);
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
@@ -152,6 +152,7 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < pagina.Items.Count; i++)
         {
@@ -159,6 +160,7 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
             var fila = hoja.Row(primeraFilaDeDatos + i);
             Assert.Equal(item.NumeroExterno, fila.Cell(1).GetString());
             Assert.Equal(item.IdProveedor, fila.Cell(2).GetValue<int>());
+            Assert.Equal(TimeZoneInfo.ConvertTime(item.FechaRecepcion!.Value, zona).DateTime, fila.Cell(3).GetValue<DateTime>());
             Assert.Equal(item.Estado.ToString(), fila.Cell(4).GetString());
             Assert.Equal(item.Total, fila.Cell(5).GetValue<decimal>());
         }

--- a/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Proveedores;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 3: <c>GET /api/compras/export</c> — mismo patrón de
+/// <c>ConstruirQuery</c> compartido que <c>VentasListadoExportTests</c>, sin
+/// <c>idPuntoVenta</c> (el listado JSON de compras tampoco lo tiene): Empresa/zona usan el
+/// default de <c>AlcanceDeListadoHttp</c>. El backstop de carrera del <c>+1</c> se prueba una
+/// sola vez para toda la slice, en <c>VentasListadoExportTests</c> (design decisión de la
+/// slice: la única query real de tipo COUNT contra la que compras/estado-de-cuenta compartirían
+/// el mismo mecanismo, ya cubierto).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Root, int IdProveedor, int IdTipoCFA,
+        int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var rootLogueado = factory.CreateClient();
+        var reloginRoot = await rootLogueado.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, reloginRoot.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, rootLogueado, proveedor.Id, idTipoCFA,
+            resultado.IdUsuarioAdmin);
+    }
+
+    /// <summary>Siembra directo en estado <c>Confirmada</c> — sin pasar por
+    /// <c>ServicioDeCompras</c>, mismo criterio que las siembras directas de reportes. Fecha fija
+    /// a mediodía UTC.</summary>
+    private async Task SembrarCompraAsync(Contexto ctx, DateOnly fecha, decimal total, string numeroExterno)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var mediodia = new DateTimeOffset(fecha.Year, fecha.Month, fecha.Day, 12, 0, 0, TimeSpan.Zero);
+
+        db.ComprobantesCompra.Add(new ComprobanteCompra
+        {
+            IdTenant = ctx.IdTenant,
+            IdProveedor = ctx.IdProveedor,
+            IdTipoComprobante = ctx.IdTipoCFA,
+            NumeroExterno = numeroExterno,
+            FechaComprobante = fecha,
+            FechaRecepcion = mediodia,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoCompra.Confirmada,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static string ConstruirQuery(DateOnly desde, DateOnly hasta, string? formato) =>
+        $"desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarListadoAsync(HttpClient cliente, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/compras?{ConstruirQuery(desde, hasta, null)}&tamanio=200");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/compras/export?{ConstruirQuery(desde, hasta, formato)}");
+
+    // ---- task 3.5: la exportación es igual al listado JSON --------------------------------------
+
+    [Fact]
+    public async Task ElExportEsIgualAlListadoJsonParaLosMismosParametros()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlListadoJsonParaLosMismosParametros), fixture);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+
+        await SembrarCompraAsync(ctx, desde, 500m, "0001-00000001");
+        await SembrarCompraAsync(ctx, hasta, 300m, "0001-00000002");
+
+        var jsonRespuesta = await LlamarListadoAsync(ctx.Admin, desde, hasta);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var pagina = JsonSerializer.Deserialize<PaginaDeCompras>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(2, pagina.Items.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, desde, hasta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < pagina.Items.Count; i++)
+        {
+            var item = pagina.Items[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(item.NumeroExterno, fila.Cell(1).GetString());
+            Assert.Equal(item.IdProveedor, fila.Cell(2).GetValue<int>());
+            Assert.Equal(item.Estado.ToString(), fila.Cell(4).GetString());
+            Assert.Equal(item.Total, fila.Cell(5).GetValue<decimal>());
+        }
+    }
+
+    // ---- task 3.6: 403 para el rol excluido de OperacionDePos ------------------------------------
+
+    [Fact]
+    public async Task UnRootEsRechazadoDelExportDeCompras()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDelExportDeCompras), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Root, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 3.7: rechazo por tope ---------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await SembrarCompraAsync(ctx, dia, 100m + i, $"0001-0000000{i}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, dia, dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+}

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.CuentaCorriente;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 3: <c>GET /api/clientes/{id}/cuenta-corriente/export</c>
+/// — mismo patrón de <c>ConstruirQuery</c> compartido que <c>VentasListadoExportTests</c>. Sin
+/// <c>histórico</c>: un export es por definición un rango acotado (design decisión 7), lo que
+/// <c>histórico</c> deliberadamente evita, así que la ruta lo excluye y <c>desde</c>/<c>hasta</c>
+/// son siempre obligatorios acá.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Root, int IdCliente, int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var rootLogueado = factory.CreateClient();
+        var reloginRoot = await rootLogueado.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, reloginRoot.StatusCode);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, rootLogueado, idCliente, resultado.IdUsuarioAdmin);
+    }
+
+    /// <summary>Siembra un ajuste manual directo — sin pasar por <c>ServicioDeCuentaCorriente</c>,
+    /// mismo criterio que las otras siembras directas de esta slice. Fecha fija a mediodía UTC.</summary>
+    private async Task SembrarMovimientoAsync(Contexto ctx, DateOnly fecha, decimal importe, decimal saldoResultante)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var mediodia = new DateTimeOffset(fecha.Year, fecha.Month, fecha.Day, 12, 0, 0, TimeSpan.Zero);
+
+        db.MovimientosCuentaCorriente.Add(new MovimientoCuentaCorriente
+        {
+            IdTenant = ctx.IdTenant,
+            IdCliente = ctx.IdCliente,
+            Fecha = mediodia,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            Tipo = TipoMovimientoCc.Ajuste,
+            Importe = importe,
+            SaldoResultante = saldoResultante,
+            Detalle = "Ajuste de prueba"
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static string ConstruirQuery(DateOnly desde, DateOnly hasta, string? formato) =>
+        $"desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarEstadoDeCuentaAsync(
+        HttpClient cliente, int idCliente, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/clientes/{idCliente}/cuenta-corriente?{ConstruirQuery(desde, hasta, null)}");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, int idCliente, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/clientes/{idCliente}/cuenta-corriente/export?{ConstruirQuery(desde, hasta, formato)}");
+
+    // ---- task 3.5: la exportación es igual al estado de cuenta JSON -----------------------------
+
+    [Fact]
+    public async Task ElExportEsIgualAlEstadoDeCuentaJsonParaLosMismosParametros()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlEstadoDeCuentaJsonParaLosMismosParametros), fixture);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+
+        await SembrarMovimientoAsync(ctx, desde, 500m, 500m);
+        await SembrarMovimientoAsync(ctx, hasta, -200m, 300m);
+
+        var jsonRespuesta = await LlamarEstadoDeCuentaAsync(ctx.Admin, ctx.IdCliente, desde, hasta);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var estado = JsonSerializer.Deserialize<EstadoDeCuenta>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(2, estado.Movimientos.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdCliente, desde, hasta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < estado.Movimientos.Count; i++)
+        {
+            var movimiento = estado.Movimientos[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(movimiento.Tipo.ToString(), fila.Cell(2).GetString());
+            Assert.Equal(movimiento.Importe, fila.Cell(3).GetValue<decimal>());
+            Assert.Equal(movimiento.SaldoResultante, fila.Cell(4).GetValue<decimal>());
+        }
+    }
+
+    // ---- task 3.6: 403 para el rol excluido de OperacionDePos ------------------------------------
+
+    [Fact]
+    public async Task UnRootEsRechazadoDelExportDeEstadoDeCuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDelExportDeEstadoDeCuenta), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Root, ctx.IdCliente, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 3.7: rechazo por tope ---------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+        var saldo = 0m;
+
+        for (var i = 0; i < 4; i++)
+        {
+            saldo += 100m;
+            await SembrarMovimientoAsync(ctx, dia, 100m, saldo);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdCliente, dia, dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+}

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
@@ -125,14 +125,17 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < estado.Movimientos.Count; i++)
         {
             var movimiento = estado.Movimientos[i];
             var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(TimeZoneInfo.ConvertTime(movimiento.Fecha, zona).DateTime, fila.Cell(1).GetValue<DateTime>());
             Assert.Equal(movimiento.Tipo.ToString(), fila.Cell(2).GetString());
             Assert.Equal(movimiento.Importe, fila.Cell(3).GetValue<decimal>());
             Assert.Equal(movimiento.SaldoResultante, fila.Cell(4).GetValue<decimal>());
+            Assert.Equal(movimiento.Detalle, fila.Cell(5).GetString());
         }
     }
 

--- a/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
@@ -1,0 +1,301 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 3: <c>GET /api/ventas/export</c> — el primer export de
+/// tipo LISTADO (a diferencia de los agregados de Slice 1b/2), donde <c>GuardaDeTope</c> corre
+/// dos veces: sobre el <c>COUNT(*)</c> y sobre la lectura de <c>.Take(tope + 1)</c> (design
+/// decisión 7). Mismo patrón de fixture propia por <c>WithWebHostBuilder</c> que
+/// <c>ReportesVentasResumenExportTests</c> — <c>OpcionesDeExportacion.TopeDeFilas</c> pisado por
+/// prueba.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private static long _numeroSecuencial = 1;
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Root, int IdCliente,
+        int IdEmpleadoAdmin, int IdTipoComprobanteTx);
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var rootLogueado = factory.CreateClient();
+        var reloginRoot = await rootLogueado.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, reloginRoot.StatusCode);
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idCliente = await dbTenant.Clientes.Select(c => c.Id).FirstAsync();
+
+        await using var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTipoComprobanteTx = await dbPlataforma.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, rootLogueado, idCliente, resultado.IdUsuarioAdmin,
+            idTipoComprobanteTx);
+    }
+
+    /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
+    /// <c>ReportesVentasResumenExportTests.SembrarComprobanteAsync</c>. Fecha fija a mediodía UTC
+    /// (evita la ventana 00-03 UTC que corre el día en zonas horarias -03).</summary>
+    private async Task SembrarComprobanteAsync(Contexto ctx, DateOnly fecha, decimal total)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var mediodia = new DateTimeOffset(fecha.Year, fecha.Month, fecha.Day, 12, 0, 0, TimeSpan.Zero);
+
+        db.ComprobantesVenta.Add(new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant,
+            IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial),
+            Fecha = mediodia,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            IdCliente = ctx.IdCliente,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato) =>
+        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarListadoAsync(
+        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/ventas?{ConstruirQuery(idPuntoVenta, desde, hasta, null)}&tamanio=200");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/ventas/export?{ConstruirQuery(idPuntoVenta, desde, hasta, formato)}");
+
+    // ---- task 3.5: la exportación es igual al listado JSON --------------------------------------
+
+    [Fact]
+    public async Task ElExportEsIgualAlListadoJsonParaLosMismosParametros()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlListadoJsonParaLosMismosParametros), fixture);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+
+        await SembrarComprobanteAsync(ctx, desde, 100m);
+        await SembrarComprobanteAsync(ctx, desde, 50m);
+        await SembrarComprobanteAsync(ctx, hasta, 200m);
+
+        var jsonRespuesta = await LlamarListadoAsync(ctx.Admin, ctx.IdPuntoVenta, desde, hasta);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var pagina = JsonSerializer.Deserialize<PaginaDeVentas>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(3, pagina.Items.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, desde, hasta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden que el listado
+        // JSON (newest-first, ver ServicioDeVentas.ConstruirQuery).
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < pagina.Items.Count; i++)
+        {
+            var item = pagina.Items[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(item.NumeroVisible, fila.Cell(1).GetString());
+            Assert.Equal(item.IdPuntoVenta, fila.Cell(3).GetValue<int>());
+            Assert.Equal(item.IdCliente, fila.Cell(4).GetValue<int>());
+            Assert.Equal(item.Estado.ToString(), fila.Cell(5).GetString());
+            Assert.Equal(item.Total, fila.Cell(6).GetValue<decimal>());
+        }
+    }
+
+    // ---- task 3.6: 403 para el rol excluido de OperacionDePos ------------------------------------
+
+    [Fact]
+    public async Task UnRootEsRechazadoDelExportDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDelExportDeVentas), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Root, ctx.IdPuntoVenta, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 3.7: rechazo por tope (COUNT real, no una serie gap-filled) ------------------------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await SembrarComprobanteAsync(ctx, dia, 100m + i);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    // ---- task 3.8: backstop de carrera del `+1` (mutation-proof-tests) ---------------------------
+
+    /// <summary>
+    /// Simula la carrera que el <c>+1</c> de <c>.Take(topeDeFilas + 1)</c> existe para atrapar:
+    /// un <c>COUNT(*)</c> que ve <c>tope</c> filas (pasa la primera <see cref="GuardaDeTope.Exigir"/>)
+    /// seguido de una fila insertada ANTES de la lectura — sin coordinar dos requests HTTP reales
+    /// (no reproducible de forma determinística), un <c>DbCommandInterceptor</c> intercepta la
+    /// SEGUNDA consulta que toca <c>comprobantes_venta</c> (la lectura <c>.Take(tope + 1)</c>) e
+    /// inserta la fila extra JUSTO ANTES de dejarla correr — mismo patrón de rendezvous que
+    /// <c>ParametrosTests.InterceptorDeRendezVous</c>, aplicado acá a una carrera de un solo
+    /// participante (el interceptor mismo hace de "segundo escritor").
+    /// Mutación aplicada (design decisión 7, <c>ServicioDeVentas.ListarParaExportacionAsync</c>):
+    /// <c>.Take(topeDeFilas + 1)</c> reemplazado por <c>.Take(topeDeFilas)</c> — esta prueba pasó
+    /// de FALLAR (200 con 3 filas, el archivo truncado escapaba) a pasar al revertir. Evidencia
+    /// registrada en el cuerpo del PR.
+    /// </summary>
+    [Fact]
+    public async Task UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion()
+    {
+        var gate = new SemaphoreSlim(0, 1);
+        Contexto? ctxRef = null;
+        DateOnly dia = default;
+
+        var interceptor = new InterceptorDeCarreraDeExportacion(async () =>
+        {
+            if (ctxRef is null)
+            {
+                return;
+            }
+
+            await SembrarComprobanteAsync(ctxRef, dia, 999m);
+            gate.Release();
+        });
+
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+            {
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3);
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor));
+            }));
+
+        var ctx = await PrepararAsync(nameof(UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion), factoryBajo);
+        dia = new DateOnly(2026, 8, 1);
+        ctxRef = ctx;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarComprobanteAsync(ctx, dia, 100m + i);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+
+        Assert.True(await gate.WaitAsync(TimeSpan.FromSeconds(10)), "El interceptor de carrera nunca insertó la fila extra.");
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Retiene la SEGUNDA consulta que toca <c>comprobantes_venta</c> (la lectura
+    /// <c>.Take(tope + 1)</c> — la primera es el <c>COUNT(*)</c>) e inyecta <paramref
+    /// name="alSegundaConsulta"/> antes de dejarla correr. Cubre tanto <c>ReaderExecutingAsync</c>
+    /// como <c>ScalarExecutingAsync</c>: si <c>CountAsync</c> se traduce a un escalar en vez de un
+    /// reader, el contador compartido sigue contando en orden.</summary>
+    private sealed class InterceptorDeCarreraDeExportacion(Func<Task> alSegundaConsulta) : DbCommandInterceptor
+    {
+        private int _coincidencias;
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            await ConsiderarAsync(command);
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            await ConsiderarAsync(command);
+            return await base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        private async Task ConsiderarAsync(DbCommand command)
+        {
+            if (!command.CommandText.Contains("comprobantes_venta", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _coincidencias) == 2)
+            {
+                await alSegundaConsulta();
+            }
+        }
+    }
+}

--- a/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
@@ -82,13 +82,13 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
     /// <summary>Siembra directo, sin pasar por <c>ServicioDeVentas</c> — mismo criterio que
     /// <c>ReportesVentasResumenExportTests.SembrarComprobanteAsync</c>. Fecha fija a mediodía UTC
     /// (evita la ventana 00-03 UTC que corre el día en zonas horarias -03).</summary>
-    private async Task SembrarComprobanteAsync(Contexto ctx, DateOnly fecha, decimal total)
+    private async Task<int> SembrarComprobanteAsync(Contexto ctx, DateOnly fecha, decimal total)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         var ahora = DateTimeOffset.UtcNow;
         var mediodia = new DateTimeOffset(fecha.Year, fecha.Month, fecha.Day, 12, 0, 0, TimeSpan.Zero);
 
-        db.ComprobantesVenta.Add(new ComprobanteVenta
+        var comprobante = new ComprobanteVenta
         {
             IdTenant = ctx.IdTenant,
             IdTipoComprobante = ctx.IdTipoComprobanteTx,
@@ -103,21 +103,25 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
             Estado = EstadoComprobante.Emitido,
             CreatedAt = ahora,
             UpdatedAt = ahora
-        });
+        };
+        db.ComprobantesVenta.Add(comprobante);
         await db.SaveChangesAsync();
+
+        return comprobante.Id;
     }
 
-    private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato) =>
+    private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato, EstadoComprobante? estado = null) =>
         $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
-        (formato is null ? string.Empty : $"&formato={formato}");
+        (formato is null ? string.Empty : $"&formato={formato}") +
+        (estado is null ? string.Empty : $"&estado={estado}");
 
     private static Task<HttpResponseMessage> LlamarListadoAsync(
-        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta) =>
-        cliente.GetAsync($"/api/ventas?{ConstruirQuery(idPuntoVenta, desde, hasta, null)}&tamanio=200");
+        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta, EstadoComprobante? estado = null) =>
+        cliente.GetAsync($"/api/ventas?{ConstruirQuery(idPuntoVenta, desde, hasta, null, estado)}&tamanio=200");
 
     private static Task<HttpResponseMessage> LlamarExportAsync(
-        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
-        cliente.GetAsync($"/api/ventas/export?{ConstruirQuery(idPuntoVenta, desde, hasta, formato)}");
+        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta, string formato = "xlsx", EstadoComprobante? estado = null) =>
+        cliente.GetAsync($"/api/ventas/export?{ConstruirQuery(idPuntoVenta, desde, hasta, formato, estado)}");
 
     // ---- task 3.5: la exportación es igual al listado JSON --------------------------------------
 
@@ -147,17 +151,52 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
 
         // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden que el listado
         // JSON (newest-first, ver ServicioDeVentas.ConstruirQuery).
+        var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < pagina.Items.Count; i++)
         {
             var item = pagina.Items[i];
             var fila = hoja.Row(primeraFilaDeDatos + i);
             Assert.Equal(item.NumeroVisible, fila.Cell(1).GetString());
+            Assert.Equal(TimeZoneInfo.ConvertTime(item.Fecha, zona).DateTime, fila.Cell(2).GetValue<DateTime>());
             Assert.Equal(item.IdPuntoVenta, fila.Cell(3).GetValue<int>());
             Assert.Equal(item.IdCliente, fila.Cell(4).GetValue<int>());
             Assert.Equal(item.Estado.ToString(), fila.Cell(5).GetString());
             Assert.Equal(item.Total, fila.Cell(6).GetValue<decimal>());
         }
+    }
+
+    /// <summary>
+    /// Cubre el filtro <c>estado</c> compartido por <c>ServicioDeVentas.ConstruirQuery</c> — sin
+    /// esta prueba, borrar el bloque <c>if (estado is { } e)</c> no lo detecta ninguna de las
+    /// otras equality tests (ninguna filtra por estado). Mutación aplicada: borrar el bloque del
+    /// filtro de estado en <c>ConstruirQuery</c> → esta prueba pasa de FALLAR (el anulado aparece
+    /// en ambas respuestas) a pasar al revertir.
+    /// </summary>
+    [Fact]
+    public async Task ElFiltroDeEstadoExcluyeElAnuladoTantoEnElListadoComoEnElExport()
+    {
+        var ctx = await PrepararAsync(nameof(ElFiltroDeEstadoExcluyeElAnuladoTantoEnElListadoComoEnElExport), fixture);
+        var dia = new DateOnly(2026, 8, 1);
+
+        await SembrarComprobanteAsync(ctx, dia, 100m);
+        var idAnulado = await SembrarComprobanteAsync(ctx, dia, 200m);
+        var anulacion = await ctx.Admin.PostAsync($"/api/ventas/{idAnulado}/anulacion", null);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var jsonRespuesta = await LlamarListadoAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia, EstadoComprobante.Emitido);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var pagina = JsonSerializer.Deserialize<PaginaDeVentas>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Single(pagina.Items);
+        Assert.DoesNotContain(pagina.Items, i => i.Id == idAnulado);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia, estado: EstadoComprobante.Emitido);
+        Assert.Equal(HttpStatusCode.OK, exportRespuesta.StatusCode);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+        Assert.Equal(pagina.Items[0].NumeroVisible, hoja.Row(7).Cell(1).GetString());
+        Assert.Empty(hoja.Row(8).Cell(1).GetString());
     }
 
     // ---- task 3.6: 403 para el rol excluido de OperacionDePos ------------------------------------


### PR DESCRIPTION
## Etapa 11, slice 3 — Exports de listados

Ventas, compras y estado de cuenta ganan su `/export`, con la mecanica que el design exigia para listados:

- `ConstruirQuery` extraido en los 3 servicios (los listados JSON byte-verdes — verificado predicado por predicado por el juez y con barrido de regresion de 340 tests).
- COUNT(*)-first → rechazo 400 con el conteo real ANTES de materializar nada; `.Take(tope+1)` como backstop de la carrera conteo/lectura, probado con un `DbCommandInterceptor` que inserta la fila entre las dos queries — determinista, no cronometrado.
- `AlcanceDeListadoHttp` para rutas sin idEmpresa ("Todas" + zona default — honesto porque el query realmente abarca todo el tenant); `desde/hasta` obligatorios en el export (nombre determinista).

### Review
Judgment-day de 2 rondas: Juez A REJECT ronda 1 (MAJOR real — reglas de null de los mappers sin NINGUN test, ni unitario ni de integracion; FechaHora jamas asertada), Juez B APPROVE-WITH-MINORS (backstop y igualdad por celda genuinos; 2 WARNINGs: fecha +10 dias sobrevivia, filtro estado mutation-invisible en AMBOS lados). Fix batch `8692f1c` test-only (8 unit tests de mapper + columnas completas + test de estado con doble verificacion JSON/export) → ronda 2: doble APPROVE re-ejecutando las mutaciones.

### Size
`size:exception` — ~1214 lineas vs ~350: el interceptor del race y la profundidad de tests son el slice.

### Tests
Application 251/251 (243+8) · export filters 11/11 · full suite en el merge secuencial

🤖 Generated with [Claude Code](https://claude.com/claude-code)