### PR TITLE
feat(caja): exports del historico G2 y el Z-report del turno (etapa 11, slice 5b)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -467,6 +467,15 @@ revert the branch.
 > the orchestrator's brief. **Both exports (5a.4/5a.5 here, 5b.4/5b.5/5b.6
 > below) are explicitly OUT OF SCOPE for this run** ("NO exports yet"),
 > deferred to a follow-up batch. `ExportacionDeCaja.cs` does not exist yet.
+>
+> **FOLLOW-UP APPLY-RUN NOTE (isolated worktree, branch
+> `feat/stage11-slice5b-exports-caja`)**: this later batch closed BOTH
+> deferred exports in one run — the G2 listing export left open here
+> (5a.4/5a.5/5a.9/5a.10 export half, now checked above) AND the G2 detail
+> Z-report export from Slice 5b below (5b.4-5b.6, 5b.9). `ExportacionDeCaja.cs`
+> now exists with both mappers. See the Slice 5b APPLY-RUN NOTE below for
+> the Z-report sheet-shape decision and the `ListarCierresParaExportacionAsync`
+> deviation recorded on 5a.4.
 
 - [x] 5a.1 Create `src/Ways.Application/Caja/ServicioDeHistoricoDeCajas.cs`:
   `ListarCierresAsync` — `TurnosCaja.Where(t => t.Estado ==
@@ -489,11 +498,27 @@ revert the branch.
 - [x] 5a.3 Modify `src/Ways.Api/Endpoints/ReportesEndpoints.cs`: `GET
   /cajas` under `LecturaDeReportes`. — appended after `/comisiones`, at the
   end of the group (append-anchor discipline, parallel sibling slice safe).
-- [ ] 5a.4 Create `src/Ways.Application/Caja/ExportacionDeCaja.cs`: `De`
+- [x] 5a.4 Create `src/Ways.Application/Caja/ExportacionDeCaja.cs`: `De`
   mapper for the G2 listing, pure, consumes `ListarCierresAsync`'s
-  response. — DEFERRED (see APPLY-RUN NOTE above).
-- [ ] 5a.5 Modify `ReportesEndpoints.cs`: `GET /cajas/export` sibling. —
-  DEFERRED (see APPLY-RUN NOTE above).
+  response. — IMPLEMENTED in the Slice 5b follow-up batch (isolated
+  worktree, branch `feat/stage11-slice5b-exports-caja`). DEVIATION FROM THE
+  LITERAL TASK TEXT, recorded: the mapper does NOT consume
+  `ListarCierresAsync`'s response — it consumes a NEW
+  `ListarCierresParaExportacionAsync` (Contar → refuse → `Take(tope + 1)` →
+  refuse, same shape as `ServicioDeVentas.ListarParaExportacionAsync`,
+  design decision 7). Reason: `ListarCierresAsync` clamps `tamanio` to a
+  hard 200 regardless of the requested value; a turno is NOT a bounded
+  catalog dimension like a punto de venta/vendedor/medio de pago (design
+  decision 6's "aggregate" classification), it accumulates unboundedly like
+  a venta — reusing the paginated method verbatim would silently truncate
+  any export past 200 closed turnos without `GuardaDeTope` ever tripping
+  (`TopeDeFilas` defaults to 25 000). `ConstruirQuery` was extracted and is
+  now shared by both methods (never a second predicate declaration).
+- [x] 5a.5 Modify `ReportesEndpoints.cs`: `GET /cajas/export` sibling. —
+  IMPLEMENTED in the Slice 5b follow-up batch; `desde`/`hasta` REQUIRED
+  (unlike `/cajas`), same criterion as the Slice 3 listing exports —
+  a deterministic filename needs a bounded range. `AlcanceDeListadoHttp`
+  resolves Empresa/zona (this route never had `idEmpresa`).
 - [x] 5a.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes. — confirmed clean (`--project src/Ways.Infrastructure
   --startup-project src/Ways.Infrastructure`, the `Ways.Api` startup project
@@ -520,14 +545,35 @@ revert the branch.
   Cerrado-filter evidence was strengthened in review with a non-crashing
   mutation (estado broadened + null-coalesced `FechaCierre` → the
   `DoesNotContain` assertion still discriminates, no NRE crash needed).
-- [ ] 5a.9 [P] Equality test on the export vs the JSON listing (combined
+- [x] 5a.9 [P] Equality test on the export vs the JSON listing (combined
   `diferencia` sums equal). *(spec: G2 Listing Export Figures Equal The
-  JSON Listing)* — DEFERRED with 5a.4/5a.5 (no export exists yet in this
-  batch).
+  JSON Listing)* — IMPLEMENTED:
+  `HistoricoDeCajasTests.ElExportDelHistoricoEsIgualAlListadoJsonTurnoPorTurno`
+  — stronger than the task text's "combined sums": compares `Diferencia`
+  TURNO POR TURNO (workbook row keyed by the `Turno` column vs. each JSON
+  item), not only the combined total.
 - [x] 5a.10 [P] 403 test: Vendedor rejected on `/cajas` and `/cajas/export`.
   *(spec: A Vendedor Is Rejected From The G2 Histórico Listing)* — JSON half
   (`/cajas`) done: `UnVendedorEsRechazadoDelHistoricoListado`. Export half
-  DEFERRED with 5a.4/5a.5.
+  IMPLEMENTED: `UnVendedorEsRechazadoDelExportDelHistorico`.
+- [x] 5a.13 (added, not in the original numbering) **Cap-refusal regression
+  test on `/cajas/export`**:
+  `UnaExportacionDelHistoricoQueSuperaElTopeSeRechazaConLaCantidadReal`
+  (`WithWebHostBuilder` with `TopeDeFilas = 3`, 4 seeded closed turnos, 400
+  `exportacion_demasiado_grande` naming `4`). Mutation evidence run and
+  recorded against the shared `GuardaDeTope.Exigir` clause (the same
+  already-proven clause from Slice 1b, reused verbatim here — not a new
+  clause): `if (cantidadDeFilas > topeDeFilas)` → `if (false && …)` → this
+  test FAILED (200 instead of 400); reverted → green. RECORDED GAP: unlike
+  Slice 3's `+1` race-backstop test (`VentasListadoExportTests`, its own
+  `DbCommandInterceptor` coupled to `comprobantes_venta`), this batch did
+  NOT reproduce a dedicated race-window mutation test for the NEW `Contar →
+  Take(topeDeFilas + 1)` clause this task introduces in
+  `ListarCierresParaExportacionAsync` — building a `turnos_caja`-specific
+  interceptor was judged out of proportion for this slice's budget. The
+  plain over-cap regression test passes and the code shape is structurally
+  identical to Slice 3's proven pattern, but the race-specific proof is a
+  recorded, deliberate gap for `sdd-verify`/a future batch to weigh.
 - [x] 5a.11 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE
   for this `sdd-apply` run (explicit boundary: no push/PR); left for the
   orchestrator's PR-validation phase, same precedent as 1b.13.
@@ -560,6 +606,27 @@ listings, exportable, gated `OperacionDePos` (same as `/resumen`).
 > 5b.4-5b.11 (the export sibling + its tests + judgment-day + PR) remain
 > fully pending — a future batch's job.
 
+> **FOLLOW-UP APPLY-RUN NOTE (isolated worktree, branch
+> `feat/stage11-slice5b-exports-caja`)**: 5b.4/5b.5/5b.6/5b.9 implemented
+> (5b.10/5b.11 — judgment-day + PR — stay pending, no push/PR in this
+> batch's boundary, same precedent as every prior slice's judgment-day
+> line). `ExportacionDeCaja.cs`'s `De(DetalleDeTurno, ContextoDeExportacion,
+> TimeZoneInfo)` writes ONE sheet (design: Interfaces/Contracts —
+> `TablaExportable` only supports a single `NombreDeHoja`/`Columnas` pair,
+> so "multiple hojas" was never an option) sectioned by a `Sección` column:
+> Medios de pago (esperado por medio) → Egresos por categoría → Egresos por
+> área → Retiros (always one row, even at 0) → Tickets → Gastos, in that
+> order. `CantidadTickets`/`PrimerTicket`/`UltimoTicket`/`IngresosPorArea`
+> are NOT written as their own rows — they are derivable from the Tickets
+> section or out of this endpoint's scope (line-level ingresos por área),
+> not a second figure to keep equal to the JSON. The route's header block
+> (PV/rango) resolves from the TURNO itself via a plain PK read
+> (`db.TurnosCaja.Where(t => t.Id == id)...FirstAsync`, run only after
+> `ServicioDeResumenDeTurno.ObtenerAsync` has already confirmed the turno
+> exists/is this tenant's) plus `AlcanceDeListadoHttp.ResolverAsync` for
+> Empresa/zona — the route itself takes no `idPuntoVenta`/`desde`/`hasta`
+> query parameters, unlike every other export in this stage.
+
 - [x] 5b.1 Create `src/Ways.Application/Caja/LectorDeLineasDelTurno.cs`:
   two plain indexed reads — `ComprobantesVenta.Where(c => c.IdTurnoCaja ==
   id)` (anulados excluded, matching the resumen) and `Gastos.Where(g =>
@@ -576,13 +643,21 @@ listings, exportable, gated `OperacionDePos` (same as `/resumen`).
   ObtenerAsync` verbatim + `LectorDeLineasDelTurno`. — implemented by the
   Slice 5a apply run (see APPLY-RUN NOTE above); appended at the end of the
   `/api/caja/turnos` group (append-anchor discipline).
-- [ ] 5b.4 Extend `ExportacionDeCaja.cs`: `De` mapper for `DetalleDeTurno`.
-- [ ] 5b.5 Modify `CajaEndpoints.cs`: `GET /{id}/detalle/export` sibling,
+- [x] 5b.4 Extend `ExportacionDeCaja.cs`: `De` mapper for `DetalleDeTurno`. —
+  IMPLEMENTED (see FOLLOW-UP APPLY-RUN NOTE above for the single-sheet,
+  sectioned-by-`Sección` shape). Unit-tested DB-free:
+  `tests/Ways.Application.Tests/Caja/ExportacionDeCajaTests.cs` (zona
+  conversion, section ordering, always-present Retiros row).
+- [x] 5b.5 Modify `CajaEndpoints.cs`: `GET /{id}/detalle/export` sibling,
   `OperacionDePos` inherited by co-location. *(design's load-bearing
   refinement — the detail route MOVED here from `/api/reportes/cajas/{id}`
-  precisely so this policy is inherited, not fought)*
-- [ ] 5b.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  precisely so this policy is inherited, not fought)* — IMPLEMENTED,
+  appended immediately after `/{id}/detalle`.
+- [x] 5b.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. — CONFIRMED CLEAN (`--project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure`); also cross-checked via `git
+  status --short` showing zero touched files under `Migrations/`,
+  `WaysDbContext`, or `Configuraciones/`.
 - [x] 5b.7 [P] The house 4-test pattern for the detail endpoint. —
   `DetalleDeTurnoTests.cs` (JSON half; implemented by the Slice 5a apply
   run): cross-tenant 404, anulados excluded from `Tickets` (matches the
@@ -601,12 +676,23 @@ listings, exportable, gated `OperacionDePos` (same as `/resumen`).
   There is no structural boundary to produce a cross-turno 403, so that half
   of the matrix does not exist to test; only the 200 half is implemented:
   `UnVendedorLeeElDetalleDelTurnoQueElMismoCerro`. The export half
-  (`/412/detalle/export`) is DEFERRED with 5b.4/5b.5.
-- [ ] 5b.9 [P] Equality test on the export vs the JSON detail. — DEFERRED
-  (no export exists yet in this batch).
-- [ ] 5b.10 Run `judgment-day`; fix; re-judge until clean.
+  IMPLEMENTED: `UnVendedorDescargaElExportDelTurnoQueElMismoCerro`
+  (`DetalleDeTurnoTests.cs`).
+- [x] 5b.9 [P] Equality test on the export vs the JSON detail. —
+  IMPLEMENTED: `DetalleDeTurnoTests.ElExportDelDetalleEsIgualAlJsonParaElMismoTurno`
+  — compares the workbook's Medios de pago figure (esperado por medio),
+  the Tickets section (count + Σ Total), and the Gastos section (importe)
+  against the SAME `DetalleDeTurno` the JSON route returns; also asserts
+  the header's PV line resolves from the turno itself, not a query param.
+- [ ] 5b.10 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE
+  for this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as 1b.13/2.9/3.9/5a.11.
 - [ ] 5b.11 Branch `feat/stage11-slice5b-cajas-detalle` off `main` (parent:
-  slices 1b + 5a); PR; merge stacked-to-main.
+  slices 1b + 5a); PR; merge stacked-to-main. — branch
+  `feat/stage11-slice5b-exports-caja` created off `main` per the
+  orchestrator's explicit instruction (isolated worktree; name differs from
+  the task's suggested branch name, same precedent as 1b.14/2.10/3.10/5a.12);
+  PR/merge left for the orchestrator.
 
 **Test plan**: 4-test pattern, Vendedor-200/cross-turno-403 matrix,
 equality.

--- a/src/Ways.Api/Endpoints/CajaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CajaEndpoints.cs
@@ -1,5 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.Exportacion;
+using Ways.Application.Parametros;
 
 namespace Ways.Api.Endpoints;
 
@@ -94,6 +100,55 @@ public static class CajaEndpoints
         .WithSummary(
             "Detalle del turno (Z-report): el mismo resumen de /resumen más los tickets y gastos " +
             "del turno — el cajero puede leer su propio cierre, mismo gate que /resumen.");
+
+        // stage-11-exportacion-reportes, Slice 5b (design's load-bearing refinement — la ruta vive
+        // acá para que OperacionDePos se herede por co-locación, spec historico-de-cajas: A Vendedor
+        // Downloads Their Own Turno's Z-Report): mismo par ServicioDeResumenDeTurno +
+        // LectorDeLineasDelTurno que /detalle, sin política propia. El guard de tope corre sobre
+        // TablaExportable.Filas.Count ya mapeado, sin COUNT(*): las líneas de UN turno no son un
+        // listado que crezca sin límite entre requests, a diferencia de /cajas/export.
+        grupo.MapGet("/{id:int}/detalle/export", async (
+            ServicioDeResumenDeTurno servicioDeResumen, LectorDeLineasDelTurno lectorDeLineas,
+            IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int id, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            // 404 ADR-8 si el turno no existe o es de otro tenant — misma resolución que /detalle,
+            // ANTES de leer punto de venta/fechas para el encabezado.
+            var resumen = await servicioDeResumen.ObtenerAsync(id, ct);
+            var tickets = await lectorDeLineas.LeerTicketsAsync(id, ct);
+            var gastos = await lectorDeLineas.LeerGastosAsync(id, ct);
+            var detalle = new DetalleDeTurno(resumen, tickets, gastos);
+
+            // El turno YA está confirmado existente por ObtenerAsync — lectura plana por PK para
+            // el encabezado (PV/rango), el único dato que ResumenDeTurno no trae (nunca duplica la
+            // derivación del arqueo).
+            var turno = await db.TurnosCaja
+                .Where(t => t.Id == id)
+                .Select(t => new { t.IdPuntoVenta, t.FechaApertura, t.FechaCierre })
+                .FirstAsync(ct);
+
+            var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, turno.IdPuntoVenta, ct);
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
+            var desde = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(turno.FechaApertura, zona).Date);
+            var hasta = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(turno.FechaCierre ?? turno.FechaApertura, zona).Date);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, empresa, $"PV {turno.IdPuntoVenta}", desde, hasta, zonaId);
+            var tabla = ExportacionDeCaja.De(detalle, ctx, zona);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("caja_z", $"turno{id}", desde, hasta);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX del Z-report: mismo resumen + tickets + gastos que /detalle, gate " +
+            "OperacionDePos heredado por co-locación — el cajero puede descargar su propio cierre.");
 
         return app;
     }

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -364,6 +364,22 @@ public static class ReportesEndpoints
             FormatoDeExportacion.Parsear(formato);
 
             var filas = await servicio.ListarParaExportacionAsync(
+        // stage-11-exportacion-reportes, Slice 5b (spec historico-de-cajas: G2 And G3 Endpoints
+        // Have Export Siblings Equal To Their JSON): a diferencia del resto de exports de esta
+        // etapa, un turno NO es un catálogo acotado — ServicioDeHistoricoDeCajas.
+        // ListarCierresParaExportacionAsync corre Contar → rechazar → Take(tope + 1) en vez de
+        // reusar el paginado (tope duro de 200) de /cajas, para que GuardaDeTope pueda dispararse
+        // de verdad más allá de esa página. `desde`/`hasta` OBLIGATORIOS, mismo criterio que los
+        // exports de listado de Slice 3: un nombre de archivo determinístico necesita un rango
+        // acotado. AlcanceDeListadoHttp resuelve Empresa/zona porque /cajas nunca tuvo idEmpresa.
+        grupo.MapGet("/cajas/export", async (
+            ServicioDeHistoricoDeCajas servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int? idPuntoVenta, DateTimeOffset desde, DateTimeOffset hasta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var filas = await servicio.ListarCierresParaExportacionAsync(
                 idPuntoVenta, desde, hasta, opciones.Value.TopeDeFilas, ct);
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
@@ -381,6 +397,18 @@ public static class ReportesEndpoints
             return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
         })
         .WithSummary("Export XLSX de /tesoreria: mismos parámetros y figuras, mismo orden de cadena.");
+                usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);
+            var tabla = ExportacionDeCaja.De(filas, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } pv ? $"pv{pv}" : "todos";
+            var nombre = NombreDeArchivo.Construir("cajas_historico", alcance, desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de /cajas: mismos filtros y figuras, gate LecturaDeReportes heredado por " +
+            "co-locación. desde/hasta obligatorios (a diferencia de /cajas), rango acotado por diseño.");
 
         return app;
     }

--- a/src/Ways.Application/Caja/ExportacionDeCaja.cs
+++ b/src/Ways.Application/Caja/ExportacionDeCaja.cs
@@ -42,5 +42,133 @@ public static class ExportacionDeCaja
             .ToList();
 
         return new TablaExportable("Tesorería", ctx, ColumnasTesoreria, celdas);
+/// Mappers puros de un response record de <c>Ways.Application.Caja</c> ya materializado a
+/// <see cref="TablaExportable"/> (design: Interfaces/Contracts — "un mapper por capability") — la
+/// etapa 11 nunca vuelve a consultar la base para exportar. <see cref="De(System.Collections.Generic.IReadOnlyList{FilaDeHistoricoDeCajas},ContextoDeExportacion,System.TimeZoneInfo)"/>
+/// llegó en Slice 5b (el listado G2 diferido de Slice 5a); <see cref="De(DetalleDeTurno,ContextoDeExportacion,System.TimeZoneInfo)"/>
+/// es el Z-report del turno, también Slice 5b.
+/// </summary>
+public static class ExportacionDeCaja
+{
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasHistoricoDeCajas =
+    [
+        new ColumnaExportable("Turno", TipoDeColumna.Entero),
+        new ColumnaExportable("Punto de venta", TipoDeColumna.Entero),
+        new ColumnaExportable("Apertura", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Cierre", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Esperado", TipoDeColumna.Moneda),
+        new ColumnaExportable("Declarado", TipoDeColumna.Moneda),
+        new ColumnaExportable("Diferencia", TipoDeColumna.Moneda),
+        new ColumnaExportable("Retiros", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>G2 listado (spec historico-de-cajas: G2 Listing Export Figures Equal The JSON
+    /// Listing) — una fila por turno cerrado, sin fila de totales: el listado ya es "una fila por
+    /// turno" (design decisión 6), mismo criterio que <c>VentasPorPuntoVenta</c>/
+    /// <c>VentasPorVendedor</c>. <c>Retiros</c> resume <see cref="EgresosDeTurno.Retiros"/>; el
+    /// desglose por categoría/área no viaja en una fila plana.</summary>
+    public static TablaExportable De(
+        IReadOnlyList<FilaDeHistoricoDeCajas> respuesta, ContextoDeExportacion ctx, TimeZoneInfo zona) =>
+        new(
+            "Histórico de cajas", ctx, ColumnasHistoricoDeCajas,
+            respuesta
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdTurnoCaja),
+                    Celda.Entero(f.IdPuntoVenta),
+                    Celda.FechaHora(f.FechaApertura, zona),
+                    Celda.FechaHora(f.FechaCierre, zona),
+                    Celda.Moneda(f.Esperado),
+                    Celda.Moneda(f.Declarado),
+                    Celda.Moneda(f.Diferencia),
+                    Celda.Moneda(f.Egresos.Retiros)
+                ])
+                .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasDetalleDeTurno =
+    [
+        new ColumnaExportable("Sección", TipoDeColumna.Texto),
+        new ColumnaExportable("Detalle", TipoDeColumna.Texto),
+        new ColumnaExportable("Fecha", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Importe", TipoDeColumna.Moneda)
+    ];
+
+    /// <summary>Z-report del turno (spec historico-de-cajas: G2 Detail Reuses ResumenDeTurno Plus
+    /// Ticket And Gasto Listings) — <see cref="TablaExportable"/> solo admite UNA hoja (design:
+    /// Interfaces/Contracts), así que el detalle vive en una única hoja seccionada por
+    /// <c>Sección</c> en vez de varias hojas: medios de pago (esperado por medio), egresos por
+    /// categoría, egresos por área, retiros, tickets y gastos, en ese orden — mismo agrupamiento
+    /// que <see cref="ResumenDeTurno.Egresos"/> ya expone. <c>CantidadTickets</c>/
+    /// <c>PrimerTicket</c>/<c>UltimoTicket</c>/<c>IngresosPorArea</c> no se repiten como filas
+    /// propias: son contenido derivable de la sección Tickets (o de las líneas de venta, fuera del
+    /// alcance del detalle de turno), no un segundo dato a mantener igual al JSON.</summary>
+    public static TablaExportable De(DetalleDeTurno respuesta, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var filas = new List<IReadOnlyList<Celda>>();
+
+        foreach (var medio in respuesta.Resumen.Medios)
+        {
+            filas.Add(
+            [
+                Celda.Texto("Medios de pago"),
+                Celda.Texto($"Medio {medio.IdMedioPago}"),
+                Celda.FechaHora(null, zona),
+                Celda.Moneda(medio.ImporteEsperado)
+            ]);
+        }
+
+        foreach (var categoria in respuesta.Resumen.Egresos.PorCategoria)
+        {
+            filas.Add(
+            [
+                Celda.Texto("Egresos por categoría"),
+                Celda.Texto(categoria.Categoria.ToString()),
+                Celda.FechaHora(null, zona),
+                Celda.Moneda(categoria.Total)
+            ]);
+        }
+
+        foreach (var area in respuesta.Resumen.Egresos.PorArea)
+        {
+            filas.Add(
+            [
+                Celda.Texto("Egresos por área"),
+                Celda.Texto(area.NombreArea),
+                Celda.FechaHora(null, zona),
+                Celda.Moneda(area.Total)
+            ]);
+        }
+
+        filas.Add(
+        [
+            Celda.Texto("Retiros"),
+            Celda.Texto("Total retiros"),
+            Celda.FechaHora(null, zona),
+            Celda.Moneda(respuesta.Resumen.Egresos.Retiros)
+        ]);
+
+        foreach (var ticket in respuesta.Tickets)
+        {
+            filas.Add(
+            [
+                Celda.Texto("Tickets"),
+                Celda.Texto(ticket.NumeroVisible),
+                Celda.FechaHora(ticket.Fecha, zona),
+                Celda.Moneda(ticket.Total)
+            ]);
+        }
+
+        foreach (var gasto in respuesta.Gastos)
+        {
+            filas.Add(
+            [
+                Celda.Texto("Gastos"),
+                Celda.Texto(gasto.Categoria.ToString()),
+                Celda.FechaHora(gasto.Fecha, zona),
+                Celda.Moneda(gasto.Importe)
+            ]);
+        }
+
+        return new TablaExportable("Caja Z", ctx, ColumnasDetalleDeTurno, filas);
     }
 }

--- a/src/Ways.Application/Caja/ServicioDeHistoricoDeCajas.cs
+++ b/src/Ways.Application/Caja/ServicioDeHistoricoDeCajas.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
 using Ways.Domain.Caja;
 
 namespace Ways.Application.Caja;
@@ -27,9 +28,64 @@ public class ServicioDeHistoricoDeCajas(IWaysDbContext db)
         pagina = Math.Max(pagina, 1);
         tamanio = Math.Clamp(tamanio, 1, 200);
 
-        // "histórico de cierres" (doc 01 G2) — solo turnos cerrados; un turno abierto NUNCA
-        // aparece acá (spec: An Open Turno Is Excluded From The Listing), tiene su propia lectura
-        // en /caja/turnos/abierto con totales parciales, no un cierre.
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta);
+
+        var total = await query.CountAsync(ct);
+
+        var turnosDeLaPagina = await query
+            .OrderByDescending(t => t.FechaCierre)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(t => new TurnoBase(t.Id, t.IdPuntoVenta, t.FechaApertura, t.FechaCierre))
+            .ToListAsync(ct);
+
+        var items = await ArmarFilasAsync(turnosDeLaPagina, ct);
+
+        return new PaginaDeHistoricoDeCajas(items, total, pagina, tamanio);
+    }
+
+    /// <summary>
+    /// Export sibling (stage-11-exportacion-reportes, Slice 5b) — a diferencia del resto de
+    /// reportes agregados de la etapa (design decisión 6), un turno NO es un catálogo acotado como
+    /// un punto de venta, un vendedor o un medio de pago: se acumula sin límite, igual que una
+    /// venta. Reusar <see cref="ListarCierresAsync"/> tal cual (paginado, tope duro de 200 por el
+    /// <c>Math.Clamp</c> de arriba) truncaría en silencio cualquier exportación con más de 200
+    /// cierres sin que <see cref="GuardaDeTope"/> llegara a dispararse — exactamente el riesgo que
+    /// esta etapa existe para evitar. Este método corre el mismo patrón <c>Contar → rechazar →
+    /// Take(tope + 1) → rechazar</c> que <c>ServicioDeVentas.ListarParaExportacionAsync</c>
+    /// (design decisión 7), reusando el MISMO <see cref="ConstruirQuery"/> que <see
+    /// cref="ListarCierresAsync"/> — nunca una segunda declaración del predicado.
+    /// </summary>
+    public async Task<IReadOnlyList<FilaDeHistoricoDeCajas>> ListarCierresParaExportacionAsync(
+        int? idPuntoVenta,
+        DateTimeOffset? desde,
+        DateTimeOffset? hasta,
+        int topeDeFilas,
+        CancellationToken ct = default)
+    {
+        var query = ConstruirQuery(idPuntoVenta, desde, hasta);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var turnos = await query
+            .OrderByDescending(t => t.FechaCierre)
+            .Take(topeDeFilas + 1)
+            .Select(t => new TurnoBase(t.Id, t.IdPuntoVenta, t.FechaApertura, t.FechaCierre))
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(turnos.Count, topeDeFilas);
+
+        return await ArmarFilasAsync(turnos, ct);
+    }
+
+    /// <summary>Filtro compartido de <see cref="ListarCierresAsync"/> y
+    /// <see cref="ListarCierresParaExportacionAsync"/> — "histórico de cierres" (doc 01 G2): solo
+    /// turnos cerrados, un turno abierto NUNCA aparece acá (spec: An Open Turno Is Excluded From
+    /// The Listing), tiene su propia lectura en <c>/caja/turnos/abierto</c> con totales parciales,
+    /// no un cierre.</summary>
+    private IQueryable<TurnoCaja> ConstruirQuery(int? idPuntoVenta, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
         var query = db.TurnosCaja.Where(t => t.Estado == EstadoTurno.Cerrado);
 
         if (idPuntoVenta is { } pv)
@@ -47,24 +103,20 @@ public class ServicioDeHistoricoDeCajas(IWaysDbContext db)
             query = query.Where(t => t.FechaCierre <= h);
         }
 
-        var total = await query.CountAsync(ct);
+        return query;
+    }
 
-        var turnosDeLaPagina = await query
-            .OrderByDescending(t => t.FechaCierre)
-            .Skip((pagina - 1) * tamanio)
-            .Take(tamanio)
-            .Select(t => new { t.Id, t.IdPuntoVenta, t.FechaApertura, t.FechaCierre })
-            .ToListAsync(ct);
-
-        var ids = turnosDeLaPagina.Select(t => t.Id).ToList();
+    private async Task<List<FilaDeHistoricoDeCajas>> ArmarFilasAsync(IReadOnlyList<TurnoBase> turnos, CancellationToken ct)
+    {
+        var ids = turnos.Select(t => t.Id).ToList();
 
         if (ids.Count == 0)
         {
-            return new PaginaDeHistoricoDeCajas([], total, pagina, tamanio);
+            return [];
         }
 
-        // Totales — Σ de las filas YA persistidas del cierre, una consulta agrupada para toda la
-        // página (design: "un GroupBy sobre ArqueosTurno para los ids de la página").
+        // Totales — Σ de las filas YA persistidas del cierre, una consulta agrupada para todo el
+        // conjunto (design: "un GroupBy sobre ArqueosTurno para los ids de la página").
         var totalesPorTurno = await db.ArqueosTurno
             .Where(a => ids.Contains(a.IdTurnoCaja))
             .GroupBy(a => a.IdTurnoCaja)
@@ -79,7 +131,7 @@ public class ServicioDeHistoricoDeCajas(IWaysDbContext db)
 
         var egresosPorTurno = await LeerEgresosDeLaPaginaAsync(ids, ct);
 
-        var items = turnosDeLaPagina
+        return turnos
             .Select(t =>
             {
                 var totales = totalesPorTurno.GetValueOrDefault(t.Id);
@@ -88,15 +140,15 @@ public class ServicioDeHistoricoDeCajas(IWaysDbContext db)
                 return new FilaDeHistoricoDeCajas(
                     t.Id, t.IdPuntoVenta, t.FechaApertura,
                     // ck_turnos_caja_cierre_consistente garantiza fecha_cierre no nula para un
-                    // turno cerrado — el filtro Estado == Cerrado de arriba ya lo exige.
+                    // turno cerrado — ConstruirQuery ya exige Estado == Cerrado.
                     t.FechaCierre!.Value,
                     totales?.Esperado ?? 0m, totales?.Declarado ?? 0m, totales?.Diferencia ?? 0m,
                     egresos);
             })
             .ToList();
-
-        return new PaginaDeHistoricoDeCajas(items, total, pagina, tamanio);
     }
+
+    private sealed record TurnoBase(int Id, int IdPuntoVenta, DateTimeOffset FechaApertura, DateTimeOffset? FechaCierre);
 
     /// <summary>Egresos de toda la página en tres consultas agrupadas de cantidad FIJA (nunca una
     /// por turno) — mismo criterio que <see cref="LectorDeContenidoDeResumen"/>, pero agrupando

--- a/tests/Ways.Application.Tests/Caja/ExportacionDeCajaTests.cs
+++ b/tests/Ways.Application.Tests/Caja/ExportacionDeCajaTests.cs
@@ -1,0 +1,143 @@
+using Ways.Application.Caja;
+using Ways.Application.Exportacion;
+using Ways.Application.Gastos;
+using Ways.Application.Ventas;
+using Ways.Domain.Gastos;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Tests.Caja;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 5b: reglas de mapeo de <see cref="ExportacionDeCaja"/> —
+/// DB-free, mismo criterio (<c>PoliticaDeRoles</c>) que el resto de <c>Application.Tests</c>.
+/// Cubre la conversión de <see cref="Celda.FechaHora"/> (design decisión 3) y la forma seccionada
+/// de la hoja del Z-report (design: Interfaces/Contracts — <see cref="TablaExportable"/> solo
+/// admite una hoja).
+/// </summary>
+public class ExportacionDeCajaTests
+{
+    private static readonly TimeZoneInfo ZonaBuenosAires = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
+
+    private static readonly ContextoDeExportacion Contexto = new(
+        Empresa: "1",
+        PuntoVenta: "PV 3",
+        Desde: new DateOnly(2026, 8, 1),
+        Hasta: new DateOnly(2026, 8, 1),
+        ZonaHoraria: "America/Argentina/Buenos_Aires",
+        Usuario: "admin@ways.test",
+        GeneradoEl: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
+        Cobertura: null);
+
+    // ---- G2 histórico --------------------------------------------------------------------------
+
+    [Fact]
+    public void HistoricoConvierteAperturaYCierreALaZonaLocalYDescartaElOffset()
+    {
+        var apertura = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var cierre = new DateTimeOffset(2026, 8, 1, 18, 0, 0, TimeSpan.Zero);
+        var fila = new FilaDeHistoricoDeCajas(412, 3, apertura, cierre, 1000m, 970m, 30m, new EgresosDeTurno([], [], 0m));
+
+        var tabla = ExportacionDeCaja.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[0][2].Valor);
+        Assert.Equal(new DateTime(2026, 8, 1, 15, 0, 0), tabla.Filas[0][3].Valor);
+    }
+
+    [Fact]
+    public void HistoricoReponeElRetiroDeLosEgresosEnSuPropiaColumna()
+    {
+        var ahora = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var fila = new FilaDeHistoricoDeCajas(412, 3, ahora, ahora, 1000m, 1000m, 0m, new EgresosDeTurno([], [], 250m));
+
+        var tabla = ExportacionDeCaja.De([fila], Contexto, ZonaBuenosAires);
+
+        Assert.Equal(250m, tabla.Filas[0][7].Valor);
+    }
+
+    [Fact]
+    public void HistoricoSinFilasProduceUnaTablaVacia()
+    {
+        var tabla = ExportacionDeCaja.De([], Contexto, ZonaBuenosAires);
+
+        Assert.Empty(tabla.Filas);
+    }
+
+    // ---- Z-report (detalle de turno) ------------------------------------------------------------
+
+    private static ResumenDeTurno ResumenVacio(
+        IReadOnlyList<LineaDeResumen>? medios = null, EgresosDeTurno? egresos = null) =>
+        new(
+            IdTurnoCaja: 412,
+            IdMedioAncla: 1,
+            Medios: medios ?? [],
+            CantidadTickets: 0,
+            PrimerTicket: null,
+            UltimoTicket: null,
+            IngresosPorArea: [],
+            Egresos: egresos ?? new EgresosDeTurno([], [], 0m));
+
+    [Fact]
+    public void DetalleEscribeUnaFilaPorMedioEnLaSeccionMediosDePago()
+    {
+        var resumen = ResumenVacio(medios: [new LineaDeResumen(IdMedioPago: 3, ImporteEsperado: 500m)]);
+        var detalle = new DetalleDeTurno(resumen, [], []);
+
+        var tabla = ExportacionDeCaja.De(detalle, Contexto, ZonaBuenosAires);
+
+        // Fila 0 = Medios de pago; la sección Retiros SIEMPRE se escribe, incluso en 0 (el
+        // mapper nunca omite una sección por valor nulo/cero — mismo criterio que el resto de
+        // filas de totales de la etapa).
+        Assert.Equal(2, tabla.Filas.Count);
+        var fila = tabla.Filas[0];
+        Assert.Equal("Medios de pago", fila[0].Valor);
+        Assert.Equal("Medio 3", fila[1].Valor);
+        Assert.Null(fila[2].Valor);
+        Assert.Equal(500m, fila[3].Valor);
+        Assert.Equal("Retiros", tabla.Filas[1][0].Valor);
+    }
+
+    [Fact]
+    public void DetalleEscribeLosEgresosPorCategoriaYPorAreaMasElTotalDeRetiros()
+    {
+        var egresos = new EgresosDeTurno(
+            PorCategoria: [new EgresoPorCategoria(CategoriaGasto.Otros, 40m)],
+            PorArea: [new EgresoPorArea(IdArea: null, NombreArea: "Sin área", Total: 40m)],
+            Retiros: 100m);
+        var detalle = new DetalleDeTurno(ResumenVacio(egresos: egresos), [], []);
+
+        var tabla = ExportacionDeCaja.De(detalle, Contexto, ZonaBuenosAires);
+
+        Assert.Equal(3, tabla.Filas.Count);
+        Assert.Equal("Egresos por categoría", tabla.Filas[0][0].Valor);
+        Assert.Equal("Otros", tabla.Filas[0][1].Valor);
+        Assert.Equal("Egresos por área", tabla.Filas[1][0].Valor);
+        Assert.Equal("Sin área", tabla.Filas[1][1].Valor);
+        Assert.Equal("Retiros", tabla.Filas[2][0].Valor);
+        Assert.Equal(100m, tabla.Filas[2][3].Valor);
+    }
+
+    [Fact]
+    public void DetalleEscribeTicketsYGastosConSuFechaConvertidaALaZonaLocal()
+    {
+        var fecha = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var ticket = new ComprobanteListado(
+            1, 1L, "0003-00000001", EstadoComprobante.Emitido, fecha, 3, 1, 150m);
+        var gasto = new GastoListado(1, 3, fecha, CategoriaGasto.Otros, 1, 40m);
+        var detalle = new DetalleDeTurno(ResumenVacio(), [ticket], [gasto]);
+
+        var tabla = ExportacionDeCaja.De(detalle, Contexto, ZonaBuenosAires);
+
+        // Fila 0 = Retiros (siempre presente, ver DetalleEscribeUnaFilaPorMedioEnLaSeccionMediosDePago),
+        // fila 1 = Tickets, fila 2 = Gastos.
+        Assert.Equal(3, tabla.Filas.Count);
+        Assert.Equal("Tickets", tabla.Filas[1][0].Valor);
+        Assert.Equal("0003-00000001", tabla.Filas[1][1].Valor);
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[1][2].Valor);
+        Assert.Equal(150m, tabla.Filas[1][3].Valor);
+
+        Assert.Equal("Gastos", tabla.Filas[2][0].Valor);
+        Assert.Equal("Otros", tabla.Filas[2][1].Valor);
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0), tabla.Filas[2][2].Valor);
+        Assert.Equal(40m, tabla.Filas[2][3].Valor);
+    }
+}

--- a/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
+++ b/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using ClosedXML.Excel;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
@@ -264,5 +265,75 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var respuesta = await ctx.Vendedor.GetAsync($"/api/caja/turnos/{turno.Id}/detalle");
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    // ---- Slice 5b (diferida de 5b.4/5b.5): GET /api/caja/turnos/{id}/detalle/export -------------
+
+    private const string ContentTypeXlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    /// <summary>task 5b.9 (spec: G2 And G3 Endpoints Have Export Siblings Equal To Their JSON): el
+    /// workbook seccionado (medios de pago, tickets, gastos) se compara contra el MISMO
+    /// <see cref="DetalleDeTurno"/> que devuelve la ruta JSON — no solo un total combinado, el
+    /// esperado por medio y la lista completa de tickets/gastos.</summary>
+    [Fact]
+    public async Task ElExportDelDetalleEsIgualAlJsonParaElMismoTurno()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDelDetalleEsIgualAlJsonParaElMismoTurno));
+        var turno = await AbrirTurnoAsync(ctx, ctx.Admin, 500m);
+
+        await SembrarVentaAsync(ctx, turno.Id, 100m);
+        await SembrarVentaAsync(ctx, turno.Id, 200m);
+        await RegistrarGastoAsync(ctx, ctx.Admin, ctx.IdMedioEfectivo, 30m);
+
+        // esperado efectivo = 500 (fondo) + 100 + 200 - 30 (gasto) = 770.
+        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 770m);
+
+        var detalle = await ctx.Admin.GetFromJsonAsync<DetalleDeTurno>($"/api/caja/turnos/{turno.Id}/detalle", OpcionesJson);
+        Assert.NotNull(detalle);
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/caja/turnos/{turno.Id}/detalle/export?formato=xlsx");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // El encabezado resuelve punto de venta/rango DESDE EL TURNO (no de query params — la
+        // ruta no recibe idPuntoVenta/desde/hasta): fila 2 del bloque tiene que nombrar el mismo
+        // PV que abrió/cerró el turno.
+        Assert.Contains($"PV {ctx.IdPuntoVenta}", hoja.Cell(2, 1).GetString());
+
+        const int primeraFilaDeDatos = 7;
+        var filas = new List<(string Seccion, string Detalle, decimal Importe)>();
+        for (var fila = primeraFilaDeDatos; !hoja.Cell(fila, 1).Value.IsBlank; fila++)
+        {
+            filas.Add((hoja.Cell(fila, 1).GetString(), hoja.Cell(fila, 2).GetString(), hoja.Cell(fila, 4).GetValue<decimal>()));
+        }
+
+        var esperadoEfectivo = detalle!.Resumen.Medios.Single(m => m.IdMedioPago == ctx.IdMedioEfectivo).ImporteEsperado;
+        Assert.Contains(
+            filas, f => f.Seccion == "Medios de pago" && f.Detalle == $"Medio {ctx.IdMedioEfectivo}" && f.Importe == esperadoEfectivo);
+
+        var filasTickets = filas.Where(f => f.Seccion == "Tickets").ToList();
+        Assert.Equal(detalle.Tickets.Count, filasTickets.Count);
+        Assert.Equal(detalle.Tickets.Sum(t => t.Total), filasTickets.Sum(f => f.Importe));
+
+        var gasto = Assert.Single(detalle.Gastos);
+        var filaGasto = Assert.Single(filas, f => f.Seccion == "Gastos");
+        Assert.Equal(gasto.Importe, filaGasto.Importe);
+    }
+
+    [Fact]
+    public async Task UnVendedorDescargaElExportDelTurnoQueElMismoCerro()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorDescargaElExportDelTurnoQueElMismoCerro));
+
+        var turno = await AbrirTurnoAsync(ctx, ctx.Vendedor, 100m);
+        await CerrarTurnoAsync(ctx.Vendedor, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+        var respuesta = await ctx.Vendedor.GetAsync($"/api/caja/turnos/{turno.Id}/detalle/export?formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
     }
 }

--- a/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
+++ b/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
@@ -8,6 +8,7 @@ using Ways.Application.Caja;
 using Ways.Application.Gastos;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Gastos;
 using Ways.Domain.Usuarios;
@@ -148,6 +149,14 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
     }
 
+    private static async Task RegistrarRetiroAsync(HttpClient cliente, int idTurno, decimal importe)
+    {
+        var respuesta = await cliente.PostAsJsonAsync(
+            $"/api/caja/turnos/{idTurno}/movimientos",
+            new SolicitudDeMovimiento(TipoMovimientoCaja.Retiro, importe, "Retiro de prueba"));
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+    }
+
     // ---- task 5b.7: 4-test pattern -----------------------------------------------------------
 
     [Fact]
@@ -284,9 +293,10 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         await SembrarVentaAsync(ctx, turno.Id, 100m);
         await SembrarVentaAsync(ctx, turno.Id, 200m);
         await RegistrarGastoAsync(ctx, ctx.Admin, ctx.IdMedioEfectivo, 30m);
+        await RegistrarRetiroAsync(ctx.Admin, turno.Id, 25m);
 
-        // esperado efectivo = 500 (fondo) + 100 + 200 - 30 (gasto) = 770.
-        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 770m);
+        // esperado efectivo = 500 (fondo) + 100 + 200 - 30 (gasto) - 25 (retiro) = 745.
+        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 745m);
 
         var detalle = await ctx.Admin.GetFromJsonAsync<DetalleDeTurno>($"/api/caja/turnos/{turno.Id}/detalle", OpcionesJson);
         Assert.NotNull(detalle);
@@ -314,13 +324,24 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Contains(
             filas, f => f.Seccion == "Medios de pago" && f.Detalle == $"Medio {ctx.IdMedioEfectivo}" && f.Importe == esperadoEfectivo);
 
+        // Igualdad POR TICKET (no solo cantidad/suma agregada): cada ticket sembrado tiene que
+        // aparecer con su propio número visible e importe — los dos tickets sembrados arriba
+        // tienen totales distintos (100/200) para que una rotación de importes entre filas sea
+        // detectable.
         var filasTickets = filas.Where(f => f.Seccion == "Tickets").ToList();
         Assert.Equal(detalle.Tickets.Count, filasTickets.Count);
-        Assert.Equal(detalle.Tickets.Sum(t => t.Total), filasTickets.Sum(f => f.Importe));
+        Assert.All(
+            detalle.Tickets,
+            ticket => Assert.Contains(filasTickets, f => f.Detalle == ticket.NumeroVisible && f.Importe == ticket.Total));
 
-        var gasto = Assert.Single(detalle.Gastos);
-        var filaGasto = Assert.Single(filas, f => f.Seccion == "Gastos");
-        Assert.Equal(gasto.Importe, filaGasto.Importe);
+        var filasGastos = filas.Where(f => f.Seccion == "Gastos").ToList();
+        Assert.Equal(detalle.Gastos.Count, filasGastos.Count);
+        Assert.All(
+            detalle.Gastos,
+            gasto => Assert.Contains(filasGastos, f => f.Detalle == gasto.Categoria.ToString() && f.Importe == gasto.Importe));
+
+        var filaRetiros = Assert.Single(filas, f => f.Seccion == "Retiros");
+        Assert.Equal(detalle.Resumen.Egresos.Retiros, filaRetiros.Importe);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -1,9 +1,13 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.Exportacion;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
 using Ways.Domain.Caja;
@@ -43,9 +47,16 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
         int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdEmpleadoAdmin, int IdCliente, int IdTipoComprobanteTx,
         int IdMedioEfectivo, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor);
 
-    private async Task<Contexto> PrepararAsync(string nombre)
+    /// <summary>Igual que <c>ReportesVentasResumenExportTests.PrepararAsync</c>: <paramref
+    /// name="factory"/> permite a las pruebas de tope (Slice 5b, export de <c>/cajas</c>) usar un
+    /// <c>WithWebHostBuilder</c> propio con <see cref="OpcionesDeExportacion.TopeDeFilas"/>
+    /// pisado, sin afectar al resto de esta clase (que sigue usando <c>fixture</c> directo).
+    /// </summary>
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
     {
-        using var root = fixture.CreateClient();
+        factory ??= fixture;
+
+        using var root = factory.CreateClient();
         var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
         Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
 
@@ -55,13 +66,13 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
         var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
 
-        var admin = fixture.CreateClient();
+        var admin = factory.CreateClient();
         var loginAdmin = await admin.PostAsJsonAsync(
             "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
         Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
 
-        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
-        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+        var supervisor = await CrearYLoguearAsync(admin, factory, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, factory, nombre, "vendedor", RolConocido.Vendedor);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
         var idMedioEfectivo = await db.MediosPago
@@ -75,14 +86,15 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
             idTipoComprobanteTx, idMedioEfectivo, admin, supervisor, vendedor);
     }
 
-    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> factory, string nombre, string sufijo, RolConocido rol)
     {
         var corto = Guid.NewGuid().ToString("N")[..8];
         var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
         var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
 
-        var cliente = fixture.CreateClient();
+        var cliente = factory.CreateClient();
         var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         return cliente;
@@ -278,5 +290,104 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
         var respuesta = await ctx.Supervisor.GetAsync("/api/reportes/cajas");
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    // ---- task 5a.9 / 5a.10 (mitad export, diferida de Slice 5a): GET /api/reportes/cajas/export --
+
+    private const string ContentTypeXlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static Task<HttpResponseMessage> LlamarExportDelHistoricoAsync(
+        HttpClient cliente, DateTimeOffset desde, DateTimeOffset hasta, int? idPuntoVenta = null, string formato = "xlsx") =>
+        cliente.GetAsync(
+            $"/api/reportes/cajas/export?desde={Uri.EscapeDataString(desde.ToString("O"))}" +
+            $"&hasta={Uri.EscapeDataString(hasta.ToString("O"))}" +
+            (idPuntoVenta is { } pv ? $"&idPuntoVenta={pv}" : string.Empty) + $"&formato={formato}");
+
+    /// <summary>task 5a.9 (spec: G2 Listing Export Figures Equal The JSON Listing): compara la
+    /// columna <c>Diferencia</c> del workbook contra <see cref="FilaDeHistoricoDeCajas.Diferencia"/>
+    /// TURNO POR TURNO (no solo la suma) — un turno ausente del export o desviado en su propia
+    /// figura queda expuesto aunque el total combinado coincida por casualidad.</summary>
+    [Fact]
+    public async Task ElExportDelHistoricoEsIgualAlListadoJsonTurnoPorTurno()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportDelHistoricoEsIgualAlListadoJsonTurnoPorTurno));
+
+        var turnoUno = await AbrirTurnoAsync(ctx, ctx.IdPuntoVenta, 500m);
+        await CerrarTurnoAsync(ctx, turnoUno.Id, [new ConteoDeclarado(ctx.IdMedioEfectivo, 470m)]);
+
+        var turnoDos = await AbrirTurnoAsync(ctx, ctx.IdPuntoVenta, 300m);
+        await CerrarTurnoAsync(ctx, turnoDos.Id, [new ConteoDeclarado(ctx.IdMedioEfectivo, 300m)]);
+
+        var listado = await ListarAsync(ctx.Admin);
+        Assert.NotNull(listado);
+        Assert.Equal(2, listado!.Items.Count);
+
+        var ahora = DateTimeOffset.UtcNow;
+        var respuesta = await LlamarExportDelHistoricoAsync(ctx.Admin, ahora.AddMinutes(-5), ahora.AddMinutes(5));
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        const int primeraFilaDeDatos = 7;
+        var diferenciaPorTurno = new Dictionary<int, decimal>();
+        for (var fila = primeraFilaDeDatos; !hoja.Cell(fila, 1).Value.IsBlank; fila++)
+        {
+            diferenciaPorTurno[hoja.Cell(fila, 1).GetValue<int>()] = hoja.Cell(fila, 7).GetValue<decimal>();
+        }
+
+        foreach (var item in listado.Items)
+        {
+            Assert.True(
+                diferenciaPorTurno.TryGetValue(item.IdTurnoCaja, out var diferencia),
+                $"Falta el turno {item.IdTurnoCaja} en el export.");
+            Assert.Equal(item.Diferencia, diferencia);
+        }
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelExportDelHistorico()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelExportDelHistorico));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var respuesta = await LlamarExportDelHistoricoAsync(ctx.Vendedor, ahora.AddMinutes(-5), ahora.AddMinutes(5));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    /// <summary>Cap guard del export del histórico — a diferencia del resto de los reportes
+    /// agregados de la etapa (design decisión 6), un turno NO es un catálogo acotado: reusa el
+    /// mismo patrón Contar → rechazar de <see cref="ServicioDeHistoricoDeCajas.ListarCierresParaExportacionAsync"/>
+    /// (design decisión 7). La cláusula (<c>GuardaDeTope.Exigir</c>) ya tiene evidencia de mutación
+    /// registrada en Slice 1b (función compartida, reusada tal cual acá) — esta prueba cubre el
+    /// comportamiento end-to-end del nuevo llamador, no repite la mutación de la cláusula
+    /// compartida.</summary>
+    [Fact]
+    public async Task UnaExportacionDelHistoricoQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDelHistoricoQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var turno = await AbrirTurnoAsync(ctx, ctx.IdPuntoVenta, 100m);
+            await CerrarTurnoAsync(ctx, turno.Id, [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)]);
+        }
+
+        var ahora = DateTimeOffset.UtcNow;
+        var respuesta = await LlamarExportDelHistoricoAsync(ctx.Admin, ahora.AddMinutes(-5), ahora.AddMinutes(5));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
     }
 }

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -303,10 +303,11 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
             $"&hasta={Uri.EscapeDataString(hasta.ToString("O"))}" +
             (idPuntoVenta is { } pv ? $"&idPuntoVenta={pv}" : string.Empty) + $"&formato={formato}");
 
-    /// <summary>task 5a.9 (spec: G2 Listing Export Figures Equal The JSON Listing): compara la
-    /// columna <c>Diferencia</c> del workbook contra <see cref="FilaDeHistoricoDeCajas.Diferencia"/>
-    /// TURNO POR TURNO (no solo la suma) — un turno ausente del export o desviado en su propia
-    /// figura queda expuesto aunque el total combinado coincida por casualidad.</summary>
+    /// <summary>task 5a.9 (spec: G2 Listing Export Figures Equal The JSON Listing): compara las
+    /// 8 columnas del workbook (Turno, Punto de venta, Apertura, Cierre, Esperado, Declarado,
+    /// Diferencia, Retiros) contra <see cref="FilaDeHistoricoDeCajas"/> TURNO POR TURNO (no solo
+    /// la suma) — un turno ausente del export o desviado en cualquiera de sus columnas queda
+    /// expuesto aunque el total combinado coincida por casualidad.</summary>
     [Fact]
     public async Task ElExportDelHistoricoEsIgualAlListadoJsonTurnoPorTurno()
     {
@@ -331,21 +332,46 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
         using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        // Las 8 columnas completas, no solo Diferencia — Apertura/Cierre se comparan
+        // zone-converted (mismo patrón que VentasListadoExportTests) porque el mapper convierte
+        // el DateTimeOffset a America/Argentina/Buenos_Aires antes de escribir la celda.
+        var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
-        var diferenciaPorTurno = new Dictionary<int, decimal>();
+        var filasPorTurno = new Dictionary<int, (
+            int IdPuntoVenta, DateTime Apertura, DateTime Cierre, decimal Esperado, decimal Declarado,
+            decimal Diferencia, decimal Retiros)>();
         for (var fila = primeraFilaDeDatos; !hoja.Cell(fila, 1).Value.IsBlank; fila++)
         {
-            diferenciaPorTurno[hoja.Cell(fila, 1).GetValue<int>()] = hoja.Cell(fila, 7).GetValue<decimal>();
+            filasPorTurno[hoja.Cell(fila, 1).GetValue<int>()] = (
+                hoja.Cell(fila, 2).GetValue<int>(),
+                hoja.Cell(fila, 3).GetValue<DateTime>(),
+                hoja.Cell(fila, 4).GetValue<DateTime>(),
+                hoja.Cell(fila, 5).GetValue<decimal>(),
+                hoja.Cell(fila, 6).GetValue<decimal>(),
+                hoja.Cell(fila, 7).GetValue<decimal>(),
+                hoja.Cell(fila, 8).GetValue<decimal>());
         }
 
         foreach (var item in listado.Items)
         {
             Assert.True(
-                diferenciaPorTurno.TryGetValue(item.IdTurnoCaja, out var diferencia),
+                filasPorTurno.TryGetValue(item.IdTurnoCaja, out var fila),
                 $"Falta el turno {item.IdTurnoCaja} en el export.");
-            Assert.Equal(item.Diferencia, diferencia);
+            Assert.Equal(item.IdPuntoVenta, fila.IdPuntoVenta);
+            // Truncado a segundos: el double de OLE Automation date que ClosedXML persiste no
+            // retiene la precisión de microsegundos de Postgres — sin el truncado, la comparación
+            // flakearía por redondeo del formato xlsx, no por un bug real (mismo criterio que el
+            // comentario de PreciosEndpointsTests sobre no comparar precisión distinta).
+            Assert.Equal(TruncarASegundos(TimeZoneInfo.ConvertTime(item.FechaApertura, zona).DateTime), TruncarASegundos(fila.Apertura));
+            Assert.Equal(TruncarASegundos(TimeZoneInfo.ConvertTime(item.FechaCierre, zona).DateTime), TruncarASegundos(fila.Cierre));
+            Assert.Equal(item.Esperado, fila.Esperado);
+            Assert.Equal(item.Declarado, fila.Declarado);
+            Assert.Equal(item.Diferencia, fila.Diferencia);
+            Assert.Equal(item.Egresos.Retiros, fila.Retiros);
         }
     }
+
+    private static DateTime TruncarASegundos(DateTime valor) => valor.AddTicks(-(valor.Ticks % TimeSpan.TicksPerSecond));
 
     [Fact]
     public async Task UnVendedorEsRechazadoDelExportDelHistorico()


### PR DESCRIPTION
## Etapa 11, slice 5b — Exports de caja

- `GET /api/reportes/cajas/export` (LecturaDeReportes): el historico de cierres a XLSX, con `ListarCierresParaExportacionAsync` count-first — reusar el listado clampeado a 200 habria TRUNCADO SILENCIOSAMENTE cualquier export grande, el pecado exacto que la etapa prohibe.
- `GET /api/caja/turnos/{id}/detalle/export` (OperacionDePos): el Z-report del cajero — una hoja seccionada (medios → egresos por categoria/area → retiros SIEMPRE presente → tickets → gastos), tipos de celda honestos por seccion.

### Review
Judgment-day de 2 rondas: Juez A APPROVE (deviation del listado justificada, hoja seccionada sin celdas deshonestas, politicas por co-locacion probadas). Juez B REJECT ronda 1 con TRES MAJORs probados por mutacion — el peor: rotar totales entre tickets (conteo y suma preservados) sobrevivia a TODAS las capas; Retiros droppeable end-to-end; 6 de 8 columnas del historico sin probar. Fix `f5c9001` (igualdad total por fila y columna) → APPROVE ronda 2 con 5 mutaciones re-ejecutadas incluida la del helper de truncado (+1 minuto sigue fallando). Este incidente (5ta ocurrencia de la clase) endurecio la skill mutation-proof-tests con la regla 6.

### Tests
22/22 filtrados post-rebase (6 unit + 16 integration) · full suite al asentar

🤖 Generated with [Claude Code](https://claude.com/claude-code)