### PR TITLE
feat(lotes): activación del módulo de lotes — etapa 12, slice 2

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/specs/lotes-y-vencimientos/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/lotes-y-vencimientos/spec.md
@@ -339,8 +339,15 @@ sin-identificar residue would understate its own totals.)
   `fecha_vencimiento = 2026-08-12`
 - WHEN the vencimientos report is requested
 - THEN "hoy" resolves to `2026-08-12` in that zona_horaria (not `2026-08-13`
-  as a naive UTC read would produce), and that lot classifies `vencido`, not
-  `por_vencer`
+  as a naive UTC read would produce), and that lot classifies `por_vencer`,
+  not `vencido` — the expiry date is inclusive: a lot expiring today is still
+  sellable today, and `vencido` means `fecha_vencimiento < hoy` strictly. A
+  naive UTC read would have tipped it into `vencido` a day early, which is
+  exactly the bug this scenario pins. (Amended at slice-2 judgment-day:
+  the original THEN said `vencido`, contradicting both design.md's boundary
+  table and this scenario's own zone-resolution intent; orchestrator decision
+  — retail semantics, conservative bias — resolved the boundary as strict
+  `<`, implemented in `ReglaDeLotes.EstaVencido`.)
 
 #### Scenario: The sin-identificar lot appears in the report as sin_fecha and counts toward the totals
 - GIVEN a lot-effective articulo at a punto de venta has a sin-identificar

--- a/openspec/changes/stage-12-lotes-vencimientos/state.yaml
+++ b/openspec/changes/stage-12-lotes-vencimientos/state.yaml
@@ -221,6 +221,17 @@ dependencies:
   verify: [apply]
   archive: [verify]
 decisiones_tomadas:
+  - "13 — SEMANTICA DE BORDE DEL VENCIMIENTO (resuelta por el orquestador en el judgment-day
+    del slice 2): LA FECHA DE VENCIMIENTO ES INCLUSIVA — un lote con fecha_vencimiento == hoy
+    NO esta vencido (clasifica por_vencer); vencido = fecha_vencimiento < hoy ESTRICTO
+    (ReglaDeLotes.EstaVencido). El juez A detecto que el escenario de zona horaria del spec
+    delta decia lo contrario del design; auditado, el THEN del spec ademas contradecia la
+    intencion de su propio escenario (el bug de UTC naive ADELANTA el vencimiento un dia).
+    Se enmendo el SPEC, no el codigo. Fundamento: semantica retail estandar (vence HOY =
+    vendible HOY con urgencia por_vencer), consistencia con el rechazo de recepcion (409
+    lote_vencido_en_recepcion rechaza fechas EN EL PASADO, no la de hoy), y sesgo
+    conservador (no bloquear/estigmatizar mercaderia legalmente vendible). Propaga a los
+    tres write sites, al reporte y al warning del POS via el unico helper ReglaDeLotes."
   - "1 — CONTROL DE LOTE POR ARTICULO, BINARIO Y OBLIGATORIO DONDE ESTA PRENDIDO:
     articulos.controla_lote boolean NOT NULL DEFAULT false, la forma exacta de EsProducto.
     Se RECHAZA el enum de tres valores (no aplica/opcional/obligatorio): 'opcional' es la

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -212,23 +212,23 @@ DB-free Domain rule; `ServicioDeVentas`'s parametro read is batched
 2→1 (three keys, one query); the query-count guard reads `16`.
 **Rollback**: revert the branch — no schema, no writer wired to lots yet.
 
-- [ ] 2.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
+- [x] 2.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
   `LotesHabilitado` (`bool`, default `false`), `DiasAlertaVencimiento`
   (`int`, default `30`), both registered in `PorClave`. *(no migration —
   stage-10 pattern)*
-- [ ] 2.2 Create `src/Ways.Domain/Stock/ReglaDeLotes.cs`: `SaldoDeLote`
+- [x] 2.2 Create `src/Ways.Domain/Stock/ReglaDeLotes.cs`: `SaldoDeLote`
   record, `EstadoDeVencimiento` enum (`Vencido`/`PorVencer`/`Vigente`/
   `SinFecha`), `CodigoSinIdentificar` constant, `ControlEfectivo`,
   `OrdenarFefo`, `ElegirFefo`, `DerivarCodigo`, `Clasificar`, `EstaVencido`
   — pure, no `IWaysDbContext`. *(design decision 1)*
-- [ ] 2.3 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
+- [x] 2.3 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
   `ResolverParametrosDeVentaAsync` — single `WHERE clave IN (...)` query for
   `tolerancia_pago`/`vuelto_maximo`/`lotes_habilitado`; per-clave
   `.Where(p => p.Clave == c.Clave)` filter **before** delegating to
   `ResolucionDeParametros.Resolver` (design decision 2 — the named mutation
   target: `Resolver` filters by PV but not by clave, so a naive multi-key
   candidate set corrupts cross-parametro).
-- [ ] 2.4 [P] Domain unit suite (`PoliticaDeRoles` pattern, no DB, 5
+- [x] 2.4 [P] Domain unit suite (`PoliticaDeRoles` pattern, no DB, 5
   facts): `ControlEfectivo` truth table *(spec lotes-y-vencimientos:
   Effective Lot Control Is `controla_lote` AND `lotes_habilitado`)*;
   `OrdenarFefo` with a sin-identificar lot + two dated lots + a tie on
@@ -238,23 +238,30 @@ DB-free Domain rule; `ServicioDeVentas`'s parametro read is batched
   ISO-formats the expiry *(spec: "A lot is created with a server-derived
   codigo")*; `Clasificar` at all four boundaries (`hoy-1`, `hoy`,
   `hoy+dias`, `hoy+dias+1`, `null`).
-- [ ] 2.5 [P] **Mutation target**: `candidatos.Where(p => p.Clave ==
+- [x] 2.5 [P] **Mutation target**: `candidatos.Where(p => p.Clave ==
   c.Clave)` — delete it; two-key test where `tolerancia_pago` has a
   PV-scoped row and `vuelto_maximo` only an empresa row, both values
   asserted correctly (must fail once deleted). *(spec parametros-operativos:
   The Batched Query Still Resolves Punto De Venta Overrides Correctly;
   mutation-proof-tests)* Record mutation evidence in the PR body.
-- [ ] 2.6 [P] Query-count test: the batched parametro read issues exactly
+  *(APPLY-RUN NOTE: mutation applied — `.Where(p => p.Clave == c.Clave)`
+  replaced by unfiltered `candidatos` in `ResolverParametrosDeVentaAsync` —
+  `ElCheckoutResuelveVueltoMaximoDeEmpresaAunConUnaFilaDePuntoDeVentaDeOtraClave`
+  went RED (`500 error_interno`: the lone PV-scoped `tolerancia_pago` row
+  leaks into `lotes_habilitado`'s resolution too, `JsonException` on `bool`
+  deserialization of `"15"`); reverted, same test back to GREEN alongside
+  the full `VentasCheckoutTests` suite (27/27).)*
+- [x] 2.6 [P] Query-count test: the batched parametro read issues exactly
   **1** query for the three keys. *(spec parametros-operativos: A Single
   Batched Query Resolves All Three Keys)*
-- [ ] 2.7 [P] `ContadorDeComandos` regression: the existing constant moves
+- [x] 2.7 [P] `ContadorDeComandos` regression: the existing constant moves
   deliberately `17 → 16`. *(spec lotes-y-vencimientos: Module Off Issues
   One Fewer Parametro Round-Trip Than The Baseline)*
-- [ ] 2.8 [P] `parametros-operativos` scenarios: `lotes_habilitado` resolves
+- [x] 2.8 [P] `parametros-operativos` scenarios: `lotes_habilitado` resolves
   `false` with no configured row; an empresa-level row turns the module on
   for every PV of that empresa; `dias_alerta_vencimiento` defaults to `30`;
   a PV-level override wins.
-- [ ] 2.9 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
+- [x] 2.9 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
   pending changes.
 - [ ] 2.10 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 2.11 Branch `feat/stage12-slice2-activacion` off `main` (parent:

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -263,8 +263,14 @@ DB-free Domain rule; `ServicioDeVentas`'s parametro read is batched
   a PV-level override wins.
 - [x] 2.9 Gate guard: `dotnet ef migrations has-pending-model-changes` → no
   pending changes.
-- [ ] 2.10 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 2.11 Branch `feat/stage12-slice2-activacion` off `main` (parent:
+- [x] 2.10 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  round 1 — judge B APPROVE with 6/6 mutations killed and strict-equality
+  guards confirmed; judge A REJECT with 1 MAJOR: the spec's timezone scenario
+  said `fecha == hoy` classifies `vencido`, contradicting design.md AND the
+  scenario's own naive-UTC intent. Orchestrator decision 13: expiry date is
+  inclusive, `vencido` = `fecha < hoy` strict — SPEC amended (cc1d10f), code
+  untouched. Round 2 — judge A APPROVE, blob-hash-verified no code drift.)*
+- [x] 2.11 Branch `feat/stage12-slice2-activacion` off `main` (parent:
   slice 1); PR; merge stacked-to-main.
 
 **Test plan**: Domain suite (2.4), parametro-filter mutation (2.5), query

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -105,12 +105,15 @@ public class ServicioDeVentas(
 
         var (items, totales) = MaterializarItems(tipo.Signo, lineas, resolucion, articuloPorId, porcentajePorAlicuota, cliente.IdListaPrecio);
 
-        // 2 consultas: tolerancia_pago + vuelto_maximo, resueltas directo (sin el pre-chequeo
-        // de pertenencia de ServicioDeParametros.ResolverAsync — puntoVenta ya se resolvió
-        // arriba, así que idEmpresa ya es de confianza) para mantener el presupuesto pineado
-        // por design (Technical Approach: "≤ 16 round trips").
-        var toleranciaPago = await ResolverParametroAsync(ParametroConocido.ToleranciaPago, puntoVenta.IdEmpresa, puntoVenta.Id, ct);
-        var vueltoMaximo = await ResolverParametroAsync(ParametroConocido.VueltoMaximo, puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+        // 1 consulta batcheada (stage-12, design decisión 2 / spec parametros-operativos: "A
+        // Single Batched Query Resolves All Three Keys"): tolerancia_pago + vuelto_maximo +
+        // lotes_habilitado, resueltas directo (sin el pre-chequeo de pertenencia de
+        // ServicioDeParametros.ResolverAsync — puntoVenta ya se resolvió arriba, así que
+        // idEmpresa ya es de confianza). Reemplaza las 2 consultas separadas de antes de esta
+        // etapa — 17 → 16 round trips (task 2.7). `lotesHabilitado` lo consume recién el plan
+        // FEFO de slice 7 (design: "Write site 1"); acá se descarta a propósito.
+        var (toleranciaPago, vueltoMaximo, _) =
+            await ResolverParametrosDeVentaAsync(puntoVenta.IdEmpresa, puntoVenta.Id, ct);
 
         // 1 consulta: medios de pago pedidos.
         var idsMedioPago = pagos.Select(p => p.IdMedioPago).Distinct().ToList();
@@ -781,16 +784,44 @@ public class ServicioDeVentas(
             ?? throw new InvalidOperationException("El tenant actual no tiene un Consumidor Final sembrado.");
     }
 
-    private async Task<decimal> ResolverParametroAsync(
-        ParametroConocido conocido, int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    /// <summary>Las tres claves que el checkout necesita, en UNA sola query <c>WHERE clave IN
+    /// (...)</c> (stage-12, design decisión 2 / spec parametros-operativos: "ServicioDeVentas
+    /// Batches Its Parametro Reads Into One Query") — reemplaza las dos consultas separadas de
+    /// <c>tolerancia_pago</c>/<c>vuelto_maximo</c> de antes de esta etapa, agregando
+    /// <c>lotes_habilitado</c> sin sumar un tercer round trip.
+    ///
+    /// <c>ResolucionDeParametros.Resolver</c> filtra los candidatos por punto de venta pero NO
+    /// por clave (fue escrita para un candidate set de una sola clave) — pasarle el set
+    /// multi-clave completo corrompería la resolución cruzada (una fila de <c>tolerancia_pago</c>
+    /// con el mismo <c>id_punto_venta</c> "gana" la resolución de <c>vuelto_maximo</c>). El
+    /// <c>Where(p => p.Clave == c.Clave)</c> de abajo es el target de mutación nombrado por el
+    /// design (mutation-proof-tests): borrarlo tiene que tirar en rojo la prueba de
+    /// <c>VentasCheckoutTests</c> que mezcla una fila de punto de venta de
+    /// <c>tolerancia_pago</c> con una fila solo de empresa de <c>vuelto_maximo</c>. Evidencia de
+    /// mutación registrada en ese archivo, junto al test.</summary>
+    private async Task<(decimal ToleranciaPago, decimal VueltoMaximo, bool LotesHabilitado)> ResolverParametrosDeVentaAsync(
+        int idEmpresa, int idPuntoVenta, CancellationToken ct)
     {
+        ParametroConocido[] conocidos =
+            [ParametroConocido.ToleranciaPago, ParametroConocido.VueltoMaximo, ParametroConocido.LotesHabilitado];
+        var claves = conocidos.Select(c => c.Clave).ToList();
+
         var candidatos = await db.Parametros
-            .Where(p => p.Clave == conocido.Clave && p.IdEmpresa == idEmpresa
+            .Where(p => claves.Contains(p.Clave) && p.IdEmpresa == idEmpresa
                 && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
             .ToListAsync(ct);
 
-        var valorJson = ResolucionDeParametros.Resolver(conocido.Clave, candidatos, idPuntoVenta);
-        return JsonSerializer.Deserialize<decimal>(valorJson);
+        var resueltoPorClave = conocidos.ToDictionary(
+            c => c.Clave,
+            c => ResolucionDeParametros.Resolver(
+                c.Clave,
+                candidatos.Where(p => p.Clave == c.Clave).ToList(),
+                idPuntoVenta));
+
+        return (
+            JsonSerializer.Deserialize<decimal>(resueltoPorClave[ParametroConocido.ToleranciaPago.Clave]),
+            JsonSerializer.Deserialize<decimal>(resueltoPorClave[ParametroConocido.VueltoMaximo.Clave]),
+            JsonSerializer.Deserialize<bool>(resueltoPorClave[ParametroConocido.LotesHabilitado.Clave]));
     }
 
     /// <summary>Corre <see cref="CalculadorDeTotales"/> (pura) sobre las líneas ya resueltas y

--- a/src/Ways.Domain/Catalogos/ParametroConocido.cs
+++ b/src/Ways.Domain/Catalogos/ParametroConocido.cs
@@ -40,11 +40,24 @@ public sealed record ParametroConocido(string Clave, Type TipoClr, string ValorP
     public static readonly ParametroConocido ComisionPorcentaje =
         new("comision_porcentaje", typeof(decimal), "0");
 
+    /// <summary>Interruptor del módulo de lotes a nivel empresa (stage-12, design: Interfaces /
+    /// Contracts): control efectivo de un artículo es este parámetro AND
+    /// <c>articulos.controla_lote</c> (<see cref="Stock.ReglaDeLotes.ControlEfectivo"/>). Sin
+    /// migración — mismo patrón que <see cref="ZonaHoraria"/>/<see cref="ComisionPorcentaje"/>
+    /// en stage-10.</summary>
+    public static readonly ParametroConocido LotesHabilitado =
+        new("lotes_habilitado", typeof(bool), "false");
+
+    /// <summary>Horizonte de alerta de "próximo a vencer" consumido por el reporte de
+    /// vencimientos (stage-12, design decisión 15). Default <c>30</c> días.</summary>
+    public static readonly ParametroConocido DiasAlertaVencimiento =
+        new("dias_alerta_vencimiento", typeof(int), "30");
+
     private static readonly IReadOnlyDictionary<string, ParametroConocido> PorClave =
         new[]
         {
             ToleranciaPago, VueltoMaximo, ImporteAdicionalRecarga, SlotsTicketsEspera,
-            ZonaHoraria, ComisionPorcentaje
+            ZonaHoraria, ComisionPorcentaje, LotesHabilitado, DiasAlertaVencimiento
         }.ToDictionary(p => p.Clave, p => p, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Devuelve el registro de <paramref name="clave"/>, o rechaza con un error de

--- a/src/Ways.Domain/Stock/ReglaDeLotes.cs
+++ b/src/Ways.Domain/Stock/ReglaDeLotes.cs
@@ -1,0 +1,96 @@
+namespace Ways.Domain.Stock;
+
+/// <summary>
+/// Proyección de saldo de un lote para las reglas puras de esta clase — <c>ServicioDeLotes</c>
+/// (Application, slice 3) es quien materializa estos records a partir del join
+/// <c>lotes ⟕ stock_lotes</c> (design decisión 6); acá no se conoce ninguna dependencia de base
+/// de datos.
+/// </summary>
+public readonly record struct SaldoDeLote(
+    int IdArticulo, int IdLote, string Codigo, bool EsSinIdentificar,
+    DateOnly? FechaVencimiento, decimal Cantidad);
+
+/// <summary>Clasificación de un lote respecto de "hoy" (design decisión 15/16). <see
+/// cref="SinFecha"/> es el lote sin identificar — se incluye en el reporte, nunca se excluye
+/// (spec lotes-y-vencimientos: "the sin-identificar residue is exactly the number that should
+/// nag someone into identifying it").</summary>
+public enum EstadoDeVencimiento
+{
+    Vencido,
+    PorVencer,
+    Vigente,
+    SinFecha
+}
+
+/// <summary>
+/// La regla de lotes, pura y sin base de datos (design decisión 1, patrón
+/// <c>PoliticaDeRoles</c>): control efectivo, orden FEFO, elección FEFO, derivación de código y
+/// clasificación de vencimiento. Cada uno de los tres sitios de escritura (venta, compra,
+/// transferencia) la consume igual — la regla se testea UNA vez acá, nunca reimplementada.
+/// </summary>
+public static class ReglaDeLotes
+{
+    /// <summary>Código reservado del lote "sin identificar" (design decisión 5) — un
+    /// <c>codigoLote</c> de cliente igual a esta literal se rechaza <c>400
+    /// codigo_de_lote_reservado</c> (slice 3).</summary>
+    public const string CodigoSinIdentificar = "SIN-IDENTIFICAR";
+
+    /// <summary>Control efectivo = flag del artículo AND parámetro de la empresa (spec
+    /// lotes-y-vencimientos: "Effective Lot Control Is controla_lote AND lotes_habilitado").
+    /// Con cualquiera de los dos en <c>false</c>, el movimiento corre byte-idéntico al camino
+    /// agregado-only anterior a esta etapa.</summary>
+    public static bool ControlEfectivo(bool controlaLote, bool lotesHabilitado) =>
+        controlaLote && lotesHabilitado;
+
+    /// <summary>Orden FEFO server-computed (spec: "FEFO Is The Server-Computed Default"):
+    /// sin-identificar PRIMERO (<c>es_sin_identificar DESC</c>), después vencimiento ascendente
+    /// (<c>NULLS</c> no aplica acá porque el sin-identificar ya quedó primero), <c>id_lote</c>
+    /// como desempate.</summary>
+    public static IReadOnlyList<SaldoDeLote> OrdenarFefo(IEnumerable<SaldoDeLote> saldos) =>
+        saldos
+            .OrderByDescending(s => s.EsSinIdentificar)
+            .ThenBy(s => s.FechaVencimiento ?? DateOnly.MinValue)
+            .ThenBy(s => s.IdLote)
+            .ToList();
+
+    /// <summary>Lote por defecto de una línea sin <c>idLote</c> explícito. <c>null</c> ⇒ ningún
+    /// lote del artículo tiene saldo positivo — el llamador resuelve (o crea, get-or-create) el
+    /// lote sin identificar en su lugar (design decisión 7), esta función nunca lo crea.</summary>
+    public static SaldoDeLote? ElegirFefo(IEnumerable<SaldoDeLote> saldosDelArticulo)
+    {
+        var conSaldoPositivo = saldosDelArticulo.Where(s => s.Cantidad > 0m).ToList();
+
+        return conSaldoPositivo.Count == 0 ? null : OrdenarFefo(conSaldoPositivo)[0];
+    }
+
+    /// <summary>Código server-derivado a partir del vencimiento ISO (spec: "A lot is created
+    /// with a server-derived codigo") — usado cuando el llamador omite <c>codigo</c> en la
+    /// recepción/alta.</summary>
+    public static string DerivarCodigo(DateOnly fechaVencimiento) =>
+        fechaVencimiento.ToString("yyyy-MM-dd");
+
+    /// <summary>Un lote sin fecha (sin identificar) nunca está vencido.</summary>
+    public static bool EstaVencido(DateOnly? fecha, DateOnly hoy) =>
+        fecha is not null && fecha.Value < hoy;
+
+    /// <summary>Clasificación en las cuatro categorías del reporte de vencimientos (design
+    /// decisión 16, spec: "Vencimientos Report Resolves Hoy…"): <c>vencido</c> si ya pasó,
+    /// <c>por_vencer</c> si entra dentro del horizonte de alerta (inclusive en ambos extremos),
+    /// <c>vigente</c> más allá del horizonte, <c>sin_fecha</c> para el lote sin identificar.</summary>
+    public static EstadoDeVencimiento Clasificar(DateOnly? fecha, DateOnly hoy, int diasDeAlerta)
+    {
+        if (fecha is null)
+        {
+            return EstadoDeVencimiento.SinFecha;
+        }
+
+        if (EstaVencido(fecha, hoy))
+        {
+            return EstadoDeVencimiento.Vencido;
+        }
+
+        return fecha.Value <= hoy.AddDays(diasDeAlerta)
+            ? EstadoDeVencimiento.PorVencer
+            : EstadoDeVencimiento.Vigente;
+    }
+}

--- a/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
+++ b/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
@@ -12,11 +12,27 @@ public class ParametroConocidoTests
     [InlineData("slots_tickets_espera")]
     [InlineData("zona_horaria")]
     [InlineData("comision_porcentaje")]
-    public void LasSeisClavesConocidasEstanRegistradas(string clave)
+    [InlineData("lotes_habilitado")]
+    [InlineData("dias_alerta_vencimiento")]
+    public void LasOchoClavesConocidasEstanRegistradas(string clave)
     {
         var conocido = ParametroConocido.Buscar(clave);
 
         Assert.Equal(clave, conocido.Clave);
+    }
+
+    [Fact]
+    public void LotesHabilitadoDeclaraElDefaultEnFalse()
+    {
+        Assert.Equal(typeof(bool), ParametroConocido.LotesHabilitado.TipoClr);
+        Assert.Equal("false", ParametroConocido.LotesHabilitado.ValorPorDefecto);
+    }
+
+    [Fact]
+    public void DiasAlertaVencimientoDeclaraElDefaultEn30()
+    {
+        Assert.Equal(typeof(int), ParametroConocido.DiasAlertaVencimiento.TipoClr);
+        Assert.Equal("30", ParametroConocido.DiasAlertaVencimiento.ValorPorDefecto);
     }
 
     [Fact]

--- a/tests/Ways.Domain.Tests/Catalogos/ResolucionDeParametrosTests.cs
+++ b/tests/Ways.Domain.Tests/Catalogos/ResolucionDeParametrosTests.cs
@@ -78,4 +78,52 @@ public class ResolucionDeParametrosTests
 
         Assert.Equal("0", resuelto);
     }
+
+    // ---- stage-12 slice 2 (task 2.8, spec parametros-operativos: "lotes_habilitado And
+    // dias_alerta_vencimiento Are Known Parametro Keys") ------------------------------------
+
+    private static Parametro FilaDe(string clave, int? idPuntoVenta, string valor) => new()
+    {
+        Id = 1, IdTenant = 1, IdEmpresa = 1, IdPuntoVenta = idPuntoVenta, Clave = clave, Valor = valor
+    };
+
+    [Fact]
+    public void LotesHabilitadoResuelveAFalseSinFilaConfigurada()
+    {
+        var resuelto = ResolucionDeParametros.Resolver("lotes_habilitado", candidatos: [], idPuntoVenta: 3);
+
+        Assert.Equal("false", resuelto);
+    }
+
+    [Fact]
+    public void UnaFilaDeEmpresaPrendeElModuloParaTodosLosPuntosDeVentaDeEsaEmpresa()
+    {
+        Parametro[] candidatos = [FilaDe("lotes_habilitado", idPuntoVenta: null, valor: "true")];
+
+        var resueltoParaPv3 = ResolucionDeParametros.Resolver("lotes_habilitado", candidatos, idPuntoVenta: 3);
+        var resueltoParaPv9 = ResolucionDeParametros.Resolver("lotes_habilitado", candidatos, idPuntoVenta: 9);
+
+        Assert.Equal("true", resueltoParaPv3);
+        Assert.Equal("true", resueltoParaPv9);
+    }
+
+    [Fact]
+    public void DiasAlertaVencimientoResuelveA30SinFilaConfigurada()
+    {
+        var resuelto = ResolucionDeParametros.Resolver("dias_alerta_vencimiento", candidatos: [], idPuntoVenta: 3);
+
+        Assert.Equal("30", resuelto);
+    }
+
+    [Fact]
+    public void UnaFilaDePuntoDeVentaGanaSobreElDefaultDeDiasAlertaVencimiento()
+    {
+        Parametro[] candidatos =
+            [FilaDe("dias_alerta_vencimiento", idPuntoVenta: null, valor: "30"),
+             FilaDe("dias_alerta_vencimiento", idPuntoVenta: 3, valor: "15")];
+
+        var resuelto = ResolucionDeParametros.Resolver("dias_alerta_vencimiento", candidatos, idPuntoVenta: 3);
+
+        Assert.Equal("15", resuelto);
+    }
 }

--- a/tests/Ways.Domain.Tests/Stock/ReglaDeLotesTests.cs
+++ b/tests/Ways.Domain.Tests/Stock/ReglaDeLotesTests.cs
@@ -1,0 +1,108 @@
+using Ways.Domain.Stock;
+
+namespace Ways.Domain.Tests.Stock;
+
+/// <summary>
+/// stage-12 slice 2 (design decisión 1, patrón <c>PoliticaDeRolesTests</c>): <see
+/// cref="ReglaDeLotes"/> es pura y sin base de datos — cada hecho de acá corre sin fixture.
+/// </summary>
+public class ReglaDeLotesTests
+{
+    private static SaldoDeLote Saldo(
+        int idLote, bool esSinIdentificar = false, DateOnly? fechaVencimiento = null, decimal cantidad = 10m) =>
+        new(IdArticulo: 40, IdLote: idLote, Codigo: $"L-{idLote}", EsSinIdentificar: esSinIdentificar,
+            FechaVencimiento: fechaVencimiento, Cantidad: cantidad);
+
+    // ---- ControlEfectivo (spec lotes-y-vencimientos: "Effective Lot Control Is controla_lote
+    // AND lotes_habilitado") -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    public void ControlEfectivoEsElAndDeAmbosFlags(bool controlaLote, bool lotesHabilitado, bool esperado)
+    {
+        Assert.Equal(esperado, ReglaDeLotes.ControlEfectivo(controlaLote, lotesHabilitado));
+    }
+
+    // ---- OrdenarFefo (spec: "FEFO Is The Server-Computed Default", "The sin-identificar lot is
+    // offered before every dated lot") --------------------------------------------------------
+
+    [Fact]
+    public void OrdenarFefoPoneElSinIdentificarPrimeroYDespuesVencimientoAscendenteConIdComoDesempate()
+    {
+        var sinIdentificar = Saldo(idLote: 1, esSinIdentificar: true);
+        var conVencimientoLejano = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2026, 9, 1));
+        var conVencimientoCercanoIdMayor = Saldo(idLote: 5, fechaVencimiento: new DateOnly(2026, 8, 1));
+        var conVencimientoCercanoIdMenor = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2026, 8, 1));
+
+        var saldos = new[] { conVencimientoLejano, sinIdentificar, conVencimientoCercanoIdMayor, conVencimientoCercanoIdMenor };
+
+        var ordenado = ReglaDeLotes.OrdenarFefo(saldos);
+
+        // sin-identificar primero; después los dos que empatan en vencimiento (2026-08-01),
+        // desempatados por id_lote ascendente (3 antes que 5); el de vencimiento más lejano
+        // (2026-09-01) al final — la secuencia de ids es la aserción, no solo el conjunto.
+        Assert.Equal([1, 3, 5, 2], ordenado.Select(s => s.IdLote));
+    }
+
+    // ---- ElegirFefo (spec: default de línea sin idLote) ---------------------------------------
+
+    [Fact]
+    public void ElegirFefoDevuelveNullCuandoNingunSaldoEsPositivo()
+    {
+        SaldoDeLote[] saldos = [Saldo(idLote: 1, cantidad: 0m), Saldo(idLote: 2, cantidad: -3m)];
+
+        Assert.Null(ReglaDeLotes.ElegirFefo(saldos));
+    }
+
+    [Fact]
+    public void ElegirFefoDevuelveElPrimeroDelOrdenFefoEntreLosDeSaldoPositivo()
+    {
+        var sinSaldo = Saldo(idLote: 1, fechaVencimiento: new DateOnly(2026, 7, 1), cantidad: 0m);
+        var conSaldoMasCercano = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2026, 8, 1), cantidad: 5m);
+        var conSaldoMasLejano = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2026, 9, 1), cantidad: 5m);
+
+        var elegido = ReglaDeLotes.ElegirFefo([sinSaldo, conSaldoMasLejano, conSaldoMasCercano]);
+
+        Assert.Equal(2, elegido!.Value.IdLote);
+    }
+
+    // ---- DerivarCodigo (spec: "A lot is created with a server-derived codigo") ----------------
+
+    [Fact]
+    public void DerivarCodigoFormateaLaFechaComoIso()
+    {
+        Assert.Equal("2026-12-31", ReglaDeLotes.DerivarCodigo(new DateOnly(2026, 12, 31)));
+    }
+
+    // ---- EstaVencido / Clasificar (spec: "Vencimientos Report Resolves Hoy…") ------------------
+
+    [Fact]
+    public void EstaVencidoEsFalsoParaUnLoteSinFecha()
+    {
+        Assert.False(ReglaDeLotes.EstaVencido(fecha: null, hoy: new DateOnly(2026, 8, 12)));
+    }
+
+    [Theory]
+    [InlineData(2026, 8, 11, EstadoDeVencimiento.Vencido)]       // hoy - 1
+    [InlineData(2026, 8, 12, EstadoDeVencimiento.PorVencer)]     // hoy
+    [InlineData(2026, 9, 11, EstadoDeVencimiento.PorVencer)]     // hoy + dias (30)
+    [InlineData(2026, 9, 12, EstadoDeVencimiento.Vigente)]       // hoy + dias + 1
+    public void ClasificarEnLosCuatroBordesDelHorizonteDeAlerta(int anio, int mes, int dia, EstadoDeVencimiento esperado)
+    {
+        var hoy = new DateOnly(2026, 8, 12);
+        var fecha = new DateOnly(anio, mes, dia);
+
+        Assert.Equal(esperado, ReglaDeLotes.Clasificar(fecha, hoy, diasDeAlerta: 30));
+    }
+
+    [Fact]
+    public void ClasificarDevuelveSinFechaParaElLoteSinIdentificar()
+    {
+        Assert.Equal(
+            EstadoDeVencimiento.SinFecha,
+            ReglaDeLotes.Clasificar(fecha: null, hoy: new DateOnly(2026, 8, 12), diasDeAlerta: 30));
+    }
+}

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -908,14 +908,178 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(consultasConPocasLineas, consultasConMuchasLineas);
         Assert.Equal(consultasConPocasLineas, consultasConMuchisimasLineas);
 
-        // El techo en sí está bajo prueba (design: Technical Approach, "≤ 16 round trips", ahora
-        // "≤ 17" — stage-6-turnos-caja design decisión 11): una baja tiene que notarse acá y
-        // actualizar la constante a propósito, nunca colarse muda detrás de un "<=". El +1 sobre
-        // el techo de stage 5 es ResolverTurnoAbiertoAsync (EF, sí dispara ReaderExecuting) — el
+        // El techo en sí está bajo prueba (design: Technical Approach, "≤ 16 round trips", subió
+        // a "≤ 17" en stage-6-turnos-caja design decisión 11, y BAJA a "16" en stage-12 slice 2
+        // (design decisión 2 / task 2.7): una baja tiene que notarse acá y actualizar la
+        // constante a propósito, nunca colarse muda detrás de un "<=". El +1 de stage 6 sobre el
+        // techo de stage 5 es ResolverTurnoAbiertoAsync (EF, sí dispara ReaderExecuting) — el
         // FOR SHARE de EjecutarTransaccionAsync es un DbCommand crudo sobre la conexión
         // subyacente, invisible a este interceptor (misma familia que UpsertStockAsync), así que
-        // no suma un segundo punto.
-        Assert.Equal(17, consultasConPocasLineas);
+        // no suma un segundo punto. El -1 de stage 12 es
+        // ServicioDeVentas.ResolverParametrosDeVentaAsync: tolerancia_pago + vuelto_maximo +
+        // lotes_habilitado ahora resuelven en UNA query batcheada (`WHERE clave IN (...)`) en vez
+        // de las dos separadas de antes de esta etapa — agrega una clave sin agregar un round
+        // trip, y de paso resta uno.
+        Assert.Equal(16, consultasConPocasLineas);
+    }
+
+    // ---- stage-12 slice 2 (design decisión 2 / tasks 2.5-2.6): parametro read batcheado -------
+
+    [Fact]
+    public async Task ElCheckoutResuelveLosTresParametrosDeVentaEnUnaSolaConsultaBatcheada()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutResuelveLosTresParametrosDeVentaEnUnaSolaConsultaBatcheada));
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Parametros Batch", limiteCredito: 1_000_000m);
+
+        var consultasDeParametros = await EmitirYContarConsultasDeParametrosAsync(ctx, idCliente);
+
+        // Spec parametros-operativos: "A Single Batched Query Resolves All Three Keys" —
+        // tolerancia_pago, vuelto_maximo y lotes_habilitado en una sola query
+        // `WHERE clave IN (...)`, nunca tres round trips separados.
+        Assert.Equal(1, consultasDeParametros);
+    }
+
+    /// <summary>Mutation target nombrado por design decisión 2
+    /// (<c>ResolverParametrosDeVentaAsync</c>'s per-clave <c>.Where(p => p.Clave == c.Clave)</c>):
+    /// una fila de <c>tolerancia_pago</c> a nivel punto de venta y una fila de
+    /// <c>vuelto_maximo</c> solo a nivel empresa, mezcladas en el mismo candidate set batcheado.
+    /// <c>ResolucionDeParametros.Resolver</c> filtra por punto de venta pero NO por clave — sin
+    /// el <c>Where</c> por clave, la fila de punto de venta de <c>tolerancia_pago</c> es la
+    /// ÚNICA con <c>id_punto_venta</c> coincidente en todo el candidate set, así que "gana" la
+    /// resolución de <c>vuelto_maximo</c> Y de <c>lotes_habilitado</c> por igual — el vuelto
+    /// pedido acá (20, válido contra el <c>vuelto_maximo</c> real de 25) queda expuesto a esa
+    /// corrupción cruzada.
+    ///
+    /// Evidencia de mutación (mutation-proof-tests regla 2, apply de slice 2): con
+    /// <c>.Where(p => p.Clave == c.Clave)</c> borrado de <c>ResolverParametrosDeVentaAsync</c>
+    /// (reemplazado por <c>candidatos</c> sin filtrar), este test corrió y dio <c>500
+    /// error_interno</c> (rojo) — <c>lotes_habilitado</c> intentó deserializar el valor de
+    /// <c>tolerancia_pago</c> ("15") como <c>bool</c> y tiró <c>JsonException</c> antes de llegar
+    /// a <c>ValidadorDePagos</c>. Revertido el borrado, vuelve a <c>201 Created</c> (verde). No
+    /// se debilitó ninguna otra capa para lograrlo — la prueba llama al endpoint real de punta a
+    /// punta.</summary>
+    [Fact]
+    public async Task ElCheckoutResuelveVueltoMaximoDeEmpresaAunConUnaFilaDePuntoDeVentaDeOtraClave()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutResuelveVueltoMaximoDeEmpresaAunConUnaFilaDePuntoDeVentaDeOtraClave));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-parametros-cruzados", 100m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Parametros Cruzados", limiteCredito: 1_000_000m);
+
+        var ahora = DateTimeOffset.UtcNow;
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            db.Parametros.AddRange(
+                new Parametro
+                {
+                    IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, IdPuntoVenta = null,
+                    Clave = "tolerancia_pago", Valor = "5", CreatedAt = ahora, UpdatedAt = ahora
+                },
+                new Parametro
+                {
+                    IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, IdPuntoVenta = ctx.IdPuntoVenta,
+                    Clave = "tolerancia_pago", Valor = "15", CreatedAt = ahora, UpdatedAt = ahora
+                },
+                new Parametro
+                {
+                    IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, IdPuntoVenta = null,
+                    Clave = "vuelto_maximo", Valor = "25", CreatedAt = ahora, UpdatedAt = ahora
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 120m, null, 20m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+        Assert.Equal(100m, emitido.Total);
+        Assert.Equal(20m, emitido.Pagos[0].Vuelto);
+    }
+
+    private async Task<int> EmitirYContarConsultasDeParametrosAsync(Contexto ctx, int idCliente)
+    {
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, $"parametros-batch-{Guid.NewGuid():N}", 10m);
+
+        var contadorDeParametros = new ContadorDeConsultasSobreTabla("parametros");
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contadorDeParametros)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 10m, null, 0m)],
+            null, null);
+
+        await servicioDeVentas.EmitirAsync(solicitud);
+
+        return contadorDeParametros.Consultas;
+    }
+
+    /// <summary>Igual que <see cref="ContadorDeComandos"/> pero filtrado a los comandos cuyo
+    /// texto referencia una tabla puntual — usado para aislar la query de <c>parametros</c> del
+    /// resto de las que dispara un checkout completo (task 2.6).</summary>
+    private sealed class ContadorDeConsultasSobreTabla(string tabla) : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        private bool Coincide(DbCommand command) =>
+            command.CommandText.Contains(tabla, StringComparison.OrdinalIgnoreCase);
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            if (Coincide(command))
+            {
+                Consultas++;
+            }
+
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (Coincide(command))
+            {
+                Consultas++;
+            }
+
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
     }
 
     private async Task<int> EmitirYContarConsultasAsync(Contexto ctx, int idCliente, int cantidadDeLineas)


### PR DESCRIPTION
## Etapa 12 — Slice 2: Activación

- **\`ReglaDeLotes\`** (Domain, pura, sin DB — patrón \`PoliticaDeRoles\`): orden FEFO (\`es_sin_identificar DESC, fecha_vencimiento ASC, id_lote ASC\`), \`ControlEfectivo\` (AND), \`ElegirFefo\`, \`DerivarCodigo\`, \`Clasificar\`/\`EstaVencido\` (4 estados: vencido/por_vencer/vigente/sin_fecha).
- **\`ParametroConocido\`**: +\`lotes_habilitado\` (bool, false) y +\`dias_alerta_vencimiento\` (int, 30) — sin migración, patrón etapa 10.
- **Batcheo de parámetros en \`ServicioDeVentas\`**: 3 claves en UNA query (\`WHERE clave IN\`) con filtro por clave pre-\`Resolver\` — el hot path baja de 17 a 16 round-trips con el módulo apagado. El filtro por clave es el target de mutación nombrado del design: sin él, la fila PV-scoped de una clave contamina la resolución de otra (probado: \`JsonException\` deserializando \"15\" como bool).

### Nota de tamaño
~539 líneas (~350 de tests) — desborde por profundidad de tests, no alcance; registrado según la regla vigente.

### Tests
Domain 416/416 (+22: ReglaDeLotes 14, ParametroConocido +3, ResolucionDeParametros +5) · Application 257/257 · VentasCheckout 27/27 (query-count exacto = 1 para las 3 claves; presupuesto 16 con igualdad estricta). Evidencia de mutación del filtro por clave registrada en el doc-comment del test y en tasks.md 2.5.

### Judgment-day
Juez B APPROVE r1 (6/6 mutaciones muertas: FEFO order, ElegirFefo saldo≤0, AND→OR, borde de Clasificar, split del batcheo, bump del presupuesto). Juez A REJECT r1 por un MAJOR legítimo: contradicción spec/design en el borde \`fecha == hoy\` — resuelta por decisión 13 del orquestador (fecha inclusiva, \`vencido\` = \`fecha < hoy\` estricto; se enmendó el SPEC, cuyo THEN contradecía la intención de su propio escenario de zona horaria). Juez A APPROVE r2 con verificación por blob-hash de cero drift de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)