### PR TITLE
feat(lotes): servicio de lotes, identidad get-or-create y ABM admin — etapa 12, slice 3

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -367,7 +367,22 @@ get-or-create and reads bounded saldos; `GET/POST /api/stock/lotes` live.
   no pending changes. *(Verified clean before AND after the slice's
   changes — no `Migraciones/`/`Configuraciones/` file touched, per the
   DB CHANGE GATE.)*
-- [ ] 3.12 Run `judgment-day`; fix; re-judge until clean.
+- [x] 3.12 Run `judgment-day`; fix; re-judge until clean. *(FIX 1 — juez A,
+  honestidad documental: doc-comment en `ListarAsync`/`CrearAsync`
+  declarando "hoy" UTC-naive interino por diseño en este slice 3, mismo
+  criterio que `diasAlertaPorDefecto`. FIX 2 — juez B, mutación
+  sobreviviente en `Sugerido` (`ServicioDeLotes.cs:162`): nuevo test con
+  ≥2 lotes fechados de vencimientos distintos + sin-identificar,
+  `sugerido` assertado en las CUATRO filas; mutación aplicada→RED→
+  revertida→GREEN. FIX 3 — juez B, cobertura de `estado` vía HTTP con
+  vencimientos fijos lejanos (`2020-01-15` vencido, `2099-12-31` vigente),
+  independiente de la hora de corrida. FIX 4 — juez B, blind spot: test
+  del código server-derivado (`POST /api/stock/lotes` sin `codigo`).
+  DEUDA MENOR ANOTADA (no en este batch): los caminos de fallo
+  `referencia_invalida`/404 de los endpoints de lotes quedan sin test
+  dedicado — patrón ya cubierto por suites hermanas del repo
+  (`LotesBackstopTests` y equivalentes de otros stocks); no bloquea el
+  merge de este slice.)*
 - [ ] 3.13 Branch `feat/stage12-slice3-servicio-de-lotes` off `main`
   (parent: slices 1+2); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -383,8 +383,14 @@ get-or-create and reads bounded saldos; `GET/POST /api/stock/lotes` live.
   dedicado — patrón ya cubierto por suites hermanas del repo
   (`LotesBackstopTests` y equivalentes de otros stocks); no bloquea el
   merge de este slice.)*
-- [ ] 3.13 Branch `feat/stage12-slice3-servicio-de-lotes` off `main`
-  (parent: slices 1+2); PR; merge stacked-to-main.
+- [x] 3.13 Branch `feat/stage12-slice3-servicio-de-lotes` off `main`
+  (parent: slices 1+2); PR; merge stacked-to-main. *(APPLY-RUN NOTE: round 1
+  double REJECT — judge A: MAJOR, missing honesty doc-comment on the
+  UTC-naive `hoy` behind `LoteListado.Estado`; judge B: MAJOR, the
+  `Sugerido = last-of-order` mutation survived because the only
+  multi-candidate test made first and last coincide, plus `Estado` and
+  derived-código had zero HTTP coverage. Fix batch f21f408/6dee921; round 2
+  double APPROVE with all three re-mutations RED→revert→GREEN.)*
 
 **Test plan**: race backstop (3.5), immutability ×2 (3.6), reserved-código
 (3.7), sin-identificar idempotence (3.8), bounded-query (3.9), role (3.10).

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -287,7 +287,7 @@ suite (2.8).
 get-or-create and reads bounded saldos; `GET/POST /api/stock/lotes` live.
 **Rollback**: revert the branch — no other write site depends on this yet.
 
-- [ ] 3.1 Create `src/Ways.Application/Stock/ServicioDeLotes.cs`:
+- [x] 3.1 Create `src/Ways.Application/Stock/ServicioDeLotes.cs`:
   `ResolverOCrearAsync` — `INSERT ... ON CONFLICT (ux_lotes_articulo_codigo)
   DO UPDATE SET updated_at = lotes.updated_at ... RETURNING id_lote,
   fecha_vencimiento` (no-op `DO UPDATE`, never `DO NOTHING` — design
@@ -297,35 +297,76 @@ get-or-create and reads bounded saldos; `GET/POST /api/stock/lotes` live.
   retry-read loop. `ResolverSinIdentificarAsync`. `LeerSaldosAsync` — one
   query, `lotes ⟕ stock_lotes` bounded to `cantidad <> 0 OR
   es_sin_identificar OR id_lote IN (@lotesPedidos)`. `ListarAsync`,
-  `CrearAsync` (admin alta).
-- [ ] 3.2 Extend `src/Ways.Application/Stock/Contratos.cs`:
+  `CrearAsync` (admin alta). *(APPLY-RUN NOTE: `ResolverOCrearAsync`/
+  `ResolverSinIdentificarAsync` came out `static` — CA1822 (error in
+  `.editorconfig`) forces it, same shape as
+  `ServicioDeStock.InsertarMovimientoStockAsync`/`UpsertStockAsync`; callers
+  from slices 5/7/8/10 invoke them as `ServicioDeLotes.ResolverOCrearAsync(...)`.
+  `IWaysDbContext` gained `DbSet<Lote> Lotes`/`DbSet<StockLote> StockLotes`
+  — Slice 1 mapped them in `WaysDbContext` but never exposed them past
+  Infrastructure; this is the first Application consumer, no migration.)*
+- [x] 3.2 Extend `src/Ways.Application/Stock/Contratos.cs`:
   `SolicitudDeLote`, `LoteListado` (with `Sugerido`).
-- [ ] 3.3 Modify `src/Ways.Api/Endpoints/StockEndpoints.cs`: `GET
+- [x] 3.3 Modify `src/Ways.Api/Endpoints/StockEndpoints.cs`: `GET
   /api/stock/lotes?idPuntoVenta&idArticulo` (`OperacionDePos`, carries
   `sugerido` per `ElegirFefo`); `POST /api/stock/lotes`
   (`GestionDeCatalogo`, admin alta, `409 lote_duplicado`).
-- [ ] 3.4 Modify `ServicioDeLotes.CrearAsync`: reject a client-supplied
+- [x] 3.4 Modify `ServicioDeLotes.CrearAsync`: reject a client-supplied
   `codigo` equal to `ReglaDeLotes.CodigoSinIdentificar` with `400
   codigo_de_lote_reservado`.
-- [ ] 3.5 [P] **`db-error-backstops`**: two concurrent `POST
+- [x] 3.5 [P] **`db-error-backstops`**: two concurrent `POST
   /api/stock/lotes` with the same código ⇒ exactly one `201` + one `409
   lote_duplicado`, SQLSTATE `23505` asserted before the mapping runs.
-- [ ] 3.6 [P] Immutability tests: matching-expiry reuse *(spec: "A second
+  *(APPLY-RUN NOTE: two tests — `DosCrearAsyncConcurrentesDelMismoCodigoChocanConSqlstate23505AntesDelMapeo`
+  calls `ServicioDeLotes.CrearAsync` directly from two independent
+  `WaysDbContext`s and asserts the raw `DbUpdateException`/`PostgresException`
+  (SqlState `23505`, ConstraintName `ux_lotes_articulo_codigo`) BEFORE
+  `ManejadorDeErrores` (HTTP-only) ever runs; `DosPostConcurrentesAApiStockLotesConElMismoCodigoDanExactamenteUnCreadoYUnConflicto`
+  races the real endpoint, asserting exactly one `201` + one `409
+  lote_duplicado`. `mutation-proof-tests` evidence on the second: temporarily
+  deleted the exact-name `ux_lotes_articulo_codigo` arm in
+  `ManejadorDeErrores` — the "_codigo" generic `ClasificarUnicidad` fallback
+  caught it first and returned `codigo_duplicado`, the exact ordering-trap
+  documented in the Slice-1 doc-comment; test went RED
+  (`Expected: "lote_duplicado" / Actual: "codigo_duplicado"`); reverted, back
+  to GREEN across the full `ServicioDeLotesTests`/`Lotes*`/`ManejadorDeErrores*`
+  suite (74/74).)*
+- [x] 3.6 [P] Immutability tests: matching-expiry reuse *(spec: "A second
   reception with a matching expiry reuses the lot")*; conflicting-expiry
   refusal → `409 lote_vencimiento_incompatible` *(spec: "A second reception
   with a conflicting expiry is refused")*.
-- [ ] 3.7 [P] `codigo_de_lote_reservado` test: client supplies
+- [x] 3.7 [P] `codigo_de_lote_reservado` test: client supplies
   `codigo = "SIN-IDENTIFICAR"` → `400`.
-- [ ] 3.8 [P] Sin-identificar idempotence: created once, reused across two
+- [x] 3.8 [P] Sin-identificar idempotence: created once, reused across two
   puntos de venta. *(spec: "The sin-identificar lot is created once and
-  reused")*
-- [ ] 3.9 [P] `LeerSaldosAsync` bounded-query test: returns lots with
+  reused")* *(APPLY-RUN NOTE: `ResolverSinIdentificarAsync` takes no
+  `idPuntoVenta` — the sin-identificar lot is tenant-wide per articulo, not
+  PV-scoped (`lotes` has no PV column) — so the test simulates two
+  independent write sites of two different PVs calling it sequentially on
+  the same raw connection and asserts the same `idLote` both times.)*
+- [x] 3.9 [P] `LeerSaldosAsync` bounded-query test: returns lots with
   nonzero balance + explicitly requested lots + the sin-identificar lot;
-  excludes a zero-balance, non-requested dated lot.
-- [ ] 3.10 [P] Role tests: `POST /api/stock/lotes` rejects a non-Admin
+  excludes a zero-balance, non-requested dated lot. *(APPLY-RUN NOTE: split
+  in two — `GetLotesDevuelveSaldoNoCeroYSinIdentificarExcluyendoUnFechadoDeSaldoCeroNoPedido`
+  end to end via `GET /api/stock/lotes` (also proves the endpoint wiring and
+  the `estado`/`sugerido` projection, dto-contract-honesty); `LeerSaldosAsyncIncluyeUnLoteDeSaldoCeroCuandoFueExplicitamentePedido`
+  calls `ServicioDeLotes.LeerSaldosAsync` directly for the "explicitly
+  requested" branch, which the picker GET route never exercises (no
+  `idsLotePedidos` parameter — only slices 5/7/8/10's writers pass that
+  list). `mutation-proof-tests` evidence, three mutations on the bounded
+  `WHERE` clause in `LeerSaldosAsync`, each run→RED→revert→GREEN: (1)
+  deleted `|| lote.EsSinIdentificar` → sin-identificar-always-included test
+  failed (`Expected: 2 / Actual: 1`); (2) deleted `|| idsLotePedidos.Contains(lote.Id)`
+  → explicitly-requested test failed (empty collection); (3) widened
+  `stockLote != null && stockLote.Cantidad != 0m` to `stockLote != null` →
+  the zero-balance dated lot leaked in (`Expected: 2 / Actual: 3`). All
+  three reverted, full suite back to green (74/74).)*
+- [x] 3.10 [P] Role tests: `POST /api/stock/lotes` rejects a non-Admin
   role.
-- [ ] 3.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+- [x] 3.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(Verified clean before AND after the slice's
+  changes — no `Migraciones/`/`Configuraciones/` file touched, per the
+  DB CHANGE GATE.)*
 - [ ] 3.12 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 3.13 Branch `feat/stage12-slice3-servicio-de-lotes` off `main`
   (parent: slices 1+2); PR; merge stacked-to-main.

--- a/src/Ways.Api/Endpoints/StockEndpoints.cs
+++ b/src/Ways.Api/Endpoints/StockEndpoints.cs
@@ -50,6 +50,25 @@ public static class StockEndpoints
         .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Conteo de inventario (admin-only) — motivo = inventario.");
 
+        // stage-12-lotes-vencimientos (Slice 3, task 3.3, design: API Surface): feed del picker
+        // FEFO — hereda OperacionDePos del grupo, cualquier rol autenticado puede consultarlo.
+        grupo.MapGet("/lotes", async (ServicioDeLotes servicio, int idPuntoVenta, int idArticulo, CancellationToken ct) =>
+        {
+            var lotes = await servicio.ListarAsync(idPuntoVenta, idArticulo, ct);
+            return Results.Ok(lotes);
+        })
+        .WithSummary("Lotes de un artículo en un punto de venta, con saldo, estado y sugerido FEFO.");
+
+        // stage-12-lotes-vencimientos (Slice 3, task 3.3, design: API Surface): alta manual de un
+        // lote — mismo apilado GestionDeCatalogo sobre OperacionDePos que /ajustes.
+        grupo.MapPost("/lotes", async (ServicioDeLotes servicio, SolicitudDeLote solicitud, CancellationToken ct) =>
+        {
+            var lote = await servicio.CrearAsync(solicitud, ct);
+            return Results.Created($"/api/stock/lotes/{lote.IdLote}", lote);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Alta manual de un lote (admin-only) — 409 lote_duplicado si el código ya existe.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -100,6 +100,12 @@ public interface IWaysDbContext
     DbSet<ComprobanteCompra> ComprobantesCompra { get; }
     DbSet<ItemComprobanteCompra> ItemsComprobanteCompra { get; }
 
+    // stage-12-lotes-vencimientos, Slice 3: ServicioDeLotes es el primer consumidor de
+    // Application de estos 2 — Slice 1 solo adelantaba el modelo a la migración (proposal gate
+    // §A/§B).
+    DbSet<Lote> Lotes { get; }
+    DbSet<StockLote> StockLotes { get; }
+
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>
     /// y <c>BeginTransactionAsync</c> no tienen un equivalente más angosto en este proyecto.

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -50,6 +50,7 @@ public static class DependencyInjection
         services.AddScoped<ServicioDeEscaneo>();
         services.AddScoped<ServicioDeVentas>();
         services.AddScoped<ServicioDeStock>();
+        services.AddScoped<ServicioDeLotes>();
 
         // stage-6-turnos-caja, Slice 4: LectorDeMovimientosDelTurno es el único lector de la
         // derivación (design decisión 5), compartido por ServicioDeTurnos.CerrarAsync y

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -1,3 +1,5 @@
+using Ways.Domain.Stock;
+
 namespace Ways.Application.Stock;
 
 /// <summary>
@@ -55,3 +57,22 @@ public sealed record SolicitudDeConteo(int IdPuntoVenta, int IdArticulo, decimal
 /// </summary>
 public sealed record ResultadoConteo(
     int IdPuntoVenta, int IdArticulo, decimal Cantidad, decimal CantidadAnterior, decimal Delta, bool MovimientoRegistrado);
+
+/// <summary>
+/// Cuerpo de <c>POST /api/stock/lotes</c> (stage-12-lotes-vencimientos, Slice 3; design: API
+/// Surface; Interfaces/Contracts). Alta manual de un lote FECHADO — <see cref="Codigo"/> es
+/// opcional (se deriva del vencimiento cuando se omite, <c>ReglaDeLotes.DerivarCodigo</c>) y NO
+/// puede ser el código reservado del lote sin identificar (<c>400
+/// codigo_de_lote_reservado</c>): ese lote solo lo crea la reconciliación, nunca esta vía.
+/// </summary>
+public sealed record SolicitudDeLote(int IdArticulo, string? Codigo, DateOnly FechaVencimiento);
+
+/// <summary>
+/// Fila de <c>GET /api/stock/lotes</c> y resultado de <c>POST /api/stock/lotes</c>
+/// (stage-12-lotes-vencimientos, Slice 3; design decisión 19). <see cref="Sugerido"/> es el pick
+/// FEFO server-computed (<c>ReglaDeLotes.ElegirFefo</c>) — el picker del POS lo renderiza, nunca
+/// lo recalcula.
+/// </summary>
+public sealed record LoteListado(
+    int IdLote, int IdArticulo, string Codigo, DateOnly? FechaVencimiento, bool EsSinIdentificar,
+    decimal Cantidad, EstadoDeVencimiento Estado, bool Sugerido);

--- a/src/Ways.Application/Stock/ServicioDeLotes.cs
+++ b/src/Ways.Application/Stock/ServicioDeLotes.cs
@@ -1,0 +1,248 @@
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+
+namespace Ways.Application.Stock;
+
+/// <summary>
+/// Slice 3 de stage-12-lotes-vencimientos: identidad de lote (get-or-create), saldos acotados
+/// (design decisión 6) y el ABM admin de <c>POST /api/stock/lotes</c>. Los tres escritores reales
+/// del stage (<c>ServicioDeVentas</c>/<c>ServicioDeCompras</c>/<c>ServicioDeStock</c>, slices
+/// 5-10) consumen <see cref="ResolverOCrearAsync"/>/<see cref="ResolverSinIdentificarAsync"/>/
+/// <see cref="LeerSaldosAsync"/> por su propia conexión/transacción — esta clase no abre
+/// transacción propia para esos tres métodos, mismo criterio que
+/// <c>ServicioDeStock.InsertarMovimientoStockAsync</c>/<c>UpsertStockAsync</c> (statements
+/// crudos, sin dueño de la transacción).
+/// </summary>
+public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj)
+{
+    // ---- identidad de lote (design decisión 4/5) -----------------------------------------------
+
+    /// <summary>Get-or-create sobre <c>ux_lotes_articulo_codigo</c> (design decisión 4):
+    /// <c>INSERT ... ON CONFLICT (id_tenant, id_articulo, codigo) WHERE deleted_at IS NULL DO
+    /// UPDATE ... RETURNING</c> — nunca <c>DO NOTHING</c>. La <c>RETURNING</c> toma el lock en el
+    /// mismo statement, así que el chequeo de inmutabilidad de <c>fecha_vencimiento</c> corre BAJO
+    /// ese lock, sin una segunda lectura (sin retry-read loop, la ventana TOCTOU que
+    /// <c>DO NOTHING</c> + <c>SELECT</c> hubiera dejado abierta).</summary>
+    public static async Task<int> ResolverOCrearAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, string? codigo,
+        DateOnly fechaVencimiento, DateTimeOffset momento, CancellationToken ct)
+    {
+        var codigoResuelto = string.IsNullOrWhiteSpace(codigo) ? ReglaDeLotes.DerivarCodigo(fechaVencimiento) : codigo.Trim();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+            "created_at, updated_at) VALUES ($1, $2, $3, $4, false, $5, $6) " +
+            "ON CONFLICT (id_tenant, id_articulo, codigo) WHERE deleted_at IS NULL DO UPDATE " +
+            "SET updated_at = lotes.updated_at " +
+            "RETURNING id_lote, fecha_vencimiento";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, codigoResuelto);
+        AgregarParametro(comando, fechaVencimiento);
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, momento);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            throw new InvalidOperationException("El get-or-create de lote no devolvió ninguna fila.");
+        }
+
+        var idLote = lector.GetInt32(0);
+        var fechaExistente = lector.IsDBNull(1) ? (DateOnly?)null : lector.GetFieldValue<DateOnly>(1);
+
+        // Chequeo de inmutabilidad BAJO el lock que la RETURNING de arriba ya tomó (design
+        // decisión 4; spec: "A Lot's Expiry Is Immutable Once Created") — nunca un retry-read.
+        if (fechaExistente != fechaVencimiento)
+        {
+            throw new ErrorDominio(
+                "lote_vencimiento_incompatible",
+                $"El lote '{codigoResuelto}' del artículo {idArticulo} ya existe con otra fecha de vencimiento.",
+                409);
+        }
+
+        return idLote;
+    }
+
+    /// <summary>Get-or-create del lote "sin identificar" (design decisión 5): mismo shape que
+    /// <see cref="ResolverOCrearAsync"/>, sobre el MISMO índice/conflict target
+    /// (<c>ux_lotes_articulo_codigo</c>) gracias al código reservado
+    /// <see cref="ReglaDeLotes.CodigoSinIdentificar"/> — es lo que serializa la creación
+    /// perezosa de este lote entre dos checkouts concurrentes del mismo artículo nunca recibido,
+    /// en vez de dejar que la carrera caiga en <c>ux_lotes_sin_identificar</c> (exención
+    /// documentada, sin camino de cliente que la dispare, task 1.21).</summary>
+    public static async Task<int> ResolverSinIdentificarAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO lotes (id_tenant, id_articulo, codigo, fecha_vencimiento, es_sin_identificar, " +
+            "created_at, updated_at) VALUES ($1, $2, $3, NULL, true, $4, $5) " +
+            "ON CONFLICT (id_tenant, id_articulo, codigo) WHERE deleted_at IS NULL DO UPDATE " +
+            "SET updated_at = lotes.updated_at " +
+            "RETURNING id_lote";
+
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, ReglaDeLotes.CodigoSinIdentificar);
+        AgregarParametro(comando, momento);
+        AgregarParametro(comando, momento);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El get-or-create del lote sin identificar no devolvió ninguna fila.");
+
+        return Convert.ToInt32(resultado);
+    }
+
+    // ---- saldos (design decisión 6) -------------------------------------------------------------
+
+    /// <summary>UNA query, acotada por decisión 6 a "lotes físicamente presentes, más los que el
+    /// cliente nombró": <c>lotes ⟕ stock_lotes</c> del punto de venta pedido, filtrado a
+    /// <c>cantidad &lt;&gt; 0 OR es_sin_identificar OR id_lote IN (@lotesPedidos)</c>. Nunca
+    /// devuelve TODOS los lotes históricos del artículo (un yogurt recibido semanalmente durante
+    /// tres años son 150 filas por línea de carrito en el camino más caliente del sistema).</summary>
+    public async Task<IReadOnlyList<SaldoDeLote>> LeerSaldosAsync(
+        int idPuntoVenta, IReadOnlyList<int> idsArticulo, IReadOnlyList<int> idsLotePedidos, CancellationToken ct)
+    {
+        if (idsArticulo.Count == 0)
+        {
+            return [];
+        }
+
+        var saldos =
+            from lote in db.Lotes
+            where idsArticulo.Contains(lote.IdArticulo)
+            join stockLote in db.StockLotes.Where(sl => sl.IdPuntoVenta == idPuntoVenta)
+                on lote.Id equals stockLote.IdLote into stockLotesDelLote
+            from stockLote in stockLotesDelLote.DefaultIfEmpty()
+            where (stockLote != null && stockLote.Cantidad != 0m)
+                  || lote.EsSinIdentificar
+                  || idsLotePedidos.Contains(lote.Id)
+            select new SaldoDeLote(
+                lote.IdArticulo, lote.Id, lote.Codigo, lote.EsSinIdentificar, lote.FechaVencimiento,
+                stockLote != null ? stockLote.Cantidad : 0m);
+
+        return await saldos.ToListAsync(ct);
+    }
+
+    // ---- ABM admin (design: API Surface) ----------------------------------------------------------
+
+    /// <summary><c>GET /api/stock/lotes</c> — feed del picker (design decisión 19): reusa la
+    /// misma query acotada de <see cref="LeerSaldosAsync"/> (sin lotes pedidos explícitos, es un
+    /// listado, no una validación) y agrega <c>estado</c>/<c>sugerido</c> server-side — el FEFO
+    /// nunca se recomputa en TypeScript.</summary>
+    public async Task<IReadOnlyList<LoteListado>> ListarAsync(int idPuntoVenta, int idArticulo, CancellationToken ct)
+    {
+        var puntoVenta = await ResolverPuntoVentaAsync(idPuntoVenta, ct);
+        await ResolverArticuloAsync(idArticulo, ct);
+
+        var saldos = await LeerSaldosAsync(idPuntoVenta, [idArticulo], [], ct);
+        var ordenados = ReglaDeLotes.OrdenarFefo(saldos);
+        var sugerido = ReglaDeLotes.ElegirFefo(saldos);
+
+        var hoy = DateOnly.FromDateTime(reloj.Ahora.UtcDateTime);
+        var diasAlerta = await ResolverDiasAlertaAsync(puntoVenta.IdEmpresa, idPuntoVenta, ct);
+
+        return ordenados
+            .Select(s => new LoteListado(
+                s.IdLote, s.IdArticulo, s.Codigo, s.FechaVencimiento, s.EsSinIdentificar, s.Cantidad,
+                ReglaDeLotes.Clasificar(s.FechaVencimiento, hoy, diasAlerta),
+                Sugerido: sugerido is not null && sugerido.Value.IdLote == s.IdLote))
+            .ToList();
+    }
+
+    /// <summary>Alta manual de un lote (design: API Surface, admin-only). A diferencia de
+    /// <see cref="ResolverOCrearAsync"/> (get-or-create silencioso de los escritores de
+    /// negocio), esta vía crea vía EF <c>SaveChangesAsync</c> — una colisión con
+    /// <c>ux_lotes_articulo_codigo</c> es un genuino <c>409 lote_duplicado</c>
+    /// (<c>ManejadorDeErrores</c>, task 1.16), nunca una reutilización silenciosa: un admin que
+    /// da de alta un lote espera que un duplicado le avise, no que la operación se pierda contra
+    /// una fila existente.</summary>
+    public async Task<LoteListado> CrearAsync(SolicitudDeLote solicitud, CancellationToken ct)
+    {
+        await ResolverArticuloAsync(solicitud.IdArticulo, ct);
+
+        var codigoNormalizado = string.IsNullOrWhiteSpace(solicitud.Codigo) ? null : solicitud.Codigo.Trim();
+
+        // Task 3.4 (design decisión 5): el código reservado del lote sin identificar no se puede
+        // dar de alta por esta vía — ese lote SOLO lo crea la reconciliación (slice 4), de forma
+        // perezosa.
+        if (codigoNormalizado is not null
+            && string.Equals(codigoNormalizado, ReglaDeLotes.CodigoSinIdentificar, StringComparison.Ordinal))
+        {
+            throw new ErrorDominio(
+                "codigo_de_lote_reservado",
+                $"'{ReglaDeLotes.CodigoSinIdentificar}' es el código reservado del lote sin identificar; no se puede dar de alta a mano.",
+                400);
+        }
+
+        var codigoResuelto = codigoNormalizado ?? ReglaDeLotes.DerivarCodigo(solicitud.FechaVencimiento);
+        var ahora = reloj.Ahora;
+
+        var lote = new Lote
+        {
+            IdArticulo = solicitud.IdArticulo,
+            Codigo = codigoResuelto,
+            FechaVencimiento = solicitud.FechaVencimiento,
+            EsSinIdentificar = false
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync(ct);
+
+        var hoy = DateOnly.FromDateTime(ahora.UtcDateTime);
+
+        // Sin punto de venta en el request (alta de catálogo, no de un movimiento): el horizonte
+        // de alerta usa el default declarado, no una resolución por empresa — el reporte real
+        // (slice 13) sí resuelve el override de la empresa/PV.
+        var diasAlertaPorDefecto = JsonSerializer.Deserialize<int>(ParametroConocido.DiasAlertaVencimiento.ValorPorDefecto);
+
+        return new LoteListado(
+            lote.Id, lote.IdArticulo, lote.Codigo, lote.FechaVencimiento, lote.EsSinIdentificar, Cantidad: 0m,
+            ReglaDeLotes.Clasificar(lote.FechaVencimiento, hoy, diasAlertaPorDefecto), Sugerido: false);
+    }
+
+    // ---- statements crudos (misma convención que ServicioDeStock/ServicioDeCompras) --------------
+
+    private static void AgregarParametro(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    // ---- validaciones ---------------------------------------------------------------------------
+
+    private async Task<Articulo> ResolverArticuloAsync(int idArticulo, CancellationToken ct) =>
+        await db.Articulos.FirstOrDefaultAsync(a => a.Id == idArticulo, ct)
+            // Mismo criterio que ServicioDeStock.ResolverArticuloAsync: el filtro de EF (+ RLS)
+            // ya deja invisible un artículo de otro tenant, "no existe" y "es de otro tenant"
+            // caen en la misma rama.
+            ?? throw new ErrorDominio("referencia_invalida", $"No existe el artículo {idArticulo}.", 400);
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<int> ResolverDiasAlertaAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == ParametroConocido.DiasAlertaVencimiento.Clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var valorJson = ResolucionDeParametros.Resolver(ParametroConocido.DiasAlertaVencimiento.Clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<int>(valorJson);
+    }
+}

--- a/src/Ways.Application/Stock/ServicioDeLotes.cs
+++ b/src/Ways.Application/Stock/ServicioDeLotes.cs
@@ -152,6 +152,11 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj)
         var ordenados = ReglaDeLotes.OrdenarFefo(saldos);
         var sugerido = ReglaDeLotes.ElegirFefo(saldos);
 
+        // Honestidad documental: "hoy" acá es UTC naive (interino por diseño en este slice 3),
+        // no la zona_horaria del PV. El reporte de vencimientos del slice 13 SÍ resuelve "hoy"
+        // en la zona_horaria del PV (requisito vinculante del spec lotes-y-vencimientos) — este
+        // picker admin no necesita esa precisión, mismo criterio de honestidad que
+        // diasAlertaPorDefecto en CrearAsync.
         var hoy = DateOnly.FromDateTime(reloj.Ahora.UtcDateTime);
         var diasAlerta = await ResolverDiasAlertaAsync(puntoVenta.IdEmpresa, idPuntoVenta, ct);
 
@@ -201,6 +206,10 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj)
         db.Lotes.Add(lote);
         await db.SaveChangesAsync(ct);
 
+        // Honestidad documental: "hoy" acá es UTC naive (interino por diseño en este slice 3),
+        // no la zona_horaria del PV — mismo criterio que ListarAsync. El reporte de
+        // vencimientos del slice 13 SÍ resuelve "hoy" en la zona_horaria del PV (requisito
+        // vinculante del spec lotes-y-vencimientos).
         var hoy = DateOnly.FromDateTime(ahora.UtcDateTime);
 
         // Sin punto de venta en el request (alta de catálogo, no de un movimiento): el horizonte

--- a/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
@@ -1,0 +1,396 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 3 (tasks 3.5-3.10): <c>ServicioDeLotes</c> punta a punta —
+/// la carrera de <c>ux_lotes_articulo_codigo</c> en el alta admin (a diferencia de
+/// <c>LotesBackstopTests</c>, Slice 1, que la prueba con INSERTs crudos sin pasar por
+/// <c>ServicioDeLotes</c>), la inmutabilidad de <c>fecha_vencimiento</c> bajo el lock de
+/// <c>ResolverOCrearAsync</c>, la idempotencia del lote sin identificar, la query acotada de
+/// <c>LeerSaldosAsync</c> (design decisión 6) y el gating de rol de <c>POST /api/stock/lotes</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeLotesTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva);
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora => ahora;
+    }
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lotes-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva);
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    // ---- task 3.5: db-error-backstops — la carrera de ux_lotes_articulo_codigo en el alta admin ---
+
+    /// <summary>Llama a <c>ServicioDeLotes.CrearAsync</c> directamente (sin HTTP, dos
+    /// <c>WaysDbContext</c> independientes) para capturar la excepción CRUDA — el
+    /// <c>DbUpdateException</c>/<c>PostgresException</c> con SQLSTATE <c>23505</c> ANTES de que
+    /// <c>ManejadorDeErrores</c> (que solo corre en el pipeline HTTP) tenga oportunidad de
+    /// traducirlo. A diferencia de <c>ResolverOCrearAsync</c> (design decisión 4, <c>ON CONFLICT
+    /// ... DO UPDATE</c> — nunca choca), esta vía es un <c>INSERT</c> EF plano: un admin que da
+    /// de alta un duplicado tiene que ver un genuino 409, no una reutilización silenciosa.</summary>
+    [Fact]
+    public async Task DosCrearAsyncConcurrentesDelMismoCodigoChocanConSqlstate23505AntesDelMapeo()
+    {
+        var ctx = await PrepararAsync(nameof(DosCrearAsyncConcurrentesDelMismoCodigoChocanConSqlstate23505AntesDelMapeo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-race-app");
+
+        await using var dbA = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        await using var dbB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var servicioA = new ServicioDeLotes(dbA, reloj);
+        var servicioB = new ServicioDeLotes(dbB, reloj);
+
+        var solicitud = new SolicitudDeLote(idArticulo, "L-RACE-APP", new DateOnly(2030, 12, 31));
+
+        var tareaA = servicioA.CrearAsync(solicitud, CancellationToken.None);
+        var tareaB = servicioB.CrearAsync(solicitud, CancellationToken.None);
+
+        // Mismo criterio que LotesBackstopTests: esperar las dos tareas sin que la primera
+        // excepción cancele la espera de la otra.
+        await Task.WhenAll(tareaA.ContinueWith(_ => { }), tareaB.ContinueWith(_ => { }));
+
+        var tareas = new Task[] { tareaA, tareaB };
+        Assert.Equal(1, tareas.Count(t => t.IsCompletedSuccessfully));
+        Assert.Equal(1, tareas.Count(t => t.IsFaulted));
+
+        var tareaFallida = tareas.Single(t => t.IsFaulted);
+        var dbUpdateException = Assert.IsType<DbUpdateException>(tareaFallida.Exception!.InnerException);
+        var postgresException = Assert.IsType<PostgresException>(dbUpdateException.InnerException);
+        Assert.Equal("23505", postgresException.SqlState);
+        Assert.Equal("ux_lotes_articulo_codigo", postgresException.ConstraintName);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var sobrevivientes = await db.Lotes.CountAsync(l => l.IdArticulo == idArticulo && l.Codigo == "L-RACE-APP");
+        Assert.Equal(1, sobrevivientes);
+    }
+
+    /// <summary>El mismo choque, ahora punta a punta contra <c>POST /api/stock/lotes</c> — el
+    /// camino que sí atraviesa <c>ManejadorDeErrores</c> (el "mapeo" de la prueba de arriba).
+    /// task 3.5 completo: exactamente un <c>201</c> y un <c>409 lote_duplicado</c>.</summary>
+    [Fact]
+    public async Task DosPostConcurrentesAApiStockLotesConElMismoCodigoDanExactamenteUnCreadoYUnConflicto()
+    {
+        var ctx = await PrepararAsync(nameof(DosPostConcurrentesAApiStockLotesConElMismoCodigoDanExactamenteUnCreadoYUnConflicto));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-race-http");
+
+        var solicitud = new SolicitudDeLote(idArticulo, "L-RACE-HTTP", new DateOnly(2030, 12, 31));
+
+        var tareaA = ctx.Admin.PostAsJsonAsync("/api/stock/lotes", solicitud);
+        var tareaB = ctx.Admin.PostAsJsonAsync("/api/stock/lotes", solicitud);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        Assert.Equal(1, respuestas.Count(r => r.StatusCode == HttpStatusCode.Created));
+        Assert.Equal(1, respuestas.Count(r => r.StatusCode == HttpStatusCode.Conflict));
+
+        var conflicto = respuestas.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await conflicto.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_duplicado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 3.6: inmutabilidad de fecha_vencimiento bajo el lock de ResolverOCrearAsync -------
+
+    [Fact]
+    public async Task UnaSegundaResolucionConVencimientoCoincidenteReutilizaElLote()
+    {
+        var ctx = await PrepararAsync(nameof(UnaSegundaResolucionConVencimientoCoincidenteReutilizaElLote));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-inmutable-ok");
+
+        await using var conexion = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant);
+        var fecha = new DateOnly(2030, 12, 31);
+        var momento = DateTimeOffset.UtcNow;
+
+        var idLote1 = await ServicioDeLotes.ResolverOCrearAsync(
+            conexion, null, ctx.IdTenant, idArticulo, "L-INM-1", fecha, momento, CancellationToken.None);
+        var idLote2 = await ServicioDeLotes.ResolverOCrearAsync(
+            conexion, null, ctx.IdTenant, idArticulo, "L-INM-1", fecha, momento, CancellationToken.None);
+
+        Assert.Equal(idLote1, idLote2);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var filas = await db.Lotes.CountAsync(l => l.IdArticulo == idArticulo && l.Codigo == "L-INM-1");
+        Assert.Equal(1, filas);
+    }
+
+    [Fact]
+    public async Task UnaSegundaResolucionConVencimientoDistintoEsRechazadaConLoteVencimientoIncompatible()
+    {
+        var ctx = await PrepararAsync(nameof(UnaSegundaResolucionConVencimientoDistintoEsRechazadaConLoteVencimientoIncompatible));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-inmutable-choque");
+
+        await using var conexion = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant);
+        var momento = DateTimeOffset.UtcNow;
+
+        var idLote1 = await ServicioDeLotes.ResolverOCrearAsync(
+            conexion, null, ctx.IdTenant, idArticulo, "L-INM-2", new DateOnly(2030, 12, 31), momento, CancellationToken.None);
+
+        var excepcion = await Assert.ThrowsAsync<ErrorDominio>(() =>
+            ServicioDeLotes.ResolverOCrearAsync(
+                conexion, null, ctx.IdTenant, idArticulo, "L-INM-2", new DateOnly(2031, 1, 15), momento, CancellationToken.None));
+
+        Assert.Equal("lote_vencimiento_incompatible", excepcion.Codigo);
+        Assert.Equal(409, excepcion.EstadoHttp);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var filas = await db.Lotes.CountAsync(l => l.IdArticulo == idArticulo && l.Codigo == "L-INM-2");
+        Assert.Equal(1, filas);
+
+        var fechaGuardada = await db.Lotes.Where(l => l.Id == idLote1).Select(l => l.FechaVencimiento).SingleAsync();
+        Assert.Equal(new DateOnly(2030, 12, 31), fechaGuardada);
+    }
+
+    // ---- task 3.7: código reservado del lote sin identificar en el alta admin ---------------------
+
+    [Fact]
+    public async Task UnCodigoReservadoEnAltaEsRechazadoCon400()
+    {
+        var ctx = await PrepararAsync(nameof(UnCodigoReservadoEnAltaEsRechazadoCon400));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-codigo-reservado");
+
+        var solicitud = new SolicitudDeLote(idArticulo, ReglaDeLotes.CodigoSinIdentificar, new DateOnly(2030, 12, 31));
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/lotes", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("codigo_de_lote_reservado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 3.8: idempotencia del lote sin identificar ------------------------------------------
+
+    /// <summary>Design decisión 5: el código reservado sirve exactamente un target de conflicto
+    /// (<c>ux_lotes_articulo_codigo</c>), así que dos resoluciones — acá, simulando dos escritores
+    /// independientes de dos puntos de venta distintos, ya que el lote sin identificar es
+    /// tenant-wide por artículo, no por PV — convergen en la MISMA fila.</summary>
+    [Fact]
+    public async Task ElLoteSinIdentificarSeCreaUnaVezYSeReusaEntreDosResoluciones()
+    {
+        var ctx = await PrepararAsync(nameof(ElLoteSinIdentificarSeCreaUnaVezYSeReusaEntreDosResoluciones));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-sin-identificar");
+
+        await using var conexion = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant);
+        var momento = DateTimeOffset.UtcNow;
+
+        var idLote1 = await ServicioDeLotes.ResolverSinIdentificarAsync(
+            conexion, null, ctx.IdTenant, idArticulo, momento, CancellationToken.None);
+        var idLote2 = await ServicioDeLotes.ResolverSinIdentificarAsync(
+            conexion, null, ctx.IdTenant, idArticulo, momento, CancellationToken.None);
+
+        Assert.Equal(idLote1, idLote2);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var filas = await db.Lotes.CountAsync(l => l.IdArticulo == idArticulo && l.EsSinIdentificar);
+        Assert.Equal(1, filas);
+    }
+
+    // ---- task 3.9: LeerSaldosAsync acotada (design decisión 6) -------------------------------------
+
+    /// <summary>Punta a punta vía <c>GET /api/stock/lotes</c>: prueba en un solo request el
+    /// endpoint (task 3.3), la cláusula acotada de <c>LeerSaldosAsync</c> (saldo distinto de cero
+    /// + sin-identificar SIEMPRE, sin importar su saldo, EXCLUYENDO un lote fechado de saldo cero
+    /// no pedido) y la proyección server-side de <c>estado</c>/<c>sugerido</c> (design decisión
+    /// 19, dto-contract-honesty: cada campo de <c>LoteListado</c> tiene un destino real acá).
+    /// <c>sugerido</c> demuestra la distinción entre ORDEN de display (sin-identificar primero,
+    /// <c>OrdenarFefo</c>) y PICK real (<c>ElegirFefo</c>, saldo positivo only) — acá el
+    /// sin-identificar tiene saldo cero, así que el lote fechado con saldo es el sugerido pese a
+    /// aparecer segundo en la lista.</summary>
+    [Fact]
+    public async Task GetLotesDevuelveSaldoNoCeroYSinIdentificarExcluyendoUnFechadoDeSaldoCeroNoPedido()
+    {
+        var ctx = await PrepararAsync(nameof(GetLotesDevuelveSaldoNoCeroYSinIdentificarExcluyendoUnFechadoDeSaldoCeroNoPedido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-saldos-acotados");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var loteConSaldo = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-CON-SALDO",
+            FechaVencimiento = new DateOnly(2030, 6, 15), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteSinSaldo = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-SIN-SALDO",
+            FechaVencimiento = new DateOnly(2030, 9, 1), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteSinIdentificar = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = ReglaDeLotes.CodigoSinIdentificar,
+            FechaVencimiento = null, EsSinIdentificar = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.AddRange(loteConSaldo, loteSinSaldo, loteSinIdentificar);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteConSaldo.Id, IdTenant = ctx.IdTenant, Cantidad = 5m
+        });
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteSinSaldo.Id, IdTenant = ctx.IdTenant, Cantidad = 0m
+        });
+        // loteSinIdentificar deliberadamente SIN fila de stock_lotes: decisión 6 lo incluye igual.
+        await db.SaveChangesAsync();
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/stock/lotes?idPuntoVenta={ctx.IdPuntoVenta}&idArticulo={idArticulo}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var lotes = JsonSerializer.Deserialize<List<LoteListado>>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(2, lotes.Count);
+        Assert.DoesNotContain(lotes, l => l.IdLote == loteSinSaldo.Id);
+
+        var conSaldo = lotes.Single(l => l.IdLote == loteConSaldo.Id);
+        Assert.Equal(5m, conSaldo.Cantidad);
+        Assert.False(conSaldo.EsSinIdentificar);
+        Assert.True(conSaldo.Sugerido);
+
+        var sinIdentificar = lotes.Single(l => l.IdLote == loteSinIdentificar.Id);
+        Assert.Equal(0m, sinIdentificar.Cantidad);
+        Assert.True(sinIdentificar.EsSinIdentificar);
+        Assert.False(sinIdentificar.Sugerido);
+    }
+
+    /// <summary>La otra mitad de la cláusula acotada — "más los que el cliente nombró" — que el
+    /// picker HTTP no ejerce (no acepta una lista de lotes pedidos; eso lo consumen los
+    /// escritores de negocio, slices 5-10). Llamada directa a <c>LeerSaldosAsync</c>: un lote
+    /// fechado de saldo CERO aparece si y solo si su id está en <c>idsLotePedidos</c>.</summary>
+    [Fact]
+    public async Task LeerSaldosAsyncIncluyeUnLoteDeSaldoCeroCuandoFueExplicitamentePedido()
+    {
+        var ctx = await PrepararAsync(nameof(LeerSaldosAsyncIncluyeUnLoteDeSaldoCeroCuandoFueExplicitamentePedido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-saldo-pedido");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lotePedidoSaldoCero = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-PEDIDO-CERO",
+            FechaVencimiento = new DateOnly(2030, 3, 1), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteNoPedidoSaldoCero = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-NO-PEDIDO-CERO",
+            FechaVencimiento = new DateOnly(2030, 4, 1), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.AddRange(lotePedidoSaldoCero, loteNoPedidoSaldoCero);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = lotePedidoSaldoCero.Id, IdTenant = ctx.IdTenant, Cantidad = 0m
+        });
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteNoPedidoSaldoCero.Id, IdTenant = ctx.IdTenant, Cantidad = 0m
+        });
+        await db.SaveChangesAsync();
+
+        var reloj = new RelojFijo(ahora);
+        var servicio = new ServicioDeLotes(db, reloj);
+
+        var saldos = await servicio.LeerSaldosAsync(
+            ctx.IdPuntoVenta, [idArticulo], [lotePedidoSaldoCero.Id], CancellationToken.None);
+
+        Assert.Contains(saldos, s => s.IdLote == lotePedidoSaldoCero.Id);
+        Assert.DoesNotContain(saldos, s => s.IdLote == loteNoPedidoSaldoCero.Id);
+    }
+
+    // ---- task 3.10: rol -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsBloqueadoDelAltaDeLotes()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsBloqueadoDelAltaDeLotes));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-vendedor-lote");
+
+        var mailVendedor = $"vendedor-{Guid.NewGuid():N}@ways.test";
+        var altaVendedor = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-lote", mailVendedor, (int)RolConocido.Vendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
+
+        using var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailVendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var solicitud = new SolicitudDeLote(idArticulo, "L-VENDEDOR", new DateOnly(2030, 12, 31));
+        var respuesta = await vendedor.PostAsJsonAsync("/api/stock/lotes", solicitud);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
@@ -393,4 +393,108 @@ public class ServicioDeLotesTests(WaysApiFixture fixture) : IClassFixture<WaysAp
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
+
+    // ---- judgment-day slice 3, FIX 2/FIX 3: sugerido multi-candidato + estado vía HTTP ------------
+
+    /// <summary>FIX 2 (juez B, mutación sobreviviente): siembra TRES lotes fechados con saldo
+    /// positivo y vencimientos fijos distintos, más el sin-identificar, y assertea
+    /// <c>sugerido</c> en las CUATRO filas (regla 6) — no solo en la que gana. Cubre también FIX 3
+    /// (juez B): <c>estado</c> vía HTTP con vencimientos fijos lejanos, independientes de la hora
+    /// de corrida (<c>2020-01-15</c> siempre <c>vencido</c>; <c>2099-12-31</c> siempre
+    /// <c>vigente</c>, muy por fuera del horizonte de alerta de 30 días default — sin ventana de
+    /// flaky en 00-03 UTC; el intermedio <c>2050-06-15</c> no se assertea por estado a propósito).
+    /// <para>Evidencia de mutación (FIX 2): aplicada la mutación del juez B en
+    /// <c>ServicioDeLotes.cs:162</c> (<c>Sugerido: ... ordenados[^1].IdLote == s.IdLote</c> en vez
+    /// de <c>sugerido.Value.IdLote == s.IdLote</c>) el pick pasa a ser la ÚLTIMA fila del orden
+    /// FEFO (sin-identificar primero, después ascendente por vencimiento) — acá
+    /// <c>loteVigente</c> (2099-12-31) en vez de <c>loteVencido</c> (2020-01-15). Build + filtro
+    /// <c>~ServicioDeLotesTests</c> con la mutación aplicada: este test cae RED
+    /// (<c>vencido.Sugerido</c> esperado <c>true</c>/actual <c>false</c>; <c>vigente.Sugerido</c>
+    /// esperado <c>false</c>/actual <c>true</c>). Revertida la mutación, build, mismo filtro:
+    /// GREEN, 10/10.</para></summary>
+    [Fact]
+    public async Task GetLotesConVariosFechadosSugiereSoloElDeVencimientoMasProximoYEstadoEsIndependienteDelReloj()
+    {
+        var ctx = await PrepararAsync(nameof(GetLotesConVariosFechadosSugiereSoloElDeVencimientoMasProximoYEstadoEsIndependienteDelReloj));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-multi-candidato");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var loteVencido = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-MULTI-VENCIDO",
+            FechaVencimiento = new DateOnly(2020, 1, 15), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteMedio = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-MULTI-MEDIO",
+            FechaVencimiento = new DateOnly(2050, 6, 15), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteVigente = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-MULTI-VIGENTE",
+            FechaVencimiento = new DateOnly(2099, 12, 31), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteSinIdentificar = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = ReglaDeLotes.CodigoSinIdentificar,
+            FechaVencimiento = null, EsSinIdentificar = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.AddRange(loteVencido, loteMedio, loteVigente, loteSinIdentificar);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.AddRange(
+            new StockLote { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteVencido.Id, IdTenant = ctx.IdTenant, Cantidad = 5m },
+            new StockLote { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteMedio.Id, IdTenant = ctx.IdTenant, Cantidad = 3m },
+            new StockLote { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteVigente.Id, IdTenant = ctx.IdTenant, Cantidad = 2m });
+        // loteSinIdentificar deliberadamente sin fila de stock_lotes: saldo 0, incluido igual (decisión 6).
+        await db.SaveChangesAsync();
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/stock/lotes?idPuntoVenta={ctx.IdPuntoVenta}&idArticulo={idArticulo}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var lotes = JsonSerializer.Deserialize<List<LoteListado>>(cuerpo, OpcionesJson)!;
+        Assert.Equal(4, lotes.Count);
+
+        var vencido = lotes.Single(l => l.IdLote == loteVencido.Id);
+        var medio = lotes.Single(l => l.IdLote == loteMedio.Id);
+        var vigente = lotes.Single(l => l.IdLote == loteVigente.Id);
+        var sinIdentificar = lotes.Single(l => l.IdLote == loteSinIdentificar.Id);
+
+        // FIX 2: sugerido EXACTAMENTE en el de vencimiento más próximo, false en las otras TRES filas (regla 6).
+        Assert.True(vencido.Sugerido);
+        Assert.False(medio.Sugerido);
+        Assert.False(vigente.Sugerido);
+        Assert.False(sinIdentificar.Sugerido);
+
+        // FIX 3: estado vía HTTP, independiente de la hora de corrida.
+        Assert.Equal(EstadoDeVencimiento.Vencido, vencido.Estado);
+        Assert.Equal(EstadoDeVencimiento.Vigente, vigente.Estado);
+    }
+
+    // ---- judgment-day slice 3, FIX 4: camino de código derivado (blind spot) ----------------------
+
+    /// <summary>spec lotes-y-vencimientos: "A lot is created with a server-derived codigo" — omitir
+    /// <c>codigo</c> en el alta hace que el server lo derive vía <c>ReglaDeLotes.DerivarCodigo</c>
+    /// (ISO del vencimiento). Vencimiento fijo para que el código esperado sea
+    /// determinístico.</summary>
+    [Fact]
+    public async Task PostLotesSinCodigoDerivaElCodigoIsoDelVencimiento()
+    {
+        var ctx = await PrepararAsync(nameof(PostLotesSinCodigoDerivaElCodigoIsoDelVencimiento));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-codigo-derivado");
+
+        var fechaVencimiento = new DateOnly(2031, 3, 7);
+        var solicitud = new SolicitudDeLote(idArticulo, Codigo: null, fechaVencimiento);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/lotes", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        var lote = JsonSerializer.Deserialize<LoteListado>(cuerpo, OpcionesJson)!;
+        Assert.Equal(ReglaDeLotes.DerivarCodigo(fechaVencimiento), lote.Codigo);
+        Assert.Equal("2031-03-07", lote.Codigo);
+    }
 }


### PR DESCRIPTION
## Etapa 12 — Slice 3: Servicio De Lotes

- **\`ServicioDeLotes\`**: \`ResolverOCrearAsync\` con \`ON CONFLICT (columnas) WHERE deleted_at IS NULL DO UPDATE\` no-op + \`RETURNING\` (jamás \`DO NOTHING\`) — el check de inmutabilidad del vencimiento (\`409 lote_vencimiento_incompatible\`) corre BAJO el lock devuelto, sin retry-read ni TOCTOU. \`ResolverSinIdentificarAsync\` serializado por el mismo conflict target con código reservado \`SIN-IDENTIFICAR\`. \`LeerSaldosAsync\` acotada (saldo ≠ 0 ∪ sin-identificar ∪ pedidos).
- **Endpoints**: \`GET /api/stock/lotes\` (OperacionDePos, con \`sugerido\` server-authored por \`ElegirFefo\` y \`estado\`) y \`POST /api/stock/lotes\` (GestionDeCatalogo, \`409 lote_duplicado\`, \`400 codigo_de_lote_reservado\`, código derivado ISO si falta).
- **Sin cambios de schema** (gate cerrado; \`has-pending-model-changes\` limpio).

### Tests (11 de integración nuevos, todos verdes)
Race 23505 con SQLSTATE+ConstraintName asertados (estable 3/3) · inmutabilidad ×2 · reservado · idempotencia sin-identificar cross-PV · bounded-query · roles · **sugerido multi-candidato (regla 6: las 4 filas)** · estado vía HTTP reloj-independiente (2020/2099, jamás por_vencer sin reloj pineado) · código derivado. 7 rondas de evidencia de mutación registradas.

### Judgment-day
Ronda 1: doble REJECT — juez A: MAJOR de honestidad documental (hoy UTC-naive de \`Estado\` sin declarar el diferimiento al slice 13); juez B: MAJOR probado por mutación (\`Sugerido = último del orden\` sobrevivía porque el único test multi-candidato hacía coincidir primero y último) + \`Estado\`/código-derivado sin cobertura HTTP. Fix batch con evidencia por fix; ronda 2 doble APPROVE con las 3 re-mutaciones RED→revert→GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)