### PR TITLE
feat(lotes): plan FEFO en la fase de decisión del checkout — etapa 12, slice 7

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/specs/comprobantes-venta/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/comprobantes-venta/spec.md
@@ -215,3 +215,11 @@ stock.
 - WHEN a sale line for articulo 40 omits `idLote`
 - THEN the server selects the non-expired lot, and the response carries no
   expired-lot warning for that line
+
+#### Scenario: A supplied idLote on a non-lot-effective line is rejected (Added at slice-7 judgment-day)
+- GIVEN a sale line for an articulo that is NOT lot-effective (`controla_lote
+  = false`, or the module is off for the empresa)
+- WHEN the line carries a non-null `idLote`
+- THEN the request is rejected with `400 lote_invalido` before reaching the
+  database — the field has no destination on that line, so it is never
+  silently ignored

--- a/openspec/changes/stage-12-lotes-vencimientos/state.yaml
+++ b/openspec/changes/stage-12-lotes-vencimientos/state.yaml
@@ -458,3 +458,15 @@ notes:
     primero o ultimo en el orden FEFO, asumido PRIMERO; (4) conteo por lote vs rechazo,
     asumido POR LOTE con el rechazo pre-aprobado como degradacion; (5) alertas pull sin canal
     push, asumido SI; (6) un lote por linea de venta forzando el split, asumido SI."
+  - "15 — LA SELECCION FEFO PREFIERE LOTES NO VENCIDOS (resuelta en el judgment-day del slice
+    7): el spec de comprobantes-venta exige 'FEFO MUST pre-select a non-expired lot whenever
+    one exists with positive balance' y el juez B probo en vivo que ElegirFefo elegia el
+    vencido (orden por fecha ascendente puro). Resolucion: la SELECCION se particiona — entre
+    los lotes con saldo positivo, primero los NO vencidos (el sin-identificar, sin fecha,
+    cuenta como no vencido y conserva su primer lugar por decision 4), despues los vencidos;
+    dentro de cada particion rige el orden FEFO base (es_sin_identificar DESC, fecha ASC, id
+    ASC). 'Nunca bloquea' intacto: si solo hay vencidos con saldo, se elige el vencido (con
+    warning LoteVencido). OrdenarFefo (el orden de LISTADO del picker) no cambia; cambia SOLO
+    ElegirFefo, que gana el parametro hoy. Consumidores actualizados: ServicioDeVentas (plan)
+    y ServicioDeLotes.ListarAsync (Sugerido — la sugerencia del picker debe ser consistente
+    con la seleccion del server, decision 12)."

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -767,46 +767,105 @@ round-trip budget verified `16 → 17` only when the cart holds a
 lot-controlled articulo. **No writes yet** — the transaction shape is
 unchanged. **Rollback**: revert the branch.
 
-- [ ] 7.1 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
+- [x] 7.1 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
   `EmitirAsync` decide phase — immediately after `MaterializarItems`
   (`articuloPorId` already loaded), compute `lineasConLote`; if non-empty,
   call `servicioDeLotes.LeerSaldosAsync(puntoVenta.Id, articulos,
-  lotesPedidos)` — the one new round trip.
-- [ ] 7.2 Modify `ServicioDeVentas.cs`: per-line resolution —
+  lotesPedidos)` — the one new round trip. *(APPLY-RUN NOTE:
+  `lineasConLote` is computed right after `ResolverParametrosDeVentaAsync`
+  (immediately follows `MaterializarItems` in the existing sequence, and is
+  the only source of `lotesHabilitado` — previously discarded with `_`, now
+  consumed); `ServicioDeLotes` is injected as a constructor dependency
+  (`servicioDeLotes`, DI-registered since slice 3) rather than invoked
+  statically, since `LeerSaldosAsync` is an instance method (unlike
+  `ResolverOCrearAsync`/`ResolverSinIdentificarAsync`, which stay static and
+  are called directly off the type per the slice 5 apply-run precedent).*)*
+- [x] 7.2 Modify `ServicioDeVentas.cs`: per-line resolution —
   `ReglaDeLotes.ElegirFefo` over saldos; a supplied `idLote` is validated
   against `saldos` (exists, belongs to the articulo, not soft-deleted) or
   rejected `400 lote_invalido`; an omitted `idLote` defaults via
   `ElegirFefo`, a `null` result (no lot with positive balance) resolves the
   sin-identificar lot via `ResolverSinIdentificarAsync` (raw
-  `ExecuteScalarAsync`, invisible to the round-trip counter).
-- [ ] 7.3 Modify `LineaDeVenta`/`PlanDeVenta`/`ItemEmitido` contracts:
+  `ExecuteScalarAsync`, invisible to the round-trip counter). *(APPLY-RUN
+  NOTE: "not soft-deleted" needs no extra code — `db.Lotes`'s global
+  `deleted_at IS NULL` query filter already excludes a soft-deleted row
+  from `LeerSaldosAsync`'s result set, so `FindIndex` naturally returns -1
+  for it, same 400 as a nonexistent/foreign-articulo id.)*
+- [x] 7.3 Modify `LineaDeVenta`/`PlanDeVenta`/`ItemEmitido` contracts:
   `LineaDeVenta.IdLote` (optional input), `ItemEmitido.IdLote`/
   `CodigoLote`/`LoteVencido` (output); the plan carries the resolved lot,
-  immutable once decided.
-- [ ] 7.4 [P] Query-count test: module on + ≥1 lot-controlled articulo in
+  immutable once decided. *(APPLY-RUN NOTE: the private `LineaDelPlan`
+  record struct gained the same three trailing optional fields — that is
+  literally "the plan", per design. Since the transaction does NOT persist
+  `id_lote` in this slice (slice 8), `Proyectar` gained an optional
+  `planItems` parameter: the fresh-checkout call site
+  (`EjecutarTransaccionAsync`) passes `plan.Items` (zipped to
+  `itemsEntidad` by `Orden`, 1-based, same order) so `ItemEmitido` carries
+  the decide-phase lot even though the DB row does not yet; the two
+  read-back call sites (`BuscarPorNumeroComprometidoAsync`/`ObtenerAsync`)
+  omit it and fall back to the persisted (currently always-NULL) entity
+  field — an accepted, documented slice-8 dependency, not a bug.)*
+- [x] 7.4 [P] Query-count test: module on + ≥1 lot-controlled articulo in
   cart → `17`. *(spec lotes-y-vencimientos: "Module on with a
-  lot-controlled articulo nets zero round-trip change")*
-- [ ] 7.5 [P] Omitted-`idLote`-picks-FEFO test. *(spec: "An omitted idLote
-  resolves to the nearest-expiry dated lot")*
-- [ ] 7.6 [P] End-to-end sin-identificar-first proof (Domain-level mutation
+  lot-controlled articulo nets zero round-trip change")* *(APPLY-RUN NOTE:
+  `PlanDeVentaFefoTests.ElCheckoutEmiteDiecisieteConsultasConUnArticuloConLoteEnElCarrito`
+  — 17 confirmed, plus a table-filtered counter asserting exactly 1
+  `lotes`/`stock_lotes` query.)*
+- [x] 7.5 [P] Omitted-`idLote`-picks-FEFO test. *(spec: "An omitted idLote
+  resolves to the nearest-expiry dated lot")* *(APPLY-RUN NOTE:
+  `UnIdLoteOmitidoResuelveAlLoteDeVencimientoMasCercano`.)*
+- [x] 7.6 [P] End-to-end sin-identificar-first proof (Domain-level mutation
   target already in slice 2; this is the write-path confirmation). *(spec:
-  "The sin-identificar lot is offered before every dated lot")*
-- [ ] 7.7 [P] Supplied-`idLote`-honoured test. *(spec: "A supplied idLote
-  is honoured even when it is not the FEFO pick")*
-- [ ] 7.8 [P] Invalid-`idLote` test → `400 lote_invalido`. *(spec: "An
-  invalid supplied idLote is rejected")*
-- [ ] 7.9 [P] No-auto-split test. *(spec: "A lot running short still
-  completes the line, never auto-splitting")*
-- [ ] 7.10 [P] Regression: module on, no lot-controlled articulo in cart →
+  "The sin-identificar lot is offered before every dated lot")* *(APPLY-RUN
+  NOTE: `ElLoteSinIdentificarSeOfreceAntesQueCualquierLoteConFecha` — no
+  new mutation evidence recorded here, per the task's own framing (already
+  proven at Domain level in slice 2's `OrdenarFefo`/`ElegirFefo` suite);
+  this is confirmation-only.)*
+- [x] 7.7 [P] Supplied-`idLote`-honoured test. *(spec: "A supplied idLote
+  is honoured even when it is not the FEFO pick")* *(APPLY-RUN NOTE:
+  `UnIdLoteProvistoSeHonraAunqueNoSeaElPickFefo`.)*
+- [x] 7.8 [P] Invalid-`idLote` test → `400 lote_invalido`. *(spec: "An
+  invalid supplied idLote is rejected")* *(APPLY-RUN NOTE: two tests —
+  `UnIdLoteInvalidoEsRechazadoConLoteInvalido` (nonexistent id) and
+  `UnIdLoteDeOtroArticuloEsRechazadoConLoteInvalido` (real id, wrong
+  articulo). Mutation evidence (permanent rule 6): the `if (posicion < 0)
+  throw ...` guard in `ServicioDeVentas.EmitirAsync` was commented out,
+  rebuilt, and both tests re-run — both went RED
+  (`500`/`ArgumentOutOfRangeException` instead of `400 lote_invalido`);
+  guard restored, rebuilt, both tests GREEN again. No other layer was
+  weakened to produce the failure.)*
+- [x] 7.9 [P] No-auto-split test. *(spec: "A lot running short still
+  completes the line, never auto-splitting")* *(APPLY-RUN NOTE:
+  `UnLoteCortoCompletaLaLineaSinAutoSplit` — FEFO lot has balance 3, line
+  requests 5; asserts the response's single item still resolves to that one
+  lot for the full quantity 5 (no second `ItemEmitido` row). The negative
+  `stock_lotes.cantidad = -2` outcome itself is NOT asserted here — that
+  write does not exist yet in this slice (slice 8's `UpsertStockLoteAsync`
+  invariant test, task 8.4).)*
+- [x] 7.10 [P] Regression: module on, no lot-controlled articulo in cart →
   still `16`, no FEFO query. *(spec: "Module on with no lot-controlled
-  articulo in the cart issues no FEFO query")*
-- [ ] 7.11 [P] Legacy-client compatibility test. *(spec comprobantes-venta:
+  articulo in the cart issues no FEFO query")* *(APPLY-RUN NOTE:
+  `ElCheckoutEmiteDieciseisConsultasSinArticuloConLoteEnElCarrito` — 16
+  confirmed, plus the table-filtered counter asserting 0 `lotes`/
+  `stock_lotes` queries.)*
+- [x] 7.11 [P] Legacy-client compatibility test. *(spec comprobantes-venta:
   "A client that knows nothing about lots still transacts correctly")*
-- [ ] 7.12 [P] Mixed-cart test (lot-controlled + non-lot line in one
+  *(APPLY-RUN NOTE: `UnClienteLegadoSinIdLoteTransaccionaCorrectamente` —
+  posts a hand-built raw JSON body whose `lineas[0]` object has NO `idLote`
+  property at all (not even `null`), to simulate a client that has never
+  heard of the field; the sale succeeds and the FEFO default applies
+  silently.)*
+- [x] 7.12 [P] Mixed-cart test (lot-controlled + non-lot line in one
   cart). *(spec: "A cart with a lot-controlled and a non-lot articulo mixes
-  both paths")*
-- [ ] 7.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  both paths")* *(APPLY-RUN NOTE:
+  `UnCarritoMixtoDeArticuloConLoteYSinLoteResuelveAmbosCaminos`.)*
+- [x] 7.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(APPLY-RUN NOTE: ran via
+  `--project src/Ways.Infrastructure --startup-project src/Ways.Infrastructure`
+  (same reason as the slice 5 apply-run note — `Ways.Api` lacks the EF
+  Design package reference). Output: "No changes have been made to the
+  model since the last migration." Expected — this slice adds no schema,
+  only C#/records.)*
 - [ ] 7.14 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 7.15 Branch `feat/stage12-slice7-venta-plan-fefo` off `main` (parent:
   slice 3); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -866,7 +866,7 @@ unchanged. **Rollback**: revert the branch.
   Design package reference). Output: "No changes have been made to the
   model since the last migration." Expected — this slice adds no schema,
   only C#/records.)*
-- [ ] 7.14 Run `judgment-day`; fix; re-judge until clean. *(JD-FIX NOTE,
+- [x] 7.14 Run `judgment-day`; fix; re-judge until clean. *(JD-FIX NOTE,
   primera ronda: 5 hallazgos confirmados — CRITICAL 1 (`ElegirFefo` elegía el
   vencido con orden fecha ASC puro, sin preferir no-vencidos — resuelto por
   decisión 15, registrada en `state.yaml`), CRITICAL 2 (el fallback
@@ -883,7 +883,7 @@ unchanged. **Rollback**: revert the branch.
   se registra ACÁ, en `tasks.md`, además de comunicarse al orquestador — la
   resolución de ESTE desvío es exactamente la decisión 15 implementada en
   esta misma ronda de fixes.)*
-- [ ] 7.15 Branch `feat/stage12-slice7-venta-plan-fefo` off `main` (parent:
+- [x] 7.15 Branch `feat/stage12-slice7-venta-plan-fefo` off `main` (parent:
   slice 3); PR; merge stacked-to-main.
 
 **Test plan**: query count ×2 (7.4, 7.10), FEFO resolution ×4 (7.5-7.9),

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -866,12 +866,34 @@ unchanged. **Rollback**: revert the branch.
   Design package reference). Output: "No changes have been made to the
   model since the last migration." Expected — this slice adds no schema,
   only C#/records.)*
-- [ ] 7.14 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 7.14 Run `judgment-day`; fix; re-judge until clean. *(JD-FIX NOTE,
+  primera ronda: 5 hallazgos confirmados — CRITICAL 1 (`ElegirFefo` elegía el
+  vencido con orden fecha ASC puro, sin preferir no-vencidos — resuelto por
+  decisión 15, registrada en `state.yaml`), CRITICAL 2 (el fallback
+  sin-identificar sin ningún lote con saldo carecía de cobertura de
+  integración), HIGH 3 (`LoteVencido == true` nunca se aserteaba en ningún
+  test, solo el caso `false`), WARNING 4 (un `idLote` sobre una línea sin
+  lote efectivo se ignoraba en silencio — ahora `400 lote_invalido`),
+  WARNING 5 (sin test que contrastara el `IdLote` del response fresco contra
+  la relectura, que hoy cae a `null` hasta slice 8). Regla de proceso
+  reforzada tras esta ronda: el "desvío 3" que el apply de esta slice
+  reportó al orquestador (FEFO no saltaba lotes vencidos, deferido a este
+  judgment-day) nunca quedó anotado en el repo — solo en el mensaje al
+  orquestador; el juez B lo encontró por grep. A partir de acá, todo desvío
+  se registra ACÁ, en `tasks.md`, además de comunicarse al orquestador — la
+  resolución de ESTE desvío es exactamente la decisión 15 implementada en
+  esta misma ronda de fixes.)*
 - [ ] 7.15 Branch `feat/stage12-slice7-venta-plan-fefo` off `main` (parent:
   slice 3); PR; merge stacked-to-main.
 
 **Test plan**: query count ×2 (7.4, 7.10), FEFO resolution ×4 (7.5-7.9),
-compatibility (7.11), mixed cart (7.12).
+compatibility (7.11), mixed cart (7.12). *(JD-FIX round 1 additions:
+decisión-15 repro ×1 (vencido+vigente ambos con saldo, elige el vigente),
+fallback sin-identificar sin ningún lote con saldo ×1, `LoteVencido == true`
+asertado ×1, `idLote` sobre línea sin lote efectivo → `400` ×1,
+response-fresco-vs-relectura ×1 — más 2 tests nuevos en
+`ServicioDeLotesTests` (decisión 15 vía el picker) y 4 hechos nuevos de
+partición en `ReglaDeLotesTests` (Domain).)*
 
 **Verify**: `dotnet test --filter FullyQualifiedName~PlanDeVentaFefo`
 
@@ -882,6 +904,14 @@ compatibility (7.11), mixed cart (7.12).
 **Start**: slice 7 merged. **Finish**: per-lot writes land inside the
 pinned lock order; the item snapshot freezes `id_lote`; anulación reverses
 the exact lot. **Rollback**: revert the branch.
+
+**JD-FIX carryover (slice 7, FIX 5)**: once this slice persists `id_lote` on
+`items_comprobante_venta`, `PlanDeVentaFefoTests
+.ElCheckoutFrescoDevuelveIdLotePeroLaRelecturaTodaviaLoDevuelveNullHastaSlice8`
+stops being true — UPDATE it to assert the SAME `IdLote` on both the fresh
+checkout response and the `ObtenerAsync` re-read (drop the `Assert.Null` on
+the re-read, replace with `Assert.Equal(idLote, itemReleido.IdLote)`); rename
+away the "HastaSlice8" suffix once updated.
 
 - [ ] 8.1 Modify `ServicioDeVentas.cs`: `EjecutarTransaccionAsync` step 5 —
   loop `OrderBy(IdArticulo).ThenBy(IdLote)`; `InsertarMovimientoStockAsync`

--- a/src/Ways.Application/Stock/ServicioDeLotes.cs
+++ b/src/Ways.Application/Stock/ServicioDeLotes.cs
@@ -393,7 +393,6 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         var saldos = await LeerSaldosAsync(idPuntoVenta, [idArticulo], [], ct);
         var ordenados = ReglaDeLotes.OrdenarFefo(saldos);
-        var sugerido = ReglaDeLotes.ElegirFefo(saldos);
 
         // Honestidad documental: "hoy" acá es UTC naive (interino por diseño en este slice 3),
         // no la zona_horaria del PV. El reporte de vencimientos del slice 13 SÍ resuelve "hoy"
@@ -401,6 +400,11 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
         // picker admin no necesita esa precisión, mismo criterio de honestidad que
         // diasAlertaPorDefecto en CrearAsync.
         var hoy = DateOnly.FromDateTime(reloj.Ahora.UtcDateTime);
+
+        // Decisión 15 (judgment-day del slice 7): el Sugerido del picker tiene que ser
+        // consistente con la selección real del server (ServicioDeVentas) — mismo "hoy", mismo
+        // ElegirFefo particionado por no-vencido primero.
+        var sugerido = ReglaDeLotes.ElegirFefo(saldos, hoy);
         var diasAlerta = await ResolverDiasAlertaAsync(puntoVenta.IdEmpresa, idPuntoVenta, ct);
 
         return ordenados

--- a/src/Ways.Application/Ventas/Contratos.cs
+++ b/src/Ways.Application/Ventas/Contratos.cs
@@ -32,7 +32,9 @@ public sealed record SolicitudDeVenta(
 /// tiene efecto para una línea lote-efectiva (<c>ControlaLote AND lotesHabilitado</c>): omitido,
 /// <see cref="ServicioDeVentas"/> aplica el default FEFO; un cliente legado que ni siquiera
 /// conoce el campo transacciona igual (spec comprobantes-venta: "A client that knows nothing
-/// about lots still transacts correctly").</summary>
+/// about lots still transacts correctly"). Provisto sobre una línea SIN lote efectivo, el campo
+/// no tiene destino real: se rechaza 400 lote_invalido en vez de ignorarse en silencio
+/// (dto-contract-honesty, judgment-day del slice 7).</summary>
 public sealed record LineaDeVenta(int IdArticulo, decimal Cantidad, string? CodigoBarra, int? IdLote = null);
 
 /// <summary>Un medio de pago del checkout (design: Checkout Contract). A diferencia de

--- a/src/Ways.Application/Ventas/Contratos.cs
+++ b/src/Ways.Application/Ventas/Contratos.cs
@@ -28,8 +28,12 @@ public sealed record SolicitudDeVenta(
 /// contabilidad. Sin <c>precioUnitario</c>/<c>descuento</c>/<c>total</c> (design decisión 3).
 /// <see cref="CodigoBarra"/> es el que devolvió el escaneo — snapshot informativo en el item, no
 /// se re-valida contra <c>codigos_barra</c> en el checkout (ya se validó en
-/// <c>GET /api/articulos/escaneo</c>).</summary>
-public sealed record LineaDeVenta(int IdArticulo, decimal Cantidad, string? CodigoBarra);
+/// <c>GET /api/articulos/escaneo</c>). <see cref="IdLote"/> (stage-12 slice 7) es opcional y solo
+/// tiene efecto para una línea lote-efectiva (<c>ControlaLote AND lotesHabilitado</c>): omitido,
+/// <see cref="ServicioDeVentas"/> aplica el default FEFO; un cliente legado que ni siquiera
+/// conoce el campo transacciona igual (spec comprobantes-venta: "A client that knows nothing
+/// about lots still transacts correctly").</summary>
+public sealed record LineaDeVenta(int IdArticulo, decimal Cantidad, string? CodigoBarra, int? IdLote = null);
 
 /// <summary>Un medio de pago del checkout (design: Checkout Contract). A diferencia de
 /// <see cref="LineaDeVenta"/>, SÍ lleva dinero: <see cref="Importe"/>/<see cref="Vuelto"/> son lo
@@ -37,7 +41,14 @@ public sealed record LineaDeVenta(int IdArticulo, decimal Cantidad, string? Codi
 /// los valida, no los calcula.</summary>
 public sealed record PagoDeVenta(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);
 
-/// <summary>Un item ya emitido — snapshot inmutable (spec: Snapshot Immutability of Items).</summary>
+/// <summary>Un item ya emitido — snapshot inmutable (spec: Snapshot Immutability of Items).
+/// <see cref="IdLote"/>/<see cref="CodigoLote"/>/<see cref="LoteVencido"/> (stage-12 slice 7) solo
+/// se completan para una línea lote-efectiva: el lote resuelto en la fase de decisión (FEFO
+/// default u honrado si vino explícito), su código proyectado, y si su vencimiento ya pasó
+/// (warning, nunca bloqueo — spec: "Expired Lot Sale Warns, Never Blocks"). NULL/false para una
+/// línea sin lote. Nota de límite de esta slice: la escritura de <c>id_lote</c> en
+/// <c>items_comprobante_venta</c> es de slice 8 — acá el dato viaja en el plan/response, todavía
+/// no en la fila persistida.</summary>
 public sealed record ItemEmitido(
     int Orden,
     int? IdArticulo,
@@ -51,7 +62,10 @@ public sealed record ItemEmitido(
     decimal Cantidad,
     decimal PrecioUnitario,
     decimal Descuento,
-    decimal Total);
+    decimal Total,
+    int? IdLote = null,
+    string? CodigoLote = null,
+    bool LoteVencido = false);
 
 /// <summary>Un pago ya emitido.</summary>
 public sealed record PagoEmitido(int IdMedioPago, decimal Importe, string? Referencia, decimal Vuelto);

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -125,6 +125,22 @@ public class ServicioDeVentas(
                 && ReglaDeLotes.ControlEfectivo(articuloPorId[x.Item.IdArticulo].ControlaLote, lotesHabilitado))
             .ToList();
 
+        // dto-contract-honesty (WARNING 4 del judgment-day de esta slice): un idLote en una línea
+        // SIN lote efectivo no tiene destino — antes se ignoraba en silencio. Un cliente que lo
+        // manda ahí está en un error real (artículo no controla lote, o el módulo está apagado),
+        // así que se rechaza con el mismo código que un idLote inválido, en vez de tragárselo.
+        var indicesConLoteEfectivo = lineasConLote.Select(x => x.Indice).ToHashSet();
+        for (var indice = 0; indice < lineas.Count; indice++)
+        {
+            if (!indicesConLoteEfectivo.Contains(indice) && lineas[indice].IdLote is not null)
+            {
+                throw new ErrorDominio(
+                    "lote_invalido",
+                    $"El artículo {lineas[indice].IdArticulo} no tiene lote efectivo; no admite idLote.",
+                    400);
+            }
+        }
+
         if (lineasConLote.Count > 0)   // ← la ÚNICA query nueva del camino caliente: 16 → 17 (spec
                                         // lotes-y-vencimientos: "Module on with a lot-controlled
                                         // articulo nets zero round-trip change")
@@ -170,7 +186,7 @@ public class ServicioDeVentas(
 
                     loteResuelto = saldosDelArticulo[posicion];
                 }
-                else if (ReglaDeLotes.ElegirFefo(saldosDelArticulo) is { } elegido)
+                else if (ReglaDeLotes.ElegirFefo(saldosDelArticulo, hoy) is { } elegido)
                 {
                     loteResuelto = elegido;
                 }

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -8,6 +8,7 @@ using Ways.Application.Caja;
 using Ways.Application.CuentaCorriente;
 using Ways.Application.Exportacion;
 using Ways.Application.Ofertas;
+using Ways.Application.Stock;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
@@ -44,7 +45,7 @@ namespace Ways.Application.Ventas;
 /// </summary>
 public class ServicioDeVentas(
     IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas,
-    ServicioDeTurnos servicioDeTurnos)
+    ServicioDeTurnos servicioDeTurnos, ServicioDeLotes servicioDeLotes)
 {
     public async Task<ComprobanteEmitido> EmitirAsync(SolicitudDeVenta solicitud, CancellationToken ct = default)
     {
@@ -110,10 +111,93 @@ public class ServicioDeVentas(
         // lotes_habilitado, resueltas directo (sin el pre-chequeo de pertenencia de
         // ServicioDeParametros.ResolverAsync — puntoVenta ya se resolvió arriba, así que
         // idEmpresa ya es de confianza). Reemplaza las 2 consultas separadas de antes de esta
-        // etapa — 17 → 16 round trips (task 2.7). `lotesHabilitado` lo consume recién el plan
-        // FEFO de slice 7 (design: "Write site 1"); acá se descarta a propósito.
-        var (toleranciaPago, vueltoMaximo, _) =
+        // etapa — 17 → 16 round trips (task 2.7). `lotesHabilitado` alimenta el plan FEFO de
+        // slice 7, inmediatamente abajo.
+        var (toleranciaPago, vueltoMaximo, lotesHabilitado) =
             await ResolverParametrosDeVentaAsync(puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+
+        // stage-12 slice 7 (design: "Write site 1", decide phase) — decidir si hay línea
+        // lote-efectiva es GRATIS: articuloPorId ya está cargado arriba (MaterializarItems),
+        // lotesHabilitado ya resolvió en la query batcheada de arriba. Cero queries de sondeo.
+        var lineasConLote = items
+            .Select((item, indice) => (Item: item, Indice: indice))
+            .Where(x => x.Item.EsProducto
+                && ReglaDeLotes.ControlEfectivo(articuloPorId[x.Item.IdArticulo].ControlaLote, lotesHabilitado))
+            .ToList();
+
+        if (lineasConLote.Count > 0)   // ← la ÚNICA query nueva del camino caliente: 16 → 17 (spec
+                                        // lotes-y-vencimientos: "Module on with a lot-controlled
+                                        // articulo nets zero round-trip change")
+        {
+            var idsArticuloConLote = lineasConLote.Select(x => x.Item.IdArticulo).Distinct().ToList();
+            var idsLotePedidos = lineasConLote
+                .Select(x => lineas[x.Indice].IdLote)
+                .Where(idLote => idLote is not null)
+                .Select(idLote => idLote!.Value)
+                .Distinct()
+                .ToList();
+
+            var saldos = await servicioDeLotes.LeerSaldosAsync(puntoVenta.Id, idsArticuloConLote, idsLotePedidos, ct);
+            var saldosPorArticulo = saldos.ToLookup(s => s.IdArticulo);
+
+            // Honestidad documental: "hoy" acá es UTC naive (interino por diseño, mismo criterio
+            // que ServicioDeCompras.EjecutarConfirmarAsync / ServicioDeLotes.ListarAsync/CrearAsync
+            // — slice 3), no la zona_horaria del PV. LoteVencido es un warning de decisión 12,
+            // nunca un bloqueo.
+            var hoy = DateOnly.FromDateTime(momento.UtcDateTime);
+            var itemsResueltos = items.ToList();
+
+            foreach (var (item, indice) in lineasConLote)
+            {
+                var saldosDelArticulo = saldosPorArticulo[item.IdArticulo].ToList();
+                var idLotePedido = lineas[indice].IdLote;
+
+                SaldoDeLote loteResuelto;
+                if (idLotePedido is { } idLote)
+                {
+                    // Un idLote provisto se valida contra `saldos` (existe, es del artículo, no
+                    // borrado — el filtro global de EF sobre Lotes ya excluye soft-deleted, así
+                    // que un id borrado simplemente no aparece acá) o se rechaza (spec
+                    // lotes-y-vencimientos: "An invalid supplied idLote is rejected").
+                    var posicion = saldosDelArticulo.FindIndex(s => s.IdLote == idLote);
+                    if (posicion < 0)
+                    {
+                        throw new ErrorDominio(
+                            "lote_invalido",
+                            $"El lote {idLote} no existe, no pertenece al artículo {item.IdArticulo} o fue eliminado.",
+                            400);
+                    }
+
+                    loteResuelto = saldosDelArticulo[posicion];
+                }
+                else if (ReglaDeLotes.ElegirFefo(saldosDelArticulo) is { } elegido)
+                {
+                    loteResuelto = elegido;
+                }
+                else
+                {
+                    // Ningún lote con saldo positivo (design decisión 7) — get-or-create perezoso
+                    // del lote sin identificar, statement crudo, invisible al contador de
+                    // presupuesto (misma familia que UpsertStockAsync).
+                    var conexionParaLotes = await ObtenerConexionAbiertaAsync(ct);
+                    var idSinIdentificar = await ServicioDeLotes.ResolverSinIdentificarAsync(
+                        conexionParaLotes, transaccion: null, idTenant, item.IdArticulo, momento, ct);
+
+                    loteResuelto = new SaldoDeLote(
+                        item.IdArticulo, idSinIdentificar, ReglaDeLotes.CodigoSinIdentificar,
+                        EsSinIdentificar: true, FechaVencimiento: null, Cantidad: 0m);
+                }
+
+                itemsResueltos[indice] = item with
+                {
+                    IdLote = loteResuelto.IdLote,
+                    CodigoLote = loteResuelto.Codigo,
+                    LoteVencido = ReglaDeLotes.EstaVencido(loteResuelto.FechaVencimiento, hoy)
+                };
+            }
+
+            items = itemsResueltos;
+        }
 
         // 1 consulta: medios de pago pedidos.
         var idsMedioPago = pagos.Select(p => p.IdMedioPago).Distinct().ToList();
@@ -742,7 +826,7 @@ public class ServicioDeVentas(
 
         await transaccion.CommitAsync(ct);
 
-        return Proyectar(comprobante, itemsEntidad, pagosEntidad);
+        return Proyectar(comprobante, itemsEntidad, pagosEntidad, plan.Items);
     }
 
     // ---- Resolución de datos, fuera de la transacción ----------------------------------------
@@ -1032,8 +1116,16 @@ public class ServicioDeVentas(
             ?? throw new InvalidOperationException(
                 "ServicioDeVentas requiere un actor de tenant; OperacionDePos no admite plataforma.");
 
+    /// <summary>Design decisión (stage-12 slice 7): la transacción todavía NO persiste
+    /// <c>id_lote</c> en <c>items_comprobante_venta</c> (esa escritura es de slice 8) — para el
+    /// checkout recién emitido, <paramref name="planItems"/> trae el lote ya resuelto en la fase
+    /// de decisión (mismo orden/índice que <paramref name="items"/>, uno a uno vía
+    /// <c>Orden</c>) y lo proyecta acá; para una relectura sin plan a mano (reprint,
+    /// idempotencia de <see cref="BuscarPorNumeroComprometidoAsync"/>) cae al valor ya persistido
+    /// en la entidad — NULL hasta que slice 8 lo escriba.</summary>
     private static ComprobanteEmitido Proyectar(
-        ComprobanteVenta comprobante, IReadOnlyList<ItemComprobanteVenta> items, IReadOnlyList<PagoComprobante> pagos) => new(
+        ComprobanteVenta comprobante, IReadOnlyList<ItemComprobanteVenta> items, IReadOnlyList<PagoComprobante> pagos,
+        IReadOnlyList<LineaDelPlan>? planItems = null) => new(
         comprobante.Id, comprobante.Numero,
         NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
         comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
@@ -1041,9 +1133,14 @@ public class ServicioDeVentas(
         comprobante.DireccionEntrega, comprobante.Observaciones,
         items
             .OrderBy(i => i.Orden)
-            .Select(i => new ItemEmitido(
-                i.Orden, i.IdArticulo, i.Descripcion, i.CodigoBarra, i.IdArea, i.IdListaPrecio, i.IdOferta,
-                i.IdAlicuotaIva, i.PorcentajeIva, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total))
+            .Select(i =>
+            {
+                var planItem = planItems?[i.Orden - 1];
+                return new ItemEmitido(
+                    i.Orden, i.IdArticulo, i.Descripcion, i.CodigoBarra, i.IdArea, i.IdListaPrecio, i.IdOferta,
+                    i.IdAlicuotaIva, i.PorcentajeIva, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total,
+                    planItem?.IdLote ?? i.IdLote, planItem?.CodigoLote, planItem?.LoteVencido ?? false);
+            })
             .ToList(),
         pagos
             .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
@@ -1054,7 +1151,8 @@ public class ServicioDeVentas(
     private readonly record struct LineaDelPlan(
         int IdArticulo, string Descripcion, string? CodigoBarra, int IdArea, int IdListaPrecio, int? IdOferta,
         int IdAlicuotaIva, decimal PorcentajeIva, decimal Cantidad, decimal PrecioUnitario, decimal Descuento,
-        decimal Total, bool EsProducto, decimal? CostoUnitario);
+        decimal Total, bool EsProducto, decimal? CostoUnitario,
+        int? IdLote = null, string? CodigoLote = null, bool LoteVencido = false);
 
     private readonly record struct PagoDelPlan(
         int IdMedioPago, ComportamientoMedioPago Comportamiento, decimal Importe, string? Referencia, decimal Vuelto);

--- a/src/Ways.Domain/Stock/ReglaDeLotes.cs
+++ b/src/Ways.Domain/Stock/ReglaDeLotes.cs
@@ -57,7 +57,7 @@ public static class ReglaDeLotes
     /// lote del artículo tiene saldo positivo — el llamador resuelve (o crea, get-or-create) el
     /// lote sin identificar en su lugar (design decisión 7), esta función nunca lo crea.
     ///
-    /// Decisión 15 (judgment-day del slice 7, spec lotes-y-vencimientos: "FEFO MUST pre-select a
+    /// Decisión 15 (judgment-day del slice 7, spec comprobantes-venta: "FEFO MUST pre-select a
     /// non-expired lot whenever one exists with positive balance"): entre los lotes con saldo
     /// positivo, la SELECCIÓN se particiona primero por vencimiento respecto de
     /// <paramref name="hoy"/> — los NO vencidos (el sin-identificar, sin fecha, cuenta como no

--- a/src/Ways.Domain/Stock/ReglaDeLotes.cs
+++ b/src/Ways.Domain/Stock/ReglaDeLotes.cs
@@ -55,12 +55,29 @@ public static class ReglaDeLotes
 
     /// <summary>Lote por defecto de una línea sin <c>idLote</c> explícito. <c>null</c> ⇒ ningún
     /// lote del artículo tiene saldo positivo — el llamador resuelve (o crea, get-or-create) el
-    /// lote sin identificar en su lugar (design decisión 7), esta función nunca lo crea.</summary>
-    public static SaldoDeLote? ElegirFefo(IEnumerable<SaldoDeLote> saldosDelArticulo)
+    /// lote sin identificar en su lugar (design decisión 7), esta función nunca lo crea.
+    ///
+    /// Decisión 15 (judgment-day del slice 7, spec lotes-y-vencimientos: "FEFO MUST pre-select a
+    /// non-expired lot whenever one exists with positive balance"): entre los lotes con saldo
+    /// positivo, la SELECCIÓN se particiona primero por vencimiento respecto de
+    /// <paramref name="hoy"/> — los NO vencidos (el sin-identificar, sin fecha, cuenta como no
+    /// vencido, <see cref="EstaVencido"/>) van antes que los vencidos — y solo DESPUÉS se aplica
+    /// el orden FEFO base (<see cref="OrdenarFefo"/>) dentro de cada partición. "Nunca bloquea"
+    /// queda intacto: si la única partición con saldo es la de vencidos, se elige el vencido (el
+    /// llamador adjunta el warning <c>LoteVencido</c>). Esto NO toca <see cref="OrdenarFefo"/> —
+    /// el orden de LISTADO del picker sigue siendo el mismo, solo cambia el PICK.</summary>
+    public static SaldoDeLote? ElegirFefo(IEnumerable<SaldoDeLote> saldosDelArticulo, DateOnly hoy)
     {
         var conSaldoPositivo = saldosDelArticulo.Where(s => s.Cantidad > 0m).ToList();
+        if (conSaldoPositivo.Count == 0)
+        {
+            return null;
+        }
 
-        return conSaldoPositivo.Count == 0 ? null : OrdenarFefo(conSaldoPositivo)[0];
+        var noVencidos = conSaldoPositivo.Where(s => !EstaVencido(s.FechaVencimiento, hoy)).ToList();
+        var particionElegida = noVencidos.Count > 0 ? noVencidos : conSaldoPositivo;
+
+        return OrdenarFefo(particionElegida)[0];
     }
 
     /// <summary>Código server-derivado a partir del vencimiento ISO (spec: "A lot is created

--- a/tests/Ways.Domain.Tests/Stock/ReglaDeLotesTests.cs
+++ b/tests/Ways.Domain.Tests/Stock/ReglaDeLotesTests.cs
@@ -49,22 +49,83 @@ public class ReglaDeLotesTests
 
     // ---- ElegirFefo (spec: default de línea sin idLote) ---------------------------------------
 
+    private static readonly DateOnly Hoy = new(2026, 8, 12);
+
     [Fact]
     public void ElegirFefoDevuelveNullCuandoNingunSaldoEsPositivo()
     {
         SaldoDeLote[] saldos = [Saldo(idLote: 1, cantidad: 0m), Saldo(idLote: 2, cantidad: -3m)];
 
-        Assert.Null(ReglaDeLotes.ElegirFefo(saldos));
+        Assert.Null(ReglaDeLotes.ElegirFefo(saldos, Hoy));
     }
 
     [Fact]
     public void ElegirFefoDevuelveElPrimeroDelOrdenFefoEntreLosDeSaldoPositivo()
     {
+        // Ambos vencimientos NO vencidos respecto de Hoy — misma partición, gana el más cercano
+        // (comportamiento FEFO base, sin interferencia de la partición de decisión 15).
         var sinSaldo = Saldo(idLote: 1, fechaVencimiento: new DateOnly(2026, 7, 1), cantidad: 0m);
-        var conSaldoMasCercano = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2026, 8, 1), cantidad: 5m);
-        var conSaldoMasLejano = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2026, 9, 1), cantidad: 5m);
+        var conSaldoMasCercano = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2027, 8, 1), cantidad: 5m);
+        var conSaldoMasLejano = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2027, 9, 1), cantidad: 5m);
 
-        var elegido = ReglaDeLotes.ElegirFefo([sinSaldo, conSaldoMasLejano, conSaldoMasCercano]);
+        var elegido = ReglaDeLotes.ElegirFefo([sinSaldo, conSaldoMasLejano, conSaldoMasCercano], Hoy);
+
+        Assert.Equal(2, elegido!.Value.IdLote);
+    }
+
+    // ---- ElegirFefo — decisión 15 (judgment-day slice 7): partición no-vencido antes que vencido ---
+
+    [Fact]
+    public void ElegirFefoPrefiereElVigenteAunqueElVencidoVenzaAntesEnElOrdenFefoBase()
+    {
+        // Orden FEFO puro (solo fecha ASC) elegiría el vencido, por vencer antes — decisión 15
+        // exige que la partición no-vencido gane primero.
+        var vencido = Saldo(idLote: 1, fechaVencimiento: new DateOnly(2020, 1, 15), cantidad: 5m);
+        var vigente = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2099, 12, 31), cantidad: 5m);
+
+        var elegido = ReglaDeLotes.ElegirFefo([vencido, vigente], Hoy);
+
+        Assert.Equal(2, elegido!.Value.IdLote);
+    }
+
+    [Fact]
+    public void ElegirFefoEligeElVencidoCuandoEsLaUnicaParticionConSaldo()
+    {
+        // "Nunca bloquea" (decisión 12): si la única partición con saldo positivo es la de
+        // vencidos, se elige el vencido igual — el llamador adjunta el warning LoteVencido.
+        var vencidoA = Saldo(idLote: 1, fechaVencimiento: new DateOnly(2020, 1, 15), cantidad: 5m);
+        var vencidoB = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2021, 6, 1), cantidad: 5m);
+
+        var elegido = ReglaDeLotes.ElegirFefo([vencidoA, vencidoB], Hoy);
+
+        Assert.Equal(1, elegido!.Value.IdLote);
+    }
+
+    [Fact]
+    public void ElegirFefoPrefiereElSinIdentificarPorSobreUnVigenteDentroDeLaParticionNoVencida()
+    {
+        // El sin-identificar (sin fecha) nunca está vencido (EstaVencido), así que cae en la
+        // misma partición no-vencido que el vigente — y OrdenarFefo lo sigue poniendo primero
+        // (es_sin_identificar DESC) dentro de esa partición, decisión 4 intacta.
+        var sinIdentificar = Saldo(idLote: 1, esSinIdentificar: true, cantidad: 5m);
+        var vigente = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2099, 12, 31), cantidad: 5m);
+        var vencido = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2020, 1, 15), cantidad: 5m);
+
+        var elegido = ReglaDeLotes.ElegirFefo([vencido, vigente, sinIdentificar], Hoy);
+
+        Assert.Equal(1, elegido!.Value.IdLote);
+    }
+
+    [Fact]
+    public void ElegirFefoDesempataDentroDeLaParticionNoVencidaPorVencimientoAscendenteYLuegoPorId()
+    {
+        var vencido = Saldo(idLote: 1, fechaVencimiento: new DateOnly(2020, 1, 15), cantidad: 5m);
+        var noVencidoLejano = Saldo(idLote: 4, fechaVencimiento: new DateOnly(2099, 12, 31), cantidad: 5m);
+        var noVencidoCercanoIdMayor = Saldo(idLote: 3, fechaVencimiento: new DateOnly(2027, 1, 1), cantidad: 5m);
+        var noVencidoCercanoIdMenor = Saldo(idLote: 2, fechaVencimiento: new DateOnly(2027, 1, 1), cantidad: 5m);
+
+        var elegido = ReglaDeLotes.ElegirFefo(
+            [vencido, noVencidoLejano, noVencidoCercanoIdMayor, noVencidoCercanoIdMenor], Hoy);
 
         Assert.Equal(2, elegido!.Value.IdLote);
     }

--- a/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
+++ b/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
@@ -525,4 +525,133 @@ public class PlanDeVentaFefoTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         Assert.Null(itemSinLote.CodigoLote);
         Assert.False(itemSinLote.LoteVencido);
     }
+
+    // ---- judgment-day slice 7, FIX 1 (CRITICAL 1) — decisión 15: ElegirFefo prefiere no vencidos ---
+
+    /// <summary>Repro exacto del juez B: un lote VENCIDO (2020-01-15) y uno VIGENTE (2099-12-31),
+    /// AMBOS con saldo positivo, <c>idLote</c> omitido. El orden FEFO base (fecha ASC pura)
+    /// elegiría el vencido, por vencer antes — decisión 15 exige que la partición no-vencido gane
+    /// primero. <para>EVIDENCIA DE MUTACIÓN: se revirtió <c>ReglaDeLotes.ElegirFefo</c> a la
+    /// partición vieja (<c>OrdenarFefo(conSaldoPositivo)[0]</c>, fecha ASC pura, sin partición por
+    /// vencimiento) — build, mismo filtro: este test cae RED (<c>item.IdLote</c> esperado
+    /// <c>idVigente</c>, actual <c>idVencido</c>). Restaurada la partición de decisión 15, build,
+    /// mismo filtro: GREEN.</para></summary>
+    [Fact]
+    public async Task UnIdLoteOmitidoConVencidoYVigenteAmbosConSaldoEligeElVigente()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteOmitidoConVencidoYVigenteAmbosConSaldoEligeElVigente));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-decision-15", 100m, controlaLote: true);
+        var idVencido = await SembrarLoteAsync(ctx, idArticulo, "L-VENCIDO", VencimientoLejanoPasado);
+        var idVigente = await SembrarLoteAsync(ctx, idArticulo, "L-VIGENTE", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idVencido, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idVigente, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idVigente, item.IdLote);
+        Assert.Equal("L-VIGENTE", item.CodigoLote);
+        Assert.False(item.LoteVencido);
+    }
+
+    // ---- judgment-day slice 7, FIX 2 (CRITICAL 2) — fallback sin-identificar sin lote con saldo ---
+
+    /// <summary>Artículo lote-efectivo sin ningún lote con saldo positivo (acá, directamente sin
+    /// ningún lote sembrado — la otra mitad válida de la condición, "o sin lotes"): el plan
+    /// resuelve el sin-identificar vía get-or-create perezoso (<c>ResolverSinIdentificarAsync</c>),
+    /// nunca revienta ni deja la línea sin lote.</summary>
+    [Fact]
+    public async Task UnArticuloSinNingunLoteConSaldoResuelveElSinIdentificarPorGetOrCreate()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloSinNingunLoteConSaldoResuelveElSinIdentificarPorGetOrCreate));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-sin-lotes", 100m, controlaLote: true);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(ReglaDeLotes.CodigoSinIdentificar, item.CodigoLote);
+        Assert.NotNull(item.IdLote);
+        Assert.False(item.LoteVencido);
+    }
+
+    // ---- judgment-day slice 7, FIX 3 (HIGH 3) — LoteVencido asertado en true ---------------------
+
+    /// <summary>Un <c>idLote</c> explícito de un lote VENCIDO se HONRA (spec: "A supplied idLote
+    /// is honoured even when it is not the FEFO pick") — a diferencia de todos los tests previos
+    /// de esta clase, que solo aserteaban <c>LoteVencido == false</c>, este es el primero que
+    /// asserta <c>true</c>.</summary>
+    [Fact]
+    public async Task UnIdLoteProvistoDeUnLoteVencidoDevuelveLoteVencidoEnTrue()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteProvistoDeUnLoteVencidoDevuelveLoteVencidoEnTrue));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-vencido-honrado", 100m, controlaLote: true);
+        var idVencido = await SembrarLoteAsync(ctx, idArticulo, "L-VENCIDO-HONRADO", VencimientoLejanoPasado);
+        await SembrarStockLoteAsync(ctx, idArticulo, idVencido, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: idVencido));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idVencido, item.IdLote);
+        Assert.Equal("L-VENCIDO-HONRADO", item.CodigoLote);
+        Assert.True(item.LoteVencido);
+    }
+
+    // ---- judgment-day slice 7, FIX 4 (WARNING 4) — idLote sobre línea sin lote efectivo -----------
+
+    /// <summary>dto-contract-honesty: un <c>idLote</c> mandado sobre una línea de un artículo que
+    /// NO controla lote no tiene destino real — antes se ignoraba en silencio, ahora se rechaza
+    /// con el mismo código que un idLote inválido (el campo no puede aterrizar en ningún lado).</summary>
+    [Fact]
+    public async Task UnIdLoteSobreUnaLineaSinLoteEfectivoEsRechazadoConLoteInvalido()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteSobreUnaLineaSinLoteEfectivoEsRechazadoConLoteInvalido));
+        var idArticuloConLote = await SembrarArticuloAsync(ctx, "articulo-fix4-con-lote", 100m, controlaLote: true);
+        var idArticuloSinLote = await SembrarArticuloAsync(ctx, "articulo-fix4-sin-lote", 50m, controlaLote: false);
+        var idLote = await SembrarLoteAsync(ctx, idArticuloConLote, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticuloConLote, idLote, 10m);
+
+        // El idLote va sobre la línea SIN lote efectivo — inválido, aunque el id exista y sea real
+        // (es de OTRO artículo que sí controla lote).
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticuloSinLote, 1m, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- judgment-day slice 7, FIX 5 (WARNING 5) — response fresco vs relectura -------------------
+
+    /// <summary>Límite honesto de esta slice (ver el doc-comment de <c>Proyectar</c> en
+    /// <c>ServicioDeVentas.cs</c>, APPLY-RUN NOTE de la task 7.3): el checkout FRESCO devuelve
+    /// <c>id_lote</c> desde el plan (no persistido todavía), pero una relectura vía
+    /// <c>ObtenerAsync</c> cae al valor YA persistido en <c>items_comprobante_venta.id_lote</c>,
+    /// que esta slice todavía no escribe — <c>null</c> hasta slice 8. (Al llegar slice 8, este test
+    /// SE ACTUALIZA para esperar el mismo <c>IdLote</c> en ambas lecturas — ver la nota del bloque
+    /// Slice 8 en tasks.md.)</summary>
+    [Fact]
+    public async Task ElCheckoutFrescoDevuelveIdLotePeroLaRelecturaTodaviaLoDevuelveNullHastaSlice8()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutFrescoDevuelveIdLotePeroLaRelecturaTodaviaLoDevuelveNullHastaSlice8));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fix5-contraste", 100m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null));
+        var itemFresco = Assert.Single(emitido.Items);
+        Assert.Equal(idLote, itemFresco.IdLote);
+
+        var respuestaRelectura = await ctx.Admin.GetAsync($"/api/ventas/{emitido.Id}");
+        var cuerpoRelectura = await respuestaRelectura.Content.ReadAsStringAsync();
+        Assert.True(respuestaRelectura.StatusCode == HttpStatusCode.OK, cuerpoRelectura);
+        var releido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoRelectura, OpcionesJson)!;
+
+        var itemReleido = Assert.Single(releido.Items);
+        Assert.Null(itemReleido.IdLote);
+    }
 }

--- a/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
+++ b/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
@@ -1,0 +1,528 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 7 (tasks 7.4-7.12): el plan FEFO de
+/// <c>ServicioDeVentas.EmitirAsync</c> punta a punta — solo la fase de DECISIÓN cambia en esta
+/// slice (design: "Write site 1", decide phase); la transacción sigue sin escribir <c>id_lote</c>
+/// (eso es slice 8), así que cada prueba acá asserta el PLAN/response (<see cref="ItemEmitido"/>),
+/// nunca <c>movimientos_stock</c>/<c>stock_lotes</c> con lote.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class PlanDeVentaFefoTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas de vencimiento FIJAS y lejanas — independientes del reloj de la
+    // corrida. LoteVencido solo se asserta con estas fechas, nunca con un borde "hoy".
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+    private static readonly DateOnly VencimientoLejanoFuturoAlterno = new(2098, 6, 30);
+    private static readonly DateOnly VencimientoLejanoPasado = new(2020, 1, 15);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva,
+        int IdListaPrecio, int IdMedioEfectivo, int IdCliente);
+
+    private async Task<Contexto> PrepararAsync(string nombre, bool lotesHabilitado = true)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Fefo-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Fefo", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        // stage-12 slice 7: módulo de lotes a nivel empresa — controlable por prueba (7.10 lo
+        // deja en true igual, el articulo del carrito es el que no controla lote).
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = lotesHabilitado ? "true" : "false", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "Cliente Fefo",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 1_000_000m,
+            CreditoIlimitado = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, idMedioEfectivo, cliente.Id);
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre, decimal precio, bool controlaLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = controlaLote, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio,
+            Monto = precio, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(
+        Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento, bool esSinIdentificar = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = esSinIdentificar, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeVenta SolicitudSimple(Contexto ctx, int idArticulo, decimal cantidad, int? idLote) =>
+        new(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, cantidad * 100m, null, 0m)],
+            null, null);
+
+    private static async Task<ComprobanteEmitido> EmitirAsync(Contexto ctx, SolicitudDeVenta solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 7.5: FEFO por defecto — nearest-expiry ------------------------------------------
+
+    [Fact]
+    public async Task UnIdLoteOmitidoResuelveAlLoteDeVencimientoMasCercano()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteOmitidoResuelveAlLoteDeVencimientoMasCercano));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-cercano", 100m, controlaLote: true);
+        var idL1 = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturoAlterno);
+        var idL2 = await SembrarLoteAsync(ctx, idArticulo, "L2", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL1, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL2, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idL1, item.IdLote);
+        Assert.Equal("L1", item.CodigoLote);
+        Assert.False(item.LoteVencido);
+    }
+
+    // ---- task 7.6: sin-identificar SIEMPRE primero (spec: "offered before every dated lot") ---
+
+    [Fact]
+    public async Task ElLoteSinIdentificarSeOfreceAntesQueCualquierLoteConFecha()
+    {
+        var ctx = await PrepararAsync(nameof(ElLoteSinIdentificarSeOfreceAntesQueCualquierLoteConFecha));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-sin-id", 100m, controlaLote: true);
+        var idSinIdentificar = await SembrarLoteAsync(ctx, idArticulo, ReglaDeLotes.CodigoSinIdentificar, null, esSinIdentificar: true);
+        var idL1 = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturoAlterno);
+        await SembrarStockLoteAsync(ctx, idArticulo, idSinIdentificar, 5m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL1, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idSinIdentificar, item.IdLote);
+        Assert.Equal(ReglaDeLotes.CodigoSinIdentificar, item.CodigoLote);
+    }
+
+    // ---- task 7.7: un idLote provisto se HONRA aunque no sea el pick FEFO ----------------------
+
+    [Fact]
+    public async Task UnIdLoteProvistoSeHonraAunqueNoSeaElPickFefo()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteProvistoSeHonraAunqueNoSeaElPickFefo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-honrado", 100m, controlaLote: true);
+        var idL1 = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturoAlterno);
+        var idL2 = await SembrarLoteAsync(ctx, idArticulo, "L2", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL1, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL2, 10m);
+
+        // El pick FEFO natural sería L1 (vence antes) — pide L2 explícito.
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: idL2));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idL2, item.IdLote);
+        Assert.Equal("L2", item.CodigoLote);
+    }
+
+    // ---- task 7.8: idLote inválido → 400 lote_invalido (mutation-proof-tests) ------------------
+
+    /// <summary>Mutation target nombrado por la regla permanente 6 de este apply: la validación
+    /// <c>saldosDelArticulo.FindIndex(s => s.IdLote == idLote)</c> en
+    /// <c>ServicioDeVentas.EmitirAsync</c> es la ÚNICA barrera entre un <c>idLote</c> ajeno/
+    /// inexistente y el checkout. Evidencia de mutación (regla permanente 6, apply de slice 7):
+    /// con el <c>if (posicion &lt; 0) throw ...</c> comentado (la línea cae directo a
+    /// <c>loteResuelto = saldosDelArticulo[posicion]</c> con <c>posicion = -1</c>), este test
+    /// corrió y **no** dio <c>400 lote_invalido</c> — tiró <c>IndexOutOfRangeException</c> sin
+    /// capturar, <c>500</c> genérico (rojo, mensaje distinto al esperado). Revertido el comentado,
+    /// vuelve a <c>400 lote_invalido</c> (verde). No se debilitó ninguna otra capa — la prueba
+    /// llama al endpoint real de punta a punta.</summary>
+    [Fact]
+    public async Task UnIdLoteInvalidoEsRechazadoConLoteInvalido()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteInvalidoEsRechazadoConLoteInvalido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-invalido", 100m, controlaLote: true);
+        var idL1 = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idL1, 10m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/ventas", SolicitudSimple(ctx, idArticulo, 1m, idLote: idL1 + 999_000));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Mismo código <c>lote_invalido</c>, otra causa: el lote existe pero es de OTRO
+    /// artículo — la búsqueda está scopeada a <c>saldosPorArticulo[item.IdArticulo]</c>, así que
+    /// un lote real ajeno tampoco aparece en <c>saldosDelArticulo</c>.</summary>
+    [Fact]
+    public async Task UnIdLoteDeOtroArticuloEsRechazadoConLoteInvalido()
+    {
+        var ctx = await PrepararAsync(nameof(UnIdLoteDeOtroArticuloEsRechazadoConLoteInvalido));
+        var idArticuloA = await SembrarArticuloAsync(ctx, "articulo-fefo-a", 100m, controlaLote: true);
+        var idArticuloB = await SembrarArticuloAsync(ctx, "articulo-fefo-b", 100m, controlaLote: true);
+        var idLoteDeB = await SembrarLoteAsync(ctx, idArticuloB, "L-B", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticuloB, idLoteDeB, 10m);
+        var idLoteDeA = await SembrarLoteAsync(ctx, idArticuloA, "L-A", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticuloA, idLoteDeA, 10m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/ventas", SolicitudSimple(ctx, idArticuloA, 1m, idLote: idLoteDeB));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 7.9: un lote corto completa la línea igual, nunca auto-split ---------------------
+
+    [Fact]
+    public async Task UnLoteCortoCompletaLaLineaSinAutoSplit()
+    {
+        var ctx = await PrepararAsync(nameof(UnLoteCortoCompletaLaLineaSinAutoSplit));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-corto", 100m, controlaLote: true);
+        var idLoteCorto = await SembrarLoteAsync(ctx, idArticulo, "L-CORTO", VencimientoLejanoFuturoAlterno);
+        var idLoteLargo = await SembrarLoteAsync(ctx, idArticulo, "L-LARGO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteCorto, 3m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteLargo, 100m);
+
+        // Pide 5 unidades — el lote FEFO (L-CORTO, vence antes) solo tiene saldo 3.
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 5m, idLote: null));
+
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idLoteCorto, item.IdLote);
+        Assert.Equal(5m, item.Cantidad);
+    }
+
+    // ---- task 7.4/7.10: guard de presupuesto de consultas — 16 → 17 solo con lote en el carrito ---
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Igual técnica que <c>VentasCheckoutTests.ContadorDeComandos</c>: cuenta cada
+    /// comando que dispara <c>ReaderExecuting</c> (incluye los dos <c>SaveChangesAsync</c> de la
+    /// mitad transaccional, de cantidad constante — no rompe el guard).</summary>
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    /// <summary>Filtrado a los comandos cuyo texto referencia <c>lotes</c>/<c>stock_lotes</c> —
+    /// aísla la query de <see cref="ServicioDeLotes.LeerSaldosAsync"/> del resto del checkout.</summary>
+    private sealed class ContadorDeConsultasDeLotes : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        private static bool Coincide(DbCommand command) =>
+            command.CommandText.Contains("stock_lotes", StringComparison.OrdinalIgnoreCase)
+            || command.CommandText.Contains("\"l\".\"id_lote\"", StringComparison.OrdinalIgnoreCase)
+            || command.CommandText.Contains("FROM lotes", StringComparison.OrdinalIgnoreCase);
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            if (Coincide(command))
+            {
+                Consultas++;
+            }
+
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (Coincide(command))
+            {
+                Consultas++;
+            }
+
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private async Task<(int Total, int DeLotes)> EmitirYContarConsultasAsync(
+        Contexto ctx, int idArticulo, int? idLote)
+    {
+        var contadorTotal = new ContadorDeComandos();
+        var contadorDeLotes = new ContadorDeConsultasDeLotes();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contadorTotal, contadorDeLotes)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
+
+        await servicioDeVentas.EmitirAsync(SolicitudSimple(ctx, idArticulo, 1m, idLote));
+
+        return (contadorTotal.Consultas, contadorDeLotes.Consultas);
+    }
+
+    [Fact]
+    public async Task ElCheckoutEmiteDiecisieteConsultasConUnArticuloConLoteEnElCarrito()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutEmiteDiecisieteConsultasConUnArticuloConLoteEnElCarrito));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-presupuesto", 10m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        var (total, deLotes) = await EmitirYContarConsultasAsync(ctx, idArticulo, idLote: null);
+
+        // spec lotes-y-vencimientos: "Module on with a lot-controlled articulo nets zero
+        // round-trip change" — 16 (baseline post-slice-2) + 1 (LeerSaldosAsync) = 17.
+        Assert.Equal(17, total);
+        Assert.Equal(1, deLotes);
+    }
+
+    [Fact]
+    public async Task ElCheckoutEmiteDieciseisConsultasSinArticuloConLoteEnElCarrito()
+    {
+        var ctx = await PrepararAsync(nameof(ElCheckoutEmiteDieciseisConsultasSinArticuloConLoteEnElCarrito));
+        // lotes_habilitado = true a nivel empresa, pero el articulo del carrito NO controla lote
+        // (spec: "Module on with no lot-controlled articulo in the cart issues no FEFO query").
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-sin-lote-presupuesto", 10m, controlaLote: false);
+
+        var (total, deLotes) = await EmitirYContarConsultasAsync(ctx, idArticulo, idLote: null);
+
+        Assert.Equal(16, total);
+        Assert.Equal(0, deLotes);
+    }
+
+    // ---- task 7.11: cliente legado sin idLote transacciona bien --------------------------------
+
+    [Fact]
+    public async Task UnClienteLegadoSinIdLoteTransaccionaCorrectamente()
+    {
+        var ctx = await PrepararAsync(nameof(UnClienteLegadoSinIdLoteTransaccionaCorrectamente));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fefo-legado", 100m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        // Payload crudo: la línea NO tiene la propiedad "idLote" en absoluto — un cliente legado
+        // que ni siquiera conoce el campo (a diferencia de mandar el campo con valor null).
+        var payload = $$"""
+            {
+              "idPuntoVenta": {{ctx.IdPuntoVenta}},
+              "idCliente": {{ctx.IdCliente}},
+              "codigoTipoComprobante": "TX",
+              "idComprobanteAsociado": null,
+              "lineas": [ { "idArticulo": {{idArticulo}}, "cantidad": 1, "codigoBarra": null } ],
+              "pagos": [ { "idMedioPago": {{ctx.IdMedioEfectivo}}, "importe": 100, "referencia": null, "vuelto": 0 } ],
+              "direccionEntrega": null,
+              "observaciones": null
+            }
+            """;
+
+        var respuesta = await ctx.Admin.PostAsync(
+            "/api/ventas", new StringContent(payload, Encoding.UTF8, "application/json"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var emitido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idLote, item.IdLote);
+    }
+
+    // ---- task 7.12: carrito mixto (lote-efectivo + sin lote) ------------------------------------
+
+    [Fact]
+    public async Task UnCarritoMixtoDeArticuloConLoteYSinLoteResuelveAmbosCaminos()
+    {
+        var ctx = await PrepararAsync(nameof(UnCarritoMixtoDeArticuloConLoteYSinLoteResuelveAmbosCaminos));
+        var idArticuloConLote = await SembrarArticuloAsync(ctx, "articulo-mixto-con-lote", 100m, controlaLote: true);
+        var idArticuloSinLote = await SembrarArticuloAsync(ctx, "articulo-mixto-sin-lote", 50m, controlaLote: false);
+        var idLote = await SembrarLoteAsync(ctx, idArticuloConLote, "L1", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticuloConLote, idLote, 10m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticuloConLote, 1m, null), new LineaDeVenta(idArticuloSinLote, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 150m, null, 0m)],
+            null, null);
+
+        var emitido = await EmitirAsync(ctx, solicitud);
+
+        Assert.Equal(2, emitido.Items.Count);
+        var itemConLote = emitido.Items.Single(i => i.IdArticulo == idArticuloConLote);
+        var itemSinLote = emitido.Items.Single(i => i.IdArticulo == idArticuloSinLote);
+        Assert.Equal(idLote, itemConLote.IdLote);
+        Assert.Null(itemSinLote.IdLote);
+        Assert.Null(itemSinLote.CodigoLote);
+        Assert.False(itemSinLote.LoteVencido);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeLotesTests.cs
@@ -418,11 +418,14 @@ public class ServicioDeLotesTests(WaysApiFixture fixture) : IClassFixture<WaysAp
     /// <c>ServicioDeLotes.cs:162</c> (<c>Sugerido: ... ordenados[^1].IdLote == s.IdLote</c> en vez
     /// de <c>sugerido.Value.IdLote == s.IdLote</c>) el pick pasa a ser la ÚLTIMA fila del orden
     /// FEFO (sin-identificar primero, después ascendente por vencimiento) — acá
-    /// <c>loteVigente</c> (2099-12-31) en vez de <c>loteVencido</c> (2020-01-15). Build + filtro
-    /// <c>~ServicioDeLotesTests</c> con la mutación aplicada: este test cae RED
-    /// (<c>vencido.Sugerido</c> esperado <c>true</c>/actual <c>false</c>; <c>vigente.Sugerido</c>
-    /// esperado <c>false</c>/actual <c>true</c>). Revertida la mutación, build, mismo filtro:
-    /// GREEN, 10/10.</para></summary>
+    /// <c>loteVigente</c> (2099-12-31) en vez del ganador esperado. Build + filtro
+    /// <c>~ServicioDeLotesTests</c> con la mutación aplicada: este test cae RED. Revertida la
+    /// mutación, build, mismo filtro: GREEN.</para>
+    /// <para>Actualizado en el judgment-day del slice 7 (decisión 15): con los TRES lotes fechados
+    /// con saldo positivo, la partición no-vencido gana primero — <c>loteVencido</c> (2020-01-15)
+    /// queda EXCLUIDO del pick pese a vencer antes en el orden FEFO base; el ganador es
+    /// <c>loteMedio</c> (2050-06-15), el más próximo DENTRO de la partición no-vencido
+    /// (<c>loteVigente</c>, 2099-12-31, sigue en esa partición pero vence más lejos).</para></summary>
     [Fact]
     public async Task GetLotesConVariosFechadosSugiereSoloElDeVencimientoMasProximoYEstadoEsIndependienteDelReloj()
     {
@@ -474,15 +477,62 @@ public class ServicioDeLotesTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         var vigente = lotes.Single(l => l.IdLote == loteVigente.Id);
         var sinIdentificar = lotes.Single(l => l.IdLote == loteSinIdentificar.Id);
 
-        // FIX 2: sugerido EXACTAMENTE en el de vencimiento más próximo, false en las otras TRES filas (regla 6).
-        Assert.True(vencido.Sugerido);
-        Assert.False(medio.Sugerido);
+        // Decisión 15 (slice 7): sugerido EXACTAMENTE en el más próximo DENTRO de la partición
+        // no-vencido (loteMedio) — el vencido queda excluido del pick pese a vencer antes.
+        Assert.False(vencido.Sugerido);
+        Assert.True(medio.Sugerido);
         Assert.False(vigente.Sugerido);
         Assert.False(sinIdentificar.Sugerido);
 
         // FIX 3: estado vía HTTP, independiente de la hora de corrida.
         Assert.Equal(EstadoDeVencimiento.Vencido, vencido.Estado);
         Assert.Equal(EstadoDeVencimiento.Vigente, vigente.Estado);
+    }
+
+    // ---- judgment-day slice 7, FIX 1 (CRITICAL 1) — decisión 15 vía el picker (GET /api/stock/lotes) ---
+
+    /// <summary>Repro exacto del juez B, ahora desde el picker: solo un lote VENCIDO
+    /// (2020-01-15) y uno VIGENTE (2099-12-31), ambos con saldo positivo — sin un tercer candidato
+    /// "medio" que enmascare el efecto. El <c>Sugerido</c> del picker tiene que ser consistente
+    /// con la selección real del server (decisión 12/15): el vigente, nunca el vencido.</summary>
+    [Fact]
+    public async Task GetLotesConVencidoYVigenteAmbosConSaldoSugiereElVigente()
+    {
+        var ctx = await PrepararAsync(nameof(GetLotesConVencidoYVigenteAmbosConSaldoSugiereElVigente));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-picker-decision-15");
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var loteVencido = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-PICKER-VENCIDO",
+            FechaVencimiento = new DateOnly(2020, 1, 15), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var loteVigente = new Lote
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, Codigo = "L-PICKER-VIGENTE",
+            FechaVencimiento = new DateOnly(2099, 12, 31), EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.AddRange(loteVencido, loteVigente);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.AddRange(
+            new StockLote { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteVencido.Id, IdTenant = ctx.IdTenant, Cantidad = 5m },
+            new StockLote { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = loteVigente.Id, IdTenant = ctx.IdTenant, Cantidad = 5m });
+        await db.SaveChangesAsync();
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/stock/lotes?idPuntoVenta={ctx.IdPuntoVenta}&idArticulo={idArticulo}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var lotes = JsonSerializer.Deserialize<List<LoteListado>>(cuerpo, OpcionesJson)!;
+
+        var vencido = lotes.Single(l => l.IdLote == loteVencido.Id);
+        var vigente = lotes.Single(l => l.IdLote == loteVigente.Id);
+
+        Assert.False(vencido.Sugerido);
+        Assert.True(vigente.Sugerido);
     }
 
     // ---- judgment-day slice 3, FIX 4: camino de código derivado (blind spot) ----------------------

--- a/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/VentasAtomicidadYConcurrenciaTests.cs
@@ -579,7 +579,8 @@ public class VentasAtomicidadYConcurrenciaTests(WaysApiFixture fixture) : IClass
         var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
         var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
         var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
 
         var metodo = typeof(ServicioDeVentas).GetMethod(
             "BuscarPorNumeroComprometidoAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -1035,7 +1035,8 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
         var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
         var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
 
         var solicitud = new SolicitudDeVenta(
             ctx.IdPuntoVenta, idCliente, "TX", null,
@@ -1123,7 +1124,8 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
         var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
         var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
 
         var solicitud = new SolicitudDeVenta(
             ctx.IdPuntoVenta, idCliente, "TX", null, lineas,

--- a/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
+++ b/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
@@ -297,7 +297,8 @@ public class VentasTurnoWiringTests(WaysApiFixture fixture) : IClassFixture<Ways
         var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
         var lector = new LectorDeMovimientosDelTurno(db);
         var servicioDeTurnos = new ServicioDeTurnos(db, reloj, contexto, lector);
-        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
 
         var solicitud = new SolicitudDeVenta(
             ctx.IdPuntoVenta, idCliente, "TX", null,


### PR DESCRIPTION
## Etapa 12 — Slice 7: Venta Plan FEFO

- **Fase decide, transacción intacta**: tras \`MaterializarItems\`, si el carrito tiene artículos con lote efectivo, UNA query de saldos (\`LeerSaldosAsync\`) — presupuesto 16→17 SOLO en ese caso, 16 sin (asertado con conteo exacto). Los items todavía NO persisten \`id_lote\` (slice 8); el response fresco SÍ lo lleva (contraste documentado y testeado).
- **Resolución por línea**: \`idLote\` provisto validado (existe, del artículo, no soft-deleted; también rechazado sobre líneas SIN lote efectivo — dto-contract-honesty, escenario ADDED al spec) o \`400 lote_invalido\`; omitido → FEFO; sin saldo positivo → sin-identificar lazy.
- **Decisión 15** (nacida del CRITICAL del juez B, probado en vivo): \`ElegirFefo(saldos, hoy)\` particiona la selección — **no vencidos primero** (sin-identificar incluido, conserva su primer lugar), vencidos como fallback; "nunca bloquea" intacto; \`OrdenarFefo\` (listado del picker) sin cambios; el \`Sugerido\` del picker actualizado para consistencia con la selección real del server.
- \`ItemEmitido.LoteVencido\` (warning de decisión 12) asertado en ambas direcciones con fechas fijas lejanas.

### Tests
PlanDeVentaFefo 15/15 · ServicioDeLotes 12/12 · regresión Ventas 121/121 · Domain 420/420 (4 facts nuevos de la partición). 9 rondas de evidencia de mutación en el slice.

### Judgment-day
Juez B ronda 1 REJECT con 2 CRITICAL + 1 HIGH reales: FEFO elegía el lote VENCIDO sobre el vigente (violación de spec reproducida end-to-end), fallback sin-identificar con cero cobertura (mutación sobrevivía 131/131), y \`LoteVencido\` jamás asertado en true (constante de test declarada y muerta). Fix batch = decisión 15 + 5 tests; ronda 2 doble APPROVE (juez A con 1 MINOR de cita de spec, corregido en el cierre). Nota de proceso: los desvíos del apply ahora se registran SIEMPRE en el repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)