### PR TITLE
feat(web): plomeria de descarga con funnel de errores (etapa 11, slice 4)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -387,46 +387,61 @@ mutation evidence.
 buttons. **Rollback**: revert the branch; buttons disappear, no route or
 policy touched.
 
-- [ ] 4.1 Modify `src/Ways.Web/src/api/cliente.ts`: extract
+- [x] 4.1 Modify `src/Ways.Web/src/api/cliente.ts`: extract
   `exigirRespuestaOk(respuesta)` out of `pedir` (`:52-69`) so both `pedir`
   and the new `descargar` share the 401/`ErrorApi` path. *(design decision
   12)*
-- [ ] 4.2 Modify `cliente.ts`: `api.descargar(ruta)` — `fetch` + blob,
+- [x] 4.2 Modify `cliente.ts`: `api.descargar(ruta)` — `fetch` + blob,
   `credentials: 'include'`, calls `exigirRespuestaOk`, reads the file name
   from `Content-Disposition` (`filename*` wins over `filename`), triggers a
   synthetic `<a>` click, revokes the object URL in a `setTimeout(…, 0)`
   after the click (not synchronously — revoking same-tick cancels the
   download in some browsers). *(proposal decision 8; design decision 12;
   design Open Questions — revoke timing)*
-- [ ] 4.3 Create `src/Ways.Web/src/componentes/BotonDeDescarga.tsx`: busy +
+- [x] 4.3 Create `src/Ways.Web/src/componentes/BotonDeDescarga.tsx`: busy +
   re-entrancy guard (disabled while in flight, exactly one `fetch` per
   click even under a double-click), errors funnelled out via `onError`
   surfacing `ErrorApi.message`. *(proposal decision 8 — "a download that
   silently does nothing is this pattern's worst failure mode")*
-- [ ] 4.4 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: wire
+- [x] 4.4 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: wire
   `BotonDeDescarga` into the existing ventas/gastos/rentabilidad panels,
   each pointing at its report's `/export` route. No new nav entry.
-- [ ] 4.5 [P] `descargar` happy path: object URL created **and** revoked
+  — **APPLY-RUN NOTE**: `rutasDeExportacion` (route-builder helpers, mirroring
+  `construirQueryDeReporte`) added to `reportes.ts` to build each panel's
+  `/export?…&formato=xlsx` route; ventas/gastos share the card's own
+  `errorDescarga` state (separate from the load `error`, so the "Reintentar"
+  button never appears next to a download failure), rentabilidad owns its
+  local `errorDescarga`. Comisiones panel intentionally left unwired — out of
+  this slice's scope per this task's literal panel list.
+- [x] 4.5 [P] `descargar` happy path: object URL created **and** revoked
   (flush timers to assert the revoke, per the design's Open Questions
   note).
-- [ ] 4.6 [P] **403 → `onError` funnel test**: `descargar` on a
+- [x] 4.6 [P] **403 → `onError` funnel test**: `descargar` on a
   403-returning route surfaces `ErrorApi.message` via `onError`, creates no
   object URL, and does **not** navigate the SPA away. *(proposal decision 8
   — the SPA-navigation failure mode)*
-- [ ] 4.7 [P] **401 → `alPerderLaSesion` funnel test**: `descargar` on a
+- [x] 4.7 [P] **401 → `alPerderLaSesion` funnel test**: `descargar` on a
   401-returning route fires the existing `alPerderLaSesion` observer, same
   as `pedir`.
-- [ ] 4.8 [P] **400 → panel error state test**: a cap-refusal 400 surfaces
+- [x] 4.8 [P] **400 → panel error state test**: a cap-refusal 400 surfaces
   in the page's existing error surface, not a raw JSON navigation.
-- [ ] 4.9 [P] `nombreDeArchivo` parsing test: `filename*` (RFC 5987, UTF-8)
+- [x] 4.9 [P] `nombreDeArchivo` parsing test: `filename*` (RFC 5987, UTF-8)
   wins over plain `filename` when both are present.
-- [ ] 4.10 [P] Double-click test: exactly one `fetch` fires; the button is
+- [x] 4.10 [P] Double-click test: exactly one `fetch` fires; the button is
   disabled for the duration (`react-async-state` busy-state discipline).
-- [ ] 4.11 [P] `BotonDeDescarga` + `Tablero` descriptor tests per
+  — **APPLY-RUN NOTE**: the two clicks are dispatched inside a single
+  `act()` (not two separate `fireEvent.click` calls) so no React re-render
+  runs between them — otherwise the test would prove the `disabled`
+  attribute, not the `useRef` re-entrancy guard it names (mutation-proof-tests
+  rule 3: the first version of this test passed even with the guard deleted).
+- [x] 4.11 [P] `BotonDeDescarga` + `Tablero` descriptor tests per
   `web-descriptor-tests`.
-- [ ] 4.12 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 4.12 Run `judgment-day`; fix; re-judge until clean. — **not run this
+  batch**; orchestrator instructions scoped this apply run to 4.1-4.11
+  (implementation + tests) only, no push/PR.
 - [ ] 4.13 Branch `feat/stage11-slice4-descarga-web` off `main` (parent:
-  slice 1b); PR; merge stacked-to-main.
+  slice 1b); PR; merge stacked-to-main. — branch created exactly as named
+  in the isolated worktree; PR/merge left for the orchestrator.
 
 **Test plan**: the six vitest cases above (happy path, 403 funnel, 401
 funnel, 400 panel state, filename parsing, double-click) + descriptor

--- a/src/Ways.Web/src/api/cliente.test.ts
+++ b/src/Ways.Web/src/api/cliente.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+const { alPerderLaSesion, api, ErrorApi, nombreDeArchivo } = await import('./cliente')
+
+function respuestaMock(init: {
+  status: number
+  ok: boolean
+  headers?: Record<string, string>
+  blob?: () => Promise<Blob>
+  json?: () => Promise<unknown>
+}): Response {
+  return {
+    status: init.status,
+    ok: init.ok,
+    headers: new Headers(init.headers ?? {}),
+    blob: init.blob ?? (() => Promise.resolve(new Blob())),
+    json: init.json ?? (() => Promise.resolve({})),
+  } as unknown as Response
+}
+
+describe('nombreDeArchivo', () => {
+  it('filename* (RFC 5987, UTF-8) gana sobre filename cuando ambos están presentes', () => {
+    const respuesta = respuestaMock({
+      status: 200,
+      ok: true,
+      headers: {
+        'Content-Disposition': "attachment; filename=\"reporte.xlsx\"; filename*=UTF-8''reporte%20especial.xlsx",
+      },
+    })
+
+    expect(nombreDeArchivo(respuesta)).toBe('reporte especial.xlsx')
+  })
+
+  it('usa filename plano cuando no hay filename*', () => {
+    const respuesta = respuestaMock({
+      status: 200,
+      ok: true,
+      headers: { 'Content-Disposition': 'attachment; filename="ventas_resumen_pv3_2026-08-01_2026-08-12.xlsx"' },
+    })
+
+    expect(nombreDeArchivo(respuesta)).toBe('ventas_resumen_pv3_2026-08-01_2026-08-12.xlsx')
+  })
+
+  it('cae a un nombre genérico sin ningún header (design: Open Questions, API no same-origin)', () => {
+    const respuesta = respuestaMock({ status: 200, ok: true })
+
+    expect(nombreDeArchivo(respuesta)).toBe('descarga.xlsx')
+  })
+})
+
+describe('api.descargar', () => {
+  const crearUrlMock = vi.fn(() => 'blob:mock-url')
+  const revocarUrlMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    crearUrlMock.mockClear()
+    revocarUrlMock.mockClear()
+    URL.createObjectURL = crearUrlMock as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revocarUrlMock as unknown as typeof URL.revokeObjectURL
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('camino feliz: crea el object URL y lo revoca tras flushear los timers (revoke no es sincrónico)', async () => {
+    vi.useFakeTimers()
+    const blob = new Blob(['contenido'])
+    fetchMock.mockResolvedValue(
+      respuestaMock({
+        status: 200,
+        ok: true,
+        headers: { 'Content-Disposition': 'attachment; filename="reporte.xlsx"' },
+        blob: () => Promise.resolve(blob),
+      }),
+    )
+
+    const promesa = api.descargar('/reportes/ventas/resumen/export?formato=xlsx')
+    await vi.runAllTimersAsync()
+    await promesa
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/reportes/ventas/resumen/export?formato=xlsx', { credentials: 'include' })
+    expect(crearUrlMock).toHaveBeenCalledWith(blob)
+    expect(revocarUrlMock).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('403 → funnel: no crea object URL, lanza ErrorApi con el mensaje del servidor, no navega la SPA', async () => {
+    fetchMock.mockResolvedValue(
+      respuestaMock({
+        status: 403,
+        ok: false,
+        json: () => Promise.resolve({ title: 'No tenés permiso para exportar este reporte.', codigo: 'prohibido' }),
+      }),
+    )
+
+    await expect(api.descargar('/reportes/ventas/resumen/export?formato=xlsx')).rejects.toMatchObject({
+      estado: 403,
+      message: 'No tenés permiso para exportar este reporte.',
+    })
+    expect(crearUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('401 → funnel: dispara el observador de alPerderLaSesion, igual que pedir', async () => {
+    const observador = vi.fn()
+    const dejarDeEscuchar = alPerderLaSesion(observador)
+    fetchMock.mockResolvedValue(respuestaMock({ status: 401, ok: false }))
+
+    await expect(api.descargar('/reportes/ventas/resumen/export?formato=xlsx')).rejects.toBeInstanceOf(ErrorApi)
+    expect(observador).toHaveBeenCalledTimes(1)
+    expect(crearUrlMock).not.toHaveBeenCalled()
+
+    dejarDeEscuchar()
+  })
+
+  it('400 (tope de filas) → funnel: ErrorApi con el código del dominio, sin object URL', async () => {
+    fetchMock.mockResolvedValue(
+      respuestaMock({
+        status: 400,
+        ok: false,
+        json: () => Promise.resolve({ title: 'El export supera el tope de filas.', codigo: 'exportacion_demasiado_grande' }),
+      }),
+    )
+
+    const error = await api.descargar('/reportes/ventas/resumen/export?formato=xlsx').catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ErrorApi)
+    expect((error as InstanceType<typeof ErrorApi>).codigo).toBe('exportacion_demasiado_grande')
+    expect(crearUrlMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/Ways.Web/src/api/cliente.ts
+++ b/src/Ways.Web/src/api/cliente.ts
@@ -38,17 +38,13 @@ export function alPerderLaSesion(observador: ObservadorDeSesion) {
   }
 }
 
-async function pedir<T>(ruta: string, init?: RequestInit): Promise<T> {
-  const respuesta = await fetch(`/api${ruta}`, {
-    ...init,
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
-      ...init?.headers,
-    },
-  })
-
+/**
+ * Valida una `Response` cruda y lanza `ErrorApi` ante 401 (disparando los observadores de sesión)
+ * o cualquier otro estado no-ok. Extraída de `pedir` (stage-11 slice 4, design decisión 12) para
+ * que `descargar` comparta el mismo camino de error en vez de duplicarlo — dos copias del camino
+ * de sesión expirada es una copia que se va a olvidar actualizar (`react-async-state` regla 10).
+ */
+async function exigirRespuestaOk(respuesta: Response): Promise<void> {
   if (respuesta.status === 401) {
     observadores.forEach((o) => o())
     throw new ErrorApi(401, 'no_autenticado', 'Tu sesión expiró.')
@@ -67,12 +63,69 @@ async function pedir<T>(ruta: string, init?: RequestInit): Promise<T> {
       problema.title ?? problema.detail ?? `Error ${respuesta.status}.`,
     )
   }
+}
+
+async function pedir<T>(ruta: string, init?: RequestInit): Promise<T> {
+  const respuesta = await fetch(`/api${ruta}`, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...init?.headers,
+    },
+  })
+
+  await exigirRespuestaOk(respuesta)
 
   if (respuesta.status === 204) {
     return undefined as T
   }
 
   return (await respuesta.json()) as T
+}
+
+/** Nombre de archivo desde `Content-Disposition`: `filename*` (RFC 5987, UTF-8) gana sobre
+ * `filename` cuando ambos están presentes — el ASCII es el fallback, no la fuente de verdad
+ * (`NombreDeArchivo.Construir` del lado del servidor siempre manda ambos). Sin ninguno de los dos
+ * (p. ej. si la API algún día deja de ser same-origin, design: Open Questions) cae a un nombre
+ * genérico en vez de romper la descarga. */
+export function nombreDeArchivo(respuesta: Response): string {
+  const disposicion = respuesta.headers.get('Content-Disposition') ?? ''
+
+  const conFilenameEstrella = /filename\*=UTF-8''([^;]+)/i.exec(disposicion)
+  if (conFilenameEstrella) return decodeURIComponent(conFilenameEstrella[1].trim())
+
+  const conFilename = /filename="?([^";]+)"?/i.exec(disposicion)
+  if (conFilename) return conFilename[1].trim()
+
+  return 'descarga.xlsx'
+}
+
+/**
+ * Descarga un archivo binario (`GET {ruta}`, típicamente un `/export`): comparte el camino de
+ * error de `pedir` vía `exigirRespuestaOk` — 401 dispara `alPerderLaSesion`, cualquier otro estado
+ * no-ok lanza `ErrorApi` para que el llamador lo funnelee a su propio estado (nunca una navegación
+ * a un JSON crudo). El `URL.revokeObjectURL` corre en un `setTimeout(…, 0)` posterior al click del
+ * enlace sintético: revocar en el mismo tick cancela la descarga en algunos navegadores (design:
+ * Open Questions).
+ */
+async function descargar(ruta: string): Promise<void> {
+  const respuesta = await fetch(`/api${ruta}`, { credentials: 'include' })
+  await exigirRespuestaOk(respuesta)
+
+  const blob = await respuesta.blob()
+  const nombre = nombreDeArchivo(respuesta)
+  const url = URL.createObjectURL(blob)
+
+  const enlace = document.createElement('a')
+  enlace.href = url
+  enlace.download = nombre
+  document.body.appendChild(enlace)
+  enlace.click()
+  enlace.remove()
+
+  setTimeout(() => URL.revokeObjectURL(url), 0)
 }
 
 export const api = {
@@ -82,4 +135,5 @@ export const api = {
   put: <T>(ruta: string, cuerpo: unknown) =>
     pedir<T>(ruta, { method: 'PUT', body: JSON.stringify(cuerpo) }),
   delete: <T>(ruta: string) => pedir<T>(ruta, { method: 'DELETE' }),
+  descargar: (ruta: string) => descargar(ruta),
 }

--- a/src/Ways.Web/src/api/reportes.test.ts
+++ b/src/Ways.Web/src/api/reportes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { FiltrosDeBreakdown, FiltrosDeBreakdownConPv, FiltrosDeReporte, FiltrosDeTopArticulos } from './reportes'
+import type {
+  FiltrosDeBreakdown,
+  FiltrosDeBreakdownConPv,
+  FiltrosDeRentabilidad,
+  FiltrosDeReporte,
+  FiltrosDeTopArticulos,
+} from './reportes'
 
 const apiGetMock = vi.fn(() => Promise.resolve(undefined))
 
@@ -7,8 +13,14 @@ vi.mock('./cliente', () => ({
   api: { get: (...args: unknown[]) => apiGetMock(...(args as [])) },
 }))
 
-const { clienteDeReportes, construirQueryDeBreakdown, construirQueryDeBreakdownConPv, construirQueryDeReporte, rangoUltimosSieteDias } =
-  await import('./reportes')
+const {
+  clienteDeReportes,
+  construirQueryDeBreakdown,
+  construirQueryDeBreakdownConPv,
+  construirQueryDeReporte,
+  rangoUltimosSieteDias,
+  rutasDeExportacion,
+} = await import('./reportes')
 
 function filtrosFixture(sobrescribir: Partial<FiltrosDeReporte> = {}): FiltrosDeReporte {
   return {
@@ -31,6 +43,10 @@ function filtrosBreakdownConPvFixture(sobrescribir: Partial<FiltrosDeBreakdownCo
 
 function filtrosTopArticulosFixture(sobrescribir: Partial<FiltrosDeTopArticulos> = {}): FiltrosDeTopArticulos {
   return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', limite: null, ...sobrescribir }
+}
+
+function filtrosRentabilidadFixture(sobrescribir: Partial<FiltrosDeRentabilidad> = {}): FiltrosDeRentabilidad {
+  return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', incluirEstimados: false, ...sobrescribir }
 }
 
 describe('construirQueryDeReporte', () => {
@@ -87,6 +103,34 @@ describe('clienteDeReportes.articulosTop', () => {
     await clienteDeReportes.articulosTop(filtrosTopArticulosFixture({ idPuntoVenta: 7, limite: 10 }))
 
     expect(apiGetMock).toHaveBeenCalledWith('/reportes/articulos/top?idEmpresa=1&idPuntoVenta=7&desde=2026-08-05&hasta=2026-08-11&limite=10')
+  })
+})
+
+describe('rutasDeExportacion', () => {
+  it('ventasResumen reutiliza construirQueryDeReporte y suma formato=xlsx al final', () => {
+    const ruta = rutasDeExportacion.ventasResumen(filtrosFixture())
+
+    expect(ruta).toBe('/reportes/ventas/resumen/export?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11&granularidad=Dia&formato=xlsx')
+  })
+
+  it('gastosResumen reutiliza construirQueryDeReporte y suma formato=xlsx al final', () => {
+    const ruta = rutasDeExportacion.gastosResumen(filtrosFixture({ idPuntoVenta: 7 }))
+
+    expect(ruta).toBe(
+      '/reportes/gastos/resumen/export?idEmpresa=1&idPuntoVenta=7&desde=2026-08-05&hasta=2026-08-11&granularidad=Dia&formato=xlsx',
+    )
+  })
+
+  it('rentabilidad omite incluirEstimados cuando es false, igual que clienteDeReportes.rentabilidad', () => {
+    const ruta = rutasDeExportacion.rentabilidad(filtrosRentabilidadFixture())
+
+    expect(ruta).toBe('/reportes/rentabilidad/export?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11&formato=xlsx')
+  })
+
+  it('rentabilidad agrega incluirEstimados=true cuando está tildado', () => {
+    const ruta = rutasDeExportacion.rentabilidad(filtrosRentabilidadFixture({ incluirEstimados: true }))
+
+    expect(ruta).toBe('/reportes/rentabilidad/export?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11&incluirEstimados=true&formato=xlsx')
   })
 })
 

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -100,6 +100,22 @@ export const clienteDeReportes = {
     api.get<Comisiones>(`/reportes/comisiones${construirQueryDeBreakdownConPv(filtros)}`),
 }
 
+/** Rutas de descarga (`/export`, stage-11 slice 4) de los tres paneles de `Tablero` que ya tienen
+ * su ruta `/export` mergeada: ventas resumen y gastos resumen (card G1) y rentabilidad. Reutilizan
+ * el mismo query string que su ruta JSON hermana — `formato=xlsx` es el único parámetro propio de
+ * la descarga (spec exportación-de-reportes: `formato` es requerido, único valor legal `xlsx`). */
+export const rutasDeExportacion = {
+  ventasResumen: (filtros: FiltrosDeReporte) =>
+    `/reportes/ventas/resumen/export${construirQueryDeReporte(filtros)}&formato=xlsx`,
+  gastosResumen: (filtros: FiltrosDeReporte) =>
+    `/reportes/gastos/resumen/export${construirQueryDeReporte(filtros)}&formato=xlsx`,
+  rentabilidad: (filtros: FiltrosDeRentabilidad) => {
+    const query = construirQueryDeBreakdownConPv(filtros)
+    const conEstimados = filtros.incluirEstimados ? `${query}&incluirEstimados=true` : query
+    return `/reportes/rentabilidad/export${conEstimados}&formato=xlsx`
+  },
+}
+
 function aFechaIso(fecha: Date): string {
   const anio = fecha.getFullYear()
   const mes = String(fecha.getMonth() + 1).padStart(2, '0')

--- a/src/Ways.Web/src/componentes/BotonDeDescarga.test.tsx
+++ b/src/Ways.Web/src/componentes/BotonDeDescarga.test.tsx
@@ -1,0 +1,91 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BotonDeDescarga } from './BotonDeDescarga'
+
+const descargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: { descargar: (...args: unknown[]) => descargarMock(...(args as [string])) },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+beforeEach(() => {
+  descargarMock.mockReset()
+})
+
+describe('BotonDeDescarga', () => {
+  it('al hacer click descarga la ruta indicada', async () => {
+    descargarMock.mockResolvedValue(undefined)
+    render(<BotonDeDescarga ruta="/reportes/ventas/resumen/export?formato=xlsx" onError={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    await waitFor(() => expect(descargarMock).toHaveBeenCalledWith('/reportes/ventas/resumen/export?formato=xlsx'))
+  })
+
+  // Prueba la guarda de re-entrancy (`if (enVueloRef.current) return`) de BotonDeDescarga
+  // (mutation-proof-tests): quitando esa línea el doble click dispara dos `api.descargar` en vez
+  // de uno — mutación aplicada, este test falló con 2 llamadas, revertida vuelve a pasar. Los dos
+  // `dispatchEvent` viajan DENTRO de un mismo `act()` (no dos `fireEvent.click` separados) para
+  // que ningún re-render de React corra entre ellos — si no, el segundo click ya vería el
+  // `disabled` puesto por el primero y el test probaría el atributo, no la guarda del `ref`
+  // (`react-async-state` regla 9: "a same-tick double click beats the disabled attribute re-render").
+  it('un doble click en el mismo tick dispara exactamente un fetch y el botón queda deshabilitado durante la descarga', async () => {
+    let resolverDescarga: () => void = () => {}
+    descargarMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolverDescarga = resolve
+        }),
+    )
+    render(<BotonDeDescarga ruta="/reportes/ventas/resumen/export?formato=xlsx" onError={vi.fn()} />)
+
+    const boton = screen.getByRole('button', { name: 'Descargar' })
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(descargarMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button')).toBeDisabled()
+
+    resolverDescarga()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+  })
+
+  it('un error de ErrorApi funnelea su mensaje vía onError, sin lanzar ni navegar', async () => {
+    const { ErrorApi } = await import('../api/cliente')
+    descargarMock.mockRejectedValue(new ErrorApi(403, 'prohibido', 'No tenés permiso para exportar este reporte.'))
+    const onError = vi.fn()
+    render(<BotonDeDescarga ruta="/reportes/ventas/resumen/export?formato=xlsx" onError={onError} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('No tenés permiso para exportar este reporte.'))
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
+  it('un error no-ErrorApi cae al mensaje genérico', async () => {
+    descargarMock.mockRejectedValue(new Error('boom'))
+    const onError = vi.fn()
+    render(<BotonDeDescarga ruta="/reportes/ventas/resumen/export?formato=xlsx" onError={onError} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('No se pudo descargar el archivo.'))
+  })
+
+  it('acepta una etiqueta personalizada', () => {
+    render(<BotonDeDescarga ruta="/x" etiqueta="Exportar a Excel" onError={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Exportar a Excel' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
+++ b/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
@@ -5,6 +5,8 @@ type PropsBotonDeDescarga = {
   ruta: string
   etiqueta?: string
   onError: (mensaje: string) => void
+  /** Se invoca al iniciar una descarga válida (tras la guarda) — limpia el error previo del caller. */
+  onInicio?: () => void
   className?: string
 }
 
@@ -16,7 +18,7 @@ type PropsBotonDeDescarga = {
  * navegan la SPA: se funnelean por `onError` al estado de la pantalla que monta el botón (proposal
  * decisión 8 — "a download that silently does nothing is this pattern's worst failure mode").
  */
-export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, className }: PropsBotonDeDescarga) {
+export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, onInicio, className }: PropsBotonDeDescarga) {
   const [descargando, setDescargando] = useState(false)
   const enVueloRef = useRef(false)
 
@@ -24,6 +26,7 @@ export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, classNa
     if (enVueloRef.current) return
     enVueloRef.current = true
     setDescargando(true)
+    onInicio?.()
 
     try {
       await api.descargar(ruta)

--- a/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
+++ b/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
@@ -1,0 +1,48 @@
+import { useRef, useState } from 'react'
+import { api, ErrorApi } from '../api/cliente'
+
+type PropsBotonDeDescarga = {
+  ruta: string
+  etiqueta?: string
+  onError: (mensaje: string) => void
+  className?: string
+}
+
+/**
+ * Botón de descarga de un `/export` (stage-11 slice 4): re-entrancy guard vía `useRef` + `disabled`
+ * cubren toda la ventana de la descarga (`react-async-state` regla 5/9) — el `ref` bloquea un
+ * doble click en el MISMO tick, antes de que React re-renderice el atributo `disabled`; un `useState`
+ * solo no alcanza porque dos clicks sincrónicos leen el mismo valor obsoleto. Los errores nunca
+ * navegan la SPA: se funnelean por `onError` al estado de la pantalla que monta el botón (proposal
+ * decisión 8 — "a download that silently does nothing is this pattern's worst failure mode").
+ */
+export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, className }: PropsBotonDeDescarga) {
+  const [descargando, setDescargando] = useState(false)
+  const enVueloRef = useRef(false)
+
+  const manejarClick = async () => {
+    if (enVueloRef.current) return
+    enVueloRef.current = true
+    setDescargando(true)
+
+    try {
+      await api.descargar(ruta)
+    } catch (e) {
+      onError(e instanceof ErrorApi ? e.message : 'No se pudo descargar el archivo.')
+    } finally {
+      enVueloRef.current = false
+      setDescargando(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={className ?? 'btn btn-sm btn-outline-secondary rounded-0'}
+      disabled={descargando}
+      onClick={manejarClick}
+    >
+      {descargando ? 'Descargando…' : etiqueta}
+    </button>
+  )
+}

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -1122,4 +1122,21 @@ describe('Tablero — Descarga de reportes (stage-11 slice 4)', () => {
       ),
     )
   })
+
+  it('un retry exitoso limpia el banner de error de la descarga anterior', async () => {
+    mockearRutasBase()
+    const { ErrorApi } = await import('../api/cliente')
+    apiDescargarMock.mockRejectedValueOnce(new ErrorApi(403, 'prohibido', 'Sin permiso para exportar.'))
+    renderTablero()
+
+    const boton = await screen.findByRole('button', { name: 'Descargar ventas' })
+    fireEvent.click(boton)
+    expect(await screen.findByText('Sin permiso para exportar.')).toBeInTheDocument()
+
+    apiDescargarMock.mockResolvedValueOnce(undefined)
+    fireEvent.click(boton)
+    await waitFor(() => {
+      expect(screen.queryByText('Sin permiso para exportar.')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -21,6 +21,7 @@ import type {
 import { RutaProtegida } from '../auth/RutaProtegida'
 
 const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
 
 // `recharts` se mockea igual que en los tests de los wrappers: bajo jsdom no renderiza
 // nada observable, y sin el stub el mapeo de datos al grafico queda sin asercion posible.
@@ -53,6 +54,7 @@ vi.mock('../api/cliente', () => ({
     post: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
     estado: number
@@ -266,6 +268,8 @@ function renderTableroProtegido() {
 
 beforeEach(() => {
   apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
   usuarioActual = usuarioFixture()
 })
 
@@ -1033,5 +1037,89 @@ describe('Tablero — Card de comisiones, PROVISIONAL (stage-10-agregacion-dashb
       const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
       expect(rutas.some((r) => r.startsWith('/reportes/comisiones?') && r.includes(`idPuntoVenta=${puntoVentaCentro.id}`))).toBe(true)
     })
+  })
+})
+
+describe('Tablero — Descarga de reportes (stage-11 slice 4)', () => {
+  it('la card G1 tiene botones de descarga de ventas y gastos, cada uno apuntando a su ruta /export con los filtros vigentes', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    const rangoEsperado = rangoUltimosSieteDias()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Descargar ventas' }))
+    await waitFor(() =>
+      expect(apiDescargarMock).toHaveBeenCalledWith(
+        `/reportes/ventas/resumen/export?idEmpresa=1&desde=${rangoEsperado.desde}&hasta=${rangoEsperado.hasta}&granularidad=Dia&formato=xlsx`,
+      ),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar gastos' }))
+    await waitFor(() =>
+      expect(apiDescargarMock).toHaveBeenCalledWith(
+        `/reportes/gastos/resumen/export?idEmpresa=1&desde=${rangoEsperado.desde}&hasta=${rangoEsperado.hasta}&granularidad=Dia&formato=xlsx`,
+      ),
+    )
+  })
+
+  // El aviso de descarga es un estado propio (`errorDescarga`), separado del `error` de carga:
+  // si compartiera ese estado, el botón "Reintentar" que viaja con él recargaría el reporte en
+  // vez de reintentar la descarga — un "Reintentar" engañoso.
+  it('un error 403 de descarga aparece en su propio aviso, sin ofrecer "Reintentar"', async () => {
+    mockearRutasBase()
+    const { ErrorApi } = await import('../api/cliente')
+    apiDescargarMock.mockRejectedValue(new ErrorApi(403, 'prohibido', 'No tenés permiso para exportar este reporte.'))
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.click(await screen.findByRole('button', { name: 'Descargar ventas' }))
+
+    expect(await screen.findByText('No tenés permiso para exportar este reporte.')).toBeInTheDocument()
+    expect(screen.queryAllByText('Reintentar')).toHaveLength(0)
+  })
+
+  // task 4.8: un 400 de rechazo por tope de filas (`exportacion_demasiado_grande`) surge en el
+  // aviso existente de la página, nunca como una navegación de la SPA a un JSON crudo.
+  it('un 400 por tope de filas surge en el aviso de descarga del panel, no navega a un JSON crudo', async () => {
+    mockearRutasBase()
+    const { ErrorApi } = await import('../api/cliente')
+    apiDescargarMock.mockRejectedValue(
+      new ErrorApi(400, 'exportacion_demasiado_grande', 'El export supera el tope de 25000 filas.'),
+    )
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.click(await screen.findByRole('button', { name: 'Descargar gastos' }))
+
+    expect(await screen.findByText('El export supera el tope de 25000 filas.')).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/')
+  })
+
+  it('el panel de rentabilidad (Admin) tiene su propio botón de descarga, con incluirEstimados reflejando el toggle', async () => {
+    usuarioActual = usuarioFixture({ id: 2, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Rentabilidad')
+    const rangoEsperado = rangoUltimosSieteDias()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar' }))
+    await waitFor(() =>
+      expect(apiDescargarMock).toHaveBeenCalledWith(
+        `/reportes/rentabilidad/export?idEmpresa=1&desde=${rangoEsperado.desde}&hasta=${rangoEsperado.hasta}&formato=xlsx`,
+      ),
+    )
+
+    fireEvent.click(screen.getByLabelText('Incluir costos estimados'))
+    await waitFor(() => expect(screen.getByLabelText('Incluir costos estimados')).toBeChecked())
+
+    apiDescargarMock.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'Descargar' }))
+    await waitFor(() =>
+      expect(apiDescargarMock).toHaveBeenCalledWith(
+        `/reportes/rentabilidad/export?idEmpresa=1&desde=${rangoEsperado.desde}&hasta=${rangoEsperado.hasta}&incluirEstimados=true&formato=xlsx`,
+      ),
+    )
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
-import { clienteDeReportes, rangoUltimosSieteDias } from '../api/reportes'
+import { clienteDeReportes, rangoUltimosSieteDias, rutasDeExportacion } from '../api/reportes'
 import type {
   CoberturaDeCosto,
   Comisiones,
@@ -21,6 +21,7 @@ import type {
 } from '../api/tipos'
 import { puedeVerComisiones, puedeVerRentabilidad } from '../api/tipos'
 import { useAuth } from '../auth/useAuth'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 import { GraficoDeBarras } from '../componentes/graficos/GraficoDeBarras'
@@ -350,6 +351,7 @@ type PropsPanelDeRentabilidad = { idEmpresa: number; desde: string; hasta: strin
  */
 function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPanelDeRentabilidad) {
   const [incluirEstimados, setIncluirEstimados] = useState(false)
+  const [errorDescarga, setErrorDescarga] = useState('')
   const cargarDatos = useCallback(
     () => clienteDeReportes.rentabilidad({ idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados }),
     [idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados],
@@ -361,7 +363,14 @@ function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPan
 
   return (
     <div className="border p-3 bg-white h-100">
-      <h6>Rentabilidad</h6>
+      <div className="d-flex justify-content-between align-items-center mb-2">
+        <h6 className="mb-0">Rentabilidad</h6>
+        <BotonDeDescarga
+          ruta={rutasDeExportacion.rentabilidad({ idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados })}
+          etiqueta="Descargar"
+          onError={setErrorDescarga}
+        />
+      </div>
       <div className="form-check form-switch mb-2">
         <input
           id="tablero-rentabilidad-incluir-estimados"
@@ -375,6 +384,7 @@ function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPan
           Incluir costos estimados
         </label>
       </div>
+      {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
       {error && <PanelDeError error={error} onReintentar={reintentar} />}
       {cargando && !datos && <Cargando />}
       {datos && (
@@ -506,6 +516,9 @@ export function Tablero() {
   const [gastos, setGastos] = useState<ResumenDeGastos | null>(null)
   const [cargando, setCargando] = useState(false)
   const [error, setError] = useState('')
+  /** Error de descarga (stage-11 slice 4) — separado de `error` (carga de ventas/gastos) para no
+   * ofrecer un botón "Reintentar" que en realidad reintenta la carga, no la descarga. */
+  const [errorDescarga, setErrorDescarga] = useState('')
   const generacionRef = useRef(0)
 
   useEffect(() => {
@@ -670,8 +683,21 @@ export function Tablero() {
 
             {cargando && !ventas && !gastos && <Cargando />}
 
-            {ventas && gastos && (
+            {ventas && gastos && idEmpresa !== null && (
               <>
+                {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorDescarga}</div>}
+                <div className="d-flex gap-2 mb-2">
+                  <BotonDeDescarga
+                    ruta={rutasDeExportacion.ventasResumen({ idEmpresa, idPuntoVenta, desde, hasta, granularidad })}
+                    etiqueta="Descargar ventas"
+                    onError={setErrorDescarga}
+                  />
+                  <BotonDeDescarga
+                    ruta={rutasDeExportacion.gastosResumen({ idEmpresa, idPuntoVenta, desde, hasta, granularidad })}
+                    etiqueta="Descargar gastos"
+                    onError={setErrorDescarga}
+                  />
+                </div>
                 <div className="row g-3 mb-4">
                   <div className="col-md-3">
                     <div className="border p-3 bg-white text-center">

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -368,7 +368,7 @@ function PanelDeRentabilidad({ idEmpresa, desde, hasta, idPuntoVenta }: PropsPan
         <BotonDeDescarga
           ruta={rutasDeExportacion.rentabilidad({ idEmpresa, idPuntoVenta, desde, hasta, incluirEstimados })}
           etiqueta="Descargar"
-          onError={setErrorDescarga}
+          onError={setErrorDescarga} onInicio={() => setErrorDescarga('')}
         />
       </div>
       <div className="form-check form-switch mb-2">
@@ -690,12 +690,12 @@ export function Tablero() {
                   <BotonDeDescarga
                     ruta={rutasDeExportacion.ventasResumen({ idEmpresa, idPuntoVenta, desde, hasta, granularidad })}
                     etiqueta="Descargar ventas"
-                    onError={setErrorDescarga}
+                    onError={setErrorDescarga} onInicio={() => setErrorDescarga('')}
                   />
                   <BotonDeDescarga
                     ruta={rutasDeExportacion.gastosResumen({ idEmpresa, idPuntoVenta, desde, hasta, granularidad })}
                     etiqueta="Descargar gastos"
-                    onError={setErrorDescarga}
+                    onError={setErrorDescarga} onInicio={() => setErrorDescarga('')}
                   />
                 </div>
                 <div className="row g-3 mb-4">


### PR DESCRIPTION
## Etapa 11, slice 4 — Descarga web

`api.descargar()` (fetch+blob+revoke, filename del Content-Disposition con variante UTF-8) + `BotonDeDescarga` (guarda de re-entrada por ref dentro de un solo act() — el doble-click del mismo tick bloqueado ANTES del re-render) + botones en los paneles de ventas/gastos y rentabilidad del Tablero.

- Funnel de errores exacto: 401 dispara `alPerderLaSesion` sin banner generico; 400/403 llegan al estado del panel con el mensaje real (el tope de filas incluido); NUNCA navegacion a ProblemDetails crudo.
- Builders de ruta verificados byte a byte contra los endpoints reales (el typo que los mocks no ven).
- Fix de ronda: el banner de error se limpia al iniciar un retry valido (`onInicio` tras la guarda — clear-on-attempt, no clear-on-success).

### Review
Judgment-day de 2 rondas: Juez A APPROVE (funnel, ciclo del blob sin fugas, rutas literales). Juez B APPROVE-WITH-MINORS ronda 1 — 6 mutaciones re-ejecutadas incluida la VALIDACION del auto-catch del apply agent (el test de doble-click reescrito era load-bearing: la version vieja pasaba vacua), 1 MINOR real por probe en vivo (banner sobreviviendo al retry — espejo de la regla 6) → fix `7f33776` con test formalizado y evidencia de mutacion → APPROVE ronda 2.

### Tests
vitest 497/497 (476 + 21) · tsc -b limpio · build limpio · oxlint sin issues nuevos

🤖 Generated with [Claude Code](https://claude.com/claude-code)