### PR TITLE
feat(lotes): venta escritura per-lot en el orden pinneado — etapa 12, slice 8

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/design.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/design.md
@@ -278,7 +278,8 @@ private async Task<(decimal Tolerancia, decimal Vuelto, bool LotesHabilitado)> R
 ```csharp
 foreach (var item in plan.Items.Where(i => i.EsProducto)
                                .OrderBy(i => i.IdArticulo)
-                               .ThenBy(i => i.IdLote))            // decisión 8/9
+                               .ThenBy(i => i.IdLote.HasValue)    // NULLS FIRST — decisión 9
+                               .ThenBy(i => i.IdLote ?? 0))       // decisión 8/9 (reconciled at slice-8 judgment-day: matches write-site 3's explicit NULLS-FIRST form and the shipped code)
 {
     var delta = -item.Cantidad;
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -949,44 +949,115 @@ the exact lot. **Rollback**: revert the branch.
 stops being true — UPDATE it to assert the SAME `IdLote` on both the fresh
 checkout response and the `ObtenerAsync` re-read (drop the `Assert.Null` on
 the re-read, replace with `Assert.Equal(idLote, itemReleido.IdLote)`); rename
-away the "HastaSlice8" suffix once updated.
+away the "HastaSlice8" suffix once updated. *(APPLY-RUN NOTE: done — renamed
+to `ElCheckoutFrescoYLaRelecturaDevuelvenElMismoIdLote`, asserts
+`Assert.Equal(idLote, itemReleido.IdLote)`. `ServicioDeVentas.Proyectar`'s
+doc-comment updated too — it previously documented the slice-7 limitation as
+permanent; now records that both paths return the same value since slice 8.
+`Contratos.cs`'s `ItemEmitido` doc-comment updated for the same reason.)*
 
-- [ ] 8.1 Modify `ServicioDeVentas.cs`: `EjecutarTransaccionAsync` step 5 —
+- [x] 8.1 Modify `ServicioDeVentas.cs`: `EjecutarTransaccionAsync` step 5 —
   loop `OrderBy(IdArticulo).ThenBy(IdLote)`; `InsertarMovimientoStockAsync`
   gains `idLote`; `UpsertStockAsync` (aggregate, `id_lote NULL`, always
   first); if `item.IdLote` present, `UpsertStockLoteAsync` (new private
   method, same `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` shape as
-  `UpsertStockAsync`).
-- [ ] 8.2 Modify the `AddRange` items block: `ItemComprobanteVenta.IdLote =
+  `UpsertStockAsync`). *(APPLY-RUN NOTE: the loop's secondary/tertiary key
+  is `.ThenBy(i => i.IdLote.HasValue).ThenBy(i => i.IdLote ?? 0)` — decisión
+  9's explicit NULLS-FIRST pattern, not the plain `.ThenBy(IdLote)` design's
+  own pseudocode shows — chosen because task 8.7 names this EXACT substring
+  as its mutation target for "the checkout ordering". `InsertarMovimientoStockAsync`
+  gained `int? idLote` + a new `AgregarParametroNulo` helper (first nullable
+  raw param this class ever sent, same pattern as `ServicioDeCompras`/
+  `ServicioDeStock`'s siblings of the same name).)*
+- [x] 8.2 Modify the `AddRange` items block: `ItemComprobanteVenta.IdLote =
   i.IdLote` — frozen snapshot, never re-derived.
-- [ ] 8.3 Modify `ServicioDeVentas.cs`: `EjecutarAnulacionAsync` reorders
+- [x] 8.3 Modify `ServicioDeVentas.cs`: `EjecutarAnulacionAsync` reorders
   `.OrderBy(m => m.IdArticulo).ThenBy(m => m.IdLote)`, the inverse movement
   copies `original.IdLote`, the `stock_lotes` upsert mirrors it — no
-  lookup, no re-derivation.
-- [ ] 8.4 [P] Invariant test: `stock.cantidad` and `stock_lotes.cantidad`
+  lookup, no re-derivation. *(APPLY-RUN NOTE: plain `.ThenBy(m => m.IdLote)`
+  here, not the HasValue pattern — this `OrderBy`/`ThenBy` runs over an
+  `IQueryable<MovimientoStock>` (SQL-translated), matching the EXACT
+  precedent already reviewed clean at slice 6's
+  `ServicioDeCompras.EjecutarAnulacionAsync` for the identical shape.)*
+- [x] 8.4 [P] Invariant test: `stock.cantidad` and `stock_lotes.cantidad`
   both correct after a venta + anulación sequence.
-- [ ] 8.5 [P] **Mutation target**: `ItemComprobanteVenta.IdLote = i.IdLote`
+  (`StockYStockLotesQuedanCorrectosTrasVentaYAnulacion`)
+- [x] 8.5 [P] **Mutation target**: `ItemComprobanteVenta.IdLote = i.IdLote`
   replaced with `null` → the exact-anulación test (asserting the reversal's
   `id_lote` **and** the resulting per-lot balance) MUST fail; revert →
   green. *(spec comprobantes-venta: "A lot-effective line freezes its
   resolved lot onto the snapshot", "Anulación of a lot-bearing sale
   reverses the exact lot"; mutation-proof-tests)* Record evidence.
-- [ ] 8.6 [P] Lock-order test: the `stock` row upserts before any
+  *(APPLY-RUN NOTE: `UnaVentaLoteEfectivaCongelaElSnapshotYSuAnulacionRevierteElLoteExacto`
+  asserts THREE things in one run: (1) the persisted snapshot
+  `items_comprobante_venta.id_lote` — this is the ONE the mutation actually
+  breaks, since `EjecutarAnulacionAsync` reads its own reversal lot from
+  `movimientos_stock` (the ledger), never from the item snapshot, so (2) the
+  reversal's `id_lote` and (3) the restored per-lot balance stay green even
+  under the mutation — documented explicitly so the next reader doesn't
+  mistake "anulación still passes" for "the mutation is dead". Mutation
+  applied — `IdLote = i.IdLote` → `IdLote = null` in the `AddRange`
+  projection; build, filter on the test: RED
+  (`Assert.Equal(idLote, itemPersistido.IdLote)` failed, `Expected: {idLote}
+  / Actual: null`). Reverted, same filter: GREEN, full
+  `VentaEscrituraLoteTests`/`PlanDeVentaFefoTests` (20/20).)*
+- [x] 8.6 [P] Lock-order test: the `stock` row upserts before any
   `stock_lotes` row for the same `(articulo, PV)`. *(spec stock: "A
   checkout locks stock before stock_lotes for the same pair")*
-- [ ] 8.7 [P] **Mutation target (half A, deadlock)**: `.ThenBy(c =>
+  (`UnCheckoutBloqueaStockAntesQueStockLotesParaElMismoPar`.) *(APPLY-RUN
+  NOTE — non-obvious discovery: both `InsertarMovimientoStockAsync`/
+  `UpsertStockAsync`/`UpsertStockLoteAsync` run on a raw `DbCommand` created
+  directly via `conexion.CreateCommand()` off the connection EF already
+  opened — this NEVER goes through EF Core's `DbCommandInterceptor`
+  pipeline (confirmed empirically: a `ScalarExecuting` override never
+  fires), and Npgsql's own `NpgsqlLoggingConfiguration.InitializeLogging`
+  is a process-wide, call-once API that must run before ANY connection
+  opens — by the time a test can call it, `WaysApiFixture` has already
+  opened connections and Npgsql has already cached a null logger (confirmed
+  empirically: zero log lines ever arrived). Neither interception technique
+  observes these statements. The test instead races a REAL Postgres lock:
+  a second raw connection (RLS-authenticated with the same
+  `set_config('app.tenant_id', ...)` GUC `InterceptorDeContextoDeTenant`
+  sets — a plain unauthenticated raw connection sees ZERO rows of
+  `stock_lotes` and its `FOR UPDATE` silently locks nothing) holds
+  `stock_lotes`'s row open under `FOR UPDATE`; the checkout is fired
+  concurrently and necessarily blocks trying to touch that same row; a
+  third connection polls `pg_locks` for the checkout's own backend pid
+  until it sees `stock`'s table-level `RowExclusiveLock` already `granted`
+  at the same moment the checkout has an ungranted lock pending (Postgres
+  represents "blocked on another transaction's row" as an ungranted
+  `transactionid` `ShareLock`, never as an ungranted `tuple` lock on the
+  contested relation — confirmed by dumping the full `pg_locks` state
+  mid-block). Releasing the held lock lets the checkout complete; final
+  `stock.cantidad` asserted too.)*
+- [x] 8.7 [P] **Mutation target (half A, deadlock)**: `.ThenBy(c =>
   c.IdLote.HasValue).ThenBy(c => c.IdLote ?? 0)` in the checkout ordering —
   delete it and confirm the ordering test now fails on a hand-built key
   set. The **joint** checkout-vs-reverse-transfer deadlock proof itself is
   deferred to slice 10 (task 10.12), once `ServicioDeStock`'s transfer
   write also exists — recorded as an explicit cross-slice dependency, not a
-  gap.
-- [ ] 8.8 [P] Non-lot-articulo regression: no lot on the item or the
+  gap. *(APPLY-RUN NOTE: "hand-built key set" implemented as a real,
+  achievable production scenario rather than an artificial in-memory
+  fixture — `LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote`
+  submits TWO lines of the SAME lot-effective articulo, each with a
+  DIFFERENT explicit `idLote`, in DESCENDING id order (higher id first);
+  `.NET`'s stable sort means that without the `ThenBy` pair, the write order
+  would silently follow submission order instead of ascending `id_lote`.
+  Mutation applied — the two `ThenBy` calls deleted from the step-5 loop,
+  leaving only `.OrderBy(i => i.IdArticulo)`; build, filter on the test:
+  RED (`Assert.Equal(idLoteMenor, movimientos[0].IdLote)` failed, `Expected:
+  1 / Actual: 2` — the higher-id lot landed first, exactly the submission
+  order). Reverted, same filter: GREEN, full suite (20/20).)*
+- [x] 8.8 [P] Non-lot-articulo regression: no lot on the item or the
   movement. *(spec comprobantes-venta: "A non-lot articulo's item never
   carries a lot"; spec stock: "A non-lot articulo's movement never carries
-  a lot")*
-- [ ] 8.9 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  a lot")* (`UnArticuloSinControlDeLoteNuncaLlevaIdLoteEnItemNiMovimiento`.)
+- [x] 8.9 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(Verified after the slice's changes — no
+  `Migraciones/`/`Configuraciones/` file touched, per the DB CHANGE GATE;
+  run via `--project src/Ways.Infrastructure --startup-project
+  src/Ways.Infrastructure`. Output: "No changes have been made to the model
+  since the last migration.")*
 - [ ] 8.10 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 8.11 Branch `feat/stage12-slice8-venta-escritura` off `main` (parent:
   slice 7); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1058,8 +1058,22 @@ permanent; now records that both paths return the same value since slice 8.
   run via `--project src/Ways.Infrastructure --startup-project
   src/Ways.Infrastructure`. Output: "No changes have been made to the model
   since the last migration.")*
-- [ ] 8.10 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 8.11 Branch `feat/stage12-slice8-venta-escritura` off `main` (parent:
+- [x] 8.10 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  two REJECT rounds, both with real findings on the hottest writer.
+  Round 1 — judge B: the "hoist first IdLote onto every reversal movement"
+  mutation survived 176 tests (every anulación test sold ONE line; balances
+  stayed correct, the ledger's per-movement lot attribution corrupted
+  silently). Fix 7b4b98a: multi-line and mixed anulación tests killing the
+  exact mutation from both angles. Round 2 — judge B APPROVE; judge A
+  (first pass): MAJOR — nothing proved the aggregate ACCUMULATES across two
+  lines of the same articulo (a group-by-articulo "optimization" using only
+  the last delta survived), plus stale design pseudocode and the
+  provider-dependent NULLS ordering of the anulación read left implicit.
+  Fix a600c52: 8.7 test extended (seeded aggregate, discriminant deltas,
+  exact final stock 12m; mutation Expected-12/Actual-15 recorded), design
+  write-site-1 pseudocode reconciled, provider note added. Round 3 — judge
+  A APPROVE with arithmetic verification of the mutation evidence.)*
+- [x] 8.11 Branch `feat/stage12-slice8-venta-escritura` off `main` (parent:
   slice 7); PR; merge stacked-to-main.
 
 **Test plan**: invariant (8.4), snapshot mutation (8.5), lock order (8.6),

--- a/src/Ways.Application/Ventas/Contratos.cs
+++ b/src/Ways.Application/Ventas/Contratos.cs
@@ -48,9 +48,9 @@ public sealed record PagoDeVenta(int IdMedioPago, decimal Importe, string? Refer
 /// se completan para una línea lote-efectiva: el lote resuelto en la fase de decisión (FEFO
 /// default u honrado si vino explícito), su código proyectado, y si su vencimiento ya pasó
 /// (warning, nunca bloqueo — spec: "Expired Lot Sale Warns, Never Blocks"). NULL/false para una
-/// línea sin lote. Nota de límite de esta slice: la escritura de <c>id_lote</c> en
-/// <c>items_comprobante_venta</c> es de slice 8 — acá el dato viaja en el plan/response, todavía
-/// no en la fila persistida.</summary>
+/// línea sin lote. Desde slice 8, <c>id_lote</c> también se persiste como snapshot congelado en
+/// <c>items_comprobante_venta.id_lote</c> — una relectura (reprint) devuelve el mismo valor que el
+/// checkout fresco.</summary>
 public sealed record ItemEmitido(
     int Orden,
     int? IdArticulo,

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -532,7 +532,10 @@ public class ServicioDeVentas(
         // convención, no por necesidad estricta. `id_lote` viaja YA en el movimiento original —
         // etapa 12, slice 8, task 8.3: la reversa lo copia estructuralmente (design: "Exactness is
         // structural, not derived"), sin re-derivar desde items_comprobante_venta ni volver a
-        // resolver FEFO.
+        // resolver FEFO. El `ThenBy(IdLote)` de abajo es un IQueryable: el orden de los NULLs queda
+        // en manos de la traducción SQL del provider (Postgres por default hace NULLS LAST en ASC),
+        // no de una comparación en memoria — acá es convención, no defensivo, por eso no repite el
+        // `ThenBy(HasValue).ThenBy(?? 0)` explícito del paso 5.
         var movimientosOriginales = await db.MovimientosStock
             .Where(m => m.IdComprobanteVenta == id && m.Motivo == MotivoStock.Venta)
             .OrderBy(m => m.IdArticulo)

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -526,13 +526,17 @@ public class ServicioDeVentas(
 
         // 2. Movimientos de stock inversos — uno por cada movimiento ORIGINAL de motivo = venta
         // de este comprobante (nunca recalculado desde items: ver el doc-comment de
-        // AnularAsync). Orden ascendente por id_articulo, mismo criterio anti-deadlock que
-        // EjecutarTransaccionAsync paso 5 (design decisión 2), aunque acá no hay otra venta
+        // AnularAsync). Orden ascendente (id_articulo, id_lote), mismo criterio anti-deadlock que
+        // EjecutarTransaccionAsync paso 5 (design decisión 2/8/9), aunque acá no hay otra venta
         // concurrente compitiendo por las mismas filas — se mantiene por consistencia de
-        // convención, no por necesidad estricta.
+        // convención, no por necesidad estricta. `id_lote` viaja YA en el movimiento original —
+        // etapa 12, slice 8, task 8.3: la reversa lo copia estructuralmente (design: "Exactness is
+        // structural, not derived"), sin re-derivar desde items_comprobante_venta ni volver a
+        // resolver FEFO.
         var movimientosOriginales = await db.MovimientosStock
             .Where(m => m.IdComprobanteVenta == id && m.Motivo == MotivoStock.Venta)
             .OrderBy(m => m.IdArticulo)
+            .ThenBy(m => m.IdLote)
             .ToListAsync(ct);
 
         foreach (var original in movimientosOriginales)
@@ -541,9 +545,15 @@ public class ServicioDeVentas(
 
             await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa,
-                MotivoStock.Anulacion, id, idEmpleado, momento, ct);
+                MotivoStock.Anulacion, id, idEmpleado, momento, original.IdLote, ct);
 
             await UpsertStockAsync(conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
+
+            if (original.IdLote is { } idLote)
+            {
+                await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, idLote, inversa, ct);
+            }
         }
 
         // 3. Contramovimiento de cuenta corriente — uno por cada consumo/pago ORIGINAL de este
@@ -769,6 +779,11 @@ public class ServicioDeVentas(
                 Descuento = i.Descuento,
                 Total = i.Total,
                 CostoUnitario = i.CostoUnitario,
+                // Etapa 12, slice 8, task 8.2 (design: "Item snapshot"): congelado desde el plan
+                // FEFO ya resuelto en la fase de decisión (Slice 7) — nunca re-derivado, legal
+                // bajo "Snapshot Immutability of Items" porque se agrega AL snapshot y no existe
+                // endpoint de edición.
+                IdLote = i.IdLote,
                 CreatedAt = plan.Momento,
                 UpdatedAt = plan.Momento
             })
@@ -794,21 +809,36 @@ public class ServicioDeVentas(
         var conexion = await ObtenerConexionAbiertaAsync(ct);
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
-        // 5. Stock — ORDEN ASCENDENTE por id_articulo (design decisión 2, no negociable): el
-        // upsert de abajo toma su propio row lock de forma implícita, así que dos ventas que
-        // comparten artículos en orden distinto se deadlockearían sin este orden total. Un
-        // artículo con EsProducto = false es un servicio (doc 10 §3: "false = servicio: no toca
-        // stock") — se salta ENTERO, ni movimiento ni upsert, en vez de escribir un movimiento
-        // sin sentido para algo que nunca tuvo una fila en stock.
-        foreach (var item in plan.Items.Where(i => i.EsProducto).OrderBy(i => i.IdArticulo))
+        // 5. Stock — ORDEN ASCENDENTE por (id_articulo, id_lote NULLS FIRST) (design decisión 2/8/9,
+        // no negociable): el upsert de abajo toma su propio row lock de forma implícita, así que
+        // dos ventas que comparten artículos/lotes en orden distinto se deadlockearían sin este
+        // orden total. `ThenBy(HasValue).ThenBy(?? 0)` en vez de `ThenBy(IdLote ?? 0)` a secas
+        // (decisión 9): el segundo es una correctness claim que solo funciona porque las columnas
+        // identity arrancan en 1; el primero declara la intención (NULLS FIRST) sin depender de la
+        // configuración de una secuencia — es el mutation target de la task 8.7. Un artículo con
+        // EsProducto = false es un servicio (doc 10 §3: "false = servicio: no toca stock") — se
+        // salta ENTERO, ni movimiento ni upsert, en vez de escribir un movimiento sin sentido para
+        // algo que nunca tuvo una fila en stock. El upsert agregado (`stock`, id_lote NULL) corre
+        // SIEMPRE, primero; el upsert de `stock_lotes` solo cuando el item resolvió un lote.
+        foreach (var item in plan.Items
+                     .Where(i => i.EsProducto)
+                     .OrderBy(i => i.IdArticulo)
+                     .ThenBy(i => i.IdLote.HasValue)
+                     .ThenBy(i => i.IdLote ?? 0))
         {
             var delta = -item.Cantidad;
 
             await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, plan.IdTenant, item.IdArticulo, plan.IdPuntoVenta, delta,
-                MotivoStock.Venta, comprobante.Id, plan.IdEmpleado, plan.Momento, ct);
+                MotivoStock.Venta, comprobante.Id, plan.IdEmpleado, plan.Momento, item.IdLote, ct);
 
             await UpsertStockAsync(conexion, transaccionCruda, plan.IdTenant, item.IdArticulo, plan.IdPuntoVenta, delta, ct);
+
+            if (item.IdLote is { } idLote)
+            {
+                await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, plan.IdTenant, item.IdArticulo, plan.IdPuntoVenta, idLote, delta, ct);
+            }
         }
 
         // 6. Cuenta corriente — un pago por vez, en el orden pedido (raw ADO: un
@@ -1007,14 +1037,14 @@ public class ServicioDeVentas(
     private static async Task InsertarMovimientoStockAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
         decimal cantidad, MotivoStock motivo, int idComprobanteVenta, int idEmpleado, DateTimeOffset creadoEl,
-        CancellationToken ct)
+        int? idLote, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccion;
         comando.CommandText =
             "INSERT INTO movimientos_stock " +
-            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_venta, id_empleado, creado_el) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
+            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_venta, id_empleado, creado_el, id_lote) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
 
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, idArticulo);
@@ -1024,6 +1054,7 @@ public class ServicioDeVentas(
         AgregarParametro(comando, idComprobanteVenta);
         AgregarParametro(comando, idEmpleado);
         AgregarParametro(comando, creadoEl);
+        AgregarParametroNulo(comando, idLote);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -1053,6 +1084,34 @@ public class ServicioDeVentas(
         await comando.ExecuteScalarAsync(ct);
     }
 
+    /// <summary>Etapa 12, slice 8 (design: "Write site 1" — "UpsertStockLoteAsync: la MISMA forma
+    /// que UpsertStockAsync, una clave más"): mismo shape que
+    /// <see cref="Ways.Application.Compras.ServicioDeCompras"/>'s sibling (Slice 5) y
+    /// <c>ServicioDeLotes.ResolverOCrearAsync</c> (Slice 3) — <c>INSERT ... ON CONFLICT DO UPDATE
+    /// ... RETURNING</c>, nunca <c>DO NOTHING</c>. Sin chequeo de negativo acá (a diferencia de
+    /// compras): revertir una venta siempre SUMA de vuelta, nunca puede dejar el saldo negativo.</summary>
+    private static async Task UpsertStockLoteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        int idLote, decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta, id_lote) DO UPDATE " +
+            "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idLote);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, delta);
+
+        await comando.ExecuteScalarAsync(ct);
+    }
+
     private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
     {
         var conexion = db.Database.GetDbConnection();
@@ -1069,6 +1128,17 @@ public class ServicioDeVentas(
     {
         var parametro = comando.CreateParameter();
         parametro.Value = valor;
+        comando.Parameters.Add(parametro);
+    }
+
+    /// <summary>Mismo criterio que <c>ServicioDeCompras.AgregarParametroNulo</c>/
+    /// <c>ServicioDeStock.AgregarParametroNulo</c> — <c>id_lote</c> es el primer parámetro nullable
+    /// que esta clase envía por statement crudo (etapa 12, slice 8); <see cref="AgregarParametro"/>
+    /// nunca necesitó <c>DBNull.Value</c> hasta ahora.</summary>
+    private static void AgregarParametroNulo(DbCommand comando, object? valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor ?? DBNull.Value;
         comando.Parameters.Add(parametro);
     }
 
@@ -1132,13 +1202,14 @@ public class ServicioDeVentas(
             ?? throw new InvalidOperationException(
                 "ServicioDeVentas requiere un actor de tenant; OperacionDePos no admite plataforma.");
 
-    /// <summary>Design decisión (stage-12 slice 7): la transacción todavía NO persiste
-    /// <c>id_lote</c> en <c>items_comprobante_venta</c> (esa escritura es de slice 8) — para el
-    /// checkout recién emitido, <paramref name="planItems"/> trae el lote ya resuelto en la fase
-    /// de decisión (mismo orden/índice que <paramref name="items"/>, uno a uno vía
-    /// <c>Orden</c>) y lo proyecta acá; para una relectura sin plan a mano (reprint,
-    /// idempotencia de <see cref="BuscarPorNumeroComprometidoAsync"/>) cae al valor ya persistido
-    /// en la entidad — NULL hasta que slice 8 lo escriba.</summary>
+    /// <summary>Design decisión (stage-12 slice 7, actualizada en slice 8): para el checkout recién
+    /// emitido, <paramref name="planItems"/> trae el lote ya resuelto en la fase de decisión (mismo
+    /// orden/índice que <paramref name="items"/>, uno a uno vía <c>Orden</c>) y lo proyecta acá; para
+    /// una relectura sin plan a mano (reprint, idempotencia de
+    /// <see cref="BuscarPorNumeroComprometidoAsync"/>) cae al valor ya persistido en la entidad —
+    /// desde slice 8 ambos caminos devuelven el MISMO <c>id_lote</c> (el snapshot de
+    /// <c>items_comprobante_venta.id_lote</c> ya se escribe en <see cref="EjecutarTransaccionAsync"/>),
+    /// el fallback queda solo por si algún día <paramref name="planItems"/> falta.</summary>
     private static ComprobanteEmitido Proyectar(
         ComprobanteVenta comprobante, IReadOnlyList<ItemComprobanteVenta> items, IReadOnlyList<PagoComprobante> pagos,
         IReadOnlyList<LineaDelPlan>? planItems = null) => new(

--- a/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
+++ b/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
@@ -625,19 +625,18 @@ public class PlanDeVentaFefoTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
     }
 
-    // ---- judgment-day slice 7, FIX 5 (WARNING 5) — response fresco vs relectura -------------------
+    // ---- judgment-day slice 7, FIX 5 (WARNING 5) — response fresco vs relectura, JD-FIX carryover
+    // actualizado en slice 8 (task 8.2 lo persiste) --------------------------------------------
 
-    /// <summary>Límite honesto de esta slice (ver el doc-comment de <c>Proyectar</c> en
-    /// <c>ServicioDeVentas.cs</c>, APPLY-RUN NOTE de la task 7.3): el checkout FRESCO devuelve
-    /// <c>id_lote</c> desde el plan (no persistido todavía), pero una relectura vía
-    /// <c>ObtenerAsync</c> cae al valor YA persistido en <c>items_comprobante_venta.id_lote</c>,
-    /// que esta slice todavía no escribe — <c>null</c> hasta slice 8. (Al llegar slice 8, este test
-    /// SE ACTUALIZA para esperar el mismo <c>IdLote</c> en ambas lecturas — ver la nota del bloque
-    /// Slice 8 en tasks.md.)</summary>
+    /// <summary>JD-FIX carryover (slice 7, FIX 5): desde que slice 8 persiste <c>id_lote</c> en
+    /// <c>items_comprobante_venta</c> (task 8.2), el contraste fresco-vs-relectura de FIX 5 dejó de
+    /// ser cierto — este test se ACTUALIZA para esperar el MISMO <c>IdLote</c> en ambas lecturas (ver
+    /// el doc-comment de <c>Proyectar</c> en <c>ServicioDeVentas.cs</c>, actualizado en esta misma
+    /// slice) y pierde el sufijo "HastaSlice8" del nombre.</summary>
     [Fact]
-    public async Task ElCheckoutFrescoDevuelveIdLotePeroLaRelecturaTodaviaLoDevuelveNullHastaSlice8()
+    public async Task ElCheckoutFrescoYLaRelecturaDevuelvenElMismoIdLote()
     {
-        var ctx = await PrepararAsync(nameof(ElCheckoutFrescoDevuelveIdLotePeroLaRelecturaTodaviaLoDevuelveNullHastaSlice8));
+        var ctx = await PrepararAsync(nameof(ElCheckoutFrescoYLaRelecturaDevuelvenElMismoIdLote));
         var idArticulo = await SembrarArticuloAsync(ctx, "articulo-fix5-contraste", 100m, controlaLote: true);
         var idLote = await SembrarLoteAsync(ctx, idArticulo, "L1", VencimientoLejanoFuturo);
         await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
@@ -652,6 +651,6 @@ public class PlanDeVentaFefoTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         var releido = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoRelectura, OpcionesJson)!;
 
         var itemReleido = Assert.Single(releido.Items);
-        Assert.Null(itemReleido.IdLote);
+        Assert.Equal(idLote, itemReleido.IdLote);
     }
 }

--- a/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
+++ b/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
@@ -1,0 +1,558 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 8 (tasks 8.1-8.8): la escritura per-lot de
+/// <c>ServicioDeVentas</c> punta a punta — el orden pinneado (<c>id_articulo, id_lote NULLS
+/// FIRST</c>) dentro de la transacción, el snapshot congelado en <c>items_comprobante_venta.id_lote</c>
+/// y la anulación exacta que revierte el lote sin re-derivarlo. A diferencia de
+/// <see cref="PlanDeVentaFefoTests"/> (Slice 7, solo la fase de DECISIÓN), acá cada prueba asserta
+/// el LEDGER (<c>movimientos_stock</c>/<c>stock_lotes</c>) además de la respuesta.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas de vencimiento FIJAS y lejanas — independientes del reloj de la
+    // corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+    private static readonly DateOnly VencimientoLejanoFuturoAlterno = new(2098, 6, 30);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva,
+        int IdListaPrecio, int IdMedioEfectivo, int IdCliente);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Escritura-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Escritura", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "Cliente Escritura",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 1_000_000m,
+            CreditoIlimitado = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, idMedioEfectivo, cliente.Id);
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre, decimal precio, bool controlaLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = controlaLote, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio,
+            Monto = precio, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>El agregado (<c>stock</c>) es un caché INDEPENDIENTE de <c>stock_lotes</c> — el
+    /// upsert de <c>UpsertStockAsync</c> lo crea desde cero (delta puro) si no existe ninguna fila
+    /// previa, así que un test de invariante que arranca sin sembrar acá vería el agregado partir
+    /// de 0, no del total físico esperado.</summary>
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeVenta SolicitudSimple(Contexto ctx, int idArticulo, decimal cantidad, int? idLote) =>
+        new(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, cantidad * 100m, null, 0m)],
+            null, null);
+
+    private static async Task<ComprobanteEmitido> EmitirAsync(Contexto ctx, SolicitudDeVenta solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<ComprobanteEmitido> AnularAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{id}/anulacion", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 8.4: invariante — stock.cantidad y stock_lotes.cantidad correctos tras venta +
+    // anulación ------------------------------------------------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "Stock Lotes Balance And Its Two Invariants" — pierna de
+    /// venta+anulación (la pierna de compra ya la prueba <c>ComprasRecepcionDeLotesTests</c>, Slice
+    /// 5). Tras la venta ambos cachés bajan; tras la anulación ambos vuelven exactamente al valor
+    /// original.</summary>
+    [Fact]
+    public async Task StockYStockLotesQuedanCorrectosTrasVentaYAnulacion()
+    {
+        var ctx = await PrepararAsync(nameof(StockYStockLotesQuedanCorrectosTrasVentaYAnulacion));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-invariante", 100m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-INV", VencimientoLejanoFuturo);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 4m, idLote: null));
+        var item = Assert.Single(emitido.Items);
+        Assert.Equal(idLote, item.IdLote);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var stock = await db.Stock.Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+                .Select(s => s.Cantidad).FirstAsync();
+            Assert.Equal(6m, stock);
+
+            var stockLote = await db.StockLotes
+                .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+                .Select(sl => sl.Cantidad).FirstAsync();
+            Assert.Equal(6m, stockLote);
+        }
+
+        await AnularAsync(ctx, emitido.Id);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var stock = await db.Stock.Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+                .Select(s => s.Cantidad).FirstAsync();
+            Assert.Equal(10m, stock);
+
+            var stockLote = await db.StockLotes
+                .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+                .Select(sl => sl.Cantidad).FirstAsync();
+            Assert.Equal(10m, stockLote);
+        }
+    }
+
+    // ---- task 8.5: mutation target — el snapshot congelado (ItemComprobanteVenta.IdLote) ----------
+
+    /// <summary>Mutation target (design: "Item snapshot"; spec comprobantes-venta: "A lot-effective
+    /// line freezes its resolved lot onto the snapshot", "Anulación of a lot-bearing sale reverses
+    /// the exact lot"; mutation-proof-tests). Asserta DOS cosas en la MISMA corrida: (1) el
+    /// snapshot persistido en <c>items_comprobante_venta.id_lote</c> — la parte que la mutación
+    /// (<c>ItemComprobanteVenta.IdLote = i.IdLote</c> reemplazado por <c>null</c>) rompe
+    /// directamente; y (2) la reversa exacta de la anulación (<c>movimientos_stock.id_lote</c> +
+    /// saldo por lote), que lee del LEDGER, no del snapshot — documentado acá para que quede claro
+    /// por qué la aserción (1) es la que efectivamente mata la mutación.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (regla permanente 6 de este apply): <c>IdLote = i.IdLote</c> en el
+    /// <c>AddRange</c> de <c>EjecutarTransaccionAsync</c> reemplazado por <c>IdLote = null</c>; build,
+    /// filtro <c>FullyQualifiedName~UnaVentaLoteEfectivaCongelaElSnapshotYSuAnulacionRevierteElLoteExacto</c>:
+    /// RED — <c>Assert.Equal(idLote, itemPersistido.IdLote)</c> falló (<c>Expected: {idLote} /
+    /// Actual: null</c>), exactamente la aserción del snapshot, mientras que la reversa de la
+    /// anulación (aserciones 2-3, más abajo) siguió en verde porque lee <c>movimientos_stock</c>, no
+    /// el snapshot — confirma que la mutación es invisible para cualquier prueba que solo mire el
+    /// ledger. Revertido, mismo filtro: GREEN, junto con la suite completa de este archivo.</summary>
+    [Fact]
+    public async Task UnaVentaLoteEfectivaCongelaElSnapshotYSuAnulacionRevierteElLoteExacto()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaLoteEfectivaCongelaElSnapshotYSuAnulacionRevierteElLoteExacto));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-snapshot", 100m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-SNAP", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 4m, idLote: null));
+
+        // (1) El snapshot persistido — GIVEN de la spec ("a sale item persisted id_lote = 7").
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var itemPersistido = await db.ItemsComprobanteVenta.SingleAsync(i => i.IdComprobanteVenta == emitido.Id);
+            Assert.Equal(idLote, itemPersistido.IdLote);
+        }
+
+        await AnularAsync(ctx, emitido.Id);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            // (2) La reversa exacta en el ledger — leída de movimientos_stock, no re-derivada.
+            var movimientoAnulacion = await db.MovimientosStock
+                .SingleAsync(m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion);
+            Assert.Equal(idLote, movimientoAnulacion.IdLote);
+            Assert.Equal(4m, movimientoAnulacion.Cantidad);
+
+            // (3) El saldo por lote, restaurado.
+            var stockLote = await db.StockLotes
+                .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+                .Select(sl => sl.Cantidad).FirstAsync();
+            Assert.Equal(10m, stockLote);
+        }
+    }
+
+    // ---- task 8.6: lock order — stock ANTES que stock_lotes para el mismo par ----------------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Los statements de <see cref="ServicioDeVentas"/>'s paso 5 (<c>InsertarMovimientoStockAsync</c>/
+    /// <c>UpsertStockAsync</c>/<c>UpsertStockLoteAsync</c>) corren sobre un <c>DbCommand</c> crudo
+    /// creado directo con <c>conexion.CreateCommand()</c> — NUNCA pasan por el pipeline de
+    /// <c>DbCommandInterceptor</c> de EF Core (ese pipeline solo envuelve comandos que EF mismo arma
+    /// para LINQ/SaveChanges; confirmado empíricamente, tanto para <c>ScalarExecuting</c> como para
+    /// el logging nativo de Npgsql configurado vía <c>NpgsqlLoggingConfiguration.InitializeLogging</c>
+    /// — este fixture ya abrió conexiones antes de que un test pueda inicializarlo, así que Npgsql
+    /// cachea su logger nulo process-wide antes de que cualquier suscripción pueda engancharse). La
+    /// prueba de orden acá NO intercepta texto de comando — observa el ESTADO DE LOCKS real en
+    /// <c>pg_locks</c> desde una conexión separada, mientras el checkout queda deliberadamente
+    /// bloqueado en <c>stock_lotes</c> por una tercera conexión que sostiene esa fila con
+    /// <c>FOR UPDATE</c>: si en ese instante <c>stock</c> YA aparece <c>granted</c> para el backend
+    /// del checkout, es prueba estructural de que el upsert de <c>stock</c> corrió (y tomó su lock)
+    /// ANTES de que el checkout siquiera intentara <c>stock_lotes</c>.</summary>
+    private async Task<(ComprobanteEmitido Emitido, bool StockYaBloqueadoMientrasEsperaStockLotes)> EmitirObservandoOrdenDeLocksAsync(
+        Contexto ctx, SolicitudDeVenta solicitud, int idArticulo, int idLote)
+    {
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        await db.Database.OpenConnectionAsync();
+        var conexionCheckout = (NpgsqlConnection)db.Database.GetDbConnection();
+        var pidCheckout = (int)(await new NpgsqlCommand("SELECT pg_backend_pid()", conexionCheckout).ExecuteScalarAsync())!;
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
+
+        // Conexión que SOSTIENE el lock de stock_lotes — deliberadamente sin comitear todavía, para
+        // forzar al checkout a bloquearse justo ahí y ensanchar la ventana de observación. RLS exige
+        // el mismo GUC que setea InterceptorDeContextoDeTenant sobre cada conexión física (ADR-3) —
+        // sin esto, la conexión cruda ve CERO filas de stock_lotes (otro tenant, invisible), el
+        // SELECT ... FOR UPDATE no toma ningún lock, y el checkout nunca se bloquea.
+        await using var conexionBloqueo = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionBloqueo.OpenAsync();
+        await using (var comandoGuc = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
+            conexionBloqueo))
+        {
+            comandoGuc.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGuc.ExecuteNonQueryAsync();
+        }
+
+        await using var transaccionBloqueo = await conexionBloqueo.BeginTransactionAsync();
+        await using (var comandoBloqueo = new NpgsqlCommand(
+            "SELECT cantidad FROM stock_lotes WHERE id_articulo = $1 AND id_punto_venta = $2 AND id_lote = $3 FOR UPDATE",
+            conexionBloqueo, transaccionBloqueo))
+        {
+            comandoBloqueo.Parameters.AddWithValue(idArticulo);
+            comandoBloqueo.Parameters.AddWithValue(ctx.IdPuntoVenta);
+            comandoBloqueo.Parameters.AddWithValue(idLote);
+            await comandoBloqueo.ExecuteScalarAsync();
+        }
+
+        var checkoutTask = servicioDeVentas.EmitirAsync(solicitud);
+
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync();
+
+        var observado = false;
+        var limite = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < limite)
+        {
+            // Postgres representa "bloqueado esperando la fila que otra transacción tiene" como un
+            // ShareLock NO otorgado sobre el transactionid de esa otra transacción (locktype
+            // 'transactionid') — NUNCA como una fila `tuple` con granted=false sobre stock_lotes
+            // directamente (comprobado empíricamente con un dump de pg_locks completo). El único
+            // lock artificialmente disputado en este test es el de stock_lotes (sostenido por
+            // conexionBloqueo), así que CUALQUIER lock no otorgado del backend del checkout es, acá,
+            // ese bloqueo.
+            await using var comandoPoll = new NpgsqlCommand(
+                "SELECT " +
+                "  bool_or(l.locktype = 'relation' AND l.relation::regclass::text = 'stock' AND l.granted) AS stock_otorgado, " +
+                "  bool_or(NOT l.granted) AS esperando_algo " +
+                "FROM pg_locks l WHERE l.pid = $1",
+                conexionPoll);
+            comandoPoll.Parameters.AddWithValue(pidCheckout);
+
+            await using var lector = await comandoPoll.ExecuteReaderAsync();
+            if (await lector.ReadAsync())
+            {
+                var stockOtorgado = !lector.IsDBNull(0) && lector.GetBoolean(0);
+                var esperandoAlgo = !lector.IsDBNull(1) && lector.GetBoolean(1);
+                if (stockOtorgado && esperandoAlgo)
+                {
+                    observado = true;
+                    break;
+                }
+            }
+
+            await Task.Delay(25);
+        }
+
+        // Libera el lock retenido — el checkout, hasta acá bloqueado, ahora puede completar.
+        await transaccionBloqueo.RollbackAsync();
+
+        var emitido = await checkoutTask;
+
+        return (emitido, observado);
+    }
+
+    /// <summary>spec stock: "A checkout locks stock before stock_lotes for the same pair" (design
+    /// decisión 1/3: <c>stock</c> es el único statement que toma el row lock que reemplaza al
+    /// advisory lock; <c>stock_lotes</c> lo sigue SIEMPRE, nunca lo precede).</summary>
+    [Fact]
+    public async Task UnCheckoutBloqueaStockAntesQueStockLotesParaElMismoPar()
+    {
+        var ctx = await PrepararAsync(nameof(UnCheckoutBloqueaStockAntesQueStockLotesParaElMismoPar));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-lock-order", 100m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-LOCK", VencimientoLejanoFuturo);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+
+        var (emitido, observado) = await EmitirObservandoOrdenDeLocksAsync(
+            ctx, SolicitudSimple(ctx, idArticulo, 1m, idLote: null), idArticulo, idLote);
+
+        Assert.True(
+            observado,
+            "Nunca se observó al checkout con el lock de stock ya otorgado mientras esperaba stock_lotes.");
+        Assert.Single(emitido.Items);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stock = await db.Stock.Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(9m, stock);
+    }
+
+    // ---- task 8.7: mutation target (half A, deadlock) — orden ascendente por id_lote, no por
+    // orden de envío -----------------------------------------------------------------------------
+
+    /// <summary>Mutation target (design decisión 8/9; spec stock: "A checkout locks stock before
+    /// stock_lotes..."; mutation-proof-tests). Dos líneas del MISMO artículo lote-efectivo, cada una
+    /// con un <c>idLote</c> EXPLÍCITO distinto, enviadas en orden DESCENDENTE (lote de id mayor
+    /// primero) — un <c>OrderBy(IdArticulo)</c> sin desempate por lote preserva el orden de arribo
+    /// (sort estable), así que sin <c>.ThenBy(IdLote.HasValue).ThenBy(IdLote ?? 0)</c> los
+    /// movimientos se escribirían en el orden de ENVÍO (lote mayor, después menor) — la "media
+    /// mitad" del proof de deadlock que le toca a esta slice (la mitad conjunta checkout-vs-transfer
+    /// es la task 10.12, cross-slice, ver la nota de la task 8.7 en tasks.md).
+    ///
+    /// EVIDENCIA DE MUTACIÓN (regla permanente 6 de este apply): borrado
+    /// <c>.ThenBy(i => i.IdLote.HasValue).ThenBy(i => i.IdLote ?? 0)</c> del loop del paso 5 de
+    /// <c>EjecutarTransaccionAsync</c> (queda solo <c>.OrderBy(i => i.IdArticulo)</c>); build, filtro
+    /// <c>FullyQualifiedName~LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote</c>:
+    /// RED — <c>Assert.Equal(idLoteMenor, movimientos[0].IdLote)</c> falló (<c>Expected: {idLoteMenor}
+    /// / Actual: {idLoteMayor}</c>): el sort estable preservó el orden de ENVÍO (mayor primero), tal
+    /// como predice el doc-comment. Revertido, mismo filtro: GREEN.</summary>
+    [Fact]
+    public async Task LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote()
+    {
+        var ctx = await PrepararAsync(nameof(LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-multilote", 100m, controlaLote: true);
+        // idLoteMenor se crea PRIMERO (id de secuencia más chico) — se envía SEGUNDO en el carrito
+        // para que el orden de escritura correcto (ascendente por id_lote) contradiga el orden de
+        // envío (mayor primero).
+        var idLoteMenor = await SembrarLoteAsync(ctx, idArticulo, "L-MENOR", VencimientoLejanoFuturoAlterno);
+        var idLoteMayor = await SembrarLoteAsync(ctx, idArticulo, "L-MAYOR", VencimientoLejanoFuturo);
+        Assert.True(idLoteMenor < idLoteMayor);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteMenor, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteMayor, 10m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [
+                new LineaDeVenta(idArticulo, 1m, null, idLoteMayor),
+                new LineaDeVenta(idArticulo, 1m, null, idLoteMenor)
+            ],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 200m, null, 0m)],
+            null, null);
+
+        var emitido = await EmitirAsync(ctx, solicitud);
+        Assert.Equal(2, emitido.Items.Count);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Venta)
+            .OrderBy(m => m.Id)
+            .ToListAsync();
+
+        Assert.Equal(2, movimientos.Count);
+        Assert.Equal(idLoteMenor, movimientos[0].IdLote);
+        Assert.Equal(idLoteMayor, movimientos[1].IdLote);
+    }
+
+    // ---- task 8.8: regresión — artículo sin control de lote nunca lleva id_lote --------------------
+
+    /// <summary>spec comprobantes-venta: "A non-lot-effective line never carries a lot"; spec stock:
+    /// "A non-lot articulo's movement never carries a lot". <c>lotes_habilitado</c> sigue ON a nivel
+    /// empresa (seteado por <see cref="PrepararAsync"/>) — lo único que decide acá es
+    /// <c>controla_lote = false</c> del artículo (decisión 2, <c>ControlEfectivo</c>).</summary>
+    [Fact]
+    public async Task UnArticuloSinControlDeLoteNuncaLlevaIdLoteEnItemNiMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloSinControlDeLoteNuncaLlevaIdLoteEnItemNiMovimiento));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-sin-lote-escritura", 100m, controlaLote: false);
+
+        var emitido = await EmitirAsync(ctx, SolicitudSimple(ctx, idArticulo, 2m, idLote: null));
+        var item = Assert.Single(emitido.Items);
+        Assert.Null(item.IdLote);
+        Assert.Null(item.CodigoLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var itemPersistido = await db.ItemsComprobanteVenta.SingleAsync(i => i.IdComprobanteVenta == emitido.Id);
+        Assert.Null(itemPersistido.IdLote);
+
+        var movimiento = await db.MovimientosStock
+            .SingleAsync(m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Venta);
+        Assert.Null(movimiento.IdLote);
+    }
+}

--- a/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
+++ b/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
@@ -534,7 +534,14 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
     /// <summary>spec comprobantes-venta: "A non-lot-effective line never carries a lot"; spec stock:
     /// "A non-lot articulo's movement never carries a lot". <c>lotes_habilitado</c> sigue ON a nivel
     /// empresa (seteado por <see cref="PrepararAsync"/>) — lo único que decide acá es
-    /// <c>controla_lote = false</c> del artículo (decisión 2, <c>ControlEfectivo</c>).</summary>
+    /// <c>controla_lote = false</c> del artículo (decisión 2, <c>ControlEfectivo</c>).
+    ///
+    /// Caveat (judgment-day slice 8, juez B, nota no bloqueante): una mutación que fuerce un
+    /// <c>id_lote</c> ajeno sobre el movimiento de este artículo muere PRIMERO en la FK compuesta
+    /// <c>fk_movimientos_stock_lote</c> (<c>IdLote, IdArticulo, IdTenant</c>) — el lote forzado no
+    /// existe para ESTE artículo, así que Postgres rechaza el INSERT antes de que la aserción de
+    /// abajo llegue a evaluarse; es el mismo patrón de defensa doble que <c>pk_stock</c> (backstop
+    /// del schema primero, aserción de C# como segunda capa).</summary>
     [Fact]
     public async Task UnArticuloSinControlDeLoteNuncaLlevaIdLoteEnItemNiMovimiento()
     {
@@ -554,5 +561,135 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
         var movimiento = await db.MovimientosStock
             .SingleAsync(m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Venta);
         Assert.Null(movimiento.IdLote);
+    }
+
+    // ---- task 8.9 (judgment-day slice 8, FIX 1): mutation target — fidelidad por-movimiento del
+    // id_lote en la anulación multi-línea ------------------------------------------------------
+
+    /// <summary>Mutation target (judgment-day slice 8, juez B REJECT: "hoistear el primer IdLote
+    /// visto y pasarlo a TODOS los contramovimientos" sobrevive los 176 tests existentes porque
+    /// ningún test de anulación previo vende más de una línea del mismo artículo). Dos líneas del
+    /// MISMO artículo, cada una con un lote EXPLÍCITO distinto (mismo fixture que la task 8.7) →
+    /// anular → CADA contramovimiento de anulación debe llevar SU <c>id_lote</c> original — no el
+    /// del primer movimiento visto en el <c>foreach</c> del paso 2 — y el saldo por lote de AMBOS
+    /// lotes debe volver exacto.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (regla permanente 6 de este apply): en <c>EjecutarAnulacionAsync</c>
+    /// (paso 2), <c>original.IdLote</c> pasado a <c>InsertarMovimientoStockAsync</c> reemplazado
+    /// por un <c>primerLoteVisto</c> hoisteado ANTES del <c>foreach</c> y fijado una única vez en
+    /// la primera iteración (mutación exacta del juez B); build, filtro
+    /// <c>FullyQualifiedName~LaAnulacionMultilineaRevierteCadaMovimientoConSuPropioIdLote</c>: RED
+    /// — el iterador procesa primero el movimiento de <c>idLoteMenor</c> (orden ascendente por
+    /// <c>id_lote</c>, task 8.7), así que <c>primerLoteVisto</c> quedó fijo en ese valor y lo
+    /// heredó también el contramovimiento del lote mayor: <c>Assert.Equal(idLoteMayor,
+    /// movimientoLoteMayor.IdLote)</c> falló (<c>Expected: idLoteMayor / Actual: idLoteMenor</c>).
+    /// Los saldos por lote (<c>stockLoteMayor</c>/<c>stockLoteMenor</c>) NO se ven afectados por
+    /// esta mutación puntual — <c>UpsertStockLoteAsync</c> sigue leyendo <c>original.IdLote</c> sin
+    /// tocar, solo el <c>id_lote</c> grabado en <c>movimientos_stock</c> queda infiel — por eso la
+    /// aserción del ledger es la que efectivamente mata la mutación, no la del agregado. Revertido,
+    /// mismo filtro: GREEN, junto con la suite completa de este archivo.</summary>
+    [Fact]
+    public async Task LaAnulacionMultilineaRevierteCadaMovimientoConSuPropioIdLote()
+    {
+        var ctx = await PrepararAsync(nameof(LaAnulacionMultilineaRevierteCadaMovimientoConSuPropioIdLote));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-anulacion-multilote", 100m, controlaLote: true);
+        var idLoteMenor = await SembrarLoteAsync(ctx, idArticulo, "L-ANUL-MENOR", VencimientoLejanoFuturoAlterno);
+        var idLoteMayor = await SembrarLoteAsync(ctx, idArticulo, "L-ANUL-MAYOR", VencimientoLejanoFuturo);
+        Assert.True(idLoteMenor < idLoteMayor);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteMenor, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLoteMayor, 10m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [
+                new LineaDeVenta(idArticulo, 3m, null, idLoteMayor),
+                new LineaDeVenta(idArticulo, 2m, null, idLoteMenor)
+            ],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 500m, null, 0m)],
+            null, null);
+
+        var emitido = await EmitirAsync(ctx, solicitud);
+        Assert.Equal(2, emitido.Items.Count);
+
+        await AnularAsync(ctx, emitido.Id);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var movimientoLoteMayor = await db.MovimientosStock.SingleAsync(
+            m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion && m.Cantidad == 3m);
+        Assert.Equal(idLoteMayor, movimientoLoteMayor.IdLote);
+
+        var movimientoLoteMenor = await db.MovimientosStock.SingleAsync(
+            m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion && m.Cantidad == 2m);
+        Assert.Equal(idLoteMenor, movimientoLoteMenor.IdLote);
+
+        var stockLoteMayor = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLoteMayor)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(10m, stockLoteMayor);
+
+        var stockLoteMenor = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLoteMenor)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(10m, stockLoteMenor);
+    }
+
+    /// <summary>Mutation target (judgment-day slice 8, FIX 1, extensión mixta): una venta MIXTA —
+    /// una línea de un artículo lote-efectivo y otra línea de un artículo SIN control de lote — al
+    /// anularse debe dejar el contramovimiento de la línea con lote con SU <c>id_lote</c> y el de
+    /// la línea sin lote con <c>id_lote</c> null. La mutación del juez B (hoistear el primer
+    /// <c>IdLote</c> visto) también se prueba acá desde el ángulo inverso: si la línea CON lote se
+    /// procesa primero (orden ascendente por <c>id_articulo</c>, este artículo se sembró primero),
+    /// el hoist filtraría ese id_lote hacia el contramovimiento que debe quedar null.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (regla permanente 6 de este apply): misma mutación exacta del juez B
+    /// aplicada a <c>EjecutarAnulacionAsync</c> (ver evidencia completa en
+    /// <see cref="LaAnulacionMultilineaRevierteCadaMovimientoConSuPropioIdLote"/>); build, filtro
+    /// <c>FullyQualifiedName~LaAnulacionDeUnaVentaMixtaRevierteLaLineaConLoteYLaLineaSinLoteCadaUnaConSuIdLote</c>:
+    /// RED — pero NO como fallo de aserción: <c>AnularAsync</c> devolvió <c>500</c> y
+    /// <c>Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo)</c> abortó el test, porque
+    /// el <c>idLote</c> hoisteado (el del artículo CON lote, primero en el orden) se intentó grabar
+    /// en el contramovimiento del artículo SIN lote — combinación que no existe y viola la FK
+    /// compuesta <c>fk_movimientos_stock_lote</c> (Postgres 23503) antes de que cualquier aserción
+    /// de C# corra. Confirma, desde el ángulo inverso, el mismo backstop de schema documentado en
+    /// <see cref="UnArticuloSinControlDeLoteNuncaLlevaIdLoteEnItemNiMovimiento"/> — acá la mutación
+    /// muere en la base, no en la aserción. Revertido, mismo filtro: GREEN.</summary>
+    [Fact]
+    public async Task LaAnulacionDeUnaVentaMixtaRevierteLaLineaConLoteYLaLineaSinLoteCadaUnaConSuIdLote()
+    {
+        var ctx = await PrepararAsync(nameof(LaAnulacionDeUnaVentaMixtaRevierteLaLineaConLoteYLaLineaSinLoteCadaUnaConSuIdLote));
+        var idArticuloConLote = await SembrarArticuloAsync(ctx, "articulo-mixto-con-lote", 100m, controlaLote: true);
+        var idArticuloSinLote = await SembrarArticuloAsync(ctx, "articulo-mixto-sin-lote", 100m, controlaLote: false);
+        var idLote = await SembrarLoteAsync(ctx, idArticuloConLote, "L-MIXTO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticuloConLote, idLote, 10m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [
+                new LineaDeVenta(idArticuloConLote, 3m, null, idLote),
+                new LineaDeVenta(idArticuloSinLote, 2m, null, null)
+            ],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 500m, null, 0m)],
+            null, null);
+
+        var emitido = await EmitirAsync(ctx, solicitud);
+        Assert.Equal(2, emitido.Items.Count);
+
+        await AnularAsync(ctx, emitido.Id);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var movimientoConLote = await db.MovimientosStock.SingleAsync(
+            m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion && m.IdArticulo == idArticuloConLote);
+        Assert.Equal(idLote, movimientoConLote.IdLote);
+
+        var movimientoSinLote = await db.MovimientosStock.SingleAsync(
+            m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion && m.IdArticulo == idArticuloSinLote);
+        Assert.Null(movimientoSinLote.IdLote);
+
+        var stockLote = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticuloConLote && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(10m, stockLote);
     }
 }

--- a/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
+++ b/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
@@ -491,7 +491,22 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
     /// <c>FullyQualifiedName~LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote</c>:
     /// RED — <c>Assert.Equal(idLoteMenor, movimientos[0].IdLote)</c> falló (<c>Expected: {idLoteMenor}
     /// / Actual: {idLoteMayor}</c>): el sort estable preservó el orden de ENVÍO (mayor primero), tal
-    /// como predice el doc-comment. Revertido, mismo filtro: GREEN.</summary>
+    /// como predice el doc-comment. Revertido, mismo filtro: GREEN.
+    ///
+    /// Extensión (judgment-day slice 8, ronda 2, juez A MAJOR): las dos líneas también asertan el
+    /// agregado <c>stock.cantidad</c> final, sembrado con un valor inicial y cantidades DISTINTAS
+    /// por línea (3 vs. 5) — discriminante contra una "optimización" que agrupe por
+    /// <c>id_articulo</c> y llame <c>UpsertStockAsync</c> UNA sola vez con el delta de la ÚLTIMA
+    /// línea en vez de re-emitirlo por línea (design decisión 8: "re-issuing is a re-lock ... zero
+    /// contention"; la alternativa agrupada es la que el design explícitamente rechaza).
+    ///
+    /// EVIDENCIA DE MUTACIÓN (agregado, regla permanente 6): paso 5 de <c>EjecutarTransaccionAsync</c>
+    /// mutado para agrupar <c>plan.Items</c> por <c>IdArticulo</c> y llamar <c>UpsertStockAsync</c>
+    /// una única vez por artículo con <c>-grupo.Last().Cantidad</c> (delta de la línea de
+    /// <c>idLoteMenor</c>, la última enviada) en vez de re-emitirlo en cada iteración; build, mismo
+    /// filtro: RED — <c>Assert.Equal(12m, stock)</c> falló (<c>Expected: 12 / Actual: 15</c>): el
+    /// agregado solo restó 5 (delta de la última línea), no 8 (3+5, la suma de ambas). Revertido,
+    /// mismo filtro: GREEN.</summary>
     [Fact]
     public async Task LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote()
     {
@@ -503,16 +518,20 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
         var idLoteMenor = await SembrarLoteAsync(ctx, idArticulo, "L-MENOR", VencimientoLejanoFuturoAlterno);
         var idLoteMayor = await SembrarLoteAsync(ctx, idArticulo, "L-MAYOR", VencimientoLejanoFuturo);
         Assert.True(idLoteMenor < idLoteMayor);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
         await SembrarStockLoteAsync(ctx, idArticulo, idLoteMenor, 10m);
         await SembrarStockLoteAsync(ctx, idArticulo, idLoteMayor, 10m);
 
+        // Cantidades DISTINTAS por línea (3 vs. 5, discriminantes) — si el agregado se upsertea una
+        // sola vez por artículo con el delta de la última línea, en vez de una vez por línea, el
+        // stock final delata cuál delta ganó.
         var solicitud = new SolicitudDeVenta(
             ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
             [
-                new LineaDeVenta(idArticulo, 1m, null, idLoteMayor),
-                new LineaDeVenta(idArticulo, 1m, null, idLoteMenor)
+                new LineaDeVenta(idArticulo, 3m, null, idLoteMayor),
+                new LineaDeVenta(idArticulo, 5m, null, idLoteMenor)
             ],
-            [new PagoDeVenta(ctx.IdMedioEfectivo, 200m, null, 0m)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 800m, null, 0m)],
             null, null);
 
         var emitido = await EmitirAsync(ctx, solicitud);
@@ -526,7 +545,23 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
 
         Assert.Equal(2, movimientos.Count);
         Assert.Equal(idLoteMenor, movimientos[0].IdLote);
+        Assert.Equal(5m, movimientos[0].Cantidad * -1);
         Assert.Equal(idLoteMayor, movimientos[1].IdLote);
+        Assert.Equal(3m, movimientos[1].Cantidad * -1);
+
+        var stock = await db.Stock.Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(12m, stock);
+
+        var stockLoteMenor = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLoteMenor)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(5m, stockLoteMenor);
+
+        var stockLoteMayor = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLoteMayor)
+            .Select(sl => sl.Cantidad).FirstAsync();
+        Assert.Equal(7m, stockLoteMayor);
     }
 
     // ---- task 8.8: regresión — artículo sin control de lote nunca lleva id_lote --------------------


### PR DESCRIPTION
## Etapa 12 — Slice 8: Venta Escritura

- **Paso 5 del checkout**: loop \`OrderBy(IdArticulo).ThenBy(IdLote.HasValue).ThenBy(IdLote ?? 0)\` (NULLS FIRST explícito); agregado SIEMPRE primero por línea (acumulación probada con multi-línea del mismo artículo), después \`UpsertStockLoteAsync\` (misma forma \`ON CONFLICT ... RETURNING\`).
- **Snapshot**: \`ItemComprobanteVenta.IdLote\` congelado en el AddRange; jamás re-derivado.
- **Anulación**: lee del LEDGER, cada contramovimiento copia SU \`original.IdLote\` (fidelidad por movimiento probada con multi-línea y mixta), espejo de \`stock_lotes\`, doble check.
- **Test de orden de locks vía \`pg_locks\` real** (los comandos raw ADO no pasan por el interceptor de EF): tercera conexión bloqueada observando el lock de \`stock\` ya otorgado — estable 3/3.
- Carryover del slice 7 aplicado: el test de contraste ahora asserta el MISMO IdLote en response fresco y relectura.

### Tests
VentaEscrituraLote + PlanDeVentaFefo 22/22 · regresión Ventas/Anulacion 158/158 · Domain 420 · Application 257. 8 rondas de evidencia de mutación.

### Judgment-day (2 rondas REJECT, ambas con hallazgos reales del writer más caliente)
Juez B: la mutación "primer lote hoisted a todos los contramovimientos" sobrevivía 176 tests (saldos bien, ledger de auditoría corrupto en silencio) → tests multi-línea y mixta que la matan por ambos ángulos. Juez A: nada probaba la ACUMULACIÓN del agregado con dos líneas del mismo artículo (agrupar-y-usar-último-delta sobrevivía) → test extendido con verificación aritmética de la evidencia (Expected 12 / Actual 15). Rondas finales: doble APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)