### PR TITLE
feat(lotes): picker de lote en POS y compras — etapa 12, slice 14

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1940,7 +1940,32 @@ change.
   `opcionDeLote` mapping unit test in `ventas.test.ts` (no DOM).
 - [x] 14.9 Gate guard: `dotnet ef migrations has-pending-model-changes` →
   no pending changes (web-only slice). Verified.
-- [ ] 14.10 Run `judgment-day`; fix; re-judge until clean.
+- [x] 14.10 Run `judgment-day`; fix; re-judge until clean. *(JD-FIX NOTE,
+  slice 14 judgment-day ronda 1, juez B: 4 hallazgos confirmados, todos
+  arreglados.*
+  - *MAJOR 2a — the picker preselection fixture put the `sugerido` lot
+    LAST, so "pick the suggested one" and "pick the last one" were
+    indistinguishable. Fixed: `Pos.test.tsx`'s preselection test now uses
+    3 lots with `sugerido` in the MIDDLE — a "pick the last" mutant goes
+    RED against this fixture (verified, then reverted).*
+  - *MAJOR 2b — `SelectorDeLote`'s `cargandoRef.current` re-entrancy guard
+    clause was dead: the button's native `disabled` wins the race before
+    a same-tick double-click ever reaches the ref check, and the removed
+    test comment's claim to the contrary was empirically false. Fixed:
+    dropped the `cargandoRef` ref entirely from `Pos.tsx` (the clause was
+    its only reader); the double-click test's comment in `Pos.test.tsx`
+    now states the true defense (`disabled` on the native button).*
+  - *MAJOR 2f — zero coverage for `loteVencido: true` on an emitted
+    ticket item. Fixed: added a "Pos — ticket: warning de lote vencido"
+    describe block in `Pos.test.tsx` asserting the "⚠ Lote vencido" text
+    renders when `true` and is absent when `false` — a mutant gating the
+    warning on `false` goes RED (verified, then reverted).*
+  - *MINOR — `SelectorDeLote`'s `/stock/lotes` rejection branch
+    (`No se pudieron cargar los lotes.`) had no test. Fixed: added a
+    rejection-path test to the picker describe block.*
+  - *Full suite after fixes: 564/564 vitest tests green (was 561), `npx
+    tsc -b` clean, `oxlint` clean (one pre-existing unrelated warning in
+    `AuthContext.tsx`).)*
 - [ ] 14.11 Branch `feat/stage12-slice14-web-operacion` off `main` (parent:
   slices 5+8); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1966,6 +1966,39 @@ change.
   - *Full suite after fixes: 564/564 vitest tests green (was 561), `npx
     tsc -b` clean, `oxlint` clean (one pre-existing unrelated warning in
     `AuthContext.tsx`).)*
+  - *(JD-FIX NOTE, slice 14 judgment-day ronda 2, juez A: 1 MAJOR + 3
+    MINOR confirmados, todos arreglados.*
+    - *MAJOR — `CompraEditor.tsx`'s `FilaDeItem.onElegir` only merged the
+      new artículo's identity; a previous artículo's `codigoLote`/
+      `fechaVencimiento` survived the swap and travelled in the save
+      payload — the server's `lote_requerido` validation is deliberately
+      unconditional and would persist the stale lot data
+      (react-async-state regla 8, subtree keyed by entity). Fixed: `onElegir`
+      now resets `codigoLote`/`fechaVencimiento` to `''` whenever the
+      chosen `idArticulo` differs from the line's current one. Two tests
+      added to `CompraEditor.test.tsx`: artículo A (lote-efectivo, loaded)
+      → artículo C (no controla lote) asserts the PUT payload carries
+      `codigoLote: null, fechaVencimiento: null`; artículo A → artículo B
+      (both lote-efectivos) asserts the inputs reset visually to `''`. A
+      revert-and-rerun against the original one-liner sent both new tests
+      RED (payload kept `'LOTE-A'`/`'2026-06-01'`), verified then restored.*
+    - *MINOR — the "⚠ Lote vencido" ticket warning already had a comment
+      citing design decisión 12, but didn't contrast it with the picker's
+      pre-submit hint (`opcionDeLote`'s plain-text "vencido" option
+      label). Fixed: comment in `Pos.tsx` now names both surfaces and why
+      the ticket one is deliberately louder.*
+    - *MINOR — `TablaDeItemsDeSoloLectura` (compra confirmada/anulada)
+      showed `codigoLote` but not `fechaVencimiento`, even though the
+      field is already mirrored on `ItemDeCompra`. Fixed: added a
+      "Vencimiento" column next to "Lote"; `colSpan` on the empty-state
+      row bumped 9 → 10.*
+    - *MINOR — the loteVencido ticket test only asserted the warning text,
+      not that `codigoLote` renders in the same row. Fixed: extended the
+      assertion in `Pos.test.tsx` to also check `within(fila)` for `Lote
+      2026-01-01`.*
+    - *Full suite after fixes: 566/566 vitest tests green (was 564), `npx
+      tsc -b` clean, `oxlint` clean (same pre-existing unrelated warning
+      in `AuthContext.tsx`).)*
 - [ ] 14.11 Branch `feat/stage12-slice14-web-operacion` off `main` (parent:
   slices 5+8); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1882,29 +1882,64 @@ FEFO and completes the happy path with zero keystrokes; the compra editor
 captures lot input per line. **Rollback**: revert the branch — no backend
 change.
 
-- [ ] 14.1 Modify `src/Ways.Web/src/paginas/Pos.tsx`: lot picker component
+- [x] 14.1 Modify `src/Ways.Web/src/paginas/Pos.tsx`: lot picker component
   fed by `GET /api/stock/lotes` (pre-selected via `sugerido`); a line for a
   lot-effective articulo omits `idLote` by default; `loteVencido` renders
   as a prominent warning, never a block.
-- [ ] 14.2 Modify `src/Ways.Web/src/paginas/CompraEditor.tsx`: lot input
+  - Deviation: the picker is click-triggered per cart line (a "Elegir
+    lote" button), not auto-fetched on add — `ArticuloEscaneado` has no
+    `controlaLote` (adding it would be a backend change, out of scope per
+    this slice's own Rollback note), so there is no client-side signal to
+    decide up front whether a line needs the picker at all. An empty
+    `GET /api/stock/lotes` response is ambiguous (not lot-effective, OR
+    lot-effective with no lots yet) but resolves to the same correct
+    action either way: leave `idLote` omitted, the server FEFO-picks or
+    creates the sin-identificar lot. Lot selections are cleared on point
+    of venta change (balances are PV-scoped) and reset after checkout.
+- [x] 14.2 Modify `src/Ways.Web/src/paginas/CompraEditor.tsx`: lot input
   fields (`codigoLote`, `fechaVencimiento`) per draft line for a
   lot-effective articulo; the incomplete-line counter includes them.
-- [ ] 14.3 Modify `src/Ways.Web/src/api/tipos.ts` / `catalogos.ts`:
+  - Deviation: `controlaLote` per line is captured from the chosen
+    `ArticuloListado` at search-selection time (exact). For a REOPENED
+    draft, `itemAFormulario` infers it from whether the persisted item
+    already carries lot data (`idLote`/`codigoLote`/`fechaVencimiento`
+    non-null) — a real signal, but a lot-effective articulo whose line was
+    saved before any lot data was entered is not detected until the
+    operator touches it again. The server's `lote_requerido` 400 at
+    confirm remains the correctness backstop in that gap; a batch
+    `clienteDeArticulos.obtener()` lookup per reopened line was considered
+    and dropped to keep this slice's diff proportional to its ~400-line
+    budget.
+- [x] 14.3 Modify `src/Ways.Web/src/api/tipos.ts` / `catalogos.ts`:
   mirrored contracts — `LineaDeVenta.idLote`, `ItemEmitido.idLote`/
   `codigoLote`/`loteVencido`, `LineaDeCompraSolicitada.codigoLote`/
   `fechaVencimiento`, `LoteListado`, `controlaLote` descriptor field.
-- [ ] 14.4 [P] Picker `sugerido`-preselection test.
-- [ ] 14.5 [P] **Stale-response test** (`mutation-proof-tests` rule 7): a
+  - Deviation: `controlaLote` landed on `ArticuloListado` in `tipos.ts`
+    (read-only mirror consumed by `CompraEditor.tsx`), NOT in
+    `catalogos.ts` — `Articulos.tsx` is a hand-built ABM screen outside the
+    `DescriptorDeCatalogo` machine (same escape hatch as `categorias`), so
+    there is no descriptor to extend there. The write-side toggle
+    (`AltaArticulo`/`EdicionArticulo.controlaLote` + the editor UI) stays
+    Slice 15's, per the coordination note in this task's brief. Also
+    mirrored `LineaTransferida.idLote` (backend already sends it since
+    Slice 10) and `ItemDeCompra.codigoLote`/`fechaVencimiento`/`idLote` —
+    both needed for `CompraEditor.tsx` to round-trip a persisted draft.
+- [x] 14.4 [P] Picker `sugerido`-preselection test.
+- [x] 14.5 [P] **Stale-response test** (`mutation-proof-tests` rule 7): a
   stale picker fetch resolves after the operator changed line — resolved
   inside `act`, asserted synchronously after the flush.
-- [ ] 14.6 [P] Double-click test: exactly one `fetch` on the picker despite
+  - Concretized as: fetch starts for PV #1, the operator switches the
+    punto de venta before it resolves (lot balances are PV-scoped), the
+    PV #1 response lands after — asserted to never paint (`Pos.test.tsx`).
+- [x] 14.6 [P] Double-click test: exactly one `fetch` on the picker despite
   a double-click (`react-async-state` busy/re-entrancy guard).
-- [ ] 14.7 [P] Incomplete-line counter test on `CompraEditor` (lot fields
+- [x] 14.7 [P] Incomplete-line counter test on `CompraEditor` (lot fields
   count toward incompleteness).
-- [ ] 14.8 [P] `web-descriptor-tests` for the `Pos.tsx` picker and
-  `CompraEditor`'s lot input, colocated `*.test.tsx`.
-- [ ] 14.9 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes (web-only slice).
+- [x] 14.8 [P] `web-descriptor-tests` for the `Pos.tsx` picker and
+  `CompraEditor`'s lot input, colocated `*.test.tsx`; plus a pure
+  `opcionDeLote` mapping unit test in `ventas.test.ts` (no DOM).
+- [x] 14.9 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes (web-only slice). Verified.
 - [ ] 14.10 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 14.11 Branch `feat/stage12-slice14-web-operacion` off `main` (parent:
   slices 5+8); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1999,7 +1999,7 @@ change.
     - *Full suite after fixes: 566/566 vitest tests green (was 564), `npx
       tsc -b` clean, `oxlint` clean (same pre-existing unrelated warning
       in `AuthContext.tsx`).)*
-- [ ] 14.11 Branch `feat/stage12-slice14-web-operacion` off `main` (parent:
+- [x] 14.11 Branch `feat/stage12-slice14-web-operacion` off `main` (parent:
   slices 5+8); PR; merge stacked-to-main.
 
 **Test plan**: preselection (14.4), stale-response (14.5), double-click

--- a/src/Ways.Web/src/api/compras.test.ts
+++ b/src/Ways.Web/src/api/compras.test.ts
@@ -28,6 +28,9 @@ function lineaFixture(sobrescribir: Partial<LineaDeCompraFormulario> = {}): Line
     descuento: '50',
     idAlicuotaIva: 3,
     actualizaCosto: true,
+    controlaLote: false,
+    codigoLote: '',
+    fechaVencimiento: '',
     ...sobrescribir,
   }
 }
@@ -47,6 +50,9 @@ function itemFixture(sobrescribir: Partial<ItemDeCompra> = {}): ItemDeCompra {
     total: 950,
     actualizaCosto: true,
     precioSugerido: 114.95,
+    codigoLote: null,
+    fechaVencimiento: null,
+    idLote: null,
     ...sobrescribir,
   }
 }
@@ -73,6 +79,9 @@ describe('lineaDeCompraVacia / itemAFormulario', () => {
       descuento: '',
       idAlicuotaIva: '',
       actualizaCosto: true,
+      controlaLote: false,
+      codigoLote: '',
+      fechaVencimiento: '',
     })
   })
 
@@ -89,6 +98,18 @@ describe('lineaDeCompraVacia / itemAFormulario', () => {
     expect(linea.unidades).toBe('2')
     expect(linea.bultos).toBe('3')
     expect(linea.unidadesPorBulto).toBe('6')
+  })
+
+  it('itemAFormulario infiere controlaLote de un dato de lote ya persistido (stage-12-lotes-vencimientos, Slice 14)', () => {
+    const conLote = itemAFormulario(1, itemFixture({ codigoLote: 'L-01', fechaVencimiento: '2026-12-01' }))
+    expect(conLote.controlaLote).toBe(true)
+    expect(conLote.codigoLote).toBe('L-01')
+    expect(conLote.fechaVencimiento).toBe('2026-12-01')
+
+    const sinLote = itemAFormulario(1, itemFixture({ codigoLote: null, fechaVencimiento: null, idLote: null }))
+    expect(sinLote.controlaLote).toBe(false)
+    expect(sinLote.codigoLote).toBe('')
+    expect(sinLote.fechaVencimiento).toBe('')
   })
 })
 
@@ -112,6 +133,18 @@ describe('lineaCompletaParaEnvio', () => {
   it('sin costo unitario tipeado no está completa', () => {
     expect(lineaCompletaParaEnvio(lineaFixture({ costoUnitario: '' }))).toBe(false)
   })
+
+  it('un artículo que controla lote sin fecha de vencimiento no está completa (espejo del 400 lote_requerido del confirm)', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ controlaLote: true, fechaVencimiento: '' }))).toBe(false)
+  })
+
+  it('un artículo que controla lote con fecha de vencimiento (sin código, se deriva) está completa', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ controlaLote: true, codigoLote: '', fechaVencimiento: '2026-12-01' }))).toBe(true)
+  })
+
+  it('un artículo que no controla lote nunca exige fecha de vencimiento', () => {
+    expect(lineaCompletaParaEnvio(lineaFixture({ controlaLote: false, fechaVencimiento: '' }))).toBe(true)
+  })
 })
 
 describe('aLineaSolicitada', () => {
@@ -126,6 +159,8 @@ describe('aLineaSolicitada', () => {
       descuento: 50,
       idAlicuotaIva: 3,
       actualizaCosto: true,
+      codigoLote: null,
+      fechaVencimiento: null,
     })
   })
 
@@ -137,6 +172,15 @@ describe('aLineaSolicitada', () => {
     const linea = aLineaSolicitada(lineaFixture({ bultos: '3', unidadesPorBulto: '6' }))
     expect(linea.bultos).toBe(3)
     expect(linea.unidadesPorBulto).toBe(6)
+  })
+
+  it('codigoLote/fechaVencimiento vacíos recortan a null; tipeados viajan tal cual', () => {
+    expect(aLineaSolicitada(lineaFixture({ codigoLote: '', fechaVencimiento: '' })).codigoLote).toBeNull()
+    expect(aLineaSolicitada(lineaFixture({ codigoLote: '', fechaVencimiento: '' })).fechaVencimiento).toBeNull()
+
+    const linea = aLineaSolicitada(lineaFixture({ codigoLote: '  L-01  ', fechaVencimiento: '2026-12-01' }))
+    expect(linea.codigoLote).toBe('L-01')
+    expect(linea.fechaVencimiento).toBe('2026-12-01')
   })
 })
 

--- a/src/Ways.Web/src/api/compras.ts
+++ b/src/Ways.Web/src/api/compras.ts
@@ -137,6 +137,15 @@ export type LineaDeCompraFormulario = {
   descuento: string
   idAlicuotaIva: number | ''
   actualizaCosto: boolean
+  /** stage-12-lotes-vencimientos (Slice 14): capturado del `ArticuloListado.controlaLote`
+   * elegido en `SelectorDeArticulo` — decide si `fechaVencimiento` entra al conteo de líneas
+   * incompletas (`lineaCompletaParaEnvio`, espejo del `lote_requerido` server-side). Al reabrir
+   * un borrador existente se infiere de si la línea YA trae dato de lote (`itemAFormulario`):
+   * una línea lote-efectiva todavía no tocada no se detecta hasta que el operador la edite — el
+   * servidor sigue siendo la autoridad final al confirmar. */
+  controlaLote: boolean
+  codigoLote: string
+  fechaVencimiento: string
 }
 
 export function lineaDeCompraVacia(clave: number): LineaDeCompraFormulario {
@@ -151,6 +160,9 @@ export function lineaDeCompraVacia(clave: number): LineaDeCompraFormulario {
     descuento: '',
     idAlicuotaIva: '',
     actualizaCosto: true,
+    controlaLote: false,
+    codigoLote: '',
+    fechaVencimiento: '',
   }
 }
 
@@ -170,6 +182,11 @@ export function itemAFormulario(clave: number, item: ItemDeCompra): LineaDeCompr
     descuento: String(item.descuento),
     idAlicuotaIva: item.idAlicuotaIva,
     actualizaCosto: item.actualizaCosto,
+    // Heurística documentada arriba (`LineaDeCompraFormulario.controlaLote`): un dato de lote ya
+    // persistido prueba que el artículo controla lote; su ausencia no prueba lo contrario.
+    controlaLote: item.idLote !== null || item.codigoLote !== null || item.fechaVencimiento !== null,
+    codigoLote: item.codigoLote ?? '',
+    fechaVencimiento: item.fechaVencimiento ?? '',
   }
 }
 
@@ -182,8 +199,17 @@ function numeroONulo(valor: string): number | null {
   return valor.trim() === '' ? null : Number(valor)
 }
 
+/** Mismo chequeo que `ServicioDeCompras` hace al confirmar (`lote_requerido`, 400) para un
+ * artículo lote-efectivo: `fechaVencimiento` es obligatoria, `codigoLote` no (se deriva del
+ * vencimiento si se omite — `ReglaDeLotes.DerivarCodigo`, design decisión 4). */
 export function lineaCompletaParaEnvio(l: LineaDeCompraFormulario): boolean {
-  return l.idArticulo !== '' && l.idAlicuotaIva !== '' && l.unidades.trim() !== '' && l.costoUnitario.trim() !== ''
+  return (
+    l.idArticulo !== '' &&
+    l.idAlicuotaIva !== '' &&
+    l.unidades.trim() !== '' &&
+    l.costoUnitario.trim() !== '' &&
+    (!l.controlaLote || l.fechaVencimiento.trim() !== '')
+  )
 }
 
 /** Fila de formulario → `LineaDeCompraSolicitada` — solo se envían las filas completas
@@ -199,6 +225,8 @@ export function aLineaSolicitada(l: LineaDeCompraFormulario): LineaDeCompraSolic
     descuento: l.descuento.trim() === '' ? 0 : numero(l.descuento),
     idAlicuotaIva: Number(l.idAlicuotaIva),
     actualizaCosto: l.actualizaCosto,
+    codigoLote: l.codigoLote.trim() === '' ? null : l.codigoLote.trim(),
+    fechaVencimiento: l.fechaVencimiento === '' ? null : l.fechaVencimiento,
   }
 }
 

--- a/src/Ways.Web/src/api/stock.ts
+++ b/src/Ways.Web/src/api/stock.ts
@@ -9,6 +9,7 @@
 import { api } from './cliente'
 import type {
   LineaDeTransferencia,
+  LoteListado,
   ResultadoConteo,
   ResultadoTransferencia,
   SolicitudDeConteo,
@@ -27,6 +28,11 @@ export const clienteDeStock = {
    * de lo que se escribió; el `GET /api/stock` previo es solo un dato de referencia en pantalla,
    * nunca lo que decide qué se renderiza después de un submit. */
   contar: (solicitud: SolicitudDeConteo) => api.post<ResultadoConteo>('/stock/conteos', solicitud),
+  /** `GET /api/stock/lotes` — feed del picker (stage-12-lotes-vencimientos, Slice 14, design
+   * decisión 19). Se pide bajo demanda (click en "Elegir lote"), nunca de arranque para cada
+   * línea del carrito — el camino feliz (omitir `idLote`) no necesita esta llamada. */
+  listarLotes: (idPuntoVenta: number, idArticulo: number) =>
+    api.get<LoteListado[]>(`/stock/lotes?idPuntoVenta=${idPuntoVenta}&idArticulo=${idArticulo}`),
 }
 
 // ---- Formulario de transferencia: una línea editable por fila (mismo patrón que compras.ts) --

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -470,6 +470,12 @@ export type ArticuloListado = {
   disponibleParaTodas: boolean
   idsEmpresas: number[]
   activo: boolean
+  /** stage-12-lotes-vencimientos (Slice 14): mirror de solo lectura — el toggle de edición
+   * (`AltaArticulo`/`EdicionArticulo`) es del editor de `Articulos.tsx` (Slice 15). Acá solo se
+   * lee para decidir si una línea de venta/compra de este artículo pide lote (`ControlEfectivo`
+   * = `controlaLote` AND `lotesHabilitado` del parámetro, decisión 2 del proposal — el picker del
+   * POS no necesita este flag porque `GET /api/stock/lotes` ya resuelve todo server-side). */
+  controlaLote: boolean
 }
 
 /** `codigoInterno: null` deja que el servidor lo autogenere desde el contador atómico del
@@ -867,7 +873,10 @@ export type Existencias = {
 // `POST /api/ventas`, mergeado en Slice 4) — usado por `ventas.ts` (mappers) y `Pos.tsx`
 // (wireado en Slice 7).
 
-export type LineaDeVenta = { idArticulo: number; cantidad: number; codigoBarra: string | null }
+/** `idLote` (stage-12-lotes-vencimientos, Slice 14): `null` es el camino feliz de cero tecleo
+ * (design decisión 19) — el servidor resuelve FEFO solo; solo viaja no-nulo cuando el cajero
+ * eligió explícitamente un lote distinto del sugerido en el picker. */
+export type LineaDeVenta = { idArticulo: number; cantidad: number; codigoBarra: string | null; idLote: number | null }
 export type PagoDeVenta = { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }
 
 export type SolicitudDeVenta = {
@@ -898,6 +907,12 @@ export type ItemEmitido = {
   precioUnitario: number
   descuento: number
   total: number
+  /** stage-12-lotes-vencimientos (Slice 14): `null`/`false` para una línea sin lote — el ticket
+   * y la reimpresión muestran lo mismo (`items_comprobante_venta.id_lote` es el snapshot
+   * congelado). `loteVencido` es un warning, nunca un bloqueo (design decisión 12). */
+  idLote: number | null
+  codigoLote: string | null
+  loteVencido: boolean
 }
 
 /** Pago ya emitido — espejo de `PagoEmitido`. */
@@ -1038,6 +1053,12 @@ export type LineaDeCompraSolicitada = {
   descuento: number
   idAlicuotaIva: number
   actualizaCosto: boolean
+  /** stage-12-lotes-vencimientos (Slice 14): input crudo de recepción para un artículo
+   * lote-efectivo — nada se resuelve a esta altura (design: "nothing is resolved at draft
+   * time"), solo se persiste tal cual mientras la compra es borrador. `null` para un artículo
+   * que no controla lote (el servidor los ignora, `ReglaDeLotes.ControlEfectivo`). */
+  codigoLote: string | null
+  fechaVencimiento: string | null
 }
 
 /** Cuerpo de `POST /api/compras` (crea un borrador) y `PUT /api/compras/{id}` (replace-set
@@ -1067,6 +1088,12 @@ export type ItemDeCompra = {
   total: number
   actualizaCosto: boolean
   precioSugerido: number | null
+  /** `codigoLote`/`fechaVencimiento`: mismo input crudo de `LineaDeCompraSolicitada`, ya
+   * persistido. `idLote` es el lote resuelto (get-or-create) — `null` mientras la compra es
+   * borrador y para un artículo que no controla lote (stage-12-lotes-vencimientos, Slice 14). */
+  codigoLote: string | null
+  fechaVencimiento: string | null
+  idLote: number | null
 }
 
 /** Detalle completo de una compra (espejo de `CompraDetalle`). */
@@ -1168,8 +1195,10 @@ export type SolicitudDeTransferencia = {
 }
 
 /** El stock resultante de un artículo en AMBOS puntos de venta tras la transacción (espejo de
- * `LineaTransferida`). */
-export type LineaTransferida = { idArticulo: number; cantidadOrigen: number; cantidadDestino: number }
+ * `LineaTransferida`). `idLote` (stage-12-lotes-vencimientos, Slice 10): el backend ya lo manda
+ * desde ese slice — mirror de solo lectura, la columna de lote en la grilla de `Transferencias.tsx`
+ * es del Slice 15. */
+export type LineaTransferida = { idArticulo: number; idLote: number | null; cantidadOrigen: number; cantidadDestino: number }
 
 /** Respuesta de `POST /api/stock/transferencias` (espejo de `ResultadoTransferencia`). */
 export type ResultadoTransferencia = {
@@ -1182,6 +1211,29 @@ export type ResultadoTransferencia = {
  * delta (espejo de `SolicitudDeConteo`; spec: conteo-de-inventario / Conteo Input Is The Counted
  * Total, Never A Delta). */
 export type SolicitudDeConteo = { idPuntoVenta: number; idArticulo: number; contada: number; observaciones: string }
+
+// --- Lotes y vencimientos (stage-12-lotes-vencimientos, Slice 14): espejo de
+// `Ways.Domain.Stock.EstadoDeVencimiento`/`Ways.Application.Stock.Contratos.LoteListado` — el
+// picker del POS/la recepción de compra NUNCA recalculan FEFO (design decisión 19), solo
+// renderizan lo que el servidor ya resolvió.
+
+/** Viaja como texto (`JsonStringEnumConverter`), nunca como ordinal — mismo criterio que
+ * `Granularidad`. */
+export type EstadoDeVencimiento = 'Vencido' | 'PorVencer' | 'Vigente' | 'SinFecha'
+
+/** Fila de `GET /api/stock/lotes` (picker) — espejo de `LoteListado`. `sugerido` es el pick FEFO
+ * server-computed (`ReglaDeLotes.ElegirFefo`, decisión 19): el picker lo resalta, nunca lo
+ * recalcula — omitir `idLote` al vender/transferir hace que el servidor elija el mismo lote. */
+export type LoteListado = {
+  idLote: number
+  idArticulo: number
+  codigo: string
+  fechaVencimiento: string | null
+  esSinIdentificar: boolean
+  cantidad: number
+  estado: EstadoDeVencimiento
+  sugerido: boolean
+}
 
 // --- Reportes (stage-10-agregacion-dashboard, Slice 7): G1 parity — ventas/resumen y
 // gastos/resumen. Espejo de `Ways.Application.Reportes.Contratos` — mismos nombres de campo que

--- a/src/Ways.Web/src/api/ventas.test.ts
+++ b/src/Ways.Web/src/api/ventas.test.ts
@@ -6,9 +6,10 @@ import {
   aSolicitudDeVenta,
   calcularSubtotalPrevia,
   indexarResolucionPorArticulo,
+  opcionDeLote,
   previaDeLinea,
 } from './ventas'
-import type { ArticuloEscaneado, PagoDeVenta, ResultadoDeResolucion } from './tipos'
+import type { ArticuloEscaneado, LoteListado, PagoDeVenta, ResultadoDeResolucion } from './tipos'
 
 function articuloEscaneadoFixture(sobrescribir: Partial<ArticuloEscaneado> = {}): ArticuloEscaneado {
   return { idArticulo: 1, codigoInterno: 'A0001', nombre: 'Coca Cola 1L', codigoBarra: '7790001234567', cantidad: 1, ...sobrescribir }
@@ -130,6 +131,7 @@ describe('aSolicitudDeVenta', () => {
       codigoTipoComprobante: 'TX',
       idComprobanteAsociado: null,
       lineas,
+      lotesSeleccionados: {},
       pagos,
       direccionEntrega: null,
       observaciones: null,
@@ -140,7 +142,7 @@ describe('aSolicitudDeVenta', () => {
       idCliente: 1,
       codigoTipoComprobante: 'TX',
       idComprobanteAsociado: null,
-      lineas: [{ idArticulo: 1, cantidad: 2, codigoBarra: '7790001234567' }],
+      lineas: [{ idArticulo: 1, cantidad: 2, codigoBarra: '7790001234567', idLote: null }],
       pagos,
       direccionEntrega: null,
       observaciones: null,
@@ -155,6 +157,7 @@ describe('aSolicitudDeVenta', () => {
       codigoTipoComprobante: 'NCX',
       idComprobanteAsociado: 42,
       lineas: [lineaFixture({ cantidad: -2 })],
+      lotesSeleccionados: {},
       pagos: [],
       direccionEntrega: null,
       observaciones: null,
@@ -163,5 +166,69 @@ describe('aSolicitudDeVenta', () => {
     expect(resultado.codigoTipoComprobante).toBe('NCX')
     expect(resultado.idComprobanteAsociado).toBe(42)
     expect(resultado.lineas[0].cantidad).toBe(-2)
+  })
+
+  it('camino feliz (design decisión 19): una línea sin selección explícita viaja con idLote null', () => {
+    const resultado = aSolicitudDeVenta({
+      idPuntoVenta: 7,
+      idCliente: 1,
+      codigoTipoComprobante: 'TX',
+      idComprobanteAsociado: null,
+      lineas: [lineaFixture({ idArticulo: 1 })],
+      lotesSeleccionados: {},
+      pagos: [],
+      direccionEntrega: null,
+      observaciones: null,
+    })
+
+    expect(resultado.lineas[0].idLote).toBeNull()
+  })
+
+  it('una elección explícita de lote viaja en idLote de esa línea', () => {
+    const resultado = aSolicitudDeVenta({
+      idPuntoVenta: 7,
+      idCliente: 1,
+      codigoTipoComprobante: 'TX',
+      idComprobanteAsociado: null,
+      lineas: [lineaFixture({ idArticulo: 1 }), lineaFixture({ idArticulo: 2 })],
+      lotesSeleccionados: { 1: 55 },
+      pagos: [],
+      direccionEntrega: null,
+      observaciones: null,
+    })
+
+    expect(resultado.lineas[0].idLote).toBe(55)
+    expect(resultado.lineas[1].idLote).toBeNull()
+  })
+})
+
+describe('opcionDeLote', () => {
+  function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+    return {
+      idLote: 3,
+      idArticulo: 1,
+      codigo: '2026-11-30',
+      fechaVencimiento: '2026-11-30',
+      esSinIdentificar: false,
+      cantidad: 12,
+      estado: 'Vigente',
+      sugerido: false,
+      ...sobrescribir,
+    }
+  }
+
+  it('arma la etiqueta con código, estado y saldo', () => {
+    const opcion = opcionDeLote(loteFixture())
+    expect(opcion).toEqual({ valor: '3', etiqueta: '2026-11-30 — vigente — saldo 12' })
+  })
+
+  it('un lote sugerido lo marca en la etiqueta — nunca lo resuelve de nuevo', () => {
+    const opcion = opcionDeLote(loteFixture({ sugerido: true }))
+    expect(opcion.etiqueta).toMatch(/— sugerido$/)
+  })
+
+  it('el lote sin identificar muestra su propio texto en vez del código reservado', () => {
+    const opcion = opcionDeLote(loteFixture({ esSinIdentificar: true, codigo: 'SIN-IDENTIFICAR', fechaVencimiento: null }))
+    expect(opcion.etiqueta).toBe('Sin identificar — vigente — saldo 12')
   })
 })

--- a/src/Ways.Web/src/api/ventas.ts
+++ b/src/Ways.Web/src/api/ventas.ts
@@ -9,8 +9,10 @@ import type { LineaCarrito } from './carrito'
 import type {
   ArticuloEscaneado,
   ComprobanteEmitido,
+  EstadoDeVencimiento,
   LineaDeResolucion,
   LineaDeVenta,
+  LoteListado,
   PagoDeVenta,
   ResultadoDeResolucion,
   SolicitudDeVenta,
@@ -86,6 +88,12 @@ export function calcularSubtotalPrevia(lineas: LineaCarrito[], precios: Record<n
   }, 0)
 }
 
+/** Selección explícita de lote por línea del carrito, indexada por `idArticulo`
+ * (stage-12-lotes-vencimientos, Slice 14) — una línea AUSENTE acá viaja con `idLote: null`, el
+ * camino feliz de cero tecleo (design decisión 19): mostrar el `sugerido` resaltado en el picker
+ * no cuenta como elección, solo tocar el select la registra. */
+export type LotesSeleccionados = Record<number, number>
+
 /**
  * Carrito confirmado → `SolicitudDeVenta` (design: Checkout Contract), invocado por `Pos.tsx`
  * al cobrar. Sin precios en `LineaDeVenta` a propósito (design decisión 3: "no precioUnitario,
@@ -97,6 +105,7 @@ export function aSolicitudDeVenta(params: {
   codigoTipoComprobante: 'TX' | 'NCX'
   idComprobanteAsociado: number | null
   lineas: LineaCarrito[]
+  lotesSeleccionados: LotesSeleccionados
   pagos: PagoDeVenta[]
   direccionEntrega: string | null
   observaciones: string | null
@@ -105,6 +114,7 @@ export function aSolicitudDeVenta(params: {
     idArticulo: l.idArticulo,
     cantidad: l.cantidad,
     codigoBarra: l.codigoBarra,
+    idLote: params.lotesSeleccionados[l.idArticulo] ?? null,
   }))
 
   return {
@@ -116,5 +126,31 @@ export function aSolicitudDeVenta(params: {
     pagos: params.pagos,
     direccionEntrega: params.direccionEntrega,
     observaciones: params.observaciones,
+  }
+}
+
+// ---- Picker de lote del carrito (stage-12-lotes-vencimientos, Slice 14) -----------------------
+
+function etiquetaDeEstadoDeVencimiento(estado: EstadoDeVencimiento): string {
+  switch (estado) {
+    case 'Vencido':
+      return 'vencido'
+    case 'PorVencer':
+      return 'por vencer'
+    case 'Vigente':
+      return 'vigente'
+    case 'SinFecha':
+      return 'sin fecha'
+  }
+}
+
+/** `LoteListado` → opción del `<select>` del picker — pura y testeable sin DOM (design decisión
+ * 19: `sugerido` es server-authored, acá solo se traduce a texto, nunca se recalcula FEFO). */
+export function opcionDeLote(l: LoteListado): { valor: string; etiqueta: string } {
+  const marca = l.sugerido ? ' — sugerido' : ''
+  const codigo = l.esSinIdentificar ? 'Sin identificar' : l.codigo
+  return {
+    valor: String(l.idLote),
+    etiqueta: `${codigo} — ${etiquetaDeEstadoDeVencimiento(l.estado)} — saldo ${l.cantidad}${marca}`,
   }
 }

--- a/src/Ways.Web/src/paginas/Articulos.test.tsx
+++ b/src/Ways.Web/src/paginas/Articulos.test.tsx
@@ -40,6 +40,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -8,6 +8,7 @@ import { ErrorApi } from '../api/cliente'
 import { ROL } from '../api/tipos'
 import type {
   AlicuotaIvaListado,
+  ArticuloListado,
   CompraDetalle,
   ItemDeCompra,
   ListaPrecioListado,
@@ -133,6 +134,32 @@ function listaPrecioFixture(sobrescribir: Partial<ListaPrecioListado> = {}): Lis
   }
 }
 
+function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloListado {
+  return {
+    id: 20,
+    codigoInterno: 'ART-20',
+    nombre: 'Leche en polvo 800g',
+    descripcion: null,
+    idArea: 1,
+    idCategoria: null,
+    idMarca: null,
+    idGrupo: null,
+    idProveedorHabitual: null,
+    idAlicuotaIva: 3,
+    unidadVenta: 'Unidad',
+    unidadesPorBulto: null,
+    esProducto: true,
+    costoLista: null,
+    descuentoProveedor: null,
+    costoNominal: null,
+    disponibleParaTodas: true,
+    idsEmpresas: [],
+    activo: true,
+    controlaLote: true,
+    ...sobrescribir,
+  }
+}
+
 function itemFixture(sobrescribir: Partial<ItemDeCompra> = {}): ItemDeCompra {
   return {
     orden: 1,
@@ -148,6 +175,9 @@ function itemFixture(sobrescribir: Partial<ItemDeCompra> = {}): ItemDeCompra {
     total: 950,
     actualizaCosto: true,
     precioSugerido: 114.95,
+    codigoLote: null,
+    fechaVencimiento: null,
+    idLote: null,
     ...sobrescribir,
   }
 }
@@ -524,6 +554,51 @@ describe('CompraEditor — líneas incompletas', () => {
 
     expect(await screen.findByText('1 línea(s) incompleta(s) — no se van a guardar.')).toBeInTheDocument()
     expect(screen.getByText('$1.149,50')).toBeInTheDocument()
+  })
+})
+
+describe('CompraEditor — líneas con control de lote (stage-12-lotes-vencimientos, Slice 14)', () => {
+  it('elegir un artículo que controla lote muestra los inputs de lote y suma al contador hasta cargar la fecha de vencimiento', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/compras/1') return Promise.resolve(compraFixture({ items: [] }))
+      if (ruta.startsWith('/articulos?busqueda=')) {
+        return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByDisplayValue('0003-00012345')
+
+    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
+    await usuario.type(screen.getByPlaceholderText('Buscar artículo…'), 'leche')
+    await screen.findByText('ART-20 — Leche en polvo 800g')
+    await usuario.click(screen.getByText('ART-20 — Leche en polvo 800g'))
+
+    expect(screen.getByLabelText('Fecha de vencimiento')).toBeInTheDocument()
+    expect(await screen.findByText('1 línea(s) incompleta(s) — no se van a guardar.')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Unidades'), '5')
+    await usuario.type(screen.getByLabelText('Costo unitario'), '20')
+    await usuario.selectOptions(screen.getByLabelText('Alícuota de IVA'), '3')
+
+    // Sigue incompleta: el artículo controla lote y la fecha de vencimiento es obligatoria
+    // (espejo del `lote_requerido` server-side) — código de lote NO es obligatorio, se deriva.
+    expect(screen.getByText('1 línea(s) incompleta(s) — no se van a guardar.')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Fecha de vencimiento'), '2026-12-01')
+
+    await waitFor(() => expect(screen.queryByText(/línea\(s\) incompleta\(s\)/)).not.toBeInTheDocument())
+  })
+
+  it('un artículo que no controla lote nunca muestra los inputs de lote', async () => {
+    mockearReferencia((ruta) => (ruta === '/compras/1' ? Promise.resolve(compraFixture()) : undefined))
+    renderEditor()
+
+    await screen.findByText('Elegido: Fideos 500g')
+    expect(screen.getByText('No controla lote')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Fecha de vencimiento')).not.toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -600,6 +600,66 @@ describe('CompraEditor — líneas con control de lote (stage-12-lotes-vencimien
     expect(screen.getByText('No controla lote')).toBeInTheDocument()
     expect(screen.queryByLabelText('Fecha de vencimiento')).not.toBeInTheDocument()
   })
+
+  it('re-elegir el artículo de una línea con lote cargado, por uno que no controla lote, no deja codigoLote/fechaVencimiento stale en el payload (judgment-day, MAJOR juez A)', async () => {
+    const articuloSinLote = articuloFixture({ id: 30, codigoInterno: 'ART-30', nombre: 'Coca Cola 1.5L', controlaLote: false })
+    mockearReferencia((ruta) => {
+      if (ruta === '/compras/1')
+        return Promise.resolve(compraFixture({ items: [itemFixture({ codigoLote: 'LOTE-A', fechaVencimiento: '2026-06-01' })] }))
+      if (ruta.startsWith('/articulos?busqueda=')) return Promise.resolve({ items: [articuloSinLote], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    apiPutMock.mockResolvedValue(compraFixture())
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByText('Elegido: Fideos 500g')
+    expect(screen.getByLabelText('Código de lote')).toHaveValue('LOTE-A')
+    expect(screen.getByLabelText('Fecha de vencimiento')).toHaveValue('2026-06-01')
+
+    await usuario.type(screen.getByPlaceholderText('Buscar artículo…'), 'coca')
+    await screen.findByText('ART-30 — Coca Cola 1.5L')
+    await usuario.click(screen.getByText('ART-30 — Coca Cola 1.5L'))
+
+    // El artículo nuevo no controla lote: los inputs de lote desaparecen — el reset no es solo
+    // interno, también es visible (el operador ve que el lote del artículo anterior ya no aplica).
+    expect(screen.getByText('No controla lote')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Código de lote')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Fecha de vencimiento')).not.toBeInTheDocument()
+
+    await usuario.click(screen.getByRole('button', { name: 'Guardar borrador' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, cuerpo] = apiPutMock.mock.calls[0] as [string, Record<string, unknown>]
+    const items = cuerpo.items as Record<string, unknown>[]
+    expect(items).toHaveLength(1)
+    expect(items[0].idArticulo).toBe(30)
+    expect(items[0].codigoLote).toBeNull()
+    expect(items[0].fechaVencimiento).toBeNull()
+  })
+
+  it('re-elegir el artículo de una línea con lote cargado, por otro que también controla lote, resetea codigoLote/fechaVencimiento visualmente (el operador recarga los del lote nuevo)', async () => {
+    const otroArticuloConLote = articuloFixture({ id: 40, codigoInterno: 'ART-40', nombre: 'Yerba 1kg', controlaLote: true })
+    mockearReferencia((ruta) => {
+      if (ruta === '/compras/1')
+        return Promise.resolve(compraFixture({ items: [itemFixture({ codigoLote: 'LOTE-A', fechaVencimiento: '2026-06-01' })] }))
+      if (ruta.startsWith('/articulos?busqueda=')) return Promise.resolve({ items: [otroArticuloConLote], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    const usuario = userEvent.setup()
+
+    renderEditor()
+    await screen.findByText('Elegido: Fideos 500g')
+    expect(screen.getByLabelText('Código de lote')).toHaveValue('LOTE-A')
+    expect(screen.getByLabelText('Fecha de vencimiento')).toHaveValue('2026-06-01')
+
+    await usuario.type(screen.getByPlaceholderText('Buscar artículo…'), 'yerba')
+    await screen.findByText('ART-40 — Yerba 1kg')
+    await usuario.click(screen.getByText('ART-40 — Yerba 1kg'))
+
+    expect(screen.getByLabelText('Código de lote')).toHaveValue('')
+    expect(screen.getByLabelText('Fecha de vencimiento')).toHaveValue('')
+  })
 })
 
 describe('CompraEditor — role gating', () => {

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -164,9 +164,37 @@ function FilaDeItem({ linea, alicuotas, disabled, discriminaIva, porcentajePorAl
         <SelectorDeArticulo
           descripcion={linea.descripcion}
           disabled={disabled}
-          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
+          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre, controlaLote: a.controlaLote })}
         />
         {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
+      </td>
+      <td style={{ minWidth: 180 }}>
+        {linea.controlaLote ? (
+          <>
+            <input
+              type="text"
+              className="form-control form-control-sm rounded-0 mb-1"
+              aria-label="Código de lote"
+              placeholder="Código de lote (opcional)"
+              value={linea.codigoLote}
+              disabled={disabled}
+              onChange={(e) => onCambio(linea.clave, { codigoLote: e.target.value })}
+            />
+            <input
+              type="date"
+              className={`form-control form-control-sm rounded-0 ${linea.fechaVencimiento.trim() === '' ? 'is-invalid' : ''}`}
+              aria-label="Fecha de vencimiento"
+              value={linea.fechaVencimiento}
+              disabled={disabled}
+              onChange={(e) => onCambio(linea.clave, { fechaVencimiento: e.target.value })}
+            />
+            {linea.fechaVencimiento.trim() === '' && (
+              <div className="invalid-feedback">Este artículo controla lote — la fecha de vencimiento es obligatoria.</div>
+            )}
+          </>
+        ) : (
+          <span className="text-muted small">No controla lote</span>
+        )}
       </td>
       <td style={{ width: 90 }}>
         <input
@@ -279,6 +307,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
         <thead>
           <tr>
             <th>Artículo</th>
+            <th>Lote</th>
             <th className="text-end">Cantidad</th>
             <th className="text-end">Costo unitario</th>
             <th className="text-end">Descuento</th>
@@ -292,6 +321,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
           {compra.items.map((item) => (
             <tr key={item.orden}>
               <td>{item.descripcion}</td>
+              <td>{item.codigoLote ?? '—'}</td>
               <td className="text-end">{item.cantidad}</td>
               <td className="text-end">{formatearMoneda(item.costoUnitario)}</td>
               <td className="text-end">{formatearMoneda(item.descuento)}</td>
@@ -303,7 +333,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
           ))}
           {compra.items.length === 0 && (
             <tr>
-              <td colSpan={8} className="text-center text-muted py-3">
+              <td colSpan={9} className="text-center text-muted py-3">
                 Esta compra no tiene items.
               </td>
             </tr>
@@ -880,6 +910,7 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
                 <thead>
                   <tr>
                     <th>Artículo</th>
+                    <th>Lote</th>
                     <th>Unidades</th>
                     <th>Bultos</th>
                     <th>Un./bulto</th>
@@ -906,7 +937,7 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
                   ))}
                   {lineas.length === 0 && (
                     <tr>
-                      <td colSpan={10} className="text-center text-muted py-3">
+                      <td colSpan={11} className="text-center text-muted py-3">
                         Todavía no hay items cargados.
                       </td>
                     </tr>

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -164,7 +164,19 @@ function FilaDeItem({ linea, alicuotas, disabled, discriminaIva, porcentajePorAl
         <SelectorDeArticulo
           descripcion={linea.descripcion}
           disabled={disabled}
-          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre, controlaLote: a.controlaLote })}
+          onElegir={(a) => {
+            // Cambiar el artículo de una línea invalida cualquier lote ya cargado (era del
+            // artículo anterior): sin este reset, codigoLote/fechaVencimiento quedan stale y
+            // viajan en el payload — la validación del servidor es incondicional y los persiste
+            // (judgment-day, slice 14, MAJOR juez A).
+            const cambioDeArticulo = linea.idArticulo !== a.id
+            onCambio(linea.clave, {
+              idArticulo: a.id,
+              descripcion: a.nombre,
+              controlaLote: a.controlaLote,
+              ...(cambioDeArticulo ? { codigoLote: '', fechaVencimiento: '' } : {}),
+            })
+          }}
         />
         {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
       </td>
@@ -308,6 +320,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
           <tr>
             <th>Artículo</th>
             <th>Lote</th>
+            <th>Vencimiento</th>
             <th className="text-end">Cantidad</th>
             <th className="text-end">Costo unitario</th>
             <th className="text-end">Descuento</th>
@@ -322,6 +335,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
             <tr key={item.orden}>
               <td>{item.descripcion}</td>
               <td>{item.codigoLote ?? '—'}</td>
+              <td>{item.fechaVencimiento ?? '—'}</td>
               <td className="text-end">{item.cantidad}</td>
               <td className="text-end">{formatearMoneda(item.costoUnitario)}</td>
               <td className="text-end">{formatearMoneda(item.descuento)}</td>
@@ -333,7 +347,7 @@ function TablaDeItemsDeSoloLectura({ compra }: { compra: CompraDetalle }) {
           ))}
           {compra.items.length === 0 && (
             <tr>
-              <td colSpan={9} className="text-center text-muted py-3">
+              <td colSpan={10} className="text-center text-muted py-3">
                 Esta compra no tiene items.
               </td>
             </tr>

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
@@ -84,6 +84,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Ofertas.test.tsx
+++ b/src/Ways.Web/src/paginas/Ofertas.test.tsx
@@ -58,6 +58,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1453,6 +1453,9 @@ describe('Pos — ticket: warning de lote vencido (design decisión 12: "Expired
     expect(await screen.findByText('Venta 0007-00000001')).toBeInTheDocument()
     const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
     expect(within(fila).getByText('⚠ Lote vencido')).toBeInTheDocument()
+    // El código de lote y el warning conviven en la misma fila del ticket (judgment-day, slice
+    // 14, MINOR 4 juez A) — el operador ve QUÉ lote venció, no solo QUE algo venció.
+    expect(within(fila).getByText('Lote 2026-01-01')).toBeInTheDocument()
   })
 
   it('un item emitido con loteVencido: false no muestra el warning', async () => {

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1314,11 +1314,15 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
   })
 
   it('preselecciona (resalta) el lote sugerido que manda el servidor — nunca lo recalcula', async () => {
+    // El sugerido va en el MEDIO de la lista, ni primero ni último: si "elegir el sugerido" y
+    // "elegir el último/primero" fueran indistinguibles, esta aserción no lo detectaría (judgment-day
+    // slice 14, MAJOR 2a — mutante "elegir el último" debe quedar RED contra este fixture).
     mockearApiGet((ruta) =>
       ruta.startsWith('/stock/lotes?')
         ? Promise.resolve<LoteListado[]>([
             loteFixture({ idLote: 1, codigo: '2026-09-01' }),
             loteFixture({ idLote: 2, codigo: '2026-10-01', sugerido: true }),
+            loteFixture({ idLote: 3, codigo: '2026-11-01' }),
           ])
         : undefined,
     )
@@ -1339,7 +1343,7 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
     expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
   })
 
-  it('doble click en "Elegir lote" dispara exactamente un fetch (react-async-state regla 9: guard de reentrancia de primera línea)', async () => {
+  it('doble click en "Elegir lote" dispara exactamente un fetch (el `disabled` nativo del botón es la defensa, no un ref)', async () => {
     let resolverLotes: (valor: LoteListado[]) => void = () => {}
     mockearApiGet((ruta) =>
       ruta.startsWith('/stock/lotes?') ? new Promise((resolve) => (resolverLotes = resolve)) : undefined,
@@ -1347,8 +1351,11 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
     await armarCarritoConUnaLinea()
 
     const boton = screen.getByRole('button', { name: 'Elegir lote' })
-    // Mismo tick: `fireEvent` (a diferencia de `userEvent.click` con `await` de por medio) es lo
-    // que reproduce el doble click que le gana al re-render del `disabled`.
+    // `fireEvent.click` (a diferencia de `userEvent.click` con `await` de por medio) dispara los
+    // dos clicks en el mismo tick — pero el segundo no hace nada: React ya marcó el botón
+    // `disabled` en el primer render posterior al `setCargando(true)`, y ni JSDOM ni un navegador
+    // real despachan `click` sobre un elemento disabled. No hay guard de reentrancia por ref: el
+    // único fetch que se prueba acá es consecuencia del atributo nativo.
     fireEvent.click(boton)
     fireEvent.click(boton)
 
@@ -1389,5 +1396,71 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
 
     expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeInTheDocument()
     expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
+  })
+
+  it('un fetch de lotes rechazado muestra "No se pudieron cargar los lotes."', async () => {
+    mockearApiGet((ruta) => (ruta.startsWith('/stock/lotes?') ? Promise.reject(new Error('boom')) : undefined))
+    await armarCarritoConUnaLinea()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
+
+    expect(await screen.findByText('No se pudieron cargar los lotes.')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
+  })
+})
+
+describe('Pos — ticket: warning de lote vencido (design decisión 12: "Expired Lot Sale Warns, Never Blocks")', () => {
+  it('un item emitido con loteVencido: true muestra el warning "⚠ Lote vencido" en el ticket', async () => {
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ofertas/resolver') {
+        const resultados: ResultadoDeResolucion[] = [
+          { idArticulo: 1, idListaPrecio: 1, precioOriginal: 100, precioFinal: 100, descuentoUnitario: 0, aplicadas: [] },
+        ]
+        return Promise.resolve(resultados)
+      }
+      if (ruta === '/ventas') {
+        return Promise.resolve(
+          comprobanteEmitidoFixture({
+            items: [
+              {
+                orden: 1,
+                idArticulo: 1,
+                descripcion: 'Coca Cola 1L',
+                codigoBarra: '7790001234567',
+                idArea: 1,
+                idListaPrecio: 1,
+                idOferta: null,
+                idAlicuotaIva: 1,
+                porcentajeIva: 21,
+                cantidad: 1,
+                precioUnitario: 100,
+                descuento: 0,
+                total: 100,
+                idLote: 2,
+                codigoLote: '2026-01-01',
+                loteVencido: true,
+              },
+            ],
+          }),
+        )
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    await armarVentaLista()
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+
+    expect(await screen.findByText('Venta 0007-00000001')).toBeInTheDocument()
+    const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
+    expect(within(fila).getByText('⚠ Lote vencido')).toBeInTheDocument()
+  })
+
+  it('un item emitido con loteVencido: false no muestra el warning', async () => {
+    await armarVentaLista()
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+
+    expect(await screen.findByText('Venta 0007-00000001')).toBeInTheDocument()
+    const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
+    expect(within(fila).queryByText('⚠ Lote vencido')).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -7,6 +7,7 @@ import type {
   ArticuloEscaneado,
   ClienteListado,
   ComprobanteEmitido,
+  LoteListado,
   MedioPagoListado,
   PaginaDe,
   ParametroResuelto,
@@ -131,6 +132,9 @@ function comprobanteEmitidoFixture(sobrescribir: Partial<ComprobanteEmitido> = {
         precioUnitario: 100,
         descuento: 0,
         total: 100,
+        idLote: null,
+        codigoLote: null,
+        loteVencido: false,
       },
     ],
     pagos: [{ idMedioPago: 1, importe: 100, referencia: null, vuelto: 0 }],
@@ -156,29 +160,41 @@ const consumidorFinal = clienteFixture()
 const otroCliente = clienteFixture({ id: 2, numero: 2, nombre: 'Juan', apellido: 'Pérez', esConsumidorFinal: false })
 const puntoVentaCentro = puntoVentaFixture()
 
-function mockearApiGet() {
+/** Rutas GET comunes a casi todos los tests — devuelve `undefined` (no `Promise`) para una ruta
+ * que no reconoce, así un test puede extender la tabla sin duplicarla entera (mismo criterio que
+ * `mockearReferencia` en CompraEditor.test.tsx). */
+function rutaBaseDePos(ruta: string, puntosVenta: PuntoVentaListado[] = [puntoVentaCentro]): Promise<unknown> | undefined {
+  if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>(puntosVenta)
+  if (ruta === '/clientes') {
+    const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
+    return Promise.resolve(pagina)
+  }
+  if (ruta.startsWith('/clientes?busqueda=')) {
+    const pagina: PaginaDe<ClienteListado> = { items: [otroCliente], total: 1, pagina: 1, tamanio: 25 }
+    return Promise.resolve(pagina)
+  }
+  if (ruta.startsWith('/articulos/escaneo?entrada=')) {
+    return Promise.resolve(articuloEscaneadoFixture())
+  }
+  if (ruta === '/catalogos/medios-pago') {
+    return Promise.resolve<MedioPagoListado[]>([medioEfectivo, medioTarjeta, medioCuentaCorriente])
+  }
+  if (ruta.startsWith('/parametros/tolerancia_pago')) {
+    return Promise.resolve<ParametroResuelto>({ clave: 'tolerancia_pago', valor: '10' })
+  }
+  if (ruta.startsWith('/parametros/vuelto_maximo')) {
+    return Promise.resolve<ParametroResuelto>({ clave: 'vuelto_maximo', valor: '20' })
+  }
+  // stage-12-lotes-vencimientos (Slice 14): sin lotes por defecto — el camino feliz de la
+  // mayoría de los tests nunca abre el picker, pero cualquier click accidental no debe romper.
+  if (ruta.startsWith('/stock/lotes?')) return Promise.resolve<LoteListado[]>([])
+  return undefined
+}
+
+function mockearApiGet(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
-    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
-    if (ruta === '/clientes') {
-      const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
-      return Promise.resolve(pagina)
-    }
-    if (ruta.startsWith('/clientes?busqueda=')) {
-      const pagina: PaginaDe<ClienteListado> = { items: [otroCliente], total: 1, pagina: 1, tamanio: 25 }
-      return Promise.resolve(pagina)
-    }
-    if (ruta.startsWith('/articulos/escaneo?entrada=')) {
-      return Promise.resolve(articuloEscaneadoFixture())
-    }
-    if (ruta === '/catalogos/medios-pago') {
-      return Promise.resolve<MedioPagoListado[]>([medioEfectivo, medioTarjeta, medioCuentaCorriente])
-    }
-    if (ruta.startsWith('/parametros/tolerancia_pago')) {
-      return Promise.resolve<ParametroResuelto>({ clave: 'tolerancia_pago', valor: '10' })
-    }
-    if (ruta.startsWith('/parametros/vuelto_maximo')) {
-      return Promise.resolve<ParametroResuelto>({ clave: 'vuelto_maximo', valor: '20' })
-    }
+    const propia = sobrescribir?.(ruta) ?? rutaBaseDePos(ruta)
+    if (propia) return propia
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -475,11 +491,11 @@ describe('Pos — vista previa de precios', () => {
     await waitFor(() => expect(apiPostMock.mock.calls.some((llamada) => llamada[0] === '/ventas')).toBe(true))
     const llamadaVentas = apiPostMock.mock.calls.find((llamada) => llamada[0] === '/ventas')
     const solicitud = llamadaVentas?.[1] as {
-      lineas: { idArticulo: number; cantidad: number; codigoBarra: string | null }[]
+      lineas: { idArticulo: number; cantidad: number; codigoBarra: string | null; idLote: number | null }[]
       pagos: { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }[]
     }
 
-    expect(solicitud.lineas).toEqual([{ idArticulo: 1, cantidad: 1, codigoBarra: '7790001234567' }])
+    expect(solicitud.lineas).toEqual([{ idArticulo: 1, cantidad: 1, codigoBarra: '7790001234567', idLote: null }])
     expect(solicitud.pagos).toEqual([{ idMedioPago: medioEfectivo.id, importe: 500, referencia: null, vuelto: 0 }])
   })
 
@@ -1262,5 +1278,116 @@ describe('Pos — limpieza de ediciones en curso', () => {
     await userEvent.click(boton)
 
     await waitFor(() => expect(screen.getByLabelText('Cantidad de Coca Cola 1L')).toHaveValue(2))
+  })
+})
+
+describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design decisión 19)', () => {
+  function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+    return {
+      idLote: 1,
+      idArticulo: 1,
+      codigo: '2026-09-01',
+      fechaVencimiento: '2026-09-01',
+      esSinIdentificar: false,
+      cantidad: 5,
+      estado: 'Vigente',
+      sugerido: false,
+      ...sobrescribir,
+    }
+  }
+
+  /** Deja el carrito con una sola línea de Coca Cola, sin pasar por el panel de pagos — punto de
+   * partida de los tests del picker. */
+  async function armarCarritoConUnaLinea() {
+    render(<Pos />)
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+  }
+
+  it('el camino feliz nunca pide los lotes — el botón "Elegir lote" no dispara ningún fetch solo por aparecer', async () => {
+    await armarCarritoConUnaLinea()
+
+    expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeInTheDocument()
+    expect(apiGetMock.mock.calls.some((call: unknown[]) => (call[0] as string).startsWith('/stock/lotes?'))).toBe(false)
+  })
+
+  it('preselecciona (resalta) el lote sugerido que manda el servidor — nunca lo recalcula', async () => {
+    mockearApiGet((ruta) =>
+      ruta.startsWith('/stock/lotes?')
+        ? Promise.resolve<LoteListado[]>([
+            loteFixture({ idLote: 1, codigo: '2026-09-01' }),
+            loteFixture({ idLote: 2, codigo: '2026-10-01', sugerido: true }),
+          ])
+        : undefined,
+    )
+    await armarCarritoConUnaLinea()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
+
+    expect(await screen.findByLabelText('Lote de Coca Cola 1L')).toHaveValue('2')
+  })
+
+  it('una lista de lotes vacía muestra el aviso de FEFO automático, sin picker', async () => {
+    mockearApiGet((ruta) => (ruta.startsWith('/stock/lotes?') ? Promise.resolve<LoteListado[]>([]) : undefined))
+    await armarCarritoConUnaLinea()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
+
+    expect(await screen.findByText('Sin lotes registrados — FEFO automático.')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
+  })
+
+  it('doble click en "Elegir lote" dispara exactamente un fetch (react-async-state regla 9: guard de reentrancia de primera línea)', async () => {
+    let resolverLotes: (valor: LoteListado[]) => void = () => {}
+    mockearApiGet((ruta) =>
+      ruta.startsWith('/stock/lotes?') ? new Promise((resolve) => (resolverLotes = resolve)) : undefined,
+    )
+    await armarCarritoConUnaLinea()
+
+    const boton = screen.getByRole('button', { name: 'Elegir lote' })
+    // Mismo tick: `fireEvent` (a diferencia de `userEvent.click` con `await` de por medio) es lo
+    // que reproduce el doble click que le gana al re-render del `disabled`.
+    fireEvent.click(boton)
+    fireEvent.click(boton)
+
+    resolverLotes([loteFixture()])
+    await screen.findByLabelText('Lote de Coca Cola 1L')
+
+    const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/stock/lotes?'))
+    expect(llamadas).toHaveLength(1)
+  })
+
+  it('una respuesta stale que llega DESPUÉS de cambiar de punto de venta no pinta el picker (mutation-proof-tests regla 7)', async () => {
+    const puntoVentaSucursal = puntoVentaFixture({ id: 8, nombre: 'Sucursal Norte' })
+    let resolverLotesPv1: (valor: LoteListado[]) => void = () => {}
+    let promesaLotesPv1: Promise<LoteListado[]> = Promise.resolve([])
+    mockearApiGet((ruta) => {
+      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro, puntoVentaSucursal])
+      if (ruta.startsWith('/stock/lotes?') && ruta.includes(`idPuntoVenta=${puntoVentaCentro.id}`)) {
+        promesaLotesPv1 = new Promise((resolve) => (resolverLotesPv1 = resolve))
+        return promesaLotesPv1
+      }
+      if (ruta.startsWith('/stock/lotes?')) return Promise.resolve<LoteListado[]>([])
+      return undefined
+    })
+    await armarCarritoConUnaLinea()
+    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(puntoVentaCentro.id)))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
+    // el fetch de PV1 queda en vuelo — `resolverLotesPv1` todavía no se llamó.
+
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), String(puntoVentaSucursal.id))
+
+    // regla 7: el flush del microtask va DENTRO de `act` — un `waitFor` pasaría en su primer
+    // tick, antes de que el `.then` stale aterrice, y saldría verde sin probar nada.
+    await act(async () => {
+      resolverLotesPv1([loteFixture({ idLote: 99, codigo: 'STALE' })])
+      await promesaLotesPv1
+    })
+
+    expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -229,7 +229,6 @@ function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegid
   const [cargando, setCargando] = useState(false)
   const [error, setError] = useState('')
   const [lotes, setLotes] = useState<LoteListado[] | null>(null)
-  const cargandoRef = useRef(false)
   const tokenRef = useRef(0)
 
   // react-async-state regla 3: los saldos de lote son por punto de venta — un cambio de PV
@@ -238,19 +237,19 @@ function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegid
   // promesa vieja DESPUÉS del cambio de PV, dentro de `act`).
   useEffect(() => {
     tokenRef.current += 1
-    cargandoRef.current = false
     setCargando(false)
     setError('')
     setLotes(null)
   }, [idPuntoVenta, idArticulo])
 
   async function cargar() {
-    // regla 9: guard de reentrancia de primera línea — un doble click en el mismo tick le gana al
-    // re-render que deshabilita el botón.
-    if (cargandoRef.current || lotes !== null) return
+    // El guard de reentrancia de primera línea es el `disabled` nativo del botón (más abajo):
+    // JSDOM y los navegadores no despachan `click` sobre un elemento disabled, así que un
+    // `cargandoRef` extra acá era inalcanzable — verificado por mutación en judgment-day
+    // (slice 14, MAJOR 2b). `lotes !== null` sigue evitando un refetch tras una carga exitosa.
+    if (lotes !== null) return
 
     const miToken = (tokenRef.current += 1)
-    cargandoRef.current = true
     setCargando(true)
     setError('')
 
@@ -263,7 +262,6 @@ function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegid
       setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
     } finally {
       if (tokenRef.current === miToken) {
-        cargandoRef.current = false
         setCargando(false)
       }
     }

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -19,16 +19,28 @@ import {
   validarPagosLocal,
   type FilaPago,
 } from '../api/pagos'
+import { clienteDeStock } from '../api/stock'
 import type {
   ClienteListado,
   ComprobanteEmitido,
+  LoteListado,
   MedioPagoAlta,
   MedioPagoListado,
   ParametroResuelto,
   PuntoVentaListado,
   ResultadoDeResolucion,
 } from '../api/tipos'
-import { aLineaDeCarritoDesdeEscaneo, aLineasDeResolucion, aSolicitudDeVenta, calcularSubtotalPrevia, clienteDeVentas, indexarResolucionPorArticulo, previaDeLinea } from '../api/ventas'
+import {
+  aLineaDeCarritoDesdeEscaneo,
+  aLineasDeResolucion,
+  aSolicitudDeVenta,
+  calcularSubtotalPrevia,
+  clienteDeVentas,
+  indexarResolucionPorArticulo,
+  opcionDeLote,
+  previaDeLinea,
+  type LotesSeleccionados,
+} from '../api/ventas'
 import { Box } from '../componentes/Box'
 
 const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
@@ -198,6 +210,109 @@ function PanelGateTurno({ idPuntoVenta, onAbierto }: PropsPanelGateTurno) {
   )
 }
 
+type PropsSelectorDeLote = {
+  idPuntoVenta: number
+  idArticulo: number
+  nombreArticulo: string
+  idLoteElegido: number | null
+  disabled: boolean
+  onElegir: (idLote: number | null) => void
+}
+
+/**
+ * Picker de lote de una línea del carrito (stage-12-lotes-vencimientos, Slice 14, design decisión
+ * 19): se pide bajo demanda (click en "Elegir lote") — el camino feliz de cero tecleo (omitir
+ * `idLote`, el servidor resuelve FEFO solo) nunca dispara este fetch. `sugerido` llega ya resuelto
+ * del servidor (`ReglaDeLotes.ElegirFefo`); acá solo se resalta, nunca se recalcula.
+ */
+function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegido, disabled, onElegir }: PropsSelectorDeLote) {
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [lotes, setLotes] = useState<LoteListado[] | null>(null)
+  const cargandoRef = useRef(false)
+  const tokenRef = useRef(0)
+
+  // react-async-state regla 3: los saldos de lote son por punto de venta — un cambio de PV
+  // invalida cualquier fetch en vuelo y cualquier lote ya cargado, nunca puede sobrevivir a la
+  // selección anterior (mutation-proof-tests regla 7: probado en Pos.test.tsx resolviendo la
+  // promesa vieja DESPUÉS del cambio de PV, dentro de `act`).
+  useEffect(() => {
+    tokenRef.current += 1
+    cargandoRef.current = false
+    setCargando(false)
+    setError('')
+    setLotes(null)
+  }, [idPuntoVenta, idArticulo])
+
+  async function cargar() {
+    // regla 9: guard de reentrancia de primera línea — un doble click en el mismo tick le gana al
+    // re-render que deshabilita el botón.
+    if (cargandoRef.current || lotes !== null) return
+
+    const miToken = (tokenRef.current += 1)
+    cargandoRef.current = true
+    setCargando(true)
+    setError('')
+
+    try {
+      const resultado = await clienteDeStock.listarLotes(idPuntoVenta, idArticulo)
+      if (tokenRef.current !== miToken) return
+      setLotes(resultado)
+    } catch (e) {
+      if (tokenRef.current !== miToken) return
+      setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
+    } finally {
+      if (tokenRef.current === miToken) {
+        cargandoRef.current = false
+        setCargando(false)
+      }
+    }
+  }
+
+  if (lotes === null) {
+    return (
+      <div>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-secondary rounded-0"
+          disabled={disabled || cargando}
+          onClick={cargar}
+        >
+          {cargando ? 'Cargando…' : 'Elegir lote'}
+        </button>
+        {error && <div className="small text-danger">{error}</div>}
+      </div>
+    )
+  }
+
+  if (lotes.length === 0) {
+    return <span className="small text-muted">Sin lotes registrados — FEFO automático.</span>
+  }
+
+  const sugerido = lotes.find((l) => l.sugerido) ?? null
+  const valorActual = idLoteElegido !== null ? String(idLoteElegido) : sugerido ? String(sugerido.idLote) : ''
+
+  return (
+    <select
+      className="form-select form-select-sm rounded-0"
+      aria-label={`Lote de ${nombreArticulo}`}
+      value={valorActual}
+      disabled={disabled}
+      onChange={(e) => onElegir(e.target.value === '' ? null : Number(e.target.value))}
+    >
+      <option value="">FEFO automático (recomendado)</option>
+      {lotes.map((l) => {
+        const opcion = opcionDeLote(l)
+        return (
+          <option key={l.idLote} value={opcion.valor}>
+            {opcion.etiqueta}
+          </option>
+        )
+      })}
+    </select>
+  )
+}
+
 /**
  * Pantalla del POS (stage-5-pos-ventas, Slice 7, design: POS Screen Composition) — escaneo +
  * carrito + selección de punto de venta/cliente (Slice 6) + panel de pagos, checkout (`POST
@@ -224,6 +339,12 @@ export function Pos() {
   const generacionResolucionRef = useRef(0)
   const ultimaAccionEsEdicionRef = useRef(false)
   const [cantidadesEnEdicion, setCantidadesEnEdicion] = useState<Record<number, string>>({})
+
+  // stage-12-lotes-vencimientos (Slice 14): elección explícita de lote por línea, indexada por
+  // `idArticulo` — una línea ausente acá viaja con `idLote: null` (design decisión 19, camino
+  // feliz de cero tecleo). Los saldos de lote son por punto de venta: cambiar de PV invalida
+  // cualquier elección hecha (`cambiarPuntoVenta` la resetea entera).
+  const [lotesSeleccionados, setLotesSeleccionados] = useState<LotesSeleccionados>({})
 
   const [entradaEscaneo, setEntradaEscaneo] = useState('')
   const [escaneando, setEscaneando] = useState(false)
@@ -462,15 +583,26 @@ export function Pos() {
         return resto
       })
 
+    // El lote elegido es propio de la línea, no de una unidad puntual: re-escanear el mismo
+    // artículo (suma cantidad) no lo invalida — solo desaparece cuando la línea entera se va.
+    const limpiarLoteDeFila = (idArticulo: number) =>
+      setLotesSeleccionados((prev) => {
+        if (!(idArticulo in prev)) return prev
+        const { [idArticulo]: _omitido, ...resto } = prev
+        return resto
+      })
+
     switch (accion.tipo) {
       case 'quitarLinea':
         limpiarFila(accion.idArticulo)
+        limpiarLoteDeFila(accion.idArticulo)
         break
       case 'escanear':
         limpiarFila(accion.linea.idArticulo)
         break
       case 'vaciar':
         setCantidadesEnEdicion({})
+        setLotesSeleccionados({})
         break
       case 'editarCantidad':
         break
@@ -557,6 +689,24 @@ export function Pos() {
     if (cobrandoRef.current) return
     setIdPuntoVenta(id)
     guardarPuntoVentaSeleccionado(id)
+    // Los saldos de lote son por punto de venta (stage-12-lotes-vencimientos, Slice 14): una
+    // elección hecha contra el PV anterior no tiene sentido en el nuevo — cada `SelectorDeLote`
+    // ya se resetea solo por su propio efecto, esto limpia el lado del carrito.
+    setLotesSeleccionados({})
+  }
+
+  /** Elección explícita de un lote en la línea de `idArticulo`, o `null` para volver al camino
+   * feliz (FEFO server-side, design decisión 19). */
+  function elegirLote(idArticulo: number, idLote: number | null) {
+    if (cobrandoRef.current) return
+    setLotesSeleccionados((prev) => {
+      if (idLote === null) {
+        if (!(idArticulo in prev)) return prev
+        const { [idArticulo]: _omitido, ...resto } = prev
+        return resto
+      }
+      return { ...prev, [idArticulo]: idLote }
+    })
   }
 
   function cambiarCliente(id: number) {
@@ -678,6 +828,7 @@ export function Pos() {
         codigoTipoComprobante: 'TX',
         idComprobanteAsociado: null,
         lineas,
+        lotesSeleccionados,
         pagos: aPagosDeVenta(pagosConVuelto),
         direccionEntrega: null,
         observaciones: null,
@@ -690,6 +841,7 @@ export function Pos() {
       setLineas([])
       setPrecios({})
       setCantidadesEnEdicion({})
+      setLotesSeleccionados({})
       setFilasPago([filaPagoVacia(proximaFilaPagoIdRef.current++)])
       setEntradaEscaneo('')
       setTerminoCliente('')
@@ -747,7 +899,15 @@ export function Pos() {
                   <tbody>
                     {comprobante.items.map((item) => (
                       <tr key={item.orden}>
-                        <td>{item.descripcion}</td>
+                        <td>
+                          {item.descripcion}
+                          {item.codigoLote && <div className="small text-muted">Lote {item.codigoLote}</div>}
+                          {item.loteVencido && (
+                            // Warning prominente, nunca un bloqueo (design decisión 12: "Expired
+                            // Lot Sale Warns, Never Blocks") — la venta ya se emitió.
+                            <div className="small text-danger fw-bold">⚠ Lote vencido</div>
+                          )}
+                        </td>
                         <td>{item.cantidad}</td>
                         <td className="text-end">{formatearMoneda(item.precioUnitario)}</td>
                         <td className="text-end">
@@ -841,6 +1001,7 @@ export function Pos() {
                     <th>Código</th>
                     <th>Artículo</th>
                     <th style={{ width: 110 }}>Cantidad</th>
+                    <th style={{ width: 160 }}>Lote</th>
                     <th className="text-end">Precio unit.</th>
                     <th className="text-end">Total</th>
                     <th className="text-end">Acciones</th>
@@ -867,6 +1028,18 @@ export function Pos() {
                             onChange={(e) => cambiarCantidad(l.idArticulo, e.target.value)}
                             onBlur={() => confirmarCantidad(l.idArticulo)}
                           />
+                        </td>
+                        <td>
+                          {puntoVentaSeleccionada && (
+                            <SelectorDeLote
+                              idPuntoVenta={puntoVentaSeleccionada.id}
+                              idArticulo={l.idArticulo}
+                              nombreArticulo={l.nombre}
+                              idLoteElegido={lotesSeleccionados[l.idArticulo] ?? null}
+                              disabled={cobrando}
+                              onElegir={(idLote) => elegirLote(l.idArticulo, idLote)}
+                            />
+                          )}
                         </td>
                         <td className="text-end">
                           {previa.precioUnitario === null ? (
@@ -910,7 +1083,7 @@ export function Pos() {
                   })}
                   {lineas.length === 0 && (
                     <tr>
-                      <td colSpan={6} className="text-center text-muted py-4">
+                      <td colSpan={7} className="text-center text-muted py-4">
                         Escaneá o tipeá un código para empezar la venta.
                       </td>
                     </tr>

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -901,8 +901,11 @@ export function Pos() {
                           {item.descripcion}
                           {item.codigoLote && <div className="small text-muted">Lote {item.codigoLote}</div>}
                           {item.loteVencido && (
-                            // Warning prominente, nunca un bloqueo (design decisión 12: "Expired
-                            // Lot Sale Warns, Never Blocks") — la venta ya se emitió.
+                            // Escalada visual deliberada (design decisión 12: "Expired Lot Sale
+                            // Warns, Never Blocks"): más fuerte que el hint pre-submit del picker
+                            // (`opcionDeLote`, texto plano "vencido" en el `<option>`) porque acá
+                            // la venta ya se emitió — es la última chance de que el operador se
+                            // entere, nunca un bloqueo.
                             <div className="small text-danger fw-bold">⚠ Lote vencido</div>
                           )}
                         </td>

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -85,6 +85,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }
@@ -158,7 +159,7 @@ describe('Transferencias — flujo feliz', () => {
     resolverTransferir({
       idPuntoVentaOrigen: 1,
       idPuntoVentaDestino: 2,
-      lineas: [{ idArticulo: 10, cantidadOrigen: 12, cantidadDestino: 13 }],
+      lineas: [{ idArticulo: 10, idLote: null, cantidadOrigen: 12, cantidadDestino: 13 }],
     })
 
     expect(await screen.findByText(/Transferencia registrada: Casa Central → Sucursal Norte/)).toBeInTheDocument()
@@ -209,7 +210,11 @@ describe('Transferencias — líneas incompletas', () => {
     await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
     await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
 
-    resolverTransferir({ idPuntoVentaOrigen: 1, idPuntoVentaDestino: 2, lineas: [{ idArticulo: 10, cantidadOrigen: 12, cantidadDestino: 13 }] })
+    resolverTransferir({
+      idPuntoVentaOrigen: 1,
+      idPuntoVentaDestino: 2,
+      lineas: [{ idArticulo: 10, idLote: null, cantidadOrigen: 12, cantidadDestino: 13 }],
+    })
     await screen.findByText(/Transferencia registrada/)
 
     const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/transferencias')


### PR DESCRIPTION
## Etapa 12 — Slice 14: Web Operación

- **POS (\`SelectorDeLote\`)**: picker alimentado por \`GET /api/stock/lotes\`, preselección EXACTA por \`sugerido\` server-authored (decisión 19: cero FEFO en TS), token gating del stale (regla 7, probado dentro de \`act\`), warning \"⚠ Lote vencido\" prominente en el ticket (decisión 12) con escalada visual documentada.
- **CompraEditor**: \`codigoLote\`/\`fechaVencimiento\` por línea de borrador; contador de incompletas los incluye; línea incompleta excluida del payload; **reset de lote al cambiar el artículo de una línea** (el leak stale que persistía datos espurios — clase regla 8); columna de vencimiento en la vista confirmada.
- **Contratos espejados** en tipos.ts/ventas.ts/compras.ts/stock.ts campo por campo contra el backend.

### Tests
vitest **566/566** (34 archivos; +22 sobre baseline). 8 rondas de evidencia de mutación.

### Judgment-day (2 rondas REJECT con hallazgos reales)
Juez B: 3 mutaciones ESCAPADAS de manual — fixture de preselección con sugerido último (indistinguible de \"elegir el último\"), guard de reentrancia MUERTO en este runtime (el \`disabled\` nativo gana; comentario del test mentía), y el warning de vencido con CERO cobertura. Juez A: MAJOR del leak de lote stale al cambiar artículo (payload deshonesto persistido por el backend) + 3 MINORs. Ambos fix batches con evidencia por fix; rondas finales doble APPROVE (B incluso mutó la defensa real del disabled para probar que el test la ejercita; el barrido mecánico final lo certificó el orquestador: alcance exacto + 566/566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)