### PR TITLE
feat(reportes): libro de tesoreria G3 con export (etapa 11, slice 7 backend)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -659,34 +659,86 @@ cross-turno matrix at the UI layer.
 G3 read endpoint live, chain-ordered, exportable, `/caja/tesoreria` screen.
 **Rollback**: revert the branch.
 
-- [ ] 7.1 Create `src/Ways.Application/Caja/ServicioDeTesoreria.cs`:
+> **APPLY-RUN NOTE (isolated worktree, branch `feat/stage11-slice7-tesoreria`,
+> explicit orchestrator instruction)**: this batch's scope was the G3 backend
+> only — the JSON listing endpoint, its export sibling, and their tests
+> (7.1-7.4, 7.7-7.11) — per explicit boundary "NO web". `ExportacionDeCaja.cs`
+> did not exist yet (5a/5b deferred it, see their APPLY-RUN NOTEs), so 7.3
+> CREATES the file (with only the tesorería mapper) instead of extending it;
+> a future G2 batch adds its own `De` overload to the same file. **7.5, 7.6,
+> 7.12 (the web screen, routing/nav, descriptor tests) are explicitly OUT OF
+> SCOPE for this run**, deferred to a follow-up batch. **7.13-7.14
+> (judgment-day, PR, merge) are OUT OF SCOPE** (explicit boundary: no
+> push/PR) — left for the orchestrator's PR-validation phase, same
+> precedent as slice 1b/5a. `idPuntoVenta` is a REQUIRED route parameter
+> (unlike G2's optional one): mixing points of venta would break the
+> chain's own meaning (design decision 11) — a deviation from the literal
+> task wording ("by PV and date range") worth flagging for verify.
+
+- [x] 7.1 Create `src/Ways.Application/Caja/ServicioDeTesoreria.cs`:
   `ListarAsync` — `MovimientosTesoreria` by PV and date range, `OrderBy(m
   => m.Id)` (never by `fecha` — the chain's meaning is insertion order,
   design decision 11), paginated. Zero derivation. *(proposal decision 6;
-  spec tesoreria: Tesorería Book Has A Read/Listing Endpoint)*
-- [ ] 7.2 Modify `ReportesEndpoints.cs`: `GET /tesoreria` under
-  `LecturaDeReportes`.
-- [ ] 7.3 Extend `ExportacionDeCaja.cs`: `De` mapper for the tesorería book.
-- [ ] 7.4 Modify `ReportesEndpoints.cs`: `GET /tesoreria/export` sibling.
+  spec tesoreria: Tesorería Book Has A Read/Listing Endpoint)* — includes
+  `ListarParaExportacionAsync` sharing a private `ConstruirQuery` (design
+  decisión 7, same discipline as `ServicioDeVentas`); `Contratos.cs` extended
+  with `MovimientoTesoreriaListado`/`PaginaDeMovimientosTesoreria`, appended
+  at the end of the file (append-anchor discipline).
+- [x] 7.2 Modify `ReportesEndpoints.cs`: `GET /tesoreria` under
+  `LecturaDeReportes`. — appended after `/cajas`, at the end of the group
+  (append-anchor discipline, parallel sibling slice safe).
+- [x] 7.3 Extend `ExportacionDeCaja.cs`: `De` mapper for the tesorería book.
+  — CREATES the file (did not exist yet, see APPLY-RUN NOTE above), with
+  only the tesorería `De` overload; columns ordered
+  inicio/ingreso/egreso/final/concepto/empleado/fecha per task 7.5's pinned
+  order.
+- [x] 7.4 Modify `ReportesEndpoints.cs`: `GET /tesoreria/export` sibling. —
+  appended immediately after `/tesoreria` (co-location); resolves
+  empresa/zona via the existing `AlcanceDeListadoHttp.ResolverAsync`, no
+  duplicated lookup.
 - [ ] 7.5 Create `src/Ways.Web/src/paginas/Tesoreria.tsx`: the book table
   (inicio/ingreso/egreso/final/concepto/empleado/fecha), `BotonDeDescarga`.
+  — DEFERRED (see APPLY-RUN NOTE above, "NO web").
 - [ ] 7.6 Modify `App.tsx`/`Layout.tsx`: `/caja/tesoreria` route
-  (`LecturaDeReportes`) and nav entry.
-- [ ] 7.7 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
-  pending changes.
-- [ ] 7.8 [P] The house 4-test pattern for the endpoint.
-- [ ] 7.9 [P] **Chain-order assertion**: three chained rows with `final`
+  (`LecturaDeReportes`) and nav entry. — DEFERRED with 7.5.
+- [x] 7.7 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
+  pending changes. — confirmed clean (`--project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure`).
+- [x] 7.8 [P] The house 4-test pattern for the endpoint. — `TesoreriaTests.cs`:
+  cross-tenant absence, PV-filter discrimination (mutation-proof: `Where(m =>
+  m.IdPuntoVenta == idPuntoVenta)` replaced with `AsQueryable()` → the
+  discrimination test FAILED; reverted → green), date-range discrimination,
+  hand-computed fixture equality (full field set).
+- [x] 7.9 [P] **Chain-order assertion**: three chained rows with `final`
   values 60, 100, 145 → returned in that order, each row's `inicio` equal
-  to the previous row's `final`. *(spec: Book Preserves Chain Order)*
-- [ ] 7.10 [P] Equality test on the export vs the JSON book. *(spec: The
-  Book Has An Export Sibling Equal To Its JSON)*
-- [ ] 7.11 [P] 403 test: Vendedor rejected on both routes. *(spec: A
-  Vendedor Is Rejected From The Tesorería Book)*
+  to the previous row's `final`. *(spec: Book Preserves Chain Order)* —
+  `TresFilasEncadenadasSeDevuelvenEnOrdenDeCadena`. MUTATION RUN AND
+  RECORDED: `OrderBy(m => m.Id)` replaced with `OrderByDescending(m =>
+  m.Id)` in `ServicioDeTesoreria.ListarAsync` → test FAILED (rows returned
+  145/100/60, `Assert.Equal([id1,id2,id3], …)` mismatched); reverted →
+  green (re-verified).
+- [x] 7.10 [P] Equality test on the export vs the JSON book. *(spec: The
+  Book Has An Export Sibling Equal To Its JSON)* — `TesoreriaExportTests.
+  ElExportEsIgualAlLibroJsonFilaPorFila`, per-row comparison (inicio/
+  ingreso/egreso/final/concepto/empleado) via ClosedXML read-back. Cap
+  guard tests (`UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal`/
+  `…ExactamenteEnElTopeSeAcepta`) added too — `GuardaDeTope` itself already
+  has mutation evidence recorded in slice 1b/3 (shared code, not a new
+  clause), so no fresh mutation run was needed for the cap.
+- [x] 7.11 [P] 403 test: Vendedor rejected on both routes. *(spec: A
+  Vendedor Is Rejected From The Tesorería Book)* — `UnVendedorEsRechazado
+  DelLibroDeTesoreria` (JSON) + `UnVendedorEsRechazadoDelExportDeTesoreria`
+  (export); `UnSupervisorLeeElLibroDeTesoreria` (200) alongside.
 - [ ] 7.12 [P] `Tesoreria.test.tsx`: renders the book in chain order,
-  download busy-state, role gating. Per `web-descriptor-tests`.
-- [ ] 7.13 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 7.14 Branch `feat/stage11-slice7-tesoreria` off `main` (parent:
-  slices 1b + 4); PR; merge stacked-to-main.
+  download busy-state, role gating. Per `web-descriptor-tests`. — DEFERRED
+  with 7.5/7.6.
+- [ ] 7.13 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as 1b.13/5a.11.
+- [x] 7.14 Branch `feat/stage11-slice7-tesoreria` off `main` (parent:
+  slices 1b + 4); PR; merge stacked-to-main. — branch created off `main`
+  per the orchestrator's explicit instruction (isolated worktree); PR/merge
+  left for the orchestrator, same precedent as 1b.14/5a.12.
 
 **Test plan**: 4-test pattern, chain-order assertion, equality, 403,
 descriptor tests.

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -4,6 +4,7 @@ using Ways.Api.Seguridad;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
 using Ways.Application.Exportacion;
+using Ways.Application.Parametros;
 using Ways.Application.Reportes;
 using Ways.Domain.Reportes;
 
@@ -337,6 +338,49 @@ public static class ReportesEndpoints
         .WithSummary(
             "Histórico de cierres (turnos cerrados únicamente): totales sumados de los arqueos ya " +
             "persistidos, nunca re-derivados. Un turno abierto nunca aparece acá.");
+
+        // stage-11-exportacion-reportes, Slice 7 (design: G2/G3 — minimal aggregation, "G3:
+        // MovimientosTesoreria by PV, OrderBy(m => m.Id), paginated. Zero derivation."; spec
+        // tesoreria: Tesorería Book Has A Read/Listing Endpoint): gate heredado del grupo, sin
+        // política propia. idPuntoVenta es OBLIGATORIO (a diferencia de /cajas): mezclar puntos de
+        // venta rompería el significado de la cadena Inicio/Final (design decisión 11).
+        grupo.MapGet("/tesoreria", (
+            ServicioDeTesoreria servicio, int idPuntoVenta, DateTimeOffset? desde, DateTimeOffset? hasta,
+            int? pagina, int? tamanio, CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary(
+            "Libro de tesorería encadenado de un punto de venta, ordenado por id (nunca por " +
+            "fecha): cero derivación, cada fila ya trae su inicio/final persistidos al cierre.");
+
+        // Sibling declarado inmediatamente después de su ruta fuente (design: Data Flow) — hereda
+        // LecturaDeReportes por co-locación. `desde`/`hasta` son OBLIGATORIOS acá (mismo criterio
+        // que /api/ventas/export): un export es por definición un rango acotado, y el nombre de
+        // archivo determinístico necesita ambas fechas.
+        grupo.MapGet("/tesoreria/export", async (
+            ServicioDeTesoreria servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int idPuntoVenta, DateTimeOffset desde, DateTimeOffset hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var filas = await servicio.ListarParaExportacionAsync(
+                idPuntoVenta, desde, hasta, opciones.Value.TopeDeFilas, ct);
+
+            var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
+            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
+            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, empresa, $"PV {idPuntoVenta}", desdeFecha, hastaFecha, zonaId);
+            var tabla = ExportacionDeCaja.De(filas, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("tesoreria", $"pv{idPuntoVenta}", desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary("Export XLSX de /tesoreria: mismos parámetros y figuras, mismo orden de cadena.");
 
         return app;
     }

--- a/src/Ways.Application/Caja/Contratos.cs
+++ b/src/Ways.Application/Caja/Contratos.cs
@@ -164,3 +164,31 @@ public sealed record DetalleDeTurno(
     ResumenDeTurno Resumen,
     IReadOnlyList<Ways.Application.Ventas.ComprobanteListado> Tickets,
     IReadOnlyList<Ways.Application.Gastos.GastoListado> Gastos);
+
+// ---- stage-11-exportacion-reportes, Slice 7 (design: G2/G3 — minimal aggregation, "G3:
+// MovimientosTesoreria by PV, OrderBy(m => m.Id), paginated. Zero derivation."; spec tesoreria:
+// Tesorería Book Has A Read/Listing Endpoint): G3, el libro encadenado ----
+
+/// <summary>Fila de <c>GET /api/reportes/tesoreria</c> — proyección de
+/// <see cref="MovimientoTesoreria"/> SIN <c>IdTenant</c> (nunca expuesto en una respuesta, doc 09),
+/// mismo criterio "mirror the entity's real columns" que <see cref="FilaDeHistoricoDeCajas"/>. Cero
+/// derivación: <see cref="Inicio"/>/<see cref="Final"/> ya vienen calculados y persistidos por
+/// <see cref="ServicioDeTurnos"/> al cierre (design decisión 6 de stage-6-turnos-caja) — este
+/// contrato solo los transporta.</summary>
+public sealed record MovimientoTesoreriaListado(
+    int Id,
+    int IdPuntoVenta,
+    DateTimeOffset Fecha,
+    TipoMovimientoTesoreria Tipo,
+    int? IdTurnoCaja,
+    string Concepto,
+    decimal Inicio,
+    decimal Ingreso,
+    decimal Egreso,
+    decimal Final,
+    int IdEmpleado);
+
+/// <summary>Página de <c>GET /api/reportes/tesoreria</c> — mismo shape que
+/// <see cref="PaginaDeHistoricoDeCajas"/>.</summary>
+public sealed record PaginaDeMovimientosTesoreria(
+    IReadOnlyList<MovimientoTesoreriaListado> Items, int Total, int Pagina, int Tamanio);

--- a/src/Ways.Application/Caja/ExportacionDeCaja.cs
+++ b/src/Ways.Application/Caja/ExportacionDeCaja.cs
@@ -1,0 +1,46 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// Mappers puros de un listado de caja ya materializado a <see cref="TablaExportable"/> — la
+/// etapa 11 nunca vuelve a consultar la base para exportar (design decisión 11). Slice 7 abre este
+/// archivo con el mapper del libro de tesorería (G3); G2 (listado/detalle) lo extiende en una
+/// slice de seguimiento (5a.4/5b.4, ver el APPLY-RUN NOTE de <c>tasks.md</c>).
+/// </summary>
+public static class ExportacionDeCaja
+{
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasTesoreria =
+    [
+        new ColumnaExportable("Inicio", TipoDeColumna.Moneda),
+        new ColumnaExportable("Ingreso", TipoDeColumna.Moneda),
+        new ColumnaExportable("Egreso", TipoDeColumna.Moneda),
+        new ColumnaExportable("Final", TipoDeColumna.Moneda),
+        new ColumnaExportable("Concepto", TipoDeColumna.Texto),
+        new ColumnaExportable("Empleado", TipoDeColumna.Entero),
+        new ColumnaExportable("Fecha", TipoDeColumna.FechaHora)
+    ];
+
+    /// <summary>Libro de tesorería (G3, spec tesoreria: The Book Has An Export Sibling Equal To
+    /// Its JSON) — misma orden de columnas que la tabla del libro (design: Slice 7 task 7.5,
+    /// "inicio/ingreso/egreso/final/concepto/empleado/fecha"), en el MISMO orden de filas que
+    /// <see cref="ServicioDeTesoreria.ListarAsync"/> devuelve (cadena por <c>Id</c> ascendente,
+    /// nunca re-ordenado acá).</summary>
+    public static TablaExportable De(IReadOnlyList<MovimientoTesoreriaListado> filas, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var celdas = filas
+            .Select(f => (IReadOnlyList<Celda>)
+            [
+                Celda.Moneda(f.Inicio),
+                Celda.Moneda(f.Ingreso),
+                Celda.Moneda(f.Egreso),
+                Celda.Moneda(f.Final),
+                Celda.Texto(f.Concepto),
+                Celda.Entero(f.IdEmpleado),
+                Celda.FechaHora(f.Fecha, zona)
+            ])
+            .ToList();
+
+        return new TablaExportable("Tesorería", ctx, ColumnasTesoreria, celdas);
+    }
+}

--- a/src/Ways.Application/Caja/ServicioDeTesoreria.cs
+++ b/src/Ways.Application/Caja/ServicioDeTesoreria.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Domain.Caja;
+
+namespace Ways.Application.Caja;
+
+/// <summary>
+/// G3 — el libro de tesorería encadenado (design: G2/G3 — minimal aggregation; spec tesoreria:
+/// Tesorería Book Has A Read/Listing Endpoint). CERO derivación: cada fila ya trae su
+/// <see cref="MovimientoTesoreria.Inicio"/>/<see cref="MovimientoTesoreria.Final"/> calculados y
+/// persistidos por <see cref="ServicioDeTurnos"/> al cierre — este servicio solo lee, ordenado por
+/// <c>Id</c> ascendente (design decisión 11: NUNCA por <c>Fecha</c> — el significado del libro es
+/// el orden de inserción; la cadena <c>Inicio</c>/<c>Final</c> no tiene por qué coincidir con el
+/// orden cronológico si dos cierres caen en el mismo segundo). <c>IdPuntoVenta</c> es obligatorio
+/// (a diferencia de G2): mezclar puntos de venta rompería el propio significado de la cadena.
+/// </summary>
+public class ServicioDeTesoreria(IWaysDbContext db)
+{
+    public async Task<PaginaDeMovimientosTesoreria> ListarAsync(
+        int idPuntoVenta,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta);
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderBy(m => m.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(m => new MovimientoTesoreriaListado(
+                m.Id, m.IdPuntoVenta, m.Fecha, m.Tipo, m.IdTurnoCaja, m.Concepto, m.Inicio, m.Ingreso, m.Egreso,
+                m.Final, m.IdEmpleado))
+            .ToListAsync(ct);
+
+        return new PaginaDeMovimientosTesoreria(items, total, pagina, tamanio);
+    }
+
+    /// <summary>stage-11-exportacion-reportes (Slice 7, design decisión 7): mismo
+    /// <see cref="ConstruirQuery"/> que <see cref="ListarAsync"/>, <c>Contar → refuse → lectura
+    /// única con .Take(topeDeFilas + 1)</c>, nunca paginada — la tesorería es un LISTADO (design
+    /// decisión 6), corre <c>COUNT(*)</c> como <c>ServicioDeVentas.ListarParaExportacionAsync</c>,
+    /// a diferencia de un agregado acotado por construcción. El segundo
+    /// <see cref="GuardaDeTope.Exigir"/> es el backstop de carrera: si la lectura trae
+    /// <c>topeDeFilas + 1</c> filas, el <c>COUNT(*)</c> de arriba quedó desactualizado.</summary>
+    public async Task<IReadOnlyList<MovimientoTesoreriaListado>> ListarParaExportacionAsync(
+        int idPuntoVenta,
+        DateTimeOffset? desde,
+        DateTimeOffset? hasta,
+        int topeDeFilas,
+        CancellationToken ct = default)
+    {
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var items = await query
+            .OrderBy(m => m.Id)
+            .Take(topeDeFilas + 1)
+            .Select(m => new MovimientoTesoreriaListado(
+                m.Id, m.IdPuntoVenta, m.Fecha, m.Tipo, m.IdTurnoCaja, m.Concepto, m.Inicio, m.Ingreso, m.Egreso,
+                m.Final, m.IdEmpleado))
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(items.Count, topeDeFilas);
+
+        return items;
+    }
+
+    /// <summary>Filtro compartido de <see cref="ListarAsync"/> y
+    /// <see cref="ListarParaExportacionAsync"/> (design decisión 7): un solo lugar declara el
+    /// predicado, nunca dos copias que puedan derivar.</summary>
+    private IQueryable<MovimientoTesoreria> ConstruirQuery(int idPuntoVenta, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var query = db.MovimientosTesoreria.Where(m => m.IdPuntoVenta == idPuntoVenta);
+
+        if (desde is { } d)
+        {
+            query = query.Where(m => m.Fecha >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(m => m.Fecha <= h);
+        }
+
+        return query;
+    }
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -104,6 +104,10 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeHistoricoDeCajas>();
         services.AddScoped<LectorDeLineasDelTurno>();
 
+        // stage-11-exportacion-reportes, Slice 7 (design: G2/G3 — minimal aggregation): G3, el
+        // libro de tesorería — cero derivación, solo lectura encadenada por Id.
+        services.AddScoped<ServicioDeTesoreria>();
+
         return services;
     }
 }

--- a/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
@@ -1,0 +1,224 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 7: <c>GET /api/reportes/tesoreria/export</c> — la
+/// tesorería es un LISTADO (design decisión 6), así que <c>GuardaDeTope</c> corre sobre un
+/// <c>COUNT(*)</c> real, mismo patrón que <c>VentasListadoExportTests</c>. La guarda de tope en sí
+/// ya tiene su evidencia de mutación registrada por la Slice 1b/3 (<see cref="GuardaDeTope"/> es
+/// código compartido, no una cláusula nueva de esta slice) — acá solo se ejercita que el libro de
+/// tesorería la dispara con la cantidad real.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, HttpClient Admin, HttpClient Vendedor);
+
+    private static async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var vendedor = await CrearYLoguearAsync(admin, factory, nombre);
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, admin, vendedor);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, WebApplicationFactory<Program> factory, string nombre)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-vendedor@ways.test";
+        var alta = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario($"vendedor-{corto}", mail, (int)RolConocido.Vendedor, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>Siembra directo — mismo criterio time-safe que <c>TesoreriaTests</c> (mediodía
+    /// UTC, nunca <c>DateTime.UtcNow</c> puro).</summary>
+    private async Task<int> SembrarMovimientoAsync(
+        Contexto ctx, DateOnly dia, decimal inicio, decimal ingreso, decimal egreso, decimal final, string concepto = "Cierre de turno")
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fecha = new DateTimeOffset(dia.Year, dia.Month, dia.Day, 12, 0, 0, TimeSpan.Zero);
+
+        var movimiento = new MovimientoTesoreria
+        {
+            IdTenant = ctx.IdTenant,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            Fecha = fecha,
+            Tipo = TipoMovimientoTesoreria.RetiroCaja,
+            IdTurnoCaja = null,
+            Concepto = concepto,
+            Inicio = inicio,
+            Ingreso = ingreso,
+            Egreso = egreso,
+            Final = final,
+            IdEmpleado = ctx.IdEmpleadoAdmin
+        };
+        db.MovimientosTesoreria.Add(movimiento);
+        await db.SaveChangesAsync();
+
+        return movimiento.Id;
+    }
+
+    private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato) =>
+        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarLibroAsync(HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/reportes/tesoreria?{ConstruirQuery(idPuntoVenta, desde, hasta, null)}&tamanio=200");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/reportes/tesoreria/export?{ConstruirQuery(idPuntoVenta, desde, hasta, formato)}");
+
+    // ---- task 7.10: equality test, por fila ----------------------------------------------------
+
+    [Fact]
+    public async Task ElExportEsIgualAlLibroJsonFilaPorFila()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlLibroJsonFilaPorFila), fixture);
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+
+        await SembrarMovimientoAsync(ctx, desde, 0m, 60m, 0m, 60m);
+        await SembrarMovimientoAsync(ctx, desde, 60m, 40m, 0m, 100m);
+        await SembrarMovimientoAsync(ctx, hasta, 100m, 60m, 15m, 145m, "Cierre de turno de mediodía");
+
+        var jsonRespuesta = await LlamarLibroAsync(ctx.Admin, ctx.IdPuntoVenta, desde, hasta);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var libro = JsonSerializer.Deserialize<PaginaDeMovimientosTesoreria>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(3, libro.Items.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, desde, hasta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        var nombreEsperado = NombreDeArchivo.Construir("tesoreria", $"pv{ctx.IdPuntoVenta}", desde, hasta);
+        var disposicion = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
+
+        using var libroXlsx = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libroXlsx.Worksheets.First();
+
+        // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden de cadena que el
+        // libro JSON (inicio/ingreso/egreso/final/concepto/empleado/fecha, design: Slice 7 task 7.5).
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < libro.Items.Count; i++)
+        {
+            var item = libro.Items[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(item.Inicio, fila.Cell(1).GetValue<decimal>());
+            Assert.Equal(item.Ingreso, fila.Cell(2).GetValue<decimal>());
+            Assert.Equal(item.Egreso, fila.Cell(3).GetValue<decimal>());
+            Assert.Equal(item.Final, fila.Cell(4).GetValue<decimal>());
+            Assert.Equal(item.Concepto, fila.Cell(5).GetString());
+            Assert.Equal(item.IdEmpleado, fila.Cell(6).GetValue<int>());
+        }
+    }
+
+    // ---- cap guard test (design decisión 6: la tesorería es un LISTADO, COUNT(*) real) --------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await SembrarMovimientoAsync(ctx, dia, 0m, 10m + i, 0m, 10m + i);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task UnaExportacionExactamenteEnElTopeSeAcepta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionExactamenteEnElTopeSeAcepta), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarMovimientoAsync(ctx, dia, 0m, 10m + i, 0m, 10m + i);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    // ---- task 7.11: rol un escalón debajo del gate, mitad export -------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelExportDeTesoreria()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelExportDeTesoreria), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
@@ -148,6 +148,7 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
 
         // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden de cadena que el
         // libro JSON (inicio/ingreso/egreso/final/concepto/empleado/fecha, design: Slice 7 task 7.5).
+        var zonaArgentina = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < libro.Items.Count; i++)
         {
@@ -159,6 +160,7 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
             Assert.Equal(item.Final, fila.Cell(4).GetValue<decimal>());
             Assert.Equal(item.Concepto, fila.Cell(5).GetString());
             Assert.Equal(item.IdEmpleado, fila.Cell(6).GetValue<int>());
+            Assert.Equal(TimeZoneInfo.ConvertTime(item.Fecha, zonaArgentina).DateTime, fila.Cell(7).GetValue<DateTime>());
         }
     }
 

--- a/tests/Ways.IntegrationTests/TesoreriaTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaTests.cs
@@ -185,16 +185,21 @@ public class TesoreriaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtu
     {
         var ctx = await PrepararAsync(nameof(ElFiltroDeFechaExcluyeMovimientosFueraDelRango));
         var dentro = new DateOnly(2026, 8, 5);
-        var fuera = new DateOnly(2026, 8, 20);
+        var fueraPorHasta = new DateOnly(2026, 8, 20);
+        // Una fila ANTERIOR a `desde`: sin ella, la cota inferior queda sin discriminar
+        // (borrar el bloque `desde` pasaba verde — hallazgo de judgment-day).
+        var fueraPorDesde = new DateOnly(2026, 7, 20);
 
         var idDentro = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dentro, 0m, 100m, 0m, 100m);
-        var idFuera = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, fuera, 100m, 50m, 0m, 150m);
+        var idFueraPorHasta = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, fueraPorHasta, 100m, 50m, 0m, 150m);
+        var idFueraPorDesde = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, fueraPorDesde, 0m, 30m, 0m, 30m);
 
         var libro = await ListarAsync(ctx.Admin, ctx.IdPuntoVenta, new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 10));
 
         Assert.NotNull(libro);
         Assert.Contains(libro!.Items, m => m.Id == idDentro);
-        Assert.DoesNotContain(libro.Items, m => m.Id == idFuera);
+        Assert.DoesNotContain(libro.Items, m => m.Id == idFueraPorHasta);
+        Assert.DoesNotContain(libro.Items, m => m.Id == idFueraPorDesde);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/TesoreriaTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 7 (design: G2/G3 — minimal aggregation, "G3:
+/// MovimientosTesoreria by PV, OrderBy(m => m.Id), paginated. Zero derivation."; spec tesoreria:
+/// Tesorería Book Has A Read/Listing Endpoint): <c>GET /api/reportes/tesoreria</c> — la casa de las
+/// 4 pruebas (cruce de tenant, discriminación por punto de venta, discriminación por rango de
+/// fecha, fixture hand-computed) más el chain-order assertion que el spec fija explícitamente y el
+/// rol un escalón debajo del gate. Siembra directa vía <c>IWaysDbContext.MovimientosTesoreria</c>
+/// (nunca a través del cierre): cada fila lleva su propio <c>Inicio</c>/<c>Final</c> explícito, sin
+/// depender del reloj del servidor — misma disciplina "time-safe seeding" que el resto de esta
+/// etapa (fechas fijas a mediodía UTC, nunca <c>DateTime.UtcNow</c> puro).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class TesoreriaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdEmpleadoAdmin, HttpClient Admin, HttpClient Supervisor,
+        HttpClient Vendedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, admin,
+            supervisor, vendedor);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarPuntoVentaAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta = new PuntoVenta { IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return puntoVenta.Id;
+    }
+
+    /// <summary>Siembra directo un <see cref="MovimientoTesoreria"/> — nunca a través del cierre:
+    /// esta clase prueba la LECTURA del libro, no la escritura encadenada (ya cubierta por las
+    /// pruebas de cierre de stage-6). <paramref name="fecha"/> fija a mediodía UTC (evita la
+    /// ventana 00-03 UTC, fix/tests-reportes-ventana-utc).</summary>
+    private async Task<int> SembrarMovimientoAsync(
+        Contexto ctx, int idPuntoVenta, DateOnly dia, decimal inicio, decimal ingreso, decimal egreso, decimal final,
+        string concepto = "Cierre de turno")
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fecha = new DateTimeOffset(dia.Year, dia.Month, dia.Day, 12, 0, 0, TimeSpan.Zero);
+
+        var movimiento = new MovimientoTesoreria
+        {
+            IdTenant = ctx.IdTenant,
+            IdPuntoVenta = idPuntoVenta,
+            Fecha = fecha,
+            Tipo = TipoMovimientoTesoreria.RetiroCaja,
+            IdTurnoCaja = null,
+            Concepto = concepto,
+            Inicio = inicio,
+            Ingreso = ingreso,
+            Egreso = egreso,
+            Final = final,
+            IdEmpleado = ctx.IdEmpleadoAdmin
+        };
+        db.MovimientosTesoreria.Add(movimiento);
+        await db.SaveChangesAsync();
+
+        return movimiento.Id;
+    }
+
+    private static Task<PaginaDeMovimientosTesoreria?> ListarAsync(
+        HttpClient cliente, int idPuntoVenta, DateOnly? desde = null, DateOnly? hasta = null)
+    {
+        var query = $"idPuntoVenta={idPuntoVenta}";
+        if (desde is { } d)
+        {
+            query += $"&desde={d:yyyy-MM-dd}T00:00:00Z";
+        }
+
+        if (hasta is { } h)
+        {
+            query += $"&hasta={h:yyyy-MM-dd}T23:59:59Z";
+        }
+
+        return cliente.GetFromJsonAsync<PaginaDeMovimientosTesoreria>($"/api/reportes/tesoreria?{query}", OpcionesJson);
+    }
+
+    // ---- task 7.8: house 4-test pattern -------------------------------------------------------
+
+    [Fact]
+    public async Task UnMovimientoDeOtroTenantNuncaApareceEnElLibro()
+    {
+        var ctxA = await PrepararAsync(nameof(UnMovimientoDeOtroTenantNuncaApareceEnElLibro) + "A");
+        var ctxB = await PrepararAsync(nameof(UnMovimientoDeOtroTenantNuncaApareceEnElLibro) + "B");
+        var dia = new DateOnly(2026, 8, 1);
+
+        var idMovimientoB = await SembrarMovimientoAsync(ctxB, ctxB.IdPuntoVenta, dia, 0m, 100m, 0m, 100m);
+
+        var libroDeA = await ListarAsync(ctxA.Admin, ctxA.IdPuntoVenta);
+
+        Assert.NotNull(libroDeA);
+        Assert.DoesNotContain(libroDeA!.Items, m => m.Id == idMovimientoB);
+    }
+
+    /// <summary>task 7.8 (mutation-proof-tests): la cláusula bajo prueba es
+    /// <c>Where(m => m.IdPuntoVenta == idPuntoVenta)</c> en <see cref="ServicioDeTesoreria"/>. Un
+    /// mismo tenant con dos puntos de venta — el libro de uno NUNCA puede traer filas del otro,
+    /// porque mezclarlas rompería el propio significado de la cadena (design decisión 11).
+    /// Mutación aplicada (reemplazar el <c>Where</c> por <c>AsQueryable()</c> en
+    /// <c>ServicioDeTesoreria.ConstruirQuery</c>): esta prueba pasó de FALLAR (el movimiento del PV
+    /// secundario aparece en el libro del PV principal) a pasar al revertir — evidencia registrada
+    /// en el cuerpo del commit (esta rama no abre PR).</summary>
+    [Fact]
+    public async Task UnMovimientoDeOtroPuntoDeVentaNuncaApareceEnElLibro()
+    {
+        var ctx = await PrepararAsync(nameof(UnMovimientoDeOtroPuntoDeVentaNuncaApareceEnElLibro));
+        var otroPuntoVenta = await SembrarPuntoVentaAsync(ctx, "PV secundario");
+        var dia = new DateOnly(2026, 8, 1);
+
+        var idPrincipal = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dia, 0m, 60m, 0m, 60m);
+        var idSecundario = await SembrarMovimientoAsync(ctx, otroPuntoVenta, dia, 0m, 999m, 0m, 999m);
+
+        var libro = await ListarAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.NotNull(libro);
+        Assert.Contains(libro!.Items, m => m.Id == idPrincipal);
+        Assert.DoesNotContain(libro.Items, m => m.Id == idSecundario);
+    }
+
+    [Fact]
+    public async Task ElFiltroDeFechaExcluyeMovimientosFueraDelRango()
+    {
+        var ctx = await PrepararAsync(nameof(ElFiltroDeFechaExcluyeMovimientosFueraDelRango));
+        var dentro = new DateOnly(2026, 8, 5);
+        var fuera = new DateOnly(2026, 8, 20);
+
+        var idDentro = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dentro, 0m, 100m, 0m, 100m);
+        var idFuera = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, fuera, 100m, 50m, 0m, 150m);
+
+        var libro = await ListarAsync(ctx.Admin, ctx.IdPuntoVenta, new DateOnly(2026, 8, 1), new DateOnly(2026, 8, 10));
+
+        Assert.NotNull(libro);
+        Assert.Contains(libro!.Items, m => m.Id == idDentro);
+        Assert.DoesNotContain(libro.Items, m => m.Id == idFuera);
+    }
+
+    [Fact]
+    public async Task LosCamposDelMovimientoCoincidenConLaFilaSembrada()
+    {
+        var ctx = await PrepararAsync(nameof(LosCamposDelMovimientoCoincidenConLaFilaSembrada));
+        var dia = new DateOnly(2026, 8, 1);
+
+        var id = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dia, 500m, 120m, 20m, 600m, "Cierre de turno de prueba");
+
+        var libro = await ListarAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.NotNull(libro);
+        var fila = Assert.Single(libro!.Items, m => m.Id == id);
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+        Assert.Equal(TipoMovimientoTesoreria.RetiroCaja, fila.Tipo);
+        Assert.Equal("Cierre de turno de prueba", fila.Concepto);
+        Assert.Equal(500m, fila.Inicio);
+        Assert.Equal(120m, fila.Ingreso);
+        Assert.Equal(20m, fila.Egreso);
+        Assert.Equal(600m, fila.Final);
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdEmpleado);
+    }
+
+    // ---- task 7.9: chain-order assertion (spec: Book Preserves Chain Order; mutation-proof) ----
+
+    /// <summary>spec tesoreria: "Book preserves chain order" — tres filas encadenadas con
+    /// <c>final</c> 60, 100, 145 tienen que volver EN ESE ORDEN, y el <c>inicio</c> de cada una
+    /// tiene que ser el <c>final</c> de la anterior. La cláusula bajo prueba es
+    /// <c>OrderBy(m => m.Id)</c> en <see cref="ServicioDeTesoreria"/> (design decisión 11: nunca
+    /// <c>OrderBy(m => m.Fecha)</c>). Mutación aplicada (reemplazar <c>OrderBy(m => m.Id)</c> por
+    /// <c>OrderByDescending(m => m.Id)</c>): esta prueba pasó de FALLAR (las filas vuelven 145,
+    /// 100, 60 — orden invertido, la cadena Inicio/Final deja de encajar) a pasar al revertir —
+    /// evidencia registrada en el cuerpo del commit.</summary>
+    [Fact]
+    public async Task TresFilasEncadenadasSeDevuelvenEnOrdenDeCadena()
+    {
+        var ctx = await PrepararAsync(nameof(TresFilasEncadenadasSeDevuelvenEnOrdenDeCadena));
+        var dia = new DateOnly(2026, 8, 1);
+
+        var id1 = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dia, 0m, 60m, 0m, 60m);
+        var id2 = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dia, 60m, 40m, 0m, 100m);
+        var id3 = await SembrarMovimientoAsync(ctx, ctx.IdPuntoVenta, dia, 100m, 60m, 15m, 145m);
+
+        var libro = await ListarAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.NotNull(libro);
+        Assert.Equal(3, libro!.Items.Count);
+        Assert.Equal([id1, id2, id3], libro.Items.Select(m => m.Id));
+        Assert.Equal([60m, 100m, 145m], libro.Items.Select(m => m.Final));
+
+        for (var i = 1; i < libro.Items.Count; i++)
+        {
+            Assert.Equal(libro.Items[i - 1].Final, libro.Items[i].Inicio);
+        }
+    }
+
+    // ---- task 7.11: rol un escalón debajo del gate ---------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelLibroDeTesoreria()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelLibroDeTesoreria));
+
+        var respuesta = await ctx.Vendedor.GetAsync($"/api/reportes/tesoreria?idPuntoVenta={ctx.IdPuntoVenta}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorLeeElLibroDeTesoreria()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorLeeElLibroDeTesoreria));
+
+        var respuesta = await ctx.Supervisor.GetAsync($"/api/reportes/tesoreria?idPuntoVenta={ctx.IdPuntoVenta}");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+}


### PR DESCRIPTION
## Etapa 11, slice 7 — Tesoreria (G3, el cajaz del legacy)

`GET /api/reportes/tesoreria` + `/export` (LecturaDeReportes): el libro del fondo de caja entre cierres, leido TAL CUAL de `movimientos_tesoreria` — cero re-derivacion de saldos.

- Orden de cadena por `Id` PROBADO contra el write path: cada eslabon deriva su Inicio del Id maximo del PV (etapa 6), asi que OrderBy(Id) es la cadena por construccion. Mutacion: invertir el orden rompe el test con los saldos 145/100/60.
- `idPuntoVenta` obligatorio: mezclar PVs rompe el significado de la cadena (design decision 11).
- Fixture verificada a mano contra el CHECK `final = inicio + ingreso - egreso`.

La pantalla web (7.5/7.6/7.12) viaja con la ola final de pantallas.

### Review
Judgment-day: Juez A APPROVE-WITH-MINORS (cadena probada contra el write path; 1 MINOR: columna Fecha sin asertar en la igualdad), Juez B APPROVE-WITH-MINORS (ambas mutaciones reclamadas + 3 propias incluida la del call-site de la guarda; 1 WARNING probado por mutacion: la cota `desde` sin discriminar — la fila fuera caia por `hasta` solo). Ambos fixes aplicados con evidencia: fila pre-desde + assert de Fecha con conversion de zona; neutralizar `desde` ahora FALLA el test, Fecha+10 dias FALLA la igualdad.

### Tests
TesoreriaTests 7 + TesoreriaExportTests 4 = 11/11 · Integration 880 en rama · full suite al asentar la ola

🤖 Generated with [Claude Code](https://claude.com/claude-code)