### PR TITLE
feat(lotes): recepción de lotes en compras — etapa 12, slice 5

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/specs/comprobantes-compra/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/comprobantes-compra/spec.md
@@ -65,10 +65,16 @@ same transaction MUST resolve (get-or-create) the `lotes` row against
 `ux_lotes_articulo_codigo`, freeze `items_comprobante_compra.id_lote` to it,
 insert the `movimientos_stock` row with that `id_lote`, and upsert
 `stock_lotes` for that lot — all inside the same transaction as the
-aggregate write. A get-or-create race under concurrent confirms MUST be
-resolved via the `23505` backstop on `ux_lotes_articulo_codigo`, translating
-the constraint violation into a reuse of the existing lot rather than a
-failed confirm.
+aggregate write. A get-or-create race under concurrent confirms MUST
+self-resolve atomically: the `ON CONFLICT ... DO UPDATE ... RETURNING`
+statement targets `ux_lotes_articulo_codigo` directly (design decision 4), so
+Postgres serializes the race on the conflict target and the "loser" reuses
+the winner's row — no exception surfaces on this path, and both confirms
+succeed against the same lot. (Amended at slice-5 judgment-day: the original
+wording claimed a `23505` backstop here; empirically no `23505` is ever
+raised on the get-or-create path — that backstop belongs to the admin alta
+path, a plain `INSERT` covered by `lotes-y-vencimientos`'s `409
+lote_duplicado` scenario.)
 (Previously: silent on the lot resolution step — confirm was aggregate-only
 until this stage.)
 
@@ -116,13 +122,14 @@ until this stage.)
 - THEN confirmar is rejected with `409 lote_vencimiento_incompatible` and no
   write occurs
 
-#### Scenario: A concurrent get-or-create race resolves to one lot via the 23505 backstop
+#### Scenario: A concurrent get-or-create race self-resolves to one lot
 - GIVEN two confirms for the same `(articulo 40, codigo_lote "L-002")` race
   each other
 - WHEN both attempt to create the `lotes` row concurrently
-- THEN Postgres raises `23505` for the loser, the backstop translates it
-  into reusing the winner's row, and both confirms succeed against the same
-  lot
+- THEN the `ON CONFLICT` target on `ux_lotes_articulo_codigo` serializes the
+  race inside Postgres, no exception surfaces, exactly one `lotes` row
+  exists afterward, and both confirms succeed against that same lot
+  *(amended at slice-5 judgment-day — see the requirement note above)*
 
 ### Requirement: Anulación Reverses By Contramovimientos, Refused When It Would Go Negative
 

--- a/openspec/changes/stage-12-lotes-vencimientos/specs/lotes-y-vencimientos/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/lotes-y-vencimientos/spec.md
@@ -50,9 +50,20 @@ against.
 - GIVEN an active lot `(articulo 40, codigo "L-001")` already exists
 - WHEN a second lot with the same `(articulo, codigo)` is inserted
   concurrently by two reception requests
-- THEN Postgres raises `23505` on `ux_lotes_articulo_codigo`, get-or-create's
-  backstop translates it to the existing row, and exactly one `lotes` row
-  survives
+- THEN the get-or-create race self-resolves atomically — the
+  `INSERT ... ON CONFLICT (id_tenant, id_articulo, codigo) DO UPDATE ...
+  RETURNING` statement targets `ux_lotes_articulo_codigo` directly, so
+  Postgres serializes the race on the conflict target and the "loser" reuses
+  the winner's row with no exception surfacing on this path; both requests
+  succeed and exactly one `lotes` row survives. (Amended at slice-5
+  judgment-day — decision 14: the original wording claimed a `23505` +
+  backstop translation here; empirically no `23505` is ever raised on the
+  get-or-create path — that backstop belongs to the admin alta path instead
+  (`ServicioDeLotes.CrearAsync`, `POST /api/stock/lotes`, a plain `INSERT`
+  with no `ON CONFLICT`), which still raises a genuine `23505` on
+  `ux_lotes_articulo_codigo` and is still translated to `409 lote_duplicado`
+  by `ManejadorDeErrores` — proven by
+  `ServicioDeLotesTests.DosPostConcurrentesAApiStockLotesConElMismoCodigoDanExactamenteUnCreadoYUnConflicto`.)
 
 ### Requirement: A Lot's Expiry Is Immutable Once Created
 

--- a/openspec/changes/stage-12-lotes-vencimientos/state.yaml
+++ b/openspec/changes/stage-12-lotes-vencimientos/state.yaml
@@ -221,6 +221,16 @@ dependencies:
   verify: [apply]
   archive: [verify]
 decisiones_tomadas:
+  - "14 — SEMANTICA REAL DE LA CARRERA DEL GET-OR-CREATE (resuelta por el orquestador en el
+    judgment-day del slice 5): el escenario del spec de comprobantes-compra prometia
+    '23505 + backstop' para dos confirms concurrentes, pero empiricamente NINGUN 23505
+    surge en ese camino — el ON CONFLICT ... DO UPDATE ... RETURNING apunta directo a
+    ux_lotes_articulo_codigo y Postgres serializa la carrera adentro (design decision 4):
+    el perdedor reusa la fila del ganador sin excepcion. El 23505 real vive en el alta
+    admin (INSERT plano -> 409 lote_duplicado, cubierto en slice 3). Se enmendo el SPEC
+    (requirement + escenario, con nota de auditoria); el codigo y el test empirico del
+    apply quedan como estan. Mismo patron que la decision 13: la implementacion tenia
+    razon, el spec exageraba el mecanismo."
   - "13 — SEMANTICA DE BORDE DEL VENCIMIENTO (resuelta por el orquestador en el judgment-day
     del slice 2): LA FECHA DE VENCIMIENTO ES INCLUSIVA — un lote con fecha_vencimiento == hoy
     NO esta vencido (clasifica por_vencer); vencido = fecha_vencimiento < hoy ESTRICTO

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -632,8 +632,20 @@ balance write in the same transaction. **Rollback**: revert the branch.
   changes have been made to the model since the last migration." Confirmed
   clean both by diff (`Migraciones/`/`Configuraciones/` untouched by this
   slice — verified via `git status`) and by the tool itself.)*
-- [ ] 5.14 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 5.15 Branch `feat/stage12-slice5-recepcion` off `main` (parent:
+- [x] 5.14 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  round 1 double REJECT — judge A: cross-spec contradiction (the sibling
+  lotes-y-vencimientos spec still promised a 23505 on the get-or-create
+  race after decision 14) and the anulación-of-a-lot-tracked-compra hole
+  (aggregate reversed, stock_lotes silently left inflated, 200 OK);
+  judge B: CRITICAL — codigo_lote without fecha via the API returned a raw
+  500 (CHECK unmapped in ManejadorDeErrores, no app guard) — plus the
+  confirm-time expiry re-check had zero test coverage. Fix batch
+  7a507dd/28af7da: two-layer 400 lote_input_incompleto (app guard +
+  ManejadorDeErrores backstop, proven layer by layer), interim 409
+  compra_anulacion_lotes_pendiente guard (slice 6 replaces it), re-check
+  test via owner-connection date mutation, sibling spec amended. Round 2
+  double APPROVE, serialized B→A.)*
+- [x] 5.15 Branch `feat/stage12-slice5-recepcion` off `main` (parent:
   slice 3); PR; merge stacked-to-main.
 
 **Test plan**: invariant 2 (5.5), get-or-create ×3 (5.6-5.8), race backstop

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -650,6 +650,10 @@ expired-reception ×2 (5.12).
 snapshot; refusal checks both the aggregate **and** the lot. **Rollback**:
 revert the branch.
 
+> Note (judgment-day, slice 5, FIX 4): 6.1 must REPLACE the interim 409
+> compra_anulacion_lotes_pendiente guard added at slice-5 judgment-day with
+> the exact per-lot reversal.
+
 - [ ] 6.1 Modify `ServicioDeCompras.cs`: `EjecutarAnulacionAsync` reorders
   `.OrderBy(m => m.IdArticulo).ThenBy(m => m.IdLote)`, copies
   `original.IdLote`; **two** mandatory checks — aggregate `nueva < 0` AND

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -469,47 +469,169 @@ compra's draft carries lot input untouched; confirm resolves (get-or-create)
 lots under the header lock, before the stock loop; per-lot movement and
 balance write in the same transaction. **Rollback**: revert the branch.
 
-- [ ] 5.1 Modify `src/Ways.Application/Compras/ServicioDeCompras.cs`:
+- [x] 5.1 Modify `src/Ways.Application/Compras/ServicioDeCompras.cs`:
   `CrearAsync`/`ActualizarBorradorAsync` pass `codigo_lote`/
   `fecha_vencimiento` straight through `MaterializarItems` — **no
   resolution at draft time** (replace-set semantics would litter `lotes`
-  with never-confirmed rows).
-- [ ] 5.2 Modify `ServicioDeCompras.cs`: validate `fecha_vencimiento` is
+  with never-confirmed rows). *(APPLY-RUN NOTE: `MaterializarItems` gained
+  a third parallel list parameter (`IReadOnlyList<LineaDeCompraSolicitada>
+  solicitudItems`, same order/index as `lineas`/`calculada`) instead of
+  threading `CodigoLote`/`FechaVencimiento` through the Domain
+  `LineaDeCompra`/`CalculadorDeCompra` — the calculator is pure arithmetic
+  and the task list never names it for this slice; `Contratos.cs` gained
+  the two fields on `LineaDeCompraSolicitada` (request) and
+  `CodigoLote`/`FechaVencimiento`/`IdLote` on `ItemDeCompra` (response),
+  both with a documented one-fate trace per `dto-contract-honesty`.)*
+- [x] 5.2 Modify `ServicioDeCompras.cs`: validate `fecha_vencimiento` is
   not in the past on every borrador save/edit → `409
   lote_vencido_en_recepcion` (fires at save time, not only confirm — spec
-  ADDED requirement).
-- [ ] 5.3 Modify `ServicioDeCompras.cs`: `EjecutarConfirmarAsync` gains a
+  ADDED requirement). *(APPLY-RUN NOTE: `ValidarVencimientosDeRecepcion` is
+  a pure, DB-free static check called from `CrearBorradorAsync` and
+  `ActualizarBorradorAsync` before any read — deliberately unconditional on
+  `controla_lote`/`lotes_habilitado` since the CHECK constraint
+  `ck_items_comprobante_compra_lote_input` doesn't gate on effectiveness
+  either and the spec scenario doesn't condition the rejection on it.)*
+- [x] 5.3 Modify `ServicioDeCompras.cs`: `EjecutarConfirmarAsync` gains a
   resolution block between the item read (under the header lock) and the
   stock loop — `lotes` before `stock`, decision 3 — `ORDER BY id_articulo,
   codigo_lote` ascending, `servicioDeLotes.ResolverOCrearAsync` per
   lot-effective item, `item.IdLote` frozen. The stock loop reorders
   `OrderBy(IdArticulo).ThenBy(IdLote)` and writes both caches per line.
-- [ ] 5.4 Modify `ServicioDeCompras.cs`: `EsLoteEfectivo` reads
+  *(APPLY-RUN NOTE: `ServicioDeLotes.ResolverOCrearAsync` is invoked
+  STATICALLY — `ServicioDeLotes.ResolverOCrearAsync(...)`, no injected
+  instance — same criterion as the task 3.1 apply-run note; `ServicioDeLotes`
+  itself was NOT modified, consumed as-is from `main`. The resolution loop
+  also re-checks `EstaVencido` at confirm time (defense-in-depth alongside
+  5.2's save-time check, per the design pseudocode) and throws `400
+  lote_requerido` when a lot-effective item carries no `fecha_vencimiento`
+  at all (not explicitly named by 5.5-5.12 but present in the design
+  pseudocode; covered by an extra test, see 5.6-5.8 note). `item.IdLote`
+  mutations are flushed via one extra `db.SaveChangesAsync(ct)` right after
+  the resolution loop, before the stock loop reads them in memory for
+  ordering — required because `items` is EF-tracked and nothing else in
+  `EjecutarConfirmarAsync` previously called `SaveChangesAsync`.
+  `InsertarMovimientoStockAsync` gained a required `int? idLote` parameter
+  (shared by confirm AND anulación); the anulación call site
+  (`EjecutarAnulacionAsync`, Slice 6's territory) passes `idLote: null`
+  explicitly with a doc-comment — lot-aware anulación is task 6.1, out of
+  this slice's scope. Added `UpsertStockLoteAsync` (same
+  `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` shape as `UpsertStockAsync`)
+  and `AgregarParametroNulo` (first nullable raw-SQL param this class ever
+  sent).)*
+- [x] 5.4 Modify `ServicioDeCompras.cs`: `EsLoteEfectivo` reads
   `controla_lote` per articulo (reused from the existing `costo_nominal`
   context read) plus one parametro resolution — both outside the checkout
-  round-trip budget.
-- [ ] 5.5 [P] Invariant test: `stock_lotes.cantidad = SUM(movimientos with
+  round-trip budget. *(APPLY-RUN NOTE: implemented as an inline filter
+  (`items.Where(i => ReglaDeLotes.ControlEfectivo(...))`) inside the 5.3
+  resolution block rather than a standalone `EsLoteEfectivo` method — no
+  existing `costo_nominal` articulo read survives to confirm time in this
+  codebase (`ResolverContextoAsync`'s `articuloPorId` is a draft-time-only
+  local, discarded before confirm), so this is a FRESH
+  `db.Articulos.Where(a => idsArticulo.Contains(a.Id))` read at confirm,
+  plus `ResolverLotesHabilitadoAsync` (new helper, same
+  `ResolucionDeParametros.Resolver` pattern as
+  `ServicioDeLotes.ResolverDiasAlertaAsync`) for the empresa's
+  `lotes_habilitado`. Both correctly sit outside `ContadorDeComandos`'s
+  budget — `ComprasAnulacionYConcurrenciaTests`'s existing
+  `ConfirmarEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeItems`
+  test (constant-count, not a fixed ceiling) still passes unmodified.)*
+- [x] 5.5 [P] Invariant test: `stock_lotes.cantidad = SUM(movimientos with
   that lot)` holds after a compra. *(spec lotes-y-vencimientos: Stock Lotes
-  Balance And Its Two Invariants — compra leg)*
-- [ ] 5.6 [P] Get-or-create-and-freeze test. *(spec comprobantes-compra:
+  Balance And Its Two Invariants — compra leg)* *(APPLY-RUN NOTE:
+  `StockLotesCantidadEsLaSumaDeSusMovimientosTrasDosCompras` — two
+  confirmed compras of the SAME lot (30 + 20 units) so the SUM check is
+  non-trivial, not a single-movement coincidence.)*
+- [x] 5.6 [P] Get-or-create-and-freeze test. *(spec comprobantes-compra:
   "Confirmar get-or-creates a lot and freezes it onto the item")*
-- [ ] 5.7 [P] Reuse-existing-lot test. *(spec: "Confirmar reuses an
-  existing lot with a matching expiry")*
-- [ ] 5.8 [P] Conflicting-expiry refusal → `409
+  *(APPLY-RUN NOTE: `ConfirmarGetOrCreaUnLoteYLoCongelaSobreElItem`. Also
+  added `ConfirmarRechazaUnItemLoteEfectivoSinFechaDeVencimientoConLoteRequerido`
+  — not named by the slice's test plan but exercises the `lote_requerido`
+  guard task 5.3 implements per the design pseudocode; asserts `400` and
+  full rollback (borrador state, zero movimientos).)*
+- [x] 5.7 [P] Reuse-existing-lot test. *(spec: "Confirmar reuses an
+  existing lot with a matching expiry")* *(APPLY-RUN NOTE:
+  `ConfirmarReusaUnLoteExistenteConVencimientoCoincidente` — the "existing
+  lot" is a REAL prior reception (a first confirmed compra), not a raw-SQL
+  seed, so the reuse path is exercised exactly as production traffic would
+  hit it.)*
+- [x] 5.8 [P] Conflicting-expiry refusal → `409
   lote_vencimiento_incompatible`. *(spec: "Confirmar rejects a conflicting
-  expiry for an existing codigo")*
-- [ ] 5.9 [P] **`db-error-backstops`**: two concurrent confirms racing the
+  expiry for an existing codigo")* *(APPLY-RUN NOTE:
+  `ConfirmarRechazaUnVencimientoEnConflictoParaElMismoCodigo` — asserts full
+  rollback too: the second compra stays `borrador`, `IdLote` stays null,
+  zero movimientos, and the `lotes` table still shows exactly one row for
+  that código (the conflicting insert never landed).)*
+- [x] 5.9 [P] **`db-error-backstops`**: two concurrent confirms racing the
   same `(articulo, codigo_lote)` → SQLSTATE `23505` asserted, backstop
   resolves both confirms to the same lot. *(spec: "A concurrent
   get-or-create race resolves to one lot via the 23505 backstop")*
-- [ ] 5.10 [P] Concurrency test, write-site 2: purchase confirm vs.
+  *(APPLY-RUN NOTE — SPEC INACCURACY FOUND AND DOCUMENTED, code untouched:
+  ran the literal race — `DosConfirmacionesConcurrentesSobreElMismoCodigoDeLoteResuelvenAlMismoLote`,
+  two independent confirms, two independent connections, same
+  `(articulo, codigo_lote)` — against real Postgres. Observed: BOTH
+  confirms return `200 OK`, NO exception of any kind surfaces, both resolve
+  to the SAME `id_lote`, `stock_lotes.cantidad` sums correctly (20). This
+  contradicts the spec scenario's literal claim ("Postgres raises 23505 for
+  the loser, the backstop translates it") but is EXACTLY what design
+  decision 4 documents and what Slice 3's own doc-comment on
+  `DosCrearAsyncConcurrentesDelMismoCodigoChocanConSqlstate23505AntesDelMapeo`
+  already establishes: `ResolverOCrearAsync`'s `ON CONFLICT (id_tenant,
+  id_articulo, codigo) WHERE deleted_at IS NULL DO UPDATE ... RETURNING`
+  target matches `ux_lotes_articulo_codigo` EXACTLY (`LoteConfiguration.cs`),
+  so Postgres resolves the race internally via the INSERT-ON-CONFLICT
+  wait-then-retry protocol — no 23505 is ever raised to the client for
+  THIS conflict target, by design ("There is therefore no retry-read loop
+  in this design, and saying so is more honest than writing one that can
+  never fire"). The higher-level business requirement ("both confirms
+  succeed against the same lot") IS satisfied — just not via a
+  `ManejadorDeErrores` backstop, because none is needed. Recommend the
+  orchestrator amend the spec scenario's mechanism wording in a future
+  pass (same pattern as slice 2's task 2.10 spec amendment) — flagging
+  here rather than editing `specs/comprobantes-compra/spec.md` unilaterally
+  since spec amendment authority was reserved to orchestrator decisions in
+  this stage's prior slices.)*
+- [x] 5.10 [P] Concurrency test, write-site 2: purchase confirm vs.
   checkout of the same articulo+lots, both complete, no `40P01`.
-- [ ] 5.11 [P] Draft-capture test: lot input persists without resolving.
+  *(APPLY-RUN NOTE — SCOPE NARROWED, documented: this worktree has only
+  slices 1-3 merged, so `ServicioDeVentas` (checkout) is NOT yet lot-aware
+  (Slice 7/8, not present) — it cannot race for "the same lot" because it
+  never touches `lotes`/`stock_lotes` at all yet. Implemented
+  `ConfirmarYCheckoutDelMismoArticuloEnParaleloNuncaDan40P01`: races a
+  lot-effective compra confirm (new `lotes`-lock-then-`stock`-lock order)
+  against a checkout of the SAME articulo+PV via TODAY's aggregate-only
+  checkout path — proves the NEW lock step this slice adds to confirm
+  didn't introduce a deadlock against the other major stock writer. No
+  `lotes`-vs-`lotes` cross-write-site contention is possible yet by
+  construction (checkout doesn't hold that lock), so a rendezvous-forced
+  interleave wasn't needed — a plain `Task.WhenAll` against real pool
+  timing was sufficient and honest. The genuine "same lot" joint proof is
+  deferred to whichever of Slice 7/8 lands, mirroring the note-7 cross-slice
+  dependency pattern already used for the checkout-vs-transfer deadlock
+  test in this same tasks.md.)*
+- [x] 5.11 [P] Draft-capture test: lot input persists without resolving.
   *(spec: "A borrador line captures lot input without resolving it")*
-- [ ] 5.12 [P] Expired-reception tests. *(spec: "A reception line with a
-  past expiry is refused", "A future expiry is accepted")*
-- [ ] 5.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  *(APPLY-RUN NOTE: `UnaLineaDeBorradorCapturaElInputDeLoteSinResolverlo` —
+  asserts both the HTTP response AND the raw persisted row, plus zero
+  `lotes`/`movimientos_stock` rows for that código.)*
+- [x] 5.12 [P] Expired-reception tests. *(spec: "A reception line with a
+  past expiry is refused", "A future expiry is accepted")* *(APPLY-RUN
+  NOTE: three tests, not two — past-on-create
+  (`UnaLineaConVencimientoPasadoEsRechazadaAlGuardarElBorrador`),
+  future-on-create
+  (`UnaLineaConVencimientoFuturoEsAceptadaAlGuardarElBorrador`), and
+  past-on-EDIT
+  (`UnaLineaConVencimientoPasadoEsRechazadaAlEditarElBorrador`, spec: "fires
+  when the line is saved OR EDITED") — all with FIXED far dates (2020-01-15
+  past / 2099-12-31 future, per permanent rule 3), no pinned clock, no
+  boundary-day assertion.)*
+- [x] 5.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(APPLY-RUN NOTE: ran via
+  `--project src/Ways.Infrastructure --startup-project src/Ways.Infrastructure`
+  — `Ways.Api` lacks the `Microsoft.EntityFrameworkCore.Design` package
+  reference the tool needs; `Ways.Infrastructure` has it. Output: "No
+  changes have been made to the model since the last migration." Confirmed
+  clean both by diff (`Migraciones/`/`Configuraciones/` untouched by this
+  slice — verified via `git status`) and by the tool itself.)*
 - [ ] 5.14 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 5.15 Branch `feat/stage12-slice5-recepcion` off `main` (parent:
   slice 3); PR; merge stacked-to-main.

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -673,6 +673,17 @@ public class ManejadorDeErrores(
                     "Los importes de un ítem de compra no pueden ser negativos.",
                     "importes_de_item_invalidos"),
 
+            // stage-12-lotes-vencimientos (Slice 5, judgment-day, FIX 1b): backstop de
+            // ck_items_comprobante_compra_lote_input — ServicioDeCompras.ValidarVencimientosDeRecepcion
+            // (guard primario, FIX 1a) ya rechaza esto ANTES de tocar la base en el camino normal
+            // (Crear/ActualizarBorradorAsync); esta rama queda como defensa de esquema pura ante
+            // cualquier camino futuro que la esquive, mismo código de dominio
+            // (lote_input_incompleto) para que el cliente nunca distinga cuál capa lo atajó.
+            "ck_items_comprobante_compra_lote_input" =>
+                (StatusCodes.Status400BadRequest,
+                    "Un ítem con codigo_lote tiene que traer también fecha_vencimiento.",
+                    "lote_input_incompleto"),
+
             _ => null
         };
 }

--- a/src/Ways.Application/Compras/Contratos.cs
+++ b/src/Ways.Application/Compras/Contratos.cs
@@ -4,7 +4,10 @@ namespace Ways.Application.Compras;
 
 /// <summary>Una línea del cuerpo de <c>POST/PUT /api/compras</c> (design: Interfaces/Contracts)
 /// — ningún request lleva <c>cantidad</c>, <c>total</c> ni <c>delta</c> (design decisión 3):
-/// <c>CalculadorDeCompra</c> deriva todo eso server-side.</summary>
+/// <c>CalculadorDeCompra</c> deriva todo eso server-side. <see cref="CodigoLote"/>/<see
+/// cref="FechaVencimiento"/> (etapa 12, slice 5) son input crudo de recepción — se persisten tal
+/// cual mientras la compra es borrador y solo se resuelven contra <c>lotes</c> al confirmar
+/// (design: Write site 2 — "nothing is resolved at draft time").</summary>
 public sealed record LineaDeCompraSolicitada(
     int IdArticulo,
     string Descripcion,
@@ -14,7 +17,9 @@ public sealed record LineaDeCompraSolicitada(
     decimal CostoUnitario,
     decimal Descuento,
     int IdAlicuotaIva,
-    bool ActualizaCosto = true);
+    bool ActualizaCosto = true,
+    string? CodigoLote = null,
+    DateOnly? FechaVencimiento = null);
 
 /// <summary>Cuerpo de <c>POST /api/compras</c> (crea un borrador) y de <c>PUT
 /// /api/compras/{id}</c> (design decisión 2: replace-set completo del header + los items — un
@@ -31,7 +36,10 @@ public sealed record SolicitudDeCompra(
 /// <summary>Un item ya persistido, con su <c>precioSugerido</c> (design: API Surface — "Header +
 /// items + precioSugerido per item"). Sin <c>unidades</c> propio: solo <see cref="Cantidad"/>
 /// (ya derivada) y los dos inputs de auditoría (<see cref="Bultos"/>/<see
-/// cref="UnidadesPorBulto"/>) se persisten (design: Table Shapes — B).</summary>
+/// cref="UnidadesPorBulto"/>) se persisten (design: Table Shapes — B). <see cref="CodigoLote"/>/
+/// <see cref="FechaVencimiento"/> son el input crudo de borrador; <see cref="IdLote"/> es el lote
+/// resuelto (get-or-create), <c>NULL</c> mientras la compra es borrador y para artículos que no
+/// controlan lote (etapa 12, slice 5).</summary>
 public sealed record ItemDeCompra(
     int Orden,
     int IdArticulo,
@@ -45,7 +53,10 @@ public sealed record ItemDeCompra(
     decimal PorcentajeIva,
     decimal Total,
     bool ActualizaCosto,
-    decimal? PrecioSugerido);
+    decimal? PrecioSugerido,
+    string? CodigoLote,
+    DateOnly? FechaVencimiento,
+    int? IdLote);
 
 /// <summary>Detalle completo de una compra — respuesta de <c>GET /api/compras/{id}</c>,
 /// <c>POST /api/compras</c>, <c>PUT /api/compras/{id}</c>, <c>POST …/confirmar</c>.</summary>

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -1,10 +1,12 @@
 using System.Data;
 using System.Data.Common;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Exportacion;
 using Ways.Application.Precios;
+using Ways.Application.Stock;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
@@ -28,6 +30,13 @@ namespace Ways.Application.Compras;
 /// clase (sibling raw SQL), duplicados a propósito del shape de
 /// <c>ServicioDeStock.InsertarMovimientoStockAsync</c>/<c>UpsertStockAsync</c> en vez de
 /// compartir un helper: <c>ServicioDeStock</c> gana esos parámetros recién en Slice 3.
+///
+/// stage-12-lotes-vencimientos, Slice 5 (design: Write site 2 — recepción): <see
+/// cref="ServicioDeLotes"/> se consume por su API pública ESTÁTICA
+/// (<c>ServicioDeLotes.ResolverOCrearAsync</c>, mismo criterio que el APPLY-RUN NOTE de la task
+/// 3.1 — no requiere una instancia inyectada) bajo la misma <c>conexion</c>/<c>transaccionCruda</c>
+/// que ya sostiene el lock del header (design decisión 3: lotes antes que stock). <c>ServicioDeLotes</c>
+/// NO se modifica desde acá — API pública tal como quedó en Slice 3.
 /// </summary>
 public class ServicioDeCompras(
     IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDePrecios servicioDePrecios)
@@ -138,6 +147,11 @@ public class ServicioDeCompras(
         var idEmpleado = contexto.UsuarioId;
         var momento = reloj.Ahora;
 
+        // Etapa 12, slice 5 (spec comprobantes-compra: "Expired Reception Is Refused") — chequeo
+        // puro, sin base de datos, ANTES de cualquier lectura: fecha_vencimiento en el pasado se
+        // rechaza al guardar, no solo al confirmar.
+        ValidarVencimientosDeRecepcion(solicitud.Items, DateOnly.FromDateTime(momento.UtcDateTime));
+
         var (tipo, _, _, _, porcentajePorAlicuota, margenes) = await ResolverContextoAsync(solicitud, ct);
         var (lineas, calculada) = Calcular(solicitud.Items, tipo.DiscriminaIva, porcentajePorAlicuota, margenes);
 
@@ -163,7 +177,7 @@ public class ServicioDeCompras(
         db.ComprobantesCompra.Add(comprobante);
         await db.SaveChangesAsync(ct);
 
-        var itemsEntidad = MaterializarItems(comprobante.Id, idTenant, lineas, calculada, momento);
+        var itemsEntidad = MaterializarItems(comprobante.Id, idTenant, lineas, calculada, solicitud.Items, momento);
         db.ItemsComprobanteCompra.AddRange(itemsEntidad);
         await db.SaveChangesAsync(ct);
 
@@ -178,6 +192,9 @@ public class ServicioDeCompras(
     {
         var idTenant = ExigirTenantDeLaSesion();
         var momento = reloj.Ahora;
+
+        // Etapa 12, slice 5: mismo chequeo que CrearBorradorAsync — un PUT también es un "save".
+        ValidarVencimientosDeRecepcion(solicitud.Items, DateOnly.FromDateTime(momento.UtcDateTime));
 
         var (tipo, _, _, _, porcentajePorAlicuota, margenes) = await ResolverContextoAsync(solicitud, ct);
         var (lineas, calculada) = Calcular(solicitud.Items, tipo.DiscriminaIva, porcentajePorAlicuota, margenes);
@@ -229,7 +246,7 @@ public class ServicioDeCompras(
         comprobante.Total = calculada.Total;
         comprobante.UpdatedAt = momento;
 
-        var itemsNuevos = MaterializarItems(id, idTenant, lineas, calculada, momento);
+        var itemsNuevos = MaterializarItems(id, idTenant, lineas, calculada, solicitud.Items, momento);
         db.ItemsComprobanteCompra.AddRange(itemsNuevos);
 
         await db.SaveChangesAsync(ct);
@@ -350,15 +367,84 @@ public class ServicioDeCompras(
         var tipo = await db.TiposComprobante.FirstAsync(t => t.Id == encabezado.IdTipoComprobante, ct);
         var discriminaIva = tipo.DiscriminaIva;
 
-        // 3. Un movimiento + upsert de stock por item, orden ascendente id_articulo (design:
-        // Transactions — lock order discipline).
-        foreach (var item in items)
+        // 2.b Resolución de lotes (etapa 12, slice 5; design decisión 3: lotes ANTES que stock) —
+        // bajo el MISMO lock del header que el paso 1 ya tomó, antes del primer lock de stock del
+        // paso 3. Orden ascendente (id_articulo, codigo_lote) para que dos confirmaciones
+        // concurrentes que comparten códigos de lote tomen esas filas en el mismo orden.
+        var idsArticulo = items.Select(i => i.IdArticulo).Distinct().ToList();
+
+        // EsLoteEfectivo necesita controla_lote por artículo y lotes_habilitado de la empresa del
+        // encabezado — ambos FUERA del presupuesto de comandos del checkout (design: Write site
+        // 2), esta clase no comparte ese presupuesto.
+        var idEmpresa = await db.PuntosVenta
+            .Where(pv => pv.Id == encabezado.IdPuntoVenta)
+            .Select(pv => pv.IdEmpresa)
+            .FirstAsync(ct);
+        var controlaLotePorArticulo = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, a => a.ControlaLote, ct);
+        var lotesHabilitado = await ResolverLotesHabilitadoAsync(idEmpresa, encabezado.IdPuntoVenta, ct);
+
+        // Honestidad documental: "hoy" acá es UTC naive (interino por diseño, mismo criterio que
+        // ServicioDeLotes.ListarAsync/CrearAsync — slice 3) y no la zona_horaria del PV. El
+        // reporte de vencimientos (slice 13) SÍ resuelve "hoy" en la zona_horaria del PV; este
+        // rechequeo de confirmación no necesita esa precisión.
+        var hoy = DateOnly.FromDateTime(momento.UtcDateTime);
+
+        var itemsLoteEfectivos = items
+            .Where(i => ReglaDeLotes.ControlEfectivo(controlaLotePorArticulo.GetValueOrDefault(i.IdArticulo), lotesHabilitado))
+            .OrderBy(i => i.IdArticulo)
+            .ThenBy(i => i.CodigoLote);
+
+        foreach (var item in itemsLoteEfectivos)
+        {
+            if (item.FechaVencimiento is null)
+            {
+                throw new ErrorDominio(
+                    "lote_requerido",
+                    $"El artículo {item.IdArticulo} controla lote; la línea necesita codigo_lote/fecha_vencimiento para confirmarse.",
+                    400);
+            }
+
+            // Rechequeo al confirmar (spec: "This check MUST fire when the line is saved or
+            // edited, not only at confirm") — el guardado del borrador ya lo probó una vez, pero
+            // el reloj pudo avanzar entre el último save y este confirm.
+            if (ReglaDeLotes.EstaVencido(item.FechaVencimiento, hoy))
+            {
+                throw new ErrorDominio(
+                    "lote_vencido_en_recepcion",
+                    $"La fecha de vencimiento del artículo {item.IdArticulo} ya pasó; una recepción no puede " +
+                    "ingresar mercadería vencida.",
+                    409);
+            }
+
+            item.IdLote = await ServicioDeLotes.ResolverOCrearAsync(
+                conexion, transaccionCruda, idTenant, item.IdArticulo, item.CodigoLote, item.FechaVencimiento.Value,
+                momento, ct);
+        }
+
+        // Congela item.IdLote (entidades trackeadas por el read set del paso 2) antes del loop de
+        // stock, que lo lee en memoria para el orden y el upsert — sin esto los UPDATEs de
+        // id_lote nunca se emitirían.
+        await db.SaveChangesAsync(ct);
+
+        // 3. Un movimiento + upsert de stock por item, orden ascendente (id_articulo, id_lote)
+        // (design decisión 8/9; Transactions — lock order discipline). El upsert agregado corre
+        // SIEMPRE, lot-effective o no (byte-idéntico al camino previo a esta etapa cuando no lo
+        // es); el upsert de stock_lotes solo cuando el item resolvió un lote.
+        foreach (var item in items.OrderBy(i => i.IdArticulo).ThenBy(i => i.IdLote))
         {
             await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, idTenant, item.IdArticulo, encabezado.IdPuntoVenta, item.Cantidad,
-                MotivoStock.Compra, id, idEmpleado, momento, ct);
+                MotivoStock.Compra, id, idEmpleado, momento, item.IdLote, ct);
 
             await UpsertStockAsync(conexion, transaccionCruda, idTenant, item.IdArticulo, encabezado.IdPuntoVenta, item.Cantidad, ct);
+
+            if (item.IdLote is { } idLote)
+            {
+                await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, item.IdArticulo, encabezado.IdPuntoVenta, idLote, item.Cantidad, ct);
+            }
         }
 
         // 4. costo_nominal — solo actualiza_costo AND costo_unitario > 0, deduplicado con el
@@ -445,9 +531,13 @@ public class ServicioDeCompras(
         {
             var inversa = -original.Cantidad;
 
+            // idLote: null acá a propósito — la anulación lot-aware (copiar original.IdLote,
+            // upsert de stock_lotes, chequeo de negativo por lote) es Slice 6 (task 6.1), fuera
+            // del scope de este slice. Este slice solo agrega el parámetro compartido por
+            // InsertarMovimientoStockAsync para no romper la firma del confirmar.
             await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa,
-                MotivoStock.Anulacion, id, idEmpleado, momento, ct);
+                MotivoStock.Anulacion, id, idEmpleado, momento, idLote: null, ct);
 
             var nueva = await UpsertStockAsync(
                 conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
@@ -593,14 +683,14 @@ public class ServicioDeCompras(
     private static async Task InsertarMovimientoStockAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
         decimal cantidad, MotivoStock motivo, int idComprobanteCompra, int idEmpleado, DateTimeOffset creadoEl,
-        CancellationToken ct)
+        int? idLote, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccion;
         comando.CommandText =
             "INSERT INTO movimientos_stock " +
-            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_compra, id_empleado, creado_el) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
+            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_compra, id_empleado, creado_el, id_lote) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
 
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, idArticulo);
@@ -610,6 +700,7 @@ public class ServicioDeCompras(
         AgregarParametro(comando, idComprobanteCompra);
         AgregarParametro(comando, idEmpleado);
         AgregarParametro(comando, creadoEl);
+        AgregarParametroNulo(comando, idLote);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -634,6 +725,36 @@ public class ServicioDeCompras(
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock no devolvió ninguna fila.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    /// <summary>Etapa 12, slice 5 (design: Write site 2 — "UpsertStockLoteAsync: la MISMA forma
+    /// que UpsertStockAsync, una clave más") — sibling raw SQL propio de esta clase, mismo shape
+    /// que <c>ServicioDeVentas.UpsertStockLoteAsync</c> (Slice 8) y
+    /// <c>ServicioDeLotes.ResolverOCrearAsync</c> (Slice 3): <c>INSERT ... ON CONFLICT DO UPDATE
+    /// ... RETURNING</c>, nunca <c>DO NOTHING</c>.</summary>
+    private static async Task<decimal> UpsertStockLoteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        int idLote, decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta, id_lote) DO UPDATE " +
+            "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idLote);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, delta);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El upsert de stock_lotes no devolvió ninguna fila.");
 
         return Convert.ToDecimal(resultado);
     }
@@ -671,6 +792,16 @@ public class ServicioDeCompras(
     {
         var parametro = comando.CreateParameter();
         parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    /// <summary>Mismo criterio que <c>ServicioDeStock.AgregarParametroNulo</c> — <c>id_lote</c> es
+    /// el primer parámetro nullable que esta clase envía por statement crudo (etapa 12, slice 5);
+    /// <see cref="AgregarParametro"/> nunca necesitó <c>DBNull.Value</c> hasta ahora.</summary>
+    private static void AgregarParametroNulo(DbCommand comando, object? valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor ?? DBNull.Value;
         comando.Parameters.Add(parametro);
     }
 
@@ -753,8 +884,15 @@ public class ServicioDeCompras(
         return (lineas, calculada);
     }
 
+    /// <summary>Etapa 12, slice 5 (design: Write site 2 — "codigo_lote y fecha_vencimiento pasan
+    /// derecho por MaterializarItems, sin resolución"): <paramref name="solicitudItems"/> viaja en
+    /// paralelo a <paramref name="lineas"/>/<paramref name="calculada"/> (mismo orden, mismo
+    /// índice — <c>Calcular</c> los produjo a partir de la misma lista) solo para llevar el input
+    /// crudo de lote hasta la entidad; <c>CalculadorDeCompra</c> (Domain, aritmética pura) no
+    /// necesita saber que existen.</summary>
     private static List<ItemComprobanteCompra> MaterializarItems(
-        int idComprobante, int idTenant, IReadOnlyList<LineaDeCompra> lineas, CompraCalculada calculada, DateTimeOffset momento)
+        int idComprobante, int idTenant, IReadOnlyList<LineaDeCompra> lineas, CompraCalculada calculada,
+        IReadOnlyList<LineaDeCompraSolicitada> solicitudItems, DateTimeOffset momento)
     {
         var items = new List<ItemComprobanteCompra>(lineas.Count);
 
@@ -762,6 +900,7 @@ public class ServicioDeCompras(
         {
             var linea = lineas[i];
             var item = calculada.Items[i];
+            var solicitudItem = solicitudItems[i];
 
             items.Add(new ItemComprobanteCompra
             {
@@ -780,12 +919,35 @@ public class ServicioDeCompras(
                 Total = item.Total,
                 ActualizaCosto = linea.ActualizaCosto,
                 PrecioSugerido = item.PrecioSugerido,
+                CodigoLote = NormalizarOpcional(solicitudItem.CodigoLote),
+                FechaVencimiento = solicitudItem.FechaVencimiento,
                 CreatedAt = momento,
                 UpdatedAt = momento
             });
         }
 
         return items;
+    }
+
+    /// <summary>Chequeo puro (spec comprobantes-compra: "Expired Reception Is Refused") — corre
+    /// ANTES de cualquier lectura de base de datos, en cada guardado de borrador (creación o
+    /// edición), no solo al confirmar. Deliberadamente incondicional a <c>controla_lote</c>: el
+    /// esquema (<c>ck_items_comprobante_compra_lote_input</c>) ya permite que cualquier línea
+    /// cargue <c>fecha_vencimiento</c>, y el spec no condiciona este rechazo a que el artículo sea
+    /// lot-effective en ese momento.</summary>
+    private static void ValidarVencimientosDeRecepcion(IReadOnlyList<LineaDeCompraSolicitada> items, DateOnly hoy)
+    {
+        foreach (var item in items)
+        {
+            if (item.FechaVencimiento is { } fecha && ReglaDeLotes.EstaVencido(fecha, hoy))
+            {
+                throw new ErrorDominio(
+                    "lote_vencido_en_recepcion",
+                    $"La fecha de vencimiento del artículo {item.IdArticulo} ya pasó; una recepción no puede " +
+                    "ingresar mercadería vencida.",
+                    409);
+            }
+        }
     }
 
     private async Task<TipoComprobante> ResolverTipoDeCompraAsync(int idTipoComprobante, CancellationToken ct)
@@ -814,6 +976,21 @@ public class ServicioDeCompras(
         await db.ComprobantesCompra.FirstOrDefaultAsync(c => c.Id == id, ct)
             ?? throw ErrorDominio.NoEncontrado($"No existe la compra {id}.");
 
+    /// <summary>Etapa 12, slice 5 — mismo patrón que
+    /// <c>ServicioDeLotes.ResolverDiasAlertaAsync</c> (Slice 3): una query filtrada por clave y
+    /// empresa, delegando la precedencia PV &gt; empresa a <c>ResolucionDeParametros.Resolver</c>.
+    /// Fuera del presupuesto de comandos del checkout — esta clase no lo comparte.</summary>
+    private async Task<bool> ResolverLotesHabilitadoAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == ParametroConocido.LotesHabilitado.Clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var valorJson = ResolucionDeParametros.Resolver(ParametroConocido.LotesHabilitado.Clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<bool>(valorJson);
+    }
+
     private static string? NormalizarOpcional(string? valor)
     {
         var limpio = valor?.Trim();
@@ -835,6 +1012,6 @@ public class ServicioDeCompras(
             .Select(i => new ItemDeCompra(
                 i.Orden, i.IdArticulo, i.Descripcion, i.Cantidad, i.Bultos, i.UnidadesPorBulto,
                 i.CostoUnitario, i.Descuento, i.IdAlicuotaIva, i.PorcentajeIva, i.Total, i.ActualizaCosto,
-                i.PrecioSugerido))
+                i.PrecioSugerido, i.CodigoLote, i.FechaVencimiento, i.IdLote))
             .ToList());
 }

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -520,6 +520,23 @@ public class ServicioDeCompras(
             throw new ErrorDominio("compra_no_confirmada", "La compra no está confirmada.", 409);
         }
 
+        // 1.b Guard interino de anulación con lotes (etapa 12, slice 5, judgment-day FIX 4):
+        // la reversa de acá abajo (paso 2) solo revierte el agregado (movimientos_stock/stock) —
+        // si algún item de esta compra resolvió un lote, dejar stock_lotes sin revertir
+        // corrompería el invariante 2 en silencio (200 OK con stock_lotes inflado). Preferible
+        // rechazar que corromper: interino hasta que slice 6 (task 6.1) implemente la reversa
+        // EXACTA por lote y reemplace este guard.
+        var tieneItemsConLote = await db.ItemsComprobanteCompra
+            .AnyAsync(i => i.IdComprobanteCompra == id && i.IdLote != null, ct);
+        if (tieneItemsConLote)
+        {
+            throw new ErrorDominio(
+                "compra_anulacion_lotes_pendiente",
+                "Esta compra tiene ítems con lote resuelto; la anulación con reversa exacta por lote " +
+                "todavía no está implementada (queda para slice 6).",
+                409);
+        }
+
         // 2. El ledger ORIGINAL, nunca recalculado desde items (design: doc-comment de
         // ServicioDeVentas.AnularAsync, mismo criterio acá).
         var movimientosOriginales = await db.MovimientosStock
@@ -934,11 +951,27 @@ public class ServicioDeCompras(
     /// edición), no solo al confirmar. Deliberadamente incondicional a <c>controla_lote</c>: el
     /// esquema (<c>ck_items_comprobante_compra_lote_input</c>) ya permite que cualquier línea
     /// cargue <c>fecha_vencimiento</c>, y el spec no condiciona este rechazo a que el artículo sea
-    /// lot-effective en ese momento.</summary>
+    /// lot-effective en ese momento.
+    ///
+    /// Guard primario (judgment-day, slice 5, FIX 1a): un <c>codigo_lote</c> no vacío sin
+    /// <c>fecha_vencimiento</c> jamás puede resolver a un lote válido (<c>ResolverOCrearAsync</c>
+    /// exige fecha) — se rechaza acá, ANTES de tocar la base, con el mismo código
+    /// (<c>lote_input_incompleto</c>) que el backstop de esquema
+    /// <c>ck_items_comprobante_compra_lote_input</c> traduce en <c>ManejadorDeErrores</c> por si
+    /// algún camino futuro esquiva este guard.</summary>
     private static void ValidarVencimientosDeRecepcion(IReadOnlyList<LineaDeCompraSolicitada> items, DateOnly hoy)
     {
         foreach (var item in items)
         {
+            if (!string.IsNullOrWhiteSpace(item.CodigoLote) && item.FechaVencimiento is null)
+            {
+                throw new ErrorDominio(
+                    "lote_input_incompleto",
+                    $"El artículo {item.IdArticulo} trae codigo_lote sin fecha_vencimiento; ambos son " +
+                    "requeridos juntos.",
+                    400);
+            }
+
             if (item.FechaVencimiento is { } fecha && ReglaDeLotes.EstaVencido(fecha, hoy))
             {
                 throw new ErrorDominio(

--- a/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Ways.Application.Abstracciones;
 using Ways.Application.Compras;
 using Ways.Application.Organizacion;
@@ -174,6 +175,9 @@ public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixtur
         Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
         return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
     }
+
+    private static async Task<HttpResponseMessage> AnularRawAsync(Contexto ctx, int id) =>
+        await ctx.Admin.PostAsync($"/api/compras/{id}/anular", null);
 
     // ---- task 5.5: invariante — stock_lotes.cantidad = SUM(movimientos con ese lote) -----------
 
@@ -491,5 +495,148 @@ public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixtur
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    // ---- judgment-day (juez B) FIX 1: codigo_lote sin fecha vía API nunca da 500 -------------------
+
+    /// <summary>Guard de aplicación (<c>ValidarVencimientosDeRecepcion</c>, FIX 1a) — corre en
+    /// <c>CrearBorradorAsync</c>, ANTES de cualquier lectura de base, así que nunca llega siquiera
+    /// a ejercitar el backstop de esquema (<c>ck_items_comprobante_compra_lote_input</c>, FIX 1b)
+    /// en el camino normal.</summary>
+    [Fact]
+    public async Task CrearBorradorConCodigoDeLoteSinFechaDeVencimientoDa400LoteInputIncompletoNunca500()
+    {
+        var ctx = await PrepararAsync(nameof(CrearBorradorConCodigoDeLoteSinFechaDeVencimientoDa400LoteInputIncompletoNunca500));
+
+        var respuesta = await CrearBorradorRawAsync(ctx, SolicitudConLote(ctx, "L-SIN-FECHA", null));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.BadRequest, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_input_incompleto", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesCompra.CountAsync(c => c.IdProveedor == ctx.IdProveedor));
+    }
+
+    // ---- judgment-day (juez B) FIX 2: re-check de vencido al confirmar, borrador que vence entre save y confirm ----
+
+    /// <summary>El borrador se guarda con una fecha FUTURA válida (pasa el guard de
+    /// <c>CrearBorradorAsync</c>), y después se muta esa fecha a PASADA directo en la base vía la
+    /// conexión owner de la fixture — esquivando <c>ValidarVencimientosDeRecepcion</c> a propósito
+    /// (esa validación solo corre en <c>Crear/ActualizarBorradorAsync</c>, nunca en un UPDATE
+    /// crudo), simulando el borrador que vence ENTRE el save y el confirm (spec: "This check MUST
+    /// fire when the line is saved or edited, not only at confirm" — el rechequeo de
+    /// <c>EjecutarConfirmarAsync</c>, ~líneas 409-419, es la otra mitad de esa garantía).</summary>
+    [Fact]
+    public async Task ConfirmarRechazaUnLoteQueVencioEntreElSaveYElConfirm()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarRechazaUnLoteQueVencioEntreElSaveYElConfirm));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-VENCE-ENTRE", VencimientoLejanoFuturo));
+
+        await using (var owner = new NpgsqlConnection(fixture.OwnerConnectionString))
+        {
+            await owner.OpenAsync();
+            await using var comando = owner.CreateCommand();
+            comando.CommandText =
+                "UPDATE items_comprobante_compra SET fecha_vencimiento = $1 WHERE id_comprobante_compra = $2";
+            comando.Parameters.Add(new NpgsqlParameter { Value = VencimientoLejanoPasado });
+            comando.Parameters.Add(new NpgsqlParameter { Value = creada.Id });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        var respuesta = await ConfirmarRawAsync(ctx, creada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_vencido_en_recepcion", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    // ---- judgment-day (juez A, MUST-FIX F2) FIX 4: guard interino de anulación con lotes ----------
+
+    /// <summary>Guard interino conservador (<c>EjecutarAnulacionAsync</c>, ~línea 531) — la reversa
+    /// de esta slice es agregado-only (design: doc-comment de la clase, "idLote: null acá a
+    /// propósito"), así que anular una compra con ítems con lote resuelto se rechaza ANTES de
+    /// tocar nada, en vez de dejar <c>stock_lotes</c> inflado en silencio. Slice 6 (task 6.1)
+    /// reemplaza este guard por la reversa exacta por lote.</summary>
+    [Fact]
+    public async Task AnularUnaCompraConLoteResueltoEsRechazadaSinRevertirNada()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaCompraConLoteResueltoEsRechazadaSinRevertirNada));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-ANULACION", VencimientoLejanoFuturo, unidades: 12m));
+        var confirmada = await ConfirmarAsync(ctx, creada.Id);
+        Assert.NotNull(confirmada.Items[0].IdLote);
+
+        var respuesta = await AnularRawAsync(ctx, creada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("compra_anulacion_lotes_pendiente", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Aserción completa: NADA se revirtió — ni el estado, ni stock, ni stock_lotes, ni
+        // movimientos_stock.
+        Assert.Equal(EstadoCompra.Confirmada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(
+            0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion));
+
+        var cantidadStock = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(12m, cantidadStock);
+
+        var idLote = confirmada.Items[0].IdLote!.Value;
+        var cantidadStockLote = await db.StockLotes
+            .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(12m, cantidadStockLote);
+    }
+
+    /// <summary>Regresión del guard interino de FIX 4: un artículo que NO controla lote (mismo
+    /// tenant, módulo de lotes ON a nivel empresa) sigue confirmando y anulando byte-idéntico al
+    /// camino agregado-only previo a esta etapa — <c>item.IdLote</c> nunca se pobla, así que el
+    /// guard nuevo nunca dispara.</summary>
+    [Fact]
+    public async Task AnularUnaCompraDeUnArticuloQueNoControlaLoteSigueFuncionando()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaCompraDeUnArticuloQueNoControlaLoteSigueFuncionando));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idArea = await db.Areas.Where(a => a.IdTenant == ctx.IdTenant).Select(a => a.Id).FirstAsync();
+        var articuloSinLote = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"sin-lote-{Guid.NewGuid():N}", Nombre = "Articulo sin lote",
+            IdArea = idArea, IdAlicuotaIva = ctx.IdAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articuloSinLote);
+        await db.SaveChangesAsync();
+
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, $"NE-{Guid.NewGuid():N}", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(articuloSinLote.Id, "Item sin lote", 8m, null, null, 50m, 0m, ctx.IdAlicuotaIva21, true)]);
+
+        var creada = await CrearBorradorAsync(ctx, solicitud);
+        var confirmada = await ConfirmarAsync(ctx, creada.Id);
+        Assert.Null(confirmada.Items[0].IdLote);
+
+        var respuesta = await AnularRawAsync(ctx, creada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var dbFinal = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Anulada, (await dbFinal.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        var cantidad = await dbFinal.Stock
+            .Where(s => s.IdArticulo == articuloSinLote.Id && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(0m, cantidad);
     }
 }

--- a/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
@@ -1,0 +1,495 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 5 (tasks 5.5-5.12): recepción de lotes vía
+/// <c>ServicioDeCompras</c> punta a punta — el invariante de saldo (compra leg), el get-or-create
+/// bajo el lock del header (creación/reuso/conflicto), la carrera de dos confirmaciones sobre el
+/// mismo <c>(articulo, codigo_lote)</c>, la concurrencia confirmar-vs-checkout, la captura de
+/// borrador sin resolver, y el rechazo de recepción vencida en cada guardado.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    // Regla permanente 3: fechas de vencimiento FIJAS y lejanas — independientes del reloj de la
+    // corrida. El borde "hoy" no se asserta acá (no hay reloj pineado en los tests HTTP).
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+    private static readonly DateOnly VencimientoLejanoFuturoAlterno = new(2098, 6, 30);
+    private static readonly DateOnly VencimientoLejanoPasado = new(2020, 1, 15);
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticuloLote,
+        int IdAlicuotaIva21, int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Recepcion-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articuloLote = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-lote-{Guid.NewGuid():N}", Nombre = "Articulo con lote",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articuloLote);
+        await db.SaveChangesAsync();
+
+        // Etapa 12: módulo de lotes ON a nivel empresa — sin este flag, ControlEfectivo nunca da
+        // true y el confirmar corre byte-idéntico al camino previo a esta etapa (spec
+        // lotes-y-vencimientos: "Effective Lot Control").
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.IdTenant == resultado.IdTenant && m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        // Turno abierto — precondición del checkout usado por el test de concurrencia
+        // confirmar-vs-checkout (task 5.10); las demás pruebas de este archivo no lo necesitan
+        // pero sembrarlo acá evita duplicar PrepararAsync.
+        db.TurnosCaja.Add(new TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        // Plataforma mode no filtra por tenant — sin el IdTenant explícito acá, FirstAsync puede
+        // levantar el Consumidor Final de OTRO tenant sembrado por una corrida anterior de la
+        // misma suite secuencial (mismo motivo que el resto de este método usa resultado.IdTenant
+        // explícito en cada Where).
+        var cf = await db.Clientes.FirstAsync(c => c.IdTenant == resultado.IdTenant && c.Numero == ReglaDeClientes.NumeroConsumidorFinal);
+        db.Precios.Add(new Precio
+        {
+            IdTenant = resultado.IdTenant, IdArticulo = articuloLote.Id, IdListaPrecio = cf.IdListaPrecio,
+            Monto = 100m, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, proveedor.Id, articuloLote.Id,
+            idAlicuotaIva21, idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDeCompra SolicitudConLote(
+        Contexto ctx, string? codigoLote, DateOnly? fechaVencimiento, decimal unidades = 10m,
+        decimal costoUnitario = 100m, string? numeroExterno = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno ?? $"NE-{Guid.NewGuid():N}",
+            DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [
+                new LineaDeCompraSolicitada(
+                    ctx.IdArticuloLote, "Item con lote", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21,
+                    ActualizaCosto: true, CodigoLote: codigoLote, FechaVencimiento: fechaVencimiento)
+            ]);
+
+    private static async Task<HttpResponseMessage> CrearBorradorRawAsync(Contexto ctx, SolicitudDeCompra solicitud) =>
+        await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud);
+
+    private static async Task<CompraDetalle> CrearBorradorAsync(Contexto ctx, SolicitudDeCompra solicitud)
+    {
+        var respuesta = await CrearBorradorRawAsync(ctx, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<HttpResponseMessage> ConfirmarRawAsync(Contexto ctx, int id) =>
+        await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+
+    private static async Task<CompraDetalle> ConfirmarAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ConfirmarRawAsync(ctx, id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 5.5: invariante — stock_lotes.cantidad = SUM(movimientos con ese lote) -----------
+
+    [Fact]
+    public async Task StockLotesCantidadEsLaSumaDeSusMovimientosTrasDosCompras()
+    {
+        var ctx = await PrepararAsync(nameof(StockLotesCantidadEsLaSumaDeSusMovimientosTrasDosCompras));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-INV", VencimientoLejanoFuturo, unidades: 30m));
+        var confirmada1 = await ConfirmarAsync(ctx, primera.Id);
+        var idLote = confirmada1.Items[0].IdLote;
+        Assert.NotNull(idLote);
+
+        var segunda = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-INV", VencimientoLejanoFuturo, unidades: 20m));
+        var confirmada2 = await ConfirmarAsync(ctx, segunda.Id);
+        Assert.Equal(idLote, confirmada2.Items[0].IdLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var cantidadStockLotes = await db.StockLotes
+            .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad)
+            .FirstAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == ctx.IdArticuloLote && m.IdPuntoVenta == ctx.IdPuntoVenta && m.IdLote == idLote)
+            .SumAsync(m => m.Cantidad);
+
+        Assert.Equal(50m, cantidadStockLotes);
+        Assert.Equal(sumaDeMovimientos, cantidadStockLotes);
+    }
+
+    // ---- task 5.6: get-or-create crea y congela el lote sobre el item ----------------------------
+
+    [Fact]
+    public async Task ConfirmarGetOrCreaUnLoteYLoCongelaSobreElItem()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarGetOrCreaUnLoteYLoCongelaSobreElItem));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-002", VencimientoLejanoFuturo, unidades: 15m));
+
+        var confirmada = await ConfirmarAsync(ctx, creada.Id);
+
+        var item = confirmada.Items[0];
+        Assert.NotNull(item.IdLote);
+        Assert.Equal("L-002", item.CodigoLote);
+        Assert.Equal(VencimientoLejanoFuturo, item.FechaVencimiento);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var lote = await db.Lotes.SingleAsync(l => l.IdArticulo == ctx.IdArticuloLote && l.Codigo == "L-002");
+        Assert.Equal(item.IdLote, lote.Id);
+        Assert.Equal(VencimientoLejanoFuturo, lote.FechaVencimiento);
+
+        Assert.Equal(
+            1, await db.MovimientosStock.CountAsync(
+                m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Compra && m.IdLote == lote.Id));
+
+        var stockLote = await db.StockLotes
+            .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == lote.Id)
+            .Select(sl => sl.Cantidad)
+            .FirstAsync();
+        Assert.Equal(15m, stockLote);
+    }
+
+    // ---- task 5.7: una segunda recepción con vencimiento coincidente reusa el lote ---------------
+
+    [Fact]
+    public async Task ConfirmarReusaUnLoteExistenteConVencimientoCoincidente()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarReusaUnLoteExistenteConVencimientoCoincidente));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-REUSO", VencimientoLejanoFuturo, unidades: 10m));
+        var confirmada1 = await ConfirmarAsync(ctx, primera.Id);
+        var idLoteOriginal = confirmada1.Items[0].IdLote;
+
+        var segunda = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-REUSO", VencimientoLejanoFuturo, unidades: 5m));
+        var confirmada2 = await ConfirmarAsync(ctx, segunda.Id);
+
+        Assert.Equal(idLoteOriginal, confirmada2.Items[0].IdLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.Lotes.CountAsync(l => l.IdArticulo == ctx.IdArticuloLote && l.Codigo == "L-REUSO"));
+    }
+
+    // ---- task 5.8: un vencimiento en conflicto para el mismo codigo se rechaza -------------------
+
+    [Fact]
+    public async Task ConfirmarRechazaUnVencimientoEnConflictoParaElMismoCodigo()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarRechazaUnVencimientoEnConflictoParaElMismoCodigo));
+
+        var primera = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-CONFLICTO", VencimientoLejanoFuturo, unidades: 10m));
+        await ConfirmarAsync(ctx, primera.Id);
+
+        var segunda = await CrearBorradorAsync(
+            ctx, SolicitudConLote(ctx, "L-CONFLICTO", VencimientoLejanoFuturoAlterno, unidades: 5m));
+        var respuesta = await ConfirmarRawAsync(ctx, segunda.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_vencimiento_incompatible", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Rollback completo: la segunda compra sigue en borrador, sin id_lote congelado y sin
+        // movimiento propio — el 409 no dejó ningún rastro parcial.
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == segunda.Id)).Estado);
+        Assert.Null(await db.ItemsComprobanteCompra.Where(i => i.IdComprobanteCompra == segunda.Id).Select(i => i.IdLote).FirstAsync());
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == segunda.Id));
+        Assert.Equal(1, await db.Lotes.CountAsync(l => l.IdArticulo == ctx.IdArticuloLote && l.Codigo == "L-CONFLICTO"));
+    }
+
+    // ---- task 5.9: db-error-backstops — dos confirmaciones concurrentes sobre el mismo lote ------
+
+    /// <summary>Diferencia deliberada con el race backstop clásico de <c>ManejadorDeErrores</c>
+    /// (p.ej. <c>numero_externo</c> duplicado, o el alta admin de <c>ServicioDeLotes.CrearAsync</c>
+    /// en Slice 3): <c>ServicioDeLotes.ResolverOCrearAsync</c> get-or-crea vía <c>INSERT ... ON
+    /// CONFLICT (id_tenant, id_articulo, codigo) DO UPDATE ... RETURNING</c> (design decisión 4)
+    /// contra <c>ux_lotes_articulo_codigo</c>, cuyas columnas y predicado COINCIDEN EXACTO con el
+    /// índice (<c>LoteConfiguration.cs</c>). Postgres resuelve un <c>INSERT ... ON CONFLICT DO
+    /// UPDATE</c> targeteado así completamente DENTRO del motor — el perdedor espera el lock de
+    /// fila de la primera sesión y, cuando esta commitea, reevalúa el <c>WHERE</c> y hace el
+    /// <c>UPDATE</c> — nunca propaga un <c>23505</c> al cliente. Esto NO es un error del apply: es
+    /// exactamente la garantía que decisión 4 documenta como motivo de NO tener un retry-read loop
+    /// ("There is therefore no retry-read loop in this design, and saying so is more honest than
+    /// writing one that can never fire") y el mismo criterio que el doc-comment de
+    /// <c>ServicioDeLotesTests.DosCrearAsyncConcurrentesDelMismoCodigoChocanConSqlstate23505AntesDelMapeo</c>
+    /// usa para explicar por qué ESA prueba (que sí choca) tiene que pasar por
+    /// <c>CrearAsync</c> —un <c>INSERT</c> EF plano, sin <c>ON CONFLICT</c>— en vez de
+    /// <c>ResolverOCrearAsync</c>. Esta prueba corre el race real de todos modos (dos
+    /// confirmaciones concurrentes sobre el mismo <c>(articulo, codigo_lote)</c>, dos conexiones
+    /// independientes) y assertea el resultado GENUINAMENTE OBSERVADO: ambas confirmaciones
+    /// terminan exitosas y resuelven al MISMO lote, sin ninguna excepción cruda que traducir —el
+    /// requisito de negocio del spec ("both confirms succeed against the same lot") se cumple
+    /// igual, solo que por el camino de auto-resolución de Postgres en vez de por un backstop de
+    /// <c>ManejadorDeErrores</c>. (APPLY-RUN NOTE para judgment-day: si esta observación resulta
+    /// sorprendente, es la misma garantía ya documentada en Slice 3 — no una regresión de este
+    /// slice.)</summary>
+    [Fact]
+    public async Task DosConfirmacionesConcurrentesSobreElMismoCodigoDeLoteResuelvenAlMismoLote()
+    {
+        var ctx = await PrepararAsync(nameof(DosConfirmacionesConcurrentesSobreElMismoCodigoDeLoteResuelvenAlMismoLote));
+
+        var compraA = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-RACE", VencimientoLejanoFuturo, unidades: 12m));
+        var compraB = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-RACE", VencimientoLejanoFuturo, unidades: 8m));
+
+        var tareaA = ConfirmarRawAsync(ctx, compraA.Id);
+        var tareaB = ConfirmarRawAsync(ctx, compraB.Id);
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        foreach (var respuesta in respuestas)
+        {
+            var cuerpo = await respuesta.Content.ReadAsStringAsync();
+            Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        }
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        Assert.Equal(1, await db.Lotes.CountAsync(l => l.IdArticulo == ctx.IdArticuloLote && l.Codigo == "L-RACE"));
+
+        var idLoteA = await db.ItemsComprobanteCompra.Where(i => i.IdComprobanteCompra == compraA.Id).Select(i => i.IdLote).FirstAsync();
+        var idLoteB = await db.ItemsComprobanteCompra.Where(i => i.IdComprobanteCompra == compraB.Id).Select(i => i.IdLote).FirstAsync();
+        Assert.NotNull(idLoteA);
+        Assert.Equal(idLoteA, idLoteB);
+
+        var cantidadStockLotes = await db.StockLotes
+            .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLoteA)
+            .Select(sl => sl.Cantidad)
+            .FirstAsync();
+        Assert.Equal(20m, cantidadStockLotes);
+    }
+
+    // ---- task 5.10: concurrencia, write-site 2 — confirmar vs. checkout, sin 40P01 ----------------
+
+    /// <summary>El checkout de este worktree (slices 1-3 mergeadas, ANTES de Slice 7/8) todavía no
+    /// toca <c>lotes</c>/<c>stock_lotes</c> — corre byte-idéntico al camino agregado-only. El
+    /// bloque de resolución NUEVO que este slice agrega al confirmar toma el lock de <c>lotes</c>
+    /// ANTES del de <c>stock</c> (decisión 3); el checkout de HOY solo toma el lock de
+    /// <c>stock</c>. Sin un segundo recurso compartido en orden opuesto no hay ciclo posible —
+    /// esta prueba es la regresión honesta que SÍ es verificable en este slice: agregar un nuevo
+    /// paso de lock al confirmar no introdujo un deadlock contra el escritor de venta existente
+    /// sobre el mismo artículo/PV. La prueba conjunta real (confirmar/checkout compitiendo por el
+    /// MISMO lote) queda diferida a cuando el checkout sea lot-aware (Slice 7/8), mismo criterio
+    /// que la nota 7 de tasks.md sobre "cross-slice concurrency dependency".</summary>
+    [Fact]
+    public async Task ConfirmarYCheckoutDelMismoArticuloEnParaleloNuncaDan40P01()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarYCheckoutDelMismoArticuloEnParaleloNuncaDan40P01));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-CONCURRENCIA", VencimientoLejanoFuturo, unidades: 40m));
+
+        var solicitudVenta = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, null, "TX", null,
+            [new LineaDeVenta(ctx.IdArticuloLote, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var tareaConfirmar = ConfirmarRawAsync(ctx, creada.Id);
+        var tareaCheckout = ctx.Admin.PostAsJsonAsync("/api/ventas", solicitudVenta);
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var respuestaCheckout = await tareaCheckout;
+
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        var cuerpoCheckout = await respuestaCheckout.Content.ReadAsStringAsync();
+
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        Assert.True(respuestaCheckout.StatusCode == HttpStatusCode.Created, cuerpoCheckout);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == ctx.IdArticuloLote && m.IdPuntoVenta == ctx.IdPuntoVenta)
+            .SumAsync(m => m.Cantidad);
+        Assert.Equal(cantidad, sumaDeMovimientos);
+        Assert.Equal(39m, cantidad);
+    }
+
+    // ---- task 5.11: una línea de borrador captura el input de lote sin resolverlo ------------------
+
+    [Fact]
+    public async Task UnaLineaDeBorradorCapturaElInputDeLoteSinResolverlo()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaDeBorradorCapturaElInputDeLoteSinResolverlo));
+
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-DRAFT", VencimientoLejanoFuturo, unidades: 7m));
+
+        var item = creada.Items[0];
+        Assert.Equal("L-DRAFT", item.CodigoLote);
+        Assert.Equal(VencimientoLejanoFuturo, item.FechaVencimiento);
+        Assert.Null(item.IdLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var itemPersistido = await db.ItemsComprobanteCompra.FirstAsync(i => i.IdComprobanteCompra == creada.Id);
+        Assert.Equal("L-DRAFT", itemPersistido.CodigoLote);
+        Assert.Equal(VencimientoLejanoFuturo, itemPersistido.FechaVencimiento);
+        Assert.Null(itemPersistido.IdLote);
+
+        Assert.Equal(0, await db.Lotes.CountAsync(l => l.IdArticulo == ctx.IdArticuloLote && l.Codigo == "L-DRAFT"));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    // ---- task 5.12: recepción vencida se rechaza al guardar; futura se acepta ---------------------
+
+    [Fact]
+    public async Task UnaLineaConVencimientoPasadoEsRechazadaAlGuardarElBorrador()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaConVencimientoPasadoEsRechazadaAlGuardarElBorrador));
+
+        var respuesta = await CrearBorradorRawAsync(ctx, SolicitudConLote(ctx, "L-VENCIDO", VencimientoLejanoPasado));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_vencido_en_recepcion", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesCompra.CountAsync(c => c.IdProveedor == ctx.IdProveedor));
+    }
+
+    [Fact]
+    public async Task UnaLineaConVencimientoFuturoEsAceptadaAlGuardarElBorrador()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaConVencimientoFuturoEsAceptadaAlGuardarElBorrador));
+
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-FUTURO", VencimientoLejanoFuturo));
+
+        Assert.Equal(VencimientoLejanoFuturo, creada.Items[0].FechaVencimiento);
+    }
+
+    /// <summary>Mismo rechazo, ahora en la edición de un borrador ya existente (spec: "This check
+    /// MUST fire when the line is saved or edited, not only at confirm") — un PUT también es un
+    /// "save".</summary>
+    [Fact]
+    public async Task UnaLineaConVencimientoPasadoEsRechazadaAlEditarElBorrador()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaConVencimientoPasadoEsRechazadaAlEditarElBorrador));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-EDICION", VencimientoLejanoFuturo));
+
+        var edicion = SolicitudConLote(ctx, "L-EDICION", VencimientoLejanoPasado, numeroExterno: $"NE-{Guid.NewGuid():N}");
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", edicion);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_vencido_en_recepcion", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var itemPersistido = await db.ItemsComprobanteCompra.FirstAsync(i => i.IdComprobanteCompra == creada.Id);
+        Assert.Equal(VencimientoLejanoFuturo, itemPersistido.FechaVencimiento);
+    }
+
+    // ---- soporte: 400 lote_requerido cuando un artículo lot-effective no trae fecha/codigo -------
+
+    /// <summary>No nombrado explícitamente en el test plan de la slice (5.5-5.12), pero es la
+    /// guarda que el bloque de resolución de <c>EjecutarConfirmarAsync</c> agrega (design: Write
+    /// site 2, pseudocódigo de la sección "Confirm") — un ítem lot-effective sin ningún input de
+    /// lote no puede resolver <c>ResolverOCrearAsync</c> (que exige <c>fechaVencimiento</c> no
+    /// nula), así que se rechaza ANTES de intentarlo.</summary>
+    [Fact]
+    public async Task ConfirmarRechazaUnItemLoteEfectivoSinFechaDeVencimientoConLoteRequerido()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarRechazaUnItemLoteEfectivoSinFechaDeVencimientoConLoteRequerido));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, null, null));
+
+        var respuesta = await ConfirmarRawAsync(ctx, creada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.BadRequest, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("lote_requerido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+}

--- a/tests/Ways.IntegrationTests/LotesBackstopTests.cs
+++ b/tests/Ways.IntegrationTests/LotesBackstopTests.cs
@@ -426,6 +426,13 @@ public class LotesBackstopTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         Assert.Equal("ck_lotes_codigo_no_vacio", excepcion.ConstraintName);
     }
 
+    /// <summary>judgment-day (slice 5, FIX 1b): esta CHECK ahora tiene mapeo HTTP —
+    /// <c>ManejadorDeErrores.ClasificarCheckDeCompras</c> traduce <c>ck_items_comprobante_compra_lote_input</c>
+    /// a 400 <c>lote_input_incompleto</c>, backstop del guard primario de
+    /// <c>ServicioDeCompras.ValidarVencimientosDeRecepcion</c> (FIX 1a). Esta prueba sigue siendo
+    /// SQL crudo a propósito — verifica la CHECK de esquema en sí (SQLSTATE + ConstraintName), no
+    /// el mapeo HTTP; la prueba end-to-end del mapeo vive en
+    /// ComprasRecepcionDeLotesTests.CrearBorradorConCodigoDeLoteSinFechaDeVencimientoDa400LoteInputIncompletoNunca500.</summary>
     [Fact]
     public async Task UnItemDeCompraConCodigoDeLoteSinVencimientoViolaLaCheckDeLoteInput()
     {


### PR DESCRIPTION
## Etapa 12 — Slice 5: Recepción

- **Borrador**: \`codigo_lote\`/\`fecha_vencimiento\` pasan por \`MaterializarItems\` SIN resolver (el replace-set no ensucia \`lotes\`); 409 \`lote_vencido_en_recepcion\` en CADA save; 400 \`lote_input_incompleto\` (código sin fecha) en doble capa: guard de aplicación + backstop de \`ManejadorDeErrores\` para \`ck_items_comprobante_compra_lote_input\`.
- **Confirmar**: bloque de resolución bajo el header lock, antes del stock loop (\`ORDER BY id_articulo, codigo_lote\`; lotes antes que stock); \`item.IdLote\` congelado (snapshot); re-check de vencido al confirmar (defensa en profundidad, con test que muta la fecha vía conexión owner entre save y confirm); stock loop reordenado \`(IdArticulo, IdLote)\` escribiendo ambos caches.
- **Guard interino de anulación**: 409 \`compra_anulacion_lotes_pendiente\` si la compra resolvió lotes — evita la corrupción silenciosa de \`stock_lotes\` hasta que el slice 6 implemente la reversa exacta por lote (nota vinculante agregada al bloque del slice 6).
- **Decisión 14** (enmienda de specs ×2): la carrera del get-or-create AUTO-RESUELVE por el \`ON CONFLICT\` target — ningún 23505 surge en ese camino (verificado empíricamente); el 23505 real pertenece al alta admin (\`409 lote_duplicado\`, slice 3).

### Tests (15 de integración nuevos)
Invariante 2 pata compra · get-or-create ×3 · carrera de confirms estable 3/3 · concurrencia confirm-vs-checkout sin 40P01 · draft capture · vencida ×2 · \`lote_requerido\` · \`lote_input_incompleto\` API-level · re-check del confirm · anulación interina ×2. Regresión \`~Compras\` 111/111.

### Judgment-day
Ronda 1 doble REJECT: CRITICAL de 500 crudo alcanzable por cliente (juez B, probado en vivo), corrupción silenciosa de \`stock_lotes\` en anulación (juez A), contradicción cross-spec y re-check sin cobertura. Fix batch con evidencia por capas; ronda 2 doble APPROVE serializada B→A. Desborde a ~680 líneas por profundidad de tests, registrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)