### PR TITLE
feat(web): vistas de impresion para estado de cuenta y Caja Z (etapa 11, slice 8)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -920,20 +920,54 @@ correctly to PDF via the browser's own "Guardar como PDF", no dedicated
 print route or second fetch. **Rollback**: revert the branch — CSS/markup
 only, no data path touched.
 
-- [ ] 8.1 Modify `src/Ways.Web/src/paginas/CuentaCorriente.tsx`: add a
+- [x] 8.1 Modify `src/Ways.Web/src/paginas/CuentaCorriente.tsx`: add a
   print layout section + `d-print-none` on chrome (filters, nav, download
   button) — same component, same fetch, `@media print` only. *(design
-  decision 13 — no dedicated print route, no second fetch)*
-- [ ] 8.2 Modify `src/Ways.Web/src/paginas/CajaZ.tsx`: same treatment for
-  the turno detail print layout.
-- [ ] 8.3 Add/modify the shared print stylesheet (`@media print` rules:
+  decision 13 — no dedicated print route, no second fetch)* — an
+  "Imprimir" button (`window.print()`) was added to the toolbar (this
+  screen had no download button to reuse — Slice 4 wired `BotonDeDescarga`
+  into Tablero only, never into `CuentaCorriente`, contra the design's
+  File Changes table row); `d-print-none` applied to Imprimir/"Volver a
+  clientes", the filtros row, and the Ajuste-manual/Actualizar-precios/
+  Ingresar-pago button row (Saldo/Límite/Disponibilidad stay visible when
+  printed). Print-only header block shows Rango (desde–hasta or "Histórico
+  completo") and Generado (fecha/hora + usuario) — Cliente is already in
+  the `Box` title, which prints unchanged. Empresa/PV are NOT rendered:
+  neither is loaded client-side today (cuenta corriente is client-level,
+  not PV-scoped) and design decision 13 forbids a second fetch to get
+  them — recorded gap, not an oversight.
+- [x] 8.2 Modify `src/Ways.Web/src/paginas/CajaZ.tsx`: same treatment for
+  the turno detail print layout. — "Imprimir" added next to the existing
+  `BotonDeDescarga`, both `d-print-none`. Print-only header shows Generado
+  (fecha/hora + usuario) only — no Rango (a single turno, not a ranged
+  report) and no Empresa/PV (`DetalleDeTurno`/`ResumenDeTurno` carry
+  neither; same no-second-fetch constraint as 8.1).
+- [x] 8.3 Add/modify the shared print stylesheet (`@media print` rules:
   page margins, hide `d-print-none`, table borders for print legibility).
-- [ ] 8.4 [P] `d-print-none`-presence tests on both pages (per the design's
+  — new `src/Ways.Web/src/estilos/impresion.css`, imported from `main.tsx`;
+  also hides the app-wide nav (`#top`, `Layout.tsx`) by id, so no
+  `Layout.tsx` edit was needed — CSS-only, matching this slice's
+  "CSS/markup only" rollback note.
+- [x] 8.4 [P] `d-print-none`-presence tests on both pages (per the design's
   recorded exemption: print rendering itself has no automated assertion
-  beyond this presence check — verified by eye).
-- [ ] 8.5 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 8.6 Branch `feat/stage11-slice8-vistas-impresion` off `main` (parent:
-  slice 6b); PR; merge stacked-to-main.
+  beyond this presence check — verified by eye). — extended
+  `CuentaCorriente.test.tsx`/`CajaZ.test.tsx`: `d-print-none` presence on
+  Imprimir/Volver/Descargar/filtros/acciones, `window.print()` invoked on
+  click, and the print header renders the REAL screen values (mutation-proof-tests:
+  clause named — "rango/usuario come from state, not a hardcoded string" —
+  mutation run: hardcoding the rango/usuario in each component made the
+  corresponding test fail; reverted, green again).
+- [x] 8.5 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as every prior slice
+  (1b.13/2.9/3.9/5a.11/5b.10/6a.4/7.13).
+- [x] 8.6 Branch `feat/stage11-slice8-vistas-impresion` off `main` (parent:
+  slice 6b); PR; merge stacked-to-main. — branch
+  `feat/stage11-slice8-print-views` created off `main` per the
+  orchestrator's explicit instruction (isolated worktree; name differs from
+  the task's suggested branch name, same precedent as
+  1b.14/2.10/3.10/5a.12/5b.11/6a.5/7.14); PR/merge left for the
+  orchestrator.
 
 **Test plan**: `d-print-none` presence only — print rendering is an
 explicitly recorded exemption (design Testing Strategy), verified by eye.

--- a/src/Ways.Web/src/estilos/impresion.css
+++ b/src/Ways.Web/src/estilos/impresion.css
@@ -1,0 +1,39 @@
+/*
+ * Vistas de impresión (stage-11-exportacion-reportes, Slice 8, design decisión 13): el mismo
+ * componente que se ve en pantalla se imprime vía el "Guardar como PDF" del navegador — no hay
+ * ruta ni fetch dedicados a impresión. Estas reglas solo aplican bajo `@media print`; en pantalla
+ * no tienen ningún efecto.
+ */
+@media print {
+  /* La barra de navegación de la app (`Layout.tsx`, id fijo `#top`) nunca forma parte del
+     documento impreso, en cualquier pantalla. */
+  #top {
+    display: none !important;
+  }
+
+  /* Bootstrap 5 ya trae `.d-print-none`; se refuerza acá para que la intención de ocultar
+     filtros/nav-en-pantalla/botones de acción quede documentada junto al resto de las reglas de
+     impresión de la pantalla, sin depender solo del utility importado. */
+  .d-print-none {
+    display: none !important;
+  }
+
+  body {
+    background: #fff;
+  }
+
+  @page {
+    margin: 12mm;
+  }
+
+  /* Legibilidad en blanco y negro: bordes explícitos por celda en vez de depender del rayado de
+     `table-striped`, que puede no imprimirse según la configuración del navegador. */
+  table {
+    border-collapse: collapse;
+  }
+
+  table th,
+  table td {
+    border: 1px solid #000 !important;
+  }
+}

--- a/src/Ways.Web/src/main.tsx
+++ b/src/Ways.Web/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './estilos/template.css'
 import './estilos/ways.css'
+import './estilos/impresion.css'
 
 import { App } from './App'
 

--- a/src/Ways.Web/src/paginas/CajaZ.test.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.test.tsx
@@ -284,3 +284,42 @@ describe('CajaZ — role gating (spec historico-de-cajas: A Vendedor Downloads T
     expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
   })
 })
+
+/**
+ * Vista de impresión (stage-11-exportacion-reportes, Slice 8, design decisión 13: mismo
+ * componente, `@media print`, sin ruta ni fetch dedicados — print rendering en sí es una
+ * exención registrada, verificada a ojo). Cubre lo único automatizable: el bloque de impresión
+ * muestra quién/cuándo lo generó con el usuario REAL de la sesión, y el chrome que no debe
+ * imprimirse (Imprimir, Descargar) lleva `d-print-none`.
+ */
+describe('CajaZ — vista de impresión (Slice 8)', () => {
+  it('el bloque de impresión muestra quién generó la vista con el usuario real de la sesión', async () => {
+    usuarioActual = usuarioFixture({ usuario: 'cajero_luis' })
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return Promise.resolve(detalleFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    renderCajaZ()
+
+    expect(await screen.findByText(/Generado:.*— cajero_luis/)).toBeInTheDocument()
+  })
+
+  it('el botón Imprimir dispara window.print() y tanto Imprimir como Descargar quedan marcados d-print-none', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/caja/turnos/412/detalle') return Promise.resolve(detalleFixture())
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const imprimirSpy = vi.fn()
+    window.print = imprimirSpy
+    renderCajaZ()
+
+    await screen.findByText('Caja Z — turno #412')
+
+    const botonImprimir = screen.getByRole('button', { name: 'Imprimir' })
+    expect(botonImprimir).toHaveClass('d-print-none')
+    await userEvent.click(botonImprimir)
+    expect(imprimirSpy).toHaveBeenCalledTimes(1)
+
+    expect(screen.getByRole('button', { name: 'Descargar' })).toHaveClass('d-print-none')
+  })
+})

--- a/src/Ways.Web/src/paginas/CajaZ.tsx
+++ b/src/Ways.Web/src/paginas/CajaZ.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router'
 import { clienteDeCaja, rutasDeExportacionDeCaja } from '../api/caja'
 import { ErrorApi } from '../api/cliente'
 import type { DetalleDeTurno } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
 import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -33,6 +34,8 @@ export function CajaZ() {
   const { id } = useParams<{ id: string }>()
   const idTurno = id !== undefined ? Number(id) : Number.NaN
   const idTurnoValido = Number.isFinite(idTurno)
+
+  const { usuario } = useAuth()
 
   const [detalle, setDetalle] = useState<DetalleDeTurno | null>(null)
   const [cargando, setCargando] = useState(true)
@@ -80,14 +83,29 @@ export function CajaZ() {
         titulo={`Caja Z — turno #${idTurno}`}
         variante="inverse"
         herramientas={
-          <BotonDeDescarga
-            ruta={rutasDeExportacionDeCaja.detalleDeTurno(idTurno)}
-            etiqueta="Descargar"
-            onError={setErrorDescarga}
-            onInicio={() => setErrorDescarga('')}
-          />
+          <div className="d-flex gap-2">
+            <button type="button" className="btn btn-sm btn-outline-light rounded-0 d-print-none" onClick={() => window.print()}>
+              Imprimir
+            </button>
+            <BotonDeDescarga
+              ruta={rutasDeExportacionDeCaja.detalleDeTurno(idTurno)}
+              etiqueta="Descargar"
+              onError={setErrorDescarga}
+              onInicio={() => setErrorDescarga('')}
+              className="btn btn-sm btn-outline-secondary rounded-0 d-print-none"
+            />
+          </div>
         }
       >
+        {/* Vista de impresión (design decisión 13: mismo componente, `@media print`, sin ruta ni
+            fetch dedicados): equivalente del encabezado de los exports XLSX — generado por/cuándo.
+            El turno ya está en el título de `Box`, que se imprime igual. */}
+        <div className="d-none d-print-block mb-3">
+          <div className="small">
+            Generado: {new Date().toLocaleString('es-AR')} — {usuario?.usuario ?? '—'}
+          </div>
+        </div>
+
         {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
         {error && (
           <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -997,3 +997,56 @@ describe('CuentaCorriente — detalle de un movimiento ActualizacionPrecios en e
     expect(await screen.findByText('{esto no es json')).toBeInTheDocument()
   })
 })
+
+/**
+ * Vista de impresión (stage-11-exportacion-reportes, Slice 8, design decisión 13: mismo
+ * componente, `@media print`, sin ruta ni fetch dedicados — print rendering en sí es una
+ * exención registrada, verificada a ojo). Estos tests cubren lo único automatizable: el bloque de
+ * impresión muestra los valores REALES de contexto (nunca un placeholder) y el chrome que no debe
+ * imprimirse lleva `d-print-none`.
+ */
+describe('CuentaCorriente — vista de impresión (Slice 8)', () => {
+  it('el bloque de impresión muestra el rango real de filtros y quién/cuándo lo generó', async () => {
+    mockearRutasBase()
+    usuarioActual = usuarioFixture({ usuario: 'cajera_ana' })
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+
+    const inputDesde = screen.getByLabelText('Desde') as HTMLInputElement
+    const inputHasta = screen.getByLabelText('Hasta') as HTMLInputElement
+
+    expect(screen.getByText(`Rango: ${inputDesde.value} a ${inputHasta.value}`)).toBeInTheDocument()
+    expect(screen.getByText(/Generado:.*— cajera_ana/)).toBeInTheDocument()
+  })
+
+  it('"Ver histórico completo" cambia el bloque de impresión de un rango de fechas a "Histórico completo"', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+    expect(screen.getByText(/^Rango: \d{4}-\d{2}-\d{2} a \d{4}-\d{2}-\d{2}$/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+
+    expect(await screen.findByText('Rango: Histórico completo')).toBeInTheDocument()
+  })
+
+  it('el botón Imprimir dispara window.print() y el resto del chrome de pantalla queda marcado d-print-none', async () => {
+    mockearRutasBase()
+    const imprimirSpy = vi.fn()
+    window.print = imprimirSpy
+    renderPantalla()
+
+    await screen.findByText('$500,00')
+
+    const botonImprimir = screen.getByRole('button', { name: 'Imprimir' })
+    expect(botonImprimir).toHaveClass('d-print-none')
+    await userEvent.click(botonImprimir)
+    expect(imprimirSpy).toHaveBeenCalledTimes(1)
+
+    expect(screen.getByRole('link', { name: 'Volver a clientes' })).toHaveClass('d-print-none')
+    expect(screen.getByLabelText('Desde').closest('.row')).toHaveClass('d-print-none')
+    expect(screen.getByRole('button', { name: 'Ingresar pago' }).closest('.d-flex')).toHaveClass('d-print-none')
+  })
+})

--- a/src/Ways.Web/src/paginas/CuentaCorriente.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.tsx
@@ -1076,11 +1076,32 @@ function PantallaCuentaCorriente({
       <Box
         titulo={`Estado de cuenta — ${nombreDeCliente(idCliente, clienteInfo)}`}
         herramientas={
-          <Link className="btn btn-sm btn-outline-light rounded-0" to="/clientes">
-            Volver a clientes
-          </Link>
+          <div className="d-flex gap-2">
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-light rounded-0 d-print-none"
+              onClick={() => window.print()}
+            >
+              Imprimir
+            </button>
+            <Link className="btn btn-sm btn-outline-light rounded-0 d-print-none" to="/clientes">
+              Volver a clientes
+            </Link>
+          </div>
         }
       >
+        {/* Vista de impresión (design decisión 13: mismo componente, `@media print`, sin ruta ni
+            fetch dedicados): equivalente del encabezado que llevan los exports XLSX — rango y
+            generado por/cuándo. Cliente ya está en el título de `Box`, que se imprime igual. */}
+        <div className="d-none d-print-block mb-3">
+          <div className="small">
+            Rango: {historico ? 'Histórico completo' : `${desde} a ${hasta}`}
+          </div>
+          <div className="small">
+            Generado: {new Date().toLocaleString('es-AR')} — {usuario?.usuario ?? '—'}
+          </div>
+        </div>
+
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
         {errorEstado && <div className="alert alert-danger rounded-0">{errorEstado}</div>}
         {(errorCliente || errorMedios || errorPuntosVenta) && (
@@ -1108,7 +1129,7 @@ function PantallaCuentaCorriente({
                 <div>{formatearDisponibilidad(estado.header.disponibilidad)}</div>
               </div>
               <div className="col-md-3 text-md-end">
-                <div className="d-flex gap-2 justify-content-md-end flex-wrap">
+                <div className="d-flex gap-2 justify-content-md-end flex-wrap d-print-none">
                   {esSupervisorOAdmin && (
                     <>
                       <button
@@ -1153,7 +1174,7 @@ function PantallaCuentaCorriente({
               </div>
             </div>
 
-            <div className="row g-2 align-items-end mb-3">
+            <div className="row g-2 align-items-end mb-3 d-print-none">
               <div className="col-md-3">
                 <label className="form-label" htmlFor="cc-filtro-desde">
                   Desde


### PR DESCRIPTION
## Etapa 11, slice 8 — Print views

Impresion por navegador (proposal decision 9: cero librerias PDF, cero riesgo de licencia):

- `impresion.css` con @media print: nav oculta por #top (sin tocar Layout), bordes de tabla forzados para legibilidad.
- Botones Imprimir en Estado de Cuenta y Caja Z (window.print), chrome interactivo con d-print-none asertado por test.
- Bloque de encabezado print-only con rango y generado desde el estado REAL (mutacion: hardcodear cualquiera de los dos rompe su test). Empresa/PV omitidos con registro: el design prohibe un segundo fetch, y la identidad de la pagina ya imprime en el titulo del Box (cliente/turno).

### Review
Judgment-day: ronda limpia — Juez A APPROVE (cobertura d-print-none completa, desviaciones genuinas verificadas contra historia git), Juez B APPROVE (ambas mutaciones reclamadas + onClick y clases probadas por mutacion propia — cero hallazgos). 1 nota especulativa fuera de alcance: modales sin print-safety global (follow-up).

### Tests
vitest 536/536 (531 + 5) · tsc/build/oxlint limpios · 182 lineas, bajo presupuesto

🤖 Generated with [Claude Code](https://claude.com/claude-code)