### PR TITLE
feat(reportes): existencias por punto de venta con export (etapa 11, slice 9)

### DIFF
--- a/openspec/changes/stage-11-exportacion-reportes/tasks.md
+++ b/openspec/changes/stage-11-exportacion-reportes/tasks.md
@@ -985,32 +985,77 @@ disappear, no migration, no persisted row to unwind. **If the budget
 tightens, this slice is dropped whole to Etapa 13** (proposal decision 10)
 — recorded so dropping it is a decision, not an oversight.
 
-- [ ] 9.1 Create `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
+- [x] 9.1 Create `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
   stock joined to articulos for a punto de venta, covered by
   `ix_stock_punto_venta`. *(proposal decision 10; spec reportes-de-gestion:
-  Existencias Report Joins Stock To Artículos Under The Same Gate)*
-- [ ] 9.2 Modify `ReportesEndpoints.cs`: `GET /stock/existencias` under
+  Existencias Report Joins Stock To Artículos Under The Same Gate)* —
+  `ObtenerExistenciasAsync(idPuntoVenta)`: `Where(s => s.IdPuntoVenta ==
+  idPuntoVenta)` ⋈ `Articulos` (EF tenant/baja-lógica filters apply free on
+  the join), ordered by `IdArticulo`. No `idEmpresa` (same shape as
+  `ServicioDeTesoreria`) and no `desde`/`hasta` — stock has no time
+  dimension, unlike every other report in this stage.
+- [x] 9.2 Modify `ReportesEndpoints.cs`: `GET /stock/existencias` under
   `LecturaDeReportes` — no `idArticulo` required, unlike `GET /api/stock`.
-- [ ] 9.3 Extend `ExportacionDeReportes.cs`: `De` mapper for existencias.
-- [ ] 9.4 Modify `ReportesEndpoints.cs`: `GET /stock/existencias/export`
-  sibling.
-- [ ] 9.5 Create `src/Ways.Web/src/paginas/Existencias.tsx`: modest table
-  screen (punto de venta filter, `BotonDeDescarga`).
-- [ ] 9.6 Modify `App.tsx`/`Layout.tsx`: `/reportes/existencias` route
+- [x] 9.3 Extend `ExportacionDeReportes.cs`: `De` mapper for existencias. —
+  no totals row (summing quantities of different articulos has no meaning);
+  `Cantidad` column typed `Cantidad`, matching `articulos/top`.
+- [x] 9.4 Modify `ReportesEndpoints.cs`: `GET /stock/existencias/export`
+  sibling. — AGGREGATE cap shape (design decision 6): `GuardaDeTope` runs
+  on `TablaExportable.Filas.Count` after mapping, no `COUNT(*)`. Empresa/zona
+  resolved via `AlcanceDeListadoHttp` from `idPuntoVenta` (tesorería/cajas
+  pattern); `desde`/`hasta` of the header and the deterministic filename are
+  both pinned to the server's "today" (`reloj.Ahora`), since the report has
+  no real range.
+- [x] 9.5 Create `src/Ways.Web/src/paginas/Existencias.tsx`: modest table
+  screen (punto de venta filter, `BotonDeDescarga`). — no date filter, no
+  pagination (mirrors the JSON/export contract: no time dimension, aggregate
+  bounded by construction).
+- [x] 9.6 Modify `App.tsx`/`Layout.tsx`: `/reportes/existencias` route
   (`LecturaDeReportes`) and nav entry.
-- [ ] 9.7 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
-  pending changes.
-- [ ] 9.8 [P] The house 4-test pattern for the endpoint.
-- [ ] 9.9 [P] Equality test on the export vs the JSON listing.
-- [ ] 9.10 [P] 403 test: role one step below `LecturaDeReportes` (Vendedor)
-  rejected on both routes.
-- [ ] 9.11 [P] `no-idArticulo-required` test: 40 stocked articulos for a PV
+- [x] 9.7 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
+  pending changes. — confirmed clean (`--project`/`--startup-project
+  src/Ways.Infrastructure`, since `Ways.Api` doesn't reference
+  `Microsoft.EntityFrameworkCore.Design`).
+- [x] 9.8 [P] The house 4-test pattern for the endpoint. —
+  `ExistenciasTests.cs`: cross-tenant absence (honesty note: PV ids are
+  globally unique, ordinary coverage), cross-PV discrimination (mutation-proof
+  clause `Where(s => s.IdPuntoVenta == idPuntoVenta)`, mutation applied/
+  reverted — evidence below), soft-deleted articulo excluded from the live
+  join, fields-match-seeded-row.
+- [x] 9.9 [P] Equality test on the export vs the JSON listing. —
+  `ExistenciasExportTests.ElExportEsIgualAlEndpointJsonParaLasDosFilas`: TWO
+  articulos with distinct name+cantidad, ALL columns asserted per row
+  (mutation-proof-tests rule 6). Mutation applied/reverted — evidence below.
+- [x] 9.10 [P] 403 test: role one step below `LecturaDeReportes` (Vendedor)
+  rejected on both routes. — `UnVendedorEsRechazadoDeLasExistencias` (JSON)
+  + `UnVendedorEsRechazadoDelExportDeExistencias` (export); Supervisor-200
+  added on both routes for parity with every other reportes-de-gestión test
+  file.
+- [x] 9.11 [P] `no-idArticulo-required` test: 40 stocked articulos for a PV
   → all 40 rows returned with only `idPuntoVenta` supplied. *(spec:
-  Existencias Needs No idArticulo, Unlike GET /api/stock)*
-- [ ] 9.12 [P] `Existencias.test.tsx` per `web-descriptor-tests`.
-- [ ] 9.13 Run `judgment-day`; fix; re-judge until clean.
+  Existencias Needs No idArticulo, Unlike GET /api/stock)* —
+  `LasExistenciasDe40ArticulosVuelvenSinPedirIdArticulo`.
+- [x] 9.12 [P] `Existencias.test.tsx` per `web-descriptor-tests`. — mirrors
+  `Tesoreria.test.tsx`'s rigor (not a smoke test): initial PV load, empty
+  state without a re-query, row rendering + no-idArticulo query assertion,
+  PV-switch re-query, download route, stale-response generation guard, role
+  gating (Supervisor in / Vendedor redirected).
+- [ ] 9.13 Run `judgment-day`; fix; re-judge until clean. — OUT OF SCOPE for
+  this `sdd-apply` run (explicit boundary: no push/PR); left for the
+  orchestrator's PR-validation phase, same precedent as every prior slice
+  (1b.13/2.9/3.9/5a.11/5b.10/6a.4/7.13/8.5).
 - [ ] 9.14 Branch `feat/stage11-slice9-existencias` off `main` (parent:
-  slices 1b + 4); PR; merge stacked-to-main.
+  slices 1b + 4); PR; merge stacked-to-main. — branch created inside the
+  isolated worktree per the orchestrator's explicit instruction; the
+  worktree's pre-existing branch name (`worktree-agent-ac822c711ae33bb08`)
+  was kept as-is rather than renamed, after an earlier accidental
+  `git checkout -b feat/stage11-slice9-existencias` on the SHARED checkout
+  (`C:\ways`, not this worktree) was caught and abandoned — that shared
+  checkout is left switched to the stray, commit-less
+  `feat/stage11-slice9-existencias` branch (same tip as `main`, zero
+  divergence) and needs a `git checkout main` cleanup by whoever owns that
+  checkout. PR/merge left for the orchestrator, same precedent as
+  1b.14/2.10/3.10/5a.12/5b.11/6a.5/7.14/8.6.
 
 **Test plan**: 4-test pattern, equality, 403, no-idArticulo-required,
 descriptor tests.

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -356,7 +356,8 @@ public static class ReportesEndpoints
             var existencias = await servicio.ObtenerExistenciasAsync(idPuntoVenta, ct);
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
-            var hoy = DateOnly.FromDateTime(reloj.Ahora.UtcDateTime);
+            var hoy = DateOnly.FromDateTime(
+                TimeZoneInfo.ConvertTime(reloj.Ahora, TimeZoneInfo.FindSystemTimeZoneById(zonaId)).Date);
 
             var ctx = ContextoDeExportacionHttp.Construir(usuario, reloj, empresa, $"PV {idPuntoVenta}", hoy, hoy, zonaId);
             var tabla = ExportacionDeReportes.De(existencias, ctx);

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -327,6 +327,51 @@ public static class ReportesEndpoints
         })
         .RequireAuthorization(Politicas.LecturaDeRentabilidad)
         .WithSummary("Export XLSX de /comisiones: mismos parámetros y figuras, etiquetado PROVISIONAL.");
+
+        // stage-11-exportacion-reportes, Slice 9 (proposal decisión 10, droppable a Etapa 13;
+        // spec reportes-de-gestion: Existencias Report Joins Stock To Artículos Under The Same
+        // Gate): gate heredado del grupo, sin política propia. Sin idArticulo (a diferencia de
+        // GET /api/stock) y sin idEmpresa (mismo criterio que /tesoreria): la ruta solo pide el
+        // punto de venta.
+        grupo.MapGet("/stock/existencias", (
+            ServicioDeReportesDeStock servicio, int idPuntoVenta, CancellationToken ct) =>
+            servicio.ObtenerExistenciasAsync(idPuntoVenta, ct))
+        .WithSummary(
+            "Existencias de un punto de venta: stock ⋈ articulos, sin idArticulo requerido — a " +
+            "diferencia de GET /api/stock, que exige el par completo.");
+
+        // Sibling declarado inmediatamente después de su ruta fuente — hereda LecturaDeReportes
+        // por co-locación. AGREGADO (design decisión 6): la guarda corre sobre
+        // TablaExportable.Filas.Count ya mapeada, sin COUNT(*) propio. Sin desde/hasta: el stock
+        // no tiene dimensión temporal, así que el encabezado y el nombre de archivo usan la
+        // fecha del servidor (hoy) para ambos extremos del rango — mismo criterio "ids, no
+        // nombres" que el resto de NombreDeArchivo, adaptado a un reporte sin rango real.
+        grupo.MapGet("/stock/existencias/export", async (
+            ServicioDeReportesDeStock servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int idPuntoVenta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var existencias = await servicio.ObtenerExistenciasAsync(idPuntoVenta, ct);
+
+            var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
+            var hoy = DateOnly.FromDateTime(reloj.Ahora.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(usuario, reloj, empresa, $"PV {idPuntoVenta}", hoy, hoy, zonaId);
+            var tabla = ExportacionDeReportes.De(existencias, ctx);
+
+            GuardaDeTope.Exigir(tabla.Filas.Count, opciones.Value.TopeDeFilas);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("existencias", $"pv{idPuntoVenta}", hoy, hoy);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de /stock/existencias: mismas filas, encabezado fechado a hoy (reporte " +
+            "de estado actual, sin rango).");
+
         // stage-11-exportacion-reportes, Slice 5a (design: G2/G3 — minimal aggregation; spec
         // historico-de-cajas: G2 Histórico Lists Closed Turnos Only, Role Split — Turno Detail
         // Under OperacionDePos, Cross-Turno Views Under LecturaDeReportes): gate heredado del

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -108,6 +108,10 @@ public static class DependencyInjection
         // libro de tesorería — cero derivación, solo lectura encadenada por Id.
         services.AddScoped<ServicioDeTesoreria>();
 
+        // stage-11-exportacion-reportes, Slice 9 (proposal decisión 10, droppable a Etapa 13):
+        // existencias — LINQ puro sobre stock ⋈ articulos, sin dependencia de LectorDeSerieTemporal.
+        services.AddScoped<ServicioDeReportesDeStock>();
+
         return services;
     }
 }

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -125,3 +125,18 @@ public sealed record ComisionPorEmpleado(int IdEmpleado, decimal NetoVendido, de
 public sealed record Comisiones(
     DateOnly Desde, DateOnly Hasta, string ZonaHoraria, decimal ComisionPorcentaje,
     IReadOnlyList<ComisionPorEmpleado> Filas, bool Provisional);
+
+/// <summary>Una fila de <c>GET /api/reportes/stock/existencias</c> (stage-11-exportacion-reportes,
+/// Slice 9; proposal decisión 10; design: "Two cap shapes, by report shape" — agregado acotado por
+/// construcción). A diferencia de <see cref="ArticuloTop"/> (que etiqueta con el snapshot congelado
+/// de una línea de venta), acá NO hay línea histórica que congelar — <c>stock</c> es estado
+/// ACTUAL, así que <see cref="Nombre"/> sale del join en vivo contra <c>articulos</c> (spec:
+/// Existencias Report Joins Stock To Artículos Under The Same Gate), nunca de un snapshot.</summary>
+public sealed record FilaExistencia(int IdArticulo, string Nombre, decimal Cantidad);
+
+/// <summary>Respuesta de <c>GET /api/reportes/stock/existencias</c>. Sin <c>desde</c>/<c>hasta</c>
+/// ni <c>ZonaHoraria</c> (a diferencia del resto de los reportes de esta etapa): el stock no tiene
+/// dimensión temporal, es una foto del estado actual — mínimos, punto de pedido y reposición
+/// quedan fuera de esta slice (proposal decisión 10: "give it the context it lacks here", reservado
+/// para Etapa 13).</summary>
+public sealed record Existencias(int IdPuntoVenta, IReadOnlyList<FilaExistencia> Filas);

--- a/src/Ways.Application/Reportes/ExportacionDeReportes.cs
+++ b/src/Ways.Application/Reportes/ExportacionDeReportes.cs
@@ -276,4 +276,26 @@ public static class ExportacionDeReportes
                     Celda.Moneda(f.Comision)
                 ])
                 .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasExistencias =
+    [
+        new ColumnaExportable("Artículo", TipoDeColumna.Entero),
+        new ColumnaExportable("Nombre", TipoDeColumna.Texto),
+        new ColumnaExportable("Cantidad", TipoDeColumna.Cantidad)
+    ];
+
+    /// <summary>Slice 9 (proposal decisión 10): sin fila de totales — a diferencia de
+    /// <c>ventas/resumen</c>/<c>compras/por-proveedor</c>, sumar cantidades de artículos distintos
+    /// no produce una figura con significado propio.</summary>
+    public static TablaExportable De(Existencias respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Existencias", ctx, ColumnasExistencias,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdArticulo),
+                    Celda.Texto(f.Nombre),
+                    Celda.Cantidad(f.Cantidad)
+                ])
+                .ToList());
 }

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -12,9 +12,11 @@ namespace Ways.Application.Reportes;
 /// Sin <c>idArticulo</c> (spec: Existencias Needs No idArticulo, Unlike GET /api/stock) y sin
 /// <c>idEmpresa</c> (mismo criterio que <c>ServicioDeTesoreria</c>: la ruta solo pide
 /// <c>idPuntoVenta</c>, la empresa se resuelve del lado HTTP cuando hace falta para el export).
-/// Los filtros de <c>Tenant</c>/<c>BajaLogica</c> de EF aplican gratis sobre <c>articulos</c>
-/// (design decisión 1); <c>stock</c> usa su propio filtro de tenant manual
-/// (<c>WaysDbContext.AplicarFiltroDeTenantEnStock</c>) — ambos activos sobre este join.
+/// Los filtros globales de <c>Tenant</c>/<c>BajaLogica</c> de EF aplican gratis sobre
+/// <c>articulos</c>; <c>stock</c> usa su propio filtro de tenant manual
+/// (<c>WaysDbContext.AplicarFiltroDeTenantEnStock</c>) — ambos activos sobre este join. Trade-off
+/// deliberado: el stock de un artículo eliminado queda oculto del reporte (cubierto por
+/// <c>ExistenciasTests.UnArticuloEliminadoNuncaApareceEnLasExistencias</c>).
 /// </summary>
 public class ServicioDeReportesDeStock(IWaysDbContext db)
 {

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+
+namespace Ways.Application.Reportes;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 9 (proposal decisión 10; design: "Two cap shapes, by
+/// report shape" — <c>/stock/existencias</c> es un AGREGADO acotado por construcción, sin
+/// <c>COUNT(*)</c> propio; spec reportes-de-gestion: Existencias Report Joins Stock To Artículos
+/// Under The Same Gate): <c>GET /api/reportes/stock/existencias</c> — LINQ puro sobre
+/// <c>stock</c> ⋈ <c>articulos</c> para UN punto de venta, cubierto por <c>ix_stock_punto_venta</c>.
+/// Sin <c>idArticulo</c> (spec: Existencias Needs No idArticulo, Unlike GET /api/stock) y sin
+/// <c>idEmpresa</c> (mismo criterio que <c>ServicioDeTesoreria</c>: la ruta solo pide
+/// <c>idPuntoVenta</c>, la empresa se resuelve del lado HTTP cuando hace falta para el export).
+/// Los filtros de <c>Tenant</c>/<c>BajaLogica</c> de EF aplican gratis sobre <c>articulos</c>
+/// (design decisión 1); <c>stock</c> usa su propio filtro de tenant manual
+/// (<c>WaysDbContext.AplicarFiltroDeTenantEnStock</c>) — ambos activos sobre este join.
+/// </summary>
+public class ServicioDeReportesDeStock(IWaysDbContext db)
+{
+    public async Task<Existencias> ObtenerExistenciasAsync(int idPuntoVenta, CancellationToken ct = default)
+    {
+        // Cláusula bajo prueba (mutation-proof-tests): Where(s => s.IdPuntoVenta == idPuntoVenta)
+        // es lo único que discrimina un punto de venta del otro — mezclar dos PVs del mismo tenant
+        // en una sola respuesta rompería el significado del reporte tanto como en
+        // ServicioDeTesoreria (design decisión 11, misma familia de bug).
+        var filas = await db.Stock
+            .Where(s => s.IdPuntoVenta == idPuntoVenta)
+            .Join(db.Articulos, s => s.IdArticulo, a => a.Id, (s, a) => new { a.Id, a.Nombre, s.Cantidad })
+            .OrderBy(x => x.Id)
+            .Select(x => new FilaExistencia(x.Id, x.Nombre, x.Cantidad))
+            .ToListAsync(ct);
+
+        return new Existencias(idPuntoVenta, filas);
+    }
+}

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -14,6 +14,7 @@ import { CompraEditor } from './paginas/CompraEditor'
 import { ConteoDeInventario } from './paginas/ConteoDeInventario'
 import { CuentaCorriente } from './paginas/CuentaCorriente'
 import { Empresas } from './paginas/Empresas'
+import { Existencias } from './paginas/Existencias'
 import { HistoricoDeCajas } from './paginas/HistoricoDeCajas'
 import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
@@ -124,6 +125,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
                   <Tesoreria />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-11-exportacion-reportes (Slice 9, design: Web Composition, droppable a
+                Etapa 13): mismo gate que /tablero (Politicas.LecturaDeReportes) — vista de
+                gestión, no el balance del POS (Politicas.OperacionDePos de GET /api/stock). */}
+            <Route
+              path="/reportes/existencias"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <Existencias />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -8,6 +8,7 @@
 import { api } from './cliente'
 import type {
   Comisiones,
+  Existencias,
   Granularidad,
   PaginaDeHistoricoDeCajas,
   PaginaDeMovimientosTesoreria,
@@ -104,6 +105,8 @@ export const clienteDeReportes = {
     api.get<PaginaDeHistoricoDeCajas>(`/reportes/cajas${construirQueryDeHistoricoDeCajas(filtros)}`),
   tesoreria: (filtros: FiltrosDeTesoreria) =>
     api.get<PaginaDeMovimientosTesoreria>(`/reportes/tesoreria${construirQueryDeTesoreria(filtros)}`),
+  existencias: (idPuntoVenta: number) =>
+    api.get<Existencias>(`/reportes/stock/existencias?idPuntoVenta=${idPuntoVenta}`),
 }
 
 // ---- Offset local para desde/hasta de /cajas y /tesoreria (stage-11-exportacion-reportes,
@@ -206,6 +209,9 @@ export const rutasDeExportacion = {
   /** `desde`/`hasta` OBLIGATORIOS en `/tesoreria/export`, mismo criterio que `historicoDeCajas`. */
   tesoreria: (filtros: { idPuntoVenta: number; desde: string; hasta: string }) =>
     `/reportes/tesoreria/export${construirQueryDeAlcanceDeTesoreria(filtros)}&formato=xlsx`,
+  /** Sin `desde`/`hasta`: el stock no tiene rango, el nombre de archivo se fecha con el día del
+   * servidor (mismo criterio que la ruta JSON hermana). */
+  existencias: (idPuntoVenta: number) => `/reportes/stock/existencias/export?idPuntoVenta=${idPuntoVenta}&formato=xlsx`,
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -845,6 +845,23 @@ export type PaginaDeMovimientosTesoreria = {
   tamanio: number
 }
 
+// --- Existencias (stage-11-exportacion-reportes, Slice 9 — droppable a Etapa 13) — espejo de
+// `Ways.Application.Reportes.Contratos`. Sin fecha/zona horaria: el stock es estado ACTUAL, no
+// tiene dimensión temporal (a diferencia del resto de los reportes de esta etapa).
+
+/** Fila de `GET /api/reportes/stock/existencias` — espejo de `FilaExistencia`. */
+export type FilaExistencia = {
+  idArticulo: number
+  nombre: string
+  cantidad: number
+}
+
+/** Respuesta de `GET /api/reportes/stock/existencias` — espejo de `Existencias`. */
+export type Existencias = {
+  idPuntoVenta: number
+  filas: FilaExistencia[]
+}
+
 // --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---
 // Espejo de `Ways.Application.Ventas.Contratos` (confirmado contra el DTO real de
 // `POST /api/ventas`, mergeado en Slice 4) — usado por `ventas.ts` (mappers) y `Pos.tsx`

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -91,6 +91,15 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-11-exportacion-reportes (Slice 9, droppable a Etapa 13): mismo gate que
+                    Tablero/Histórico de cajas/Tesorería. */}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/reportes/existencias">
+                      Existencias
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -216,8 +216,13 @@ describe('Existencias — reporte (stage-11-exportacion-reportes, Slice 9 — we
     await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
     expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
 
-    resolverPrimera(existenciasFixture([filaFixture({ idArticulo: 1, nombre: 'primera-respuesta-vieja' })]))
-    await waitFor(() => expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument())
+    // El flush del microtask va DENTRO de act: un waitFor solo pasaría en su primer tick,
+    // antes de que el .then stale aterrice, y saldría verde sin probar nada.
+    await act(async () => {
+      resolverPrimera(existenciasFixture([filaFixture({ idArticulo: 1, nombre: 'primera-respuesta-vieja' })]))
+      await primera
+    })
+    expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument()
     expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -1,0 +1,243 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Existencias } from './Existencias'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { Existencias as ExistenciasRespuesta, FilaExistencia, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const puntoVentaNorte: PuntoVentaListado = {
+  id: 11,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Norte',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function filaFixture(sobrescribir: Partial<FilaExistencia> = {}): FilaExistencia {
+  return { idArticulo: 100, nombre: 'Yerba mate 1kg', cantidad: 42.5, ...sobrescribir }
+}
+
+function existenciasFixture(filas: FilaExistencia[] = [filaFixture()], idPuntoVenta = 10): ExistenciasRespuesta {
+  return { idPuntoVenta, filas }
+}
+
+function renderExistencias() {
+  return render(<Existencias />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para `/reportes/existencias`
+ * (`Politicas.LecturaDeReportes`). */
+function renderExistenciasProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/reportes/existencias']}>
+      <Routes>
+        <Route
+          path="/reportes/existencias"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <Existencias />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro, puntoVentaNorte])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
+})
+
+describe('Existencias — reporte (stage-11-exportacion-reportes, Slice 9 — web)', () => {
+  it('arranca con el primer punto de venta cargado', async () => {
+    mockearRutasBase()
+    renderExistencias()
+
+    await screen.findByLabelText('Punto de venta')
+    expect(screen.getByLabelText('Punto de venta')).toHaveValue('10')
+  })
+
+  it('sin stock cargado muestra un estado vacío, no un re-query', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture([]))
+      return undefined
+    })
+    renderExistencias()
+
+    expect(await screen.findByText('No hay stock cargado para este punto de venta.')).toBeInTheDocument()
+    const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/existencias?'))
+    expect(llamadas).toHaveLength(1)
+  })
+
+  it('renderiza las filas devueltas por el backend, sin idArticulo faltante en la consulta', async () => {
+    const filaUno = filaFixture({ idArticulo: 1, nombre: 'Aceite de girasol 900ml', cantidad: 12 })
+    const filaDos = filaFixture({ idArticulo: 2, nombre: 'Fideos guiseros 500g', cantidad: 87.5 })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture([filaUno, filaDos]))
+      return undefined
+    })
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    const filas = screen.getAllByRole('row').slice(1) // sin la fila de encabezado
+    expect(within(filas[0]).getByText('Aceite de girasol 900ml')).toBeInTheDocument()
+    expect(within(filas[0]).getByText('12')).toBeInTheDocument()
+    expect(within(filas[1]).getByText('Fideos guiseros 500g')).toBeInTheDocument()
+    expect(within(filas[1]).getByText('87,5')).toBeInTheDocument()
+
+    const llamada = apiGetMock.mock.calls.find((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/existencias?'))!
+    expect(llamada[0] as string).not.toContain('idArticulo')
+  })
+
+  it('cambiar el punto de venta dispara una nueva consulta con el idPuntoVenta elegido', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/existencias?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('idPuntoVenta=11'))).toBe(true)
+    })
+  })
+
+  it('el botón de descarga apunta a /reportes/stock/existencias/export con el idPuntoVenta elegido', async () => {
+    mockearRutasBase()
+    apiDescargarMock.mockRejectedValueOnce(new Error('no se pudo descargar'))
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(await screen.findByText('No se pudo descargar el archivo.')).toBeInTheDocument()
+    expect(apiDescargarMock.mock.calls[0][0]).toMatch(/^\/reportes\/stock\/existencias\/export\?idPuntoVenta=10/)
+  })
+
+  it('una respuesta desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: ExistenciasRespuesta) => void = () => {}
+    const primera = new Promise<ExistenciasRespuesta>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(existenciasFixture([filaFixture({ idArticulo: 999, nombre: 'segunda-respuesta' })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderExistencias()
+    await screen.findByLabelText('Punto de venta')
+
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
+
+    resolverPrimera(existenciasFixture([filaFixture({ idArticulo: 1, nombre: 'primera-respuesta-vieja' })]))
+    await waitFor(() => expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument())
+    expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Existencias — role gating (spec: A Supervisor Exports Existencias)', () => {
+  it('un Supervisor llega a /reportes/existencias', async () => {
+    mockearRutasBase()
+    renderExistenciasProtegido()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /reportes/existencias: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderExistenciasProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Existencias')).not.toBeInTheDocument())
+  })
+})

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
+import type { Existencias as ExistenciasRespuesta, PuntoVentaListado } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearCantidad(valor: number): string {
+  return valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
+}
+
+/**
+ * Existencias (stage-11-exportacion-reportes, Slice 9 — web, droppable a Etapa 13; design: Web
+ * Composition; proposal decisión 10) — pantalla modesta: `stock` ⋈ `articulos` de UN punto de
+ * venta, sin filtro de fecha (el stock no tiene dimensión temporal) y sin paginado (agregado
+ * acotado por construcción, design decisión 6). Misma política que `/tablero`
+ * (`Politicas.LecturaDeReportes`: Supervisor + Admin).
+ */
+export function Existencias() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | null>(null)
+  const [existencias, setExistencias] = useState<ExistenciasRespuesta | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        if (lista.length > 0) setIdPuntoVenta(lista[0].id)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    if (idPuntoVenta === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeReportes
+      .existencias(idPuntoVenta)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setExistencias(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setExistencias(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las existencias.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [idPuntoVenta])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Existencias" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        {puntosVenta === null ? (
+          <Cargando />
+        ) : puntosVenta.length === 0 ? (
+          <p className="text-muted text-center py-4">No hay puntos de venta visibles para las existencias.</p>
+        ) : idPuntoVenta === null ? (
+          <Cargando />
+        ) : (
+          <>
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="existencias-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="existencias-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  onChange={(e) => setIdPuntoVenta(Number(e.target.value))}
+                >
+                  {puntosVenta.map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-auto">
+                <BotonDeDescarga
+                  ruta={rutasDeExportacion.existencias(idPuntoVenta)}
+                  etiqueta="Descargar"
+                  onError={setErrorDescarga}
+                  onInicio={() => setErrorDescarga('')}
+                />
+              </div>
+            </div>
+
+            {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+            {cargando && !existencias && <Cargando />}
+
+            {existencias && (
+              <div className="table-responsive">
+                <table className="table table-sm table-striped table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Artículo</th>
+                      <th>Nombre</th>
+                      <th className="text-end">Cantidad</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {existencias.filas.map((fila) => (
+                      <tr key={fila.idArticulo}>
+                        <td>{fila.idArticulo}</td>
+                        <td>{fila.nombre}</td>
+                        <td className="text-end">{formatearCantidad(fila.cantidad)}</td>
+                      </tr>
+                    ))}
+                    {existencias.filas.length === 0 && (
+                      <tr>
+                        <td colSpan={3} className="text-center text-muted py-4">
+                          No hay stock cargado para este punto de venta.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 9: <c>GET /api/reportes/stock/existencias/export</c> —
+/// equality fila-por-fila con DOS filas de valores distintos y TODAS las columnas comparadas
+/// (mutation-proof-tests regla 6: un test de igualdad con una sola fila o con columnas salteadas
+/// deja pasar mutaciones de mapeo, hallazgo repetido cinco veces en esta misma etapa), más el rol
+/// un escalón debajo del gate y el nombre de archivo determinístico del spec (A Supervisor Exports
+/// Existencias).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area existencias export", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, supervisor, vendedor);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private async Task SembrarStockAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Ways.Domain.Stock.Stock
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(HttpClient cliente, int idPuntoVenta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/reportes/stock/existencias/export?idPuntoVenta={idPuntoVenta}&formato={formato}");
+
+    // ---- task 9.9: equality test — 2+ filas con valores distintos, TODAS las columnas ------------
+
+    /// <summary>Nombra el objetivo de mutación (mutation-proof-tests regla 6): el call site de
+    /// <c>ExportacionDeReportes.De(Existencias, ContextoDeExportacion)</c> dentro del endpoint
+    /// <c>/stock/existencias/export</c>. Dos artículos con nombre Y cantidad distintos, ambas filas
+    /// comparadas contra el workbook — un test de una sola fila (el patrón que
+    /// <c>ExportacionDeReportesTests</c> usa para los otros ocho mappers de la Slice 2) no habría
+    /// detectado un <c>.Reverse()</c> ni un swap de columnas. Mutación aplicada
+    /// (<c>.Reverse()</c> antes del <c>.Select</c> en el mapper de <c>Existencias</c>): este test
+    /// pasó de FALLAR (fila 7 esperada = artículo A, fila 7 real = artículo B) a pasar al revertir
+    /// — evidencia registrada en el resumen de apply.</summary>
+    [Fact]
+    public async Task ElExportEsIgualAlEndpointJsonParaLasDosFilas()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlEndpointJsonParaLasDosFilas));
+
+        var idArticuloA = await SembrarArticuloAsync(ctx, "Aceite de girasol 900ml");
+        await SembrarStockAsync(ctx, idArticuloA, 12m);
+        var idArticuloB = await SembrarArticuloAsync(ctx, "Fideos guiseros 500g");
+        await SembrarStockAsync(ctx, idArticuloB, 87.5m);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/existencias?idPuntoVenta={ctx.IdPuntoVenta}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var existencias = JsonSerializer.Deserialize<Existencias>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(2, existencias.Filas.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla, los datos empiezan en la fila 7 — EN ORDEN (OrderBy(IdArticulo)
+        // del lado del servicio), ambas filas con TODAS sus columnas comparadas.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < existencias.Filas.Count; i++)
+        {
+            var esperado = existencias.Filas[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(esperado.IdArticulo, fila.Cell(1).GetValue<int>());
+            Assert.Equal(esperado.Nombre, fila.Cell(2).GetString());
+            Assert.Equal(esperado.Cantidad, fila.Cell(3).GetValue<decimal>());
+        }
+
+        // Sin fila de totales (design: existencias no suma cantidades de artículos distintos) — la
+        // fila siguiente a la última fila de datos tiene que estar vacía.
+        Assert.True(hoja.Cell(primeraFilaDeDatos + existencias.Filas.Count, 1).Value.IsBlank);
+    }
+
+    // ---- spec: A Supervisor Exports Existencias — 200 con nombre de archivo determinístico -------
+
+    [Fact]
+    public async Task UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yerba mate 1kg");
+        await SembrarStockAsync(ctx, idArticulo, 5m);
+
+        var respuesta = await LlamarExportAsync(ctx.Supervisor, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
+        var nombreEsperado = NombreDeArchivo.Construir("existencias", $"pv{ctx.IdPuntoVenta}", hoy, hoy);
+        var disposicion = respuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
+        Assert.Contains($"filename*=UTF-8''{nombreEsperado}", disposicion);
+    }
+
+    // ---- task 9.10: rol un escalón debajo del gate, mitad export ---------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelExportDeExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelExportDeExistencias));
+
+        var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Exportacion;
 using Ways.Application.Organizacion;
@@ -38,9 +40,10 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
         HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor);
 
-    private async Task<Contexto> PrepararAsync(string nombre)
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
     {
-        var root = fixture.CreateClient();
+        var host = factory ?? fixture;
+        var root = host.CreateClient();
         var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
         Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
 
@@ -50,13 +53,13 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
         var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
 
-        var admin = fixture.CreateClient();
+        var admin = host.CreateClient();
         var loginAdmin = await admin.PostAsJsonAsync(
             "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
         Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
 
-        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
-        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+        var supervisor = await CrearYLoguearAsync(admin, host, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, host, nombre, "vendedor", RolConocido.Vendedor);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
         var ahora = DateTimeOffset.UtcNow;
@@ -70,14 +73,15 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
             resultado.IdTenant, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, supervisor, vendedor);
     }
 
-    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> host, string nombre, string sufijo, RolConocido rol)
     {
         var corto = Guid.NewGuid().ToString("N")[..8];
         var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
         var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
 
-        var cliente = fixture.CreateClient();
+        var cliente = host.CreateClient();
         var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         return cliente;
@@ -165,10 +169,26 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
 
     // ---- spec: A Supervisor Exports Existencias — 200 con nombre de archivo determinístico -------
 
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>Reloj fijado a las 22:30 ART del 5/8 (01:30 UTC del 6/8): si el nombre de archivo
+    /// usara el día UTC crudo en lugar del día de la zona resuelta del punto de venta, caería en
+    /// el 6/8 — un día que todavía no empezó para ese punto de venta. Discrimina en cualquier
+    /// horario real de ejecución, a diferencia de comparar contra <c>DateTime.UtcNow</c> (que
+    /// reproduce el mismo bug que intenta probar).</summary>
     [Fact]
     public async Task UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico()
     {
-        var ctx = await PrepararAsync(nameof(UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico));
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico), factoryConRelojFijo);
         var idArticulo = await SembrarArticuloAsync(ctx, "Yerba mate 1kg");
         await SembrarStockAsync(ctx, idArticulo, 5m);
 
@@ -176,9 +196,13 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
 
-        var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
-        var nombreEsperado = NombreDeArchivo.Construir("existencias", $"pv{ctx.IdPuntoVenta}", hoy, hoy);
+        var diaDelPuntoDeVenta = new DateOnly(2026, 8, 5);
+        var nombreEsperado = NombreDeArchivo.Construir("existencias", $"pv{ctx.IdPuntoVenta}", diaDelPuntoDeVenta, diaDelPuntoDeVenta);
+        var diaUtcIncorrecto = new DateOnly(2026, 8, 6);
+        var nombreConDiaUtc = NombreDeArchivo.Construir("existencias", $"pv{ctx.IdPuntoVenta}", diaUtcIncorrecto, diaUtcIncorrecto);
+
         var disposicion = respuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.DoesNotContain(nombreConDiaUtc, disposicion);
         Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
         Assert.Contains($"filename*=UTF-8''{nombreEsperado}", disposicion);
     }
@@ -193,5 +217,33 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta);
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- cap guard test — mismo patrón que TesoreriaExportTests: tope acotado vía
+    // WithWebHostBuilder, cantidad real de filas en el mensaje de rechazo ---------------------------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(ctx, $"articulo-tope-{i}");
+            await SembrarStockAsync(ctx, idArticulo, 1m);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
     }
 }

--- a/tests/Ways.IntegrationTests/ExistenciasTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-11-exportacion-reportes, Slice 9: <c>GET /api/reportes/stock/existencias</c> — la casa de
+/// las 4 pruebas (cruce de tenant, discriminación por punto de venta, artículo eliminado excluido
+/// del join en vivo, fixture hand-computed) más la garantía propia del spec (sin
+/// <c>idArticulo</c>) y el rol un escalón debajo del gate. Siembra directa vía
+/// <c>IWaysDbContext.Stock</c>/<c>Articulos</c> (nunca a través de <c>ServicioDeStock</c>, que
+/// exige un movimiento): esta clase prueba la LECTURA del reporte, no la escritura del caché de
+/// stock — ya cubierta por las pruebas de stage-5/8.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area existencias", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, area.Id, idAlicuotaIva,
+            admin, supervisor, vendedor);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarPuntoVentaAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta = new PuntoVenta { IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return puntoVenta.Id;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre, bool eliminado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora, DeletedAt = eliminado ? ahora : null
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private async Task SembrarStockAsync(Contexto ctx, int idPuntoVenta, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Ways.Domain.Stock.Stock
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = idPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static Task<HttpResponseMessage> LlamarExistenciasAsync(HttpClient cliente, int idPuntoVenta) =>
+        cliente.GetAsync($"/api/reportes/stock/existencias?idPuntoVenta={idPuntoVenta}");
+
+    private static async Task<Existencias> ObtenerExistenciasAsync(HttpClient cliente, int idPuntoVenta)
+    {
+        var respuesta = await LlamarExistenciasAsync(cliente, idPuntoVenta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<Existencias>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 9.8: house 4-test pattern ---------------------------------------------------------
+
+    /// <summary>Nota de honestidad (mutation-proof-tests, mismo criterio que
+    /// <c>ReportesArticulosTopTests.UnaFilaDeOtroTenantNuncaApareceEnElTop</c>): los ids de punto
+    /// de venta son globalmente únicos (secuencia compartida entre tenants), así que este test
+    /// prueba el aislamiento en la práctica, NO específicamente el filtro Tenant de EF — ese queda
+    /// cubierto de forma no confundida por <see cref="UnaFilaDeOtroPuntoDeVentaNuncaApareceEnLasExistencias"/>,
+    /// que sí discrimina por la cláusula bajo prueba dentro de un mismo tenant.</summary>
+    [Fact]
+    public async Task UnaFilaDeOtroTenantNuncaApareceEnLasExistencias()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaFilaDeOtroTenantNuncaApareceEnLasExistencias) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnaFilaDeOtroTenantNuncaApareceEnLasExistencias) + "-B");
+
+        var idArticuloB = await SembrarArticuloAsync(ctxB, "articulo-otro-tenant");
+        await SembrarStockAsync(ctxB, ctxB.IdPuntoVenta, idArticuloB, 999m);
+
+        var existencias = await ObtenerExistenciasAsync(ctxA.Admin, ctxA.IdPuntoVenta);
+
+        Assert.Empty(existencias.Filas);
+    }
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests):
+    /// <c>Where(s => s.IdPuntoVenta == idPuntoVenta)</c> en
+    /// <c>ServicioDeReportesDeStock.ObtenerExistenciasAsync</c>. Mismo tenant con dos puntos de
+    /// venta — las existencias de uno NUNCA pueden traer filas del otro. Mutación aplicada
+    /// (reemplazar el <c>Where</c> por un no-op que deja pasar todas las filas del tenant): esta
+    /// prueba pasó de FALLAR (la fila del PV secundario aparece en el reporte del PV principal) a
+    /// pasar al revertir — evidencia registrada en el resumen de apply.</summary>
+    [Fact]
+    public async Task UnaFilaDeOtroPuntoDeVentaNuncaApareceEnLasExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFilaDeOtroPuntoDeVentaNuncaApareceEnLasExistencias));
+        var otroPuntoVenta = await SembrarPuntoVentaAsync(ctx, "PV secundario");
+
+        var idArticuloPrincipal = await SembrarArticuloAsync(ctx, "articulo-principal");
+        var idArticuloSecundario = await SembrarArticuloAsync(ctx, "articulo-secundario");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticuloPrincipal, 10m);
+        await SembrarStockAsync(ctx, otroPuntoVenta, idArticuloSecundario, 999m);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(existencias.Filas);
+        Assert.Equal(idArticuloPrincipal, fila.IdArticulo);
+    }
+
+    [Fact]
+    public async Task UnArticuloEliminadoNuncaApareceEnLasExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloEliminadoNuncaApareceEnLasExistencias));
+
+        var idArticuloEliminado = await SembrarArticuloAsync(ctx, "articulo-eliminado", eliminado: true);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticuloEliminado, 5m);
+        var idArticuloVigente = await SembrarArticuloAsync(ctx, "articulo-vigente");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticuloVigente, 7m);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(existencias.Filas);
+        Assert.Equal(idArticuloVigente, fila.IdArticulo);
+    }
+
+    [Fact]
+    public async Task LosCamposDeLaFilaCoincidenConElStockSembrado()
+    {
+        var ctx = await PrepararAsync(nameof(LosCamposDeLaFilaCoincidenConElStockSembrado));
+
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yerba mate 1kg");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticulo, 42.5m);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(existencias.Filas);
+        Assert.Equal(idArticulo, fila.IdArticulo);
+        Assert.Equal("Yerba mate 1kg", fila.Nombre);
+        Assert.Equal(42.5m, fila.Cantidad);
+    }
+
+    // ---- task 9.11: no-idArticulo-required (spec: Existencias Needs No idArticulo) --------------
+
+    [Fact]
+    public async Task LasExistenciasDe40ArticulosVuelvenSinPedirIdArticulo()
+    {
+        var ctx = await PrepararAsync(nameof(LasExistenciasDe40ArticulosVuelvenSinPedirIdArticulo));
+
+        for (var i = 0; i < 40; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(ctx, $"articulo-{i}");
+            await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticulo, i + 1m);
+        }
+
+        var respuesta = await LlamarExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        Assert.DoesNotContain("idArticulo", respuesta.RequestMessage!.RequestUri!.Query);
+
+        var existencias = JsonSerializer.Deserialize<Existencias>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(40, existencias.Filas.Count);
+    }
+
+    // ---- task 9.10: rol un escalón debajo del gate ------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDeLasExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDeLasExistencias));
+
+        var respuesta = await LlamarExistenciasAsync(ctx.Vendedor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorLeeLasExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorLeeLasExistencias));
+
+        var respuesta = await LlamarExistenciasAsync(ctx.Supervisor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+}


### PR DESCRIPTION
## Etapa 11, slice 9 — Existencias (el cierre de la etapa)

`GET /api/reportes/stock/existencias` (+ `/export`) bajo LecturaDeReportes: el reporte de stock que el legacy nunca pudo imprimir en produccion, ahora real — join vivo stock ⋈ articulos (Nombre actual, no snapshot: el stock es estado presente), pantalla web con nav gateada, droppable por diseño (diff puramente aditivo).

### Review
Judgment-day de 2 rondas: Juez A REJECT ronda 1 con un MAJOR DE PRODUCCION cazado de lleno — la zona resuelta se descartaba y el "hoy" del filename/header se computaba en UTC crudo: entre las 21 y medianoche ART cada export salia fechado MAÑANA, y el test replicaba la misma matematica errada en ambos lados. Juez B APPROVE-WITH-MINORS con 2 WARNINGs (test stale con el anti-patron de la regla 7 funcionando de casualidad; call-site de la guarda sin cobertura — borrado sobrevivia 10/10). Fix batch `08e7707`+`86f22cf`: ConvertTime con la zona en scope (patron CajaEndpoints) + test con RELOJ PINEADO a 01:30Z asertando el dia ART con doble asercion (positiva y negativa) + patron rule-7 + test de tope con evidencia de call-site → ronda 2: doble APPROVE re-ejecutando todo.

### Tests
Integration 896 en rama (885 + 11) · vitest 544 (536 + 8) · cero migraciones · full suites en main al cierre

🤖 Generated with [Claude Code](https://claude.com/claude-code)