### PR TITLE
feat(lotes): reporte de vencimientos con export XLSX — etapa 12, slice 13

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1239,7 +1239,9 @@ a `/resumen` tile feed. **Rollback**: revert the branch.
   `ObtenerVencimientosAsync` — lot rows with positive `stock_lotes.cantidad`,
   classified via `ReglaDeLotes.Clasificar` (four states incl. `SinFecha`),
   ordered `fecha_vencimiento ASC NULLS LAST`, `dias` defaults to the
-  resolved `dias_alerta_vencimiento`; `ResolverZonaAsync` resolves "hoy" in
+  resolved `dias_alerta_vencimiento`; `ResolverZonaAsync` *(shipped as
+  `ResolverContextoAsync` — broader name, it also resolves `idEmpresa` for
+  the dias chain; rename noted at judgment-day, judge A MINOR-1)* resolves "hoy" in
   the PV's own `zona_horaria`, never UTC.
 - [x] 13.2 Modify the same file: `ObtenerResumenDeVencimientosAsync` —
   Tablero tile counts (`vencido`/`por_vencer`/`sin_fecha`).
@@ -1309,8 +1311,17 @@ a `/resumen` tile feed. **Rollback**: revert the branch.
   no pending changes. Confirmed clean: "No changes have been made to the
   model since the last migration." (this slice touches only Application/Api
   layers — no `Ways.Domain`/EF configuration edits).
-- [ ] 13.12 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 13.13 Branch `feat/stage12-slice13-vencimientos` off `main` (parent:
+- [x] 13.12 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  round 1 — judge B APPROVE-with-MAJOR: the `dias ?? resolved` override
+  branch had zero coverage on both report and export; all 8 mutation probes
+  killed (zone flip, boundary, sin_fecha exclusion, zero-balance, cell swap,
+  row drop, cap truncation, tile miscount). Fix 59474d7: 2 override tests
+  with mutation evidence. Round 2 judge B APPROVE; judge A APPROVE with 4
+  MINORs — rename note added above; accepted debt: the export-dias test
+  uses UtcNow with a 5-day safety margin instead of RelojFijo (verified
+  safe across the 00-03 UTC window by both judges), and the report's
+  ORDER BY has no id tiebreaker (display-only, spec-silent).)*
+- [x] 13.13 Branch `feat/stage12-slice13-vencimientos` off `main` (parent:
   slice 1); PR; merge stacked-to-main.
 
 **Test plan**: non-UTC mutation (13.5), classification ×4 (13.6),

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1235,44 +1235,80 @@ invariants ×3 (12.12).
 states resolved in the PV's own zona horaria, with an `/export` sibling and
 a `/resumen` tile feed. **Rollback**: revert the branch.
 
-- [ ] 13.1 Modify `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
+- [x] 13.1 Modify `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
   `ObtenerVencimientosAsync` — lot rows with positive `stock_lotes.cantidad`,
   classified via `ReglaDeLotes.Clasificar` (four states incl. `SinFecha`),
   ordered `fecha_vencimiento ASC NULLS LAST`, `dias` defaults to the
   resolved `dias_alerta_vencimiento`; `ResolverZonaAsync` resolves "hoy" in
   the PV's own `zona_horaria`, never UTC.
-- [ ] 13.2 Modify the same file: `ObtenerResumenDeVencimientosAsync` —
+- [x] 13.2 Modify the same file: `ObtenerResumenDeVencimientosAsync` —
   Tablero tile counts (`vencido`/`por_vencer`/`sin_fecha`).
-- [ ] 13.3 Modify `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
+- [x] 13.3 Modify `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
   `De(Vencimientos, ctx)` mapper — **listing shape** (design decision 17):
   `COUNT(*) → refuse → single read with .Take(tope + 1)`, never an
   aggregate-row-count guard.
-- [ ] 13.4 Modify `src/Ways.Api/Endpoints/ReportesEndpoints.cs`: `GET
+  *(Deviation, non-functional: the COUNT/refuse/Take pipeline lives in
+  `ServicioDeReportesDeStock.ObtenerVencimientosParaExportacionAsync`, not
+  inside the mapper itself — `De(Vencimientos, ctx)` stays pure/no-DB,
+  matching this file's own documented "No Re-Query" invariant and the exact
+  precedent of `ServicioDeHistoricoDeCajas.ListarCierresParaExportacionAsync`
+  / `ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaParaExportacionAsync`.
+  The end-to-end shape — Count → refuse → Take(tope+1) → refuse — is
+  unchanged; only which layer executes the SQL differs from a literal
+  reading of the task line.)*
+- [x] 13.4 Modify `src/Ways.Api/Endpoints/ReportesEndpoints.cs`: `GET
   /reportes/stock/vencimientos` (`LecturaDeReportes`), `GET
   .../vencimientos/export` (co-located, inherited policy), `GET
   .../vencimientos/resumen`.
-- [ ] 13.5 [P] **Mutation target**: `TimeZoneInfo.ConvertTime(reloj.Ahora,
+- [x] 13.5 [P] **Mutation target**: `TimeZoneInfo.ConvertTime(reloj.Ahora,
   zona)` replaced with `reloj.Ahora.UtcDateTime` → the non-UTC
   classification test MUST fail (the lot flips `PorVencer → Vencido`);
   revert → green. *(spec: "'Hoy' is resolved in the punto de venta's own
   zona horaria, not UTC"; mutation-proof-tests)* Record evidence.
-- [ ] 13.6 [P] Classification-boundary tests: `vencido`/`por_vencer`/
+  **Evidence**: `VencimientosReporteTests.LaClasificacionSeResuelveEnLaZonaHorariaDelPuntoDeVentaNoEnUtc`
+  — reloj pinned to `2026-08-13T01:30:00Z` (same instant as the spec
+  scenario), PV zona `America/Argentina/Buenos_Aires` (default), lot
+  `fecha_vencimiento = 2026-08-12`. Mutation applied to
+  `ServicioDeReportesDeStock.ResolverContextoAsync` (`TimeZoneInfo.ConvertTime(reloj.Ahora,
+  zona).DateTime` → `reloj.Ahora.UtcDateTime`): test FAILED — `Hoy` expected
+  `12/08/2026`, actual `13/08/2026` (the lot would flip `PorVencer` →
+  `Vencido`). Reverted → all 8 filtered tests green. The lock-step (dias,
+  boundary-inclusive) domain-level `Clasificar` boundary math itself was
+  already covered by `ReglaDeLotesTests` from an earlier slice; this
+  mutation isolates the zone-conversion clause specifically, at the
+  integration/HTTP level.
+- [x] 13.6 [P] Classification-boundary tests: `vencido`/`por_vencer`/
   `vigente`/`sin_fecha`-counts-in-totals. *(spec: "A lot past its expiry
   classifies as vencido", "A lot within the alert horizon classifies as
   por_vencer", "A lot beyond the horizon classifies as vigente", "The
   sin-identificar lot appears in the report as sin_fecha and counts toward
-  the totals")*
-- [ ] 13.7 [P] Zero-balance-lot-excluded test. *(spec: "A zero-balance lot
-  never appears in the report")*
-- [ ] 13.8 [P] Export equality, cell by cell (`mutation-proof-tests` rule
+  the totals")* **Test**: `VencimientosReporteTests.ClasificaLosCuatroEstadosYElSinFechaCuentaEnLosTotales`
+  — 4 lots (`vencido`/`por_vencer`/`vigente`/`sin_fecha`, dias_alerta default
+  30, boundary dates matching `ReglaDeLotesTests`), asserts each row's
+  `Estado` plus the `/resumen` tile counts (1/1/1) consistent with the
+  report.
+- [x] 13.7 [P] Zero-balance-lot-excluded test. *(spec: "A zero-balance lot
+  never appears in the report")* **Test**: `VencimientosReporteTests.UnLoteConSaldoCeroNuncaApareceEnElReporte`.
+- [x] 13.8 [P] Export equality, cell by cell (`mutation-proof-tests` rule
   6): different values per row and column so a swap is detectable. *(spec:
-  "The export sibling's figures equal the JSON endpoint's")*
-- [ ] 13.9 [P] Cap + `+1` race backstop (listing shape, stage-11
-  precedent): `COUNT(*) → refuse` with the actual row count named.
-- [ ] 13.10 [P] 403 test. *(spec: "A Vendedor is rejected from the
-  vencimientos report and its export")*
-- [ ] 13.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  "The export sibling's figures equal the JSON endpoint's")* **Test**:
+  `VencimientosExportTests.ElExportEsIgualAlEndpointJsonFilaPorFilaEnTodasLasColumnas`
+  — 2 lots with distinct values on every column (one dated, one
+  sin-identificar to cover the blank-date cell), all 7 columns compared per
+  row.
+- [x] 13.9 [P] Cap + `+1` race backstop (listing shape, stage-11
+  precedent): `COUNT(*) → refuse` with the actual row count named. **Test**:
+  `VencimientosExportTests.UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal`
+  — tope forced to 3 via `WithWebHostBuilder`, 4 lots seeded, asserts `400
+  exportacion_demasiado_grande` naming `4`.
+- [x] 13.10 [P] 403 test. *(spec: "A Vendedor is rejected from the
+  vencimientos report and its export")* **Tests**:
+  `VencimientosReporteTests.UnVendedorEsRechazadoDelReporteDeVencimientos`,
+  `VencimientosExportTests.UnVendedorEsRechazadoDelExportDeVencimientos`.
+- [x] 13.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. Confirmed clean: "No changes have been made to the
+  model since the last migration." (this slice touches only Application/Api
+  layers — no `Ways.Domain`/EF configuration edits).
 - [ ] 13.12 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 13.13 Branch `feat/stage12-slice13-vencimientos` off `main` (parent:
   slice 1); PR; merge stacked-to-main.

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -373,6 +373,58 @@ public static class ReportesEndpoints
             "Export XLSX de /stock/existencias: mismas filas, encabezado fechado a hoy (reporte " +
             "de estado actual, sin rango).");
 
+        // stage-12-lotes-vencimientos, Slice 13 (design decisión 15/16, spec lotes-y-vencimientos:
+        // "Vencimientos Report Resolves 'Hoy' In The Punto De Venta's Own Zona Horaria, With An
+        // Export Sibling"): gate heredado del grupo (LecturaDeReportes). "hoy" y
+        // dias_alerta_vencimiento se resuelven DENTRO del servicio (ResolverContextoAsync) —
+        // gobiernan tanto este JSON como /resumen y /export, nunca solo un encabezado HTTP.
+        grupo.MapGet("/stock/vencimientos", (
+            ServicioDeReportesDeStock servicio, int idPuntoVenta, int? dias, CancellationToken ct) =>
+            servicio.ObtenerVencimientosAsync(idPuntoVenta, dias, ct))
+        .WithSummary(
+            "Lotes con saldo positivo de un punto de venta, clasificados vencido/por_vencer/" +
+            "vigente/sin_fecha en la zona horaria del punto de venta — dias por defecto: " +
+            "dias_alerta_vencimiento.");
+
+        // Tile de Tablero (design: API Surface) — reusa la misma clasificación que el JSON de
+        // arriba, nunca una segunda query de agregación (ObtenerResumenDeVencimientosAsync).
+        grupo.MapGet("/stock/vencimientos/resumen", (
+            ServicioDeReportesDeStock servicio, int idPuntoVenta, CancellationToken ct) =>
+            servicio.ObtenerResumenDeVencimientosAsync(idPuntoVenta, ct))
+        .WithSummary("Tile de Tablero: conteos de vencido/por_vencer/sin_fecha del punto de venta.");
+
+        // Sibling declarado inmediatamente después de su ruta fuente — hereda LecturaDeReportes
+        // por co-locación. LISTADO (design decisión 17): el tope de filas ya lo exige el servicio
+        // (Contar → rechazar → Take(tope + 1)) antes de volver acá, mismo shape que /cajas/export
+        // — sin un GuardaDeTope adicional en este nivel, el servicio ya la corrió dos veces.
+        // AlcanceDeListadoHttp resuelve solo la ETIQUETA de empresa del encabezado: la zona
+        // efectivamente usada para clasificar es la que devuelve el propio servicio
+        // (vencimientos.ZonaHoraria), nunca una segunda resolución que pudiera divergir.
+        grupo.MapGet("/stock/vencimientos/export", async (
+            ServicioDeReportesDeStock servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            int idPuntoVenta, int? dias, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var vencimientos = await servicio.ObtenerVencimientosParaExportacionAsync(
+                idPuntoVenta, dias, opciones.Value.TopeDeFilas, ct);
+
+            var (empresa, _) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, empresa, $"PV {idPuntoVenta}", vencimientos.Hoy, vencimientos.Hoy, vencimientos.ZonaHoraria);
+            var tabla = ExportacionDeReportes.De(vencimientos, ctx);
+
+            var bytes = exportador.Generar(tabla);
+            var nombre = NombreDeArchivo.Construir("vencimientos", $"pv{idPuntoVenta}", vencimientos.Hoy, vencimientos.Hoy);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de /stock/vencimientos: mismas filas, tope de filas exigido antes de " +
+            "generar el archivo (design decisión 17).");
+
         // stage-11-exportacion-reportes, Slice 5a (design: G2/G3 — minimal aggregation; spec
         // historico-de-cajas: G2 Histórico Lists Closed Turnos Only, Role Split — Turno Detail
         // Under OperacionDePos, Cross-Turno Views Under LecturaDeReportes): gate heredado del

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -1,5 +1,6 @@
 using Ways.Domain.Gastos;
 using Ways.Domain.Reportes;
+using Ways.Domain.Stock;
 
 namespace Ways.Application.Reportes;
 
@@ -140,3 +141,30 @@ public sealed record FilaExistencia(int IdArticulo, string Nombre, decimal Canti
 /// quedan fuera de esta slice (proposal decisión 10: "give it the context it lacks here", reservado
 /// para Etapa 13).</summary>
 public sealed record Existencias(int IdPuntoVenta, IReadOnlyList<FilaExistencia> Filas);
+
+/// <summary>Fila de <c>GET /api/reportes/stock/vencimientos</c> (stage-12-lotes-vencimientos,
+/// Slice 13; design decisión 15/16). Solo lotes con <c>stock_lotes.cantidad</c> positivo (spec
+/// lotes-y-vencimientos: "A zero-balance lot never appears in the report") — <see cref="Articulo"/>
+/// sale del join en vivo, mismo criterio que <see cref="FilaExistencia.Nombre"/> (estado actual,
+/// nunca un snapshot). <see cref="FechaVencimiento"/> es <c>null</c> exactamente para el lote sin
+/// identificar, que clasifica <see cref="EstadoDeVencimiento.SinFecha"/> y SE INCLUYE en el
+/// reporte (nunca excluido — la omisión mentiría por defecto sobre el total).</summary>
+public sealed record FilaDeVencimiento(
+    int IdArticulo, string Articulo, int IdLote, string CodigoLote, DateOnly? FechaVencimiento,
+    decimal Cantidad, EstadoDeVencimiento Estado);
+
+/// <summary>Respuesta de <c>GET /api/reportes/stock/vencimientos</c>. <see cref="Hoy"/> y
+/// <see cref="ZonaHoraria"/> son la fecha y la zona efectivamente resueltas para clasificar cada
+/// fila — echo obligatorio (mismo criterio que <see cref="ResumenDeVentas.ZonaHoraria"/>): "hoy"
+/// se calcula en la zona horaria del punto de venta, NUNCA en UTC (spec: "'Hoy' Is Resolved In The
+/// Punto De Venta's Own Zona Horaria, Not UTC" — vinculante). <see cref="DiasDeAlerta"/> es el
+/// horizonte efectivamente aplicado: el parámetro <c>dias</c> de la query si vino, si no el
+/// <c>dias_alerta_vencimiento</c> resuelto (PV → empresa → default).</summary>
+public sealed record Vencimientos(
+    int IdPuntoVenta, DateOnly Hoy, int DiasDeAlerta, string ZonaHoraria, IReadOnlyList<FilaDeVencimiento> Filas);
+
+/// <summary>Respuesta de <c>GET /api/reportes/stock/vencimientos/resumen</c> — el tile de Tablero
+/// (spec: "a Tablero tile MUST surface the counts of vencido, por_vencer, and sin_fecha"). Mismos
+/// tres conteos que <see cref="Vencimientos.Filas"/> agrupados por <see cref="FilaDeVencimiento.Estado"/>
+/// — nunca una query de agregación separada, para que el tile y el reporte no puedan divergir.</summary>
+public sealed record ResumenDeVencimientos(int IdPuntoVenta, int Vencidos, int PorVencer, int SinFecha);

--- a/src/Ways.Application/Reportes/ExportacionDeReportes.cs
+++ b/src/Ways.Application/Reportes/ExportacionDeReportes.cs
@@ -298,4 +298,37 @@ public static class ExportacionDeReportes
                     Celda.Cantidad(f.Cantidad)
                 ])
                 .ToList());
+
+    private static readonly IReadOnlyList<ColumnaExportable> ColumnasVencimientos =
+    [
+        new ColumnaExportable("Artículo", TipoDeColumna.Entero),
+        new ColumnaExportable("Nombre", TipoDeColumna.Texto),
+        new ColumnaExportable("Lote", TipoDeColumna.Entero),
+        new ColumnaExportable("Código de lote", TipoDeColumna.Texto),
+        new ColumnaExportable("Vencimiento", TipoDeColumna.Fecha),
+        new ColumnaExportable("Cantidad", TipoDeColumna.Cantidad),
+        new ColumnaExportable("Estado", TipoDeColumna.Texto)
+    ];
+
+    /// <summary>stage-12-lotes-vencimientos, Slice 13 (design decisión 17): LISTADO, no agregado —
+    /// el tope de filas ya lo exigió <c>ServicioDeReportesDeStock.ObtenerVencimientosParaExportacionAsync</c>
+    /// (Contar → rechazar → <c>.Take(tope + 1)</c>) ANTES de llegar acá; este mapper sigue siendo
+    /// puro y sin re-consultar la base (design decisión 11 heredada, "No Re-Query"). Sin fila de
+    /// totales: sumar cantidades de lotes de artículos distintos no produce una figura con
+    /// significado propio, mismo criterio que <see cref="Existencias"/>.</summary>
+    public static TablaExportable De(Vencimientos respuesta, ContextoDeExportacion ctx) =>
+        new(
+            "Vencimientos", ctx, ColumnasVencimientos,
+            respuesta.Filas
+                .Select(f => (IReadOnlyList<Celda>)
+                [
+                    Celda.Entero(f.IdArticulo),
+                    Celda.Texto(f.Articulo),
+                    Celda.Entero(f.IdLote),
+                    Celda.Texto(f.CodigoLote),
+                    Celda.Fecha(f.FechaVencimiento),
+                    Celda.Cantidad(f.Cantidad),
+                    Celda.Texto(f.Estado.ToString())
+                ])
+                .ToList());
 }

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -1,5 +1,11 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Parametros;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Common;
+using Ways.Domain.Stock;
 
 namespace Ways.Application.Reportes;
 
@@ -17,8 +23,17 @@ namespace Ways.Application.Reportes;
 /// (<c>WaysDbContext.AplicarFiltroDeTenantEnStock</c>) — ambos activos sobre este join. Trade-off
 /// deliberado: el stock de un artículo eliminado queda oculto del reporte (cubierto por
 /// <c>ExistenciasTests.UnArticuloEliminadoNuncaApareceEnLasExistencias</c>).
+///
+/// stage-12-lotes-vencimientos, Slice 13 (design decisión 15/16/17, spec lotes-y-vencimientos:
+/// "Vencimientos Report Resolves 'Hoy' In The Punto De Venta's Own Zona Horaria, With An Export
+/// Sibling"): agrega <see cref="ObtenerVencimientosAsync"/>/<see cref="ObtenerResumenDeVencimientosAsync"/>/
+/// <see cref="ObtenerVencimientosParaExportacionAsync"/>. A diferencia de existencias (agregado
+/// acotado por el catálogo), vencimientos es un LISTADO cuyo volumen crece con el tiempo (design
+/// decisión 17) — solo el export exige tope (<c>Contar → rechazar → .Take(tope + 1)</c>, mismo
+/// shape que <c>ServicioDeHistoricoDeCajas.ListarCierresParaExportacionAsync</c>); el JSON no lo
+/// pagina, mismo criterio que <c>ObtenerExistenciasAsync</c>.
 /// </summary>
-public class ServicioDeReportesDeStock(IWaysDbContext db)
+public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros parametros, IRelojDelSistema reloj)
 {
     public async Task<Existencias> ObtenerExistenciasAsync(int idPuntoVenta, CancellationToken ct = default)
     {
@@ -35,4 +50,114 @@ public class ServicioDeReportesDeStock(IWaysDbContext db)
 
         return new Existencias(idPuntoVenta, filas);
     }
+
+    /// <summary>Lotes con saldo positivo del punto de venta, clasificados en la zona horaria del
+    /// PV — sin paginar (task 13.1). <paramref name="dias"/> ausente ⇒ se resuelve
+    /// <c>dias_alerta_vencimiento</c> (PV → empresa → default).</summary>
+    public async Task<Vencimientos> ObtenerVencimientosAsync(
+        int idPuntoVenta, int? dias, CancellationToken ct = default)
+    {
+        var (idEmpresa, zonaId, hoy) = await ResolverContextoAsync(idPuntoVenta, ct);
+        var diasDeAlerta = dias ?? await ResolverDiasAlertaAsync(idEmpresa, idPuntoVenta, ct);
+
+        var filas = await ConstruirQueryDeVencimientos(idPuntoVenta).ToListAsync(ct);
+
+        return new Vencimientos(idPuntoVenta, hoy, diasDeAlerta, zonaId, Clasificar(filas, hoy, diasDeAlerta));
+    }
+
+    /// <summary>Tile de Tablero (task 13.2) — reusa <see cref="ObtenerVencimientosAsync"/> con
+    /// <c>dias</c> nulo (el horizonte default) y agrupa por <see cref="EstadoDeVencimiento"/>: el
+    /// tile nunca puede divergir del reporte porque no hay una segunda query de agregación.</summary>
+    public async Task<ResumenDeVencimientos> ObtenerResumenDeVencimientosAsync(
+        int idPuntoVenta, CancellationToken ct = default)
+    {
+        var vencimientos = await ObtenerVencimientosAsync(idPuntoVenta, dias: null, ct);
+
+        return new ResumenDeVencimientos(
+            idPuntoVenta,
+            vencimientos.Filas.Count(f => f.Estado == EstadoDeVencimiento.Vencido),
+            vencimientos.Filas.Count(f => f.Estado == EstadoDeVencimiento.PorVencer),
+            vencimientos.Filas.Count(f => f.Estado == EstadoDeVencimiento.SinFecha));
+    }
+
+    /// <summary>design decisión 17: vencimientos es un LISTADO, no un agregado — <c>Contar →
+    /// rechazar → lectura única con .Take(tope + 1)</c>, nunca una guarda sobre
+    /// <c>TablaExportable.Filas.Count</c> ya mapeada (esa es la forma de un agregado acotado por
+    /// construcción, como <see cref="ObtenerExistenciasAsync"/>). Mismo <see cref="ConstruirQueryDeVencimientos"/>
+    /// que el JSON, así que las figuras del export son estructuralmente las mismas que las del
+    /// endpoint — nunca dos consultas que puedan divergir.</summary>
+    public async Task<Vencimientos> ObtenerVencimientosParaExportacionAsync(
+        int idPuntoVenta, int? dias, int topeDeFilas, CancellationToken ct = default)
+    {
+        var (idEmpresa, zonaId, hoy) = await ResolverContextoAsync(idPuntoVenta, ct);
+        var diasDeAlerta = dias ?? await ResolverDiasAlertaAsync(idEmpresa, idPuntoVenta, ct);
+
+        var query = ConstruirQueryDeVencimientos(idPuntoVenta);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, topeDeFilas);
+
+        var filas = await query.Take(topeDeFilas + 1).ToListAsync(ct);
+        GuardaDeTope.Exigir(filas.Count, topeDeFilas);
+
+        return new Vencimientos(idPuntoVenta, hoy, diasDeAlerta, zonaId, Clasificar(filas, hoy, diasDeAlerta));
+    }
+
+    /// <summary>Proyección cruda de <c>stock_lotes ⋈ lotes ⋈ articulos</c> (spec: "lot rows...
+    /// with a positive stock_lotes.cantidad") — <c>Cantidad &gt; 0</c> estrictamente, nunca
+    /// <c>&lt;&gt; 0</c> (spec: "A zero-balance lot never appears in the report"; un saldo
+    /// negativo tampoco debería listarse acá, mismo criterio). Orden <c>fecha_vencimiento ASC</c>
+    /// ANTES del <c>select</c> hacia el record: EF Core no traduce un <c>OrderBy</c> sobre la
+    /// propiedad de un objeto recién construido (mismo obstáculo de traducción que
+    /// <c>ServicioDeReportesDeVentas.ComprobantesVentaDelPeriodo</c> documenta para <c>GroupBy</c>).
+    /// Postgres ya ordena NULL último en ascendente por default, sin necesitar <c>NULLS LAST</c>
+    /// explícito.</summary>
+    private IQueryable<FilaCruda> ConstruirQueryDeVencimientos(int idPuntoVenta) =>
+        from stockLote in db.StockLotes
+        where stockLote.IdPuntoVenta == idPuntoVenta && stockLote.Cantidad > 0m
+        join lote in db.Lotes on stockLote.IdLote equals lote.Id
+        join articulo in db.Articulos on lote.IdArticulo equals articulo.Id
+        orderby lote.FechaVencimiento
+        select new FilaCruda(articulo.Id, articulo.Nombre, lote.Id, lote.Codigo, lote.FechaVencimiento, stockLote.Cantidad);
+
+    private static IReadOnlyList<FilaDeVencimiento> Clasificar(
+        IReadOnlyList<FilaCruda> filas, DateOnly hoy, int diasDeAlerta) =>
+        filas
+            .Select(f => new FilaDeVencimiento(
+                f.IdArticulo, f.Articulo, f.IdLote, f.CodigoLote, f.FechaVencimiento, f.Cantidad,
+                ReglaDeLotes.Clasificar(f.FechaVencimiento, hoy, diasDeAlerta)))
+            .ToList();
+
+    /// <summary>"hoy" es el ÚNICO valor sensible a zona del reporte (design decisión 15) —
+    /// <c>reloj.Ahora</c> (instante absoluto) se convierte a la zona del PV ANTES de tomar el
+    /// <c>DateOnly</c>. Mutation target (task 13.5): reemplazar la conversión por
+    /// <c>reloj.Ahora.UtcDateTime</c> directo tiene que hacer fallar el test de zona (spec: "'Hoy'
+    /// Is Resolved In The Punto De Venta's Own Zona Horaria, Not UTC" — vinculante), mismo
+    /// precedente que el fix de <c>/stock/existencias/export</c> (commit 08e7707).</summary>
+    private async Task<(int IdEmpresa, string ZonaId, DateOnly Hoy)> ResolverContextoAsync(
+        int idPuntoVenta, CancellationToken ct)
+    {
+        var idEmpresa = await db.PuntosVenta
+            .Where(pv => pv.Id == idPuntoVenta)
+            .Select(pv => (int?)pv.IdEmpresa)
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.ZonaHoraria.Clave, idEmpresa, idPuntoVenta, ct);
+        var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
+        var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
+
+        var hoy = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(reloj.Ahora, zona).DateTime);
+
+        return (idEmpresa, zonaId, hoy);
+    }
+
+    private async Task<int> ResolverDiasAlertaAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.DiasAlertaVencimiento.Clave, idEmpresa, idPuntoVenta, ct);
+        return JsonSerializer.Deserialize<int>(resuelto.Valor);
+    }
+
+    private sealed record FilaCruda(
+        int IdArticulo, string Articulo, int IdLote, string CodigoLote, DateOnly? FechaVencimiento, decimal Cantidad);
 }

--- a/tests/Ways.IntegrationTests/VencimientosExportTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosExportTests.cs
@@ -133,8 +133,11 @@ public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<Way
         return lote.Id;
     }
 
-    private static Task<HttpResponseMessage> LlamarExportAsync(HttpClient cliente, int idPuntoVenta, string formato = "xlsx") =>
-        cliente.GetAsync($"/api/reportes/stock/vencimientos/export?idPuntoVenta={idPuntoVenta}&formato={formato}");
+    private static Task<HttpResponseMessage> LlamarExportAsync(
+        HttpClient cliente, int idPuntoVenta, string formato = "xlsx", int? dias = null) =>
+        cliente.GetAsync(
+            $"/api/reportes/stock/vencimientos/export?idPuntoVenta={idPuntoVenta}&formato={formato}"
+            + (dias is { } valorDias ? $"&dias={valorDias}" : string.Empty));
 
     // ---- task 13.8: equality fila-por-fila, columnas discriminantes (mutation-proof-tests regla 6) --
 
@@ -235,5 +238,50 @@ public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<Way
         var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta);
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- JD-FIX (judgment-day slice 13, juez B MAJOR): cobertura del override dias= --------------
+
+    /// <summary>JD-FIX NOTE (judgment-day slice 13, juez B MAJOR): la misma rama
+    /// <c>dias ?? await ResolverDiasAlertaAsync(...)</c> se repite en
+    /// <c>ObtenerVencimientosParaExportacionAsync</c> — sin test tampoco. Se propaga el mismo
+    /// <c>dias=45</c> explícito al JSON y al export (mismo lote a 40 días de "hoy", que con
+    /// dias=45 clasifica <c>por_vencer</c>): la igualdad fila-por-fila entre ambos endpoints se
+    /// mantiene con el override, evidencia de que <c>ObtenerVencimientosParaExportacionAsync</c>
+    /// también respeta el parámetro y no solo el default resuelto.</summary>
+    [Fact]
+    public async Task ElExportPropagaElOverrideDeDiasYClasificaIgualQueElJson()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportPropagaElOverrideDeDiasYClasificaIgualQueElJson));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yogur bebible frutilla 900ml");
+
+        // Reloj real (sin pinear): la fecha de vencimiento se ancla a "hoy real + 40 días" para no
+        // depender de un reloj fijo — dias=45 explícito -> por_vencer (40 <= 45); el default (30)
+        // habría dado vigente, así el test discrimina que el export usó el override, no el default.
+        var hoyReal = DateOnly.FromDateTime(DateTime.UtcNow);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, hoyReal.AddDays(40), cantidad: 3m, codigo: "L-EXPORT-OVERRIDE");
+
+        var jsonRespuesta = await ctx.Admin.GetAsync(
+            $"/api/reportes/stock/vencimientos?idPuntoVenta={ctx.IdPuntoVenta}&dias=45");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var vencimientos = JsonSerializer.Deserialize<Vencimientos>(
+            await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        var filaJson = Assert.Single(vencimientos.Filas);
+        Assert.Equal(idLote, filaJson.IdLote);
+        Assert.Equal(EstadoDeVencimiento.PorVencer, filaJson.Estado);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 45);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+        const int primeraFilaDeDatos = 7;
+        var fila = hoja.Row(primeraFilaDeDatos);
+
+        Assert.Equal(filaJson.IdArticulo, fila.Cell(1).GetValue<int>());
+        Assert.Equal(filaJson.IdLote, fila.Cell(3).GetValue<int>());
+        Assert.Equal(filaJson.Estado.ToString(), fila.Cell(7).GetString());
+        Assert.True(hoja.Cell(primeraFilaDeDatos + vencimientos.Filas.Count, 1).Value.IsBlank);
     }
 }

--- a/tests/Ways.IntegrationTests/VencimientosExportTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosExportTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 13: <c>GET /api/reportes/stock/vencimientos/export</c> —
+/// equality fila-por-fila con columnas discriminantes (mutation-proof-tests regla 6), el cap
+/// (design decisión 17: LISTADO, `Contar → rechazar → .Take(tope + 1)`) y el 403 del gate. La
+/// clasificación y el 403 del JSON viven en <see cref="VencimientosReporteTests"/>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Vendedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
+    {
+        var host = factory ?? fixture;
+        var root = host.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = host.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var vendedor = await CrearYLoguearAsync(admin, host, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area vencimientos export", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, vendedor);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> host, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = host.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(
+        Contexto ctx, int idArticulo, DateOnly? fechaVencimiento, decimal cantidad,
+        bool esSinIdentificar = false, string? codigo = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdTenant = ctx.IdTenant,
+            IdArticulo = idArticulo,
+            Codigo = codigo ?? (esSinIdentificar ? ReglaDeLotes.CodigoSinIdentificar : fechaVencimiento!.Value.ToString("yyyy-MM-dd")),
+            FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = esSinIdentificar,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = lote.Id, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(HttpClient cliente, int idPuntoVenta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/reportes/stock/vencimientos/export?idPuntoVenta={idPuntoVenta}&formato={formato}");
+
+    // ---- task 13.8: equality fila-por-fila, columnas discriminantes (mutation-proof-tests regla 6) --
+
+    /// <summary>Nombra el objetivo de mutación (mutation-proof-tests regla 6): el call site de
+    /// <c>ExportacionDeReportes.De(Vencimientos, ContextoDeExportacion)</c> dentro del endpoint
+    /// <c>/stock/vencimientos/export</c>. Dos lotes con TODOS los valores distintos entre sí
+    /// (artículo, nombre, id de lote, código, vencimiento — uno con fecha y uno sin ella, así la
+    /// celda de fecha vacía también queda cubierta —, cantidad, estado), ambas filas comparadas
+    /// contra el workbook columna por columna: un test de una sola fila o de columnas salteadas no
+    /// habría detectado un <c>.Reverse()</c> ni un swap de columnas.</summary>
+    [Fact]
+    public async Task ElExportEsIgualAlEndpointJsonFilaPorFilaEnTodasLasColumnas()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlEndpointJsonFilaPorFilaEnTodasLasColumnas));
+
+        var idArticuloA = await SembrarArticuloAsync(ctx, "Leche entera 1L");
+        await SembrarLoteAsync(ctx, idArticuloA, new DateOnly(2026, 12, 31), 15m, codigo: "L-A");
+
+        var idArticuloB = await SembrarArticuloAsync(ctx, "Dulce de leche 400g");
+        await SembrarLoteAsync(ctx, idArticuloB, fechaVencimiento: null, 23.5m, esSinIdentificar: true);
+
+        var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/vencimientos?idPuntoVenta={ctx.IdPuntoVenta}");
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var vencimientos = JsonSerializer.Deserialize<Vencimientos>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(2, vencimientos.Filas.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla, los datos empiezan en la fila 7 — orden fecha_vencimiento ASC
+        // NULLS LAST del lado del servicio, ambas filas con TODAS sus columnas comparadas.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < vencimientos.Filas.Count; i++)
+        {
+            var esperado = vencimientos.Filas[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+            Assert.Equal(esperado.IdArticulo, fila.Cell(1).GetValue<int>());
+            Assert.Equal(esperado.Articulo, fila.Cell(2).GetString());
+            Assert.Equal(esperado.IdLote, fila.Cell(3).GetValue<int>());
+            Assert.Equal(esperado.CodigoLote, fila.Cell(4).GetString());
+            if (esperado.FechaVencimiento is { } fecha)
+            {
+                Assert.Equal(fecha.ToDateTime(TimeOnly.MinValue), fila.Cell(5).GetDateTime());
+            }
+            else
+            {
+                Assert.True(fila.Cell(5).Value.IsBlank);
+            }
+
+            Assert.Equal(esperado.Cantidad, fila.Cell(6).GetValue<decimal>());
+            Assert.Equal(esperado.Estado.ToString(), fila.Cell(7).GetString());
+        }
+
+        // Sin fila de totales (design: sumar cantidades de lotes de artículos distintos no tiene
+        // significado propio, mismo criterio que existencias) — la fila siguiente tiene que estar vacía.
+        Assert.True(hoja.Cell(primeraFilaDeDatos + vencimientos.Filas.Count, 1).Value.IsBlank);
+    }
+
+    // ---- task 13.9: cap + backstop del +1 (design decisión 17, patrón slice 3 de la etapa 11) ------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo con muchos lotes");
+
+        for (var i = 0; i < 4; i++)
+        {
+            await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2027, 1, 1 + i), 1m, codigo: $"L-TOPE-{i}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    // ---- task 13.10: 403 ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelExportDeVencimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelExportDeVencimientos));
+
+        var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/VencimientosReporteTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosReporteTests.cs
@@ -138,8 +138,10 @@ public class VencimientosReporteTests(WaysApiFixture fixture) : IClassFixture<Wa
         return lote.Id;
     }
 
-    private static Task<HttpResponseMessage> LlamarReporteAsync(HttpClient cliente, int idPuntoVenta) =>
-        cliente.GetAsync($"/api/reportes/stock/vencimientos?idPuntoVenta={idPuntoVenta}");
+    private static Task<HttpResponseMessage> LlamarReporteAsync(HttpClient cliente, int idPuntoVenta, int? dias = null) =>
+        cliente.GetAsync(
+            $"/api/reportes/stock/vencimientos?idPuntoVenta={idPuntoVenta}"
+            + (dias is { } valorDias ? $"&dias={valorDias}" : string.Empty));
 
     // ---- task 13.5: MUTATION TARGET — TimeZoneInfo.ConvertTime(reloj.Ahora, zona) reemplazado
     // por reloj.Ahora.UtcDateTime tiene que hacer fallar este test --------------------------------
@@ -252,5 +254,50 @@ public class VencimientosReporteTests(WaysApiFixture fixture) : IClassFixture<Wa
         var respuesta = await LlamarReporteAsync(ctx.Vendedor, ctx.IdPuntoVenta);
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- JD-FIX (judgment-day slice 13, juez B MAJOR): cobertura del override dias= --------------
+
+    /// <summary>JD-FIX NOTE (judgment-day slice 13, juez B MAJOR): la rama
+    /// <c>dias ?? await ResolverDiasAlertaAsync(...)</c> en <c>ObtenerVencimientosAsync</c> no
+    /// tenía NINGÚN test — todos los tests existentes ejercitaban solo el default resuelto
+    /// (<c>dias</c> ausente). Un mismo lote (vencimiento a 40 días de "hoy") clasifica distinto
+    /// según el horizonte aplicado: con el default (<c>dias_alerta_vencimiento</c> = 30) es
+    /// <c>vigente</c> (40 &gt; 30); con <c>dias=45</c> explícito por query string es
+    /// <c>por_vencer</c> (40 &lt;= 45). Mutation target: el operador <c>??</c> del override en
+    /// <c>ObtenerVencimientosAsync</c>. Mutación aplicada (reemplazado
+    /// <c>dias ?? await ResolverDiasAlertaAsync(idEmpresa, idPuntoVenta, ct)</c> por
+    /// <c>await ResolverDiasAlertaAsync(idEmpresa, idPuntoVenta, ct)</c>, ignorando el parámetro):
+    /// este test pasó de esperar <c>PorVencer</c>/<c>DiasDeAlerta == 45</c> con el override y
+    /// obtener <c>Vigente</c>/<c>DiasDeAlerta == 30</c> — FALLÓ — a pasar al revertir.</summary>
+    [Fact]
+    public async Task ElOverrideDeDiasExplicitoCambiaLaClasificacionRespectoDelDefault()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 12, 15, 0, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(ElOverrideDeDiasExplicitoCambiaLaClasificacionRespectoDelDefault), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yogur descremado 500g");
+
+        // hoy resuelto = 2026-08-12. Vencimiento a 40 días: default (dias_alerta=30) -> vigente
+        // (40 > 30); dias=45 explícito -> por_vencer (40 <= 45).
+        await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2026, 9, 21), cantidad: 5m, codigo: "L-OVERRIDE");
+
+        var respuestaDefault = await LlamarReporteAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(HttpStatusCode.OK, respuestaDefault.StatusCode);
+        var vencimientosDefault = JsonSerializer.Deserialize<Vencimientos>(
+            await respuestaDefault.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(30, vencimientosDefault.DiasDeAlerta);
+        Assert.Equal(EstadoDeVencimiento.Vigente, Assert.Single(vencimientosDefault.Filas).Estado);
+
+        var respuestaOverride = await LlamarReporteAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 45);
+        Assert.Equal(HttpStatusCode.OK, respuestaOverride.StatusCode);
+        var vencimientosOverride = JsonSerializer.Deserialize<Vencimientos>(
+            await respuestaOverride.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(45, vencimientosOverride.DiasDeAlerta);
+        Assert.Equal(EstadoDeVencimiento.PorVencer, Assert.Single(vencimientosOverride.Filas).Estado);
     }
 }

--- a/tests/Ways.IntegrationTests/VencimientosReporteTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosReporteTests.cs
@@ -1,0 +1,256 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Reportes;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 13: <c>GET /api/reportes/stock/vencimientos</c> y su
+/// <c>/resumen</c> — clasificación de cuatro estados (spec lotes-y-vencimientos: "Vencimientos
+/// Report Resolves 'Hoy' In The Punto De Venta's Own Zona Horaria, With An Export Sibling"),
+/// exclusión de saldo cero, y el 403 del gate. El export sibling (equality fila-por-fila, cap +
+/// 403) vive en <see cref="VencimientosExportTests"/>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VencimientosReporteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Vendedor);
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
+    {
+        var host = factory ?? fixture;
+        var root = host.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = host.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var vendedor = await CrearYLoguearAsync(admin, host, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area vencimientos", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, vendedor);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> host, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = host.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    /// <summary>Siembra directa de <c>lotes</c> + <c>stock_lotes</c> (bypass de los tres
+    /// escritores reales — esta slice no toca la recepción/venta) — mismo criterio que
+    /// <c>ExistenciasExportTests.SembrarStockAsync</c> sembrando <c>stock</c> directo.</summary>
+    private async Task<int> SembrarLoteAsync(
+        Contexto ctx, int idArticulo, DateOnly? fechaVencimiento, decimal cantidad,
+        bool esSinIdentificar = false, string? codigo = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdTenant = ctx.IdTenant,
+            IdArticulo = idArticulo,
+            Codigo = codigo ?? (esSinIdentificar ? ReglaDeLotes.CodigoSinIdentificar : fechaVencimiento!.Value.ToString("yyyy-MM-dd")),
+            FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = esSinIdentificar,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = lote.Id, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private static Task<HttpResponseMessage> LlamarReporteAsync(HttpClient cliente, int idPuntoVenta) =>
+        cliente.GetAsync($"/api/reportes/stock/vencimientos?idPuntoVenta={idPuntoVenta}");
+
+    // ---- task 13.5: MUTATION TARGET — TimeZoneInfo.ConvertTime(reloj.Ahora, zona) reemplazado
+    // por reloj.Ahora.UtcDateTime tiene que hacer fallar este test --------------------------------
+
+    /// <summary>Nombra el objetivo de mutación (mutation-proof-tests regla 1):
+    /// <c>ServicioDeReportesDeStock.ResolverContextoAsync</c>, la conversión
+    /// <c>TimeZoneInfo.ConvertTime(reloj.Ahora, zona)</c> antes de tomar el <c>DateOnly</c>. Reloj
+    /// fijado a las 22:30 ART del 12/8 (01:30 UTC del 13/8, mismo instante que el escenario del
+    /// spec) y un lote que vence el 12/8: si el servicio leyera <c>reloj.Ahora.UtcDateTime</c>
+    /// directo, "hoy" caería en el 13/8 y el lote (vencimiento 12/8 &lt; hoy 13/8) clasificaría
+    /// <c>vencido</c>; con la conversión correcta "hoy" es 12/8 y el lote — vencimiento inclusive,
+    /// decisión de la spec — clasifica <c>por_vencer</c>. El resultado es el mismo sin importar la
+    /// hora real de corrida del test, a diferencia de comparar contra <c>DateTime.UtcNow</c>.
+    /// Mutación aplicada (reemplazado <c>TimeZoneInfo.ConvertTime(reloj.Ahora, zona).DateTime</c>
+    /// por <c>reloj.Ahora.UtcDateTime</c> en <c>ResolverContextoAsync</c>): este test pasó de
+    /// esperar <c>PorVencer</c> y obtener <c>Vencido</c> — FALLÓ — a pasar al revertir. Evidencia
+    /// registrada en el resumen de apply.</summary>
+    [Fact]
+    public async Task LaClasificacionSeResuelveEnLaZonaHorariaDelPuntoDeVentaNoEnUtc()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 13, 1, 30, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(LaClasificacionSeResuelveEnLaZonaHorariaDelPuntoDeVentaNoEnUtc), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yogur bebible 200ml");
+        await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2026, 8, 12), cantidad: 6m);
+
+        var respuesta = await LlamarReporteAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var vencimientos = JsonSerializer.Deserialize<Vencimientos>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        Assert.Equal(new DateOnly(2026, 8, 12), vencimientos.Hoy);
+        var fila = Assert.Single(vencimientos.Filas);
+        Assert.Equal(EstadoDeVencimiento.PorVencer, fila.Estado);
+    }
+
+    // ---- task 13.6: los cuatro estados, sin_fecha cuenta en los totales --------------------------
+
+    [Fact]
+    public async Task ClasificaLosCuatroEstadosYElSinFechaCuentaEnLosTotales()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 12, 15, 0, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(nameof(ClasificaLosCuatroEstadosYElSinFechaCuentaEnLosTotales), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Queso crema 300g");
+
+        // hoy resuelto = 2026-08-12 (mediodía UTC, sin riesgo de borde de zona). dias_alerta
+        // default = 30 (mismos bordes que ReglaDeLotesTests.ClasificarEnLosCuatroBordesDelHorizonteDeAlerta).
+        var idVencido = await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2026, 8, 11), 4m, codigo: "L-VENCIDO");
+        var idPorVencer = await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2026, 9, 11), 7m, codigo: "L-PORVENCER");
+        var idVigente = await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2026, 9, 12), 9m, codigo: "L-VIGENTE");
+        var idSinFecha = await SembrarLoteAsync(ctx, idArticulo, fechaVencimiento: null, cantidad: 12m, esSinIdentificar: true);
+
+        var respuesta = await LlamarReporteAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var vencimientos = JsonSerializer.Deserialize<Vencimientos>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        Assert.Equal(4, vencimientos.Filas.Count);
+        Assert.Equal(EstadoDeVencimiento.Vencido, vencimientos.Filas.Single(f => f.IdLote == idVencido).Estado);
+        Assert.Equal(EstadoDeVencimiento.PorVencer, vencimientos.Filas.Single(f => f.IdLote == idPorVencer).Estado);
+        Assert.Equal(EstadoDeVencimiento.Vigente, vencimientos.Filas.Single(f => f.IdLote == idVigente).Estado);
+        Assert.Equal(EstadoDeVencimiento.SinFecha, vencimientos.Filas.Single(f => f.IdLote == idSinFecha).Estado);
+
+        // Tile de Tablero: mismos tres conteos (vencido/por_vencer/sin_fecha), nunca una segunda
+        // agregación que pudiera divergir (task 13.2).
+        var resumenRespuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/vencimientos/resumen?idPuntoVenta={ctx.IdPuntoVenta}");
+        Assert.Equal(HttpStatusCode.OK, resumenRespuesta.StatusCode);
+        var resumen = JsonSerializer.Deserialize<ResumenDeVencimientos>(await resumenRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        Assert.Equal(1, resumen.Vencidos);
+        Assert.Equal(1, resumen.PorVencer);
+        Assert.Equal(1, resumen.SinFecha);
+    }
+
+    // ---- task 13.7: saldo cero nunca aparece -------------------------------------------------------
+
+    [Fact]
+    public async Task UnLoteConSaldoCeroNuncaApareceEnElReporte()
+    {
+        var ctx = await PrepararAsync(nameof(UnLoteConSaldoCeroNuncaApareceEnElReporte));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Manteca 200g");
+        await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2027, 1, 1), cantidad: 0m);
+
+        var respuesta = await LlamarReporteAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var vencimientos = JsonSerializer.Deserialize<Vencimientos>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+
+        Assert.Empty(vencimientos.Filas);
+    }
+
+    // ---- task 13.10: 403 ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelReporteDeVencimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelReporteDeVencimientos));
+
+        var respuesta = await LlamarReporteAsync(ctx.Vendedor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}


### PR DESCRIPTION
## Etapa 12 — Slice 13: Vencimientos

- **\`GET /api/reportes/stock/vencimientos\`** (LecturaDeReportes): filas de lote con saldo positivo, clasificación de 4 estados (\`vencido\`/\`por_vencer\`/\`vigente\`/\`sin_fecha\`) vía \`ReglaDeLotes.Clasificar\` — sin re-implementar el borde de la decisión 13 — con **"hoy" resuelto en la \`zona_horaria\` del PV** (patrón del fix 08e7707 de la etapa 11; criterio vinculante del spec), \`dias\` con default resuelto + override por query cubierto por mutación.
- **\`/resumen\`**: tile del Tablero (vencido/por_vencer/sin_fecha).
- **\`/export\`**: hermano co-locado, forma LISTADO (COUNT → rechazo con la cantidad real → Take(tope+1)) en el servicio con mapper puro (precedente exacto de la etapa 11); igualdad JSON↔XLSX celda por celda.

### Tests (10)
Mutación de zona con reloj pineado al instante del spec (2026-08-13T01:30Z, ART, lote 2026-08-12: UTC naive lo tiraría a vencido un día antes) · clasificación ×4 con sin_fecha en totales · saldo cero excluido · igualdad celda-por-celda (sobrevive a swap de columnas y drop de filas: NO) · cap que rechaza · 403 ×2 · override dias ×2. Regresión export 58/58.

### Judgment-day
Juez B: 8/8 probes de mutación cazadas + 1 MAJOR real (la rama del override \`dias=\` sin ninguna cobertura) corregido con evidencia; juez A APPROVE con 4 MINORs (rename documentado; deuda aceptada: margen UtcNow del test de export y ORDER BY sin desempate — ambas registradas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)