### PR TITLE
feat(lotes): transferencias lote-conscientes — el lote viaja — etapa 12, slice 10

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1252,6 +1252,47 @@ the branch.
 >
 > Filtro `~TransferenciaLote`: 13/13 (11 previos + 2 nuevos). Regresión
 > `~TransferenciasYConteo`: 28/28.
+> Note (judgment-day, slice 10, FIX round — juez A, 1 MAJOR + 1 MINOR
+> confirmados):
+> 1. **MAJOR — `LineaTransferida` sin `IdLote` + agregación que colapsaba
+>    multi-lote** (design.md:180, `dto-contract-honesty`): el shipped había
+>    dropeado `IdLote` del record sin documentar, y `EjecutarTransferenciaAsync`
+>    agregaba por `IdArticulo` solo — dos líneas del mismo artículo con lotes
+>    distintos (caso ACEPTADO por spec, ver `DosLineasDelMismoArticuloConLotesExplicitosDistintosSonAceptadas`)
+>    colapsaban en una sola fila del response, y el caller nunca sabía qué
+>    lote viajó en el FEFO-default. Fix: `LineaTransferida(int IdArticulo,
+>    int? IdLote, decimal CantidadOrigen, decimal CantidadDestino)` restaurado
+>    igual que el design; `resultadosPorArticuloYLote` ensanchado a clave
+>    `(IdArticulo, IdLote)` — una fila por (artículo, lote), lote FEFO incluido.
+>    `CantidadOrigen`/`CantidadDestino` siguen siendo el checkpoint del
+>    `stock.cantidad` agregado devuelto por el upsert de ESA línea puntual, no
+>    el saldo final del artículo ni el de `stock_lotes` (documentado en el
+>    doc-comment del record). Test nuevo:
+>    `LaRespuestaDeUnaTransferenciaConDosLotesDelMismoArticuloTraeUnaFilaPorLoteConIdLote`
+>    — 2 líneas de un mismo artículo con lotes explícitos distintos + 1 línea
+>    FEFO-default de otro artículo, asserta las 3 filas del body con
+>    IdArticulo/IdLote/cantidades exactos. Evidencia de mutación: clave
+>    revertida a `IdArticulo` solo → el test FALLA (2 filas en vez de 3);
+>    revertido, GREEN. Consumidores verificados: `Ways.Web` (`tipos.ts`,
+>    `Transferencias.tsx`) todavía NO consume lote en transferencias (ni
+>    `LineaDeTransferencia` ni `LineaTransferida` tienen `idLote` del lado
+>    TS) — el campo nuevo es transparente para el cliente actual. Riesgo
+>    latente anotado, no corregido acá (fuera de alcance del slice 10):
+>    `Transferencias.tsx:288` usa `key={l.idArticulo}` en la tabla de
+>    resultado — el día que un slice futuro (14/15) sume selección de lote a
+>    la UI, dos filas del mismo artículo con lotes distintos van a colisionar
+>    esa key de React.
+> 2. **MINOR — faltaba el test del FEFO-default que resuelve a un lote
+>    solo-vencido**: el código ya hacía el re-check incondicional de
+>    `EstaVencido` (aunque el lote viniera de FEFO), pero no había cobertura
+>    para el caso "único lote con saldo, y ese lote está vencido". Test
+>    nuevo: `UnaLineaSinIdLoteQueResuelvePorFefoAUnUnicoLoteVencidoEsRechazada`.
+>    Evidencia de mutación: anulado el `if (ReglaDeLotes.EstaVencido(...))` →
+>    el test FALLA (200, transfiere el vencido); revertido, GREEN.
+>
+> Filtro `~TransferenciaLote`: 15/15 (13 previos + 2 nuevos). Regresión
+> `~TransferenciasYConteo`: 28/28. `has-pending-model-changes`: sin cambios
+> pendientes (fix puramente de capa Application, sin tocar el modelo).
 - [ ] 10.14 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 10.15 Branch `feat/stage12-slice10-transferencias` off `main`
   (parent: slice 3); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1232,6 +1232,26 @@ the branch.
   `Microsoft.EntityFrameworkCore.Design`, mismo criterio que slices previos.
   Output: "No changes have been made to the model since the last
   migration.")*
+> Note (judgment-day, slice 10, FIX round — juez B, 2 gaps de cobertura
+> confirmados, ambos ya smoke-testeados en verde por el juez, dejados como
+> tests permanentes en `TransferenciaLoteTests.cs`):
+> 1. **Transferencia mixta** (`UnaTransferenciaMixtaConLineaLoteEfectivaYLineaSinLoteCompletaAmbas`):
+>    una línea de artículo lote-efectivo + una línea de artículo sin lote en
+>    la misma solicitud — ambas completan, sin que el filtro
+>    `indicesConLoteEfectivo` de `ResolverLineasDeTransferenciaAsync`
+>    contamine el tratamiento de la otra. Evidencia de mutación: el ternario
+>    de `ConstruirClavesOrdenadas` mutado para emitir también una clave de
+>    lote en la rama sin-lote → el test FALLA (500 por FK inválida sobre
+>    `stock_lotes`); revertido, GREEN.
+> 2. **`lote_invalido` sobre línea sin lote efectivo**
+>    (`UnaLineaSinLoteEfectivoConIdLoteProvistoEsRechazadaComoLoteInvalido`):
+>    un `idLote` provisto en una línea de artículo sin control de lote se
+>    rechaza (400), nada se escribe. Evidencia de mutación: anulado el guard
+>    de `ServicioDeStock.cs` (~269-281) → el test FALLA (200 en vez de 400);
+>    revertido, GREEN.
+>
+> Filtro `~TransferenciaLote`: 13/13 (11 previos + 2 nuevos). Regresión
+> `~TransferenciasYConteo`: 28/28.
 - [ ] 10.14 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 10.15 Branch `feat/stage12-slice10-transferencias` off `main`
   (parent: slice 3); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1293,8 +1293,23 @@ the branch.
 > Filtro `~TransferenciaLote`: 15/15 (13 previos + 2 nuevos). Regresión
 > `~TransferenciasYConteo`: 28/28. `has-pending-model-changes`: sin cambios
 > pendientes (fix puramente de capa Application, sin tocar el modelo).
-- [ ] 10.14 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 10.15 Branch `feat/stage12-slice10-transferencias` off `main`
+- [x] 10.14 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  this slice's apply died mid-run with the host process; the rescued wip had
+  two defects the continuation caught — comments claiming a lock tie-break
+  the code lacked (restored) and FALSE mutation evidence for 10.4 (the
+  shared aggregate row is a natural lock convoy; judge B later derived the
+  STRUCTURAL proof that a lot-row deadlock cycle is impossible by
+  construction, validated cross-articulo ×3 under mutation — the tie-break
+  stands as cross-write-site convention, honestly documented). Judge B:
+  APPROVE ×2 with 5 standard mutations killed + 2 coverage gaps closed
+  (mixed transfer, lote_invalido). Judge A: REJECT round 1 with a MAJOR
+  contract drift — LineaTransferida had silently dropped the design-mandated
+  IdLote and the per-articulo aggregation collapsed multi-lot lines in the
+  response; fixed in 5703a29 (per-(articulo,lote) rows, field-by-field
+  3-row test, FEFO-to-expired 409 test); APPROVE round 2 with hand-derived
+  arithmetic verification. Latent Web risk (key={l.idArticulo} in
+  Transferencias.tsx) recorded for slice 14/15.)*
+- [x] 10.15 Branch `feat/stage12-slice10-transferencias` off `main`
   (parent: slice 3); PR; merge stacked-to-main.
 
 **Test plan**: deadlock mutation (10.4), A→B/B→A concurrency (10.5),

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1036,7 +1036,19 @@ permanent; now records that both paths return the same value since slice 8.
   set. The **joint** checkout-vs-reverse-transfer deadlock proof itself is
   deferred to slice 10 (task 10.12), once `ServicioDeStock`'s transfer
   write also exists — recorded as an explicit cross-slice dependency, not a
-  gap. *(APPLY-RUN NOTE: "hand-built key set" implemented as a real,
+  gap. *(PAIRING CLOSED at slice 10, task 10.12 —
+  `UnCheckoutYUnaTransferenciaConcurrentesDelMismoArticuloYLoteNoDeadlockean`
+  in `TransferenciaLoteTests.cs` runs the checkout-vs-reverse-transfer
+  scenario end to end and passes. Note also the negative finding recorded
+  at slice 10's task 10.4: the joint proof, like the transfer-vs-transfer
+  deadlock test, does NOT independently discriminate the `id_lote` `ThenBy`
+  mutation — both checkout and transfer write the aggregate `stock` row
+  before any `stock_lotes` row for the same pair, so two transactions
+  sharing an articulo/PV always convoy-serialize on that shared row before
+  either reaches lot granularity. 8.7's OWN single-transaction ordering
+  test still kills the mutation correctly — that discriminating power
+  never depended on a second, concurrent transaction.)* *(APPLY-RUN NOTE:
+  "hand-built key set" implemented as a real,
   achievable production scenario rather than an artificial in-memory
   fixture — `LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote`
   submits TWO lines of the SAME lot-effective articulo, each with a
@@ -1132,52 +1144,94 @@ travels with the merchandise; the lock order gains a `≥2N`-key form; per-lot
 insufficiency and expired-lot transfer are refused. **Rollback**: revert
 the branch.
 
-- [ ] 10.1 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
+- [x] 10.1 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
   `ClaveDeStock` widens (`IdLote`, `IdLoteDelMovimiento`);
   `ConstruirClavesOrdenadas` — per lot-effective line, 4 keys (aggregate +
   lot at origen, aggregate + lot at destino); order
   `.OrderBy(IdArticulo).ThenBy(IdPuntoVenta).ThenBy(IdLote.HasValue).ThenBy(IdLote ?? 0)`.
-- [ ] 10.2 Modify `ServicioDeStock.cs`: pre-transaction phase — read
+  *(APPLY-RUN NOTE — continuación tras corte de proceso: el wip rescatado
+  (`e37313e`) tenía TODO el resto de la task correcto pero el `ThenBy` de
+  `id_lote` estaba directamente AUSENTE del código shipeado — quedó solo
+  `.OrderBy(IdArticulo).ThenBy(IdPuntoVenta)`, a pesar de que el doc-comment
+  de la clase y el comentario de la task 10.4 en el test lo daban por
+  puesto y por probado. Restaurado en esta continuación.)*
+- [x] 10.2 Modify `ServicioDeStock.cs`: pre-transaction phase — read
   `stock_lotes` of the origin PV for requested articulos, FEFO-default
   omitted lots via `ReglaDeLotes.ElegirFefo`, apply decision 11's
   `(IdArticulo, IdLote)` duplicate refusal **after** defaulting;
   `transferencia_lote_vencido` check alongside `ResolverArticuloAsync`.
-- [ ] 10.3 Modify `ServicioDeStock.cs`: transaction loop — at an aggregate
+  *(Ya estaba correcto en el wip rescatado — sin cambios en esta
+  continuación.)*
+- [x] 10.3 Modify `ServicioDeStock.cs`: transaction loop — at an aggregate
   element, insert the ledger row (carrying `IdLoteDelMovimiento`) + upsert
   `stock`; at a lot element, upsert `stock_lotes` only. Both `RETURNING`
   values checked for negativity → `409
   stock_insuficiente_para_transferencia` (aggregate check unchanged, lot
-  check new).
-- [ ] 10.4 [P] **Mutation target**: `.ThenBy(c => c.IdLote.HasValue).ThenBy(c
+  check new). *(Ya estaba correcto en el wip rescatado — sin cambios en
+  esta continuación.)*
+- [x] 10.4 [P] **Mutation target**: `.ThenBy(c => c.IdLote.HasValue).ThenBy(c
   => c.IdLote ?? 0)` deleted in `ConstruirClavesOrdenadas` → the
   transfer-vs-reverse-transfer deadlock test MUST fail; revert → green.
-  Record evidence.
-- [ ] 10.5 [P] A→B vs. B→A concurrency test, write-site 3: both transfers
-  complete, no `40P01`.
-- [ ] 10.6 [P] Per-lot insufficiency with a sufficient aggregate. *(spec
+  Record evidence. *(DESVÍO documentado — el wip dejaba una "EVIDENCIA DE
+  MUTACIÓN" en el doc-comment del test afirmando un ciclo RED→GREEN que la
+  corrida real de esta continuación NO reprodujo: con el `ThenBy` borrado,
+  el archivo completo (11/11, incluidos este test, 10.11 y el joint proof
+  10.12) siguió en GREEN, corrida ×2. Causa raíz analizada y confirmada
+  empíricamente: dentro de un mismo `(id_articulo, id_punto_venta)`, el
+  elemento AGREGADO de cada línea precede a su elemento LOTE por
+  construcción del array por línea, sea cual sea el `ThenBy` — así que el
+  primer elemento nuevo tocado por dos transferencias recíprocas del MISMO
+  artículo es siempre la MISMA fila física de `stock`, que actúa de convoy:
+  quien la toca primero la retiene hasta el commit y la otra transacción
+  simplemente espera, sin llegar nunca a competir en el orden opuesto que
+  el test intenta forzar sobre `stock_lotes`. El mismo mecanismo neutraliza
+  el joint proof 10.12 (checkout y transferencia comparten la fila
+  agregada del mismo artículo/PV). El `ThenBy` de `id_lote` se mantiene —
+  sigue siendo exigido por el design/spec (orden total `≥2N`, consistente
+  con los otros dos sitios de escritura) y es la forma correcta — pero
+  NINGÚN test de este archivo lo prueba por mutación viva; el comentario
+  falso del wip fue corregido en el test para reflejar este hallazgo
+  negativo documentado en vez de una evidencia fabricada. Ver el doc-comment
+  de `TransferenciasReciprocasDelMismoArticuloConLotesEnOrdenOpuestoNoDeadlockean`
+  en `TransferenciaLoteTests.cs`.)*
+- [x] 10.5 [P] A→B vs. B→A concurrency test, write-site 3: both transfers
+  complete, no `40P01`. *(Ya estaba correcto en el wip rescatado — mismo
+  test que 10.4, sin cambios en esta continuación.)*
+- [x] 10.6 [P] Per-lot insufficiency with a sufficient aggregate. *(spec
   transferencias-de-stock: "A lot-level underflow is refused even with a
   sufficient aggregate")*
-- [ ] 10.7 [P] Lot-travels test. *(spec: "A lot-effective articulo transfer
+- [x] 10.7 [P] Lot-travels test. *(spec: "A lot-effective articulo transfer
   moves the same lot at both ends")*
-- [ ] 10.8 [P] Omitted-`idLote`-resolves-via-FEFO test. *(spec: "An omitted
+- [x] 10.8 [P] Omitted-`idLote`-resolves-via-FEFO test. *(spec: "An omitted
   idLote resolves via FEFO at transfer time")*
-- [ ] 10.9 [P] `transferencia_lote_vencido` tests. *(spec: "Transferring an
+- [x] 10.9 [P] `transferencia_lote_vencido` tests. *(spec: "Transferring an
   explicitly expired lot is refused", "A non-expired lot transfers
   normally")*
-- [ ] 10.10 [P] Duplicate-line detection ×3. *(spec: "Two lines of the same
+- [x] 10.10 [P] Duplicate-line detection ×3. *(spec: "Two lines of the same
   articulo with different explicit lots are accepted", "Two lines
   resolving to the same explicit lot are rejected", "Two lines both
   omitting idLote that resolve to the same FEFO lot are rejected")*
-- [ ] 10.11 [P] Single-ascending-order test over both origin and
+- [x] 10.11 [P] Single-ascending-order test over both origin and
   destination lot rows. *(spec: "A single ascending order covers both
   origin and destination lot rows")*
-- [ ] 10.12 [P] **Joint deadlock proof** (completes the pairing opened at
+- [x] 10.12 [P] **Joint deadlock proof** (completes the pairing opened at
   slice 8.7): a checkout selling lot 7 of articulo 40 at PV 1, concurrent
   with a transferencia moving the same lot 7 of articulo 40 from PV 1 to
   PV 2 — both complete, no deadlock. *(spec stock: "A concurrent checkout
   and reverse transfer of the same articulo and lots do not deadlock")*
-- [ ] 10.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
+  Cierra la nota cross-slice de la task 8.7. *(APPLY-RUN NOTE: verificado
+  ×1 GREEN con el código correcto; verificado empíricamente que este test
+  TAMPOCO discrimina la mutación del 10.4 por el mismo mecanismo de
+  convoy sobre la fila agregada compartida — ver la nota de 10.4. El
+  proof queda como cobertura funcional real (checkout y transferencia
+  concurrentes del mismo artículo/lote no deadlockean), no como prueba de
+  mutación del `ThenBy` de `id_lote`.)*
+- [x] 10.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(Ejecutado con `--project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` — Ways.Api no referencia
+  `Microsoft.EntityFrameworkCore.Design`, mismo criterio que slices previos.
+  Output: "No changes have been made to the model since the last
+  migration.")*
 - [ ] 10.14 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 10.15 Branch `feat/stage12-slice10-transferencias` off `main`
   (parent: slice 3); PR; merge stacked-to-main.

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -29,7 +29,14 @@ public sealed record SolicitudDeTransferencia(
     int IdPuntoVentaOrigen, int IdPuntoVentaDestino, string Observaciones,
     IReadOnlyList<LineaDeTransferencia> Lineas);
 
-public sealed record LineaDeTransferencia(int IdArticulo, decimal Cantidad);
+/// <summary>
+/// Etapa 12, slice 10 (design: Write site 3 — "the lot travels"): <see cref="IdLote"/> es
+/// opcional para un artículo lote-efectivo — omitido, el servidor lo resuelve vía FEFO en la
+/// misma fase de decisión que el checkout (<c>ServicioDeStock.ResolverLineasDeTransferenciaAsync</c>).
+/// Para un artículo SIN control de lote efectivo, un <c>idLote</c> no tiene destino y se rechaza
+/// (<c>400 lote_invalido</c>) en vez de ignorarse en silencio.
+/// </summary>
+public sealed record LineaDeTransferencia(int IdArticulo, decimal Cantidad, int? IdLote = null);
 
 /// <summary>Resultado de una transferencia: el stock resultante de cada artículo en AMBOS puntos
 /// de venta tras la transacción (design: Transactions — TRANSFERENCIA).</summary>

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -43,7 +43,12 @@ public sealed record LineaDeTransferencia(int IdArticulo, decimal Cantidad, int?
 public sealed record ResultadoTransferencia(
     int IdPuntoVentaOrigen, int IdPuntoVentaDestino, IReadOnlyList<LineaTransferida> Lineas);
 
-public sealed record LineaTransferida(int IdArticulo, decimal CantidadOrigen, decimal CantidadDestino);
+/// <summary>Etapa 12, slice 10 (design: dto-contract-honesty — "every field named below has a
+/// destination"): <see cref="IdLote"/> viaja igual que <c>ItemEmitido.IdLote</c> — el caller
+/// necesita saber qué lote se movió, sea explícito o resuelto por FEFO. La clave de agregación de
+/// <c>ServicioDeStock.EjecutarTransferenciaAsync</c> es <c>(IdArticulo, IdLote)</c>, no solo
+/// <c>IdArticulo</c>: dos líneas del mismo artículo con lotes distintos son filas separadas.</summary>
+public sealed record LineaTransferida(int IdArticulo, int? IdLote, decimal CantidadOrigen, decimal CantidadDestino);
 
 /// <summary>
 /// Cuerpo de <c>POST /api/stock/conteos</c> (stage-8-compras-transferencias-inventario, Slice 3;

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -1,9 +1,11 @@
 using System.Data;
 using System.Data.Common;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -17,8 +19,13 @@ namespace Ways.Application.Stock;
 /// (<c>Politicas.GestionDeCatalogo</c>) es quien bloquea al Vendedor — este servicio no repite
 /// ese chequeo, mismo criterio que el resto de los ABM del proyecto (autorización vive en la capa
 /// de API, nunca duplicada en Application).
+///
+/// Etapa 12, slice 10 (design: Write site 3): <see cref="ServicioDeLotes"/> se inyecta para el
+/// mismo trío de primitivas que <c>ServicioDeVentas</c> ya consume — <c>LeerSaldosAsync</c> (fase
+/// de resolución de la transferencia) y <c>ResolverSinIdentificarAsync</c> (get-or-create
+/// perezoso, statement crudo, cuando ningún lote del artículo tiene saldo positivo en el origen).
 /// </summary>
-public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeLotes servicioDeLotes)
 {
     public async Task<decimal> ObtenerCantidadAsync(int idPuntoVenta, int idArticulo, CancellationToken ct = default) =>
         await db.Stock
@@ -61,7 +68,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, cantidad, MotivoStock.Ajuste, idEmpleado,
-            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, ct);
+            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote: null, ct);
 
         var nuevaCantidad = await UpsertStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, cantidad, ct);
 
@@ -72,12 +79,16 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
     // ---- transferencia entre puntos de venta (design: Transactions — TRANSFERENCIA; decisión 9) ----
 
-    /// <summary>Design decisión 9: rechaza un artículo repetido en un mismo request, arma UN
-    /// único orden ascendente sobre las <c>2N</c> claves <c>(id_articulo, id_punto_venta)</c> —
-    /// nunca "todo el origen, después todo el destino" — y aplica cada una en ese orden. Ese
-    /// orden total es lo que evita el deadlock contra una transferencia inversa simultánea
-    /// (B→A) y contra un checkout en cualquiera de los dos puntos de venta (que ya ordena sus
-    /// upserts de stock asc <c>id_articulo</c>).</summary>
+    /// <summary>Design decisión 9: rechaza líneas vacías/inválidas en memoria, antes de cualquier
+    /// consulta. Etapa 12, slice 10 (design: Write site 3): el lote viaja — cada línea
+    /// lote-efectiva resuelve su <c>idLote</c> (explícito o FEFO-defaulted) en la fase de
+    /// resolución, ANTES de que la transacción abra, y esa fase es también donde corren el
+    /// rechazo de duplicados <c>(IdArticulo, IdLote)</c> post-defaulting (decisión 11) y el
+    /// chequeo de <c>transferencia_lote_vencido</c>. Dentro de la transacción, un único orden
+    /// ascendente sobre las <c>≥2N</c> claves <c>(id_articulo, id_punto_venta, id_lote NULLS
+    /// FIRST)</c> — nunca "todo el origen, después todo el destino" — es lo que evita el deadlock
+    /// contra una transferencia inversa simultánea (B→A) y contra un checkout concurrente del
+    /// mismo artículo/lote en cualquiera de los dos puntos de venta.</summary>
     public async Task<ResultadoTransferencia> TransferirAsync(SolicitudDeTransferencia solicitud, CancellationToken ct = default)
     {
         var idTenant = ExigirTenantDeLaSesion();
@@ -100,24 +111,31 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         // Pre-checks de existencia/tenant ANTES de la transacción (mismo criterio que
         // AjustarAsync): ResolverPuntoVentaAsync da el mismo 404 para "no existe" y "es de otro
         // tenant" (ADR-8), tanto para origen como para destino.
-        await ResolverPuntoVentaAsync(solicitud.IdPuntoVentaOrigen, ct);
+        var puntoVentaOrigen = await ResolverPuntoVentaAsync(solicitud.IdPuntoVentaOrigen, ct);
         await ResolverPuntoVentaAsync(solicitud.IdPuntoVentaDestino, ct);
 
+        var articuloPorId = new Dictionary<int, Articulo>();
         foreach (var idArticulo in lineas.Select(l => l.IdArticulo).Distinct())
         {
-            await ResolverArticuloAsync(idArticulo, ct);
+            articuloPorId[idArticulo] = await ResolverArticuloAsync(idArticulo, ct);
         }
+
+        // Etapa 12, slice 10 (design: Write site 3 — "lot resolution happens before the
+        // transaction opens, same phase as the existing pre-checks"): FEFO-default de lotes
+        // omitidos, chequeo de vencido y rechazo de duplicados post-defaulting.
+        var lineasResueltas = await ResolverLineasDeTransferenciaAsync(
+            idTenant, puntoVentaOrigen, articuloPorId, lineas, momento, ct);
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
         return await estrategia.ExecuteAsync(async () =>
             await EjecutarTransferenciaAsync(
-                idTenant, idEmpleado, solicitud.IdPuntoVentaOrigen, solicitud.IdPuntoVentaDestino, lineas, observaciones,
-                momento, ct));
+                idTenant, idEmpleado, solicitud.IdPuntoVentaOrigen, solicitud.IdPuntoVentaDestino, lineasResueltas,
+                observaciones, momento, ct));
     }
 
     private async Task<ResultadoTransferencia> EjecutarTransferenciaAsync(
         int idTenant, int idEmpleado, int idPuntoVentaOrigen, int idPuntoVentaDestino,
-        IReadOnlyList<LineaDeTransferencia> lineas, string observaciones, DateTimeOffset momento, CancellationToken ct)
+        IReadOnlyList<LineaDeTransferenciaResuelta> lineas, string observaciones, DateTimeOffset momento, CancellationToken ct)
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
@@ -129,28 +147,51 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         foreach (var clave in claves)
         {
-            await InsertarMovimientoStockAsync(
-                conexion, transaccionCruda, idTenant, clave.IdArticulo, clave.IdPuntoVenta, clave.Delta,
-                MotivoStock.Transferencia, idEmpleado, observaciones, momento,
-                idComprobanteCompra: null, idPuntoVentaDestino: idPuntoVentaDestino, ct);
-
-            var nueva = await UpsertStockAsync(conexion, transaccionCruda, idTenant, clave.IdArticulo, clave.IdPuntoVenta, clave.Delta, ct);
-
-            // La RETURNING del upsert ES el chequeo de suficiencia (design decisión 5): sin
-            // segunda consulta, sin TOCTOU. Back-office tightening (spec: Insufficient Origin
-            // Stock Is Refused) — asimétrico a propósito respecto de una venta, que nunca bloquea.
-            if (clave.Delta < 0m && nueva < 0m)
+            if (clave.IdLote is null)
             {
-                throw new ErrorDominio(
-                    "stock_insuficiente_para_transferencia",
-                    $"No hay stock suficiente del artículo {clave.IdArticulo} en el punto de venta de origen para transferir.",
-                    409);
-            }
+                // Elemento AGREGADO (design decisión 10): el ledger se escribe ACÁ, cargando
+                // IdLoteDelMovimiento cuando la línea era lote-efectiva — el elemento LOTE (más
+                // abajo) nunca escribe una segunda fila de movimientos_stock para el mismo par.
+                await InsertarMovimientoStockAsync(
+                    conexion, transaccionCruda, idTenant, clave.IdArticulo, clave.IdPuntoVenta, clave.Delta,
+                    MotivoStock.Transferencia, idEmpleado, observaciones, momento,
+                    idComprobanteCompra: null, idPuntoVentaDestino, clave.IdLoteDelMovimiento, ct);
 
-            var previo = resultadosPorArticulo.TryGetValue(clave.IdArticulo, out var existente) ? existente : (Origen: 0m, Destino: 0m);
-            resultadosPorArticulo[clave.IdArticulo] = clave.IdPuntoVenta == idPuntoVentaOrigen
-                ? (nueva, previo.Destino)
-                : (previo.Origen, nueva);
+                var nueva = await UpsertStockAsync(conexion, transaccionCruda, idTenant, clave.IdArticulo, clave.IdPuntoVenta, clave.Delta, ct);
+
+                // La RETURNING del upsert ES el chequeo de suficiencia (design decisión 5): sin
+                // segunda consulta, sin TOCTOU. Back-office tightening (spec: Insufficient Origin
+                // Stock Is Refused) — asimétrico a propósito respecto de una venta, que nunca bloquea.
+                if (clave.Delta < 0m && nueva < 0m)
+                {
+                    throw new ErrorDominio(
+                        "stock_insuficiente_para_transferencia",
+                        $"No hay stock suficiente del artículo {clave.IdArticulo} en el punto de venta de origen para transferir.",
+                        409);
+                }
+
+                var previo = resultadosPorArticulo.TryGetValue(clave.IdArticulo, out var existente) ? existente : (Origen: 0m, Destino: 0m);
+                resultadosPorArticulo[clave.IdArticulo] = clave.IdPuntoVenta == idPuntoVentaOrigen
+                    ? (nueva, previo.Destino)
+                    : (previo.Origen, nueva);
+            }
+            else
+            {
+                // Elemento LOTE: upsert de stock_lotes SOLO, sin fila de ledger propia (el
+                // movimiento ya se escribió en el elemento agregado del mismo par). La RETURNING
+                // es la suficiencia POR LOTE (spec: "even when the origin's aggregate
+                // stock.cantidad is sufficient" — decisión 7 de la propuesta).
+                var nuevaDelLote = await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, clave.IdArticulo, clave.IdPuntoVenta, clave.IdLote.Value, clave.Delta, ct);
+
+                if (clave.Delta < 0m && nuevaDelLote < 0m)
+                {
+                    throw new ErrorDominio(
+                        "stock_insuficiente_para_transferencia",
+                        $"No hay stock suficiente del lote {clave.IdLote} del artículo {clave.IdArticulo} en el punto de venta de origen para transferir.",
+                        409);
+                }
+            }
         }
 
         await transaccion.CommitAsync(ct);
@@ -163,19 +204,186 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         return new ResultadoTransferencia(idPuntoVentaOrigen, idPuntoVentaDestino, lineasResultado);
     }
 
-    private readonly record struct ClaveDeTransferencia(int IdArticulo, int IdPuntoVenta, decimal Delta);
+    /// <summary>Línea de transferencia YA resuelta (design: "LineaResuelta") — <see cref="IdLote"/>
+    /// es <c>null</c> para un artículo sin control de lote efectivo, o el lote explícito/FEFO-defaulted
+    /// para uno lote-efectivo. Producida por <see cref="ResolverLineasDeTransferenciaAsync"/>, fuera
+    /// de la transacción — <see cref="ConstruirClavesOrdenadas"/> nunca vuelve a tocar <c>lotes</c>.</summary>
+    private readonly record struct LineaDeTransferenciaResuelta(int IdArticulo, decimal Cantidad, int? IdLote);
 
-    private static List<ClaveDeTransferencia> ConstruirClavesOrdenadas(
-        int idPuntoVentaOrigen, int idPuntoVentaDestino, IReadOnlyList<LineaDeTransferencia> lineas) =>
+    /// <summary>Etapa 12, slice 10 (design: Write site 3 — "the lot travels"): claves ensanchadas a
+    /// <c>(IdArticulo, IdPuntoVenta, IdLote, Delta, IdLoteDelMovimiento)</c>. Por línea
+    /// lote-efectiva, 4 claves — agregado + su movimiento y saldo del lote, en origen y en
+    /// destino; por línea sin lote, las 2 de siempre. El orden asc
+    /// <c>(id_articulo, id_punto_venta, id_lote NULLS FIRST)</c> es el mismo orden total que los
+    /// otros dos sitios de escritura (decisión 6, spec stock), lo que hace posible el joint proof
+    /// checkout-vs-transferencia (task 10.12).</summary>
+    private readonly record struct ClaveDeStock(int IdArticulo, int IdPuntoVenta, int? IdLote, decimal Delta, int? IdLoteDelMovimiento);
+
+    private static List<ClaveDeStock> ConstruirClavesOrdenadas(
+        int idPuntoVentaOrigen, int idPuntoVentaDestino, IReadOnlyList<LineaDeTransferenciaResuelta> lineas) =>
         lineas
-            .SelectMany(l => new[]
-            {
-                new ClaveDeTransferencia(l.IdArticulo, idPuntoVentaOrigen, -l.Cantidad),
-                new ClaveDeTransferencia(l.IdArticulo, idPuntoVentaDestino, l.Cantidad)
-            })
+            .SelectMany(l => l.IdLote is { } lote
+                ? new[]
+                  {
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaOrigen, null, -l.Cantidad, lote),   // agregada + su movimiento
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaOrigen, lote, -l.Cantidad, null),    // saldo del lote
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaDestino, null, l.Cantidad, lote),
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaDestino, lote, l.Cantidad, null)
+                  }
+                : new[]
+                  {
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaOrigen, null, -l.Cantidad, null),
+                      new ClaveDeStock(l.IdArticulo, idPuntoVentaDestino, null, l.Cantidad, null)
+                  })
             .OrderBy(c => c.IdArticulo)
             .ThenBy(c => c.IdPuntoVenta)
+            .ThenBy(c => c.IdLote.HasValue)          // NULLS FIRST — decisión 9
+            .ThenBy(c => c.IdLote ?? 0)
             .ToList();
+
+    /// <summary>Etapa 12, slice 10 (design: Write site 3, fase de resolución — "keeps lotes and
+    /// reads out of the transaction entirely"): para cada línea lote-efectiva, resuelve su lote
+    /// (explícito validado contra <see cref="ServicioDeLotes.LeerSaldosAsync"/>, o FEFO-defaulted,
+    /// o el sin-identificar perezoso cuando ningún lote tiene saldo positivo — mismo camino que
+    /// <c>ServicioDeVentas</c>), rechaza un vencido (<c>transferencia_lote_vencido</c> — a
+    /// diferencia del checkout, acá SIEMPRE bloquea, sea el lote explícito o resuelto por FEFO) y,
+    /// al final, rechaza duplicados <c>(IdArticulo, IdLote)</c> evaluados DESPUÉS del defaulting
+    /// (decisión 11 — reusa el código <c>articulo_repetido</c>).</summary>
+    private async Task<IReadOnlyList<LineaDeTransferenciaResuelta>> ResolverLineasDeTransferenciaAsync(
+        int idTenant, PuntoVenta puntoVentaOrigen, IReadOnlyDictionary<int, Articulo> articuloPorId,
+        IReadOnlyList<LineaDeTransferencia> lineas, DateTimeOffset momento, CancellationToken ct)
+    {
+        var lineasResueltas = lineas.Select(l => new LineaDeTransferenciaResuelta(l.IdArticulo, l.Cantidad, IdLote: null)).ToList();
+
+        var indicesConArticuloControlaLote = lineas
+            .Select((l, indice) => (Linea: l, Indice: indice))
+            .Where(x => articuloPorId[x.Linea.IdArticulo].ControlaLote)
+            .Select(x => x.Indice)
+            .ToList();
+
+        var lotesHabilitado = indicesConArticuloControlaLote.Count > 0
+            && await ResolverLotesHabilitadoAsync(puntoVentaOrigen.IdEmpresa, puntoVentaOrigen.Id, ct);
+
+        var indicesConLoteEfectivo = lotesHabilitado ? indicesConArticuloControlaLote : [];
+
+        // dto-contract-honesty / mismo criterio que ServicioDeVentas: un idLote en una línea SIN
+        // lote efectivo no tiene destino — se rechaza en vez de tragárselo en silencio.
+        var indicesConLoteEfectivoSet = indicesConLoteEfectivo.ToHashSet();
+        for (var indice = 0; indice < lineas.Count; indice++)
+        {
+            if (!indicesConLoteEfectivoSet.Contains(indice) && lineas[indice].IdLote is not null)
+            {
+                throw new ErrorDominio(
+                    "lote_invalido",
+                    $"El artículo {lineas[indice].IdArticulo} no tiene lote efectivo; no admite idLote.",
+                    400);
+            }
+        }
+
+        if (indicesConLoteEfectivo.Count > 0)
+        {
+            var idsArticuloConLote = indicesConLoteEfectivo.Select(i => lineas[i].IdArticulo).Distinct().ToList();
+            var idsLotePedidos = indicesConLoteEfectivo
+                .Select(i => lineas[i].IdLote)
+                .Where(idLote => idLote is not null)
+                .Select(idLote => idLote!.Value)
+                .Distinct()
+                .ToList();
+
+            var saldos = await servicioDeLotes.LeerSaldosAsync(puntoVentaOrigen.Id, idsArticuloConLote, idsLotePedidos, ct);
+            var saldosPorArticulo = saldos.ToLookup(s => s.IdArticulo);
+
+            // Honestidad documental: "hoy" acá es UTC naive, mismo criterio interino que
+            // ServicioDeVentas/ServicioDeCompras/ServicioDeLotes en esta etapa.
+            var hoy = DateOnly.FromDateTime(momento.UtcDateTime);
+
+            foreach (var indice in indicesConLoteEfectivo)
+            {
+                var linea = lineas[indice];
+                var saldosDelArticulo = saldosPorArticulo[linea.IdArticulo].ToList();
+
+                SaldoDeLote loteResuelto;
+                if (linea.IdLote is { } idLote)
+                {
+                    var posicion = saldosDelArticulo.FindIndex(s => s.IdLote == idLote);
+                    if (posicion < 0)
+                    {
+                        throw new ErrorDominio(
+                            "lote_invalido",
+                            $"El lote {idLote} no existe, no pertenece al artículo {linea.IdArticulo} o fue eliminado.",
+                            400);
+                    }
+
+                    loteResuelto = saldosDelArticulo[posicion];
+                }
+                else if (ReglaDeLotes.ElegirFefo(saldosDelArticulo, hoy) is { } elegido)
+                {
+                    loteResuelto = elegido;
+                }
+                else
+                {
+                    // Ningún lote con saldo positivo (design decisión 7) — get-or-create perezoso
+                    // del sin-identificar, statement crudo fuera de la transacción. En una
+                    // transferencia (a diferencia del checkout) esto típicamente desemboca en
+                    // stock_insuficiente_para_transferencia dentro de la transacción — el sin
+                    // identificar arranca en 0, y transferir cualquier cantidad positiva lo deja
+                    // negativo, exactamente el mismo camino de rechazo que un lote explícito
+                    // insuficiente.
+                    var conexionParaLotes = await ObtenerConexionAbiertaAsync(ct);
+                    var idSinIdentificar = await ServicioDeLotes.ResolverSinIdentificarAsync(
+                        conexionParaLotes, transaccion: null, idTenant, linea.IdArticulo, momento, ct);
+
+                    loteResuelto = new SaldoDeLote(
+                        linea.IdArticulo, idSinIdentificar, ReglaDeLotes.CodigoSinIdentificar,
+                        EsSinIdentificar: true, FechaVencimiento: null, Cantidad: 0m);
+                }
+
+                // spec transferencias-de-stock: "Expired Lot Transfer Is Refused" — a diferencia
+                // del checkout (decisión 12: solo un warning), una transferencia SIEMPRE bloquea
+                // sobre un lote vencido, sea explícito o resuelto por FEFO.
+                if (ReglaDeLotes.EstaVencido(loteResuelto.FechaVencimiento, hoy))
+                {
+                    throw new ErrorDominio(
+                        "transferencia_lote_vencido",
+                        $"El lote {loteResuelto.Codigo} del artículo {linea.IdArticulo} está vencido; no se puede transferir.",
+                        409);
+                }
+
+                lineasResueltas[indice] = lineasResueltas[indice] with { IdLote = loteResuelto.IdLote };
+            }
+        }
+
+        // spec transferencias-de-stock: "Duplicate-Line Detection Widens To (IdArticulo, IdLote),
+        // Evaluated After FEFO Defaulting" (decisión 11) — reusa el código articulo_repetido,
+        // evaluado sobre el resultado YA resuelto, nunca contra el input crudo del cliente.
+        var repetida = lineasResueltas
+            .GroupBy(l => (l.IdArticulo, l.IdLote))
+            .FirstOrDefault(g => g.Count() > 1);
+        if (repetida is not null)
+        {
+            throw new ErrorDominio(
+                "articulo_repetido",
+                $"El artículo {repetida.Key.IdArticulo} aparece más de una vez en la transferencia para el mismo lote.",
+                400);
+        }
+
+        return lineasResueltas;
+    }
+
+    /// <summary>Mismo patrón que <see cref="ServicioDeLotes"/>'s resolución de un único parámetro
+    /// de clave (<c>ResolverDiasAlertaAsync</c>): candidatos filtrados por <c>Clave</c> ANTES de
+    /// <c>ResolucionDeParametros.Resolver</c> (design decisión 2 — nunca un candidato multi-clave
+    /// sin filtrar).</summary>
+    private async Task<bool> ResolverLotesHabilitadoAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == ParametroConocido.LotesHabilitado.Clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var valorJson = ResolucionDeParametros.Resolver(ParametroConocido.LotesHabilitado.Clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<bool>(valorJson);
+    }
 
     // ---- conteo de inventario (design: Transactions — CONTEO DE INVENTARIO; decisión 10) ----------
 
@@ -222,7 +430,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, MotivoStock.Inventario, idEmpleado,
-            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, ct);
+            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote: null, ct);
 
         var final = await UpsertStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, ct);
 
@@ -281,18 +489,22 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
     /// acá solo por simetría de firma con el statement gemelo de <c>ServicioDeCompras</c> (design:
     /// File Changes — "the two raw statements gain motivo/idComprobanteCompra/idPuntoVentaDestino
     /// parameters").</summary>
+    /// <summary>Etapa 12, slice 10: gana <paramref name="idLote"/> (design decisión 10 — en una
+    /// transferencia, el ledger se escribe en el elemento AGREGADO de <c>ConstruirClavesOrdenadas</c>
+    /// y lleva el <c>IdLoteDelMovimiento</c> de esa clave; <c>Ajustar</c>/<c>Contar</c> siguen
+    /// pasando <c>null</c>, sin cambio de comportamiento).</summary>
     private static async Task InsertarMovimientoStockAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
         decimal cantidad, MotivoStock motivo, int idEmpleado, string? observaciones, DateTimeOffset creadoEl,
-        int? idComprobanteCompra, int? idPuntoVentaDestino, CancellationToken ct)
+        int? idComprobanteCompra, int? idPuntoVentaDestino, int? idLote, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccion;
         comando.CommandText =
             "INSERT INTO movimientos_stock " +
             "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_empleado, observaciones, " +
-            "id_comprobante_compra, id_punto_venta_destino, creado_el) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+            "id_comprobante_compra, id_punto_venta_destino, creado_el, id_lote) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
 
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, idArticulo);
@@ -304,6 +516,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         AgregarParametroNulo(comando, idComprobanteCompra);
         AgregarParametroNulo(comando, idPuntoVentaDestino);
         AgregarParametro(comando, creadoEl);
+        AgregarParametroNulo(comando, idLote);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -328,6 +541,37 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock no devolvió ninguna fila.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    /// <summary>Etapa 12, slice 10 (design: Write site 3 — "UpsertStockLoteAsync: la MISMA forma
+    /// que UpsertStockAsync, una clave más"): mismo shape que
+    /// <c>Ways.Application.Ventas.ServicioDeVentas</c>/<c>Ways.Application.Compras.ServicioDeCompras</c>
+    /// (copia deliberada, no compartida — mismo criterio de "frentes en paralelo" que el resto de
+    /// la etapa). La <c>RETURNING</c> es el chequeo de suficiencia POR LOTE (spec transferencias-de-stock:
+    /// "Insufficient Origin Stock Is Refused" extendido al lote) — sin segunda consulta, sin TOCTOU.</summary>
+    private static async Task<decimal> UpsertStockLoteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        int idLote, decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta, id_lote) DO UPDATE " +
+            "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idLote);
+        AgregarParametro(comando, idTenant);
+        AgregarParametro(comando, delta);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El upsert de stock_lotes no devolvió ninguna fila.");
 
         return Convert.ToDecimal(resultado);
     }
@@ -403,9 +647,11 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         return limpio;
     }
 
-    /// <summary>Design decisión 9: un artículo repetido en un mismo request se rechaza entero
-    /// (spec: transferencias-de-stock — "articulo_repetido"), antes de resolver referencias o
-    /// tocar la base.</summary>
+    /// <summary>Validación puramente en memoria, antes de resolver referencias o tocar la base.
+    /// Etapa 12, slice 10: el rechazo de artículo repetido (<c>articulo_repetido</c>) se MUDÓ
+    /// de acá a <see cref="ResolverLineasDeTransferenciaAsync"/> — la clave se ensanchó a
+    /// <c>(IdArticulo, IdLote)</c> y decisión 11 exige evaluarla DESPUÉS del defaulting de FEFO,
+    /// que solo corre una vez resueltos el punto de venta y los artículos.</summary>
     private static IReadOnlyList<LineaDeTransferencia> ExigirLineasDeTransferenciaValidas(
         IReadOnlyList<LineaDeTransferencia> lineas)
     {
@@ -413,13 +659,6 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         {
             throw new ErrorDominio(
                 "transferencia_sin_lineas", "La transferencia no tiene líneas para procesar.", 400);
-        }
-
-        var repetida = lineas.GroupBy(l => l.IdArticulo).FirstOrDefault(g => g.Count() > 1);
-        if (repetida is not null)
-        {
-            throw new ErrorDominio(
-                "articulo_repetido", $"El artículo {repetida.Key} aparece más de una vez en la transferencia.", 400);
         }
 
         foreach (var linea in lineas)

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -143,7 +143,10 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
         var claves = ConstruirClavesOrdenadas(idPuntoVentaOrigen, idPuntoVentaDestino, lineas);
-        var resultadosPorArticulo = new Dictionary<int, (decimal Origen, decimal Destino)>();
+        // Etapa 12, slice 10, judgment-day fix (juez A, FIX 1): clave ensanchada a
+        // (IdArticulo, IdLote) — dos líneas del mismo artículo con lotes distintos son ACEPTADAS
+        // por spec y no pueden colapsar en una sola fila del response (dto-contract-honesty).
+        var resultadosPorArticuloYLote = new Dictionary<(int IdArticulo, int? IdLote), (decimal Origen, decimal Destino)>();
 
         foreach (var clave in claves)
         {
@@ -170,8 +173,9 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
                         409);
                 }
 
-                var previo = resultadosPorArticulo.TryGetValue(clave.IdArticulo, out var existente) ? existente : (Origen: 0m, Destino: 0m);
-                resultadosPorArticulo[clave.IdArticulo] = clave.IdPuntoVenta == idPuntoVentaOrigen
+                var claveResultado = (clave.IdArticulo, clave.IdLoteDelMovimiento);
+                var previo = resultadosPorArticuloYLote.TryGetValue(claveResultado, out var existente) ? existente : (Origen: 0m, Destino: 0m);
+                resultadosPorArticuloYLote[claveResultado] = clave.IdPuntoVenta == idPuntoVentaOrigen
                     ? (nueva, previo.Destino)
                     : (previo.Origen, nueva);
             }
@@ -196,9 +200,11 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         await transaccion.CommitAsync(ct);
 
-        var lineasResultado = resultadosPorArticulo
-            .OrderBy(kv => kv.Key)
-            .Select(kv => new LineaTransferida(kv.Key, kv.Value.Origen, kv.Value.Destino))
+        var lineasResultado = resultadosPorArticuloYLote
+            .OrderBy(kv => kv.Key.IdArticulo)
+            .ThenBy(kv => kv.Key.IdLote.HasValue)   // NULLS FIRST, mismo criterio que ConstruirClavesOrdenadas
+            .ThenBy(kv => kv.Key.IdLote ?? 0)
+            .Select(kv => new LineaTransferida(kv.Key.IdArticulo, kv.Key.IdLote, kv.Value.Origen, kv.Value.Destino))
             .ToList();
 
         return new ResultadoTransferencia(idPuntoVentaOrigen, idPuntoVentaDestino, lineasResultado);

--- a/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
@@ -161,6 +161,34 @@ public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<Ways
         return articulo.Id;
     }
 
+    /// <summary>Artículo SIN control de lote — <c>ControlaLote = false</c>, contraparte del
+    /// lote-efectivo de arriba, usado por el caso mixto y por el rechazo de <c>lote_invalido</c>
+    /// (mismo criterio que <c>TransferenciasYConteoDeInventarioTests.SembrarArticuloConPrecioAsync</c>,
+    /// copiado acá a propósito — frentes en paralelo, sin infra de test compartida entre archivos).</summary>
+    private async Task<int> SembrarArticuloSinLoteAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
     private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
@@ -445,6 +473,97 @@ public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<Ways
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+    }
+
+    // ---- gaps de cobertura (judgment-day, ronda de fix): mixta + lote_invalido sobre línea sin lote --
+
+    /// <summary>spec transferencias-de-stock: una transferencia con una línea de artículo
+    /// lote-efectivo y una línea de artículo SIN control de lote completa AMBAS en la misma
+    /// transacción — el filtro <c>indicesConLoteEfectivo</c> de <see cref="ServicioDeStock"/>
+    /// separa las líneas correctamente en <c>ConstruirClavesOrdenadas</c> (2 claves para la línea
+    /// sin lote, 4 para la línea con lote), sin que una contamine el tratamiento de la otra.
+    ///
+    /// EVIDENCIA DE MUTACIÓN: mutado el ternario de <c>ConstruirClavesOrdenadas</c> para emitir
+    /// también una clave de lote (<c>IdLote = 0</c>) en la rama sin-lote — build, filtro
+    /// <c>FullyQualifiedName~TransferenciaLote</c>: este test <b>FALLA</b> (el movimiento sin lote
+    /// deja de tener <c>id_lote == null</c> / aparece una fila de <c>stock_lotes</c> inesperada).
+    /// Revertido el mutante, corrida de nuevo: GREEN.</summary>
+    [Fact]
+    public async Task UnaTransferenciaMixtaConLineaLoteEfectivaYLineaSinLoteCompletaAmbas()
+    {
+        var ctx = await PrepararAsync(nameof(UnaTransferenciaMixtaConLineaLoteEfectivaYLineaSinLoteCompletaAmbas));
+
+        var idArticuloConLote = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-mixta-con-lote", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticuloConLote, "L-MIXTA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloConLote, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloConLote, 20m);
+
+        var idArticuloSinLote = await SembrarArticuloSinLoteAsync(ctx, "articulo-mixta-sin-lote", 15m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloSinLote, 30m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Transferencia mixta",
+            [new LineaDeTransferencia(idArticuloSinLote, 6m, null), new LineaDeTransferencia(idArticuloConLote, 8m, idLote)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var movimientosSinLote = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticuloSinLote && m.Motivo == MotivoStock.Transferencia)
+            .ToListAsync();
+        Assert.Equal(2, movimientosSinLote.Count);
+        Assert.All(movimientosSinLote, m => Assert.Null(m.IdLote));
+        Assert.Contains(movimientosSinLote, m => m.IdPuntoVenta == ctx.IdPuntoVentaOrigen && m.Cantidad == -6m);
+        Assert.Contains(movimientosSinLote, m => m.IdPuntoVenta == ctx.IdPuntoVentaDestino && m.Cantidad == 6m);
+
+        var movimientosConLote = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticuloConLote && m.Motivo == MotivoStock.Transferencia)
+            .ToListAsync();
+        Assert.Equal(2, movimientosConLote.Count);
+        Assert.All(movimientosConLote, m => Assert.Equal(idLote, m.IdLote));
+        Assert.Contains(movimientosConLote, m => m.IdPuntoVenta == ctx.IdPuntoVentaOrigen && m.Cantidad == -8m);
+        Assert.Contains(movimientosConLote, m => m.IdPuntoVenta == ctx.IdPuntoVentaDestino && m.Cantidad == 8m);
+
+        Assert.Equal(24m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloSinLote));
+        Assert.Equal(6m, await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticuloSinLote));
+        Assert.Equal(12m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloConLote));
+        Assert.Equal(8m, await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticuloConLote));
+        Assert.Equal(12m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloConLote, idLote));
+        Assert.Equal(8m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticuloConLote, idLote));
+    }
+
+    /// <summary>dto-contract-honesty (mismo criterio que <c>ServicioDeVentas</c>): un <c>idLote</c>
+    /// provisto en una línea de artículo SIN lote efectivo (<c>ControlaLote = false</c>) se
+    /// rechaza explícitamente en vez de ignorarse en silencio — <c>ServicioDeStock.cs</c>,
+    /// guard ~269-281.
+    ///
+    /// EVIDENCIA DE MUTACIÓN: anulado el guard (comentado el <c>if</c> que lanza
+    /// <c>lote_invalido</c>) — build, filtro <c>FullyQualifiedName~TransferenciaLote</c>: este
+    /// test <b>FALLA</b> (200 en vez de 400 — el idLote ajeno se ignora en silencio). Revertido
+    /// el mutante, corrida de nuevo: GREEN.</summary>
+    [Fact]
+    public async Task UnaLineaSinLoteEfectivoConIdLoteProvistoEsRechazadaComoLoteInvalido()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaSinLoteEfectivoConIdLoteProvistoEsRechazadaComoLoteInvalido));
+
+        var idArticuloSinLote = await SembrarArticuloSinLoteAsync(ctx, "articulo-sin-lote-invalido", 12m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloSinLote, 20m);
+
+        var idArticuloConLote = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-lote-ajeno", 10m);
+        var idLoteAjeno = await SembrarLoteAsync(ctx, idArticuloConLote, "L-AJENO", VencimientoLejanoFuturo);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticuloSinLote, 5m, idLoteAjeno));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticuloSinLote && m.Motivo == MotivoStock.Transferencia));
+        Assert.Equal(20m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloSinLote));
     }
 
     // ---- task 10.4 / 10.5: mutation target + A→B vs. B→A, sin 40P01 -------------------------------

--- a/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
@@ -566,6 +566,115 @@ public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(20m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloSinLote));
     }
 
+    // ---- judgment-day (juez A, ronda 1, FIX 1): el response no colapsa multi-lote del mismo artículo --
+
+    /// <summary>dto-contract-honesty (design.md:180 — <c>LineaTransferida(int IdArticulo, int? IdLote,
+    /// decimal CantidadOrigen, decimal CantidadDestino)</c>): dos líneas del MISMO artículo con lotes
+    /// explícitos distintos son un caso ACEPTADO por spec (mismo escenario que
+    /// <see cref="DosLineasDelMismoArticuloConLotesExplicitosDistintosSonAceptadas"/>) — la clave de
+    /// agregación del response ensancha a <c>(IdArticulo, IdLote)</c>, así que esas dos líneas producen
+    /// DOS filas, no una sola que las colapsa. Se suma una tercera línea de un artículo DISTINTO sin
+    /// <c>idLote</c> (FEFO-default) para probar que el lote resuelto por FEFO también viaja en la fila.
+    ///
+    /// <see cref="LineaTransferida.CantidadOrigen"/>/<see cref="LineaTransferida.CantidadDestino"/> son
+    /// el valor de <c>stock.cantidad</c> (la fila AGREGADA, compartida por todos los lotes del mismo
+    /// artículo) tal como lo devolvió el upsert de ESA línea puntual, en el orden en que las líneas
+    /// llegaron en la solicitud — no el saldo final del artículo ni el saldo del lote en particular
+    /// (ese vive en <c>stock_lotes</c>, fuera de este contrato). Para una única línea por artículo
+    /// (todos los tests de arriba) ese checkpoint coincide con el saldo final, que es lo que ya
+    /// probaban; acá, con dos líneas del mismo artículo, se ven los DOS checkpoints intermedios.
+    ///
+    /// EVIDENCIA DE MUTACIÓN: revertida la clave de <c>resultadosPorArticuloYLote</c> a <c>IdArticulo</c>
+    /// solo (<c>ServicioDeStock.EjecutarTransferenciaAsync</c>) — build, filtro
+    /// <c>FullyQualifiedName~TransferenciaLote</c>: este test <b>FALLA</b> (2 filas en <c>Lineas</c> en
+    /// vez de 3, la del artículo A pisada por la segunda línea). Revertido el mutante, corrida de
+    /// nuevo: GREEN.</summary>
+    [Fact]
+    public async Task LaRespuestaDeUnaTransferenciaConDosLotesDelMismoArticuloTraeUnaFilaPorLoteConIdLote()
+    {
+        var ctx = await PrepararAsync(nameof(LaRespuestaDeUnaTransferenciaConDosLotesDelMismoArticuloTraeUnaFilaPorLoteConIdLote));
+
+        var idArticuloA = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-response-dos-lotes", 10m);
+        var idLoteA1 = await SembrarLoteAsync(ctx, idArticuloA, "L-RESP-A1", VencimientoLejanoFuturo);
+        var idLoteA2 = await SembrarLoteAsync(ctx, idArticuloA, "L-RESP-A2", VencimientoLejanoFuturoTemprano);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloA, idLoteA1, 10m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloA, idLoteA2, 10m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloA, 20m);
+
+        var idArticuloB = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-response-fefo", 10m);
+        var idLoteB = await SembrarLoteAsync(ctx, idArticuloB, "L-RESP-B", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloB, idLoteB, 15m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloB, 15m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Response multi-lote del mismo artículo",
+            [
+                new LineaDeTransferencia(idArticuloA, 3m, idLoteA1),
+                new LineaDeTransferencia(idArticuloA, 4m, idLoteA2),
+                new LineaDeTransferencia(idArticuloB, 5m, null)
+            ]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<ResultadoTransferencia>(cuerpo, OpcionesJson)!;
+        Assert.Equal(3, resultado.Lineas.Count);
+
+        var filaA1 = Assert.Single(resultado.Lineas, l => l.IdArticulo == idArticuloA && l.IdLote == idLoteA1);
+        Assert.Equal(17m, filaA1.CantidadOrigen);
+        Assert.Equal(3m, filaA1.CantidadDestino);
+
+        var filaA2 = Assert.Single(resultado.Lineas, l => l.IdArticulo == idArticuloA && l.IdLote == idLoteA2);
+        Assert.Equal(13m, filaA2.CantidadOrigen);
+        Assert.Equal(7m, filaA2.CantidadDestino);
+
+        // FEFO-default: idLoteB es el único lote con saldo del artículo B — el lote resuelto viaja
+        // en IdLote aunque el cliente nunca lo pidió explícito.
+        var filaB = Assert.Single(resultado.Lineas, l => l.IdArticulo == idArticuloB && l.IdLote == idLoteB);
+        Assert.Equal(10m, filaB.CantidadOrigen);
+        Assert.Equal(5m, filaB.CantidadDestino);
+
+        Assert.Equal(7m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloA, idLoteA1));
+        Assert.Equal(6m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloA, idLoteA2));
+        Assert.Equal(10m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticuloB, idLoteB));
+    }
+
+    // ---- judgment-day (juez A, ronda 1, FIX 2): re-check de vencido corre también sobre FEFO --------
+
+    /// <summary>spec transferencias-de-stock: "Transferring an expired lot is refused... always,
+    /// whether the lot is explicit or FEFO-resolved" — contraparte por FEFO de
+    /// <see cref="UnLoteVencidoExplicitoEsRechazadoSinEscribirNingunMovimiento"/>: el ÚNICO lote con
+    /// saldo positivo del artículo está vencido, la línea omite <c>idLote</c>, FEFO lo resuelve de
+    /// todos modos (no filtra por vencido, solo por saldo positivo) y el re-check incondicional de
+    /// <c>ServicioDeStock.ResolverLineasDeTransferenciaAsync</c> lo rechaza igual que si hubiera sido
+    /// explícito.
+    ///
+    /// EVIDENCIA DE MUTACIÓN: comentado el <c>if (ReglaDeLotes.EstaVencido(...))</c> que lanza
+    /// <c>transferencia_lote_vencido</c> — build, filtro <c>FullyQualifiedName~TransferenciaLote</c>:
+    /// este test <b>FALLA</b> (200, transfiere el lote vencido resuelto por FEFO). Revertido el
+    /// mutante, corrida de nuevo: GREEN.</summary>
+    [Fact]
+    public async Task UnaLineaSinIdLoteQueResuelvePorFefoAUnUnicoLoteVencidoEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaSinIdLoteQueResuelvePorFefoAUnUnicoLoteVencidoEsRechazada));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-fefo-unico-vencido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-FEFO-VENCIDO", VencimientoLejanoPasado);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 5m, idLote: null));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("transferencia_lote_vencido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+        Assert.Equal(20m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote));
+        Assert.Equal(20m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+    }
+
     // ---- task 10.4 / 10.5: mutation target + A→B vs. B→A, sin 40P01 -------------------------------
 
     /// <summary>Pausa la transacción manual justo DESPUÉS de <c>BeginTransactionAsync</c> hasta que

--- a/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
@@ -1,0 +1,787 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 10 (tasks 10.4-10.12): la transferencia lote-consciente
+/// punta a punta — el orden ensanchado a <c>≥2N</c> claves <c>(id_articulo, id_punto_venta,
+/// id_lote NULLS FIRST)</c>, el lote que viaja, la suficiencia per-lote, el default FEFO, el
+/// rechazo de vencidos y de duplicados post-defaulting, y el joint deadlock proof que cierra el
+/// pairing dejado abierto en la task 8.7 de <c>VentaEscrituraLoteTests</c> (el checkout ya es
+/// lot-aware desde el slice 8, así que la mitad conjunta del proof es posible acá).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas fijas y lejanas — independientes del reloj de la corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+    private static readonly DateOnly VencimientoLejanoFuturoTemprano = new(2090, 1, 1);
+    private static readonly DateOnly VencimientoLejanoPasado = new(2020, 1, 1);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVentaOrigen, int IdPuntoVentaDestino, HttpClient Admin,
+        int IdArea, int IdAlicuotaIva, int IdListaPrecio, int IdMedioEfectivo, int IdCliente,
+        string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Transferencia-lote-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Transferencia Lote", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        // Segundo punto de venta REAL — nace DESPUÉS del de origen, así que su id SIEMPRE es
+        // mayor (usado por la task 10.11 para forzar el caso discriminante: transferir desde el
+        // PV de id MAYOR hacia el de id MENOR).
+        var puntoVentaDestino = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, Nombre = "Local 2 (lote)",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVentaDestino);
+        await db.SaveChangesAsync();
+
+        // Módulo de lotes ON a nivel empresa — todas las pruebas de este archivo son sobre
+        // artículos lote-efectivos (mismo criterio que VentaEscrituraLoteTests.PrepararAsync).
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        // Turno abierto en el origen — necesario para el checkout del joint proof (task 10.12).
+        db.TurnosCaja.Add(new TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "Cliente Transferencia Lote",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 1_000_000m,
+            CreditoIlimitado = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, puntoVentaDestino.Id, admin, area.Id,
+            idAlicuotaIva, lista.Id, idMedioEfectivo, cliente.Id, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private async Task<int> SembrarArticuloLoteEfectivoAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    /// <summary>Ajuste manual (<c>/api/stock/ajustes</c>) TODAVÍA no es lote-consciente en este
+    /// worktree — esa extensión es slice 11 (Ajuste + Decomiso), fuera del alcance de este slice.
+    /// Sembrar <c>stock</c>/<c>stock_lotes</c> directo por EF es el mismo criterio que
+    /// <c>VentaEscrituraLoteTests</c>.</summary>
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idPuntoVenta, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = idPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idPuntoVenta, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = idPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeTransferencia SolicitudDeUnaLinea(
+        Contexto ctx, int idArticulo, decimal cantidad, int? idLote,
+        int? idPuntoVentaOrigen = null, int? idPuntoVentaDestino = null, string observaciones = "Reposición con lote") =>
+        new(
+            idPuntoVentaOrigen ?? ctx.IdPuntoVentaOrigen, idPuntoVentaDestino ?? ctx.IdPuntoVentaDestino, observaciones,
+            [new LineaDeTransferencia(idArticulo, cantidad, idLote)]);
+
+    private async Task<decimal> LeerStockAsync(Contexto ctx, int idPuntoVenta, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == idPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private async Task<decimal> LeerStockLoteAsync(Contexto ctx, int idPuntoVenta, int idArticulo, int idLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == idPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstOrDefaultAsync();
+    }
+
+    // ---- task 10.7: el lote viaja ------------------------------------------------------------------
+
+    /// <summary>spec transferencias-de-stock: "A lot-effective articulo transfer moves the same lot
+    /// at both ends" — ambos movimientos_stock llevan el MISMO id_lote y ambos stock_lotes (origen Y
+    /// destino, este último recién creado) quedan exactos.</summary>
+    [Fact]
+    public async Task UnaTransferenciaDeUnArticuloLoteEfectivoMueveElMismoLoteEnAmbasPuntas()
+    {
+        var ctx = await PrepararAsync(nameof(UnaTransferenciaDeUnArticuloLoteEfectivoMueveElMismoLoteEnAmbasPuntas));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-lote-viaja", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-VIAJA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 8m, idLote));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia)
+            .ToListAsync();
+        Assert.Equal(2, movimientos.Count);
+        Assert.All(movimientos, m => Assert.Equal(idLote, m.IdLote));
+
+        Assert.Equal(12m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote));
+        Assert.Equal(8m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLote));
+        Assert.Equal(12m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+        Assert.Equal(8m, await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo));
+    }
+
+    // ---- task 10.6: insuficiencia per-lote con agregado suficiente ----------------------------------
+
+    /// <summary>spec transferencias-de-stock: "A lot-level underflow is refused even with a
+    /// sufficient aggregate" — mata el confound: el agregado (30) alcanzaría de sobra para 8
+    /// unidades, pero el lote pedido (L1) solo tiene 5.</summary>
+    [Fact]
+    public async Task UnaTransferenciaConInsuficienciaDeLoteEsRechazadaAunqueElAgregadoAlcance()
+    {
+        var ctx = await PrepararAsync(nameof(UnaTransferenciaConInsuficienciaDeLoteEsRechazadaAunqueElAgregadoAlcance));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-insuficiencia-lote", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L-INSUF-1", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L-INSUF-2", VencimientoLejanoFuturoTemprano);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote1, 5m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote2, 25m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 30m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 8m, idLote1));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("stock_insuficiente_para_transferencia", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+
+        // El rollback deja TODO exactamente como estaba — agregado suficiente incluido, la
+        // parte del confound que este test existe para matar.
+        Assert.Equal(30m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+        Assert.Equal(5m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote1));
+    }
+
+    // ---- task 10.8: default FEFO en la fase de decisión ---------------------------------------------
+
+    /// <summary>spec: "An omitted idLote resolves via FEFO at transfer time" — L1 vence antes que
+    /// L2, ninguno vencido, así que el FEFO puro (sin partición por vencido) elige L1.</summary>
+    [Fact]
+    public async Task UnaLineaSinIdLoteResuelveViaFefoEnLaTransferencia()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaSinIdLoteResuelveViaFefoEnLaTransferencia));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-fefo-transferencia", 10m);
+        var idLoteTemprano = await SembrarLoteAsync(ctx, idArticulo, "L-FEFO-TEMPRANO", VencimientoLejanoFuturoTemprano);
+        var idLoteTardio = await SembrarLoteAsync(ctx, idArticulo, "L-FEFO-TARDIO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteTemprano, 10m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteTardio, 10m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 3m, idLote: null));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia)
+            .ToListAsync();
+        Assert.Equal(2, movimientos.Count);
+        Assert.All(movimientos, m => Assert.Equal(idLoteTemprano, m.IdLote));
+
+        Assert.Equal(7m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteTemprano));
+        Assert.Equal(10m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteTardio));
+    }
+
+    // ---- task 10.9: transferencia_lote_vencido ×2 --------------------------------------------------
+
+    /// <summary>spec: "Transferring an explicitly expired lot is refused".</summary>
+    [Fact]
+    public async Task UnLoteVencidoExplicitoEsRechazadoSinEscribirNingunMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnLoteVencidoExplicitoEsRechazadoSinEscribirNingunMovimiento));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-lote-vencido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-VENCIDO", VencimientoLejanoPasado);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 5m, idLote));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("transferencia_lote_vencido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+        Assert.Equal(20m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote));
+    }
+
+    /// <summary>spec: "A non-expired lot transfers normally" — regresión positiva junto al
+    /// rechazo de arriba, mismo artículo/forma, solo cambia la fecha.</summary>
+    [Fact]
+    public async Task UnLoteNoVencidoTransfiereNormalmente()
+    {
+        var ctx = await PrepararAsync(nameof(UnLoteNoVencidoTransfiereNormalmente));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-lote-no-vencido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-NO-VENCIDO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/stock/transferencias", SolicitudDeUnaLinea(ctx, idArticulo, 5m, idLote));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote));
+        Assert.Equal(5m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLote));
+    }
+
+    // ---- task 10.10: duplicados ×3 -------------------------------------------------------------------
+
+    /// <summary>spec: "Two lines of the same articulo with different explicit lots are accepted" —
+    /// mueve DOS lotes del mismo artículo en una sola transferencia, operación de depósito legítima
+    /// que la clave pre-etapa-12 (solo id_articulo) hubiera rechazado sin motivo.</summary>
+    [Fact]
+    public async Task DosLineasDelMismoArticuloConLotesExplicitosDistintosSonAceptadas()
+    {
+        var ctx = await PrepararAsync(nameof(DosLineasDelMismoArticuloConLotesExplicitosDistintosSonAceptadas));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-dos-lotes-distintos", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L-DUP-A", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L-DUP-B", VencimientoLejanoFuturoTemprano);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote1, 10m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote2, 10m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Dos lotes del mismo artículo",
+            [new LineaDeTransferencia(idArticulo, 3m, idLote1), new LineaDeTransferencia(idArticulo, 4m, idLote2)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia && m.IdPuntoVenta == ctx.IdPuntoVentaOrigen)
+            .ToListAsync();
+        Assert.Equal(2, movimientos.Count);
+        Assert.Contains(movimientos, m => m.IdLote == idLote1 && m.Cantidad == -3m);
+        Assert.Contains(movimientos, m => m.IdLote == idLote2 && m.Cantidad == -4m);
+
+        Assert.Equal(7m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote1));
+        Assert.Equal(6m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote2));
+        Assert.Equal(13m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+    }
+
+    /// <summary>spec: "Two lines resolving to the same explicit lot are rejected".</summary>
+    [Fact]
+    public async Task DosLineasConElMismoLoteExplicitoSonRechazadas()
+    {
+        var ctx = await PrepararAsync(nameof(DosLineasConElMismoLoteExplicitoSonRechazadas));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-mismo-lote-explicito", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-MISMO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Mismo lote dos veces",
+            [new LineaDeTransferencia(idArticulo, 3m, idLote), new LineaDeTransferencia(idArticulo, 2m, idLote)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("articulo_repetido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+    }
+
+    /// <summary>spec: "Two lines both omitting idLote that resolve to the same FEFO lot are
+    /// rejected" — el chequeo corre DESPUÉS del defaulting, no contra el input (vacío) del
+    /// cliente: solo hay un lote con saldo positivo, así que ambas líneas resuelven a él.</summary>
+    [Fact]
+    public async Task DosLineasSinIdLoteQueResuelvenAlMismoLotePorFefoSonRechazadas()
+    {
+        var ctx = await PrepararAsync(nameof(DosLineasSinIdLoteQueResuelvenAlMismoLotePorFefoSonRechazadas));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-fefo-duplicado", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-FEFO-UNICO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Dos líneas sin idLote",
+            [new LineaDeTransferencia(idArticulo, 3m, null), new LineaDeTransferencia(idArticulo, 2m, null)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("articulo_repetido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia));
+    }
+
+    // ---- task 10.4 / 10.5: mutation target + A→B vs. B→A, sin 40P01 -------------------------------
+
+    /// <summary>Pausa la transacción manual justo DESPUÉS de <c>BeginTransactionAsync</c> hasta que
+    /// AMBOS participantes llegaron — mismo patrón (<c>CountdownEvent</c> de N) que
+    /// <c>TransferenciasYConteoDeInventarioTests.InterceptorDeRendezVousDeTransaccion</c>, copiado
+    /// acá a propósito (frentes en paralelo de la etapa, mismo criterio de no compartir infra de
+    /// test entre archivos).</summary>
+    private sealed class InterceptorDeRendezVousDeTransaccion(CountdownEvent gate) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            if (!gate.IsSet)
+            {
+                gate.Signal();
+                var senializo = gate.Wait(TimeSpan.FromSeconds(10));
+                Assert.True(senializo, "El rendezvous de InterceptorDeRendezVousDeTransaccion no llegó a los participantes a tiempo.");
+            }
+
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target (design decisión 9, forma ensanchada de la task 8.7; spec stock:
+    /// "Lock Order Extends To The Lot Dimension..."; mutation-proof-tests): DOS transferencias
+    /// RECÍPROCAS (A: origen→destino, B: destino→origen) del MISMO artículo, cada una con DOS
+    /// líneas de lotes explícitos DISTINTOS, enviadas en orden OPUESTO entre sí (A: [L-menor,
+    /// L-mayor]; B: [L-mayor, L-menor]) — sin <c>.ThenBy(IdLote.HasValue).ThenBy(IdLote ?? 0)</c>,
+    /// el sort estable preserva el orden de ARRIBO dentro de cada punto de venta compartido, así
+    /// que A bloquearía sus filas de lote en orden (menor, mayor) mientras B las bloquea en orden
+    /// (mayor, menor) — el ciclo clásico de deadlock (A retiene menor, espera mayor; B retiene
+    /// mayor, espera menor). El <c>CountdownEvent(2)</c> fuerza que AMBAS transacciones ya estén
+    /// abiertas antes de que cualquiera intente su primer lock, maximizando la ventana de carrera
+    /// real — sin este forced rendezvous, la carrera podría no manifestarse de forma confiable.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (retomada tras el corte del proceso — corrida real, no la aspiracional
+    /// que dejó el wip): borrado <c>.ThenBy(c => c.IdLote.HasValue).ThenBy(c => c.IdLote ?? 0)</c> de
+    /// <c>ConstruirClavesOrdenadas</c> (queda solo <c>.OrderBy(IdArticulo).ThenBy(IdPuntoVenta)</c>);
+    /// build, filtro <c>FullyQualifiedName~TransferenciaLote</c> (el archivo completo, no solo este
+    /// test), corrida ×2: <b>GREEN las 2 corridas, sin excepción</b> — este test NO mata la mutación.
+    /// Causa raíz (analizada, no adivinada): dentro de un mismo <c>(id_articulo, id_punto_venta)</c>,
+    /// el elemento AGREGADO de CADA línea precede a su elemento LOTE por construcción del array por
+    /// línea (<c>new[] { agg, lote, agg, lote }</c>), independientemente de cualquier <c>ThenBy</c>
+    /// adicional — así que el PRIMER elemento del bucket compartido por dos transferencias recíprocas
+    /// del MISMO artículo es SIEMPRE un elemento agregado, y ambas transacciones lo tocan sobre la
+    /// MISMA fila física de <c>stock</c>. Esa fila compartida actúa de convoy: quien la toca primero
+    /// la retiene hasta el <c>COMMIT</c>, y la otra transacción queda bloqueada ahí mismo — nunca
+    /// llega a competir por las filas de <c>stock_lotes</c> en el orden opuesto que este test intenta
+    /// forzar, así que el ciclo clásico de deadlock nunca se forma. El tie-break por <c>id_lote</c>
+    /// sigue siendo correcto y exigido por el design/spec (orden total ≥2N-key, consistente con los
+    /// otros dos sitios de escritura), pero ESTE test de transferencias recíprocas del mismo artículo
+    /// no es el que lo prueba — la convoy del agregado lo neutraliza estructuralmente. Ningún test de
+    /// este archivo (tampoco 10.11, de una sola línea/lote, ni 10.12, mismo artículo y PV) queda
+    /// expuesto a esta mutación por el mismo motivo. Dejado como evidencia negativa documentada en
+    /// vez de una afirmación falsa de RED→GREEN — ver la nota de la task 10.4 en tasks.md.</summary>
+    [Fact]
+    public async Task TransferenciasReciprocasDelMismoArticuloConLotesEnOrdenOpuestoNoDeadlockean()
+    {
+        var ctx = await PrepararAsync(nameof(TransferenciasReciprocasDelMismoArticuloConLotesEnOrdenOpuestoNoDeadlockean));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-deadlock-reciproco", 10m);
+        var idLoteMenor = await SembrarLoteAsync(ctx, idArticulo, "L-RECIPROCO-MENOR", VencimientoLejanoFuturo);
+        var idLoteMayor = await SembrarLoteAsync(ctx, idArticulo, "L-RECIPROCO-MAYOR", VencimientoLejanoFuturo);
+        Assert.True(idLoteMenor < idLoteMayor);
+
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteMenor, 100m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteMayor, 100m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 200m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLoteMenor, 100m);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLoteMayor, 100m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, 200m);
+
+        using var gate = new CountdownEvent(2);
+        var interceptor = new InterceptorDeRendezVousDeTransaccion(gate);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var solicitudA = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Transferencia A: menor luego mayor",
+            [new LineaDeTransferencia(idArticulo, 3m, idLoteMenor), new LineaDeTransferencia(idArticulo, 5m, idLoteMayor)]);
+        var solicitudB = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaDestino, ctx.IdPuntoVentaOrigen, "Transferencia B: mayor luego menor",
+            [new LineaDeTransferencia(idArticulo, 2m, idLoteMayor), new LineaDeTransferencia(idArticulo, 4m, idLoteMenor)]);
+
+        var tareaA = cliente.PostAsJsonAsync("/api/stock/transferencias", solicitudA);
+        var tareaB = cliente.PostAsJsonAsync("/api/stock/transferencias", solicitudB);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        var cuerpos = await Task.WhenAll(respuestas.Select(r => r.Content.ReadAsStringAsync()));
+
+        Assert.True(respuestas[0].StatusCode == HttpStatusCode.OK, cuerpos[0]);
+        Assert.True(respuestas[1].StatusCode == HttpStatusCode.OK, cuerpos[1]);
+
+        // Invariante final: ningún artículo se creó ni se destruyó — la suma de ambos puntos de
+        // venta se mantiene en 400 exactamente (200+200 iniciales).
+        var totalFinal =
+            await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo) + await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo);
+        Assert.Equal(400m, totalFinal);
+
+        var totalLoteMenor =
+            await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteMenor)
+            + await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLoteMenor);
+        var totalLoteMayor =
+            await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLoteMayor)
+            + await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLoteMayor);
+        Assert.Equal(200m, totalLoteMenor);
+        Assert.Equal(200m, totalLoteMayor);
+
+        // Origen: -3(A, menor) +4(B, menor) -5(A, mayor) +2(B, mayor) = 200 -3+4-5+2 = 198.
+        Assert.Equal(198m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+        Assert.Equal(202m, await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo));
+    }
+
+    // ---- task 10.11: un único orden ascendente, origen Y destino -----------------------------------
+
+    /// <summary>Construye un <see cref="ServicioDeStock"/> propio, con su PROPIA conexión (mismo
+    /// patrón que <c>VentaEscrituraLoteTests.EmitirObservandoOrdenDeLocksAsync</c>) — necesario
+    /// para conocer <c>pg_backend_pid()</c> de la transacción de la transferencia y poder pollear
+    /// <c>pg_locks</c> por ese PID específico.</summary>
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>spec stock: "Lock Order Extends To The Lot Dimension..."; spec
+    /// transferencias-de-stock: "A single ascending order covers both origin and destination lot
+    /// rows... never all-origin-then-all-destino". El caso discriminante NECESITA que el destino
+    /// tenga un <c>id_punto_venta</c> MENOR que el origen — con la asignación natural (destino
+    /// nace después, id mayor) el orden ascendente COINCIDE por casualidad con "todo el origen
+    /// primero", así que este test transfiere en la dirección INVERSA de la fixture: origen =
+    /// <see cref="Contexto.IdPuntoVentaDestino"/> (id mayor), destino = <see
+    /// cref="Contexto.IdPuntoVentaOrigen"/> (id menor). Bajo el orden correcto, el PRIMER elemento
+    /// tocado es el agregado del PV de id MENOR (el destino semántico) — jamás el del PV de id
+    /// MAYOR (el origen semántico). Retiene esa fila y confirma, vía el mismo mecanismo empírico a
+    /// nivel relación que <c>VentaEscrituraLoteTests.EmitirObservandoOrdenDeLocksAsync</c>, que
+    /// ningún statement contra <c>stock_lotes</c> corrió todavía mientras la transacción espera
+    /// ahí — "todo el origen primero" habría procesado agregado Y lote del origen antes de llegar
+    /// a esa fila.</summary>
+    [Fact]
+    public async Task ElOrdenDeLocksDeUnaTransferenciaConLoteEsUnaUnicaSecuenciaAscendentePorPuntoDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(ElOrdenDeLocksDeUnaTransferenciaConLoteEsUnaUnicaSecuenciaAscendentePorPuntoDeVenta));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-orden-de-locks", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-ORDEN", VencimientoLejanoFuturo);
+
+        // Caso discriminante: origen = PV de id MAYOR (ctx.IdPuntoVentaDestino), destino = PV de
+        // id MENOR (ctx.IdPuntoVentaOrigen) — dirección INVERSA de la fixture a propósito.
+        var idPuntoVentaConIdMayor = ctx.IdPuntoVentaDestino;
+        var idPuntoVentaConIdMenor = ctx.IdPuntoVentaOrigen;
+        Assert.True(idPuntoVentaConIdMenor < idPuntoVentaConIdMayor);
+
+        await SembrarStockLoteAsync(ctx, idPuntoVentaConIdMayor, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idPuntoVentaConIdMayor, idArticulo, 20m);
+        await SembrarStockAgregadoAsync(ctx, idPuntoVentaConIdMenor, idArticulo, 0m);
+
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        await db.Database.OpenConnectionAsync();
+        var conexionTransferencia = (NpgsqlConnection)db.Database.GetDbConnection();
+        var pidTransferencia = (int)(await new NpgsqlCommand("SELECT pg_backend_pid()", conexionTransferencia).ExecuteScalarAsync())!;
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
+        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes);
+
+        var solicitud = new SolicitudDeTransferencia(
+            idPuntoVentaConIdMayor, idPuntoVentaConIdMenor, "Orden de locks",
+            [new LineaDeTransferencia(idArticulo, 5m, idLote)]);
+
+        // Retiene el PRIMER elemento del orden ascendente correcto (stock del DESTINO, id menor,
+        // el agregado) — deliberadamente sin comitear, para forzar a la transferencia a
+        // bloquearse ahí mismo, en el primer statement de la transacción completa.
+        await using var conexionBloqueo = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionBloqueo.OpenAsync();
+        await using (var comandoGuc = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)", conexionBloqueo))
+        {
+            comandoGuc.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGuc.ExecuteNonQueryAsync();
+        }
+
+        await using var transaccionBloqueo = await conexionBloqueo.BeginTransactionAsync();
+        await using (var comandoBloqueo = new NpgsqlCommand(
+            "SELECT cantidad FROM stock WHERE id_articulo = $1 AND id_punto_venta = $2 FOR UPDATE",
+            conexionBloqueo, transaccionBloqueo))
+        {
+            comandoBloqueo.Parameters.AddWithValue(idArticulo);
+            comandoBloqueo.Parameters.AddWithValue(idPuntoVentaConIdMenor);
+            await comandoBloqueo.ExecuteScalarAsync();
+        }
+
+        var tareaTransferencia = servicioDeStock.TransferirAsync(solicitud);
+
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync();
+
+        var observado = false;
+        var stockLotesYaTocado = true;
+        var limite = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < limite)
+        {
+            // Mismo mecanismo empírico que VentaEscrituraLoteTests.EmitirObservandoOrdenDeLocksAsync
+            // (chequeo a nivel RELACIÓN, nunca 'tuple' directo sobre la fila en pugna — comprobado
+            // ahí que el bloqueo real aparece como una espera de transactionid, no como una fila
+            // tuple con granted=false): mientras el backend de la transferencia está bloqueado en
+            // el PRIMER elemento del orden (stock del destino, id menor), NINGÚN statement contra
+            // stock_lotes pudo haber corrido todavía — "todo el origen primero" habría procesado
+            // agregado Y lote del origen (id mayor) ANTES de llegar acá, dejando una entrada de
+            // relación 'stock_lotes' ya presente.
+            await using var comandoPoll = new NpgsqlCommand(
+                "SELECT " +
+                "  bool_or(l.locktype = 'relation' AND l.relation::regclass::text = 'stock_lotes') AS stock_lotes_tocado, " +
+                "  bool_or(NOT l.granted) AS esperando_algo " +
+                "FROM pg_locks l WHERE l.pid = $1",
+                conexionPoll);
+            comandoPoll.Parameters.AddWithValue(pidTransferencia);
+
+            await using var lector = await comandoPoll.ExecuteReaderAsync();
+            if (await lector.ReadAsync())
+            {
+                var stockLotesTocado = !lector.IsDBNull(0) && lector.GetBoolean(0);
+                var esperandoAlgo = !lector.IsDBNull(1) && lector.GetBoolean(1);
+                if (esperandoAlgo)
+                {
+                    observado = true;
+                    stockLotesYaTocado = stockLotesTocado;
+                    break;
+                }
+            }
+
+            await Task.Delay(25);
+        }
+
+        await transaccionBloqueo.RollbackAsync();
+        var resultado = await tareaTransferencia;
+
+        Assert.True(observado, "Nunca se observó a la transferencia bloqueada esperando la fila retenida.");
+        Assert.False(
+            stockLotesYaTocado,
+            "stock_lotes ya fue tocado mientras la transferencia esperaba la PRIMERA fila del orden — " +
+            "prueba que el origen se procesó antes que el destino (bug 'todo el origen primero').");
+        Assert.Single(resultado.Lineas);
+
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idPuntoVentaConIdMayor, idArticulo, idLote));
+        Assert.Equal(5m, await LeerStockLoteAsync(ctx, idPuntoVentaConIdMenor, idArticulo, idLote));
+    }
+
+    // ---- task 10.12: joint proof checkout × transferencia (cierra el pairing de la task 8.7) ------
+
+    /// <summary>spec stock: "A concurrent checkout and reverse transfer of the same articulo and
+    /// lots do not deadlock" — cierra el pairing dejado abierto en <c>VentaEscrituraLoteTests</c>,
+    /// task 8.7 (ver la nota de esa task en tasks.md: "la mitad conjunta del proof queda diferida a
+    /// cuando la transferencia sea lot-aware — task 10.12"). Un checkout vendiendo del lote 7 del
+    /// artículo 40 en PV1, CONCURRENTE con una transferencia moviendo el MISMO lote 7 del MISMO
+    /// artículo desde PV1 hacia PV2 — ambas construyen el MISMO orden ascendente total
+    /// <c>(id_articulo, id_punto_venta, id_lote NULLS FIRST)</c> sobre las filas que tocan (design:
+    /// "identically at all three write sites"), así que ninguna puede formar un ciclo con la otra.
+    /// <c>CountdownEvent(2)</c> fuerza el rendezvous — ambas transacciones abiertas antes de que
+    /// cualquiera intente su primer lock.</summary>
+    [Fact]
+    public async Task UnCheckoutYUnaTransferenciaConcurrentesDelMismoArticuloYLoteNoDeadlockean()
+    {
+        var ctx = await PrepararAsync(nameof(UnCheckoutYUnaTransferenciaConcurrentesDelMismoArticuloYLoteNoDeadlockean));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-joint-proof", 100m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-JOINT-7", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, 20m);
+
+        using var gate = new CountdownEvent(2);
+        var interceptor = new InterceptorDeRendezVousDeTransaccion(gate);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var solicitudVenta = new SolicitudDeVenta(
+            ctx.IdPuntoVentaOrigen, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)],
+            null, null);
+        var solicitudTransferencia = SolicitudDeUnaLinea(ctx, idArticulo, 1m, idLote);
+
+        var tareaVenta = cliente.PostAsJsonAsync("/api/ventas", solicitudVenta);
+        var tareaTransferencia = cliente.PostAsJsonAsync("/api/stock/transferencias", solicitudTransferencia);
+
+        await Task.WhenAll(tareaVenta, tareaTransferencia);
+
+        var respuestaVenta = await tareaVenta;
+        var respuestaTransferencia = await tareaTransferencia;
+        var cuerpoVenta = await respuestaVenta.Content.ReadAsStringAsync();
+        var cuerpoTransferencia = await respuestaTransferencia.Content.ReadAsStringAsync();
+
+        Assert.True(respuestaVenta.StatusCode == HttpStatusCode.Created, cuerpoVenta);
+        Assert.True(respuestaTransferencia.StatusCode == HttpStatusCode.OK, cuerpoTransferencia);
+
+        // 20 iniciales - 1 (venta) - 1 (transferencia) = 18 en origen; 1 llegó a destino.
+        Assert.Equal(18m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo, idLote));
+        Assert.Equal(1m, await LeerStockLoteAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo, idLote));
+        Assert.Equal(18m, await LeerStockAsync(ctx, ctx.IdPuntoVentaOrigen, idArticulo));
+        Assert.Equal(1m, await LeerStockAsync(ctx, ctx.IdPuntoVentaDestino, idArticulo));
+    }
+}


### PR DESCRIPTION
## Etapa 12 — Slice 10: Transferencias

- **El lote viaja**: mismo \`id_lote\` decrementado en origen e incrementado en destino (identidad de la mercadería, no de la ubicación); sin-identificar lazy reutilizando el patrón de ventas.
- **Orden ≥2N**: \`ClaveDeStock\` ensanchada; 4 claves por línea con lote (agregado+lote × origen+destino); orden \`(IdArticulo, IdPuntoVenta, IdLote NULLS FIRST)\`; loop transaccional con ambos \`RETURNING\` chequeados → \`409 stock_insuficiente_para_transferencia\` (agregado y por-lote al mismo código).
- **Fase pre-transacción**: FEFO default con \`hoy\` (decisión 15), duplicados por \`(IdArticulo, IdLote)\` POST-defaulting (3 escenarios), \`409 transferencia_lote_vencido\` incondicional (lote explícito O resuelto por FEFO).
- **Response honesto**: \`LineaTransferida\` con \`IdLote\` (contrato del design restaurado tras drift silencioso), una fila por (artículo, lote).
- **Joint deadlock proof 10.12**: checkout vs transferencia del MISMO lote concurrentes — cierra el pairing abierto en el slice 8.

### Historia del slice
El apply murió con el proceso host; el wip rescatado tenía comentarios que declaraban un tie-break inexistente y evidencia de mutación FALSA — ambos corregidos por la continuación con honestidad documental. El juez B derivó la **prueba estructural** de que el deadlock por filas de lote es imposible por construcción (la fila agregada compartida es un convoy natural), validada cross-artículo ×3 bajo mutación.

### Tests
TransferenciaLote 15/15 · regresión TransferenciasYConteo 28/28 · VentaEscritura 7/7. 9 rondas de evidencia de mutación.

### Judgment-day
Juez B APPROVE ×2 (5 mutaciones + 2 gaps cerrados). Juez A REJECT ronda 1 (MAJOR: drift del contrato \`LineaTransferida\` + colapso multi-lote del response) → fix con test campo-por-campo de 3 filas → APPROVE ronda 2 con verificación aritmética a mano. Riesgo latente web anotado para el slice 14/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)