### PR TITLE
feat(lotes): conteo por lote con split adquisición/aplicación — etapa 12, slice 12

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/specs/conteo-de-inventario/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/conteo-de-inventario/spec.md
@@ -163,9 +163,10 @@ per-lot path, not a missing-feature fallback.)
   endpoint DOES support the per-lot contract
 - WHEN a conteo request for articulo 40 supplies a single aggregate
   `cantidad_contada = 50` (no `lotes`)
-- THEN it is rejected with `400 conteo_requiere_lotes` before reaching the
-  database, no `movimientos_stock` row is written, and `stock.cantidad`
-  stays `40`
+- THEN it is rejected with `400 conteo_requiere_lotes` before any lock is
+  acquired (the guard runs after the read-only articulo/parametro
+  resolution SELECTs but before any row lock or write), no
+  `movimientos_stock` row is written, and `stock.cantidad` stays `40`
 
 #### Scenario: A per-lot conteo of an articulo WITHOUT lot-effective control is refused
 (Amended at slice-12 judgment-day, juez B FIX 1 — inverse symmetry: a
@@ -175,5 +176,7 @@ lot-effective, same criterion as `lote_no_aplica` in
 - GIVEN articulo 41 is NOT lot-effective
 - WHEN a conteo request for articulo 41 supplies a `lotes` breakdown (no
   `cantidad_contada`)
-- THEN it is rejected with `400 conteo_no_aplica_lotes` before reaching the
-  database, and no `movimientos_stock` row is written
+- THEN it is rejected with `400 conteo_no_aplica_lotes` before any lock is
+  acquired, and no `movimientos_stock` row is written *(wording aligned at
+  judge-A round: the guard follows the read-only resolution SELECTs, unlike
+  the truly zero-DB exactly-one-of check)*

--- a/openspec/changes/stage-12-lotes-vencimientos/specs/conteo-de-inventario/spec.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/specs/conteo-de-inventario/spec.md
@@ -146,3 +146,34 @@ refusal is strictly better than a silent divergence between `stock` and
   `cantidad_contada`
 - THEN it is rejected with `409 conteo_lote_no_soportado`, and no
   `movimientos_stock` row is written
+
+#### Scenario: An aggregate-only conteo of a lot-effective articulo is refused when per-lot conteo IS shipped
+(Amended at slice-12 judgment-day, juez B FIX 1: the per-lot conteo path is
+complete in this delivery slice, so the `409 conteo_lote_no_soportado`
+degradation above never fires — but nothing had guarded the aggregate-only
+path against a lot-effective articulo once per-lot support existed. Silently
+accepting it would move `stock.cantidad` without ever touching
+`stock_lotes`, breaking the third invariant — `SUM(stock_lotes.cantidad) =
+stock.cantidad` — without any error surfaced. The honest refusal here is
+`400 conteo_requiere_lotes`, distinct from the pre-approved `409`
+degradation: this is a well-formed request against a fully-implemented
+per-lot path, not a missing-feature fallback.)
+- GIVEN articulo 40 is lot-effective (`stock.cantidad = 40`,
+  `stock_lotes` sums to `40` across its lots) and the deployed conteo
+  endpoint DOES support the per-lot contract
+- WHEN a conteo request for articulo 40 supplies a single aggregate
+  `cantidad_contada = 50` (no `lotes`)
+- THEN it is rejected with `400 conteo_requiere_lotes` before reaching the
+  database, no `movimientos_stock` row is written, and `stock.cantidad`
+  stays `40`
+
+#### Scenario: A per-lot conteo of an articulo WITHOUT lot-effective control is refused
+(Amended at slice-12 judgment-day, juez B FIX 1 — inverse symmetry: a
+`lotes` breakdown has no destination for an articulo that is not
+lot-effective, same criterion as `lote_no_aplica` in
+`ServicioDeStock.ResolverIdLoteEfectivoAsync`.)
+- GIVEN articulo 41 is NOT lot-effective
+- WHEN a conteo request for articulo 41 supplies a `lotes` breakdown (no
+  `cantidad_contada`)
+- THEN it is rejected with `400 conteo_no_aplica_lotes` before reaching the
+  database, and no `movimientos_stock` row is written

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1746,10 +1746,21 @@ across all eight motivos. **Rollback**: revert the branch.
 > tras el commit.
 
 - [x] 12.14 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN
-  NOTE: ronda 1, juez B, 2 gaps confirmados y corregidos — ver nota arriba.
-  Re-judge de la ronda 2 queda a cargo del orquestador.)*
-- [ ] 12.15 Branch `feat/stage12-slice12-conteo` off `main` (parent:
-  slice 11); PR; merge stacked-to-main. *(Orchestrator scope.)*
+  NOTE: judge B round 1 REJECT with a genuine BLOCKER — aggregate `Contada`
+  against a lot-effective articulo returned 200 and silently broke
+  invariant 3 (stock 40→50, stock_lotes stayed 40), the exact divergence
+  decision 11 exists to prevent; the original 12.11 test HID it by seeding
+  lot-effective with a zero delta. Plus the raw-500 on an unknown conteo
+  idLote. Fix 7b88759: ExigirFormaDeConteoCoincideConControlDeLote (400
+  conteo_requiere_lotes / 400 conteo_no_aplica_lotes, spec amended) +
+  SELECT-first lote validation (400 lote_invalido) + the 12.11 test
+  corrected. Judge B round 2 APPROVE (empirical re-probe: 400 and invariant
+  intact). Judge A APPROVE with 2 MINORs: spec wording "before reaching the
+  database" tightened to "before any lock" in this branch; recorded debt —
+  the per-lot path lacks the aggregate path's defense-in-depth
+  final!=contada loud check (consistency suggestion, very low risk).)*
+- [x] 12.15 Branch `feat/stage12-slice12-conteo` off `main` (parent:
+  slice 11); PR; merge stacked-to-main.
 
 **Test plan**: acquisition order (12.5), zero-diff per lot (12.6),
 exactly-one-of ×2 (12.7), aggregate-from-per-lot (12.8), no-fabrication

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1578,45 +1578,74 @@ counts per lot, acquiring every lock before deriving any delta; the
 cross-cutting stock/stock_lotes invariants are now provable end to end
 across all eight motivos. **Rollback**: revert the branch.
 
-- [ ] 12.1 Modify `src/Ways.Application/Stock/Contratos.cs`:
+- [x] 12.1 Modify `src/Ways.Application/Stock/Contratos.cs`:
   `SolicitudDeConteo.Contada` widens to `decimal?`; add `Lotes:
   IReadOnlyList<ConteoDeLote>?`; `ConteoDeLote(IdLote, Contada)`;
-  `ResultadoConteo.Lotes: IReadOnlyList<LoteContado>`.
-- [ ] 12.2 Modify `ServicioDeStock.cs`: `ContarAsync` — exactly-one-of
+  `ResultadoConteo.Lotes: IReadOnlyList<LoteContado>`. *(APPLY-RUN NOTE:
+  both `SolicitudDeConteo.Lotes` and `ResultadoConteo.Lotes` carry a
+  `= null` default to stay source-compatible with every positional caller
+  already in the repo — matches decision 18's "source-compatible for every
+  existing caller".)*
+- [x] 12.2 Modify `ServicioDeStock.cs`: `ContarAsync` — exactly-one-of
   validation (`400 conteo_contada_y_lotes` if both or neither present);
   `conteo_lote_repetido` refusal on a duplicated `idLote` before any lock.
-- [ ] 12.3 Modify `ServicioDeStock.cs`: per-lot conteo, decision 12's
+  *(APPLY-RUN NOTE: an empty `Lotes` array (`[]`) is treated the same as
+  absent — `ExigirExactamenteUnaFormaDeConteo` checks `Count: > 0`, per
+  dto-contract-honesty "a field with no actionable value is absent".)*
+- [x] 12.3 Modify `ServicioDeStock.cs`: per-lot conteo, decision 12's
   split — **acquisition phase**: `BloquearYCrearSiFaltaStockAsync`
   (aggregate first), then each lot's `BloquearYCrearSiFaltaStockLoteAsync`
   ascending `id_lote`, no delta written yet; **application phase**: derive
   every delta, write `movimientos_stock` (`motivo = inventario`) + upsert
   `stock_lotes` per lot with a non-zero delta, aggregate accumulates the
-  sum.
-- [ ] 12.4 Note: proposal decision 11's pre-approved degradation (`409
+  sum. *(APPLY-RUN NOTE: `BloquearYCrearSiFaltaStockLoteAsync` is new —
+  same no-op `SET cantidad = stock_lotes.cantidad ... RETURNING` shape as
+  `BloquearYCrearSiFaltaStockAsync`, one more key. `EjecutarConteoPorLoteAsync`
+  mirrors `EjecutarConteoAsync`'s transaction/connection setup.)*
+- [x] 12.4 Note: proposal decision 11's pre-approved degradation (`409
   conteo_lote_no_soportado`) exists for a delivery slice that ships an
   aggregate-only conteo without per-lot support. This slice ships per-lot
   conteo in full, so the refusal path is documented but not the primary
   behavior — keep the `409` branch reachable only if a future regression
-  removes per-lot support.
-- [ ] 12.5 [P] Lock-acquisition-order test: every lock (aggregate no-op
+  removes per-lot support. *(APPLY-RUN NOTE: no `409 conteo_lote_no_soportado`
+  code was written — an unreachable branch with zero test coverage would be
+  dead code, not a documented fallback. Doc-comment on `ContarAsync` records
+  the decision instead.)*
+- [x] 12.5 [P] Lock-acquisition-order test: every lock (aggregate no-op
   upsert, then each lot's no-op upsert ascending) is acquired before any
   delta write. *(design decision 12, proves the acquisition/application
   split)*
-- [ ] 12.6 [P] Zero-difference-lot-writes-nothing test. *(spec
+- [x] 12.6 [P] Zero-difference-lot-writes-nothing test. *(spec
   conteo-de-inventario: "A lot with no difference writes no row even when
-  a sibling lot differs")*
-- [ ] 12.7 [P] `conteo_contada_y_lotes` tests. *(spec: "Supplying both
+  a sibling lot differs")* *(APPLY-RUN NOTE:
+  `ConteoPorLoteTests.UnLoteSinDiferenciaNoEscribeFilaAunqueUnLoteHermanoDifiera`.)*
+- [x] 12.7 [P] `conteo_contada_y_lotes` tests. *(spec: "Supplying both
   cantidad_contada and lotes is rejected", "Supplying neither
-  cantidad_contada nor lotes is rejected")*
-- [ ] 12.8 [P] Per-lot-derives-aggregate-delta test. *(spec: "A
+  cantidad_contada nor lotes is rejected")* *(APPLY-RUN NOTE: three tests,
+  not two —
+  `UnConteoConCantidadContadaYLotesEsRechazado`,
+  `UnConteoSinCantidadContadaNiLotesEsRechazado`, plus
+  `UnConteoConListaDeLotesVaciaEsRechazadoComoSiEstuvieraAusente` (an empty
+  `Lotes: []` array counts as "absent", dto-contract-honesty).)*
+- [x] 12.8 [P] Per-lot-derives-aggregate-delta test. *(spec: "A
   lot-effective conteo derives the aggregate delta from per-lot deltas")*
-- [ ] 12.9 [P] Never-fabricate-into-sin-identificar test. *(spec: "A
+  *(APPLY-RUN NOTE:
+  `ConteoPorLoteTests.UnConteoLoteEfectivoDerivaElDeltaAgregadoDeLosDeltasPorLote`
+  — literal spec scenario numbers, L1 12→15/+3, L2 28→20/-8, agregado -5.)*
+- [x] 12.9 [P] Never-fabricate-into-sin-identificar test. *(spec: "A
   lot-effective conteo never writes into the sin-identificar lot to absorb
-  a difference")*
-- [ ] 12.10 [P] `conteo_lote_repetido` test.
-- [ ] 12.11 [P] Aggregate-grain regression: a matching count still writes
-  nothing. *(spec: "A matching count writes nothing")*
-- [ ] 12.12 [P] **Cross-cutting invariant suite** (now provable with all
+  a difference")* *(APPLY-RUN NOTE:
+  `ConteoPorLoteTests.UnConteoLoteEfectivoNuncaEscribeEnElLoteSinIdentificarParaAbsorberUnaDiferencia`
+  — seeds the sin-identificar lot at saldo 0 and asserts it stays exactly
+  0 after a differing per-lot count on a sibling lot.)*
+- [x] 12.10 [P] `conteo_lote_repetido` test. *(APPLY-RUN NOTE:
+  `ConteoPorLoteTests.UnConteoConUnIdLoteRepetidoEsRechazado`.)*
+- [x] 12.11 [P] Aggregate-grain regression: a matching count still writes
+  nothing. *(spec: "A matching count writes nothing")* *(APPLY-RUN NOTE:
+  `ConteoPorLoteTests.UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada`
+  — proves the pre-slice-12 aggregate (`Contada`) path is byte-identical
+  after the `decimal?`/exactly-one-of widening.)*
+- [x] 12.12 [P] **Cross-cutting invariant suite** (now provable with all
   eight motivos live), one long-form test per invariant asserting **every**
   row, not just totals: (1) `stock.cantidad = SUM(movimientos)` after a
   sequence covering all eight motivos including a `reclasificacion` pair
@@ -1625,11 +1654,36 @@ across all eight motivos. **Rollback**: revert the branch.
   compra→venta→transferencia→NCX→anulación→conteo→decomiso *(spec
   lotes-y-vencimientos: Stock Lotes Balance And Its Two Invariants)*; (3)
   `SUM(stock_lotes) = stock.cantidad` for a reconciled lot-effective pair.
-- [ ] 12.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes.
-- [ ] 12.14 Run `judgment-day`; fix; re-judge until clean.
+  *(APPLY-RUN NOTE: `InvarianteStockYStockLotesTests.cs`, three tests,
+  invariant asserted after EACH step of the sequence (not only at the
+  end), same discipline as `SaldoLedgerInvarianteTests` from stage 7: (1)
+  `LaCantidadDeStockEsLaSumaDeSusMovimientosTrasUnaSecuenciaConLosOchoMotivos`
+  — non-lot articulo through ajuste→compra→venta→transferencia→NCX→
+  anulación→conteo→decomiso, THEN flips `controla_lote` and runs
+  reconciliation to add the `reclasificacion` pair, asserting the
+  aggregate invariant unmoved (decision 14: `stock` never touched by
+  reconciliation) and that all eight `MotivoStock` values are present on
+  the ledger; (2)
+  `StockLotesCantidadEsLaSumaDeSusMovimientosConEseLoteTrasLaCadenaCompraVentaTransferenciaNcxAnulacionConteoDecomiso`
+  — a single lot traced through the exact 7-step chain named by this task,
+  asserted after each step at the origin PV (plus a bonus assertion at the
+  destination PV after the transfer); (3)
+  `LaSumaDeStockLotesIgualaElAgregadoParaUnParLoteEfectivoReconciliado` —
+  pre-existing stock reconciled into the sin-identificar lot, then a
+  dated-lot compra confirmed on top (proves the invariant holds under a
+  MIX of lots, not only the trivial single-lot case), then a second
+  reconciliation run (idempotence) re-checked. All 3 green against real
+  Postgres.)*
+- [x] 12.13 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes. *(Verified via `--project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` — "No changes have been made
+  to the model since the last migration." No `Migraciones/`/`Configuraciones/`
+  file touched by this slice, per the DB CHANGE GATE — `Contratos.cs`/
+  `ServicioDeStock.cs` are Application-layer, no EF model surface.)*
+- [ ] 12.14 Run `judgment-day`; fix; re-judge until clean. *(Orchestrator
+  scope — not run by this apply batch per the launch contract.)*
 - [ ] 12.15 Branch `feat/stage12-slice12-conteo` off `main` (parent:
-  slice 11); PR; merge stacked-to-main.
+  slice 11); PR; merge stacked-to-main. *(Orchestrator scope.)*
 
 **Test plan**: acquisition order (12.5), zero-diff per lot (12.6),
 exactly-one-of ×2 (12.7), aggregate-from-per-lot (12.8), no-fabrication

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1680,8 +1680,74 @@ across all eight motivos. **Rollback**: revert the branch.
   to the model since the last migration." No `Migraciones/`/`Configuraciones/`
   file touched by this slice, per the DB CHANGE GATE — `Contratos.cs`/
   `ServicioDeStock.cs` are Application-layer, no EF model surface.)*
-- [ ] 12.14 Run `judgment-day`; fix; re-judge until clean. *(Orchestrator
-  scope — not run by this apply batch per the launch contract.)*
+> **JUDGMENT-DAY FIX NOTE (12.14, ronda 1, juez B)**: 2 gaps confirmados —
+> uno BLOCKER de correctitud, uno secundario:
+>
+> 1. (BLOCKER) `ContarAsync`/`EjecutarConteoAsync` no chequeaba
+>    `ReglaDeLotes.ControlEfectivo` antes de aceptar una `Contada` agregada:
+>    un POST con solo `Contada` para un artículo lote-efectivo devolvía 200,
+>    movía `stock.cantidad` y dejaba `stock_lotes` intacto — invariante 3
+>    roto en silencio (probado empíricamente: 40→50 agregado, lotes quedan
+>    en 40). El `409 conteo_lote_no_soportado` de la task 12.4 es la
+>    degradación pre-aprobada para "el per-lot conteo no está implementado"
+>    — no cubre este caso, donde SÍ está implementado. Fix:
+>    `ExigirFormaDeConteoCoincideConControlDeLote`, guard en `ContarAsync`
+>    ANTES de cualquier lock — `400 conteo_requiere_lotes` (código nuevo,
+>    honesto, distinto del `409` de la degradación) para `Contada` contra
+>    un artículo lote-efectivo; simetría inversa `400 conteo_no_aplica_lotes`
+>    para `Lotes` contra un artículo SIN lote efectivo (¿ya existía? no —
+>    mismo tratamiento que `lote_no_aplica` de `ResolverIdLoteEfectivoAsync`).
+>    Spec `conteo-de-inventario` ENMENDADO (dos escenarios nuevos bajo
+>    "Conteo Of A Lot-Effective Articulo...", marcados "Amended at slice-12
+>    judgment-day"). Tests nuevos en `ConteoPorLoteTests.cs`:
+>    `UnConteoAgregadoParaUnArticuloLoteEfectivoEsRechazado` (delta NO cero
+>    a propósito — expone la escritura real si el guard fallara; la 12.11
+>    original probaba delta CERO, que nunca llega a escribir nada
+>    independientemente de la forma del conteo, escondiendo el gap) y
+>    `UnConteoPorLoteParaUnArticuloSinLoteEfectivoEsRechazado`. La 12.11
+>    original (`UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada`)
+>    usaba (incorrectamente) `SembrarArticuloLoteEfectivoAsync` para un
+>    escenario que su propio doc-comment describía como "sin control de
+>    lote efectivo" — corregida a un nuevo helper
+>    `SembrarArticuloSinLoteAsync` (`ControlaLote = false`), ahora
+>    consistente con su propio contrato. Evidencia de mutación: guard
+>    anulado (`if (false && ...)`) → `UnConteoAgregadoParaUnArticuloLoteEfectivoEsRechazado`
+>    **FALLÓ** (200 real vs. 400 esperado); revertido, **GREEN**.
+> 2. (secundario) `ExigirLotesDeConteoValidos` no validaba existencia/
+>    pertenencia del `idLote` del desglose por lote — un `idLote` inexistente
+>    solo se descubría dentro de la FK cruda del upsert no-op de
+>    `BloquearYCrearSiFaltaStockLoteAsync`, un 500 crudo. Fix:
+>    `ExigirLotesDeConteoExistenAsync`, SELECT-first contra
+>    `ServicioDeLotes.LeerSaldosAsync` (mismo criterio que
+>    `ResolverIdLoteEfectivoAsync`), ANTES de la transacción → `400
+>    lote_invalido`. Test nuevo: `UnConteoPorLoteConUnIdLoteInexistenteEsRechazado`.
+>    Evidencia de mutación: validación anulada (`if (false && ...)`) → el
+>    test **FALLÓ** empíricamente con `500 InternalServerError` /
+>    `SqlState 23503`, `fk_stock_lotes_lote` — exactamente el crudo que el
+>    fix previene; revertido, **GREEN**.
+>
+> Nota adicional sin código (hallazgo 2(e) del juez B): el orden ascendente
+> de adquisición del conteo por lote está under-tested para el orden
+> cross-request concurrente entre dos conteos simultáneos del mismo par —
+> mismo convoy-masking ya documentado en el slice 10 (una única transacción
+> observada a la vez basta para probar el orden intra-request; el orden
+> cross-request queda como convención probada por diseño, no por prueba
+> directa, mismo criterio aceptado en slices previos).
+>
+> El gap sistémico de `ManejadorDeErrores` con excepciones ADO crudas (no
+> `DbUpdateException`) — el mismo mecanismo detrás del hallazgo 2 de arriba
+> — es repo-wide, no específico de este slice: se registra como follow-up
+> del orquestador (chip ya spawneado), no se resuelve acá.
+>
+> Filtro `~ConteoPorLoteTests`: 12/12 (9 + 3 nuevos). Filtro
+> `~InvarianteStockYStockLotesTests`: 3/3. Regresión combinada
+> `~AjusteDeStockTests|~AjusteDecomisoLoteTests|~TransferenciaLoteTests|~TransferenciasYConteoDeInventarioTests`:
+> 71/71. `has-pending-model-changes`: sin cambios pendientes. Árbol limpio
+> tras el commit.
+
+- [x] 12.14 Run `judgment-day`; fix; re-judge until clean. *(APPLY-RUN
+  NOTE: ronda 1, juez B, 2 gaps confirmados y corregidos — ver nota arriba.
+  Re-judge de la ronda 2 queda a cargo del orquestador.)*
 - [ ] 12.15 Branch `feat/stage12-slice12-conteo` off `main` (parent:
   slice 11); PR; merge stacked-to-main. *(Orchestrator scope.)*
 

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -62,8 +62,27 @@ public sealed record LineaTransferida(int IdArticulo, int? IdLote, decimal Canti
 /// design: API Surface; Interfaces/Contracts; decisión 10). <see cref="Contada"/> es el TOTAL
 /// físicamente contado — nunca un delta (spec: conteo-de-inventario / Conteo Input Is The Counted
 /// Total, Never A Delta): el servidor deriva el ajuste bajo el lock de la fila de <c>stock</c>.
+///
+/// Etapa 12, slice 12 (design decisión 18, dto-contract-honesty): <see cref="Contada"/> se ensancha
+/// a <c>decimal?</c> — el contrato pasa a EXACTLY-ONE-OF <see cref="Contada"/> / <see cref="Lotes"/>
+/// (<c>400 conteo_contada_y_lotes</c> si vienen ambos o ninguno). Un artículo lote-efectivo cuenta
+/// por lote (<see cref="Lotes"/>, un total contado por cada <c>idLote</c>); uno sin lote efectivo
+/// sigue mandando el total agregado (<see cref="Contada"/>). El ensanchamiento es
+/// source-compatible: todo caller previo que pasaba un <c>decimal</c> posicional sigue compilando
+/// (conversión implícita a <c>decimal?</c>), y <see cref="Lotes"/> con su default <c>null</c> no
+/// rompe ninguna llamada existente.
 /// </summary>
-public sealed record SolicitudDeConteo(int IdPuntoVenta, int IdArticulo, decimal Contada, string Observaciones);
+public sealed record SolicitudDeConteo(
+    int IdPuntoVenta, int IdArticulo, decimal? Contada, string Observaciones,
+    IReadOnlyList<ConteoDeLote>? Lotes = null);
+
+/// <summary>
+/// Una línea del desglose por lote de un conteo (etapa 12, slice 12, design decisión 12/18).
+/// <see cref="Contada"/> es el total físicamente contado de ESE lote — nunca un delta, misma
+/// disciplina que <see cref="SolicitudDeConteo.Contada"/> un nivel arriba: el servidor deriva
+/// <c>delta = Contada − stock_lotes.cantidad</c> bajo el row lock propio del lote.
+/// </summary>
+public sealed record ConteoDeLote(int IdLote, decimal Contada);
 
 /// <summary>
 /// Resultado de <c>POST /api/stock/conteos</c> (stage-8, judgment-day fix: la respuesta anterior
@@ -73,9 +92,24 @@ public sealed record SolicitudDeConteo(int IdPuntoVenta, int IdArticulo, decimal
 /// cualquiera de las dos direcciones. Este contrato lleva la verdad tal como el servidor la
 /// escribió, bajo el mismo lock de fila que calculó <see cref="Delta"/>: nunca hace falta que el
 /// cliente adivine.
+///
+/// Etapa 12, slice 12: <see cref="Lotes"/> lleva el resultado por lote cuando el conteo llegó vía
+/// <see cref="SolicitudDeConteo.Lotes"/> — <c>null</c> para un conteo agregado (misma disciplina de
+/// "un campo sin destino no existe" que <see cref="SolicitudDeConteo"/>). <see cref="Cantidad"/>/
+/// <see cref="CantidadAnterior"/>/<see cref="Delta"/> siguen siendo el AGREGADO (la suma de los
+/// deltas por lote cuando <see cref="Lotes"/> está presente, design decisión 12) — el caller nunca
+/// necesita sumar a mano.
 /// </summary>
 public sealed record ResultadoConteo(
-    int IdPuntoVenta, int IdArticulo, decimal Cantidad, decimal CantidadAnterior, decimal Delta, bool MovimientoRegistrado);
+    int IdPuntoVenta, int IdArticulo, decimal Cantidad, decimal CantidadAnterior, decimal Delta, bool MovimientoRegistrado,
+    IReadOnlyList<LoteContado>? Lotes = null);
+
+/// <summary>Resultado por lote de un conteo (etapa 12, slice 12) — mismo shape que
+/// <see cref="ResultadoConteo"/> un nivel abajo, una fila por cada <see cref="ConteoDeLote"/> del
+/// request, incluidos los lotes sin diferencia (<see cref="MovimientoRegistrado"/> en <c>false</c>,
+/// spec: "A lot with no difference writes no row").</summary>
+public sealed record LoteContado(
+    int IdLote, decimal Cantidad, decimal CantidadAnterior, decimal Delta, bool MovimientoRegistrado);
 
 /// <summary>
 /// Cuerpo de <c>POST /api/stock/lotes</c> (stage-12-lotes-vencimientos, Slice 3; design: API

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -558,7 +558,17 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
     /// proposal (decisión 11 — <c>409 conteo_lote_no_soportado</c>) NO se implementa en este
     /// slice: el conteo por lote se entrega completo, así que esa rama queda documentada acá pero
     /// deliberadamente sin código muerto (design: "keep the 409 branch reachable only if a future
-    /// regression removes per-lot support" — no aplica hoy).</summary>
+    /// regression removes per-lot support" — no aplica hoy).
+    ///
+    /// Etapa 12, slice 12, judgment-day fix (juez B, FIX 1): el <c>409 conteo_lote_no_soportado</c>
+    /// de arriba cubre "el per-lot conteo no está implementado" — no cubre "está implementado pero
+    /// el cliente igual mandó un total agregado para un artículo lote-efectivo". Ese segundo caso
+    /// se rechaza acá, ANTES de cualquier lock, con el código honesto <c>400
+    /// conteo_requiere_lotes</c> — aceptar el total agregado hubiera movido <c>stock.cantidad</c>
+    /// sin tocar <c>stock_lotes</c>, rompiendo el invariante 3 en silencio. Simetría inversa:
+    /// <see cref="SolicitudDeConteo.Lotes"/> para un artículo SIN lote efectivo no tiene destino
+    /// (<c>400 conteo_no_aplica_lotes</c>), mismo criterio que <c>lote_no_aplica</c> en
+    /// <see cref="ResolverIdLoteEfectivoAsync"/>. (Amended at slice-12 judgment-day.)</summary>
     public async Task<ResultadoConteo> ContarAsync(SolicitudDeConteo solicitud, CancellationToken ct = default)
     {
         var idTenant = ExigirTenantDeLaSesion();
@@ -568,14 +578,25 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         ExigirExactamenteUnaFormaDeConteo(solicitud.Contada, solicitud.Lotes);
         var observaciones = ExigirObservaciones(solicitud.Observaciones);
 
-        await ResolverArticuloAsync(solicitud.IdArticulo, ct);
-        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var articulo = await ResolverArticuloAsync(solicitud.IdArticulo, ct);
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var lotesHabilitado = await ResolverLotesHabilitadoAsync(puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+        var esLoteEfectivo = ReglaDeLotes.ControlEfectivo(articulo.ControlaLote, lotesHabilitado);
+        ExigirFormaDeConteoCoincideConControlDeLote(esLoteEfectivo, solicitud.Contada, solicitud.Lotes, solicitud.IdArticulo);
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
 
         if (solicitud.Lotes is { Count: > 0 } lotes)
         {
             var lotesValidados = ExigirLotesDeConteoValidos(lotes);
+
+            // Etapa 12, slice 12, judgment-day fix (juez B, FIX 2): SELECT-first estilo
+            // ResolverIdLoteEfectivoAsync — nunca dejar que la FK real de stock_lotes/lotes
+            // rechace un id_lote inexistente/ajeno con un 500 crudo dentro del upsert no-op de
+            // BloquearYCrearSiFaltaStockLoteAsync.
+            await ExigirLotesDeConteoExistenAsync(solicitud.IdPuntoVenta, solicitud.IdArticulo, lotesValidados, ct);
+
             return await estrategia.ExecuteAsync(async () =>
                 await EjecutarConteoPorLoteAsync(
                     idTenant, idEmpleado, solicitud.IdPuntoVenta, solicitud.IdArticulo, lotesValidados, observaciones,
@@ -1016,6 +1037,60 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
                 "conteo_contada_y_lotes",
                 "El conteo tiene que traer exactamente uno de cantidad contada o desglose por lote, nunca ambos ni ninguno.",
                 400);
+        }
+    }
+
+    /// <summary>Etapa 12, slice 12, judgment-day fix (juez B, FIX 1): la forma del conteo tiene
+    /// que coincidir con el control efectivo de lote del artículo — chequeado ANTES de cualquier
+    /// lock, mismo criterio "en memoria primero" que <see cref="ExigirLineasDeTransferenciaValidas"/>.
+    /// Un artículo lote-efectivo no admite <c>Contada</c> agregada (rompería el invariante 3 en
+    /// silencio); uno SIN lote efectivo no admite <c>Lotes</c> (no tiene destino, mismo criterio
+    /// que <c>lote_no_aplica</c> en <see cref="ResolverIdLoteEfectivoAsync"/>). El <c>409
+    /// conteo_lote_no_soportado</c> documentado en <see cref="ContarAsync"/> es la degradación
+    /// pre-aprobada para "el per-lot conteo no está implementado" — no aplica acá, donde SÍ está
+    /// implementado; el rechazo honesto de un total agregado contra un artículo lote-efectivo es
+    /// <c>400 conteo_requiere_lotes</c>.</summary>
+    private static void ExigirFormaDeConteoCoincideConControlDeLote(
+        bool esLoteEfectivo, decimal? contada, IReadOnlyList<ConteoDeLote>? lotes, int idArticulo)
+    {
+        if (esLoteEfectivo && contada is not null)
+        {
+            throw new ErrorDominio(
+                "conteo_requiere_lotes",
+                $"El artículo {idArticulo} es lote-efectivo; el conteo requiere desglose por lote, no un total agregado.",
+                400);
+        }
+
+        if (!esLoteEfectivo && lotes is { Count: > 0 })
+        {
+            throw new ErrorDominio(
+                "conteo_no_aplica_lotes",
+                $"El artículo {idArticulo} no tiene lote efectivo; el conteo no admite desglose por lote.",
+                400);
+        }
+    }
+
+    /// <summary>Etapa 12, slice 12, judgment-day fix (juez B, FIX 2): SELECT-first contra
+    /// <see cref="ServicioDeLotes.LeerSaldosAsync"/> — mismo criterio que
+    /// <see cref="ResolverIdLoteEfectivoAsync"/>, ANTES de la transacción. Sin esto, un
+    /// <c>idLote</c> inexistente/ajeno solo se descubre dentro de la FK cruda del upsert no-op de
+    /// <see cref="BloquearYCrearSiFaltaStockLoteAsync"/> — un 500, nunca un 400.</summary>
+    private async Task ExigirLotesDeConteoExistenAsync(
+        int idPuntoVenta, int idArticulo, IReadOnlyList<ConteoDeLote> lotes, CancellationToken ct)
+    {
+        var idsLotePedidos = lotes.Select(l => l.IdLote).Distinct().ToList();
+        var saldos = await servicioDeLotes.LeerSaldosAsync(idPuntoVenta, [idArticulo], idsLotePedidos, ct);
+        var idsLoteValidos = saldos.Select(s => s.IdLote).ToHashSet();
+
+        foreach (var idLote in idsLotePedidos)
+        {
+            if (!idsLoteValidos.Contains(idLote))
+            {
+                throw new ErrorDominio(
+                    "lote_invalido",
+                    $"El lote {idLote} no existe, no pertenece al artículo {idArticulo} o fue eliminado.",
+                    400);
+            }
         }
     }
 

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -549,20 +549,40 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
     /// <summary>Design decisión 10: el cliente manda el TOTAL contado, nunca un delta. El delta
     /// se deriva del lado del servidor bajo el mismo lock de fila que <c>AjustarAsync</c> usa
     /// (el upsert no-op de <see cref="BloquearYCrearSiFaltaStockAsync"/>), así que un conteo
-    /// nunca puede pisar una venta que corrió entre el conteo físico y el submit.</summary>
+    /// nunca puede pisar una venta que corrió entre el conteo físico y el submit.
+    ///
+    /// Etapa 12, slice 12 (design decisión 18 — exactly-one-of; decisión 12 — conteo por lote):
+    /// <see cref="SolicitudDeConteo.Contada"/>/<see cref="SolicitudDeConteo.Lotes"/> son mutuamente
+    /// excluyentes, validado ANTES de resolver referencias (<c>400 conteo_contada_y_lotes</c>, ni
+    /// siquiera un SELECT si el request está mal formado). La degradación pre-aprobada del
+    /// proposal (decisión 11 — <c>409 conteo_lote_no_soportado</c>) NO se implementa en este
+    /// slice: el conteo por lote se entrega completo, así que esa rama queda documentada acá pero
+    /// deliberadamente sin código muerto (design: "keep the 409 branch reachable only if a future
+    /// regression removes per-lot support" — no aplica hoy).</summary>
     public async Task<ResultadoConteo> ContarAsync(SolicitudDeConteo solicitud, CancellationToken ct = default)
     {
         var idTenant = ExigirTenantDeLaSesion();
         var idEmpleado = contexto.UsuarioId;
         var momento = reloj.Ahora;
 
-        var contada = ExigirContadaValida(solicitud.Contada);
+        ExigirExactamenteUnaFormaDeConteo(solicitud.Contada, solicitud.Lotes);
         var observaciones = ExigirObservaciones(solicitud.Observaciones);
 
         await ResolverArticuloAsync(solicitud.IdArticulo, ct);
         await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
 
         var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+
+        if (solicitud.Lotes is { Count: > 0 } lotes)
+        {
+            var lotesValidados = ExigirLotesDeConteoValidos(lotes);
+            return await estrategia.ExecuteAsync(async () =>
+                await EjecutarConteoPorLoteAsync(
+                    idTenant, idEmpleado, solicitud.IdPuntoVenta, solicitud.IdArticulo, lotesValidados, observaciones,
+                    momento, ct));
+        }
+
+        var contada = ExigirContadaValida(solicitud.Contada!.Value);
         return await estrategia.ExecuteAsync(async () =>
             await EjecutarConteoAsync(idTenant, idEmpleado, solicitud.IdPuntoVenta, solicitud.IdArticulo, contada, observaciones, momento, ct));
     }
@@ -607,6 +627,79 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         return new ResultadoConteo(idPuntoVenta, idArticulo, final, actual, delta, MovimientoRegistrado: delta != 0m);
     }
 
+    /// <summary>Etapa 12, slice 12 (design decisión 12 — "the per-lot conteo acquires all its locks
+    /// first ..., derives every delta, and only then writes"): split ADQUISICIÓN/APLICACIÓN. El
+    /// agregado no puede escribirse hasta conocer TODOS los deltas por lote (su delta es la SUMA de
+    /// ellos) pero el orden pineado lo exige PRIMERO — la única salida sin inventar un segundo
+    /// protocolo de lock es tomar cada lock (agregado, después cada lote ascendente) como un
+    /// upsert no-op ANTES de escribir ningún delta, y recién ahí aplicar. Los locks ya tomados
+    /// vuelven irrelevante el orden de la fase de aplicación para la concurrencia — se mantiene
+    /// ascendente por determinismo del resultado, no por lock order.</summary>
+    private async Task<ResultadoConteo> EjecutarConteoPorLoteAsync(
+        int idTenant, int idEmpleado, int idPuntoVenta, int idArticulo, IReadOnlyList<ConteoDeLote> lotes,
+        string observaciones, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // ---- ADQUISICIÓN: todos los locks, en el orden pineado (agregado, después cada lote
+        // ascendente por id_lote) — ningún delta escrito todavía.
+        var actualAgregado = await BloquearYCrearSiFaltaStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, ct);
+
+        var lotesAscendentes = lotes.OrderBy(l => l.IdLote).ToList();
+        var actualPorLote = new Dictionary<int, decimal>();
+        foreach (var lote in lotesAscendentes)
+        {
+            actualPorLote[lote.IdLote] = await BloquearYCrearSiFaltaStockLoteAsync(
+                conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, lote.IdLote, ct);
+        }
+
+        // ---- APLICACIÓN: todos los locks ya están tomados. Un lote sin diferencia no escribe fila
+        // (spec: "A lot with no difference writes no row even when a sibling lot differs") — y
+        // nunca se fabrica saldo en el sin-identificar para absorber una diferencia (spec: "A
+        // lot-effective conteo never writes into the sin-identificar lot"): el delta SIEMPRE se
+        // escribe con el id_lote exacto que lo originó.
+        var resultadosPorLote = new List<LoteContado>(lotesAscendentes.Count);
+        var deltaAgregado = 0m;
+        var cantidadAgregadaFinal = actualAgregado;
+
+        foreach (var lote in lotesAscendentes)
+        {
+            var actualDelLote = actualPorLote[lote.IdLote];
+            var deltaDelLote = lote.Contada - actualDelLote;
+
+            if (deltaDelLote == 0m)
+            {
+                resultadosPorLote.Add(new LoteContado(lote.IdLote, actualDelLote, actualDelLote, 0m, MovimientoRegistrado: false));
+                continue;
+            }
+
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, deltaDelLote, MotivoStock.Inventario,
+                idEmpleado, observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, lote.IdLote, ct);
+
+            var finalDelLote = await UpsertStockLoteAsync(
+                conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, lote.IdLote, deltaDelLote, ct);
+
+            // El agregado acumula la SUMA de los deltas por lote (design decisión 12) — un upsert
+            // por lote con diferencia, nunca uno solo con el total al final: mismo criterio de
+            // "re-lock de una fila que esta transacción ya tiene" que Write site 3 usa en
+            // transferencias (decisión 8).
+            cantidadAgregadaFinal = await UpsertStockAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, deltaDelLote, ct);
+
+            deltaAgregado += deltaDelLote;
+            resultadosPorLote.Add(new LoteContado(lote.IdLote, finalDelLote, actualDelLote, deltaDelLote, MovimientoRegistrado: true));
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return new ResultadoConteo(
+            idPuntoVenta, idArticulo, cantidadAgregadaFinal, actualAgregado, deltaAgregado,
+            MovimientoRegistrado: deltaAgregado != 0m, resultadosPorLote);
+    }
+
     /// <summary>Upsert no-op — <c>SET cantidad = stock.cantidad</c> — que crea la fila si falta
     /// (con <c>cantidad = 0</c>) Y toma el row lock en el mismo statement, sin escribir ningún
     /// delta todavía (design decisión 5: "the conteo uses the same primitive as a no-op upsert to
@@ -633,6 +726,34 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert no-op de stock no devolvió ninguna fila.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    /// <summary>Etapa 12, slice 12 (design decisión 12 — "the stock_lotes twin is a copy with a
+    /// third key"): mismo upsert no-op que <see cref="BloquearYCrearSiFaltaStockAsync"/> un nivel
+    /// arriba, sobre <c>stock_lotes</c> — crea la fila del lote si falta (<c>cantidad = 0</c>) Y
+    /// toma su row lock en el mismo statement, sin escribir ningún delta todavía.</summary>
+    private static async Task<decimal> BloquearYCrearSiFaltaStockLoteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta, int idLote,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, 0) " +
+            "ON CONFLICT (id_articulo, id_punto_venta, id_lote) DO UPDATE " +
+            "SET cantidad = stock_lotes.cantidad " +
+            "RETURNING cantidad";
+
+        AgregarParametro(comando, idArticulo);
+        AgregarParametro(comando, idPuntoVenta);
+        AgregarParametro(comando, idLote);
+        AgregarParametro(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El upsert no-op de stock_lotes no devolvió ninguna fila.");
 
         return Convert.ToDecimal(resultado);
     }
@@ -877,6 +998,48 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         }
 
         return contada;
+    }
+
+    /// <summary>Etapa 12, slice 12 (design decisión 18 — exactly-one-of; dto-contract-honesty):
+    /// validación puramente en memoria, ANTES de resolver referencias — un request mal formado no
+    /// amerita ni un SELECT. Un <see cref="SolicitudDeConteo.Lotes"/> vacío (<c>[]</c>) cuenta como
+    /// "ausente", mismo criterio que <c>null</c>: ninguna de las dos formas del conteo trajo un
+    /// valor accionable.</summary>
+    private static void ExigirExactamenteUnaFormaDeConteo(decimal? contada, IReadOnlyList<ConteoDeLote>? lotes)
+    {
+        var tieneContada = contada is not null;
+        var tieneLotes = lotes is { Count: > 0 };
+
+        if (tieneContada == tieneLotes)
+        {
+            throw new ErrorDominio(
+                "conteo_contada_y_lotes",
+                "El conteo tiene que traer exactamente uno de cantidad contada o desglose por lote, nunca ambos ni ninguno.",
+                400);
+        }
+    }
+
+    /// <summary>Etapa 12, slice 12 (design decisión 12): <c>conteo_lote_repetido</c> se rechaza
+    /// ANTES de cualquier lock — mismo criterio "en memoria primero" que <see cref="ExigirLineasDeTransferenciaValidas"/>.
+    /// Reusa <see cref="ExigirContadaValida"/> por línea: el total contado de un lote es la MISMA
+    /// magnitud física que el total agregado un nivel arriba, misma disciplina de signo/precisión.</summary>
+    private static IReadOnlyList<ConteoDeLote> ExigirLotesDeConteoValidos(IReadOnlyList<ConteoDeLote> lotes)
+    {
+        foreach (var lote in lotes)
+        {
+            ExigirContadaValida(lote.Contada);
+        }
+
+        var repetido = lotes.GroupBy(l => l.IdLote).FirstOrDefault(g => g.Count() > 1);
+        if (repetido is not null)
+        {
+            throw new ErrorDominio(
+                "conteo_lote_repetido",
+                $"El lote {repetido.Key} aparece más de una vez en el desglose del conteo.",
+                400);
+        }
+
+        return lotes;
     }
 
     private int ExigirTenantDeLaSesion() =>

--- a/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
+++ b/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
@@ -1,0 +1,552 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 12 (tasks 12.5-12.11): el conteo por lote punta a punta —
+/// el split adquisición/aplicación de locks (design decisión 12), el contrato exactly-one-of
+/// <c>Contada</c>/<c>Lotes</c> (decisión 18), el delta agregado derivado de los deltas por lote, la
+/// disciplina de "nunca fabricar en el sin-identificar" y <c>conteo_lote_repetido</c>. La suite de
+/// invariantes cross-cutting (task 12.12) vive en <see cref="InvarianteStockYStockLotesTests"/>.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas fijas y lejanas — independientes del reloj de la corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva, int IdListaPrecio);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Conteo-por-lote-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Conteo Por Lote", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        // Módulo de lotes ON a nivel empresa — mismo criterio que AjusteDecomisoLoteTests.
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva, lista.Id);
+    }
+
+    private async Task<int> SembrarArticuloLoteEfectivoAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento, bool esSinIdentificar = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = esSinIdentificar, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<decimal> LeerStockAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private async Task<decimal> LeerStockLoteAsync(Contexto ctx, int idArticulo, int idLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == ctx.IdPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private static async Task<HttpResponseMessage> ContarRawAsync(Contexto ctx, SolicitudDeConteo solicitud) =>
+        await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+
+    private static async Task<ResultadoConteo> ContarAsync(Contexto ctx, SolicitudDeConteo solicitud)
+    {
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 12.7: exactly-one-of ---------------------------------------------------------------
+
+    /// <summary>spec conteo-de-inventario: "Supplying both cantidad_contada and lotes is
+    /// rejected".</summary>
+    [Fact]
+    public async Task UnConteoConCantidadContadaYLotesEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoConCantidadContadaYLotesEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-ambos", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-AMBOS", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 12m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, 40m, "Ambos a la vez", [new ConteoDeLote(idLote, 10m)]);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_contada_y_lotes", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+    }
+
+    /// <summary>spec conteo-de-inventario: "Supplying neither cantidad_contada nor lotes is
+    /// rejected".</summary>
+    [Fact]
+    public async Task UnConteoSinCantidadContadaNiLotesEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoSinCantidadContadaNiLotesEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-ninguno", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, null, "Ninguno provisto", null);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_contada_y_lotes", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Contraparte del guard: un <c>Lotes</c> presente pero VACÍO cuenta como "ausente" —
+    /// mismo código de rechazo que enviar <c>null</c> (dto-contract-honesty: un array vacío no trae
+    /// ningún total accionable).</summary>
+    [Fact]
+    public async Task UnConteoConListaDeLotesVaciaEsRechazadoComoSiEstuvieraAusente()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoConListaDeLotesVaciaEsRechazadoComoSiEstuvieraAusente));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-lotes-vacio", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, null, "Lotes vacío", []);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_contada_y_lotes", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 12.10: conteo_lote_repetido -----------------------------------------------------
+
+    /// <summary>design decisión 12: <c>conteo_lote_repetido</c> se rechaza ANTES de cualquier
+    /// lock — ningún <c>movimientos_stock</c> se escribe.</summary>
+    [Fact]
+    public async Task UnConteoConUnIdLoteRepetidoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoConUnIdLoteRepetidoEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-repetido", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-REPETIDO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 12m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Lote repetido",
+            [new ConteoDeLote(idLote, 10m), new ConteoDeLote(idLote, 15m)]);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_lote_repetido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(12m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+    }
+
+    // ---- task 12.6: zero-difference-lot-writes-nothing -------------------------------------------
+
+    /// <summary>spec conteo-de-inventario: "A lot with no difference writes no row even when a
+    /// sibling lot differs".</summary>
+    [Fact]
+    public async Task UnLoteSinDiferenciaNoEscribeFilaAunqueUnLoteHermanoDifiera()
+    {
+        var ctx = await PrepararAsync(nameof(UnLoteSinDiferenciaNoEscribeFilaAunqueUnLoteHermanoDifiera));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-cero-diff", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-CERO-DIFF", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L2-CERO-DIFF", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote1, 12m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote2, 28m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "L1 matching, L2 difiere",
+            [new ConteoDeLote(idLote1, 12m), new ConteoDeLote(idLote2, 30m)]);
+        var resultado = await ContarAsync(ctx, solicitud);
+
+        Assert.Equal(2, resultado.Lotes!.Count);
+        var l1 = Assert.Single(resultado.Lotes, l => l.IdLote == idLote1);
+        Assert.False(l1.MovimientoRegistrado);
+        Assert.Equal(0m, l1.Delta);
+        var l2 = Assert.Single(resultado.Lotes, l => l.IdLote == idLote2);
+        Assert.True(l2.MovimientoRegistrado);
+        Assert.Equal(2m, l2.Delta);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario).ToListAsync();
+        var movimiento = Assert.Single(movimientos);
+        Assert.Equal(idLote2, movimiento.IdLote);
+        Assert.Equal(2m, movimiento.Cantidad);
+
+        Assert.Equal(12m, await LeerStockLoteAsync(ctx, idArticulo, idLote1));
+        Assert.Equal(30m, await LeerStockLoteAsync(ctx, idArticulo, idLote2));
+        Assert.Equal(42m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- task 12.8: per-lot-derives-aggregate-delta ------------------------------------------------
+
+    /// <summary>spec: "A lot-effective conteo derives the aggregate delta from per-lot deltas" —
+    /// literalmente el escenario del spec: L1 12→15 (+3), L2 28→20 (-8), agregado se mueve -5.</summary>
+    [Fact]
+    public async Task UnConteoLoteEfectivoDerivaElDeltaAgregadoDeLosDeltasPorLote()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoLoteEfectivoDerivaElDeltaAgregadoDeLosDeltasPorLote));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-deriva", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-DERIVA", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L2-DERIVA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote1, 12m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote2, 28m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Deriva agregado",
+            [new ConteoDeLote(idLote1, 15m), new ConteoDeLote(idLote2, 20m)]);
+        var resultado = await ContarAsync(ctx, solicitud);
+
+        Assert.Equal(-5m, resultado.Delta);
+        Assert.Equal(35m, resultado.Cantidad);
+        Assert.Equal(40m, resultado.CantidadAnterior);
+        Assert.True(resultado.MovimientoRegistrado);
+
+        var l1 = Assert.Single(resultado.Lotes!, l => l.IdLote == idLote1);
+        Assert.Equal(3m, l1.Delta);
+        var l2 = Assert.Single(resultado.Lotes!, l => l.IdLote == idLote2);
+        Assert.Equal(-8m, l2.Delta);
+
+        Assert.Equal(35m, await LeerStockAsync(ctx, idArticulo));
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote1));
+        Assert.Equal(20m, await LeerStockLoteAsync(ctx, idArticulo, idLote2));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario).ToListAsync();
+        Assert.Equal(2, movimientos.Count);
+        Assert.Contains(movimientos, m => m.IdLote == idLote1 && m.Cantidad == 3m);
+        Assert.Contains(movimientos, m => m.IdLote == idLote2 && m.Cantidad == -8m);
+    }
+
+    // ---- task 12.9: never-fabricate-into-sin-identificar ------------------------------------------
+
+    /// <summary>spec: "A lot-effective conteo never writes into the sin-identificar lot to absorb
+    /// a difference" — L1 12→10 (-2) escribe con <c>id_lote = L1</c>; el sin-identificar (sembrado,
+    /// saldo 0) queda EXACTAMENTE en 0, nunca absorbe la diferencia.</summary>
+    [Fact]
+    public async Task UnConteoLoteEfectivoNuncaEscribeEnElLoteSinIdentificarParaAbsorberUnaDiferencia()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoLoteEfectivoNuncaEscribeEnElLoteSinIdentificarParaAbsorberUnaDiferencia));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-no-fabrica", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-NO-FABRICA", VencimientoLejanoFuturo);
+        var idSinIdentificar = await SembrarLoteAsync(
+            ctx, idArticulo, ReglaDeLotes.CodigoSinIdentificar, null, esSinIdentificar: true);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote1, 12m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idSinIdentificar, 0m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "No fabrica en sin-identificar",
+            [new ConteoDeLote(idLote1, 10m)]);
+        var resultado = await ContarAsync(ctx, solicitud);
+
+        Assert.Equal(-2m, resultado.Delta);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock
+            .SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario);
+        Assert.Equal(idLote1, movimiento.IdLote);
+        Assert.NotEqual(idSinIdentificar, movimiento.IdLote);
+        Assert.Equal(-2m, movimiento.Cantidad);
+
+        Assert.Equal(10m, await LeerStockLoteAsync(ctx, idArticulo, idLote1));
+        Assert.Equal(0m, await LeerStockLoteAsync(ctx, idArticulo, idSinIdentificar));
+    }
+
+    // ---- task 12.11: aggregate-grain regression ----------------------------------------------------
+
+    /// <summary>spec: "A matching count writes nothing" — regresión del camino agregado
+    /// (<c>Contada</c>, artículo SIN lote efectivo) tras el ensanchamiento a <c>decimal?</c> /
+    /// exactly-one-of de esta slice: sigue siendo un no-op byte-idéntico al de slices previos.</summary>
+    [Fact]
+    public async Task UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-agregado-regresion", 10m);
+        // Sin lotes/stock_lotes sembrados a propósito: este es el camino agregado puro
+        // (Contada), el mismo contrato que un artículo sin control de lote efectivo usa.
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, 40m, "Recuento sin diferencias");
+        var resultado = await ContarAsync(ctx, solicitud);
+
+        Assert.False(resultado.MovimientoRegistrado);
+        Assert.Equal(0m, resultado.Delta);
+        Assert.Equal(40m, resultado.Cantidad);
+        Assert.Null(resultado.Lotes);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- task 12.5: lock-acquisition-order ----------------------------------------------------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>design decisión 12: "the per-lot conteo acquires all its locks first ..., derives
+    /// every delta, and only then writes". Caso discriminante: dos lotes, L1 (id menor) y L2 (id
+    /// mayor) — el orden ascendente pineado procesa PRIMERO el agregado, después L1 (sin
+    /// contención), y recién ahí L2. Reteniendo EXTERNAMENTE el lock no-op de L2 (el ÚLTIMO
+    /// elemento del orden), el conteo se bloquea justo ahí — DESPUÉS de haber adquirido el lock de
+    /// L1, pero ANTES de aplicar cualquier delta (ni siquiera el de L1, cuyo lock ya tiene). La
+    /// prueba, mismo mecanismo empírico a nivel RELACIÓN que
+    /// <c>TransferenciaLoteTests.ElOrdenDeLocksDeUnaTransferenciaConLoteEsUnaUnicaSecuenciaAscendentePorPuntoDeVenta</c>:
+    /// mientras el backend del conteo espera ahí, NINGÚN statement contra <c>movimientos_stock</c>
+    /// pudo haber corrido todavía — una implementación que escribiera el delta de L1 apenas
+    /// adquirido su lock (sin esperar al de L2) ya habría tocado esa relación.</summary>
+    [Fact]
+    public async Task ElConteoPorLoteAdquiereTodosLosLocksAntesDeEscribirCualquierDelta()
+    {
+        var ctx = await PrepararAsync(nameof(ElConteoPorLoteAdquiereTodosLosLocksAntesDeEscribirCualquierDelta));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-orden-conteo", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-ORDEN-CONTEO", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L2-ORDEN-CONTEO", VencimientoLejanoFuturo);
+        Assert.True(idLote1 < idLote2);
+
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote1, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote2, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 30m);
+
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<Ways.Domain.Organizacion.EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<Ways.Domain.Catalogos.ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Ways.Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<Ways.Domain.Ventas.EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        await db.Database.OpenConnectionAsync();
+        var conexionConteo = (NpgsqlConnection)db.Database.GetDbConnection();
+        var pidConteo = (int)(await new NpgsqlCommand("SELECT pg_backend_pid()", conexionConteo).ExecuteScalarAsync())!;
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
+        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Orden de locks",
+            [new ConteoDeLote(idLote1, 15m), new ConteoDeLote(idLote2, 25m)]);
+
+        // Retiene EXTERNAMENTE el lock no-op del ÚLTIMO elemento del orden (L2, id mayor) — el
+        // conteo tiene que bloquearse ahí, después de L1 pero antes de aplicar ningún delta.
+        await using var conexionBloqueo = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionBloqueo.OpenAsync();
+        await using (var comandoGuc = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)", conexionBloqueo))
+        {
+            comandoGuc.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGuc.ExecuteNonQueryAsync();
+        }
+
+        await using var transaccionBloqueo = await conexionBloqueo.BeginTransactionAsync();
+        await using (var comandoBloqueo = new NpgsqlCommand(
+            "SELECT cantidad FROM stock_lotes WHERE id_articulo = $1 AND id_punto_venta = $2 AND id_lote = $3 FOR UPDATE",
+            conexionBloqueo, transaccionBloqueo))
+        {
+            comandoBloqueo.Parameters.AddWithValue(idArticulo);
+            comandoBloqueo.Parameters.AddWithValue(ctx.IdPuntoVenta);
+            comandoBloqueo.Parameters.AddWithValue(idLote2);
+            await comandoBloqueo.ExecuteScalarAsync();
+        }
+
+        var tareaConteo = servicioDeStock.ContarAsync(solicitud);
+
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync();
+
+        var observado = false;
+        var movimientosStockYaTocado = true;
+        var limite = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < limite)
+        {
+            await using var comandoPoll = new NpgsqlCommand(
+                "SELECT " +
+                "  bool_or(l.locktype = 'relation' AND l.relation::regclass::text = 'movimientos_stock') AS movimientos_tocado, " +
+                "  bool_or(NOT l.granted) AS esperando_algo " +
+                "FROM pg_locks l WHERE l.pid = $1",
+                conexionPoll);
+            comandoPoll.Parameters.AddWithValue(pidConteo);
+
+            await using var lector = await comandoPoll.ExecuteReaderAsync();
+            if (await lector.ReadAsync())
+            {
+                var movimientosTocado = !lector.IsDBNull(0) && lector.GetBoolean(0);
+                var esperandoAlgo = !lector.IsDBNull(1) && lector.GetBoolean(1);
+                if (esperandoAlgo)
+                {
+                    observado = true;
+                    movimientosStockYaTocado = movimientosTocado;
+                    break;
+                }
+            }
+
+            await Task.Delay(25);
+        }
+
+        await transaccionBloqueo.RollbackAsync();
+        var resultado = await tareaConteo;
+
+        Assert.True(observado, "Nunca se observó al conteo bloqueado esperando el lock retenido del segundo lote.");
+        Assert.False(
+            movimientosStockYaTocado,
+            "movimientos_stock ya fue tocado mientras el conteo esperaba el lock del SEGUNDO lote (L2) — " +
+            "prueba que se escribió un delta (el de L1) antes de terminar la fase de ADQUISICIÓN completa " +
+            "(design decisión 12: adquisición de TODOS los locks, después aplicación).");
+
+        Assert.Equal(2, resultado.Lotes!.Count);
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, idLote1));
+        Assert.Equal(25m, await LeerStockLoteAsync(ctx, idArticulo, idLote2));
+        Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+    }
+}

--- a/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
+++ b/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
@@ -111,6 +111,34 @@ public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         return articulo.Id;
     }
 
+    /// <summary>Judgment-day fix (juez B, FIX 1): contraparte SIN control efectivo de lote —
+    /// <c>ControlaLote = false</c>, a diferencia de <see cref="SembrarArticuloLoteEfectivoAsync"/>.
+    /// Necesaria porque la 12.11 usaba (incorrectamente) un artículo lote-efectivo para su
+    /// escenario de regresión del camino agregado.</summary>
+    private async Task<int> SembrarArticuloSinLoteAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
     private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento, bool esSinIdentificar = false)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
@@ -382,14 +410,18 @@ public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
 
     /// <summary>spec: "A matching count writes nothing" — regresión del camino agregado
     /// (<c>Contada</c>, artículo SIN lote efectivo) tras el ensanchamiento a <c>decimal?</c> /
-    /// exactly-one-of de esta slice: sigue siendo un no-op byte-idéntico al de slices previos.</summary>
+    /// exactly-one-of de esta slice: sigue siendo un no-op byte-idéntico al de slices previos.
+    /// Judgment-day fix (juez B, FIX 1): esta versión usa <see cref="SembrarArticuloSinLoteAsync"/> —
+    /// la original usaba (incorrectamente) un artículo lote-efectivo, lo que escondía el bug del
+    /// FIX 1 (delta cero nunca llega a escribir nada, sea cual sea la forma del conteo, así que el
+    /// gap de correctitud quedaba invisible acá; ver
+    /// <see cref="UnConteoAgregadoParaUnArticuloLoteEfectivoEsRechazado"/> para el caso con delta
+    /// NO cero que sí lo exponía).</summary>
     [Fact]
     public async Task UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada()
     {
         var ctx = await PrepararAsync(nameof(UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada));
-        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-agregado-regresion", 10m);
-        // Sin lotes/stock_lotes sembrados a propósito: este es el camino agregado puro
-        // (Contada), el mismo contrato que un artículo sin control de lote efectivo usa.
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-conteo-agregado-regresion", 10m);
         await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
 
         var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, 40m, "Recuento sin diferencias");
@@ -403,6 +435,87 @@ public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
         Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    /// <summary>spec conteo-de-inventario (Amended at slice-12 judgment-day, juez B FIX 1): un
+    /// total agregado (<c>Contada</c>) contra un artículo lote-efectivo se rechaza con <c>400
+    /// conteo_requiere_lotes</c> ANTES de cualquier lock — nunca movió <c>stock.cantidad</c> sin
+    /// tocar <c>stock_lotes</c> (el bug empírico: 40→50 agregado, lotes quedan en 40, invariante 3
+    /// roto en silencio). Delta explícitamente NO cero para que la escritura real quede expuesta si
+    /// el guard llegara a fallar.</summary>
+    [Fact]
+    public async Task UnConteoAgregadoParaUnArticuloLoteEfectivoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoAgregadoParaUnArticuloLoteEfectivoEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-agregado-rechazado", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-AGREGADO-RECHAZADO", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, 50m, "Total agregado sobre lote-efectivo");
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_requiere_lotes", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+        Assert.Equal(40m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+    }
+
+    /// <summary>Simetría inversa del FIX 1: un desglose por lote (<c>Lotes</c>) contra un artículo
+    /// SIN control efectivo de lote no tiene destino — rechazado con <c>400
+    /// conteo_no_aplica_lotes</c>, mismo criterio que <c>lote_no_aplica</c> en
+    /// <c>ResolverIdLoteEfectivoAsync</c>.</summary>
+    [Fact]
+    public async Task UnConteoPorLoteParaUnArticuloSinLoteEfectivoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoPorLoteParaUnArticuloSinLoteEfectivoEsRechazado));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-conteo-lotes-sin-lote-efectivo", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Desglose sobre articulo sin lote efectivo",
+            [new ConteoDeLote(999_999, 10m)]);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("conteo_no_aplica_lotes", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(40m, await LeerStockAsync(ctx, idArticulo));
+    }
+
+    // ---- judgment-day fix (juez B, FIX 2): idLote inválido en conteo por lote ---------------------
+
+    /// <summary>Un <c>idLote</c> inexistente en el desglose por lote se rechaza con <c>400
+    /// lote_invalido</c> ANTES de cualquier lock — nunca un 500 crudo de FK dentro del upsert
+    /// no-op de <c>BloquearYCrearSiFaltaStockLoteAsync</c>.</summary>
+    [Fact]
+    public async Task UnConteoPorLoteConUnIdLoteInexistenteEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoPorLoteConUnIdLoteInexistenteEsRechazado));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-lote-inexistente", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-LOTE-INEXISTENTE", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 12m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 12m);
+
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Lote inexistente", [new ConteoDeLote(999_999, 10m)]);
+        var respuesta = await ContarRawAsync(ctx, solicitud);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("lote_invalido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(12m, await LeerStockLoteAsync(ctx, idArticulo, idLote));
+        Assert.Equal(12m, await LeerStockAsync(ctx, idArticulo));
     }
 
     // ---- task 12.5: lock-acquisition-order ----------------------------------------------------------

--- a/tests/Ways.IntegrationTests/InvarianteStockYStockLotesTests.cs
+++ b/tests/Ways.IntegrationTests/InvarianteStockYStockLotesTests.cs
@@ -1,0 +1,542 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-12-lotes-vencimientos, Slice 12 (task 12.12): la SUITE DE INVARIANTES cross-cutting —
+/// ahora provable end to end con los OCHO motivos vivos (Venta, Compra, Anulacion, Ajuste,
+/// Transferencia, Inventario, Decomiso, Reclasificacion). Tres tests long-form, cada uno asertando
+/// la igualdad DESPUÉS DE CADA PASO de la secuencia (no solo al final, mismo criterio que
+/// <see cref="SaldoLedgerInvarianteTests"/>):
+/// <list type="number">
+/// <item><see cref="LaCantidadDeStockEsLaSumaDeSusMovimientosTrasUnaSecuenciaConLosOchoMotivos"/> —
+/// <c>stock.cantidad = SUM(movimientos)</c> (spec stock: "Cantidad Is Always The Sum Of Its
+/// Movimientos"), incluyendo un par de <c>reclasificacion</c>.</item>
+/// <item><see cref="StockLotesCantidadEsLaSumaDeSusMovimientosConEseLoteTrasLaCadenaCompraVentaTransferenciaNcxAnulacionConteoDecomiso"/> —
+/// <c>stock_lotes.cantidad = SUM(movimientos con ese id_lote)</c> (spec lotes-y-vencimientos: "Stock
+/// Lotes Balance And Its Two Invariants") tras compra→venta→transferencia→NCX→anulación→conteo→decomiso.</item>
+/// <item><see cref="LaSumaDeStockLotesIgualaElAgregadoParaUnParLoteEfectivoReconciliado"/> —
+/// <c>SUM(stock_lotes) = stock.cantidad</c> para un par lote-efectivo reconciliado.</item>
+/// </list>
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class InvarianteStockYStockLotesTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas fijas y lejanas — independientes del reloj de la corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVentaOrigen, int IdPuntoVentaDestino, HttpClient Admin,
+        int IdArea, int IdAlicuotaIva, int IdListaPrecio, int IdMedioEfectivo, int IdCliente,
+        int IdProveedor, int IdTipoCFA);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Invariante-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Invariante", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        // Segundo punto de venta REAL — destino de la transferencia de la secuencia.
+        var puntoVentaDestino = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, Nombre = "Local invariante 2",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVentaDestino);
+        await db.SaveChangesAsync();
+
+        // El checkout (TX/NCX) exige un turno abierto en el punto de venta de origen.
+        db.TurnosCaja.Add(new TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "Cliente invariante",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 1_000_000m,
+            CreditoIlimitado = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        // condiciones_fiscales es catálogo de PLATAFORMA (sin id_tenant) — el alta necesita el
+        // contexto de plataforma, mismo criterio que ComprasRecepcionDeLotesTests.PrepararAsync.
+        int idCondicionFiscalProveedor;
+        await using (var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma))
+        {
+            var condicionFiscalProveedor = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+            dbPlataforma.CondicionesFiscales.Add(condicionFiscalProveedor);
+            await dbPlataforma.SaveChangesAsync();
+            idCondicionFiscalProveedor = condicionFiscalProveedor.Id;
+        }
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"Proveedor {nombre}", IdCondicionFiscal = idCondicionFiscalProveedor,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        // Módulo de lotes ON a nivel empresa — necesario para el paso de reclasificación de los
+        // tres tests (aunque los tests 1/2 solo lo usan al final o desde el arranque).
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, puntoVentaDestino.Id, admin, area.Id,
+            idAlicuotaIva, lista.Id, idMedioEfectivo, cliente.Id, proveedor.Id, idTipoCFA);
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre, bool controlaLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = controlaLote, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = 100m,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    /// <summary>Flip <c>ControlaLote</c> DIRECTO por EF (no vía <c>ServicioDeArticulos</c>) — mismo
+    /// criterio que <c>ReconciliacionTests</c>: no dispara la reconciliación automática, así que el
+    /// test controla explícitamente CUÁNDO corre (vía <see cref="ReconciliarAsync"/>).</summary>
+    private async Task FlipControlaLoteAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var articulo = await db.Articulos.SingleAsync(a => a.Id == idArticulo);
+        articulo.ControlaLote = true;
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeCompra SolicitudCompra(
+        Contexto ctx, int idArticulo, decimal unidades, string? codigoLote, DateOnly? fechaVencimiento) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVentaOrigen, $"NE-{Guid.NewGuid():N}",
+            DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [
+                new LineaDeCompraSolicitada(
+                    idArticulo, "Item invariante", unidades, null, null, 10m, 0m, ctx.IdAlicuotaIva,
+                    ActualizaCosto: true, CodigoLote: codigoLote, FechaVencimiento: fechaVencimiento)
+            ]);
+
+    private static async Task<CompraDetalle> CrearYConfirmarCompraAsync(
+        Contexto ctx, int idArticulo, decimal unidades, string? codigoLote, DateOnly? fechaVencimiento)
+    {
+        var borrador = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudCompra(ctx, idArticulo, unidades, codigoLote, fechaVencimiento));
+        var cuerpoBorrador = await borrador.Content.ReadAsStringAsync();
+        Assert.True(borrador.StatusCode == HttpStatusCode.Created, cuerpoBorrador);
+        var detalle = JsonSerializer.Deserialize<CompraDetalle>(cuerpoBorrador, OpcionesJson)!;
+
+        var confirmar = await ctx.Admin.PostAsync($"/api/compras/{detalle.Id}/confirmar", null);
+        var cuerpoConfirmar = await confirmar.Content.ReadAsStringAsync();
+        Assert.True(confirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpoConfirmar, OpcionesJson)!;
+    }
+
+    private static SolicitudDeVenta SolicitudTx(Contexto ctx, int idArticulo, decimal cantidad, int? idLote) =>
+        new(
+            ctx.IdPuntoVentaOrigen, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, cantidad * 100m, null, 0m)],
+            null, null);
+
+    private static SolicitudDeVenta SolicitudNcx(Contexto ctx, int idArticulo, decimal cantidad, int? idLote) =>
+        new(
+            ctx.IdPuntoVentaOrigen, ctx.IdCliente, "NCX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null, idLote)],
+            [],
+            null, null);
+
+    private static async Task<ComprobanteEmitido> EmitirAsync(Contexto ctx, SolicitudDeVenta solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<ComprobanteEmitido> AnularVentaAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{id}/anulacion", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task TransferirAsync(Contexto ctx, int idArticulo, decimal cantidad, int? idLote)
+    {
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVentaOrigen, ctx.IdPuntoVentaDestino, "Transferencia invariante",
+            [new LineaDeTransferencia(idArticulo, cantidad, idLote)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+    }
+
+    private static async Task<ResultadoConteo> ContarAgregadoAsync(Contexto ctx, int idArticulo, decimal contada)
+    {
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVentaOrigen, idArticulo, contada, "Conteo invariante agregado");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<ResultadoConteo> ContarPorLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal contada)
+    {
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVentaOrigen, idArticulo, null, "Conteo invariante por lote", [new ConteoDeLote(idLote, contada)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoConteo>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task DecomisarAsync(Contexto ctx, int idArticulo, int? idLote, decimal cantidad)
+    {
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVentaOrigen, idArticulo, idLote, cantidad, "Decomiso invariante");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+    }
+
+    private static async Task AjustarAsync(Contexto ctx, int idArticulo, int? idLote, decimal cantidad)
+    {
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVentaOrigen, idArticulo, cantidad, "Ajuste invariante", idLote);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+    }
+
+    private static async Task<ResultadoDeReconciliacion> ReconciliarAsync(Contexto ctx, int idArticulo, int idPuntoVenta)
+    {
+        var solicitud = new SolicitudDeReconciliacion(idArticulo, idPuntoVenta);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/lotes/reconciliacion", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResultadoDeReconciliacion>(cuerpo, OpcionesJson)!;
+    }
+
+    private async Task<decimal> LeerStockAsync(Contexto ctx, int idArticulo, int idPuntoVenta)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == idPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+    }
+
+    private async Task<decimal> LeerStockLoteAsync(Contexto ctx, int idArticulo, int idPuntoVenta, int idLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == idPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstOrDefaultAsync();
+    }
+
+    /// <summary>El invariante 1 en sí (spec stock: "Cantidad Is Always The Sum Of Its
+    /// Movimientos"): <c>stock.cantidad</c> == Σ <c>movimientos_stock.cantidad</c> del par
+    /// (articulo, punto de venta), leído directo de la base.</summary>
+    private async Task AssertInvarianteStockAsync(Contexto ctx, int idArticulo, int idPuntoVenta)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == idPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == idPuntoVenta)
+            .SumAsync(m => m.Cantidad);
+        Assert.Equal(sumaDeMovimientos, cantidad);
+    }
+
+    /// <summary>El invariante 2 en sí (spec lotes-y-vencimientos: "Stock Lotes Balance And Its Two
+    /// Invariants"): <c>stock_lotes.cantidad</c> == Σ <c>movimientos_stock.cantidad</c> de ESE
+    /// <c>id_lote</c> en ESE punto de venta.</summary>
+    private async Task AssertInvarianteStockLoteAsync(Contexto ctx, int idArticulo, int idPuntoVenta, int idLote)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var cantidad = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == idPuntoVenta && sl.IdLote == idLote)
+            .Select(sl => sl.Cantidad).FirstOrDefaultAsync();
+        var sumaDeMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == idPuntoVenta && m.IdLote == idLote)
+            .SumAsync(m => m.Cantidad);
+        Assert.Equal(sumaDeMovimientos, cantidad);
+    }
+
+    /// <summary>El invariante 3 en sí: para un par (articulo, PV) lote-efectivo y reconciliado,
+    /// Σ <c>stock_lotes.cantidad</c> == <c>stock.cantidad</c>.</summary>
+    private async Task AssertSumaDeStockLotesIgualaAlAgregadoAsync(Contexto ctx, int idArticulo, int idPuntoVenta)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var agregado = await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == idPuntoVenta)
+            .Select(s => s.Cantidad).FirstOrDefaultAsync();
+        var sumaDeLotes = await db.StockLotes
+            .Where(sl => sl.IdArticulo == idArticulo && sl.IdPuntoVenta == idPuntoVenta)
+            .SumAsync(sl => sl.Cantidad);
+        Assert.Equal(agregado, sumaDeLotes);
+    }
+
+    // ---- invariante 1: stock.cantidad = SUM(movimientos), los OCHO motivos ------------------------
+
+    [Fact]
+    public async Task LaCantidadDeStockEsLaSumaDeSusMovimientosTrasUnaSecuenciaConLosOchoMotivos()
+    {
+        var ctx = await PrepararAsync(nameof(LaCantidadDeStockEsLaSumaDeSusMovimientosTrasUnaSecuenciaConLosOchoMotivos));
+        // NO lote-efectivo hasta el último paso — así los primeros ocho movimientos ejercitan el
+        // camino agregado puro de los siete motivos de escritura previos a esta etapa, y el
+        // noveno (el flip) agrega Reclasificacion sin re-derivar nada de lo anterior.
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-invariante-8-motivos", controlaLote: false);
+
+        // 1. Ajuste: +100.
+        await AjustarAsync(ctx, idArticulo, idLote: null, 100m);
+        Assert.Equal(100m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 2. Compra: +50.
+        await CrearYConfirmarCompraAsync(ctx, idArticulo, 50m, codigoLote: null, fechaVencimiento: null);
+        Assert.Equal(150m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 3. Venta (TX): -20.
+        var tx = await EmitirAsync(ctx, SolicitudTx(ctx, idArticulo, 20m, idLote: null));
+        Assert.Equal(130m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 4. Transferencia: -10 en el origen (el +10 del destino es un stock row distinto, fuera
+        // del alcance de este invariante puntual).
+        await TransferirAsync(ctx, idArticulo, 10m, idLote: null);
+        Assert.Equal(120m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 5. NCX (devolución): +5 — mismo motivo Venta que la TX, sign flip por tipo comprobante.
+        await EmitirAsync(ctx, SolicitudNcx(ctx, idArticulo, 5m, idLote: null));
+        Assert.Equal(125m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 6. Anulación: reversa exacta de la TX del paso 3, +20.
+        await AnularVentaAsync(ctx, tx.Id);
+        Assert.Equal(145m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 7. Conteo (Inventario): 145 → 150, +5.
+        await ContarAgregadoAsync(ctx, idArticulo, 150m);
+        Assert.Equal(150m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 8. Decomiso: -8.
+        await DecomisarAsync(ctx, idArticulo, idLote: null, 8m);
+        Assert.Equal(142m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // 9. Reclasificación: flip controla_lote (sin stock_lotes previo) → residuo = 142, par neto
+        // cero (design decisión 14: stock NUNCA se toca acá) — el invariante tiene que seguir
+        // sosteniéndose exactamente igual.
+        await FlipControlaLoteAsync(ctx, idArticulo);
+        var resultado = await ReconciliarAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+        Assert.Equal(1, resultado.ParesReconciliados);
+        Assert.Equal(142m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertInvarianteStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var motivosPresentes = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == ctx.IdPuntoVentaOrigen)
+            .Select(m => m.Motivo).Distinct().ToListAsync();
+        Assert.Equal(
+            new[]
+            {
+                MotivoStock.Venta, MotivoStock.Compra, MotivoStock.Anulacion, MotivoStock.Ajuste,
+                MotivoStock.Transferencia, MotivoStock.Inventario, MotivoStock.Decomiso, MotivoStock.Reclasificacion
+            }.OrderBy(m => m),
+            motivosPresentes.OrderBy(m => m));
+    }
+
+    // ---- invariante 2: stock_lotes.cantidad = SUM(movimientos con ese lote), la cadena de 12.12 ---
+
+    [Fact]
+    public async Task StockLotesCantidadEsLaSumaDeSusMovimientosConEseLoteTrasLaCadenaCompraVentaTransferenciaNcxAnulacionConteoDecomiso()
+    {
+        var ctx = await PrepararAsync(
+            nameof(StockLotesCantidadEsLaSumaDeSusMovimientosConEseLoteTrasLaCadenaCompraVentaTransferenciaNcxAnulacionConteoDecomiso));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-invariante-cadena", controlaLote: true);
+
+        // 1. Compra: +30 del lote L (get-or-create lo crea).
+        var confirmada = await CrearYConfirmarCompraAsync(ctx, idArticulo, 30m, "L-INV8", VencimientoLejanoFuturo);
+        var idLote = confirmada.Items[0].IdLote;
+        Assert.NotNull(idLote);
+        Assert.Equal(30m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote!.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        // 2. Venta (TX): -5 del lote L, explícito.
+        var tx = await EmitirAsync(ctx, SolicitudTx(ctx, idArticulo, 5m, idLote));
+        Assert.Equal(25m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        // 3. Transferencia: -10 del lote L en origen (el destino recibe su propia fila, verificada
+        // aparte por brevedad no repetida acá — TransferenciaLoteTests ya la cubre punta a punta).
+        await TransferirAsync(ctx, idArticulo, 10m, idLote);
+        Assert.Equal(15m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+        // Bonus: el destino también sostiene el invariante sobre SU propia fila del mismo lote.
+        Assert.Equal(10m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaDestino, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaDestino, idLote.Value);
+
+        // 4. NCX (devolución): +3 al lote L, explícito (NCX exige idLote — nunca default FEFO).
+        await EmitirAsync(ctx, SolicitudNcx(ctx, idArticulo, 3m, idLote));
+        Assert.Equal(18m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        // 5. Anulación: reversa exacta de la TX del paso 2, +5.
+        await AnularVentaAsync(ctx, tx.Id);
+        Assert.Equal(23m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        // 6. Conteo por lote: 23 → 30, +7.
+        await ContarPorLoteAsync(ctx, idArticulo, idLote.Value, 30m);
+        Assert.Equal(30m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        // 7. Decomiso: -4 del lote L.
+        await DecomisarAsync(ctx, idArticulo, idLote, 4m);
+        Assert.Equal(26m, await LeerStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value));
+        await AssertInvarianteStockLoteAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen, idLote.Value);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var motivosDelLoteEnOrigen = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == ctx.IdPuntoVentaOrigen && m.IdLote == idLote)
+            .Select(m => m.Motivo).Distinct().ToListAsync();
+        Assert.Equal(
+            new[]
+            {
+                MotivoStock.Compra, MotivoStock.Venta, MotivoStock.Transferencia, MotivoStock.Anulacion,
+                MotivoStock.Inventario, MotivoStock.Decomiso
+            }.OrderBy(m => m),
+            motivosDelLoteEnOrigen.OrderBy(m => m));
+    }
+
+    // ---- invariante 3: SUM(stock_lotes) = stock.cantidad, par lote-efectivo reconciliado ----------
+
+    [Fact]
+    public async Task LaSumaDeStockLotesIgualaElAgregadoParaUnParLoteEfectivoReconciliado()
+    {
+        var ctx = await PrepararAsync(nameof(LaSumaDeStockLotesIgualaElAgregadoParaUnParLoteEfectivoReconciliado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-invariante-reconciliado", controlaLote: false);
+
+        // Stock preexistente ANTES de activar el control de lote (el escenario que la
+        // reconciliación existe para resolver — decisión 3 del proposal).
+        await AjustarAsync(ctx, idArticulo, idLote: null, 50m);
+        Assert.Equal(50m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+
+        await FlipControlaLoteAsync(ctx, idArticulo);
+        var resultado = await ReconciliarAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+        Assert.Equal(1, resultado.ParesReconciliados);
+
+        // Tras la reconciliación: el residuo entero (50) quedó en el lote sin-identificar, el
+        // agregado no se movió (decisión 14) — el invariante 3 tiene que sostenerse.
+        Assert.Equal(50m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertSumaDeStockLotesIgualaAlAgregadoAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // Una recepción de un lote FECHADO nuevo, además del residuo sin-identificar — prueba que
+        // el invariante se sostiene con una MEZCLA de lotes, no solo con el caso trivial de un
+        // único lote.
+        var confirmada = await CrearYConfirmarCompraAsync(ctx, idArticulo, 10m, "L-RECON", VencimientoLejanoFuturo);
+        Assert.NotNull(confirmada.Items[0].IdLote);
+
+        Assert.Equal(60m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertSumaDeStockLotesIgualaAlAgregadoAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+
+        // Una segunda reconciliación sobre el mismo par es un no-op (idempotencia, decisión 13) —
+        // el invariante sigue sosteniéndose byte-idéntico.
+        var segunda = await ReconciliarAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+        Assert.Equal(1, segunda.ParesSinResiduo);
+        Assert.Equal(60m, await LeerStockAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen));
+        await AssertSumaDeStockLotesIgualaAlAgregadoAsync(ctx, idArticulo, ctx.IdPuntoVentaOrigen);
+    }
+}


### PR DESCRIPTION
## Etapa 12 — Slice 12: Conteo (último slice de backend)

- **Conteo por lote** con el split de la decisión 12: fase de ADQUISICIÓN (agregado primero, lotes ascendente, upserts no-op, cero deltas) separada de la fase de APLICACIÓN (deltas derivados bajo locks ya tenidos, movimiento \`inventario\` + espejo por lote con delta ≠ 0, agregado acumula la suma) — probado con \`pg_locks\` real.
- **exactly-one-of** \`Contada\`/\`Lotes\` (400 \`conteo_contada_y_lotes\`), \`conteo_lote_repetido\` pre-lock, y — nacidos del BLOCKER del juez B — **400 \`conteo_requiere_lotes\`** (Contada agregada para artículo lote-efectivo: antes daba 200 y rompía el invariante 3 en silencio) y **400 \`conteo_no_aplica_lotes\`** (simetría inversa), más validación SELECT-first del \`idLote\` (400 en vez del 500 crudo de la FK).
- **Regla "nunca un delta"** intacta en ambas formas; jamás se fabrica al sin-identificar.
- **Suite de invariantes cross-cutting (12.12)**: 3 tests long-form re-asertando tras CADA paso — los OCHO motivos vivos incluido el par \`reclasificacion\`, la cadena compra→venta→transferencia→NCX→anulación→conteo→decomiso por lote, y SUM(stock_lotes)=stock para par reconciliado con idempotencia.

### Tests
ConteoPorLote 12/12 · Invariantes 3/3 · regresión 71/71 · Domain 420. 8 rondas de evidencia de mutación.

### Judgment-day
Juez B REJECT ronda 1 con un BLOCKER empírico de primera (el test 12.11 original ESCONDÍA el bug sembrando lote-efectivo con delta cero) → fix + spec enmendado → APPROVE ronda 2 con re-probe del invariante intacto. Juez A APPROVE con 2 MINORs (redacción del spec precisada acá; deuda registrada: defense-in-depth del camino per-lot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)