### PR TITLE
feat(lotes): ajuste lote-consciente + decomiso de primera clase — etapa 12, slice 11

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/specs/stock/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/stock/spec.md
@@ -165,11 +165,16 @@ not refactored away.
   retry strategy) with no deadlock, because both build the same ascending
   `(id_articulo, id_punto_venta, id_lote NULLS FIRST)` order over their keys
 
-#### Scenario: A multi-lot ajuste locks lots in ascending id_lote order
-- GIVEN an ajuste touching lots 3 and 9 of the same articulo and punto de
+#### Scenario: A multi-lot conteo locks lots in ascending id_lote order
+- GIVEN a conteo touching lots 3 and 9 of the same articulo and punto de
   venta in one request
-- WHEN the transaction writes
-- THEN lot 3 upserts before lot 9
+- WHEN the transaction acquires its locks
+- THEN lot 3's row locks before lot 9's
+  *(Amended at slice-11 judgment-day, judge A MINOR-2: the original scenario
+  said "ajuste", but `SolicitudDeAjusteDeStock` carries a single `IdLote` —
+  one lot per request, per design's write-site-3 shape. The only stock-write
+  request carrying a lot LIST is `SolicitudDeConteo` (slice 12), which is
+  where the multi-lot ascending lock order actually lives.)*
 
 ## Purpose Update (informational — apply manually at archive)
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1436,40 +1436,40 @@ expired-transfer ×2 (10.9), duplicate-line ×3 (10.10), single order
 /api/stock/decomiso` is a first-class, Admin-only, never-negative write
 path. **Rollback**: revert the branch.
 
-- [ ] 11.1 Modify `ServicioDeStock.cs`: `EjecutarAjusteAsync` — a
+- [x] 11.1 Modify `ServicioDeStock.cs`: `EjecutarAjusteAsync` — a
   lot-effective articulo requires `idLote` (`400 lote_requerido`), a
   non-lot articulo refuses it (`400 lote_no_aplica`); aggregate upsert then
   lot upsert, in that order; no negativity refusal (ajuste is the
   correction operation).
-- [ ] 11.2 Create `EjecutarDecomisoAsync` in `ServicioDeStock.cs`
+- [x] 11.2 Create `EjecutarDecomisoAsync` in `ServicioDeStock.cs`
   (structurally `EjecutarAjusteAsync` with three deltas): `motivo =
   Decomiso`; client-supplied `cantidad` is positive, negated server-side;
   the `RETURNING` of the lot upsert (or aggregate for a non-lot articulo)
   checked `< 0` → `409 stock_insuficiente_para_decomiso`; `observaciones`
   mandatory (`ExigirObservaciones` reused verbatim).
-- [ ] 11.3 Modify `StockEndpoints.cs`: `POST /api/stock/decomiso`,
+- [x] 11.3 Modify `StockEndpoints.cs`: `POST /api/stock/decomiso`,
   `Politicas.GestionDeCatalogo` stacked over `OperacionDePos`.
-- [ ] 11.4 [P] **Mutation target**:
+- [x] 11.4 [P] **Mutation target**:
   `.RequireAuthorization(Politicas.GestionDeCatalogo)` deleted on
   `/stock/decomiso` → the Vendedor-403 test MUST fail (the group's
   `OperacionDePos` alone admits Vendedor); revert → green. *(spec:
   "Vendedor is blocked from decomiso"; mutation-proof-tests)* Record
   evidence.
-- [ ] 11.5 [P] `stock_insuficiente_para_decomiso` test. *(spec: "A decomiso
+- [x] 11.5 [P] `stock_insuficiente_para_decomiso` test. *(spec: "A decomiso
   that would go negative is refused")*
-- [ ] 11.6 [P] Sign-discipline test: positive client `cantidad` negated
+- [x] 11.6 [P] Sign-discipline test: positive client `cantidad` negated
   server-side. *(spec: "A positive client cantidad is negated by the
   server")*
-- [ ] 11.7 [P] Decomiso-of-lot-effective-requires-`idLote` test. *(spec:
+- [x] 11.7 [P] Decomiso-of-lot-effective-requires-`idLote` test. *(spec:
   "A decomiso of a lot-effective articulo requires idLote")*
-- [ ] 11.8 [P] Non-expired-lot decomiso allowed. *(spec: "Decomiso applies
+- [x] 11.8 [P] Non-expired-lot decomiso allowed. *(spec: "Decomiso applies
   to a non-expired lot too")*
-- [ ] 11.9 [P] Observaciones-required test. *(spec: "Decomiso without
+- [x] 11.9 [P] Observaciones-required test. *(spec: "Decomiso without
   observaciones is rejected")*
-- [ ] 11.10 [P] Ajuste lot-aware tests. *(spec stock: "Ajuste of a
+- [x] 11.10 [P] Ajuste lot-aware tests. *(spec stock: "Ajuste of a
   lot-effective articulo requires idLote and updates both caches", "Ajuste
   of a lot-effective articulo without idLote is rejected")*
-- [ ] 11.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+- [x] 11.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes.
 - [ ] 11.12 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 11.13 Branch `feat/stage12-slice11-ajuste-decomiso` off `main`
@@ -1480,6 +1480,47 @@ path. **Rollback**: revert the branch.
 ajuste ×2 (11.10).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~Decomiso|FullyQualifiedName~AjusteLote`
+
+> **APPLY-RUN NOTE (tasks 11.1-11.11, sdd-apply)**: nuevo archivo
+> `tests/Ways.IntegrationTests/AjusteDecomisoLoteTests.cs` (11 tests),
+> `ServicioDeStock.AjustarAsync`/`EjecutarAjusteAsync` ganan la dimensión de
+> lote vía `ResolverIdLoteEfectivoAsync` (helper compartido con
+> `DecomisarAsync`, reusa `ServicioDeLotes.LeerSaldosAsync` para validar un
+> `idLote` explícito — existe/pertenece al artículo/no borrado — antes de la
+> transacción, mismo criterio que `TransferirAsync`); `DecomisarAsync` +
+> `EjecutarDecomisoAsync` nuevos, motivo `Decomiso` de primera clase; nuevo
+> endpoint `POST /api/stock/decomiso`. `Contratos.cs`:
+> `SolicitudDeAjusteDeStock` gana `IdLote` opcional (posicional al final, no
+> rompe los call-sites existentes); nuevo `SolicitudDeDecomiso`.
+>
+> Cobertura más allá de los 8 tests enumerados en el test plan: 3 tests
+> extra para los guards `lote_no_aplica` (ajuste) y `lote_invalido`
+> (decomiso) — código ya escrito por `ResolverIdLoteEfectivoAsync` (mismo
+> guard que `TransferirAsync` usa para `lote_invalido`) que hubiera quedado
+> sin cobertura si me ceñía estrictamente a la lista de 8; y un decomiso de
+> lote VENCIDO como contraparte del "no vencido" de la task 11.8, probando
+> que la fecha nunca entra en la decisión en ninguno de los dos sentidos.
+> `ExigirCantidadDeDecomisoValida` (cantidad > 0, hasta 3 decimales) reusa
+> el código `cantidad_de_ajuste_invalida`/`cantidad_invalida` de
+> `ExigirCantidadValida` — no hay código nuevo para esto en la lista de la
+> etapa (design.md "New domain error codes").
+>
+> Evidencia de mutación (11.4): borrado
+> `.RequireAuthorization(Politicas.GestionDeCatalogo)` de `/decomiso` en
+> `StockEndpoints.cs` — build, filtro
+> `FullyQualifiedName~UnVendedorEsBloqueadoDelDecomiso`: el test **FALLÓ**
+> (`200 OK` en vez de `403 Forbidden` — el Vendedor pasa con solo
+> `OperacionDePos` del grupo). Revertido el mutante, build, corrida de
+> nuevo: **GREEN**.
+>
+> Filtro `~AjusteDecomisoLoteTests`: 11/11. Regresión `~AjusteDeStockTests`:
+> 10/10. Regresión `~TransferenciaLoteTests`: 15/15. Regresión
+> `~TransferenciasYConteoDeInventarioTests`: 28/28. Corrida combinada de los
+> tres archivos de regresión + el nuevo: 53/53 (10 + 15 + 28, sin contar el
+> archivo nuevo en esa corrida puntual).
+> `has-pending-model-changes`: sin cambios pendientes, antes y después de
+> los edits (gate cerrado — los valores de enum `Decomiso` ya existen desde
+> el slice 1).
 
 ---
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1471,8 +1471,21 @@ path. **Rollback**: revert the branch.
   of a lot-effective articulo without idLote is rejected")*
 - [x] 11.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes.
-- [ ] 11.12 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 11.13 Branch `feat/stage12-slice11-ajuste-decomiso` off `main`
+- [x] 11.12 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN NOTE:
+  judge B round 1 APPROVE-with-findings — 5 mutations killed cleanly but 3
+  coverage gaps confirmed by SURVIVING mutations: the aggregate branch of
+  decomiso (no-lot articulo) was dead code to the tests, invalid-cantidad
+  validation was never exercised via /decomiso, and nothing proved an ajuste
+  CAN leave a negative balance (its central difference from decomiso). Fix
+  d36554a: 7 new tests (11→18), each verified by re-running the surviving
+  mutation to RED. Judge B round 2 APPROVE with surgical-precision kills
+  (1/18, 2/18, 2/18 — no collateral). Judge A APPROVE with 3 MINORs:
+  ExigirObservaciones message says "ajuste" on the decomiso path
+  (pre-existing since stage 5, follow-up ticket); the stock spec's multi-lot
+  scenario was mislabeled "ajuste" — amended to "conteo" in this branch
+  (single-IdLote request shape confirmed); cantidad-code reuse cosmetic and
+  documented.)*
+- [x] 11.13 Branch `feat/stage12-slice11-ajuste-decomiso` off `main`
   (parent: slice 10); PR; merge stacked-to-main.
 
 **Test plan**: 403 mutation (11.4), insufficiency (11.5), sign discipline

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1522,6 +1522,40 @@ ajuste ×2 (11.10).
 > los edits (gate cerrado — los valores de enum `Decomiso` ya existen desde
 > el slice 1).
 
+> **JUDGMENT-DAY FIX NOTE (11.12, ronda 2, juez B)**: 3 gaps confirmados, los
+> 3 sobre código ya escrito en el slice pero sin cobertura — 7 tests nuevos
+> en `AjusteDecomisoLoteTests.cs` (11 → 18):
+>
+> 1. Decomiso de artículo SIN lote efectivo (rama `else`/`else if` de
+>    `EjecutarDecomisoAsync`, código muerto para tests hasta esta ronda):
+>    `UnDecomisoDeUnArticuloSinLoteEfectivoEsAceptado` (200, agregado baja,
+>    movimiento con `id_lote = null`) y
+>    `UnDecomisoDeUnArticuloSinLoteEfectivoQueDejariaElAgregadoNegativoEsRechazado`
+>    (409 `stock_insuficiente_para_decomiso` sobre el agregado). Evidencia:
+>    unconditional `throw` en la rama `else` — ambos **FALLARON** (200/409
+>    reales vs. 409 forzado); revertido, **GREEN**.
+> 2. Cantidad inválida en decomiso:
+>    `UnDecomisoConCantidadCeroONegativaEsRechazado` (Theory, cantidad 0 y
+>    -5 → 400 `cantidad_de_ajuste_invalida`) y
+>    `UnDecomisoConMasDeTresDecimalesEsRechazado` (400 `cantidad_invalida`).
+>    Evidencia: anulado el `if (cantidad <= 0)` de
+>    `ExigirCantidadDeDecomisoValida` (`if (false)`) — ambos casos del
+>    Theory **FALLARON** (200/500 en vez de 400); revertido, **GREEN**.
+> 3. El ajuste PUEDE dejar negativo (diferencia central con decomiso):
+>    `UnAjusteQueDejaSaldoNegativoEsAceptado` (200, saldo de lote Y agregado
+>    negativo persistido exacto, -2). Evidencia: agregado temporalmente un
+>    `if (nuevaDelLote < 0m) throw ...` a `EjecutarAjusteAsync` — el test
+>    **FALLÓ** (409 en vez de 200); revertido, **GREEN**.
+>
+> Hallazgo menor (barato, helper ya existía):
+> `UnDecomisoDeUnArticuloSinLoteConIdLoteProvistoEsRechazado` — guard
+> simétrico de `lote_no_aplica` en decomiso, mismo criterio que el
+> equivalente de ajuste.
+>
+> Filtro `~AjusteDecomisoLoteTests`: 18/18. Regresión `~AjusteDeStockTests`:
+> 10/10. `has-pending-model-changes`: sin cambios pendientes (solo se tocó
+> el archivo de tests). Árbol limpio tras el commit.
+
 ---
 
 ## Slice 12: Conteo (PR 12)

--- a/src/Ways.Api/Endpoints/StockEndpoints.cs
+++ b/src/Ways.Api/Endpoints/StockEndpoints.cs
@@ -85,6 +85,17 @@ public static class StockEndpoints
         .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Re-run manual de la reconciliación de lotes (admin-only) — motivo = reclasificacion.");
 
+        // stage-12-lotes-vencimientos (Slice 11, task 11.3, design: API Surface; proposal
+        // decisión 9): decomiso, motivo de primera clase — mismo apilado GestionDeCatalogo sobre
+        // OperacionDePos que /ajustes. NO restringido a lotes vencidos.
+        grupo.MapPost("/decomiso", async (ServicioDeStock servicio, SolicitudDeDecomiso solicitud, CancellationToken ct) =>
+        {
+            var cantidad = await servicio.DecomisarAsync(solicitud, ct);
+            return Results.Ok(new StockActual(solicitud.IdPuntoVenta, solicitud.IdArticulo, cantidad));
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Decomiso de stock (admin-only) — motivo = decomiso, nunca negativo.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -8,8 +8,15 @@ namespace Ways.Application.Stock;
 /// y nunca cero (<c>ck_movimientos_stock_cantidad_no_cero</c>). Sin campo de empleado, mismo
 /// criterio que <c>Ways.Application.Ventas.SolicitudDeVenta</c>: <c>id_empleado</c> siempre sale
 /// del actor autenticado.
+///
+/// Etapa 12, slice 11 (design: Write site 3 — "IdLote required when lot-effective"): <see
+/// cref="IdLote"/> es obligatorio para un artículo lote-efectivo (<c>400 lote_requerido</c> si se
+/// omite) y se rechaza para uno sin control de lote efectivo (<c>400 lote_no_aplica</c> si se
+/// provee). A diferencia de una transferencia, el ajuste NO tiene rechazo de negatividad — es la
+/// operación que corrige un saldo negativo.
 /// </summary>
-public sealed record SolicitudDeAjusteDeStock(int IdPuntoVenta, int IdArticulo, decimal Cantidad, string? Observaciones);
+public sealed record SolicitudDeAjusteDeStock(
+    int IdPuntoVenta, int IdArticulo, decimal Cantidad, string? Observaciones, int? IdLote = null);
 
 /// <summary>
 /// Balance de <c>GET /api/stock</c> (design: API Surface — "balance for the POS badge").
@@ -106,3 +113,15 @@ public sealed record SolicitudDeReconciliacion(int? IdArticulo, int? IdPuntoVent
 /// La suma de ambos es el total de pares dentro del alcance pedido.
 /// </summary>
 public sealed record ResultadoDeReconciliacion(int ParesReconciliados, int ParesSinResiduo);
+
+/// <summary>
+/// Cuerpo de <c>POST /api/stock/decomiso</c> (stage-12-lotes-vencimientos, Slice 11; design: API
+/// Surface; proposal decisión 9). <see cref="Cantidad"/> SIEMPRE POSITIVA — el servidor la niega
+/// antes de escribir el movimiento (misma disciplina que <c>ContarAsync</c>: nunca un delta con
+/// signo provisto por el cliente). <see cref="IdLote"/> es obligatorio para un artículo
+/// lote-efectivo (<c>400 lote_requerido</c>), rechazado para uno sin control de lote efectivo
+/// (<c>400 lote_no_aplica</c>). <see cref="Observaciones"/> obligatoria (misma disciplina que
+/// <see cref="SolicitudDeAjusteDeStock"/>). NO restringido a lotes vencidos (decisión 9 del
+/// proposal) — la merma real (rotura, pérdida) entra en el mismo cajón.
+/// </summary>
+public sealed record SolicitudDeDecomiso(int IdPuntoVenta, int IdArticulo, int? IdLote, decimal Cantidad, string Observaciones);

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -24,6 +24,13 @@ namespace Ways.Application.Stock;
 /// mismo trío de primitivas que <c>ServicioDeVentas</c> ya consume — <c>LeerSaldosAsync</c> (fase
 /// de resolución de la transferencia) y <c>ResolverSinIdentificarAsync</c> (get-or-create
 /// perezoso, statement crudo, cuando ningún lote del artículo tiene saldo positivo en el origen).
+///
+/// Etapa 12, slice 11 (design: Write site 3, proposal decisión 9): <c>AjustarAsync</c> gana la
+/// dimensión de lote (<c>idLote</c> requerido/rechazado según <c>EsLoteEfectivo</c>) y
+/// <c>DecomisarAsync</c> nace como motivo de primera clase — estructuralmente el mismo camino de
+/// <c>AjustarAsync</c>, con la cantidad positiva del cliente negada server-side (disciplina de
+/// <c>ContarAsync</c>) y el único rechazo de negatividad que este servicio conoce
+/// (<c>409 stock_insuficiente_para_decomiso</c>). No restringido a lotes vencidos.
 /// </summary>
 public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeLotes servicioDeLotes)
 {
@@ -48,18 +55,24 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         // Pre-checks de existencia/tenant ANTES de la transacción (mismo criterio que
         // ServicioDeVentas: la referencia se valida sobre una lectura simple, nunca dejando que
         // el FK real de la base la rechace con un 500 crudo dentro del INSERT crudo de abajo).
-        await ResolverArticuloAsync(solicitud.IdArticulo, ct);
-        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var articulo = await ResolverArticuloAsync(solicitud.IdArticulo, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        // Etapa 12, slice 11 (design: Write site 3 — "IdLote required when lot-effective"):
+        // resuelto/validado ANTES de la transacción, mismo criterio que la fase de resolución de
+        // TransferirAsync.
+        var idLote = await ResolverIdLoteEfectivoAsync(puntoVenta.IdEmpresa, puntoVenta.Id, articulo, solicitud.IdLote, ct);
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
         return await estrategia.ExecuteAsync(async () =>
             await EjecutarAjusteAsync(
-                idTenant, idEmpleado, solicitud.IdArticulo, solicitud.IdPuntoVenta, cantidad, observaciones, momento, ct));
+                idTenant, idEmpleado, solicitud.IdArticulo, solicitud.IdPuntoVenta, cantidad, observaciones, idLote,
+                momento, ct));
     }
 
     private async Task<decimal> EjecutarAjusteAsync(
         int idTenant, int idEmpleado, int idArticulo, int idPuntoVenta, decimal cantidad, string observaciones,
-        DateTimeOffset momento, CancellationToken ct)
+        int? idLote, DateTimeOffset momento, CancellationToken ct)
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
@@ -68,13 +81,104 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, cantidad, MotivoStock.Ajuste, idEmpleado,
-            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote: null, ct);
+            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote, ct);
 
         var nuevaCantidad = await UpsertStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, cantidad, ct);
+
+        // Etapa 12, slice 11 (design: Write site 3 — "aggregate upsert then lot upsert, in that
+        // order"): el agregado SIEMPRE upsertea primero (lock order, decisión 6/9 del proposal);
+        // el lote solo cuando el artículo es lote-efectivo. Sin rechazo de negatividad — el ajuste
+        // es la operación que CORRIGE un saldo negativo (spec: "no negativity refusal").
+        if (idLote is { } idLoteEfectivo)
+        {
+            await UpsertStockLoteAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, idLoteEfectivo, cantidad, ct);
+        }
 
         await transaccion.CommitAsync(ct);
 
         return nuevaCantidad;
+    }
+
+    // ---- decomiso (design: Write site 3 — "EjecutarDecomisoAsync, structurally EjecutarAjusteAsync
+    // with three deltas"; proposal decisión 9) --------------------------------------------------
+
+    /// <summary>Design: API Surface — <c>POST /api/stock/decomiso</c>, <c>motivo = decomiso</c>,
+    /// primera clase (proposal decisión 9: NO una bandera de <c>ajuste</c>). Tres diferencias con
+    /// <see cref="AjustarAsync"/>: (1) <see cref="SolicitudDeDecomiso.Cantidad"/> llega SIEMPRE
+    /// positiva y se niega acá, nunca en el servicio de abajo (misma disciplina que
+    /// <c>ContarAsync</c> — el cliente nunca manda un delta con signo); (2) el único rechazo de
+    /// negatividad de este servicio (<c>409 stock_insuficiente_para_decomiso</c>) sobre el saldo
+    /// OPERATIVO — el del lote si es lote-efectivo, si no el agregado (spec: "the target balance");
+    /// (3) <c>observaciones</c> obligatoria igual que un ajuste. NO restringido a lotes vencidos
+    /// (decisión 9 del proposal) — la merma real entra en el mismo cajón que la vencida.</summary>
+    public async Task<decimal> DecomisarAsync(SolicitudDeDecomiso solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var cantidadPositiva = ExigirCantidadDeDecomisoValida(solicitud.Cantidad);
+        var observaciones = ExigirObservaciones(solicitud.Observaciones);
+
+        var articulo = await ResolverArticuloAsync(solicitud.IdArticulo, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var idLote = await ResolverIdLoteEfectivoAsync(puntoVenta.IdEmpresa, puntoVenta.Id, articulo, solicitud.IdLote, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarDecomisoAsync(
+                idTenant, idEmpleado, solicitud.IdArticulo, solicitud.IdPuntoVenta, cantidadPositiva, observaciones,
+                idLote, momento, ct));
+    }
+
+    private async Task<decimal> EjecutarDecomisoAsync(
+        int idTenant, int idEmpleado, int idArticulo, int idPuntoVenta, decimal cantidadPositiva, string observaciones,
+        int? idLote, DateTimeOffset momento, CancellationToken ct)
+    {
+        // Disciplina de ContarAsync: nunca un delta con signo provisto por el cliente — acá es
+        // donde el "positivo" del contrato se convierte en la baja real.
+        var delta = -cantidadPositiva;
+
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await InsertarMovimientoStockAsync(
+            conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, MotivoStock.Decomiso, idEmpleado,
+            observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote, ct);
+
+        var nuevaAgregada = await UpsertStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, ct);
+
+        if (idLote is { } idLoteEfectivo)
+        {
+            var nuevaDelLote = await UpsertStockLoteAsync(
+                conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, idLoteEfectivo, delta, ct);
+
+            // spec lotes-y-vencimientos: "the target balance (the lot's stock_lotes.cantidad when
+            // lot-effective, otherwise stock.cantidad)" — SOLO el lote decide cuando es
+            // lote-efectivo, el agregado nunca se vuelve a chequear acá (a diferencia de una
+            // transferencia, que chequea ambos).
+            if (nuevaDelLote < 0m)
+            {
+                throw new ErrorDominio(
+                    "stock_insuficiente_para_decomiso",
+                    $"No hay stock suficiente del lote {idLoteEfectivo} del artículo {idArticulo} para decomisar.",
+                    409);
+            }
+        }
+        else if (nuevaAgregada < 0m)
+        {
+            throw new ErrorDominio(
+                "stock_insuficiente_para_decomiso",
+                $"No hay stock suficiente del artículo {idArticulo} para decomisar.",
+                409);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return nuevaAgregada;
     }
 
     // ---- transferencia entre puntos de venta (design: Transactions — TRANSFERENCIA; decisión 9) ----
@@ -391,6 +495,55 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         return JsonSerializer.Deserialize<bool>(valorJson);
     }
 
+    /// <summary>Etapa 12, slice 11 (design: Write site 3 — "IdLote required when lot-effective
+    /// (lote_requerido), refused when not (lote_no_aplica)"). Compartido por
+    /// <see cref="AjustarAsync"/> y <see cref="DecomisarAsync"/> — ambos operan sobre UN solo
+    /// artículo/punto de venta, a diferencia de <see cref="ResolverLineasDeTransferenciaAsync"/>
+    /// (multi-línea, con FEFO-default). Acá NO hay FEFO-default: el ajuste/decomiso de un
+    /// artículo lote-efectivo siempre exige el <c>idLote</c> explícito — no hay "línea de venta"
+    /// que el operador esté surtiendo, así que no hay lote físico implícito que adivinar.
+    /// <see cref="ServicioDeLotes.LeerSaldosAsync"/> valida que el <c>idLote</c> explícito existe,
+    /// pertenece al artículo y no está borrado (<c>400 lote_invalido</c>) — mismo criterio de
+    /// nunca dejar que la FK real de la base rechace con un 500 crudo.</summary>
+    private async Task<int?> ResolverIdLoteEfectivoAsync(
+        int idEmpresa, int idPuntoVenta, Articulo articulo, int? idLotePedido, CancellationToken ct)
+    {
+        var lotesHabilitado = await ResolverLotesHabilitadoAsync(idEmpresa, idPuntoVenta, ct);
+        var esLoteEfectivo = ReglaDeLotes.ControlEfectivo(articulo.ControlaLote, lotesHabilitado);
+
+        if (!esLoteEfectivo)
+        {
+            if (idLotePedido is not null)
+            {
+                throw new ErrorDominio(
+                    "lote_no_aplica",
+                    $"El artículo {articulo.Id} no tiene lote efectivo; no admite idLote.",
+                    400);
+            }
+
+            return null;
+        }
+
+        if (idLotePedido is null)
+        {
+            throw new ErrorDominio(
+                "lote_requerido",
+                $"El artículo {articulo.Id} es lote-efectivo; requiere idLote.",
+                400);
+        }
+
+        var saldos = await servicioDeLotes.LeerSaldosAsync(idPuntoVenta, [articulo.Id], [idLotePedido.Value], ct);
+        if (!saldos.Any(s => s.IdLote == idLotePedido.Value))
+        {
+            throw new ErrorDominio(
+                "lote_invalido",
+                $"El lote {idLotePedido} no existe, no pertenece al artículo {articulo.Id} o fue eliminado.",
+                400);
+        }
+
+        return idLotePedido;
+    }
+
     // ---- conteo de inventario (design: Transactions — CONTEO DE INVENTARIO; decisión 10) ----------
 
     /// <summary>Design decisión 10: el cliente manda el TOTAL contado, nunca un delta. El delta
@@ -635,6 +788,28 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         if (decimal.Round(cantidad, 3, MidpointRounding.AwayFromZero) != cantidad)
         {
             throw new ErrorDominio("cantidad_invalida", "La cantidad del ajuste admite hasta 3 decimales.", 400);
+        }
+
+        return cantidad;
+    }
+
+    /// <summary>Etapa 12, slice 11 (design: Write site 3 — "cantidad arrives positive and is
+    /// negated server-side"; spec lotes-y-vencimientos: "the client MUST send a positive
+    /// cantidad"). A diferencia de <see cref="ExigirCantidadValida"/> (que solo prohíbe cero,
+    /// porque un ajuste carga o descarga con signo), un decomiso SIEMPRE resta — cero o negativo
+    /// del cliente es un error de contrato, no una operación legítima. Reusa el mismo código de
+    /// familia que <see cref="ExigirCantidadValida"/> (decomiso es estructuralmente un ajuste,
+    /// design decisión 9 del proposal), sin un código nuevo en la lista de la etapa.</summary>
+    private static decimal ExigirCantidadDeDecomisoValida(decimal cantidad)
+    {
+        if (cantidad <= 0)
+        {
+            throw new ErrorDominio("cantidad_de_ajuste_invalida", "La cantidad del decomiso tiene que ser mayor a cero.", 400);
+        }
+
+        if (decimal.Round(cantidad, 3, MidpointRounding.AwayFromZero) != cantidad)
+        {
+            throw new ErrorDominio("cantidad_invalida", "La cantidad del decomiso admite hasta 3 decimales.", 400);
         }
 
         return cantidad;

--- a/tests/Ways.IntegrationTests/AjusteDecomisoLoteTests.cs
+++ b/tests/Ways.IntegrationTests/AjusteDecomisoLoteTests.cs
@@ -1,0 +1,481 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 11 (tasks 11.4-11.10): el ajuste lote-consciente y el
+/// decomiso de primera clase punta a punta — <c>idLote</c> requerido/rechazado según
+/// <c>EsLoteEfectivo</c> (spec stock: Manual Ajuste Path Is Admin-Only), la disciplina de signo de
+/// <c>ContarAsync</c> aplicada a un decomiso (cantidad positiva del cliente, negada server-side), el
+/// único rechazo de negatividad de <c>ServicioDeStock</c> (<c>409
+/// stock_insuficiente_para_decomiso</c>) y la decisión 9 del proposal: decomiso NO restringido a
+/// lotes vencidos, Admin-only vía <c>GestionDeCatalogo</c> apilada sobre <c>OperacionDePos</c>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AjusteDecomisoLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas fijas y lejanas — independientes del reloj de la corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+    private static readonly DateOnly VencimientoLejanoPasado = new(2020, 1, 1);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva, int IdListaPrecio);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Ajuste-decomiso-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Ajuste Decomiso", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        // Módulo de lotes ON a nivel empresa — mismo criterio que TransferenciaLoteTests.
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva, lista.Id);
+    }
+
+    private async Task<int> SembrarArticuloLoteEfectivoAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    /// <summary>Artículo SIN control de lote — contraparte del lote-efectivo, usado por el rechazo
+    /// de <c>observaciones_requeridas</c>/mutación (no necesitan la dimensión de lote).</summary>
+    private async Task<int> SembrarArticuloSinLoteAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<decimal> LeerStockAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private async Task<decimal> LeerStockLoteAsync(Contexto ctx, int idArticulo, int idLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private async Task<HttpClient> CrearClienteVendedorAsync(Contexto ctx, string nombre)
+    {
+        var mailVendedor = $"vendedor-{Guid.NewGuid():N}@ways.test";
+        var altaVendedor = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario(nombre, mailVendedor, (int)RolConocido.Vendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var login = await vendedor.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailVendedor, "una-contraseña-larga"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        return vendedor;
+    }
+
+    // ---- task 11.10: ajuste lote-consciente ×2 ------------------------------------------------
+
+    /// <summary>spec stock: "Ajuste of a lot-effective articulo requires idLote and updates both
+    /// caches" — un único <c>movimientos_stock</c> con <c>id_lote</c>, ambas cachés (agregada Y de
+    /// lote) actualizadas en la misma transacción.</summary>
+    [Fact]
+    public async Task UnAjusteDeUnArticuloLoteEfectivoConIdLoteActualizaAmbasCaches()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteDeUnArticuloLoteEfectivoConIdLoteActualizaAmbasCaches));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-ajuste-lote", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-AJUSTE", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVenta, idArticulo, 5m, "Reconteo físico", idLote);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var actual = JsonSerializer.Deserialize<StockActual>(cuerpo, OpcionesJson)!;
+        Assert.Equal(45m, actual.Cantidad);
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+        Assert.Equal(45m, await LeerStockAsync(ctx, idArticulo));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Ajuste);
+        Assert.Equal(5m, movimiento.Cantidad);
+        Assert.Equal(idLote, movimiento.IdLote);
+    }
+
+    /// <summary>spec stock: "Ajuste of a lot-effective articulo without idLote is rejected".</summary>
+    [Fact]
+    public async Task UnAjusteDeUnArticuloLoteEfectivoSinIdLoteEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteDeUnArticuloLoteEfectivoSinIdLoteEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-ajuste-sin-lote", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVenta, idArticulo, 5m, "Reconteo físico");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_requerido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Ajuste));
+        Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- gap de cobertura (dto-contract-honesty): guard simétrico de lote_no_aplica ------------
+
+    /// <summary>spec stock (guard simétrico del anterior): un <c>idLote</c> provisto sobre un
+    /// artículo SIN lote efectivo se rechaza en vez de ignorarse en silencio — mismo criterio que
+    /// <c>TransferenciaLoteTests.UnaLineaSinLoteEfectivoConIdLoteProvistoEsRechazadaComoLoteInvalido</c>.</summary>
+    [Fact]
+    public async Task UnAjusteDeUnArticuloSinLoteConIdLoteProvistoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteDeUnArticuloSinLoteConIdLoteProvistoEsRechazado));
+        var idArticuloSinLote = await SembrarArticuloSinLoteAsync(ctx, "articulo-ajuste-sin-lote-idlote", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloSinLote, 40m);
+
+        var idArticuloConLote = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-ajeno-ajuste", 10m);
+        var idLoteAjeno = await SembrarLoteAsync(ctx, idArticuloConLote, "L-AJENO-AJUSTE", VencimientoLejanoFuturo);
+
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVenta, idArticuloSinLote, 5m, "Idlote ajeno", idLoteAjeno);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_no_aplica", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticuloSinLote && m.Motivo == MotivoStock.Ajuste));
+    }
+
+    // ---- task 11.6: disciplina de signo --------------------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "A positive client cantidad is negated by the server" —
+    /// el cliente manda 5 (positivo), el movimiento queda -5 y el saldo baja, nunca sube.</summary>
+    [Fact]
+    public async Task UnDecomisoConCantidadPositivaDelClienteSeNiegaServerSide()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoConCantidadPositivaDelClienteSeNiegaServerSide));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-signo", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-SIGNO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Rotura de envase");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+        Assert.Equal(15m, await LeerStockAsync(ctx, idArticulo));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso);
+        Assert.Equal(-5m, movimiento.Cantidad);
+        Assert.Equal(idLote, movimiento.IdLote);
+    }
+
+    // ---- task 11.7: idLote requerido en decomiso -----------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "A decomiso of a lot-effective articulo requires
+    /// idLote".</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnArticuloLoteEfectivoSinIdLoteEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnArticuloLoteEfectivoSinIdLoteEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-sin-lote", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, null, 5m, "Rotura sin lote");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_requerido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+        Assert.Equal(20m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- gap de cobertura: lote_invalido en decomiso -------------------------------------------
+
+    /// <summary>dto-contract-honesty: un <c>idLote</c> que no pertenece al artículo se rechaza
+    /// explícitamente (<c>ResolverIdLoteEfectivoAsync</c>) en vez de romper con la FK cruda de
+    /// <c>stock_lotes</c>.</summary>
+    [Fact]
+    public async Task UnDecomisoConIdLoteQueNoPerteneceAlArticuloEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoConIdLoteQueNoPerteneceAlArticuloEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-lote-ajeno", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var idOtroArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-otro", 10m);
+        var idLoteAjeno = await SembrarLoteAsync(ctx, idOtroArticulo, "L-AJENO-DECOMISO", VencimientoLejanoFuturo);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLoteAjeno, 5m, "Lote ajeno");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 11.5: stock_insuficiente_para_decomiso -------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "A decomiso that would go negative is refused" — back-
+    /// office tightening, mismo criterio asimétrico que una transferencia (nunca una venta).</summary>
+    [Fact]
+    public async Task UnDecomisoQueDejariaElLoteNegativoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoQueDejariaElLoteNegativoEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-insuficiente", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-INSUF", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 3m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 3m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Rotura mayor al saldo");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("stock_insuficiente_para_decomiso", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+
+        // El rollback deja TODO exactamente como estaba.
+        Assert.Equal(3m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+        Assert.Equal(3m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- task 11.8: decomiso de lote NO vencido permitido (decisión 9) --------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "Decomiso applies to a non-expired lot too" — decisión 9
+    /// del proposal: decomiso NO restringido a lotes vencidos, la merma real (rotura) entra en el
+    /// mismo cajón que la vencida.</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnLoteNoVencidoEsPermitido()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnLoteNoVencidoEsPermitido));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-no-vencido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-NO-VENCIDO-DECOMISO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Rotura, lote no vencido");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+    }
+
+    /// <summary>Contraparte del anterior con un lote VENCIDO — decomiso también se permite, mismo
+    /// resultado, probando que la fecha de vencimiento nunca entra en la decisión.</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnLoteVencidoTambienEsPermitido()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnLoteVencidoTambienEsPermitido));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-vencido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-VENCIDO-DECOMISO", VencimientoLejanoPasado);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Merma por vencimiento");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+    }
+
+    // ---- task 11.9: observaciones obligatoria ----------------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "Decomiso without observaciones is rejected".</summary>
+    [Fact]
+    public async Task UnDecomisoSinObservacionesEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoSinObservacionesEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-sin-obs", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-SIN-OBS", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("observaciones_requeridas", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+    }
+
+    // ---- task 11.4: mutation target — Vendedor-403 -----------------------------------------------
+
+    /// <summary>Mutation target (spec: "Vendedor is blocked from decomiso"; mutation-proof-tests):
+    /// el grupo <c>/api/stock</c> apila SOLO <c>OperacionDePos</c> — cualquier rol autenticado pasa
+    /// esa política. Es <c>Politicas.GestionDeCatalogo</c> apilada en <c>/decomiso</c>
+    /// (<c>StockEndpoints.cs</c>) quien bloquea al Vendedor.
+    ///
+    /// EVIDENCIA DE MUTACIÓN: borrado <c>.RequireAuthorization(Politicas.GestionDeCatalogo)</c> de
+    /// <c>/decomiso</c> en <c>StockEndpoints.cs</c> — build, filtro
+    /// <c>FullyQualifiedName~UnVendedorEsBloqueadoDelDecomiso</c>: este test <b>FALLÓ</b> (200 en
+    /// vez de 403 — el Vendedor pasa con solo <c>OperacionDePos</c> del grupo). Revertido el
+    /// mutante, corrida de nuevo: <b>GREEN</b>.</summary>
+    [Fact]
+    public async Task UnVendedorEsBloqueadoDelDecomiso()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsBloqueadoDelDecomiso));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-vendedor", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-VENDEDOR", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var vendedor = await CrearClienteVendedorAsync(ctx, "vendedor-decomiso");
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Intento de vendedor");
+        var respuesta = await vendedor.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+        Assert.Equal(20m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+    }
+}

--- a/tests/Ways.IntegrationTests/AjusteDecomisoLoteTests.cs
+++ b/tests/Ways.IntegrationTests/AjusteDecomisoLoteTests.cs
@@ -255,6 +255,38 @@ public class AjusteDecomisoLoteTests(WaysApiFixture fixture) : IClassFixture<Way
         Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
     }
 
+    // ---- judgment-day (juez B): el ajuste PUEDE dejar negativo, a diferencia del decomiso -------
+
+    /// <summary>spec stock: "no negativity refusal" para el ajuste (a diferencia del único rechazo
+    /// que conoce <c>DecomisarAsync</c>) — un ajuste que deja el lote Y el agregado NEGATIVOS se
+    /// acepta con 200 y el saldo negativo queda persistido exacto.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (juez B): agregado temporalmente un chequeo de negatividad a
+    /// <c>EjecutarAjusteAsync</c> (mismo <c>if (nuevaDelLote &lt; 0m) throw ...</c> que usa el
+    /// decomiso) — build, filtro
+    /// <c>FullyQualifiedName~UnAjusteQueDejaSaldoNegativoEsAceptado</c>: este test <b>FALLÓ</b>
+    /// (409 en vez de 200 — la rama muerta habría bloqueado la corrección de un saldo negativo).
+    /// Revertido el mutante, corrida de nuevo: <b>GREEN</b>.</summary>
+    [Fact]
+    public async Task UnAjusteQueDejaSaldoNegativoEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteQueDejaSaldoNegativoEsAceptado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-ajuste-negativo", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-AJUSTE-NEGATIVO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 3m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 3m);
+
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVenta, idArticulo, -5m, "Corrección a negativo", idLote);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var actual = JsonSerializer.Deserialize<StockActual>(cuerpo, OpcionesJson)!;
+        Assert.Equal(-2m, actual.Cantidad);
+        Assert.Equal(-2m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+        Assert.Equal(-2m, await LeerStockAsync(ctx, idArticulo));
+    }
+
     // ---- gap de cobertura (dto-contract-honesty): guard simétrico de lote_no_aplica ------------
 
     /// <summary>spec stock (guard simétrico del anterior): un <c>idLote</c> provisto sobre un
@@ -308,6 +340,64 @@ public class AjusteDecomisoLoteTests(WaysApiFixture fixture) : IClassFixture<Way
         Assert.Equal(idLote, movimiento.IdLote);
     }
 
+    // ---- judgment-day (juez B): cantidad inválida en decomiso ----------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: "the client MUST send a positive cantidad" —
+    /// <c>ExigirCantidadDeDecomisoValida</c> rechaza cero y negativo con <c>400
+    /// cantidad_de_ajuste_invalida</c>, antes de tocar la base.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (juez B): anulado el <c>if (cantidad &lt;= 0)</c> de
+    /// <c>ExigirCantidadDeDecomisoValida</c> — build, filtro
+    /// <c>FullyQualifiedName~UnDecomisoConCantidadCeroOatNegativaEsRechazado</c>: este test
+    /// <b>FALLÓ</b> (la cantidad cero/negativa del cliente pasaba sin chequeo). Revertido el
+    /// mutante, corrida de nuevo: <b>GREEN</b>.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public async Task UnDecomisoConCantidadCeroONegativaEsRechazado(decimal cantidad)
+    {
+        var ctx = await PrepararAsync($"{nameof(UnDecomisoConCantidadCeroONegativaEsRechazado)}-{cantidad}");
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-cant-invalida", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-CANT-INVALIDA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, cantidad, "Cantidad inválida");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("cantidad_de_ajuste_invalida", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+        Assert.Equal(20m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    /// <summary>spec lotes-y-vencimientos / ck_movimientos_stock_cantidad — misma disciplina de
+    /// precisión que <c>ExigirCantidadValida</c>: más de 3 decimales se rechaza con <c>400
+    /// cantidad_invalida</c>.</summary>
+    [Fact]
+    public async Task UnDecomisoConMasDeTresDecimalesEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoConMasDeTresDecimalesEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-4-decimales", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-4-DECIMALES", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5.1234m, "Cuatro decimales");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("cantidad_invalida", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+        Assert.Equal(20m, await LeerStockAsync(ctx, idArticulo));
+    }
+
     // ---- task 11.7: idLote requerido en decomiso -----------------------------------------------
 
     /// <summary>spec lotes-y-vencimientos: "A decomiso of a lot-effective articulo requires
@@ -352,6 +442,83 @@ public class AjusteDecomisoLoteTests(WaysApiFixture fixture) : IClassFixture<Way
         Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- judgment-day (juez B): decomiso de artículo SIN lote efectivo (rama else, código muerto
+    // para tests hasta esta ronda) -----------------------------------------------------------------
+
+    /// <summary>spec lotes-y-vencimientos: un artículo SIN lote efectivo también admite decomiso —
+    /// baja el agregado, el movimiento queda con <c>motivo = Decomiso</c> e <c>id_lote = null</c>.
+    ///
+    /// EVIDENCIA DE MUTACIÓN (juez B): forzado un <c>throw</c> incondicional en la rama
+    /// <c>else</c> de <c>EjecutarDecomisoAsync</c> (la que corre cuando <c>idLote is null</c>) —
+    /// build, filtro <c>FullyQualifiedName~UnDecomisoDeUnArticuloSinLoteEfectivoEsAceptado</c>:
+    /// este test <b>FALLÓ</b> (la rama era código muerto para la suite hasta ahora). Revertido el
+    /// mutante, corrida de nuevo: <b>GREEN</b>.</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnArticuloSinLoteEfectivoEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnArticuloSinLoteEfectivoEsAceptado));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-decomiso-sin-lote-ok", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, null, 5m, "Rotura, artículo sin lote");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        Assert.Equal(15m, await LeerStockAsync(ctx, idArticulo));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso);
+        Assert.Equal(-5m, movimiento.Cantidad);
+        Assert.Null(movimiento.IdLote);
+    }
+
+    /// <summary>Contraparte 409 de la anterior: mismo <c>stock_insuficiente_para_decomiso</c> que
+    /// el camino lote-efectivo, pero evaluado sobre el agregado (rama <c>else if (nuevaAgregada
+    /// &lt; 0m)</c> de <c>EjecutarDecomisoAsync</c>).</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnArticuloSinLoteEfectivoQueDejariaElAgregadoNegativoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnArticuloSinLoteEfectivoQueDejariaElAgregadoNegativoEsRechazado));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-decomiso-sin-lote-insuf", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 3m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, null, 5m, "Rotura mayor al saldo agregado");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("stock_insuficiente_para_decomiso", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso));
+        Assert.Equal(3m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    /// <summary>Hallazgo menor del juez B: guard simétrico de <c>lote_no_aplica</c> en decomiso —
+    /// mismo criterio que <c>UnAjusteDeUnArticuloSinLoteConIdLoteProvistoEsRechazado</c>, barato
+    /// porque <c>ResolverIdLoteEfectivoAsync</c> ya es compartido por ambos servicios.</summary>
+    [Fact]
+    public async Task UnDecomisoDeUnArticuloSinLoteConIdLoteProvistoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeUnArticuloSinLoteConIdLoteProvistoEsRechazado));
+        var idArticuloSinLote = await SembrarArticuloSinLoteAsync(ctx, "articulo-decomiso-sin-lote-idlote", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloSinLote, 20m);
+
+        var idArticuloConLote = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-ajeno-decomiso-idlote", 10m);
+        var idLoteAjeno = await SembrarLoteAsync(ctx, idArticuloConLote, "L-AJENO-DECOMISO-IDLOTE", VencimientoLejanoFuturo);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticuloSinLote, idLoteAjeno, 5m, "Idlote ajeno en decomiso");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_no_aplica", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticuloSinLote && m.Motivo == MotivoStock.Decomiso));
     }
 
     // ---- task 11.5: stock_insuficiente_para_decomiso -------------------------------------------


### PR DESCRIPTION
## Etapa 12 — Slice 11: Ajuste + Decomiso

- **\`POST /api/stock/decomiso\`** (GestionDeCatalogo apilada sobre OperacionDePos): motivo \`Decomiso\` de primera clase — la merma por vencimiento/rotura como número de resultado reportable (decisión 9), NO restringido a lotes vencidos. Cantidad POSITIVA del cliente negada server-side (disciplina ContarAsync); **nunca-negativo** por \`RETURNING\` (lote o agregado según el artículo) → \`409 stock_insuficiente_para_decomiso\`; observaciones obligatoria.
- **Ajuste lot-aware**: \`lote_requerido\`/\`lote_no_aplica\`/\`lote_invalido\` vía resolución compartida; agregado primero, lote después; **SIN rechazo de negatividad** — el ajuste es LA operación de corrección, y esa diferencia central con decomiso ahora tiene test propio con evidencia de mutación inversa.
- Enmienda de spec (juez A): el escenario multi-lote del spec de stock estaba mal atribuido al ajuste (request de un solo IdLote) — corregido a conteo (slice 12).

### Tests
AjusteDecomisoLote 18/18 (11 del apply + 7 del fix de gaps: rama agregada del decomiso, cantidad inválida ×3, ajuste-negativo-aceptado, lote_no_aplica) · regresiones AjusteDeStock 10/10, TransferenciaLote 15/15, TransferenciasYConteo 28/28. 9 rondas de evidencia de mutación con kills quirúrgicos (1/18, 2/18, 2/18 sin colaterales).

### Judgment-day
Juez B: APPROVE r1 con 3 gaps confirmados por mutación sobreviviente (la rama sin-lote del decomiso era código muerto para los tests) → cerrados en d36554a → APPROVE r2. Juez A: APPROVE con 3 MINORs (mensaje de observaciones pre-existente desde la etapa 5 — ticket de seguimiento; spec enmendado; reuso de códigos documentado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)