### PR TITLE
feat(lotes): anulación de compra revierte el lote exacto — etapa 12, slice 6

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -730,24 +730,53 @@ revert the branch.
 > compra_anulacion_lotes_pendiente guard added at slice-5 judgment-day with
 > the exact per-lot reversal.
 
-- [ ] 6.1 Modify `ServicioDeCompras.cs`: `EjecutarAnulacionAsync` reorders
+- [x] 6.1 Modify `ServicioDeCompras.cs`: `EjecutarAnulacionAsync` reorders
   `.OrderBy(m => m.IdArticulo).ThenBy(m => m.IdLote)`, copies
   `original.IdLote`; **two** mandatory checks — aggregate `nueva < 0` AND
   per-lot `nuevaDelLote < 0` — both raise `409
-  compra_anulacion_stock_negativo`.
-- [ ] 6.2 [P] **Mutation target**: `if (clave.IdLote is not null && delta <
-  0 && nueva < 0) throw` — delete the `if` → the per-lot insufficiency test
-  (seeded with a **sufficient aggregate** across two lots) MUST fail;
-  revert → green. *(spec: "Anulación refused by a lot-level underflow
-  despite a sufficient aggregate"; mutation-proof-tests)* Record evidence.
-- [ ] 6.3 [P] Exact reversal test. *(spec: "Anulación reverses a
-  lot-bearing item into its exact lot")*
-- [ ] 6.4 [P] Aggregate refusal regression, unaffected by the lot
+  compra_anulacion_stock_negativo`. *(APPLY-RUN NOTE: replaces the interim
+  `compra_anulacion_lotes_pendiente` guard from slice 5 FIX 4 in full — the
+  guard block and its now-superseded doc-comments are removed. The per-lot
+  `UpsertStockLoteAsync` upsert + check run right after the aggregate
+  `UpsertStockAsync` + check, inside the same per-movement loop iteration,
+  so a rejection at either level rolls back the whole `EjecutarAnulacionAsync`
+  transaction via the outer `using`.)*
+- [x] 6.2 [P] **Mutation target**: the per-lot `if (nuevaDelLote < 0m)
+  throw` guard — delete the `if` → the per-lot insufficiency test (seeded
+  with a **sufficient aggregate** across two lots) MUST fail; revert →
+  green. *(spec: "Anulación refused by a lot-level underflow despite a
+  sufficient aggregate"; mutation-proof-tests)* Record evidence.
+  *(APPLY-RUN NOTE: mutation applied — the per-lot guard's condition
+  replaced with `if (false)` in `EjecutarAnulacionAsync`; build, filter
+  `AnularUnaCompraEsRechazadaPorUnLoteInsuficienteAunConAgregadoSuficiente`:
+  RED — anulación returned `200 OK`/`Anulada` instead of `409
+  compra_anulacion_stock_negativo` (the aggregate-only check alone did not
+  catch the lot-7 underflow, aggregate stayed at 60 ≥ 0). Reverted, build,
+  same filter: GREEN; full `ComprasRecepcionDeLotesTests` +
+  `ComprasAnulacionYConcurrenciaTests`: GREEN, 31/31.)*
+- [x] 6.3 [P] Exact reversal test. *(spec: "Anulación reverses a
+  lot-bearing item into its exact lot")* *(APPLY-RUN NOTE:
+  `AnularUnaCompraConLoteResueltoRevierteElLoteExacto` — replaces the slice-5
+  interim guard test `AnularUnaCompraConLoteResueltoEsRechazadaSinRevertirNada`
+  per the slice-5 judgment-day FIX-4 note; asserts the inverse movimiento's
+  `id_lote`, the aggregate `stock.cantidad`, and `stock_lotes.cantidad` for
+  the lot all land at zero after anulación.)*
+- [x] 6.4 [P] Aggregate refusal regression, unaffected by the lot
   dimension. *(spec: "Anulación refused when the goods were already sold")*
-- [ ] 6.5 [P] `costo_nominal`-not-reverted regression (unaffected by this
-  slice).
-- [ ] 6.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  *(APPLY-RUN NOTE: no new test — the existing
+  `ComprasAnulacionYConcurrenciaTests.AnulacionEsRechazadaCuandoLaMercaderiaYaFueVendida`
+  (lot-less articulo, pre-dates this slice) exercises this scenario
+  end-to-end; re-ran the full suite after 6.1's reorder/copy changes to
+  confirm it is byte-identically unaffected — GREEN, 15/15.)*
+- [x] 6.5 [P] `costo_nominal`-not-reverted regression (unaffected by this
+  slice). *(APPLY-RUN NOTE: no new test — the existing
+  `ComprasAnulacionYConcurrenciaTests.CostoNominalNoSeRevierteAlAnular`
+  covers this; confirmed GREEN in the same full-suite run as 6.4.)*
+- [x] 6.6 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(Confirmed via `--project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure`: "No changes have been made to
+  the model since the last migration." No `Migraciones/`/`Configuraciones/`
+  file touched by this slice.)*
 - [ ] 6.7 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 6.8 Branch `feat/stage12-slice6-compra-anulacion` off `main` (parent:
   slice 5); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -777,8 +777,17 @@ revert the branch.
   --startup-project src/Ways.Infrastructure`: "No changes have been made to
   the model since the last migration." No `Migraciones/`/`Configuraciones/`
   file touched by this slice.)*
-- [ ] 6.7 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 6.8 Branch `feat/stage12-slice6-compra-anulacion` off `main` (parent:
+- [x] 6.7 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  FIRST CLEAN ROUND-1 of the stage — double APPROVE. Judge B re-ran the 6.2
+  mutation plus 4 new probes (inexact reversal, order flip, aggregate-check
+  removal, doubled reversal delta) — all caught except the order flip, which
+  is the known cross-slice anti-deadlock dependency deferred to slice 8's
+  joint proof (slice-5 precedent). Judge A verified ledger-sourced reversal
+  (never re-derived), double check via RETURNING with no TOCTOU, and full
+  removal of the interim guard. Recorded debt (both judges, SUGGESTION): no
+  dedicated mixed-compra (lot + non-lot items) end-to-end anulación test —
+  structurally the union of two covered paths, per-line independent loop.)*
+- [x] 6.8 Branch `feat/stage12-slice6-compra-anulacion` off `main` (parent:
   slice 5); PR; merge stacked-to-main.
 
 **Test plan**: per-lot insufficiency mutation (6.2), exact reversal (6.3),

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -520,41 +520,26 @@ public class ServicioDeCompras(
             throw new ErrorDominio("compra_no_confirmada", "La compra no está confirmada.", 409);
         }
 
-        // 1.b Guard interino de anulación con lotes (etapa 12, slice 5, judgment-day FIX 4):
-        // la reversa de acá abajo (paso 2) solo revierte el agregado (movimientos_stock/stock) —
-        // si algún item de esta compra resolvió un lote, dejar stock_lotes sin revertir
-        // corrompería el invariante 2 en silencio (200 OK con stock_lotes inflado). Preferible
-        // rechazar que corromper: interino hasta que slice 6 (task 6.1) implemente la reversa
-        // EXACTA por lote y reemplace este guard.
-        var tieneItemsConLote = await db.ItemsComprobanteCompra
-            .AnyAsync(i => i.IdComprobanteCompra == id && i.IdLote != null, ct);
-        if (tieneItemsConLote)
-        {
-            throw new ErrorDominio(
-                "compra_anulacion_lotes_pendiente",
-                "Esta compra tiene ítems con lote resuelto; la anulación con reversa exacta por lote " +
-                "todavía no está implementada (queda para slice 6).",
-                409);
-        }
-
         // 2. El ledger ORIGINAL, nunca recalculado desde items (design: doc-comment de
-        // ServicioDeVentas.AnularAsync, mismo criterio acá).
+        // ServicioDeVentas.AnularAsync, mismo criterio acá). Orden ascendente (id_articulo,
+        // id_lote) — etapa 12, slice 6, mismo criterio de lock que el confirmar (decisión 8/9).
         var movimientosOriginales = await db.MovimientosStock
             .Where(m => m.IdComprobanteCompra == id && m.Motivo == MotivoStock.Compra)
             .OrderBy(m => m.IdArticulo)
+            .ThenBy(m => m.IdLote)
             .ToListAsync(ct);
 
         foreach (var original in movimientosOriginales)
         {
             var inversa = -original.Cantidad;
 
-            // idLote: null acá a propósito — la anulación lot-aware (copiar original.IdLote,
-            // upsert de stock_lotes, chequeo de negativo por lote) es Slice 6 (task 6.1), fuera
-            // del scope de este slice. Este slice solo agrega el parámetro compartido por
-            // InsertarMovimientoStockAsync para no romper la firma del confirmar.
+            // Reversa EXACTA por lote (etapa 12, slice 6, reemplaza el guard interino de slice 5
+            // FIX 4): el movimiento original ya trae su propio id_lote — la reversa lo copia
+            // estructuralmente, sin re-derivar nada (design: "Exactness is structural, not
+            // derived").
             await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa,
-                MotivoStock.Anulacion, id, idEmpleado, momento, idLote: null, ct);
+                MotivoStock.Anulacion, id, idEmpleado, momento, original.IdLote, ct);
 
             var nueva = await UpsertStockAsync(
                 conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
@@ -565,6 +550,26 @@ public class ServicioDeCompras(
                     "compra_anulacion_stock_negativo",
                     $"El artículo {original.IdArticulo} quedaría con stock negativo al anular esta compra.",
                     409);
+            }
+
+            // Chequeo por lote (spec comprobantes-compra: "the negative-balance refusal MUST also
+            // apply at the lot level... even if the articulo's aggregate stock.cantidad would stay
+            // non-negative") — un agregado suficiente puede esconder un lote específico ya vendido
+            // por debajo de la cantidad que esta anulación intenta devolverle.
+            if (original.IdLote is { } idLoteReversa)
+            {
+                var nuevaDelLote = await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, idLoteReversa,
+                    inversa, ct);
+
+                if (nuevaDelLote < 0m)
+                {
+                    throw new ErrorDominio(
+                        "compra_anulacion_stock_negativo",
+                        $"El lote {idLoteReversa} del artículo {original.IdArticulo} quedaría con stock " +
+                        "negativo al anular esta compra.",
+                        409);
+                }
             }
         }
 

--- a/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasRecepcionDeLotesTests.cs
@@ -49,7 +49,8 @@ public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixtur
 
     private sealed record Contexto(
         int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticuloLote,
-        int IdAlicuotaIva21, int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
+        int IdAlicuotaIva21, int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin,
+        int IdUsuarioAdmin);
 
     private async Task<Contexto> PrepararAsync(string nombre)
     {
@@ -139,7 +140,7 @@ public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixtur
 
         return new Contexto(
             resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, proveedor.Id, articuloLote.Id,
-            idAlicuotaIva21, idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
+            idAlicuotaIva21, idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal, resultado.IdUsuarioAdmin);
     }
 
     private static SolicitudDeCompra SolicitudConLote(
@@ -557,46 +558,124 @@ public class ComprasRecepcionDeLotesTests(WaysApiFixture fixture) : IClassFixtur
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
     }
 
-    // ---- judgment-day (juez A, MUST-FIX F2) FIX 4: guard interino de anulación con lotes ----------
+    // ---- task 6.3: reversa exacta por lote (reemplaza el guard interino de slice 5 FIX 4) --------
 
-    /// <summary>Guard interino conservador (<c>EjecutarAnulacionAsync</c>, ~línea 531) — la reversa
-    /// de esta slice es agregado-only (design: doc-comment de la clase, "idLote: null acá a
-    /// propósito"), así que anular una compra con ítems con lote resuelto se rechaza ANTES de
-    /// tocar nada, en vez de dejar <c>stock_lotes</c> inflado en silencio. Slice 6 (task 6.1)
-    /// reemplaza este guard por la reversa exacta por lote.</summary>
+    /// <summary>Etapa 12, slice 6, task 6.1 — reemplaza el guard interino
+    /// (<c>compra_anulacion_lotes_pendiente</c>) documentado en el judgment-day de slice 5 (FIX 4)
+    /// por la reversa EXACTA: el movimiento inverso copia <c>original.IdLote</c> (sin re-derivar,
+    /// design: "Exactness is structural, not derived") y <c>stock_lotes</c> del lote se revierte en
+    /// la misma transacción. (spec comprobantes-compra: "Anulación reverses a lot-bearing item into
+    /// its exact lot")</summary>
     [Fact]
-    public async Task AnularUnaCompraConLoteResueltoEsRechazadaSinRevertirNada()
+    public async Task AnularUnaCompraConLoteResueltoRevierteElLoteExacto()
     {
-        var ctx = await PrepararAsync(nameof(AnularUnaCompraConLoteResueltoEsRechazadaSinRevertirNada));
-        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-ANULACION", VencimientoLejanoFuturo, unidades: 12m));
+        var ctx = await PrepararAsync(nameof(AnularUnaCompraConLoteResueltoRevierteElLoteExacto));
+        var creada = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-REVERSA", VencimientoLejanoFuturo, unidades: 12m));
         var confirmada = await ConfirmarAsync(ctx, creada.Id);
-        Assert.NotNull(confirmada.Items[0].IdLote);
+        var idLote = confirmada.Items[0].IdLote;
+        Assert.NotNull(idLote);
 
         var respuesta = await AnularRawAsync(ctx, creada.Id);
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
-
-        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
-        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
-        Assert.Equal("compra_anulacion_lotes_pendiente", problema.GetProperty("codigo").GetString());
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
 
-        // Aserción completa: NADA se revirtió — ni el estado, ni stock, ni stock_lotes, ni
-        // movimientos_stock.
-        Assert.Equal(EstadoCompra.Confirmada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
-        Assert.Equal(
-            0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion));
+        Assert.Equal(EstadoCompra.Anulada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+
+        var movimientoAnulacion = await db.MovimientosStock
+            .SingleAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion);
+        Assert.Equal(idLote, movimientoAnulacion.IdLote);
+        Assert.Equal(-12m, movimientoAnulacion.Cantidad);
 
         var cantidadStock = await db.Stock
             .Where(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta)
             .Select(s => s.Cantidad).FirstAsync();
-        Assert.Equal(12m, cantidadStock);
+        Assert.Equal(0m, cantidadStock);
 
-        var idLote = confirmada.Items[0].IdLote!.Value;
         var cantidadStockLote = await db.StockLotes
             .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
             .Select(sl => sl.Cantidad).FirstAsync();
-        Assert.Equal(12m, cantidadStockLote);
+        Assert.Equal(0m, cantidadStockLote);
+    }
+
+    // ---- task 6.2: mutation target — el chequeo POR LOTE, no solo el agregado ---------------------
+
+    /// <summary>Mutation target (spec: "Anulación refused by a lot-level underflow despite a
+    /// sufficient aggregate"; mutation-proof-tests). Regla 3 de mutation-proof-tests, matar el
+    /// confound del agregado: sembramos el mismo artículo con SALDO SUFICIENTE en el agregado
+    /// repartido en DOS lotes (lote L-7 con 50 recibidas, lote L-9 con 100 recibidas, agregado =
+    /// 150) — si el chequeo por lote se borrara, el chequeo agregado por sí solo NO detectaría el
+    /// problema, porque el agregado nunca queda negativo. Una venta simulada (mismo patrón que la
+    /// prueba self-heal de <c>ReconciliacionTests</c>, task 4.7 — el escritor de venta lot-aware es
+    /// Slice 7/8, todavía no aterriza en esta rama) saca 40 unidades ESPECÍFICAMENTE del lote L-7
+    /// (deja <c>stock_lotes</c> de L-7 en 10, agregado en 110). Anular la compra que recibió L-7 (50
+    /// unidades) dejaría el agregado en 60 (positivo, el chequeo agregado lo aprobaría) pero el
+    /// lote L-7 en -40 — solo el chequeo por lote lo detecta.</summary>
+    [Fact]
+    public async Task AnularUnaCompraEsRechazadaPorUnLoteInsuficienteAunConAgregadoSuficiente()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaCompraEsRechazadaPorUnLoteInsuficienteAunConAgregadoSuficiente));
+
+        var compraLote7 = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-7", VencimientoLejanoFuturo, unidades: 50m));
+        var confirmadaLote7 = await ConfirmarAsync(ctx, compraLote7.Id);
+        var idLote7 = confirmadaLote7.Items[0].IdLote!.Value;
+
+        var compraLote9 = await CrearBorradorAsync(ctx, SolicitudConLote(ctx, "L-9", VencimientoLejanoFuturo, unidades: 100m));
+        await ConfirmarAsync(ctx, compraLote9.Id);
+
+        // Venta simulada: 40 unidades salen específicamente del lote 7 (patrón self-heal de
+        // ReconciliacionTests task 4.7 — sin escritor de venta lot-aware todavía en esta rama).
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            db.MovimientosStock.Add(new MovimientoStock
+            {
+                IdTenant = ctx.IdTenant, IdArticulo = ctx.IdArticuloLote, IdPuntoVenta = ctx.IdPuntoVenta, Cantidad = -40m,
+                Motivo = MotivoStock.Venta, IdLote = idLote7, IdEmpleado = ctx.IdUsuarioAdmin, CreadoEl = ahora
+            });
+
+            var stock = await db.Stock.SingleAsync(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta);
+            stock.Cantidad -= 40m;
+
+            var stockLote7 = await db.StockLotes.SingleAsync(
+                sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote7);
+            stockLote7.Cantidad -= 40m;
+
+            await db.SaveChangesAsync();
+        }
+
+        await using (var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var agregadoAntes = await dbAntes.Stock
+                .Where(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta)
+                .Select(s => s.Cantidad).FirstAsync();
+            Assert.Equal(110m, agregadoAntes);
+        }
+
+        var respuesta = await AnularRawAsync(ctx, compraLote7.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("compra_anulacion_stock_negativo", problema.GetProperty("codigo").GetString());
+
+        await using var db2 = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Rollback completo: ni el estado, ni el agregado, ni el lote 7 cambiaron.
+        Assert.Equal(EstadoCompra.Confirmada, (await db2.ComprobantesCompra.FirstAsync(c => c.Id == compraLote7.Id)).Estado);
+        Assert.Equal(
+            0, await db2.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == compraLote7.Id && m.Motivo == MotivoStock.Anulacion));
+
+        var agregadoDespues = await db2.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticuloLote && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(110m, agregadoDespues);
+
+        var stockLote7Despues = await db2.StockLotes
+            .Where(sl => sl.IdArticulo == ctx.IdArticuloLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote7)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(10m, stockLote7Despues);
     }
 
     /// <summary>Regresión del guard interino de FIX 4: un artículo que NO controla lote (mismo


### PR DESCRIPTION
## Etapa 12 — Slice 6: Compra Anulación

- **Reversa exacta por snapshot**: el contramovimiento copia \`original.IdLote\` del LEDGER (jamás re-derivado de items); orden \`(IdArticulo, IdLote)\` alineado al lock order del confirmar; upsert espejo de \`stock_lotes\`.
- **Doble check obligatorio**: agregado Y por-lote, ambos al código existente \`409 compra_anulacion_stock_negativo\` (extendido, no duplicado), detectados por el \`RETURNING\` del upsert — sin TOCTOU.
- **Guard interino eliminado**: \`compra_anulacion_lotes_pendiente\` (del judgment-day del slice 5) reemplazado por la reversa real, cumpliendo la nota vinculante; cero residuos en src/.

### Tests
Reversa exacta (id_lote del contramovimiento + saldos, regla 6) · insuficiencia por lote con agregado SUFICIENTE (mata el confound, regla 3, con evidencia de mutación) · regresiones de rechazo agregado y costo_nominal (preexistentes, verificadas end-to-end por mutación del juez B). Filtros: 16/16 + 15/15.

### Judgment-day
**Primera ronda 1 limpia de la etapa** — doble APPROVE. 5 probes de mutación del juez B (4 cazadas; el flip del orden es la dependencia anti-deadlock cross-slice diferida al joint proof del slice 8, precedente del 5). Deuda registrada: test dedicado de compra mixta (unión estructural de dos caminos ya cubiertos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)