### PR TITLE
feat(web): pantallas de historico de cajas, Caja Z y tesoreria (etapa 11, slices 6a+6b+7web)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -891,7 +891,7 @@ G3 read endpoint live, chain-ordered, exportable, `/caja/tesoreria` screen.
 - [x] 7.12 [P] `Tesoreria.test.tsx`: renders the book in chain order,
   download busy-state, role gating. Per `web-descriptor-tests`. —
   IMPLEMENTED in the same follow-up batch as 7.5/7.6: renders a 3-row
-  chained fixture (`final` 60/100/145-style, same shape as the backend's
+  chained fixture (`final` 60/100/55 (tres filas encadenadas con valores distintos por columna)-style, same shape as the backend's
   own `TresFilasEncadenadasSeDevuelvenEnOrdenDeCadena` fixture) asserting
   DOM row order matches array order with no client sort, per-row column
   mapping with distinct values (mutation-proof-tests rule 6), download

--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -707,19 +707,38 @@ equality.
 closed turnos with totals, download button wired, Supervisor/Admin nav
 entry. **Rollback**: revert the branch; route/nav entry removed.
 
-- [ ] 6a.1 Create `src/Ways.Web/src/paginas/HistoricoDeCajas.tsx`: table of
+> **APPLY-RUN NOTE (isolated worktree, branch
+> `feat/stage11-slice6-pantallas-caja`, explicit orchestrator instruction)**:
+> this batch merges Slices 6a + 6b + the deferred web sub-tasks of Slice 7
+> (7.5/7.6/7.12) into one apply run — "the three caja/tesorería screens
+> share nav wiring and patterns; batching them avoids three trivial PRs".
+> All backend routes were already live from prior batches
+> (`/api/reportes/cajas(+export)`, `/api/caja/turnos/{id}/detalle(+export)`,
+> `/api/reportes/tesoreria(+export)`) — zero backend changes this run.
+
+- [x] 6a.1 Create `src/Ways.Web/src/paginas/HistoricoDeCajas.tsx`: table of
   closed turnos (PV/fecha/esperado/declarado/diferencia), filter bar,
   `BotonDeDescarga` pointed at `/cajas/export`.
-- [ ] 6a.2 Modify `src/Ways.Web/src/App.tsx` and `componentes/Layout.tsx`:
+- [x] 6a.2 Modify `src/Ways.Web/src/App.tsx` and `componentes/Layout.tsx`:
   add the `/caja/historico` route (`LecturaDeReportes` role gate) and nav
   entry under Caja.
-- [ ] 6a.3 [P] `HistoricoDeCajas.test.tsx`: renders the listing; download
+- [x] 6a.3 [P] `HistoricoDeCajas.test.tsx`: renders the listing; download
   button busy-state per `react-async-state`; role-gating (Supervisor
   reaches the route, Vendedor redirects) via `RutaProtegida`. Per
-  `web-descriptor-tests`.
-- [ ] 6a.4 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 6a.5 Branch `feat/stage11-slice6a-historico-web` off `main` (parent:
-  slices 4 + 5a); PR; merge stacked-to-main.
+  `web-descriptor-tests`. — extended with a mapping test asserting every
+  column of two per-row-distinct fixtures (mutation-proof-tests rule 6)
+  and a stale-response/generation test (`react-async-state`).
+- [x] 6a.4 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as every prior slice
+  (1b.13/2.9/3.9/5a.11/5b.10/7.13).
+- [x] 6a.5 Branch `feat/stage11-slice6a-historico-web` off `main` (parent:
+  slices 4 + 5a); PR; merge stacked-to-main. — branch
+  `feat/stage11-slice6-pantallas-caja` created off `main` per the
+  orchestrator's explicit instruction (isolated worktree; single branch
+  for the three-screen batch, name differs from the task's suggested
+  branch name, same precedent as 1b.14/2.10/3.10/5a.12/5b.11/7.14);
+  PR/merge left for the orchestrator.
 
 **Test plan**: descriptor tests, busy-state, role gating.
 
@@ -733,19 +752,42 @@ entry. **Rollback**: revert the branch; route/nav entry removed.
 renders `ResumenDeTurno` + ticket/gasto listings, download button, linked
 from the cierre-de-caja flow. **Rollback**: revert the branch.
 
-- [ ] 6b.1 Create `src/Ways.Web/src/paginas/CajaZ.tsx`: renders
+> **APPLY-RUN NOTE**: same batch as Slice 6a above (branch
+> `feat/stage11-slice6-pantallas-caja`). 6b.3's "nav entry" is deliberately
+> NOT added for `CajaZ` itself — it is a turno-detail screen reached only
+> via a link (from `HistoricoDeCajas`... no, from `CierreDeCaja`'s
+> just-closed-turno panel and from the URL), same convention as
+> `CompraEditor.tsx`/`CuentaCorriente.tsx`, neither of which has its own
+> top-level nav entry either. 6b.4's literal "a cross-turno attempt is
+> rejected" half does NOT exist to test at the UI layer either: the Slice
+> 5b apply run confirmed `Politicas.OperacionDePos` is a role-only gate
+> with no PV/turno-ownership claim (see 5b.8's note in the Slice 5b
+> section above) — same recorded gap, propagated to this UI test.
+
+- [x] 6b.1 Create `src/Ways.Web/src/paginas/CajaZ.tsx`: renders
   `DetalleDeTurno`, `BotonDeDescarga` pointed at `/{id}/detalle/export`.
-- [ ] 6b.2 Modify `src/Ways.Web/src/paginas/CierreDeCaja.tsx`: link from
+- [x] 6b.2 Modify `src/Ways.Web/src/paginas/CierreDeCaja.tsx`: link from
   the just-closed turno to its Caja Z screen.
-- [ ] 6b.3 Modify `App.tsx`/`Layout.tsx`: add the `/caja/turnos/:id/z`
-  route (`OperacionDePos` role gate) and nav entry.
-- [ ] 6b.4 [P] `CajaZ.test.tsx`: renders resumen + both listings; download
+- [x] 6b.3 Modify `App.tsx`/`Layout.tsx`: add the `/caja/turnos/:id/z`
+  route (`OperacionDePos` role gate) and nav entry. — route added; nav
+  entry deliberately omitted for the reason recorded in the APPLY-RUN NOTE
+  above (detail screen reached by link, not a top-level nav destination).
+- [x] 6b.4 [P] `CajaZ.test.tsx`: renders resumen + both listings; download
   busy-state; a Vendedor reaches their own turno's Z, a cross-turno
   attempt is rejected (mirrors the API's 5b.8 matrix at the UI layer). Per
-  `web-descriptor-tests`.
-- [ ] 6b.5 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 6b.6 Branch `feat/stage11-slice6b-caja-z-web` off `main` (parent:
-  slices 4 + 5b); PR; merge stacked-to-main.
+  `web-descriptor-tests`. — the 200 half is implemented
+  (`un Vendedor llega a la Caja Z de su propio turno`); the cross-turno
+  403 half does not exist to test (see APPLY-RUN NOTE above, same gap as
+  5b.8). Extended with a per-row mapping test (mutation-proof-tests rule
+  6, two medios/tickets/gastos rows with distinct values per column) and
+  a same-mounted-screen stale-response/generation test (turno navigation
+  via `useNavigate`, `react-async-state`).
+- [x] 6b.5 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run, same precedent as 6a.4.
+- [x] 6b.6 Branch `feat/stage11-slice6b-caja-z-web` off `main` (parent:
+  slices 4 + 5b); PR; merge stacked-to-main. — same single batch branch as
+  6a.5 (`feat/stage11-slice6-pantallas-caja`); PR/merge left for the
+  orchestrator.
 
 **Test plan**: descriptor tests, busy-state, Vendedor-own-turno/
 cross-turno matrix at the UI layer.
@@ -775,6 +817,13 @@ G3 read endpoint live, chain-ordered, exportable, `/caja/tesoreria` screen.
 > (unlike G2's optional one): mixing points of venta would break the
 > chain's own meaning (design decision 11) — a deviation from the literal
 > task wording ("by PV and date range") worth flagging for verify.
+>
+> **FOLLOW-UP APPLY-RUN NOTE (isolated worktree, branch
+> `feat/stage11-slice6-pantallas-caja`)**: 7.5/7.6/7.12 (the deferred web
+> screen, routing/nav, descriptor tests) IMPLEMENTED in this batch,
+> together with Slices 6a and 6b — see the APPLY-RUN NOTE at the top of
+> the Slice 6a section above for the three-screen batching rationale.
+> 7.13-7.14 (judgment-day, PR, merge) remain OUT OF SCOPE, same precedent.
 
 - [x] 7.1 Create `src/Ways.Application/Caja/ServicioDeTesoreria.cs`:
   `ListarAsync` — `MovimientosTesoreria` by PV and date range, `OrderBy(m
@@ -797,11 +846,20 @@ G3 read endpoint live, chain-ordered, exportable, `/caja/tesoreria` screen.
   appended immediately after `/tesoreria` (co-location); resolves
   empresa/zona via the existing `AlcanceDeListadoHttp.ResolverAsync`, no
   duplicated lookup.
-- [ ] 7.5 Create `src/Ways.Web/src/paginas/Tesoreria.tsx`: the book table
+- [x] 7.5 Create `src/Ways.Web/src/paginas/Tesoreria.tsx`: the book table
   (inicio/ingreso/egreso/final/concepto/empleado/fecha), `BotonDeDescarga`.
-  — DEFERRED (see APPLY-RUN NOTE above, "NO web").
-- [ ] 7.6 Modify `App.tsx`/`Layout.tsx`: `/caja/tesoreria` route
-  (`LecturaDeReportes`) and nav entry. — DEFERRED with 7.5.
+  — IMPLEMENTED in the Slice 6a/6b/7-web follow-up batch (isolated
+  worktree, branch `feat/stage11-slice6-pantallas-caja`, see the
+  APPLY-RUN NOTE at the top of the Slice 6a section above — the three
+  caja/tesorería screens were batched into one apply run). Column order
+  pinned as specified (inicio/ingreso/egreso/final/concepto/empleado/
+  fecha); no "Todos" option for punto de venta (required, design decisión
+  11); rows render in the backend's own chain order, no client sort.
+- [x] 7.6 Modify `App.tsx`/`Layout.tsx`: `/caja/tesoreria` route
+  (`LecturaDeReportes`) and nav entry. — IMPLEMENTED in the same follow-up
+  batch; nav entry placed next to `/caja/historico`, both gated by
+  `puedeVerReportes` (mirror of `Politicas.LecturaDeReportes`, same as
+  `/tablero`).
 - [x] 7.7 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
   pending changes. — confirmed clean (`--project src/Ways.Infrastructure
   --startup-project src/Ways.Infrastructure`).
@@ -830,9 +888,15 @@ G3 read endpoint live, chain-ordered, exportable, `/caja/tesoreria` screen.
   Vendedor Is Rejected From The Tesorería Book)* — `UnVendedorEsRechazado
   DelLibroDeTesoreria` (JSON) + `UnVendedorEsRechazadoDelExportDeTesoreria`
   (export); `UnSupervisorLeeElLibroDeTesoreria` (200) alongside.
-- [ ] 7.12 [P] `Tesoreria.test.tsx`: renders the book in chain order,
-  download busy-state, role gating. Per `web-descriptor-tests`. — DEFERRED
-  with 7.5/7.6.
+- [x] 7.12 [P] `Tesoreria.test.tsx`: renders the book in chain order,
+  download busy-state, role gating. Per `web-descriptor-tests`. —
+  IMPLEMENTED in the same follow-up batch as 7.5/7.6: renders a 3-row
+  chained fixture (`final` 60/100/145-style, same shape as the backend's
+  own `TresFilasEncadenadasSeDevuelvenEnOrdenDeCadena` fixture) asserting
+  DOM row order matches array order with no client sort, per-row column
+  mapping with distinct values (mutation-proof-tests rule 6), download
+  busy-state/error-funnel wiring, role gating (Supervisor reaches the
+  route, Vendedor redirects), and a stale-response/generation test.
 - [x] 7.13 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
   this `sdd-apply` run (explicit boundary: no push/PR); left for the
   orchestrator's PR-validation phase, same precedent as 1b.13/5a.11.

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -4,6 +4,7 @@ import { RutaProtegida } from './auth/RutaProtegida'
 import { Layout } from './componentes/Layout'
 import { Articulos } from './paginas/Articulos'
 import { Caja } from './paginas/Caja'
+import { CajaZ } from './paginas/CajaZ'
 import { CierreDeCaja } from './paginas/CierreDeCaja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
@@ -13,6 +14,7 @@ import { CompraEditor } from './paginas/CompraEditor'
 import { ConteoDeInventario } from './paginas/ConteoDeInventario'
 import { CuentaCorriente } from './paginas/CuentaCorriente'
 import { Empresas } from './paginas/Empresas'
+import { HistoricoDeCajas } from './paginas/HistoricoDeCajas'
 import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
 import { NuevoTenant } from './paginas/NuevoTenant'
@@ -25,6 +27,7 @@ import { PuntosVenta } from './paginas/PuntosVenta'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
 import { Tablero } from './paginas/Tablero'
 import { Tenants } from './paginas/Tenants'
+import { Tesoreria } from './paginas/Tesoreria'
 import { Transferencias } from './paginas/Transferencias'
 import { Usuarios } from './paginas/Usuarios'
 import { descriptorListasPrecio } from './api/catalogos'
@@ -90,6 +93,37 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <CierreDeCaja />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-11-exportacion-reportes (Slice 6b, design: Web Composition): Caja Z —
+                mismo gate que /caja (Politicas.OperacionDePos), el cajero lee su propio cierre. */}
+            <Route
+              path="/caja/turnos/:id/z"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <CajaZ />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-11-exportacion-reportes (Slice 6a, design: Web Composition, spec
+                historico-de-cajas: Role Split): G2 — mismo gate que /tablero
+                (Politicas.LecturaDeReportes), vista de gestión sobre turnos ajenos. */}
+            <Route
+              path="/caja/historico"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <HistoricoDeCajas />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-11-exportacion-reportes (Slice 7, design: Web Composition, spec tesoreria):
+                G3 — mismo gate que /tablero (Politicas.LecturaDeReportes). */}
+            <Route
+              path="/caja/tesoreria"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <Tesoreria />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/caja.test.ts
+++ b/src/Ways.Web/src/api/caja.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { aSolicitudDeMovimiento, importeValidoParaTipo, motivoValido } from './caja'
+import { describe, expect, it, vi } from 'vitest'
+
+const apiGetMock = vi.fn(() => Promise.resolve(undefined))
+
+vi.mock('./cliente', () => ({
+  api: { get: (...args: unknown[]) => apiGetMock(...(args as [])) },
+}))
+
+const { aSolicitudDeMovimiento, clienteDeCaja, importeValidoParaTipo, motivoValido, rutasDeExportacionDeCaja } = await import('./caja')
 
 describe('motivoValido', () => {
   it('rechaza un motivo vacío', () => {
@@ -64,5 +71,23 @@ describe('aSolicitudDeMovimiento', () => {
     const resultado = aSolicitudDeMovimiento('Refuerzo', 'abc', 'motivo válido')
 
     expect(Number.isNaN(resultado.importe)).toBe(true)
+  })
+})
+
+// ---- stage-11-exportacion-reportes, Slice 6b: clienteDeCaja.obtenerDetalle + la ruta de export
+// del Z-report -----------------------------------------------------------------------------
+
+describe('clienteDeCaja.obtenerDetalle', () => {
+  it('pega contra GET /caja/turnos/{id}/detalle', async () => {
+    apiGetMock.mockClear()
+    await clienteDeCaja.obtenerDetalle(412)
+
+    expect(apiGetMock).toHaveBeenCalledWith('/caja/turnos/412/detalle')
+  })
+})
+
+describe('rutasDeExportacionDeCaja.detalleDeTurno', () => {
+  it('arma la ruta del export sibling con formato=xlsx', () => {
+    expect(rutasDeExportacionDeCaja.detalleDeTurno(412)).toBe('/caja/turnos/412/detalle/export?formato=xlsx')
   })
 })

--- a/src/Ways.Web/src/api/caja.ts
+++ b/src/Ways.Web/src/api/caja.ts
@@ -7,6 +7,7 @@
  */
 import { api } from './cliente'
 import type {
+  DetalleDeTurno,
   MovimientoRegistrado,
   ResumenDeTurno,
   SolicitudDeApertura,
@@ -38,6 +39,18 @@ export const clienteDeCaja = {
    * Declared Counts). */
   cerrar: (idTurnoCaja: number, solicitud: SolicitudDeCierre) =>
     api.post<TurnoConArqueos>(`/caja/turnos/${idTurnoCaja}/cierre`, solicitud),
+  /** `GET /api/caja/turnos/{id}/detalle` (stage-11-exportacion-reportes, Slice 5a/6b, spec
+   * historico-de-cajas: G2 Detail Reuses ResumenDeTurno Plus Ticket And Gasto Listings) — el
+   * Z-report: mismo `ResumenDeTurno` que `/resumen` más los tickets y gastos del turno. Mismo
+   * gate `OperacionDePos` que `/resumen`: el cajero puede leer su propio cierre. */
+  obtenerDetalle: (idTurnoCaja: number) => api.get<DetalleDeTurno>(`/caja/turnos/${idTurnoCaja}/detalle`),
+}
+
+/** Rutas de descarga (`/export`, stage-11 slice 6b) del Z-report — sibling de `/detalle` bajo el
+ * mismo gate `OperacionDePos` heredado por co-locación (design: "The load-bearing refinement of
+ * the proposal is where the caja detail lives"). */
+export const rutasDeExportacionDeCaja = {
+  detalleDeTurno: (idTurnoCaja: number) => `/caja/turnos/${idTurnoCaja}/detalle/export?formato=xlsx`,
 }
 
 /** Longitud mínima del motivo, uniforme para los 3 tipos de movimiento (design decisión 8;

--- a/src/Ways.Web/src/api/reportes.test.ts
+++ b/src/Ways.Web/src/api/reportes.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type {
   FiltrosDeBreakdown,
   FiltrosDeBreakdownConPv,
+  FiltrosDeHistoricoDeCajas,
   FiltrosDeRentabilidad,
   FiltrosDeReporte,
+  FiltrosDeTesoreria,
   FiltrosDeTopArticulos,
 } from './reportes'
 
@@ -17,7 +19,10 @@ const {
   clienteDeReportes,
   construirQueryDeBreakdown,
   construirQueryDeBreakdownConPv,
+  construirQueryDeHistoricoDeCajas,
   construirQueryDeReporte,
+  construirQueryDeTesoreria,
+  filtrosDeHistoricoDeCajasVacios,
   rangoUltimosSieteDias,
   rutasDeExportacion,
 } = await import('./reportes')
@@ -47,6 +52,26 @@ function filtrosTopArticulosFixture(sobrescribir: Partial<FiltrosDeTopArticulos>
 
 function filtrosRentabilidadFixture(sobrescribir: Partial<FiltrosDeRentabilidad> = {}): FiltrosDeRentabilidad {
   return { idEmpresa: 1, idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', incluirEstimados: false, ...sobrescribir }
+}
+
+function filtrosHistoricoDeCajasFixture(sobrescribir: Partial<FiltrosDeHistoricoDeCajas> = {}): FiltrosDeHistoricoDeCajas {
+  return { idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11', pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function filtrosTesoreriaFixture(sobrescribir: Partial<FiltrosDeTesoreria> = {}): FiltrosDeTesoreria {
+  return { idPuntoVenta: 7, desde: '2026-08-05', hasta: '2026-08-11', pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+// ---- construirQueryDeHistoricoDeCajas / construirQueryDeTesoreria: mismo patrón de offset
+// explícito que compras.ts/cuentaCorriente.ts — /cajas y /tesoreria filtran contra un timestamptz. --
+
+function offsetEsperado(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
 }
 
 describe('construirQueryDeReporte', () => {
@@ -131,6 +156,95 @@ describe('rutasDeExportacion', () => {
     const ruta = rutasDeExportacion.rentabilidad(filtrosRentabilidadFixture({ incluirEstimados: true }))
 
     expect(ruta).toBe('/reportes/rentabilidad/export?idEmpresa=1&desde=2026-08-05&hasta=2026-08-11&incluirEstimados=true&formato=xlsx')
+  })
+
+  it('historicoDeCajas reutiliza el offset de /cajas y suma formato=xlsx, sin pagina/tamanio', () => {
+    const offsetDesde = offsetEsperado(2026, 8, 5)
+    const offsetHasta = offsetEsperado(2026, 8, 11)
+    const ruta = decodeURIComponent(rutasDeExportacion.historicoDeCajas({ idPuntoVenta: null, desde: '2026-08-05', hasta: '2026-08-11' }))
+
+    expect(ruta).toBe(`/reportes/cajas/export?desde=2026-08-05T00:00:00${offsetDesde}&hasta=2026-08-11T23:59:59.999${offsetHasta}&formato=xlsx`)
+  })
+
+  it('historicoDeCajas agrega idPuntoVenta solo cuando está seteado', () => {
+    const ruta = rutasDeExportacion.historicoDeCajas({ idPuntoVenta: 7, desde: '2026-08-05', hasta: '2026-08-11' })
+
+    expect(ruta).toContain('idPuntoVenta=7')
+  })
+
+  it('tesoreria reutiliza el offset de /tesoreria y suma formato=xlsx, sin pagina/tamanio', () => {
+    const offsetDesde = offsetEsperado(2026, 8, 5)
+    const offsetHasta = offsetEsperado(2026, 8, 11)
+    const ruta = decodeURIComponent(rutasDeExportacion.tesoreria({ idPuntoVenta: 7, desde: '2026-08-05', hasta: '2026-08-11' }))
+
+    expect(ruta).toBe(
+      `/reportes/tesoreria/export?idPuntoVenta=7&desde=2026-08-05T00:00:00${offsetDesde}&hasta=2026-08-11T23:59:59.999${offsetHasta}&formato=xlsx`,
+    )
+  })
+})
+
+describe('construirQueryDeHistoricoDeCajas', () => {
+  it('omite idPuntoVenta cuando es null, agrega desde/hasta con offset y pagina/tamanio', () => {
+    const offsetDesde = offsetEsperado(2026, 8, 5)
+    const offsetHasta = offsetEsperado(2026, 8, 11)
+    const query = decodeURIComponent(construirQueryDeHistoricoDeCajas(filtrosHistoricoDeCajasFixture()))
+
+    expect(query).toBe(`?desde=2026-08-05T00:00:00${offsetDesde}&hasta=2026-08-11T23:59:59.999${offsetHasta}&pagina=1&tamanio=25`)
+  })
+
+  it('agrega idPuntoVenta solo cuando está seteado', () => {
+    const query = construirQueryDeHistoricoDeCajas(filtrosHistoricoDeCajasFixture({ idPuntoVenta: 7 }))
+
+    expect(query).toContain('idPuntoVenta=7')
+  })
+
+  it('filtrosDeHistoricoDeCajasVacios arranca sin idPuntoVenta, con el rango de los últimos 7 días', () => {
+    const filtros = filtrosDeHistoricoDeCajasVacios()
+
+    expect(filtros.idPuntoVenta).toBeNull()
+    expect(filtros.pagina).toBe(1)
+    expect(filtros.tamanio).toBe(25)
+    expect(filtros.desde).not.toBe('')
+    expect(filtros.hasta).not.toBe('')
+  })
+})
+
+describe('construirQueryDeTesoreria', () => {
+  it('idPuntoVenta viaja siempre (obligatorio), con desde/hasta y pagina/tamanio', () => {
+    const offsetDesde = offsetEsperado(2026, 8, 5)
+    const offsetHasta = offsetEsperado(2026, 8, 11)
+    const query = decodeURIComponent(construirQueryDeTesoreria(filtrosTesoreriaFixture()))
+
+    expect(query).toBe(`?idPuntoVenta=7&desde=2026-08-05T00:00:00${offsetDesde}&hasta=2026-08-11T23:59:59.999${offsetHasta}&pagina=1&tamanio=25`)
+  })
+})
+
+describe('construirQueryDeHistoricoDeCajas / construirQueryDeTesoreria — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00 en ambos', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+
+    expect(decodeURIComponent(construirQueryDeHistoricoDeCajas(filtrosHistoricoDeCajasFixture()))).toContain('desde=2026-08-05T00:00:00-03:00')
+    expect(decodeURIComponent(construirQueryDeTesoreria(filtrosTesoreriaFixture()))).toContain('desde=2026-08-05T00:00:00-03:00')
+  })
+})
+
+describe('clienteDeReportes.historicoDeCajas / clienteDeReportes.tesoreria', () => {
+  it('historicoDeCajas pega contra /reportes/cajas con el query armado', async () => {
+    apiGetMock.mockClear()
+    await clienteDeReportes.historicoDeCajas(filtrosHistoricoDeCajasFixture())
+
+    expect(apiGetMock).toHaveBeenCalledWith(expect.stringMatching(/^\/reportes\/cajas\?/))
+  })
+
+  it('tesoreria pega contra /reportes/tesoreria con el query armado', async () => {
+    apiGetMock.mockClear()
+    await clienteDeReportes.tesoreria(filtrosTesoreriaFixture())
+
+    expect(apiGetMock).toHaveBeenCalledWith(expect.stringMatching(/^\/reportes\/tesoreria\?idPuntoVenta=7/))
   })
 })
 

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -9,6 +9,8 @@ import { api } from './cliente'
 import type {
   Comisiones,
   Granularidad,
+  PaginaDeHistoricoDeCajas,
+  PaginaDeMovimientosTesoreria,
   Rentabilidad,
   ResumenDeGastos,
   ResumenDeVentas,
@@ -98,6 +100,88 @@ export const clienteDeReportes = {
   },
   comisiones: (filtros: FiltrosDeBreakdownConPv) =>
     api.get<Comisiones>(`/reportes/comisiones${construirQueryDeBreakdownConPv(filtros)}`),
+  historicoDeCajas: (filtros: FiltrosDeHistoricoDeCajas) =>
+    api.get<PaginaDeHistoricoDeCajas>(`/reportes/cajas${construirQueryDeHistoricoDeCajas(filtros)}`),
+  tesoreria: (filtros: FiltrosDeTesoreria) =>
+    api.get<PaginaDeMovimientosTesoreria>(`/reportes/tesoreria${construirQueryDeTesoreria(filtros)}`),
+}
+
+// ---- Offset local para desde/hasta de /cajas y /tesoreria (stage-11-exportacion-reportes,
+// Slices 6a/7): a diferencia de ventas/resumen (arriba, `DateOnly` del lado del servidor), estas
+// dos rutas filtran contra un `timestamptz` (`fecha_cierre`/`fecha`) — mismo criterio de offset
+// explícito que `compras.ts`/`cuentaCorriente.ts`. Duplicado a propósito: no hay un módulo
+// compartido de utilidades de fecha en esta web todavía. -------------------------------------
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+/** Filtro de `GET /api/reportes/cajas` — `idPuntoVenta` es opcional (a diferencia de
+ * `FiltrosDeTesoreria`): el histórico de cierres admite "Todos". */
+export type FiltrosDeHistoricoDeCajas = {
+  idPuntoVenta: number | null
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+export function filtrosDeHistoricoDeCajasVacios(): FiltrosDeHistoricoDeCajas {
+  const rango = rangoUltimosSieteDias()
+  return { idPuntoVenta: null, desde: rango.desde, hasta: rango.hasta, pagina: 1, tamanio: 25 }
+}
+
+/** Query compartido de `/cajas` y `/cajas/export` — `pagina`/`tamanio` NO viajan al export
+ * (`ListarCierresParaExportacionAsync` no los lee, dto-contract-honesty), así que quedan fuera de
+ * este helper y los agrega solo `construirQueryDeHistoricoDeCajas`. */
+function construirQueryDeAlcanceDeCajas(filtros: { idPuntoVenta: number | null; desde: string; hasta: string }): string {
+  const parametros = new URLSearchParams()
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  return `?${parametros.toString()}`
+}
+
+export function construirQueryDeHistoricoDeCajas(filtros: FiltrosDeHistoricoDeCajas): string {
+  const parametros = new URLSearchParams(construirQueryDeAlcanceDeCajas(filtros).slice(1))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+/** Filtro de `GET /api/reportes/tesoreria` — `idPuntoVenta` es OBLIGATORIO (a diferencia de
+ * `FiltrosDeHistoricoDeCajas`): mezclar puntos de venta rompería el significado de la cadena
+ * inicio/final (design decisión 11), así que acá no existe la opción "Todos". */
+export type FiltrosDeTesoreria = {
+  idPuntoVenta: number
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+function construirQueryDeAlcanceDeTesoreria(filtros: { idPuntoVenta: number; desde: string; hasta: string }): string {
+  const parametros = new URLSearchParams()
+  parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  return `?${parametros.toString()}`
+}
+
+export function construirQueryDeTesoreria(filtros: FiltrosDeTesoreria): string {
+  const parametros = new URLSearchParams(construirQueryDeAlcanceDeTesoreria(filtros).slice(1))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
 }
 
 /** Rutas de descarga (`/export`, stage-11 slice 4) de los tres paneles de `Tablero` que ya tienen
@@ -114,6 +198,14 @@ export const rutasDeExportacion = {
     const conEstimados = filtros.incluirEstimados ? `${query}&incluirEstimados=true` : query
     return `/reportes/rentabilidad/export${conEstimados}&formato=xlsx`
   },
+  /** `desde`/`hasta` son OBLIGATORIOS en `/cajas/export` (a diferencia de `/cajas`): un nombre de
+   * archivo determinístico necesita un rango acotado (mismo criterio que los exports de listado
+   * de Slice 3). `pagina`/`tamanio` no viajan — el export no pagina. */
+  historicoDeCajas: (filtros: { idPuntoVenta: number | null; desde: string; hasta: string }) =>
+    `/reportes/cajas/export${construirQueryDeAlcanceDeCajas(filtros)}&formato=xlsx`,
+  /** `desde`/`hasta` OBLIGATORIOS en `/tesoreria/export`, mismo criterio que `historicoDeCajas`. */
+  tesoreria: (filtros: { idPuntoVenta: number; desde: string; hasta: string }) =>
+    `/reportes/tesoreria/export${construirQueryDeAlcanceDeTesoreria(filtros)}&formato=xlsx`,
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -760,6 +760,91 @@ export type LineaDeArqueoResumen = {
  * payload del comprobante Z) — mismos campos planos que `TurnoResumen` más `arqueos`. */
 export type TurnoConArqueos = TurnoResumen & { arqueos: LineaDeArqueoResumen[] }
 
+// --- Histórico de cajas (G2) y detalle de turno (stage-11-exportacion-reportes, Slice 5a/5b,
+// Slices 6a/6b web): espejo de `Ways.Application.Caja.Contratos` — turnos cerrados con totales
+// ya sumados de sus `arqueos_turno` persistidos (nunca re-derivados) y el detalle del turno
+// (mismo `ResumenDeTurno` que `/resumen` más los tickets y gastos leídos por
+// `LectorDeLineasDelTurno`).
+
+/** Fila de `GET /api/reportes/cajas` — espejo de `FilaDeHistoricoDeCajas`. */
+export type FilaDeHistoricoDeCajas = {
+  idTurnoCaja: number
+  idPuntoVenta: number
+  fechaApertura: string
+  fechaCierre: string
+  esperado: number
+  declarado: number
+  diferencia: number
+  egresos: EgresosDeTurno
+}
+
+/** Página de `GET /api/reportes/cajas` — espejo de `PaginaDeHistoricoDeCajas`. */
+export type PaginaDeHistoricoDeCajas = { items: FilaDeHistoricoDeCajas[]; total: number; pagina: number; tamanio: number }
+
+/** Un ticket del turno dentro de `DetalleDeTurno.tickets` — espejo reducido de
+ * `Ways.Application.Ventas.ComprobanteListado` (los mismos campos que `GET /api/ventas` lista,
+ * anulados excluidos por `LectorDeLineasDelTurno`). */
+export type TicketDeTurno = {
+  id: number
+  numero: number
+  numeroVisible: string
+  estado: EstadoComprobante
+  fecha: string
+  idPuntoVenta: number
+  idCliente: number
+  total: number
+}
+
+/** Un gasto del turno dentro de `DetalleDeTurno.gastos` — espejo de
+ * `Ways.Application.Gastos.GastoListado`. */
+export type GastoDeTurno = {
+  id: number
+  idPuntoVenta: number
+  fecha: string
+  categoria: CategoriaGasto
+  idMedioPago: number
+  importe: number
+}
+
+/** Respuesta de `GET /api/caja/turnos/{id}/detalle` — espejo de `DetalleDeTurno`: el mismo
+ * `ResumenDeTurno` que `/resumen` devuelve, sin tocarlo, más las dos listas del turno. */
+export type DetalleDeTurno = {
+  resumen: ResumenDeTurno
+  tickets: TicketDeTurno[]
+  gastos: GastoDeTurno[]
+}
+
+// --- Tesorería (G3): libro encadenado (stage-11-exportacion-reportes, Slice 7) — espejo de
+// `Ways.Application.Caja.Contratos`. `inicio`/`final` ya vienen calculados y persistidos al
+// cierre (design decisión 6 de stage-6-turnos-caja); este contrato solo los transporta.
+
+/** Espejo del enum `TipoMovimientoTesoreria` (Ways.Domain.Caja) — viaja como texto. */
+export type TipoMovimientoTesoreria = 'RetiroCaja' | 'Deposito' | 'Gasto' | 'Ajuste'
+
+/** Fila de `GET /api/reportes/tesoreria` — espejo de `MovimientoTesoreriaListado`, SIN
+ * `idTenant` (nunca expuesto en una respuesta, doc 09). */
+export type MovimientoTesoreriaListado = {
+  id: number
+  idPuntoVenta: number
+  fecha: string
+  tipo: TipoMovimientoTesoreria
+  idTurnoCaja: number | null
+  concepto: string
+  inicio: number
+  ingreso: number
+  egreso: number
+  final: number
+  idEmpleado: number
+}
+
+/** Página de `GET /api/reportes/tesoreria` — espejo de `PaginaDeMovimientosTesoreria`. */
+export type PaginaDeMovimientosTesoreria = {
+  items: MovimientoTesoreriaListado[]
+  total: number
+  pagina: number
+  tamanio: number
+}
+
 // --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---
 // Espejo de `Ways.Application.Ventas.Contratos` (confirmado contra el DTO real de
 // `POST /api/ventas`, mergeado en Slice 4) — usado por `ventas.ts` (mappers) y `Pos.tsx`

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -74,6 +74,23 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-11-exportacion-reportes (Slices 6a/7, design: "nav entries + routes
+                    gated like /tablero (puedeVerReportes) for cajas/tesorería"): mismo gate que
+                    Tablero — nunca el cajero (/caja), esta es la vista de gestión. */}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/caja/historico">
+                      Histórico de cajas
+                    </NavLink>
+                  </li>
+                )}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/caja/tesoreria">
+                      Tesorería
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/CajaZ.test.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -248,11 +248,14 @@ describe('CajaZ — detalle del turno (stage-11-exportacion-reportes, Slice 6b)'
     expect(await screen.findByText('7')).toBeInTheDocument() // cantidadTickets del turno 413
 
     // La respuesta stale del 412 trae cantidadTickets 99: si pisara el estado, el 7 desaparece.
-    resolverPrimera(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 412, cantidadTickets: 99 }) }))
-    await waitFor(() => {
-      expect(screen.getByText('7')).toBeInTheDocument()
-      expect(screen.queryByText('99')).not.toBeInTheDocument()
+    // El flush del microtask va DENTRO de act: waitFor solo pasaria en su primer tick,
+    // antes de que el .then stale aterrice, y saldria verde sin probar nada.
+    await act(async () => {
+      resolverPrimera(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 412, cantidadTickets: 99 }) }))
+      await primera
     })
+    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(screen.queryByText('99')).not.toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/CajaZ.test.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.test.tsx
@@ -1,0 +1,277 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CajaZ } from './CajaZ'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { DetalleDeTurno, ResumenDeTurno, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 4,
+    usuario: 'vendedor',
+    mail: 'vendedor@ways.test',
+    rolId: ROL.Vendedor,
+    rol: 'Vendedor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function resumenFixture(sobrescribir: Partial<ResumenDeTurno> = {}): ResumenDeTurno {
+  return {
+    idTurnoCaja: 412,
+    idMedioAncla: 1,
+    medios: [
+      { idMedioPago: 1, importeEsperado: 1000 },
+      { idMedioPago: 2, importeEsperado: 500 },
+    ],
+    cantidadTickets: 2,
+    primerTicket: { numero: 1, fecha: '2026-08-05T08:30:00Z', codigo: 'TX' },
+    ultimoTicket: { numero: 2, fecha: '2026-08-05T19:30:00Z', codigo: 'TX' },
+    ingresosPorArea: [],
+    egresos: { porCategoria: [], porArea: [], retiros: 100 },
+    ...sobrescribir,
+  }
+}
+
+function detalleFixture(sobrescribir: Partial<DetalleDeTurno> = {}): DetalleDeTurno {
+  return {
+    resumen: resumenFixture(),
+    tickets: [
+      { id: 1, numero: 1, numeroVisible: '0003-00000001', estado: 'Emitido', fecha: '2026-08-05T08:30:00Z', idPuntoVenta: 10, idCliente: 1, total: 750 },
+      { id: 2, numero: 2, numeroVisible: '0003-00000002', estado: 'Anulado', fecha: '2026-08-05T19:30:00Z', idPuntoVenta: 10, idCliente: 2, total: 250 },
+    ],
+    gastos: [
+      { id: 1, idPuntoVenta: 10, fecha: '2026-08-05T09:00:00Z', categoria: 'Sueldos', idMedioPago: 1, importe: 300 },
+      { id: 2, idPuntoVenta: 10, fecha: '2026-08-05T10:00:00Z', categoria: 'Viaticos', idMedioPago: 2, importe: 120 },
+    ],
+    ...sobrescribir,
+  }
+}
+
+function renderCajaZ(idTurno = 412) {
+  return render(<CajaZ />, {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[`/caja/turnos/${idTurno}/z`]}>
+        <Routes>
+          <Route path="/caja/turnos/:id/z" element={children} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/caja/turnos/:id/z`
+ * (`Politicas.OperacionDePos`). */
+function renderCajaZProtegido(idTurno = 412) {
+  return render(
+    <MemoryRouter initialEntries={[`/caja/turnos/${idTurno}/z`]}>
+      <Routes>
+        <Route
+          path="/caja/turnos/:id/z"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+              <CajaZ />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
+})
+
+describe('CajaZ — detalle del turno (stage-11-exportacion-reportes, Slice 6b)', () => {
+  it('renderiza el resumen (tickets/primer/último/retiros) y cada fila de medios/tickets/gastos', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return Promise.resolve(detalleFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    renderCajaZ()
+
+    expect(await screen.findByText('Caja Z — turno #412')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument() // cantidadTickets
+    expect(screen.getByText('TX #1')).toBeInTheDocument() // primerTicket
+    expect(screen.getByText('TX #2')).toBeInTheDocument() // ultimoTicket
+    expect(screen.getByText('$100,00')).toBeInTheDocument() // retiros
+
+    // mutation-proof-tests rule 6: dos filas con valores DISTINTOS por columna.
+    const filaMedioUno = screen.getByRole('row', { name: /Medio #1/ })
+    expect(within(filaMedioUno).getByText('$1.000,00')).toBeInTheDocument()
+    const filaMedioDos = screen.getByRole('row', { name: /Medio #2/ })
+    expect(within(filaMedioDos).getByText('$500,00')).toBeInTheDocument()
+
+    const filaTicketUno = screen.getByRole('row', { name: /0003-00000001/ })
+    expect(within(filaTicketUno).getByText('Emitido')).toBeInTheDocument()
+    expect(within(filaTicketUno).getByText('$750,00')).toBeInTheDocument()
+    const filaTicketDos = screen.getByRole('row', { name: /0003-00000002/ })
+    expect(within(filaTicketDos).getByText('Anulado')).toBeInTheDocument()
+    expect(within(filaTicketDos).getByText('$250,00')).toBeInTheDocument()
+
+    const filaGastoUno = screen.getByRole('row', { name: /Sueldos/ })
+    expect(within(filaGastoUno).getByText('$300,00')).toBeInTheDocument()
+    const filaGastoDos = screen.getByRole('row', { name: /Viaticos/ })
+    expect(within(filaGastoDos).getByText('$120,00')).toBeInTheDocument()
+  })
+
+  it('sin medios/tickets/gastos muestra los estados vacíos de cada sección', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') {
+        return Promise.resolve(detalleFixture({ resumen: resumenFixture({ medios: [] }), tickets: [], gastos: [] }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    renderCajaZ()
+
+    expect(await screen.findByText('Este turno no tuvo actividad: no hay ningún medio arqueado.')).toBeInTheDocument()
+    expect(screen.getByText('Sin tickets.')).toBeInTheDocument()
+    expect(screen.getByText('Sin gastos.')).toBeInTheDocument()
+  })
+
+  it('el botón de descarga apunta a /caja/turnos/{id}/detalle/export y limpia el error al reintentar', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return Promise.resolve(detalleFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    apiDescargarMock.mockRejectedValueOnce(new Error('no se pudo descargar'))
+    const usuario = userEvent.setup()
+    renderCajaZ()
+
+    await screen.findByText('Caja Z — turno #412')
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(await screen.findByText('No se pudo descargar el archivo.')).toBeInTheDocument()
+    expect(apiDescargarMock).toHaveBeenCalledWith('/caja/turnos/412/detalle/export?formato=xlsx')
+
+    apiDescargarMock.mockResolvedValueOnce(undefined)
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+    await waitFor(() => expect(screen.queryByText('No se pudo descargar el archivo.')).not.toBeInTheDocument())
+  })
+
+  it('un id de turno inválido en la URL no dispara ningún fetch', () => {
+    render(<CajaZ />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={['/caja/turnos/no-numerico/z']}>
+          <Routes>
+            <Route path="/caja/turnos/:id/z" element={children} />
+          </Routes>
+        </MemoryRouter>
+      ),
+    })
+
+    expect(screen.getByText('No se especificó el turno a mostrar.')).toBeInTheDocument()
+    expect(apiGetMock).not.toHaveBeenCalled()
+  })
+
+  it('cambiar de turno (misma pantalla montada) descarta una respuesta desactualizada del turno anterior', async () => {
+    let resolverPrimera: (valor: DetalleDeTurno) => void = () => {}
+    const primera = new Promise<DetalleDeTurno>((resolve) => {
+      resolverPrimera = resolve
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return primera
+      if (ruta === '/caja/turnos/413/detalle') {
+        return Promise.resolve(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 413 }) }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+
+    function ArnesDeNavegacion() {
+      const navegar = useNavigate()
+      return (
+        <button type="button" onClick={() => navegar('/caja/turnos/413/z')}>
+          ir al turno 413
+        </button>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/caja/turnos/412/z']}>
+        <Routes>
+          <Route
+            path="/caja/turnos/:id/z"
+            element={
+              <>
+                <ArnesDeNavegacion />
+                <CajaZ />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const usuario = userEvent.setup()
+    await screen.findByText('ir al turno 413')
+    await usuario.click(screen.getByText('ir al turno 413'))
+    expect(await screen.findByText('Caja Z — turno #413')).toBeInTheDocument()
+
+    resolverPrimera(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 412 }) }))
+    await waitFor(() => expect(screen.getByText('Caja Z — turno #413')).toBeInTheDocument())
+  })
+})
+
+describe('CajaZ — role gating (spec historico-de-cajas: A Vendedor Downloads Their Own Turno\'s Z-Report)', () => {
+  // La API no tiene un límite cross-turno propio: OperacionDePos es un gate solo de rol, sin
+  // claim de PV ni de turno (verificado en la Slice 5b) — así que a diferencia de la matriz de
+  // 5b.8, esta pantalla solo prueba la mitad de 200 (un Vendedor llega a SU Z). No existe un
+  // límite estructural que produzca un 403 cross-turno para probar del lado del cliente.
+  it('un Vendedor llega a la Caja Z de su propio turno', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return Promise.resolve(detalleFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    renderCajaZProtegido()
+
+    expect(await screen.findByText('Caja Z — turno #412')).toBeInTheDocument()
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Root nunca llega a /caja/turnos/:id/z: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 1, usuario: 'root', rolId: ROL.Root, rol: 'Root', idTenant: null })
+    apiGetMock.mockImplementation(() => Promise.reject(new Error('no debería llamarse')))
+
+    renderCajaZProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/CajaZ.test.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.test.tsx
@@ -210,7 +210,7 @@ describe('CajaZ — detalle del turno (stage-11-exportacion-reportes, Slice 6b)'
     apiGetMock.mockImplementation((ruta: string) => {
       if (ruta === '/caja/turnos/412/detalle') return primera
       if (ruta === '/caja/turnos/413/detalle') {
-        return Promise.resolve(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 413 }) }))
+        return Promise.resolve(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 413, cantidadTickets: 7 }) }))
       }
       return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
     })
@@ -245,8 +245,14 @@ describe('CajaZ — detalle del turno (stage-11-exportacion-reportes, Slice 6b)'
     await usuario.click(screen.getByText('ir al turno 413'))
     expect(await screen.findByText('Caja Z — turno #413')).toBeInTheDocument()
 
-    resolverPrimera(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 412 }) }))
-    await waitFor(() => expect(screen.getByText('Caja Z — turno #413')).toBeInTheDocument())
+    expect(await screen.findByText('7')).toBeInTheDocument() // cantidadTickets del turno 413
+
+    // La respuesta stale del 412 trae cantidadTickets 99: si pisara el estado, el 7 desaparece.
+    resolverPrimera(detalleFixture({ resumen: resumenFixture({ idTurnoCaja: 412, cantidadTickets: 99 }) }))
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeInTheDocument()
+      expect(screen.queryByText('99')).not.toBeInTheDocument()
+    })
   })
 })
 

--- a/src/Ways.Web/src/paginas/CajaZ.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react'
+import { useParams } from 'react-router'
+import { clienteDeCaja, rutasDeExportacionDeCaja } from '../api/caja'
+import { ErrorApi } from '../api/cliente'
+import type { DetalleDeTurno } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+/**
+ * Caja Z (stage-11-exportacion-reportes, Slice 6b, design: Web Composition) — detalle del turno
+ * cerrado: el mismo `ResumenDeTurno` que `/caja/cierre` usó para derivar el arqueo, más los
+ * tickets y gastos del turno, con descarga XLSX. Misma política que `/caja`
+ * (`Politicas.OperacionDePos`): el cajero puede leer su propio cierre — mismo gate que
+ * `GET .../resumen`.
+ *
+ * `GET .../detalle` no discrimina por turno-ownership (spec historico-de-cajas: A Vendedor
+ * Downloads Their Own Turno's Z-Report; verificado en la Slice 5b — `OperacionDePos` es un gate
+ * de rol solo, sin claim de PV ni de turno): esta pantalla tampoco intenta un bloqueo cross-turno
+ * que la API no tiene — cualquier Vendedor/Supervisor/Admin autenticado que conozca el id ve el
+ * detalle, igual que del lado del servidor.
+ */
+export function CajaZ() {
+  const { id } = useParams<{ id: string }>()
+  const idTurno = id !== undefined ? Number(id) : Number.NaN
+  const idTurnoValido = Number.isFinite(idTurno)
+
+  const [detalle, setDetalle] = useState<DetalleDeTurno | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (!idTurnoValido) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeCaja
+      .obtenerDetalle(idTurno)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDetalle(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDetalle(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el detalle del turno.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idTurno, idTurnoValido])
+
+  if (!idTurnoValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Caja Z" variante="warning">
+          <p className="text-muted mb-0">No se especificó el turno a mostrar.</p>
+        </Box>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={`Caja Z — turno #${idTurno}`}
+        variante="inverse"
+        herramientas={
+          <BotonDeDescarga
+            ruta={rutasDeExportacionDeCaja.detalleDeTurno(idTurno)}
+            etiqueta="Descargar"
+            onError={setErrorDescarga}
+            onInicio={() => setErrorDescarga('')}
+          />
+        }
+      >
+        {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+          </div>
+        )}
+
+        {cargando && !detalle && <Cargando />}
+
+        {detalle && (
+          <>
+            <div className="row g-3 mb-3">
+              <div className="col-md-3">
+                <div className="text-muted small">Tickets</div>
+                <div className="fs-5">{detalle.resumen.cantidadTickets}</div>
+              </div>
+              <div className="col-md-3">
+                <div className="text-muted small">Primer ticket</div>
+                <div>
+                  {detalle.resumen.primerTicket
+                    ? `${detalle.resumen.primerTicket.codigo} #${detalle.resumen.primerTicket.numero}`
+                    : '—'}
+                </div>
+              </div>
+              <div className="col-md-3">
+                <div className="text-muted small">Último ticket</div>
+                <div>
+                  {detalle.resumen.ultimoTicket
+                    ? `${detalle.resumen.ultimoTicket.codigo} #${detalle.resumen.ultimoTicket.numero}`
+                    : '—'}
+                </div>
+              </div>
+              <div className="col-md-3">
+                <div className="text-muted small">Retiros</div>
+                <div>{formatearMoneda(detalle.resumen.egresos.retiros)}</div>
+              </div>
+            </div>
+
+            <h6>Medios de pago (esperado)</h6>
+            <div className="table-responsive mb-3">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Medio</th>
+                    <th className="text-end">Esperado</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detalle.resumen.medios.map((m) => (
+                    <tr key={m.idMedioPago}>
+                      <td>Medio #{m.idMedioPago}</td>
+                      <td className="text-end">{formatearMoneda(m.importeEsperado)}</td>
+                    </tr>
+                  ))}
+                  {detalle.resumen.medios.length === 0 && (
+                    <tr>
+                      <td colSpan={2} className="text-center text-muted">
+                        Este turno no tuvo actividad: no hay ningún medio arqueado.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <h6>Tickets</h6>
+            <div className="table-responsive mb-3">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Número</th>
+                    <th>Fecha</th>
+                    <th>Estado</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detalle.tickets.map((t) => (
+                    <tr key={t.id}>
+                      <td>{t.numeroVisible}</td>
+                      <td>{formatearFechaHora(t.fecha)}</td>
+                      <td>{t.estado}</td>
+                      <td className="text-end">{formatearMoneda(t.total)}</td>
+                    </tr>
+                  ))}
+                  {detalle.tickets.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="text-center text-muted py-3">
+                        Sin tickets.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <h6>Gastos</h6>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Categoría</th>
+                    <th className="text-end">Importe</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detalle.gastos.map((g) => (
+                    <tr key={g.id}>
+                      <td>{formatearFechaHora(g.fecha)}</td>
+                      <td>{g.categoria}</td>
+                      <td className="text-end">{formatearMoneda(g.importe)}</td>
+                    </tr>
+                  ))}
+                  {detalle.gastos.length === 0 && (
+                    <tr>
+                      <td colSpan={3} className="text-center text-muted py-3">
+                        Sin gastos.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/CierreDeCaja.tsx
+++ b/src/Ways.Web/src/paginas/CierreDeCaja.tsx
@@ -238,9 +238,17 @@ export function CierreDeCaja() {
                 </table>
               </div>
 
-              <Link className="btn btn-outline-secondary rounded-0" to="/caja">
-                Volver a caja
-              </Link>
+              {/* stage-11-exportacion-reportes (Slice 6b, design: Web Composition, "link from
+                  the just-closed turno to its Caja Z screen"): mismo gate OperacionDePos que
+                  /caja/turnos/:id/z, el cajero recién cerró este turno. */}
+              <div className="d-flex gap-2">
+                <Link className="btn btn-outline-secondary rounded-0" to="/caja">
+                  Volver a caja
+                </Link>
+                <Link className="btn btn-primary rounded-0" to={`/caja/turnos/${idTurno}/z`}>
+                  Ver Caja Z
+                </Link>
+              </div>
             </Box>
           </div>
         </div>

--- a/src/Ways.Web/src/paginas/HistoricoDeCajas.test.tsx
+++ b/src/Ways.Web/src/paginas/HistoricoDeCajas.test.tsx
@@ -1,0 +1,270 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HistoricoDeCajas } from './HistoricoDeCajas'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { FilaDeHistoricoDeCajas, PaginaDeHistoricoDeCajas, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const puntoVentaNorte: PuntoVentaListado = {
+  id: 11,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Norte',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function filaFixture(sobrescribir: Partial<FilaDeHistoricoDeCajas> = {}): FilaDeHistoricoDeCajas {
+  return {
+    idTurnoCaja: 100,
+    idPuntoVenta: 10,
+    fechaApertura: '2026-08-05T08:00:00Z',
+    fechaCierre: '2026-08-05T20:00:00Z',
+    esperado: 1000,
+    declarado: 950,
+    diferencia: -50,
+    egresos: { porCategoria: [], porArea: [], retiros: 0 },
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(items: FilaDeHistoricoDeCajas[] = [filaFixture()], sobrescribir: Partial<PaginaDeHistoricoDeCajas> = {}): PaginaDeHistoricoDeCajas {
+  return { items, total: items.length, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function renderHistoricoDeCajas() {
+  return render(<HistoricoDeCajas />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/caja/historico`
+ * (`Politicas.LecturaDeReportes`: Supervisor + Admin). */
+function renderHistoricoDeCajasProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/caja/historico']}>
+      <Routes>
+        <Route
+          path="/caja/historico"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <HistoricoDeCajas />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro, puntoVentaNorte])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/reportes/cajas?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
+})
+
+describe('HistoricoDeCajas — listado (stage-11-exportacion-reportes, Slice 6a)', () => {
+  it('un listado vacío muestra un estado vacío, no un re-query', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/cajas?')) return Promise.resolve(paginaFixture([]))
+      return undefined
+    })
+    renderHistoricoDeCajas()
+
+    expect(await screen.findByText('No hay turnos cerrados que coincidan con los filtros.')).toBeInTheDocument()
+    const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/cajas?'))
+    expect(llamadas).toHaveLength(1)
+  })
+
+  // mutation-proof-tests rule 6: dos filas con valores DISTINTOS en cada columna — una fila
+  // rotada tiene que fallar esta prueba.
+  it('renderiza cada columna de cada fila (PV, apertura, cierre, esperado, declarado, diferencia)', async () => {
+    const filaUno = filaFixture({
+      idTurnoCaja: 100,
+      idPuntoVenta: 10,
+      fechaApertura: '2026-08-05T08:00:00Z',
+      fechaCierre: '2026-08-05T20:00:00Z',
+      esperado: 1000,
+      declarado: 950,
+      diferencia: -50,
+    })
+    const filaDos = filaFixture({
+      idTurnoCaja: 101,
+      idPuntoVenta: 11,
+      fechaApertura: '2026-08-06T08:00:00Z',
+      fechaCierre: '2026-08-06T20:00:00Z',
+      esperado: 2500,
+      declarado: 2550,
+      diferencia: 50,
+    })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/cajas?')) return Promise.resolve(paginaFixture([filaUno, filaDos]))
+      return undefined
+    })
+    renderHistoricoDeCajas()
+
+    await screen.findByText('#100')
+    const filaUnoDom = screen.getByRole('row', { name: /#100/ })
+    expect(within(filaUnoDom).getByText('PV Centro')).toBeInTheDocument()
+    expect(within(filaUnoDom).getByText('$1.000,00')).toBeInTheDocument()
+    expect(within(filaUnoDom).getByText('$950,00')).toBeInTheDocument()
+    expect(within(filaUnoDom).getByText('-$50,00')).toBeInTheDocument()
+
+    const filaDosDom = screen.getByRole('row', { name: /#101/ })
+    expect(within(filaDosDom).getByText('PV Norte')).toBeInTheDocument()
+    expect(within(filaDosDom).getByText('$2.500,00')).toBeInTheDocument()
+    expect(within(filaDosDom).getByText('$2.550,00')).toBeInTheDocument()
+    expect(within(filaDosDom).getByText('$50,00')).toBeInTheDocument()
+  })
+
+  it('cambiar el filtro de punto de venta dispara una nueva consulta con idPuntoVenta', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderHistoricoDeCajas()
+
+    await screen.findByText('#100')
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/cajas?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('idPuntoVenta=11'))).toBe(true)
+    })
+  })
+
+  it('el botón de descarga apunta a /reportes/cajas/export y limpia el error previo al reintentar', async () => {
+    mockearRutasBase()
+    apiDescargarMock.mockRejectedValueOnce(new Error('no se pudo descargar'))
+    const usuario = userEvent.setup()
+    renderHistoricoDeCajas()
+
+    await screen.findByText('#100')
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(await screen.findByText('No se pudo descargar el archivo.')).toBeInTheDocument()
+    expect(apiDescargarMock.mock.calls[0][0]).toMatch(/^\/reportes\/cajas\/export\?/)
+
+    apiDescargarMock.mockResolvedValueOnce(undefined)
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+    await waitFor(() => expect(screen.queryByText('No se pudo descargar el archivo.')).not.toBeInTheDocument())
+  })
+
+  it('una respuesta de listado desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: PaginaDeHistoricoDeCajas) => void = () => {}
+    const primera = new Promise<PaginaDeHistoricoDeCajas>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/cajas?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(paginaFixture([filaFixture({ idTurnoCaja: 202 })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderHistoricoDeCajas()
+    await screen.findByLabelText('Punto de venta')
+
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '10')
+    expect(await screen.findByText('#202')).toBeInTheDocument()
+
+    resolverPrimera(paginaFixture([filaFixture({ idTurnoCaja: 909 })]))
+    await waitFor(() => expect(screen.queryByText('#909')).not.toBeInTheDocument())
+    expect(screen.getByText('#202')).toBeInTheDocument()
+  })
+})
+
+describe('HistoricoDeCajas — role gating (spec historico-de-cajas: Role Split)', () => {
+  it('un Supervisor llega a /caja/historico', async () => {
+    mockearRutasBase()
+    renderHistoricoDeCajasProtegido()
+
+    await screen.findByText('#100')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /caja/historico: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderHistoricoDeCajasProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Histórico de cajas')).not.toBeInTheDocument())
+  })
+})

--- a/src/Ways.Web/src/paginas/HistoricoDeCajas.tsx
+++ b/src/Ways.Web/src/paginas/HistoricoDeCajas.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, filtrosDeHistoricoDeCajasVacios, rutasDeExportacion, type FiltrosDeHistoricoDeCajas } from '../api/reportes'
+import type { PaginaDeHistoricoDeCajas, PuntoVentaListado } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+/**
+ * Histórico de cajas (stage-11-exportacion-reportes, Slice 6a, design: Web Composition) — G2:
+ * turnos CERRADOS únicamente, con totales ya sumados de sus `arqueos_turno` persistidos (nunca
+ * re-derivados) y descarga XLSX. Misma política que `/tablero` (`Politicas.LecturaDeReportes`:
+ * Supervisor + Admin) — es la vista de gestión sobre turnos ajenos; el cajero ve su propio cierre
+ * en `/caja` (spec historico-de-cajas: Role Split).
+ *
+ * Per `react-async-state` reglas 2/4/9: cada cambio de filtro dispara una nueva consulta gateada
+ * por un único `useRef` de generación — una respuesta desactualizada nunca pisa un filtro que el
+ * usuario ya cambió.
+ */
+export function HistoricoDeCajas() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDeHistoricoDeCajas>(filtrosDeHistoricoDeCajasVacios())
+  const [pagina, setPagina] = useState<PaginaDeHistoricoDeCajas | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeReportes
+      .historicoDeCajas(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el histórico de cajas.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const puntoVentaPorId = useMemo(() => {
+    const indice: Record<number, PuntoVentaListado> = {}
+    for (const pv of puntosVenta ?? []) indice[pv.id] = pv
+    return indice
+  }, [puntosVenta])
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeHistoricoDeCajas, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Histórico de cajas" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="historico-cajas-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="historico-cajas-punto-venta"
+              className="form-select rounded-0"
+              value={filtros.idPuntoVenta ?? ''}
+              onChange={(e) => cambiarFiltro({ idPuntoVenta: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="historico-cajas-desde">
+              Desde
+            </label>
+            <input
+              id="historico-cajas-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="historico-cajas-hasta">
+              Hasta
+            </label>
+            <input
+              id="historico-cajas-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+          <div className="col-auto">
+            <BotonDeDescarga
+              ruta={rutasDeExportacion.historicoDeCajas(filtros)}
+              etiqueta="Descargar"
+              onError={setErrorDescarga}
+              onInicio={() => setErrorDescarga('')}
+            />
+          </div>
+        </div>
+
+        {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Turno</th>
+                    <th>Punto de venta</th>
+                    <th>Apertura</th>
+                    <th>Cierre</th>
+                    <th className="text-end">Esperado</th>
+                    <th className="text-end">Declarado</th>
+                    <th className="text-end">Diferencia</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((f) => (
+                    <tr key={f.idTurnoCaja}>
+                      <td>#{f.idTurnoCaja}</td>
+                      <td>{puntoVentaPorId[f.idPuntoVenta]?.nombre ?? `PV #${f.idPuntoVenta}`}</td>
+                      <td>{formatearFechaHora(f.fechaApertura)}</td>
+                      <td>{formatearFechaHora(f.fechaCierre)}</td>
+                      <td className="text-end">{formatearMoneda(f.esperado)}</td>
+                      <td className="text-end">{formatearMoneda(f.declarado)}</td>
+                      <td className="text-end">{formatearMoneda(f.diferencia)}</td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="text-center text-muted py-4">
+                        No hay turnos cerrados que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} turno(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/Tesoreria.test.tsx
+++ b/src/Ways.Web/src/paginas/Tesoreria.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Tesoreria } from './Tesoreria'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { MovimientoTesoreriaListado, PaginaDeMovimientosTesoreria, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const puntoVentaNorte: PuntoVentaListado = {
+  id: 11,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Norte',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function movimientoFixture(sobrescribir: Partial<MovimientoTesoreriaListado> = {}): MovimientoTesoreriaListado {
+  return {
+    id: 60,
+    idPuntoVenta: 10,
+    fecha: '2026-08-05T08:00:00Z',
+    tipo: 'Deposito',
+    idTurnoCaja: 412,
+    concepto: 'Apertura de turno',
+    inicio: 0,
+    ingreso: 60,
+    egreso: 0,
+    final: 60,
+    idEmpleado: 4,
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(items: MovimientoTesoreriaListado[] = [movimientoFixture()], sobrescribir: Partial<PaginaDeMovimientosTesoreria> = {}): PaginaDeMovimientosTesoreria {
+  return { items, total: items.length, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function renderTesoreria() {
+  return render(<Tesoreria />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/caja/tesoreria`
+ * (`Politicas.LecturaDeReportes`). */
+function renderTesoreriaProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/caja/tesoreria']}>
+      <Routes>
+        <Route
+          path="/caja/tesoreria"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <Tesoreria />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro, puntoVentaNorte])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/reportes/tesoreria?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
+})
+
+describe('Tesoreria — libro (stage-11-exportacion-reportes, Slice 7 — web)', () => {
+  it('arranca con el primer punto de venta cargado, nunca la opción "Todos"', async () => {
+    mockearRutasBase()
+    renderTesoreria()
+
+    await screen.findByLabelText('Punto de venta')
+    expect(screen.getByLabelText('Punto de venta')).toHaveValue('10')
+    expect(screen.queryByText('Todos')).not.toBeInTheDocument()
+  })
+
+  it('un libro vacío muestra un estado vacío, no un re-query', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/tesoreria?')) return Promise.resolve(paginaFixture([]))
+      return undefined
+    })
+    renderTesoreria()
+
+    expect(await screen.findByText('No hay movimientos que coincidan con los filtros.')).toBeInTheDocument()
+    const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/tesoreria?'))
+    expect(llamadas).toHaveLength(1)
+  })
+
+  // Las filas se renderizan en el MISMO orden que llegan del backend (OrderBy(m => m.Id), spec
+  // tesoreria: Book Preserves Chain Order) — sin ningún sort del lado del cliente. Tres filas
+  // encadenadas con `final` values 60, 100, 145 (mismo fixture que el test de backend).
+  it('renderiza las filas en el orden de cadena que devuelve el backend, con cada columna', async () => {
+    const filaUno = movimientoFixture({ id: 60, inicio: 5, ingreso: 55, egreso: 0, final: 60, concepto: 'Apertura', idEmpleado: 4 })
+    const filaDos = movimientoFixture({ id: 61, inicio: 60, ingreso: 40, egreso: 0, final: 100, concepto: 'Depósito', idEmpleado: 5 })
+    const filaTres = movimientoFixture({ id: 62, inicio: 100, ingreso: 0, egreso: 45, final: 55, concepto: 'Retiro', idEmpleado: 4 })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/tesoreria?')) return Promise.resolve(paginaFixture([filaUno, filaDos, filaTres]))
+      return undefined
+    })
+    renderTesoreria()
+
+    await screen.findByText('Apertura')
+    const filas = screen.getAllByRole('row').slice(1) // sin la fila de encabezado
+    expect(within(filas[0]).getByText('Apertura')).toBeInTheDocument()
+    expect(within(filas[0]).getByText('$60,00')).toBeInTheDocument()
+    expect(within(filas[1]).getByText('Depósito')).toBeInTheDocument()
+    expect(within(filas[1]).getByText('$100,00')).toBeInTheDocument()
+    expect(within(filas[2]).getByText('Retiro')).toBeInTheDocument()
+    expect(within(filas[2]).getByText('$55,00')).toBeInTheDocument()
+  })
+
+  it('cambiar el punto de venta dispara una nueva consulta con el idPuntoVenta elegido', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderTesoreria()
+
+    await screen.findByText('Apertura de turno')
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/tesoreria?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('idPuntoVenta=11'))).toBe(true)
+    })
+  })
+
+  it('el botón de descarga apunta a /reportes/tesoreria/export con idPuntoVenta obligatorio', async () => {
+    mockearRutasBase()
+    apiDescargarMock.mockRejectedValueOnce(new Error('no se pudo descargar'))
+    const usuario = userEvent.setup()
+    renderTesoreria()
+
+    await screen.findByText('Apertura de turno')
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(await screen.findByText('No se pudo descargar el archivo.')).toBeInTheDocument()
+    expect(apiDescargarMock.mock.calls[0][0]).toMatch(/^\/reportes\/tesoreria\/export\?idPuntoVenta=10/)
+  })
+
+  it('una respuesta de listado desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: PaginaDeMovimientosTesoreria) => void = () => {}
+    const primera = new Promise<PaginaDeMovimientosTesoreria>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/tesoreria?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(paginaFixture([movimientoFixture({ id: 999, concepto: 'segunda-respuesta' })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderTesoreria()
+    await screen.findByLabelText('Punto de venta')
+
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
+
+    resolverPrimera(paginaFixture([movimientoFixture({ id: 1, concepto: 'primera-respuesta-vieja' })]))
+    await waitFor(() => expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument())
+    expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Tesoreria — role gating (spec: A Supervisor Reads The G2 Listing And The G3 Book)', () => {
+  it('un Supervisor llega a /caja/tesoreria', async () => {
+    mockearRutasBase()
+    renderTesoreriaProtegido()
+
+    await screen.findByText('Apertura de turno')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /caja/tesoreria: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderTesoreriaProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Tesorería')).not.toBeInTheDocument())
+  })
+})

--- a/src/Ways.Web/src/paginas/Tesoreria.tsx
+++ b/src/Ways.Web/src/paginas/Tesoreria.tsx
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, rangoUltimosSieteDias, rutasDeExportacion, type FiltrosDeTesoreria } from '../api/reportes'
+import type { PaginaDeMovimientosTesoreria, PuntoVentaListado } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+/**
+ * Tesorería (stage-11-exportacion-reportes, Slice 7 — web, design: Web Composition) — G3: libro
+ * encadenado de `movimientos_tesoreria` de UN punto de venta, ordenado por id (nunca por fecha,
+ * spec tesoreria: Book Preserves Chain Order) — mezclar puntos de venta rompería el significado
+ * de la cadena inicio/final (design decisión 11), así que a diferencia de `/caja/historico` acá
+ * no hay opción "Todos": el filtro exige un punto de venta puntual. Misma política que `/tablero`
+ * (`Politicas.LecturaDeReportes`: Supervisor + Admin).
+ *
+ * Las filas se renderizan en el mismo orden que el backend las devuelve (`OrderBy(m => m.Id)`) —
+ * sin ningún reordenamiento del lado del cliente, para no enmascarar una regresión del orden de
+ * cadena detrás de un `sort` en pantalla.
+ */
+export function Tesoreria() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDeTesoreria | null>(null)
+  const [pagina, setPagina] = useState<PaginaDeMovimientosTesoreria | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        if (lista.length > 0) {
+          const rango = rangoUltimosSieteDias()
+          setFiltros({ idPuntoVenta: lista[0].id, desde: rango.desde, hasta: rango.hasta, pagina: 1, tamanio: 25 })
+        }
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    if (filtros === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeReportes
+      .tesoreria(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el libro de tesorería.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeTesoreria, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => (prev ? { ...prev, ...cambios, pagina: 1 } : prev))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => (prev ? { ...prev, pagina: Math.max(1, prev.pagina + delta) } : prev))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Tesorería" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        {puntosVenta === null ? (
+          <Cargando />
+        ) : puntosVenta.length === 0 ? (
+          <p className="text-muted text-center py-4">No hay puntos de venta visibles para el libro de tesorería.</p>
+        ) : filtros === null ? (
+          <Cargando />
+        ) : (
+          <>
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="tesoreria-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="tesoreria-punto-venta"
+                  className="form-select rounded-0"
+                  value={filtros.idPuntoVenta}
+                  onChange={(e) => cambiarFiltro({ idPuntoVenta: Number(e.target.value) })}
+                >
+                  {puntosVenta.map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-2">
+                <label className="form-label" htmlFor="tesoreria-desde">
+                  Desde
+                </label>
+                <input
+                  id="tesoreria-desde"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={filtros.desde}
+                  onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+                />
+              </div>
+              <div className="col-md-2">
+                <label className="form-label" htmlFor="tesoreria-hasta">
+                  Hasta
+                </label>
+                <input
+                  id="tesoreria-hasta"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={filtros.hasta}
+                  onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+                />
+              </div>
+              <div className="col-auto">
+                <BotonDeDescarga
+                  ruta={rutasDeExportacion.tesoreria(filtros)}
+                  etiqueta="Descargar"
+                  onError={setErrorDescarga}
+                  onInicio={() => setErrorDescarga('')}
+                />
+              </div>
+            </div>
+
+            {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+            {cargando && !pagina && <Cargando />}
+
+            {pagina && (
+              <>
+                <div className="table-responsive">
+                  <table className="table table-sm table-striped table-bordered align-middle">
+                    <thead>
+                      <tr>
+                        <th className="text-end">Inicio</th>
+                        <th className="text-end">Ingreso</th>
+                        <th className="text-end">Egreso</th>
+                        <th className="text-end">Final</th>
+                        <th>Concepto</th>
+                        <th>Empleado</th>
+                        <th>Fecha</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pagina.items.map((m) => (
+                        <tr key={m.id}>
+                          <td className="text-end">{formatearMoneda(m.inicio)}</td>
+                          <td className="text-end">{formatearMoneda(m.ingreso)}</td>
+                          <td className="text-end">{formatearMoneda(m.egreso)}</td>
+                          <td className="text-end">{formatearMoneda(m.final)}</td>
+                          <td>{m.concepto}</td>
+                          <td>Empleado #{m.idEmpleado}</td>
+                          <td>{formatearFechaHora(m.fecha)}</td>
+                        </tr>
+                      ))}
+                      {pagina.items.length === 0 && (
+                        <tr>
+                          <td colSpan={7} className="text-center text-muted py-4">
+                            No hay movimientos que coincidan con los filtros.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+
+                <div className="d-flex justify-content-between align-items-center">
+                  <span className="small text-muted">
+                    Página {pagina.pagina} de {totalPaginas} — {pagina.total} movimiento(s)
+                  </span>
+                  <div className="d-flex gap-2">
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-secondary rounded-0"
+                      disabled={pagina.pagina <= 1 || cargando}
+                      onClick={() => cambiarPagina(-1)}
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-secondary rounded-0"
+                      disabled={pagina.pagina >= totalPaginas || cargando}
+                      onClick={() => cambiarPagina(1)}
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}


### PR DESCRIPTION
## Etapa 11 — Las tres pantallas de caja

- **/caja/historico** (Supervisor+Admin): el Ver Cajas del legacy con datos reales — cierres con totales de arqueos persistidos, filtros y export.
- **/caja/turnos/:id/z** (Vendedor+): la Caja Z — el detalle del turno con su Z-report descargable; link directo post-cierre; sin entrada de nav (convencion CompraEditor).
- **/caja/tesoreria** (Supervisor+Admin): el libro G3 encadenado con export.

Tipos espejados campo a campo contra Contratos.cs; builders con offset explicito (la ventana UTC muerta tambien a nivel UI, con test que pinea el -03:00); BotonDeDescarga con limpieza de error en cada pantalla; regla 6 en todos los tests de mapeo.

### Review
Judgment-day: Juez A APPROVE cero hallazgos (gates dobles nav+ruta verificados contra el split real de politicas; DTOs y offsets limpios). Juez B APPROVE-WITH-MINORS con 1 WARNING probado por mutacion: el test stale de CajaZ asertaba el titulo derivado de la URL, no el estado protegido. El fix destapo un confound NUEVO: waitFor pasaba en su primer tick antes del microtask stale — resuelto flusheando dentro de act con aserciones sincronicas discriminantes. Evidencia final: borrar la guarda del then → falla; revert → 531/531.

### Size
`size:exception` — ~1993 lineas: batch deliberado de 3 slices de pantalla (decision del orquestador) para evitar tres PRs triviales de nav compartida.

### Tests
vitest 531/531 (497 + 34) · tsc -b limpio · build limpio · oxlint sin issues nuevos

🤖 Generated with [Claude Code](https://claude.com/claude-code)