### PR TITLE
feat(stock): esquema de lotes y vencimientos — etapa 12, slice 1 [size:exception]

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -517,10 +517,35 @@ movimientos_stock (           -- [operativa]
     cantidad numeric(12,3),                  -- con signo: venta −, compra +, anulación inversa
     motivo   motivo_stock,                   -- enum: venta | compra | anulacion | ajuste
                                              --     | transferencia | inventario
+                                             --     | decomiso | reclasificacion (Etapa 12)
     id_comprobante_venta NULL, id_comprobante_compra NULL,
     id_punto_venta_destino NULL,             -- transferencias entre locales (nuevo)
+    id_lote NULL,                            -- dimensión de lote (Etapa 12)
     id_empleado, observaciones, creado_el
 );
+
+lotes (                        -- [catálogo — tenant-wide, sin id_empresa, como articulos] (Etapa 12)
+    id_lote, id_tenant, id_articulo,
+    codigo text NOT NULL,                    -- server-derivado del vencimiento ISO si se omite
+    fecha_vencimiento date NULL,             -- NULL si y solo si es_sin_identificar
+    es_sin_identificar boolean NOT NULL DEFAULT false,
+    created_at, updated_at, deleted_at
+);
+-- Clave natural: UNIQUE (id_tenant, id_articulo, codigo) WHERE deleted_at IS NULL
+--   (ux_lotes_articulo_codigo) — target del get-or-create.
+-- A lo sumo un lote sin identificar por artículo: UNIQUE (id_tenant, id_articulo)
+--   WHERE es_sin_identificar AND deleted_at IS NULL (ux_lotes_sin_identificar).
+-- fecha_vencimiento es inmutable una vez creado el lote — una segunda recepción con
+-- fecha distinta se rechaza (409 lote_vencimiento_incompatible) en vez de sobrescribir.
+
+stock_lotes (                  -- [operativa] (Etapa 12)
+    id_articulo, id_punto_venta, id_lote, id_tenant,
+    cantidad numeric(12,3) NOT NULL DEFAULT 0,          -- cache del libro, por lote
+    PRIMARY KEY (id_articulo, id_punto_venta, id_lote)
+);
+-- PK-only, sin auditoría — mismo criterio que `stock`. Sin CHECK sobre cantidad: un saldo
+-- de lote negativo está permitido en el mostrador (legacy parity), refusado solo en
+-- caminos de back-office (transferencia, decomiso).
 ```
 
 > **Estado (Etapa 5, Slice 3):** `stock` y `movimientos_stock` implementadas — `motivo` solo
@@ -553,6 +578,18 @@ movimientos_stock (           -- [operativa]
 > diferencia no escribe ninguna fila (evita `ck_movimientos_stock_cantidad_no_cero` en vez de
 > chocar contra ella). Ningún enum, columna ni invariante del esquema de arriba cambió de
 > forma — el trabajo de esta etapa fue enteramente de escritores nuevos, nunca de esquema.
+>
+> **Estado (Etapa 12, Slice 1 — esquema, sin escritor):** `lotes`/`stock_lotes` nuevas, con RLS
+> propia; seis columnas aditivas (`movimientos_stock.id_lote`, `articulos.controla_lote`,
+> `items_comprobante_venta.id_lote`, `items_comprobante_compra.codigo_lote`/
+> `fecha_vencimiento`/`id_lote`) y dos valores nuevos de `motivo_stock` (`decomiso`,
+> `reclasificacion`) — ambos agregados vía `ALTER TYPE ... ADD VALUE`, sin escritor todavía
+> (ningún `Sql()` de la migración que los agrega puede nombrarlos, PG lo prohíbe dentro de la
+> misma transacción). `stock.cantidad = SUM(movimientos)` sigue intacto; se agrega el segundo
+> invariante `stock_lotes.cantidad = SUM(movimientos con ese id_lote)`. Ningún dato existente se
+> reescribe: `controla_lote` default `false`, todo lo demás nullable. Los escritores reales
+> (get-or-create, reconciliación, recepción, venta, transferencia, ajuste, conteo, decomiso)
+> aterrizan en las slices 2-12.
 
 `stock.cantidad` es un cache mantenido en la misma transacción del movimiento.
 Transferencia entre locales: dos movimientos espejados — feature nueva que el legacy

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -91,23 +91,23 @@ maps the new `23505` target. **No writer touches these columns yet.**
 **Rollback**: revert the branch — every element is additive/nullable, zero
 rows rewritten.
 
-- [ ] 1.1 Create `src/Ways.Domain/Stock/Lote.cs`: `EntidadTenant`,
+- [x] 1.1 Create `src/Ways.Domain/Stock/Lote.cs`: `EntidadTenant`,
   `IdArticulo`, `Codigo`, `FechaVencimiento`, `EsSinIdentificar`. *(proposal
   gate §A)*
-- [ ] 1.2 Create `src/Ways.Domain/Stock/StockLote.cs`: PK-only,
+- [x] 1.2 Create `src/Ways.Domain/Stock/StockLote.cs`: PK-only,
   `IdArticulo`/`IdPuntoVenta`/`IdLote`/`IdTenant`/`Cantidad`, no audit
   columns — the `Stock` precedent. *(proposal gate §B)*
-- [ ] 1.3 Modify `src/Ways.Domain/Stock/MotivoStock.cs`: add `Decomiso`,
+- [x] 1.3 Modify `src/Ways.Domain/Stock/MotivoStock.cs`: add `Decomiso`,
   `Reclasificacion`.
-- [ ] 1.4 Modify `src/Ways.Domain/Stock/MovimientoStock.cs`: add
+- [x] 1.4 Modify `src/Ways.Domain/Stock/MovimientoStock.cs`: add
   `int? IdLote`.
-- [ ] 1.5 Modify `src/Ways.Domain/Articulos/Articulo.cs`: add
+- [x] 1.5 Modify `src/Ways.Domain/Articulos/Articulo.cs`: add
   `bool ControlaLote` (default `false`).
-- [ ] 1.6 Modify `src/Ways.Domain/Ventas/ItemComprobanteVenta.cs`: add
+- [x] 1.6 Modify `src/Ways.Domain/Ventas/ItemComprobanteVenta.cs`: add
   `int? IdLote` (snapshot field, no re-derivation).
-- [ ] 1.7 Modify `src/Ways.Domain/Compras/ItemComprobanteCompra.cs`: add
+- [x] 1.7 Modify `src/Ways.Domain/Compras/ItemComprobanteCompra.cs`: add
   `string? CodigoLote`, `DateOnly? FechaVencimiento`, `int? IdLote`.
-- [ ] 1.8 Create `.../Configuraciones/LoteConfiguration.cs`: `pk_lotes`;
+- [x] 1.8 Create `.../Configuraciones/LoteConfiguration.cs`: `pk_lotes`;
   alternate key `ux_lotes_id_articulo_tenant`; `fk_lotes_tenant`,
   `fk_lotes_articulo`; `ck_lotes_vencimiento_segun_tipo`,
   `ck_lotes_codigo_no_vacio`; unique partial indexes
@@ -115,40 +115,40 @@ rows rewritten.
   `ux_lotes_sin_identificar` (`WHERE es_sin_identificar AND deleted_at IS NULL`);
   `ix_lotes_tenant`, `ix_lotes_articulo`, `ix_lotes_vencimiento`. All names
   explicit — EF's PascalCase default is always overridden.
-- [ ] 1.9 Create `.../Configuraciones/StockLoteConfiguration.cs`:
+- [x] 1.9 Create `.../Configuraciones/StockLoteConfiguration.cs`:
   `pk_stock_lotes (id_articulo, id_punto_venta, id_lote)`;
   `fk_stock_lotes_tenant`, `fk_stock_lotes_lote` (composite against
   `ux_lotes_id_articulo_tenant`), `fk_stock_lotes_punto_venta`;
   `ix_stock_lotes_tenant`, `ix_stock_lotes_punto_venta`,
   `ix_stock_lotes_lote`. **No CHECK on `cantidad`** (deliberate — negative
   balance is legal at the counter, `stock` parity).
-- [ ] 1.10 Modify `ArticuloConfiguration.cs`: `controla_lote boolean NOT
+- [x] 1.10 Modify `ArticuloConfiguration.cs`: `controla_lote boolean NOT
   NULL DEFAULT false`; `ix_articulos_controla_lote (id_tenant) WHERE
   controla_lote AND deleted_at IS NULL`.
-- [ ] 1.11 Modify `MovimientoStockConfiguration.cs`: `id_lote integer NULL`;
+- [x] 1.11 Modify `MovimientoStockConfiguration.cs`: `id_lote integer NULL`;
   `fk_movimientos_stock_lote (id_lote, id_articulo, id_tenant)` against
   `lotes`'s alternate key; `ix_movimientos_stock_lote`.
-- [ ] 1.12 Modify `ItemComprobanteVentaConfiguration.cs`: `id_lote integer
+- [x] 1.12 Modify `ItemComprobanteVentaConfiguration.cs`: `id_lote integer
   NULL`; `fk_items_comprobante_venta_lote` (3-column composite, gate
   amendment 2, `MATCH SIMPLE`); `ix_items_comprobante_venta_lote`.
-- [ ] 1.13 Modify `ItemComprobanteCompraConfiguration.cs`: `codigo_lote text
+- [x] 1.13 Modify `ItemComprobanteCompraConfiguration.cs`: `codigo_lote text
   NULL`, `fecha_vencimiento date NULL`, `id_lote integer NULL`;
   `fk_items_comprobante_compra_lote` (gate amendment 2);
   `ix_items_comprobante_compra_lote`;
   `ck_items_comprobante_compra_lote_input`.
-- [ ] 1.14 Modify `WaysDbContext.cs`: `DbSet<Lote>`, `DbSet<StockLote>`,
+- [x] 1.14 Modify `WaysDbContext.cs`: `DbSet<Lote>`, `DbSet<StockLote>`,
   `AplicarFiltroDeTenantEnStockLote` mirroring
   `AplicarFiltroDeTenantEnStock` (decision 20 — `stock_lotes` has no audit
   columns, so it needs the hand-rolled filter, not `EntidadTenant`'s global
   one), register both configurations.
-- [ ] 1.15 Create `.../Migraciones/…_LotesYVencimientosEtapa12.cs`:
+- [x] 1.15 Create `.../Migraciones/…_LotesYVencimientosEtapa12.cs`:
   statement order per design — `AlterDatabase` (enum diff) first,
   `CreateTable lotes`, `CreateTable stock_lotes`, `AddColumn ×6` with FKs +
   indexes, `HabilitarRlsDeTenant("lotes")` +
   `HabilitarRlsDeTenant("stock_lotes")`. **No `Sql()` statement in this
   migration may name `'decomiso'`/`'reclasificacion'`** (PG forbids using an
   `ADD VALUE` enum member in the same transaction that added it).
-- [ ] 1.16 Modify `src/Ways.Api/Seguridad/ManejadorDeErrores.cs`: `23505` on
+- [x] 1.16 Modify `src/Ways.Api/Seguridad/ManejadorDeErrores.cs`: `23505` on
   `ux_lotes_articulo_codigo` → `409 lote_duplicado`; document the
   `ux_lotes_sin_identificar` backstop exemption (no live route races it —
   proven by raw SQL only, `pk_stock` precedent). `23503` needs no change

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -186,9 +186,16 @@ rows rewritten.
 - [x] 1.24 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes after this migration (confirms the EF model matches
   exactly the gate-approved schema, nothing more).
-- [ ] 1.25 Run `judgment-day` on the slice diff; fix confirmed issues;
-  re-judge until clean.
-- [ ] 1.26 Branch `feat/stage12-slice1-esquema` off `main`; PR **flagged
+- [x] 1.25 Run `judgment-day` on the slice diff; fix confirmed issues;
+  re-judge until clean. *(APPLY-RUN NOTE: round 1 double REJECT — judge A:
+  BLOCKER, duplicate `HasIndex(IdTenant)` metadata slot silently dropped
+  `ix_articulos_tenant` from the model; judge B: BLOCKER, `Down()` threw
+  `NotSupportedException` on enum-label removal, proven live on postgres:17,
+  plus MAJOR, the two EF-filter tests were vacuous under the RLS confound —
+  proven by mutation. Fix batch bf45913/d0be19c/b7aa957 with per-fix mutation
+  evidence; round 2 double APPROVE, including a fresh snapshot-drift mutation
+  probe on the partial index filter.)*
+- [x] 1.26 Branch `feat/stage12-slice1-esquema` off `main`; PR **flagged
   `size:exception`** per design decision 21; merge stacked-to-main.
 
 **Test plan**: migration apply, RLS ×2, `23505` backstop ×2, `23503`

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -156,34 +156,34 @@ rows rewritten.
 - [x] 1.17 Update `docs/10-modelo-de-datos.md` §6: add `lotes` and
   `stock_lotes` table entries and the two new `motivo_stock` values, tagged
   `Estado (Etapa 12)` per the doc's existing annotation convention.
-- [ ] 1.18 [P] Migration-apply test: fresh testcontainer DB applies
+- [x] 1.18 [P] Migration-apply test: fresh testcontainer DB applies
   cleanly; both tables, all six columns, both enum values exist post-`Up()`.
-- [ ] 1.19 [P] RLS tests ×2 over the **`ways_app`** connection (NOSUPERUSER
+- [x] 1.19 [P] RLS tests ×2 over the **`ways_app`** connection (NOSUPERUSER
   NOBYPASSRLS, `mutation-proof-tests` rule 5): `lotes` and `stock_lotes`
   cross-tenant `SELECT`/`INSERT`/`UPDATE` at statement level, asserting row
   counts for silent 0-row cases and `42501` where an error is raised.
-- [ ] 1.20 [P] **`db-error-backstops`**: two concurrent inserts racing
+- [x] 1.20 [P] **`db-error-backstops`**: two concurrent inserts racing
   `ux_lotes_articulo_codigo` → SQLSTATE `23505` asserted, backstop
   translates to the existing row, exactly one `lotes` row survives. *(spec
   lotes-y-vencimientos: The Same Articulo And Codigo Cannot Be Created
   Twice)*
-- [ ] 1.21 [P] **`db-error-backstops`**, documented exemption: raw-SQL proof
+- [x] 1.21 [P] **`db-error-backstops`**, documented exemption: raw-SQL proof
   that `ux_lotes_sin_identificar` fires `23505` on a second
   `es_sin_identificar = true` row for the same articulo — no application
   route races this index directly (get-or-create serializes on
   `ux_lotes_articulo_codigo` first, per design decision 5), so the proof is
   a direct constraint test, not an end-to-end race.
-- [ ] 1.22 [P] `23503` regression ×4 FKs (`fk_movimientos_stock_lote`,
+- [x] 1.22 [P] `23503` regression ×4 FKs (`fk_movimientos_stock_lote`,
   `fk_items_comprobante_venta_lote`, `fk_items_comprobante_compra_lote`,
   `fk_stock_lotes_lote`): a lot referenced with a mismatched articulo is
   rejected. *(spec stock: A Movement Referencing A Foreign Articulo's Lot
   Is Unrepresentable)*
-- [ ] 1.23 [P] CHECK constraint tests: `ck_lotes_vencimiento_segun_tipo`,
+- [x] 1.23 [P] CHECK constraint tests: `ck_lotes_vencimiento_segun_tipo`,
   `ck_lotes_codigo_no_vacio`, `ck_items_comprobante_compra_lote_input`.
   *(spec lotes-y-vencimientos: A Blank Codigo Is Unrepresentable, A Dated
   Lot Without An Expiry Is Unrepresentable; spec comprobantes-compra: A Lot
   Code Without An Expiry Is Unrepresentable)*
-- [ ] 1.24 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+- [x] 1.24 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes after this migration (confirms the EF model matches
   exactly the gate-approved schema, nothing more).
 - [ ] 1.25 Run `judgment-day` on the slice diff; fix confirmed issues;

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -153,7 +153,7 @@ rows rewritten.
   `ux_lotes_sin_identificar` backstop exemption (no live route races it —
   proven by raw SQL only, `pk_stock` precedent). `23503` needs no change
   (the existing `fk_` prefix arm covers the four new FKs).
-- [ ] 1.17 Update `docs/10-modelo-de-datos.md` §6: add `lotes` and
+- [x] 1.17 Update `docs/10-modelo-de-datos.md` §6: add `lotes` and
   `stock_lotes` table entries and the two new `motivo_stock` values, tagged
   `Estado (Etapa 12)` per the doc's existing annotation convention.
 - [ ] 1.18 [P] Migration-apply test: fresh testcontainer DB applies

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -65,6 +65,34 @@ public class ManejadorDeErrores(
                 when string.Equals(uxOrdenCompra, "ux_items_comprobante_compra_orden", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "Ya existe un ítem con ese orden en esta compra.", "orden_de_item_duplicado"),
 
+            // stage-12-lotes-vencimientos (Slice 1, task 1.16, db-error-backstops, design
+            // decisión 5): ux_lotes_articulo_codigo tiene que resolverse por nombre EXACTO,
+            // ANTES de llegar a ClasificarUnicidad (el caso genérico de más abajo) — su nombre
+            // contiene la substring "_codigo" (la rama genérica "_codigo" de ClasificarUnicidad
+            // lo atraparía primero y lo clasificaría como "codigo_duplicado", el mensaje
+            // genérico), mismo "ordering trap" que ux_comprobantes_venta_numero/
+            // ux_comprobantes_compra_numero_externo de arriba. La carrera es real: get-or-create
+            // (slice 3, ServicioDeLotes.ResolverOCrearAsync) usa un INSERT ... ON CONFLICT DO
+            // UPDATE que resuelve la carrera normal sin tocar nunca esta rama; esta rama es el
+            // backstop de una escritura cruda/fuera de banda o de un `POST /api/stock/lotes`
+            // (slice 3) concurrente con el mismo código.
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string uxLote } }
+                when string.Equals(uxLote, "ux_lotes_articulo_codigo", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un lote con ese código para este artículo.", "lote_duplicado"),
+
+            // stage-12-lotes-vencimientos (Slice 1, task 1.16, design decisión 5): exención
+            // documentada de prueba de carrera, mismo patrón que pk_stock/
+            // pk_numeraciones_comprobante — ningún camino de escritura de esta slice ni de las
+            // siguientes hace un INSERT crudo contra este índice: el lote sin identificar se
+            // crea siempre a través de ux_lotes_articulo_codigo primero (design decisión 5, el
+            // código reservado SIN-IDENTIFICAR serializa la creación en ESE índice), así que
+            // ux_lotes_sin_identificar nunca puede chocar por el camino de servicio. Defensa de
+            // esquema pura, alcanzable solo por un INSERT crudo/fuera de banda, probada con SQL
+            // directo (task 1.21).
+            DbUpdateException { InnerException: PostgresException { SqlState: "23505", ConstraintName: string uxSinIdentificar } }
+                when string.Equals(uxSinIdentificar, "ux_lotes_sin_identificar", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un lote sin identificar para este artículo.", "lote_sin_identificar_duplicado"),
+
             // Backstop genérico (judgment-day, slice 3 ronda 1) para las ~10 unicidades nuevas
             // de catálogos/parámetros/catálogos fiscales: mismo mecanismo de carrera que los
             // dos casos de arriba, pero agrupado por familia (a partir del nombre del índice,

--- a/src/Ways.Domain/Articulos/Articulo.cs
+++ b/src/Ways.Domain/Articulos/Articulo.cs
@@ -56,4 +56,14 @@ public class Articulo : EntidadTenant
     public bool DisponibleParaTodas { get; set; } = true;
 
     public bool Activo { get; set; } = true;
+
+    /// <summary>Etapa 12 (proposal decisión 1, gate §E): <c>true</c> ⇒ todo movimiento de stock
+    /// de este artículo (venta, compra, transferencia, ajuste, conteo, decomiso, anulación)
+    /// tiene que llevar un lote — el control efectivo también exige el parámetro de empresa
+    /// <c>lotes_habilitado</c> (<c>ReglaDeLotes.ControlEfectivo</c>, slice 2). Tenant-wide,
+    /// mismo criterio que <see cref="EsProducto"/>: un booleano en <c>articulos</c> que decide
+    /// si un camino de código entero aplica, ya cargado por todo llamador que lo necesita.
+    /// Default <c>false</c> — byte-idéntico al comportamiento de hoy para cualquier fila
+    /// existente.</summary>
+    public bool ControlaLote { get; set; }
 }

--- a/src/Ways.Domain/Compras/ItemComprobanteCompra.cs
+++ b/src/Ways.Domain/Compras/ItemComprobanteCompra.cs
@@ -63,4 +63,23 @@ public class ItemComprobanteCompra : EntidadTenant
     /// nunca aplicada por la confirmación (design decisión 3). <c>NULL</c> solo si el artículo
     /// no tiene margen configurado.</summary>
     public decimal? PrecioSugerido { get; set; }
+
+    /// <summary>Etapa 12 (proposal gate §G): input de lote a nivel de borrador — capturado tal
+    /// cual mientras la compra es <see cref="EstadoCompra.Borrador"/>, sin resolver contra
+    /// <c>lotes</c> todavía (las líneas de borrador se reemplazan físicamente en cada edición,
+    /// resolver temprano ensuciaría <c>lotes</c> con filas de borradores que nunca confirman).
+    /// <c>NULL</c> si la línea no lleva código de lote (artículo no lot-effective, o el operador
+    /// todavía no lo cargó).</summary>
+    public string? CodigoLote { get; set; }
+
+    /// <summary>Input de vencimiento a nivel de borrador, acompaña a <see cref="CodigoLote"/> —
+    /// <c>ck_items_comprobante_compra_lote_input</c> exige que si hay código también haya fecha
+    /// (un código sin vencimiento nunca puede resolver a una fila válida de <c>lotes</c>).</summary>
+    public DateOnly? FechaVencimiento { get; set; }
+
+    /// <summary>Resuelto (get-or-create) recién al confirmar, contra
+    /// <c>ux_lotes_articulo_codigo</c> (slice 5, <c>ServicioDeCompras.EjecutarConfirmarAsync</c>).
+    /// <c>NULL</c> mientras la compra es borrador y para artículos que no son lot-effective.
+    /// Snapshot desde ese momento — es lo que hace exacta la anulación.</summary>
+    public int? IdLote { get; set; }
 }

--- a/src/Ways.Domain/Stock/Lote.cs
+++ b/src/Ways.Domain/Stock/Lote.cs
@@ -1,0 +1,36 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Stock;
+
+/// <summary>
+/// Identidad de lote (doc 10 §6, proposal gate §A, gate amendment 1): catálogo tenant-wide
+/// (<c>id_tenant</c>, SIN <c>id_empresa</c>) — sigue al artículo (<see cref="Articulos.Articulo"/>)
+/// igual que <see cref="Precios.Precio"/>, no la categoría "catálogo" que carga
+/// <c>id_empresa NULL</c>. Con auditoría completa (<see cref="EntidadTenant"/>): tiene identidad
+/// y ciclo de vida propios, a diferencia de las cachés PK-only (<see cref="StockLote"/>).
+///
+/// <see cref="FechaVencimiento"/> es inmutable una vez creado el lote (proposal decisión 3 del
+/// gate; <c>ServicioDeLotes.ResolverOCrearAsync</c>, slice 3): una segunda recepción del mismo
+/// <c>(articulo, codigo)</c> con otra fecha se rechaza <c>409 lote_vencimiento_incompatible</c>
+/// en vez de sobrescribir la fila.
+///
+/// <see cref="Codigo"/> se deriva server-side del vencimiento ISO cuando el llamador lo omite
+/// (<c>ReglaDeLotes.DerivarCodigo</c>, slice 2). El lote "sin identificar"
+/// (<see cref="EsSinIdentificar"/> = true) usa el código reservado
+/// <c>ReglaDeLotes.CodigoSinIdentificar</c> — a lo sumo uno por artículo
+/// (<c>ux_lotes_sin_identificar</c>).
+/// </summary>
+public class Lote : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdArticulo { get; set; }
+
+    public required string Codigo { get; set; }
+
+    /// <summary><c>NULL</c> si y solo si <see cref="EsSinIdentificar"/> es <c>true</c>
+    /// (<c>ck_lotes_vencimiento_segun_tipo</c>).</summary>
+    public DateOnly? FechaVencimiento { get; set; }
+
+    public bool EsSinIdentificar { get; set; }
+}

--- a/src/Ways.Domain/Stock/MotivoStock.cs
+++ b/src/Ways.Domain/Stock/MotivoStock.cs
@@ -5,7 +5,15 @@ namespace Ways.Domain.Stock;
 /// (<c>motivo_stock</c>). <see cref="Compra"/> abre camino de escritura en stage-8 Slice 2
 /// (<c>ServicioDeCompras.ConfirmarAsync</c>/<c>AnularAsync</c>); <see cref="Transferencia"/> e
 /// <see cref="Inventario"/> lo abren en Slice 3 (<c>ServicioDeStock.TransferirAsync</c>/
-/// <c>ContarAsync</c>) — ningún escritor nuevo se agrega en esta slice (schema + seed gate).
+/// <c>ContarAsync</c>).
+///
+/// <see cref="Decomiso"/> y <see cref="Reclasificacion"/> (etapa 12, proposal decisiones 3/9,
+/// gate §D): dos valores agregados por esta migración vía <c>ALTER TYPE ... ADD VALUE</c> —
+/// ningún escritor de esta slice los usa todavía (schema + seed gate); ningún <c>Sql()</c> de
+/// esta misma migración puede nombrarlos (Postgres prohíbe usar un valor de enum agregado
+/// dentro de la misma transacción que lo agregó). <see cref="Decomiso"/> abre camino de
+/// escritura recién en slice 11 (<c>ServicioDeStock.EjecutarDecomisoAsync</c>);
+/// <see cref="Reclasificacion"/> en slice 4 (<c>ServicioDeLotes.ReconciliarAsync</c>).
 /// </summary>
 public enum MotivoStock
 {
@@ -14,5 +22,7 @@ public enum MotivoStock
     Anulacion,
     Ajuste,
     Transferencia,
-    Inventario
+    Inventario,
+    Decomiso,
+    Reclasificacion
 }

--- a/src/Ways.Domain/Stock/MovimientoStock.cs
+++ b/src/Ways.Domain/Stock/MovimientoStock.cs
@@ -47,6 +47,16 @@ public class MovimientoStock
     /// espejadas de una transferencia llevan acá el destino (design decisión 5 del proposal).</summary>
     public int? IdPuntoVentaDestino { get; set; }
 
+    /// <summary>Etapa 12 (proposal decisión 5, gate §C): dimensión de lote del movimiento, con
+    /// FK compuesta <c>fk_movimientos_stock_lote</c> sobre <c>(id_lote, id_articulo, id_tenant)</c>
+    /// contra la clave alterna de <see cref="Lote"/> — Postgres garantiza a nivel de esquema que
+    /// el lote de un movimiento pertenece a su mismo artículo. <c>NOT NULL</c> exigido para
+    /// movimientos de un artículo lot-effective y siempre <c>NULL</c> para uno que no lo es —
+    /// invariante cruzado entre tablas (no una CHECK), probado con un test de integración
+    /// dedicado (design decisión 5). Columna creada en esta slice, escrita recién a partir de las
+    /// slices 4-12 (ningún escritor nuevo en esta slice: schema + seed gate).</summary>
+    public int? IdLote { get; set; }
+
     public int IdEmpleado { get; set; }
 
     public string? Observaciones { get; set; }

--- a/src/Ways.Domain/Stock/StockLote.cs
+++ b/src/Ways.Domain/Stock/StockLote.cs
@@ -1,0 +1,31 @@
+namespace Ways.Domain.Stock;
+
+/// <summary>
+/// Caché de saldo de lote por <c>(articulo, punto_venta, lote)</c> (doc 10 §6, proposal gate §B).
+/// PK-only, sin auditoría ni baja lógica — el mismo criterio que <see cref="Stock"/>: la PK
+/// natural (<see cref="IdArticulo"/>, <see cref="IdPuntoVenta"/>, <see cref="IdLote"/>) ya
+/// identifica la fila, <see cref="IdTenant"/> es columna no-key solo para RLS (filtro manual en
+/// <c>WaysDbContext.AplicarFiltroDeTenantEnStockLote</c>, design decisión 20 — esta clase no
+/// hereda de <see cref="Common.EntidadTenant"/>).
+///
+/// <see cref="Cantidad"/> es un CACHÉ MANTENIDO del ledger de <see cref="MovimientoStock"/>
+/// (proposal decisión 5): se escribe con <c>INSERT ... ON CONFLICT (id_articulo, id_punto_venta,
+/// id_lote) DO UPDATE SET cantidad = stock_lotes.cantidad + $delta RETURNING cantidad</c> — la
+/// misma forma atómica que <see cref="Stock.Cantidad"/> usa, nunca un read-modify-write vía
+/// <c>SaveChangesAsync</c>. Sin CHECK sobre <see cref="Cantidad"/> — un saldo de lote negativo
+/// está permitido en el mostrador (legacy parity, proposal decisión 7), refusado solo en
+/// caminos de back-office (transferencia, decomiso, en Application).
+///
+/// <see cref="IdTenant"/> NO se auto-estampa (no hereda <c>EntidadTenant</c>) — quien escriba la
+/// fila (slices 4-12) DEBE asignarlo a mano; el RLS <c>WITH CHECK</c> rechaza el INSERT con
+/// SQLSTATE 42501 si falta.
+/// </summary>
+public class StockLote
+{
+    public int IdArticulo { get; set; }
+    public int IdPuntoVenta { get; set; }
+    public int IdLote { get; set; }
+    public int IdTenant { get; set; }
+
+    public decimal Cantidad { get; set; }
+}

--- a/src/Ways.Domain/Ventas/ItemComprobanteVenta.cs
+++ b/src/Ways.Domain/Ventas/ItemComprobanteVenta.cs
@@ -68,4 +68,12 @@ public class ItemComprobanteVenta : EntidadTenant
     /// <c>CostoCongeladoEnVentaEtapa9</c> (stage 9, decisión 2): una aproximación, no un costo
     /// real capturado al emitir.</summary>
     public bool CostoEsEstimado { get; set; }
+
+    /// <summary>Etapa 12 (proposal decisión 8, gate §F): snapshot del lote resuelto al emitir —
+    /// congelado, nunca re-derivado (doc 10 principio 6), legal bajo "Snapshot Immutability of
+    /// Items" porque se AGREGA al snapshot y no existe endpoint de edición. Es lo que hace exacta
+    /// la anulación: la reversión lee el <see cref="IdLote"/> de la propia fila, sin lookup ni
+    /// ambigüedad. <c>NULL</c> para un artículo que no es lot-effective. Columna creada en esta
+    /// slice, escrita recién en slice 8 (<c>ServicioDeVentas</c>).</summary>
+    public int? IdLote { get; set; }
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ArticuloConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ArticuloConfiguration.cs
@@ -91,6 +91,12 @@ public class ArticuloConfiguration : IEntityTypeConfiguration<Articulo>
             .HasDefaultValue(true)
             .IsRequired();
 
+        // Etapa 12 (proposal decisión 1, gate §E).
+        builder.Property(a => a.ControlaLote)
+            .HasColumnName("controla_lote")
+            .HasDefaultValue(false)
+            .IsRequired();
+
         builder.Property(a => a.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(a => a.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(a => a.DeletedAt).HasColumnName("deleted_at");
@@ -106,6 +112,12 @@ public class ArticuloConfiguration : IEntityTypeConfiguration<Articulo>
             .IsUnique();
 
         builder.HasIndex(a => a.IdTenant).HasDatabaseName("ix_articulos_tenant");
+
+        // Etapa 12 (proposal decisión 1, gate §E): sirve tanto el conjunto de reconciliación
+        // (ServicioDeLotes.ReconciliarAsync, slice 4) como el listado de artículos lot-effective.
+        builder.HasIndex(a => a.IdTenant)
+            .HasDatabaseName("ix_articulos_controla_lote")
+            .HasFilter("controla_lote AND deleted_at IS NULL");
 
         // Nombres explícitos en snake_case (doc 10): sin esto EF nombra los índices de
         // soporte de cada FK con su convención propia (IX_articulos_id_area, PascalCase),

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ArticuloConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ArticuloConfiguration.cs
@@ -115,7 +115,10 @@ public class ArticuloConfiguration : IEntityTypeConfiguration<Articulo>
 
         // Etapa 12 (proposal decisión 1, gate §E): sirve tanto el conjunto de reconciliación
         // (ServicioDeLotes.ReconciliarAsync, slice 4) como el listado de artículos lot-effective.
-        builder.HasIndex(a => a.IdTenant)
+        // Overload nombrado: mismo property set que ix_articulos_tenant, pero es un índice
+        // distinto (parcial) — sin el nombre explícito, EF los trata como el mismo slot de
+        // metadata y uno pisa al otro.
+        builder.HasIndex(a => a.IdTenant, "ix_articulos_controla_lote")
             .HasDatabaseName("ix_articulos_controla_lote")
             .HasFilter("controla_lote AND deleted_at IS NULL");
 

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteCompraConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteCompraConfiguration.cs
@@ -4,6 +4,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Compras;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
 
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
 
@@ -27,6 +28,12 @@ public class ItemComprobanteCompraConfiguration : IEntityTypeConfiguration<ItemC
             t.HasCheckConstraint(
                 "ck_items_comprobante_compra_importes_no_negativos",
                 "descuento >= 0 AND total >= 0");
+
+            // Etapa 12 (proposal gate §G): un código de lote sin vencimiento nunca puede
+            // resolver a una fila válida de `lotes` — se rechaza en la puerta.
+            t.HasCheckConstraint(
+                "ck_items_comprobante_compra_lote_input",
+                "(codigo_lote IS NULL AND fecha_vencimiento IS NULL) OR fecha_vencimiento IS NOT NULL");
         });
 
         builder.HasKey(i => i.Id).HasName("pk_items_comprobante_compra");
@@ -73,6 +80,12 @@ public class ItemComprobanteCompraConfiguration : IEntityTypeConfiguration<ItemC
 
         builder.Property(i => i.PrecioSugerido).HasColumnName("precio_sugerido").HasColumnType("numeric(14,2)");
 
+        // Etapa 12 (proposal gate §G): input de borrador, capturado tal cual — nunca resuelto
+        // antes de Confirmar (slice 5).
+        builder.Property(i => i.CodigoLote).HasColumnName("codigo_lote").HasColumnType("text");
+        builder.Property(i => i.FechaVencimiento).HasColumnName("fecha_vencimiento").HasColumnType("date");
+        builder.Property(i => i.IdLote).HasColumnName("id_lote");
+
         builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(i => i.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(i => i.DeletedAt).HasColumnName("deleted_at");
@@ -87,6 +100,9 @@ public class ItemComprobanteCompraConfiguration : IEntityTypeConfiguration<ItemC
         builder.HasIndex(i => new { i.IdComprobanteCompra, i.IdTenant }).HasDatabaseName("ix_items_comprobante_compra_comprobante");
         builder.HasIndex(i => new { i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_comprobante_compra_articulo");
         builder.HasIndex(i => i.IdAlicuotaIva).HasDatabaseName("ix_items_comprobante_compra_alicuota_iva");
+
+        // Etapa 12 (proposal gate §G): soporte de fk_items_comprobante_compra_lote.
+        builder.HasIndex(i => new { i.IdLote, i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_comprobante_compra_lote");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -113,6 +129,15 @@ public class ItemComprobanteCompraConfiguration : IEntityTypeConfiguration<ItemC
             .WithMany()
             .HasForeignKey(i => i.IdAlicuotaIva)
             .HasConstraintName("fk_items_comprobante_compra_alicuota_iva")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Etapa 12 (proposal gate §G, gate amendment 2): a diferencia de la de venta, IdArticulo
+        // es NOT NULL acá, así que la FK queda completamente exigida en cuanto IdLote se setea.
+        builder.HasOne<Lote>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdLote, i.IdArticulo, i.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasConstraintName("fk_items_comprobante_compra_lote")
             .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteVentaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemComprobanteVentaConfiguration.cs
@@ -4,6 +4,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
 using Ways.Domain.Ventas;
 
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
@@ -75,6 +76,10 @@ public class ItemComprobanteVentaConfiguration : IEntityTypeConfiguration<ItemCo
             .HasDefaultValue(false)
             .IsRequired();
 
+        // Etapa 12 (proposal decisión 8, gate §F): snapshot del lote, columna creada acá,
+        // escrita recién en slice 8.
+        builder.Property(i => i.IdLote).HasColumnName("id_lote");
+
         builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(i => i.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(i => i.DeletedAt).HasColumnName("deleted_at");
@@ -92,6 +97,9 @@ public class ItemComprobanteVentaConfiguration : IEntityTypeConfiguration<ItemCo
         builder.HasIndex(i => new { i.IdListaPrecio, i.IdTenant }).HasDatabaseName("ix_items_comprobante_venta_lista_precio");
         builder.HasIndex(i => new { i.IdOferta, i.IdTenant }).HasDatabaseName("ix_items_comprobante_venta_oferta");
         builder.HasIndex(i => i.IdAlicuotaIva).HasDatabaseName("ix_items_comprobante_venta_alicuota_iva");
+
+        // Etapa 12 (proposal decisión 8, gate §F): soporte de fk_items_comprobante_venta_lote.
+        builder.HasIndex(i => new { i.IdLote, i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_comprobante_venta_lote");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -139,6 +147,17 @@ public class ItemComprobanteVentaConfiguration : IEntityTypeConfiguration<ItemCo
             .WithMany()
             .HasForeignKey(i => i.IdAlicuotaIva)
             .HasConstraintName("fk_items_comprobante_venta_alicuota_iva")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Etapa 12 (proposal decisión 8, gate §F, gate amendment 2): MATCH SIMPLE (default de
+        // Postgres) — IdArticulo es nullable acá (líneas de concepto libre, doc 10 §4), pero una
+        // línea con lote necesariamente referencia un artículo; la FK se evalúa solo cuando las
+        // tres columnas son no-NULL, la aplicación valida ese emparejamiento.
+        builder.HasOne<Lote>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdLote, i.IdArticulo, i.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasConstraintName("fk_items_comprobante_venta_lote")
             .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/LoteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/LoteConfiguration.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Articulos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Lote"/> (proposal gate §A, DB CHANGE GATE aprobado con enmiendas). Catálogo
+/// tenant-wide con auditoría completa, mismo criterio que <c>ArticuloConfiguration</c>. Todos
+/// los nombres son explícitos — la convención PascalCase por default de EF se pisa siempre.
+/// </summary>
+public class LoteConfiguration : IEntityTypeConfiguration<Lote>
+{
+    public void Configure(EntityTypeBuilder<Lote> builder)
+    {
+        builder.ToTable("lotes", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_lotes_vencimiento_segun_tipo",
+                "(es_sin_identificar AND fecha_vencimiento IS NULL) OR (NOT es_sin_identificar AND fecha_vencimiento IS NOT NULL)");
+
+            t.HasCheckConstraint("ck_lotes_codigo_no_vacio", "length(btrim(codigo)) > 0");
+        });
+
+        builder.HasKey(l => l.Id).HasName("pk_lotes");
+
+        builder.Property(l => l.Id)
+            .HasColumnName("id_lote")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(l => l.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        // Clave alterna — principal de las FKs compuestas de stock_lotes/movimientos_stock/
+        // items_comprobante_venta/items_comprobante_compra (proposal gate §A): así la base misma
+        // garantiza "el lote pertenece a ese artículo". Nombre literal del gate, no "ak_" pese a
+        // ser una alternate key — el contrato lo pinea así.
+        builder.HasAlternateKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasName("ux_lotes_id_articulo_tenant");
+
+        builder.Property(l => l.IdArticulo).HasColumnName("id_articulo").IsRequired();
+
+        builder.Property(l => l.Codigo)
+            .HasColumnName("codigo")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(l => l.FechaVencimiento).HasColumnName("fecha_vencimiento").HasColumnType("date");
+
+        builder.Property(l => l.EsSinIdentificar)
+            .HasColumnName("es_sin_identificar")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(l => l.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(l => l.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(l => l.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(l => l.EstaEliminada);
+
+        // Clave natural — target del get-or-create (slice 3, ServicioDeLotes.ResolverOCrearAsync).
+        builder.HasIndex(l => new { l.IdTenant, l.IdArticulo, l.Codigo })
+            .HasDatabaseName("ux_lotes_articulo_codigo")
+            .HasFilter("deleted_at IS NULL")
+            .IsUnique();
+
+        // A lo sumo un lote "sin identificar" por artículo (proposal decisión 3).
+        builder.HasIndex(l => new { l.IdTenant, l.IdArticulo })
+            .HasDatabaseName("ux_lotes_sin_identificar")
+            .HasFilter("es_sin_identificar AND deleted_at IS NULL")
+            .IsUnique();
+
+        builder.HasIndex(l => l.IdTenant).HasDatabaseName("ix_lotes_tenant");
+
+        // Nombre explícito (mismo fix que ArticuloConfiguration): sin esto EF nombra el índice
+        // de soporte de fk_lotes_articulo con su convención propia (PascalCase).
+        builder.HasIndex(l => new { l.IdArticulo, l.IdTenant }).HasDatabaseName("ix_lotes_articulo");
+
+        // Filtro del reporte de vencimientos (slice 13).
+        builder.HasIndex(l => new { l.IdTenant, l.FechaVencimiento })
+            .HasDatabaseName("ix_lotes_vencimiento")
+            .HasFilter("deleted_at IS NULL");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(l => l.IdTenant)
+            .HasConstraintName("fk_lotes_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Articulo>()
+            .WithMany()
+            .HasForeignKey(l => new { l.IdArticulo, l.IdTenant })
+            .HasPrincipalKey(a => new { a.Id, a.IdTenant })
+            .HasConstraintName("fk_lotes_articulo")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
@@ -52,6 +52,10 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
 
         builder.Property(m => m.IdPuntoVentaDestino).HasColumnName("id_punto_venta_destino");
 
+        // Etapa 12 (proposal decisión 5, gate §C): columna creada acá, escrita recién desde
+        // slice 4.
+        builder.Property(m => m.IdLote).HasColumnName("id_lote");
+
         builder.Property(m => m.IdEmpleado).HasColumnName("id_empleado").IsRequired();
         builder.Property(m => m.Observaciones).HasColumnName("observaciones").HasColumnType("text");
 
@@ -75,6 +79,10 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
         builder.HasIndex(m => new { m.IdPuntoVenta, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_punto_venta");
         builder.HasIndex(m => new { m.IdPuntoVentaDestino, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_punto_venta_destino");
         builder.HasIndex(m => m.IdEmpleado).HasDatabaseName("ix_movimientos_stock_empleado");
+
+        // Etapa 12 (proposal decisión 5, gate §C): soporte de fk_movimientos_stock_lote y
+        // reconstrucción del ledger por lote.
+        builder.HasIndex(m => new { m.IdLote, m.IdArticulo, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_lote");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -117,6 +125,15 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
             .HasForeignKey(m => new { m.IdComprobanteCompra, m.IdTenant })
             .HasPrincipalKey(c => new { c.Id, c.IdTenant })
             .HasConstraintName("fk_movimientos_stock_comprobante_compra")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Etapa 12 (proposal decisión 5, gate §C): garantiza a nivel de base que el lote del
+        // movimiento pertenece a su mismo artículo.
+        builder.HasOne<Lote>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdLote, m.IdArticulo, m.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasConstraintName("fk_movimientos_stock_lote")
             .OnDelete(DeleteBehavior.Restrict);
 
         // id_empleado: FK SIMPLE (no compuesta), misma deviación deliberada que

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/StockLoteConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/StockLoteConfiguration.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="StockLote"/> (proposal gate §B). PK-only, sin auditoría — mismo criterio que
+/// <c>StockConfiguration</c>. Sin CHECK sobre <c>cantidad</c>: un saldo de lote negativo está
+/// permitido en el mostrador (legacy parity, proposal decisión 7).
+/// </summary>
+public class StockLoteConfiguration : IEntityTypeConfiguration<StockLote>
+{
+    public void Configure(EntityTypeBuilder<StockLote> builder)
+    {
+        builder.ToTable("stock_lotes");
+
+        builder.HasKey(s => new { s.IdArticulo, s.IdPuntoVenta, s.IdLote }).HasName("pk_stock_lotes");
+
+        builder.Property(s => s.IdArticulo).HasColumnName("id_articulo").ValueGeneratedNever();
+        builder.Property(s => s.IdPuntoVenta).HasColumnName("id_punto_venta").ValueGeneratedNever();
+        builder.Property(s => s.IdLote).HasColumnName("id_lote").ValueGeneratedNever();
+
+        builder.Property(s => s.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(s => s.Cantidad)
+            .HasColumnName("cantidad")
+            .HasColumnType("numeric(12,3)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.HasIndex(s => s.IdTenant).HasDatabaseName("ix_stock_lotes_tenant");
+
+        // Ruta de acceso del reporte de vencimientos (slice 13) — mismo shape que
+        // ix_stock_punto_venta.
+        builder.HasIndex(s => new { s.IdPuntoVenta, s.IdTenant }).HasDatabaseName("ix_stock_lotes_punto_venta");
+
+        // Soporte de fk_stock_lotes_lote (evita el índice implícito PascalCase de EF).
+        builder.HasIndex(s => new { s.IdLote, s.IdArticulo, s.IdTenant }).HasDatabaseName("ix_stock_lotes_lote");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(s => s.IdTenant)
+            .HasConstraintName("fk_stock_lotes_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Coherencia lote/artículo a nivel de base — mismo target que el resto de las FKs de
+        // lote (proposal gate §A/§B).
+        builder.HasOne<Lote>()
+            .WithMany()
+            .HasForeignKey(s => new { s.IdLote, s.IdArticulo, s.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasConstraintName("fk_stock_lotes_lote")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(s => new { s.IdPuntoVenta, s.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_stock_lotes_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -22,9 +23,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813003414_LotesYVencimientosEtapa12")]
+    partial class LotesYVencimientosEtapa12
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.cs
@@ -324,39 +324,10 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                 name: "controla_lote",
                 table: "articulos");
 
-            migrationBuilder.AlterDatabase()
-                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
-                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
-                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
-                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
-                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
-                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
-                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
-                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
-                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
-                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
-                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
-                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
-                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
-                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
-                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
-                .Annotation("Npgsql:PostgresExtension:citext", ",,")
-                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
-                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
-                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
-                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
-                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
-                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
-                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
-                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
-                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
-                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,transferencia,venta")
-                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
-                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
-                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
-                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
-                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
-                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+            // Sin reversa del enum motivo_stock (decisión 9 del proposal): Postgres no soporta
+            // DROP VALUE, así que 'decomiso'/'reclasificacion' quedan como miembros muertos
+            // documentados tras el rollback — el resto de la reversa (FKs, tablas, índices,
+            // CHECK, columnas) sí se ejecuta.
         }
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260813003414_LotesYVencimientosEtapa12.cs
@@ -1,0 +1,362 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class LotesYVencimientosEtapa12 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Orden de statements per design (binding): 1) AlterDatabase (diff de enum) primero
+            // — PG permite ADD VALUE dentro de una transacción pero prohíbe USAR el valor nuevo
+            // en esa misma transacción, así que ningún Sql() de esta migración puede nombrar
+            // 'decomiso'/'reclasificacion'. 2) CreateTable lotes. 3) CreateTable stock_lotes.
+            // 4) AddColumn ×6 con sus FKs/índices. 5) HabilitarRlsDeTenant sobre las dos tablas
+            // nuevas, al final (RLS necesita que la tabla ya exista).
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "lotes",
+                columns: table => new
+                {
+                    id_lote = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_articulo = table.Column<int>(type: "integer", nullable: false),
+                    codigo = table.Column<string>(type: "text", nullable: false),
+                    fecha_vencimiento = table.Column<DateOnly>(type: "date", nullable: true),
+                    es_sin_identificar = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_lotes", x => x.id_lote);
+                    table.UniqueConstraint("ux_lotes_id_articulo_tenant", x => new { x.id_lote, x.id_articulo, x.id_tenant });
+                    table.CheckConstraint("ck_lotes_codigo_no_vacio", "length(btrim(codigo)) > 0");
+                    table.CheckConstraint("ck_lotes_vencimiento_segun_tipo", "(es_sin_identificar AND fecha_vencimiento IS NULL) OR (NOT es_sin_identificar AND fecha_vencimiento IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_lotes_articulo",
+                        columns: x => new { x.id_articulo, x.id_tenant },
+                        principalTable: "articulos",
+                        principalColumns: new[] { "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_lotes_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "stock_lotes",
+                columns: table => new
+                {
+                    id_articulo = table.Column<int>(type: "integer", nullable: false),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    id_lote = table.Column<int>(type: "integer", nullable: false),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    cantidad = table.Column<decimal>(type: "numeric(12,3)", nullable: false, defaultValue: 0m)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_stock_lotes", x => new { x.id_articulo, x.id_punto_venta, x.id_lote });
+                    table.ForeignKey(
+                        name: "fk_stock_lotes_lote",
+                        columns: x => new { x.id_lote, x.id_articulo, x.id_tenant },
+                        principalTable: "lotes",
+                        principalColumns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_stock_lotes_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_stock_lotes_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.AddColumn<int>(
+                name: "id_lote",
+                table: "movimientos_stock",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "id_lote",
+                table: "items_comprobante_venta",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "codigo_lote",
+                table: "items_comprobante_compra",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "fecha_vencimiento",
+                table: "items_comprobante_compra",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "id_lote",
+                table: "items_comprobante_compra",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "controla_lote",
+                table: "articulos",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_stock_lote",
+                table: "movimientos_stock",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_venta_lote",
+                table: "items_comprobante_venta",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_comprobante_compra_lote",
+                table: "items_comprobante_compra",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" });
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_items_comprobante_compra_lote_input",
+                table: "items_comprobante_compra",
+                sql: "(codigo_lote IS NULL AND fecha_vencimiento IS NULL) OR fecha_vencimiento IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_articulos_controla_lote",
+                table: "articulos",
+                column: "id_tenant",
+                filter: "controla_lote AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_lotes_articulo",
+                table: "lotes",
+                columns: new[] { "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_lotes_tenant",
+                table: "lotes",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_lotes_vencimiento",
+                table: "lotes",
+                columns: new[] { "id_tenant", "fecha_vencimiento" },
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_lotes_articulo_codigo",
+                table: "lotes",
+                columns: new[] { "id_tenant", "id_articulo", "codigo" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_lotes_sin_identificar",
+                table: "lotes",
+                columns: new[] { "id_tenant", "id_articulo" },
+                unique: true,
+                filter: "es_sin_identificar AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_stock_lotes_lote",
+                table: "stock_lotes",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_stock_lotes_punto_venta",
+                table: "stock_lotes",
+                columns: new[] { "id_punto_venta", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_stock_lotes_tenant",
+                table: "stock_lotes",
+                column: "id_tenant");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_items_comprobante_compra_lote",
+                table: "items_comprobante_compra",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                principalTable: "lotes",
+                principalColumns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_items_comprobante_venta_lote",
+                table: "items_comprobante_venta",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                principalTable: "lotes",
+                principalColumns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_movimientos_stock_lote",
+                table: "movimientos_stock",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                principalTable: "lotes",
+                principalColumns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            // RLS al final (ADR-15): las dos tablas nuevas ya existen acá, misma migración que
+            // las crea — nunca una ventana con la tabla scopeada y sin policy.
+            migrationBuilder.HabilitarRlsDeTenant("lotes");
+            migrationBuilder.HabilitarRlsDeTenant("stock_lotes");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_items_comprobante_compra_lote",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_items_comprobante_venta_lote",
+                table: "items_comprobante_venta");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_movimientos_stock_lote",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropTable(
+                name: "stock_lotes");
+
+            migrationBuilder.DropTable(
+                name: "lotes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_movimientos_stock_lote",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropIndex(
+                name: "ix_items_comprobante_venta_lote",
+                table: "items_comprobante_venta");
+
+            migrationBuilder.DropIndex(
+                name: "ix_items_comprobante_compra_lote",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_items_comprobante_compra_lote_input",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropIndex(
+                name: "ix_articulos_controla_lote",
+                table: "articulos");
+
+            migrationBuilder.DropColumn(
+                name: "id_lote",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropColumn(
+                name: "id_lote",
+                table: "items_comprobante_venta");
+
+            migrationBuilder.DropColumn(
+                name: "codigo_lote",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropColumn(
+                name: "fecha_vencimiento",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropColumn(
+                name: "id_lote",
+                table: "items_comprobante_compra");
+
+            migrationBuilder.DropColumn(
+                name: "controla_lote",
+                table: "articulos");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,inventario,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/WaysDbContextModelSnapshot.cs
@@ -184,6 +184,9 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                         .HasDatabaseName("ix_articulos_alicuota_iva");
 
                     b.HasIndex("IdTenant")
+                        .HasDatabaseName("ix_articulos_tenant");
+
+                    b.HasIndex(new[] { "IdTenant" }, "ix_articulos_controla_lote")
                         .HasDatabaseName("ix_articulos_controla_lote")
                         .HasFilter("controla_lote AND deleted_at IS NULL");
 

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -110,6 +110,13 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<ComprobanteCompra> ComprobantesCompra => Set<ComprobanteCompra>();
     public DbSet<ItemComprobanteCompra> ItemsComprobanteCompra => Set<ItemComprobanteCompra>();
 
+    // stage-12-lotes-vencimientos, Slice 1 (schema + seed gate, DB CHANGE GATE aprobado con
+    // enmiendas): modelo adelantado a la migración, mismo trámite que ComprobanteCompra/
+    // ItemComprobanteCompra en stage-8 Slice 1 — sin exponer en IWaysDbContext todavía, slice 3
+    // (ServicioDeLotes) es el primer consumidor de Application.
+    public DbSet<Lote> Lotes => Set<Lote>();
+    public DbSet<StockLote> StockLotes => Set<StockLote>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>
@@ -147,6 +154,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenantEnOfertaLista(modelBuilder);
         AplicarFiltroDeTenantEnNumeracionComprobante(modelBuilder);
         AplicarFiltroDeTenantEnStock(modelBuilder);
+        AplicarFiltroDeTenantEnStockLote(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoStock(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoCuentaCorriente(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoCaja(modelBuilder);
@@ -524,6 +532,25 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         // completo en vez de renombrar el DbSet (que sí matchea doc 10: la tabla es "stock",
         // invariante en singular, igual que su propiedad acá).
         var propiedadIdTenant = Expression.Property(parametro, nameof(Ways.Domain.Stock.Stock.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// stage-12-lotes-vencimientos (Slice 1, design decisión 20): <see cref="StockLote"/>
+    /// PK-only, sin auditoría (proposal gate §B, mismo criterio que <see cref="Stock"/>) —
+    /// necesita la variante escrita a mano, mismo criterio que
+    /// <see cref="AplicarFiltroDeTenantEnStock"/>. <see cref="Lote"/> SÍ hereda
+    /// <see cref="EntidadTenant"/> (gate §A), así que el loop por convención de
+    /// <see cref="AplicarFiltroDeTenant"/> ya lo cubre — no necesita variante propia.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnStockLote(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(StockLote))!;
+
+        var parametro = Expression.Parameter(typeof(StockLote), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(StockLote.IdTenant));
         var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
 
         entidad.SetQueryFilter("Tenant", filtro);

--- a/tests/Ways.IntegrationTests/LotesBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/LotesBackstopTests.cs
@@ -1,0 +1,451 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 1 (tasks 1.20-1.23, db-error-backstops, design decisión
+/// 5): raw-SQL INSERTs que bypasean por completo <c>ServicioDeLotes</c> (no existe todavía,
+/// Slice 3) — mismo patrón que <c>ComprasSchemaBackstopTests</c>/<c>VentasStockBackstopTests</c>.
+/// Prueban la traducción de esquema (SQLSTATE + <c>ConstraintName</c>), no un camino de cliente
+/// HTTP real — honesto sobre alcanzabilidad: bajo operación normal (Slice 3 en adelante) el
+/// get-or-create serializa sobre <c>ux_lotes_articulo_codigo</c>, así que estas ramas quedan
+/// como backstop de una escritura cruda/fuera de banda o de una carrera genuina en el alta admin
+/// (<c>POST /api/stock/lotes</c>, Slice 3).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class LotesBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private sealed record Prerequisitos(
+        int IdTenant, int IdPuntoVenta, int IdArticuloA, int IdArticuloB, int IdEmpleado,
+        int IdCliente, int IdProveedor, int IdListaPrecio, int IdAlicuotaIva, int IdArea,
+        int IdTipoComprobanteTx, int IdTipoComprobanteCompra);
+
+    private async Task<Prerequisitos> SembrarPrerequisitosAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas, tipos de comprobante)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articuloA = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-A",
+            Nombre = $"{nombre}-A",
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            ControlaLote = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articuloA);
+        await db.SaveChangesAsync();
+
+        var articuloB = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-B",
+            Nombre = $"{nombre}-B",
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            ControlaLote = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articuloB);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var listaPrecio = new ListaPrecio
+        {
+            IdTenant = tenant.Id, Nombre = nombre, EsDefault = true, Modo = ModoLista.Fija, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(listaPrecio);
+        await db.SaveChangesAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = tenant.Id,
+            Numero = 2,
+            Nombre = nombre,
+            IdCondicionFiscal = condicionFiscal.Id,
+            IdListaPrecio = listaPrecio.Id,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = tenant.Id,
+            RazonSocial = nombre,
+            IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var usuario = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = "vendedor",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+        var idTipoComprobanteCompra = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Prerequisitos(
+            tenant.Id, puntoVenta.Id, articuloA.Id, articuloB.Id, usuario.Id, cliente.Id, proveedor.Id,
+            listaPrecio.Id, idAlicuotaIva, area.Id, idTipoComprobanteTx, idTipoComprobanteCompra);
+    }
+
+    /// <summary>Crea un lote fechado (no sin-identificar) para <see cref="Prerequisitos.IdArticuloA"/>
+    /// vía EF — sin pasar por <c>ServicioDeLotes</c>, que no existe todavía.</summary>
+    private async Task<int> SembrarLoteDeArticuloAAsync(Prerequisitos p, string codigo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var lote = new Lote
+        {
+            IdTenant = p.IdTenant,
+            IdArticulo = p.IdArticuloA,
+            Codigo = codigo,
+            FechaVencimiento = new DateOnly(2026, 12, 31),
+            EsSinIdentificar = false,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+        return lote.Id;
+    }
+
+    private async Task<int> SembrarComprobanteVentaAsync(Prerequisitos p)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = p.IdTenant,
+            IdTipoComprobante = p.IdTipoComprobanteTx,
+            Numero = Random.Shared.Next(1, 1_000_000),
+            Fecha = ahora,
+            IdPuntoVenta = p.IdPuntoVenta,
+            IdEmpleado = p.IdEmpleado,
+            IdCliente = p.IdCliente,
+            Subtotal = 100m,
+            DescuentoTotal = 0m,
+            Total = 100m,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    private async Task<int> SembrarComprobanteCompraAsync(Prerequisitos p)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var comprobante = new ComprobanteCompra
+        {
+            IdTenant = p.IdTenant,
+            IdProveedor = p.IdProveedor,
+            IdTipoComprobante = p.IdTipoComprobanteCompra,
+            IdPuntoVenta = p.IdPuntoVenta,
+            IdEmpleado = p.IdEmpleado,
+            Subtotal = 100m,
+            DescuentoTotal = 0m,
+            Total = 100m,
+            Estado = EstadoCompra.Borrador,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesCompra.Add(comprobante);
+        await db.SaveChangesAsync();
+        return comprobante.Id;
+    }
+
+    // ---- ux_lotes_articulo_codigo: carrera genuina (task 1.20) --------------------------------
+
+    [Fact]
+    public async Task DosLotesConcurrentesDelMismoArticuloYCodigoDanExactamenteUnGanador()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(DosLotesConcurrentesDelMismoArticuloYCodigoDanExactamenteUnGanador));
+
+        await using var conexionA = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var conexionB = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        async Task InsertarAsync(NpgsqlConnection cx)
+        {
+            await using var comando = cx.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+                "created_at, updated_at) VALUES ($1, $2, 'L-CARRERA', $3, false, now(), now())";
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloA });
+            comando.Parameters.Add(new NpgsqlParameter { Value = new DateOnly(2026, 12, 31) });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        var tareaA = InsertarAsync(conexionA);
+        var tareaB = InsertarAsync(conexionB);
+
+        // Espera las dos tareas sin dejar que la primera excepción cancele la espera de la
+        // otra (a diferencia de Task.WhenAll, que relanza apenas la primera falla).
+        await Task.WhenAll(tareaA.ContinueWith(_ => { }), tareaB.ContinueWith(_ => { }));
+
+        var tareas = new[] { tareaA, tareaB };
+        Assert.Equal(1, tareas.Count(t => t.IsCompletedSuccessfully));
+        Assert.Equal(1, tareas.Count(t => t.IsFaulted));
+
+        var tareaFallida = tareas.Single(t => t.IsFaulted);
+        var excepcion = Assert.IsType<PostgresException>(tareaFallida.Exception!.InnerException);
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_lotes_articulo_codigo", excepcion.ConstraintName);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var sobrevivientes = await db.Lotes.CountAsync(l => l.IdArticulo == p.IdArticuloA && l.Codigo == "L-CARRERA");
+        Assert.Equal(1, sobrevivientes);
+    }
+
+    // ---- ux_lotes_sin_identificar: exención documentada, raw-SQL directo (task 1.21) ----------
+
+    [Fact]
+    public async Task UnSegundoLoteSinIdentificarDelMismoArticuloViolaLaUnicidadParcial()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnSegundoLoteSinIdentificarDelMismoArticuloViolaLaUnicidadParcial));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+
+        async Task InsertarSinIdentificarAsync(string codigo)
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+                "created_at, updated_at) VALUES ($1, $2, $3, NULL, true, now(), now())";
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+            comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloA });
+            comando.Parameters.Add(new NpgsqlParameter { Value = codigo });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await InsertarSinIdentificarAsync("SIN-IDENTIFICAR");
+
+        // Código distinto a propósito: lo que se prueba acá es ux_lotes_sin_identificar
+        // (es_sin_identificar), no ux_lotes_articulo_codigo.
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => InsertarSinIdentificarAsync("SIN-IDENTIFICAR-2"));
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_lotes_sin_identificar", excepcion.ConstraintName);
+    }
+
+    // ---- las cuatro FKs de coherencia lote/artículo (task 1.22) --------------------------------
+
+    [Fact]
+    public async Task UnMovimientoDeStockReferenciandoElLoteDeUnArticuloAjenoViolaLaFk()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnMovimientoDeStockReferenciandoElLoteDeUnArticuloAjenoViolaLaFk));
+        var idLoteDeA = await SembrarLoteDeArticuloAAsync(p, "L-001");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO movimientos_stock (id_tenant, id_articulo, id_punto_venta, cantidad, motivo, " +
+            "id_lote, id_empleado, creado_el) VALUES ($1, $2, $3, 5, 'ajuste', $4, $5, now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloB });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idLoteDeA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_movimientos_stock_lote", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnItemDeVentaReferenciandoElLoteDeUnArticuloAjenoViolaLaFk()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemDeVentaReferenciandoElLoteDeUnArticuloAjenoViolaLaFk));
+        var idLoteDeA = await SembrarLoteDeArticuloAAsync(p, "L-002");
+        var idComprobante = await SembrarComprobanteVentaAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_venta (id_tenant, id_comprobante_venta, orden, id_articulo, " +
+            "descripcion, id_area, id_lista_precio, id_alicuota_iva, porcentaje_iva, cantidad, " +
+            "precio_unitario, descuento, total, id_lote, created_at, updated_at) " +
+            "VALUES ($1, $2, 1, $3, 'item-lote-ajeno', $4, $5, $6, 21, 1, 100, 0, 100, $7, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloB });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArea });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdListaPrecio });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idLoteDeA });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_comprobante_venta_lote", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnItemDeCompraReferenciandoElLoteDeUnArticuloAjenoViolaLaFk()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemDeCompraReferenciandoElLoteDeUnArticuloAjenoViolaLaFk));
+        var idLoteDeA = await SembrarLoteDeArticuloAAsync(p, "L-003");
+        var idComprobante = await SembrarComprobanteCompraAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "id_lote, created_at, updated_at) " +
+            "VALUES ($1, $2, 1, $3, 'item-lote-ajeno', 1, 10, 0, $4, 21, 10, $5, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloB });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idLoteDeA });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_comprobante_compra_lote", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnStockLoteReferenciandoElLoteDeUnArticuloAjenoViolaLaFk()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnStockLoteReferenciandoElLoteDeUnArticuloAjenoViolaLaFk));
+        var idLoteDeA = await SembrarLoteDeArticuloAAsync(p, "L-004");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, 0)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloB });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idLoteDeA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_stock_lotes_lote", excepcion.ConstraintName);
+    }
+
+    // ---- las tres CHECKs de esta slice (task 1.23) ---------------------------------------------
+
+    [Fact]
+    public async Task UnLoteFechadoSinVencimientoViolaLaCheckDeVencimientoSegunTipo()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnLoteFechadoSinVencimientoViolaLaCheckDeVencimientoSegunTipo));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+            "created_at, updated_at) VALUES ($1, $2, 'L-SIN-FECHA', NULL, false, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloA });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_lotes_vencimiento_segun_tipo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnLoteConCodigoEnBlancoViolaLaCheckDeCodigoNoVacio()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnLoteConCodigoEnBlancoViolaLaCheckDeCodigoNoVacio));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+            "created_at, updated_at) VALUES ($1, $2, '   ', $3, false, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = new DateOnly(2026, 12, 31) });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_lotes_codigo_no_vacio", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnItemDeCompraConCodigoDeLoteSinVencimientoViolaLaCheckDeLoteInput()
+    {
+        var p = await SembrarPrerequisitosAsync(nameof(UnItemDeCompraConCodigoDeLoteSinVencimientoViolaLaCheckDeLoteInput));
+        var idComprobante = await SembrarComprobanteCompraAsync(p);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", p.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_comprobante_compra (id_tenant, id_comprobante_compra, orden, id_articulo, " +
+            "descripcion, cantidad, costo_unitario, descuento, id_alicuota_iva, porcentaje_iva, total, " +
+            "codigo_lote, fecha_vencimiento, created_at, updated_at) " +
+            "VALUES ($1, $2, 1, $3, 'item-lote-input-invalido', 1, 10, 0, $4, 21, 10, 'L-005', NULL, now(), now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdArticuloA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = p.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_comprobante_compra_lote_input", excepcion.ConstraintName);
+    }
+}

--- a/tests/Ways.IntegrationTests/LotesMigracionTests.cs
+++ b/tests/Ways.IntegrationTests/LotesMigracionTests.cs
@@ -1,0 +1,93 @@
+using Npgsql;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 1 (task 1.18): prueba que la migración
+/// <c>LotesYVencimientosEtapa12</c> aplica limpiamente sobre un Postgres 17 fresco —
+/// <see cref="WaysApiFixture.InitializeAsync"/> ya corre <c>Database.MigrateAsync()</c> como
+/// <c>ways_owner</c> antes de que exista ningún cliente HTTP (todo test de esta suite ya ejerce
+/// esa aplicación); acá se afirma explícitamente el post-estado: las dos tablas nuevas, las seis
+/// columnas aditivas y los dos valores nuevos de <c>motivo_stock</c> existen post-<c>Up()</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class LotesMigracionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private async Task<NpgsqlConnection> AbrirAsync()
+    {
+        using var _ = fixture.CreateClient(); // fuerza el arranque del host (siembra + migración ya corrida en InitializeAsync)
+        return await fixture.AbrirConexionCrudaAsync("plataforma", null);
+    }
+
+    [Theory]
+    [InlineData("lotes")]
+    [InlineData("stock_lotes")]
+    public async Task LaTablaExistePostMigracion(string tabla)
+    {
+        await using var cruda = await AbrirAsync();
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(1, total);
+    }
+
+    public static TheoryData<string, string> ColumnasAditivas => new()
+    {
+        { "movimientos_stock", "id_lote" },
+        { "articulos", "controla_lote" },
+        { "items_comprobante_venta", "id_lote" },
+        { "items_comprobante_compra", "codigo_lote" },
+        { "items_comprobante_compra", "fecha_vencimiento" },
+        { "items_comprobante_compra", "id_lote" }
+    };
+
+    [Theory]
+    [MemberData(nameof(ColumnasAditivas))]
+    public async Task LaColumnaAditivaExistePostMigracion(string tabla, string columna)
+    {
+        await using var cruda = await AbrirAsync();
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT count(*) FROM information_schema.columns " +
+            "WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+        comando.Parameters.Add(new NpgsqlParameter { Value = columna });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(1, total);
+    }
+
+    [Theory]
+    [InlineData("decomiso")]
+    [InlineData("reclasificacion")]
+    public async Task ElValorDeEnumExistePostMigracion(string valor)
+    {
+        await using var cruda = await AbrirAsync();
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT count(*) FROM pg_enum e JOIN pg_type t ON e.enumtypid = t.oid " +
+            "WHERE t.typname = 'motivo_stock' AND e.enumlabel = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = valor });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(1, total);
+    }
+
+    /// <summary>Ocho motivos en total (seis previos + los dos de esta etapa) — asegura que la
+    /// migración no perdió ninguno de los preexistentes al reescribir el enum.</summary>
+    [Fact]
+    public async Task ElEnumMotivoStockTieneLosOchoValores()
+    {
+        await using var cruda = await AbrirAsync();
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT count(*) FROM pg_enum e JOIN pg_type t ON e.enumtypid = t.oid " +
+            "WHERE t.typname = 'motivo_stock'";
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(8, total);
+    }
+}

--- a/tests/Ways.IntegrationTests/LotesRlsTests.cs
+++ b/tests/Ways.IntegrationTests/LotesRlsTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 1 (task 1.19, mutation-proof-tests rule 5, design
+/// decisión 20): RLS de <c>lotes</c>/<c>stock_lotes</c> sobre la conexión <c>ways_app</c>
+/// (<c>NOSUPERUSER NOBYPASSRLS</c>) — la única bajo la cual una prueba de RLS prueba algo real
+/// (ver <c>WaysApiFixture</c>). <c>lotes</c> hereda <c>EntidadTenant</c> (filtro genérico de
+/// <c>WaysDbContext.AplicarFiltroDeTenant</c>); <c>stock_lotes</c> es PK-only con el filtro
+/// escrito a mano (<c>AplicarFiltroDeTenantEnStockLote</c>) — mismo criterio que
+/// <c>StockRlsTests</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private sealed record Escenario(int IdTenant, int IdArticulo, int IdPuntoVenta, int IdLote);
+
+    private async Task<Escenario> SembrarEscenarioAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            ControlaLote = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var lote = new Lote
+        {
+            IdTenant = tenant.Id,
+            IdArticulo = articulo.Id,
+            Codigo = "2026-12-31",
+            FechaVencimiento = new DateOnly(2026, 12, 31),
+            EsSinIdentificar = false,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = articulo.Id, IdPuntoVenta = puntoVenta.Id, IdLote = lote.Id, IdTenant = tenant.Id, Cantidad = 10m
+        });
+        await db.SaveChangesAsync();
+
+        return new Escenario(tenant.Id, articulo.Id, puntoVenta.Id, lote.Id);
+    }
+
+    private async Task<Tenant> SembrarTenantBAsync(string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenantB = new Tenant
+        {
+            Nombre = nombre, Estado = EstadoTenant.Activo,
+            CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenantB);
+        await db.SaveChangesAsync();
+        return tenantB;
+    }
+
+    // ---- lotes ------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeElLotePorSelect()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeElLotePorSelect));
+        var tenantB = await SembrarTenantBAsync(nameof(UnaSesionDeOtroTenantNoVeElLotePorSelect) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM lotes WHERE id_lote = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdLote });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarElLote()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElLote));
+        var tenantB = await SembrarTenantBAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElLote) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "UPDATE lotes SET codigo = 'tocado por intruso' WHERE id_lote = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdLote });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    [Fact]
+    public async Task UnInsertDeLoteConIdTenantAjenoSeRechaza()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnInsertDeLoteConIdTenantAjenoSeRechaza));
+        var tenantB = await SembrarTenantBAsync(nameof(UnInsertDeLoteConIdTenantAjenoSeRechaza) + "-B");
+
+        // Sesión del tenant A intentando insertar con id_tenant del tenant B (ajeno).
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", escenario.IdTenant);
+        var ahora = DateTimeOffset.UtcNow;
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+            "created_at, updated_at) VALUES ($1, $2, 'intruso', $3, false, $4, $4)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = new DateOnly(2027, 1, 1) });
+        comando.Parameters.Add(new NpgsqlParameter { Value = ahora });
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) — se dispara antes de
+        // cualquier FK/CHECK, sin importar que el resto de columnas referencien filas válidas
+        // del tenant A.
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ): <see cref="Lote"/> hereda <c>EntidadTenant</c>, así que
+    /// el filtro genérico de <c>WaysDbContext.AplicarFiltroDeTenant</c> la cubre sin filtro
+    /// manual.</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant));
+        var tenantB = await SembrarTenantBAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-B");
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
+        var visible = await sesionB.Lotes.AnyAsync(l => l.Id == escenario.IdLote);
+
+        Assert.False(visible);
+    }
+
+    // ---- stock_lotes --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeElStockLotePorSelect()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeElStockLotePorSelect));
+        var tenantB = await SembrarTenantBAsync(nameof(UnaSesionDeOtroTenantNoVeElStockLotePorSelect) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT count(*) FROM stock_lotes WHERE id_articulo = $1 AND id_punto_venta = $2 AND id_lote = $3";
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdLote });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarElStockLote()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElStockLote));
+        var tenantB = await SembrarTenantBAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElStockLote) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", tenantB.Id);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "UPDATE stock_lotes SET cantidad = cantidad + 1 " +
+            "WHERE id_articulo = $1 AND id_punto_venta = $2 AND id_lote = $3";
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdLote });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    [Fact]
+    public async Task UnInsertDeStockLoteConIdTenantAjenoSeRechaza()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(UnInsertDeStockLoteConIdTenantAjenoSeRechaza));
+        var tenantB = await SembrarTenantBAsync(nameof(UnInsertDeStockLoteConIdTenantAjenoSeRechaza) + "-B");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        // Un segundo lote del mismo tenant A, para no chocar con la fila ya sembrada por
+        // SembrarEscenarioAsync (misma PK que stock_lotes usaría).
+        var otroLote = new Lote
+        {
+            IdTenant = escenario.IdTenant,
+            IdArticulo = escenario.IdArticulo,
+            Codigo = "otro-lote",
+            FechaVencimiento = new DateOnly(2027, 6, 1),
+            EsSinIdentificar = false,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Lotes.Add(otroLote);
+        await db.SaveChangesAsync();
+
+        // Sesión del tenant A intentando insertar con id_tenant del tenant B (ajeno).
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", escenario.IdTenant);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, 0)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = escenario.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = otroLote.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = tenantB.Id });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    /// <summary>Proof a nivel EF (LINQ) — <see cref="StockLote"/> usa el filtro manual (design
+    /// decisión 20, no hereda <c>EntidadTenant</c>).</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant()
+    {
+        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant));
+        var tenantB = await SembrarTenantBAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-B");
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
+        var visible = await sesionB.StockLotes.AnyAsync(s =>
+            s.IdArticulo == escenario.IdArticulo && s.IdPuntoVenta == escenario.IdPuntoVenta && s.IdLote == escenario.IdLote);
+
+        Assert.False(visible);
+    }
+}

--- a/tests/Ways.IntegrationTests/LotesRlsTests.cs
+++ b/tests/Ways.IntegrationTests/LotesRlsTests.cs
@@ -2,10 +2,18 @@ using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 
 namespace Ways.IntegrationTests;
 
@@ -22,6 +30,39 @@ namespace Ways.IntegrationTests;
 public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
     private sealed record Escenario(int IdTenant, int IdArticulo, int IdPuntoVenta, int IdLote);
+
+    /// <summary>Judgment-day fix (juez B, MAJOR): un <see cref="WaysDbContext"/> sobre
+    /// <c>ways_owner</c> (bypassea RLS) para que las dos pruebas de "el filtro de EF nunca
+    /// devuelve filas ajenas" prueben genuinamente el query filter — sobre <c>ways_app</c>
+    /// RLS filtra igual aunque el filtro de EF no exista, así esas pruebas no distinguían
+    /// nada (comprobado comentando <c>SetQueryFilter</c> y viendo los 8 tests pasar
+    /// igual).</summary>
+    private WaysDbContext CrearContextoDeOwner(ITenantActual tenantActual)
+    {
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.OwnerConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        return new WaysDbContext(opciones, tenantActual);
+    }
 
     private async Task<Escenario> SembrarEscenarioAsync(string nombre)
     {
@@ -162,17 +203,33 @@ public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtur
 
     /// <summary>Proof a nivel EF (LINQ): <see cref="Lote"/> hereda <c>EntidadTenant</c>, así que
     /// el filtro genérico de <c>WaysDbContext.AplicarFiltroDeTenant</c> la cubre sin filtro
-    /// manual.</summary>
+    /// manual.
+    ///
+    /// Judgment-day fix (juez B, MAJOR): corre sobre <c>ways_owner</c> (bypassea RLS,
+    /// <see cref="CrearContextoDeOwner"/>), no sobre <c>ways_app</c> — bajo <c>ways_app</c>
+    /// RLS excluye la fila ajena igual aunque el query filter de EF no exista, así que la
+    /// prueba original no probaba nada del filtro. Seed cross-tenant (dos escenarios
+    /// completos) más el control de <c>count &gt; 0</c> del propio tenant evita que la
+    /// prueba pase en vacío.
+    ///
+    /// Evidencia de mutación: comentando <c>entidad.SetQueryFilter("Tenant", filtro);</c> en
+    /// <c>WaysDbContext.AplicarFiltroDeTenant</c> y corriendo el filtro
+    /// <c>--filter "FullyQualifiedName~LotesRlsTests"</c>, este test (y el análogo de
+    /// <c>stock_lotes</c>) fallaron: <c>visibleAjeno</c> pasó a ser <c>true</c> (mutant
+    /// caught). Revertida la mutación, la suite vuelve a estar verde.</summary>
     [Fact]
     public async Task ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant()
     {
-        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant));
-        var tenantB = await SembrarTenantBAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-B");
+        var escenarioA = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-A");
+        var escenarioB = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-B");
 
-        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
-        var visible = await sesionB.Lotes.AnyAsync(l => l.Id == escenario.IdLote);
+        await using var sesionB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
 
-        Assert.False(visible);
+        var visibleAjeno = await sesionB.Lotes.AnyAsync(l => l.Id == escenarioA.IdLote);
+        Assert.False(visibleAjeno);
+
+        var visiblePropio = await sesionB.Lotes.AnyAsync(l => l.Id == escenarioB.IdLote);
+        Assert.True(visiblePropio);
     }
 
     // ---- stock_lotes --------------------------------------------------------------------------
@@ -254,17 +311,31 @@ public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtur
     }
 
     /// <summary>Proof a nivel EF (LINQ) — <see cref="StockLote"/> usa el filtro manual (design
-    /// decisión 20, no hereda <c>EntidadTenant</c>).</summary>
+    /// decisión 20, no hereda <c>EntidadTenant</c>).
+    ///
+    /// Judgment-day fix (juez B, MAJOR): mismo criterio que
+    /// <see cref="ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant"/> — corre sobre
+    /// <c>ways_owner</c> para que solo el query filter de EF pueda excluir la fila ajena.
+    ///
+    /// Evidencia de mutación: comentando <c>entidad.SetQueryFilter("Tenant", filtro);</c> en
+    /// <c>WaysDbContext.AplicarFiltroDeTenantEnStockLote</c> y corriendo el filtro
+    /// <c>--filter "FullyQualifiedName~LotesRlsTests"</c>, este test falló:
+    /// <c>visibleAjeno</c> pasó a ser <c>true</c> (mutant caught). Revertida la mutación, la
+    /// suite vuelve a estar verde.</summary>
     [Fact]
     public async Task ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant()
     {
-        var escenario = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant));
-        var tenantB = await SembrarTenantBAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-B");
+        var escenarioA = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-A");
+        var escenarioB = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-B");
 
-        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, tenantB.Id));
-        var visible = await sesionB.StockLotes.AnyAsync(s =>
-            s.IdArticulo == escenario.IdArticulo && s.IdPuntoVenta == escenario.IdPuntoVenta && s.IdLote == escenario.IdLote);
+        await using var sesionB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
 
-        Assert.False(visible);
+        var visibleAjeno = await sesionB.StockLotes.AnyAsync(s =>
+            s.IdArticulo == escenarioA.IdArticulo && s.IdPuntoVenta == escenarioA.IdPuntoVenta && s.IdLote == escenarioA.IdLote);
+        Assert.False(visibleAjeno);
+
+        var visiblePropio = await sesionB.StockLotes.AnyAsync(s =>
+            s.IdArticulo == escenarioB.IdArticulo && s.IdPuntoVenta == escenarioB.IdPuntoVenta && s.IdLote == escenarioB.IdLote);
+        Assert.True(visiblePropio);
     }
 }

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresLotesTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 1 (task 1.16, db-error-backstops, design decisión 5):
+/// mismo patrón unit-style que <see cref="ManejadorDeErroresComprasTests"/> — sin
+/// <c>WaysApiFixture</c> ni Postgres real, la <see cref="PostgresException"/> se construye "a
+/// mano". No hay ningún endpoint todavía en esta slice (<c>ServicioDeLotes</c> es Slice 3) para
+/// ejercer el round-trip HTTP completo, así que la prueba de que <c>ux_lotes_articulo_codigo</c>
+/// gana la rama nueva ANTES de caer en la familia genérica de <c>ClasificarUnicidad</c> (que la
+/// clasificaría como <c>codigo_duplicado</c>, por la substring "_codigo") vive acá — el mismo
+/// hallazgo que <c>ux_comprobantes_venta_numero</c>/<c>ux_comprobantes_compra_numero_externo</c>
+/// ya necesitaron.
+/// </summary>
+public class ManejadorDeErroresLotesTests
+{
+    private sealed class ServicioDeProblemDetailsFalso : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Ultimo { get; private set; }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.FromResult(true);
+        }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static PostgresException CrearExcepcion(string sqlState, string constraintName) =>
+        new(
+            messageText: "mensaje de prueba",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: null,
+            columnName: null,
+            dataTypeName: null,
+            constraintName: constraintName,
+            file: null,
+            line: null,
+            routine: null);
+
+    private static async Task<(int Estado, string? Codigo)> ManejarAsync(Exception excepcion)
+    {
+        var servicioDeProblemDetails = new ServicioDeProblemDetailsFalso();
+        var manejador = new ManejadorDeErrores(servicioDeProblemDetails, NullLogger<ManejadorDeErrores>.Instance);
+        var contexto = new DefaultHttpContext();
+
+        var manejado = await manejador.TryHandleAsync(contexto, excepcion, CancellationToken.None);
+
+        Assert.True(manejado);
+        Assert.NotNull(servicioDeProblemDetails.Ultimo);
+
+        var problema = servicioDeProblemDetails.Ultimo!.ProblemDetails;
+        return (contexto.Response.StatusCode, problema.Extensions["codigo"] as string);
+    }
+
+    // ---- ux_lotes_articulo_codigo (el trap de ordering: substring "_codigo") -----------------
+
+    [Fact]
+    public async Task UxLotesArticuloCodigoGanaLaRamaNuevaAntesQueLaFamiliaGenericaDeCodigo()
+    {
+        var postgres = CrearExcepcion("23505", "ux_lotes_articulo_codigo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("lote_duplicado", codigo);
+        // La prueba negativa que cierra el trap: NUNCA el código genérico "_codigo" —
+        // sin la rama exacta ANTES de ClasificarUnicidad, la substring "_codigo" la atraparía
+        // primero y la clasificaría mal.
+        Assert.NotEqual("codigo_duplicado", codigo);
+    }
+
+    // ---- ux_lotes_sin_identificar (exención documentada, sin ruta de cliente que la ejerza) --
+
+    [Fact]
+    public async Task UxLotesSinIdentificarSeTraduceA409LoteSinIdentificarDuplicado()
+    {
+        var postgres = CrearExcepcion("23505", "ux_lotes_sin_identificar");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("lote_sin_identificar_duplicado", codigo);
+    }
+
+    // ---- las cuatro FKs nuevas: el match genérico por prefijo "fk_" ya las cubre --------------
+
+    [Theory]
+    [InlineData("fk_lotes_tenant")]
+    [InlineData("fk_lotes_articulo")]
+    [InlineData("fk_stock_lotes_tenant")]
+    [InlineData("fk_stock_lotes_lote")]
+    [InlineData("fk_stock_lotes_punto_venta")]
+    [InlineData("fk_movimientos_stock_lote")]
+    [InlineData("fk_items_comprobante_venta_lote")]
+    [InlineData("fk_items_comprobante_compra_lote")]
+    public async Task CadaFkNuevaSeTraduceA400ReferenciaInvalida(string nombreDeFk)
+    {
+        var postgres = CrearExcepcion("23503", nombreDeFk);
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("fk", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("referencia_invalida", codigo);
+    }
+}


### PR DESCRIPTION
## Etapa 12 — Slice 1: Esquema (size:exception declarada)

Migración única \`LotesYVencimientosEtapa12\` implementando EXACTAMENTE el modelo aprobado por el gate de DB (proposal § Modelo de datos propuesto, con enmiendas):

- **Tablas nuevas**: \`lotes\` (Tenant-wide, EntidadTenant, RLS FORCE) y \`stock_lotes\` (operativa, PK-only cache con filtro de tenant hand-rolled, RLS FORCE).
- **Enum**: \`motivo_stock\` +\`decomiso\` +\`reclasificacion\` (Down() no intenta removerlos — PG no tiene DROP VALUE; decisión 9 del proposal).
- **Columnas aditivas**: \`movimientos_stock.id_lote\`, \`articulos.controla_lote\`, \`items_comprobante_venta.id_lote\`, \`items_comprobante_compra.{codigo_lote,fecha_vencimiento,id_lote}\` — FKs compuestas de 3 columnas contra \`ux_lotes_id_articulo_tenant\` (enmienda 2 del gate).
- **ManejadorDeErrores**: 23505 \`ux_lotes_articulo_codigo\` → \`409 lote_duplicado\` (resolución por nombre exacto antes de la clasificación por substring); exención documentada de \`ux_lotes_sin_identificar\`.
- **Doc 10 §6** actualizado (convención "Estado (Etapa 12)").
- **Ningún writer toca las columnas todavía** — este slice es solo esquema + backstops.

**size:exception**: ~430 líneas de producción; la migración del gate es una sola y no se parte (design decisión 21). El desborde es la migración + snapshot, no alcance.

### Tests (38 nuevos de integración, todos verdes)
migración 11 · RLS 8 (incl. 2 del filtro EF probados sobre ways_owner, bajo el confound de RLS) · backstops 9 (carrera 23505 con SQLSTATE asertado) · manejador de errores 10. Domain 394 · Application 257 verdes.

### Judgment-day
Ronda 1: doble REJECT (2 BLOCKER + 1 MAJOR reales: índice pisado en el slot de metadata de EF, Down() con NotSupportedException probada en vivo, tests EF vacuos bajo RLS). Fix batch con evidencia de mutación por fix. Ronda 2: doble APPROVE con probe nuevo de drift del snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)