### PR TITLE
feat(lotes): pantallas de back-office con lote — etapa 12, slice 15 (final)

### DIFF
--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1923,32 +1923,58 @@ change.
 the lot column on transfers/conteo all ship. **Rollback**: revert the
 branch — no backend change.
 
-- [ ] 15.1 Create `src/Ways.Web/src/paginas/Vencimientos.tsx`: report
+- [x] 15.1 Create `src/Ways.Web/src/paginas/Vencimientos.tsx`: report
   screen — filters, four-state classification badges (incl. `sin_fecha`),
   download button.
-- [ ] 15.2 Modify `src/Ways.Web/src/App.tsx` + `componentes/Layout.tsx`:
+- [x] 15.2 Modify `src/Ways.Web/src/App.tsx` + `componentes/Layout.tsx`:
   `/reportes/stock/vencimientos` route (`LecturaDeReportes`) + nav entry.
-- [ ] 15.3 Modify `src/Ways.Web/src/paginas/Articulos.tsx`: `controlaLote`
+- [x] 15.3 Modify `src/Ways.Web/src/paginas/Articulos.tsx`: `controlaLote`
   toggle on the articulo editor.
-- [ ] 15.4 Modify `src/Ways.Web/src/paginas/Parametros.tsx`:
-  `lotesHabilitado` + `diasAlertaVencimiento` toggles.
-- [ ] 15.5 Modify `src/Ways.Web/src/paginas/Transferencias.tsx`: lot column
-  + picker per line, incomplete-line counter extended.
-- [ ] 15.6 Modify `src/Ways.Web/src/paginas/ConteoDeInventario.tsx`:
+- [x] 15.4 Modify `src/Ways.Web/src/paginas/Parametros.tsx`:
+  `lotesHabilitado` + `diasAlertaVencimiento` toggles. *(APPLY-RUN NOTE:
+  `PARAMETROS_CONOCIDOS` gained a fourth `tipo` — `'booleano'` — the first
+  boolean-typed entry of the registry; `Parametros.tsx` gained a checkbox
+  branch alongside the existing texto/entero branches, JSON-serializing the
+  raw `true`/`false` literal, never a quoted string.)*
+- [x] 15.5 Modify `src/Ways.Web/src/paginas/Transferencias.tsx`: lot column
+  + picker per line, incomplete-line counter extended. *(APPLY-RUN NOTE:
+  closed the slice-10 debt — `key={l.idArticulo}` on the result table
+  replaced by a composite `${idArticulo}-${idLote ?? 'sin-lote'}` key; the
+  per-line picker pre-selects `sugerido` (design decisión 19) and can be
+  cleared back to "Auto (FEFO)"; `LineaDeTransferenciaFormulario` gained a
+  UI-only `controlaLote` field (never sent to the backend) to decide
+  per-row whether the picker renders.)*
+- [x] 15.6 Modify `src/Ways.Web/src/paginas/ConteoDeInventario.tsx`:
   per-lot counted-total input UI, exactly-one-of enforcement mirrored
-  client-side.
-- [ ] 15.7 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: vencimientos tile
-  (counts + link), completing slice 13's backend groundwork.
-- [ ] 15.8 [P] `web-descriptor-tests` for `Vencimientos.tsx`,
+  client-side. *(APPLY-RUN NOTE: the aggregate "Cantidad contada" field and
+  the per-lot grid are structurally mutually exclusive in the render tree
+  — never both mounted — which is the client-side mirror of the backend's
+  `400 conteo_contada_y_lotes`; an incomplete-lot counter mirrors
+  `Transferencias.tsx`'s pattern, per react-async-state rule 10.)*
+- [x] 15.7 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: vencimientos tile
+  (counts + link), completing slice 13's backend groundwork. *(APPLY-RUN
+  NOTE: the tile requires a concrete punto de venta — `/vencimientos/resumen`
+  doesn't accept "Todos" — and shows a neutral aviso instead of a query
+  with a manufactured PV when none is chosen.)*
+- [x] 15.8 [P] `web-descriptor-tests` for `Vencimientos.tsx`,
   `Articulos.tsx` (`controlaLote`), `Parametros.tsx` (2 toggles),
   `Transferencias.tsx`, `ConteoDeInventario.tsx`, the Tablero tile.
-- [ ] 15.9 [P] Incomplete-line-counter test replicated across both
+- [x] 15.9 [P] Incomplete-line-counter test replicated across both
   `Transferencias` and `ConteoDeInventario` grids (mirrors slice 14.7's
   `CompraEditor` pattern).
-- [ ] 15.10 [P] `controlaLote` coercion test (`'' → null`, `aAlta`/
-  `aValores` boolean coercion).
-- [ ] 15.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
-  no pending changes (web-only slice).
+- [x] 15.10 [P] `controlaLote` coercion test (`aAlta`/`aEdicion` boolean
+  coercion). *(APPLY-RUN NOTE — task wording amended: `controlaLote` is a
+  plain boolean toggle (`e.target.checked`), not a nullable field — the
+  `'' → null` half of the task's literal wording doesn't apply to this
+  field's shape (no empty-string state is representable by a checkbox).
+  Delivered instead: three tests proving the checkbox never leaks a string/
+  `"on"`/`1` — `true`/`false` travel as JSON booleans end-to-end through
+  `aEdicion`, both toggled and left untouched.)*
+- [x] 15.11 Gate guard: `dotnet ef migrations has-pending-model-changes` →
+  no pending changes (web-only slice). *(Verified via `--project
+  src/Ways.Infrastructure --startup-project src/Ways.Infrastructure`, same
+  precedent as slices 4/5: "No changes have been made to the model since
+  the last migration.")*
 - [ ] 15.12 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
   (parent: slices 12+13); PR; merge stacked-to-main.

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -2012,6 +2012,24 @@ branch — no backend change.
   (colisión de `key` de React). Bug preexistente en HEAD, ajeno a los dos
   fixes de esta ronda — los tests nuevos lo esquivan quitando la fila
   inicial antes de agregar líneas frescas; no reabierto acá.)*
+
+  *(Ronda 2, mini-fix: se verificó el origen del `proximaClaveRef` discovery
+  de la ronda 1 — el bug ya existía en `main` (`feat(stock): agregar
+  pantallas de transferencias...`), este slice no lo introdujo, solo lo
+  heredó y lo esquivó en los tests. Fix real: `CuentaCorriente.tsx` y
+  `Pos.tsx` ya resuelven este mismo patrón correctamente con un
+  inicializador perezoso de `useState` que consume el ref
+  (`() => [algoVacio(ref.current++)]`); `Transferencias.tsx` en cambio
+  sembraba la fila inicial con un literal `lineaDeTransferenciaVacia(1)`
+  sin tocar el ref. Alineado al patrón ya establecido en el codebase.
+  Simplificado el helper `completarDosLineasMismoArticulo` (ya no necesita
+  quitar la fila inicial) y agregado un test nuevo que agrega una línea
+  justo tras el mount y verifica, por comportamiento observable (la fila
+  inicial no se modifica al editar la nueva) + ausencia del warning de
+  React de `key` duplicada, que las claves ya no colisionan. Mutación
+  aplicada (revertir al literal `lineaDeTransferenciaVacia(1)`) → RED en el
+  test nuevo + 2 tests existentes de la ronda 1 (que ahora sí ejercitan el
+  camino real sin el rodeo) → revertida → GREEN.)*
 - [ ] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
   (parent: slices 12+13); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1983,7 +1983,35 @@ branch — no backend change.
   src/Ways.Infrastructure --startup-project src/Ways.Infrastructure`, same
   precedent as slices 4/5: "No changes have been made to the model since
   the last migration.")*
-- [ ] 15.12 Run `judgment-day`; fix; re-judge until clean.
+- [x] 15.12 Run `judgment-day`; fix; re-judge until clean. *(Ronda 1, Judge
+  B, dos MAJOR fixed: (1) `Tablero.test.tsx` — el tile de vencimientos
+  asertaba los tres conteos por presencia suelta (`within(tile).getByText`),
+  sin atar cada valor a SU métrica; un swap vencidos↔porVencer en
+  `PanelDeVencimientos` no lo detectaba. Fix: `data-testid` por métrica
+  (`vencimientos-tile-vencidos`/`-por-vencer`/`-sin-fecha`) + aserciones
+  `toHaveTextContent` atadas 1:1. Mutación aplicada (swap) → RED → revertida
+  → GREEN. (2) `articulosRepetidosEnTransferencia` (stock.ts) dedupeaba por
+  `idArticulo` a secas y bloqueaba una transferencia legal: el backend
+  acepta dos líneas del mismo artículo con lotes explícitos DISTINTOS
+  (decisión 11) — la operación real de depósito que el picker de lote
+  existe para habilitar. Fix: la clave espeja `(idArticulo, idLote)` —
+  mismo lote explícito repetido O ambas líneas en Auto/FEFO bloquean (el
+  cliente no puede adivinar si el server las resolvería al mismo lote),
+  lotes explícitos distintos o explícito+Auto pasan el gate cliente (el
+  servidor arbitra con `400 articulo_repetido`, mostrado por el funnel de
+  error existente, no tragado). El Set devuelto pasó de `idArticulo` a
+  `clave` de línea — dos líneas del mismo artículo ya pueden coexistir sin
+  conflicto, así que "repetido" no puede marcarse por artículo. Tests: 4
+  casos discriminantes en `stock.test.ts` (unit) + 2 en `Transferencias.
+  test.tsx` (component, caso c botón habilitado / caso d 400 visible).
+  Mutación aplicada (idArticulo-solo) → RED en los 4 tests unit + 2
+  component → revertida → GREEN. DISCOVERY fuera de alcance, no tocado:
+  `proximaClaveRef` (Transferencias.tsx) arranca en `1`, el mismo valor
+  que la `clave` de la fila inicial (`lineaDeTransferenciaVacia(1)`) — el
+  primer click de "+ Agregar línea" produce una `clave` duplicada
+  (colisión de `key` de React). Bug preexistente en HEAD, ajeno a los dos
+  fixes de esta ronda — los tests nuevos lo esquivan quitando la fila
+  inicial antes de agregar líneas frescas; no reabierto acá.)*
 - [ ] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
   (parent: slices 12+13); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -2030,6 +2030,48 @@ branch — no backend change.
   aplicada (revertir al literal `lineaDeTransferenciaVacia(1)`) → RED en el
   test nuevo + 2 tests existentes de la ronda 1 (que ahora sí ejercitan el
   camino real sin el rodeo) → revertida → GREEN.)*
+
+  *(Ronda 3, Judge A, un CRITICAL + un WARNING + un MINOR fixed: (1) CRITICAL
+  — `ConteoDeInventario.tsx` derivaba `esLoteEfectivo` de `controlaLote` a
+  secas, ignorando `lotes_habilitado` de la empresa (espejo roto de
+  `ReglaDeLotes.ControlEfectivo`, que SÍ es el AND de ambos flags). Con
+  `controla_lote=true` y el módulo apagado, la grilla por lote se mostraba
+  igual, `GET /api/stock/lotes` devolvía cero lotes (nunca hubo
+  reconciliación) y `puedeContar` exigía ≥1 línea completa → dead-end
+  permanente, el operador nunca podía contar ese artículo. Solución elegida:
+  el parámetro resuelto SÍ existe y es consumible (`GET
+  /api/parametros/lotes_habilitado`, `Politicas.OperacionDePos`, el mismo que
+  prueba `Parametros.tsx` vía "Probar") — se agregó `clienteDeParametros`
+  (`api/parametros.ts`) y un efecto token-gated (mismo patrón que
+  `actual`/`lineasDeLote`) que lo resuelve solo cuando el artículo elegido
+  tiene `controlaLote`, usando el `idEmpresa` del punto de venta
+  seleccionado. Mientras no resuelve o si el fetch falla, el default es
+  agregado (mismo default `"false"` del parámetro en el servidor) — nunca un
+  dead-end: si el módulo está realmente ON, el servidor rechaza el envío
+  agregado con `400 conteo_requiere_lotes`, visible por el funnel existente.
+  Tests: (a) módulo off + artículo flaggeado → agregado usable, submit OK;
+  (b) módulo on + artículo con lotes → grilla como antes; (c) fetch de
+  `lotes_habilitado` fallido → cae a agregado (mismo criterio honesto).
+  Mutación aplicada (`esLoteEfectivo = articuloControlaLote` a secas) → RED
+  en (a) (dead-end reproducido: grilla vacía, botón deshabilitado) →
+  revertida → GREEN. (2) WARNING — `Transferencias.tsx`'s `SelectorDeLote`
+  no reseteaba un `idLote` explícito al cambiar el punto de venta Origen: la
+  selección viajaba stale contra el PV nuevo. Fix: el efecto que ya
+  refetchea lotes ahora también resetea el `idLote` de la línea (vía
+  `onCambio('', '')`) cuando detecta, con un ref, que `idPuntoVenta`
+  específicamente cambió — un cambio de `idArticulo` no necesita este reset
+  porque `onElegir` ya limpia `idLote` en el mismo `setLineas`. Test: elegir
+  lote explícito → cambiar Origen → el `idLote` de la línea vuelve a ''
+  (Auto) y el request nunca lleva el stale. Mutación aplicada (revertir el
+  reset) → RED (el POST llevó `idLote: 42`, del PV anterior) → revertida →
+  GREEN. (3) MINOR — comentario de `stock.ts` corregido: "el servidor las
+  rechazaría igual con `400 articulo_repetido` en el caso más probable" →
+  la garantía real, verificada en `ServicioDeStock.ResolverLineasAsync`: una
+  sola lectura de saldos pre-transacción (`LeerSaldosAsync`) + `ElegirFefo`
+  puro sobre ese mismo snapshot ⇒ dos líneas Auto del mismo artículo SIEMPRE
+  resuelven al mismo lote, nunca "probablemente". Suite completa tras la
+  ronda: 590/590 (586 + 4 nuevos) + `tsc -b` limpio + `oxlint` limpio (solo
+  warning preexistente ajeno en `AuthContext.tsx`).)*
 - [ ] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
   (parent: slices 12+13); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -1943,7 +1943,15 @@ branch — no backend change.
   per-line picker pre-selects `sugerido` (design decisión 19) and can be
   cleared back to "Auto (FEFO)"; `LineaDeTransferenciaFormulario` gained a
   UI-only `controlaLote` field (never sent to the backend) to decide
-  per-row whether the picker renders.)*
+  per-row whether the picker renders. `mutation-proof-tests` evidence on
+  the composite key: a plain content-only assertion (two rows, correct
+  cantidades) passed EVEN with the mutation reverted to `key={l.idArticulo}`
+  — a first controlled render never shows stale content, the exact
+  confound rule 3 warns about. Re-routed below the confound: spy on
+  `console.error` and assert the ABSENCE of React's "Encountered two
+  children with the same key" warning, which fires ONLY on the collision.
+  Mutation applied → RED (warning captured, assertion failed) → reverted →
+  GREEN, full `Transferencias.test.tsx` suite 12/12.)*
 - [x] 15.6 Modify `src/Ways.Web/src/paginas/ConteoDeInventario.tsx`:
   per-lot counted-total input UI, exactly-one-of enforcement mirrored
   client-side. *(APPLY-RUN NOTE: the aggregate "Cantidad contada" field and

--- a/openspec/changes/stage-12-lotes-vencimientos/tasks.md
+++ b/openspec/changes/stage-12-lotes-vencimientos/tasks.md
@@ -2072,7 +2072,7 @@ branch — no backend change.
   resuelven al mismo lote, nunca "probablemente". Suite completa tras la
   ronda: 590/590 (586 + 4 nuevos) + `tsc -b` limpio + `oxlint` limpio (solo
   warning preexistente ajeno en `AuthContext.tsx`).)*
-- [ ] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
+- [x] 15.13 Branch `feat/stage12-slice15-web-backoffice` off `main`
   (parent: slices 12+13); PR; merge stacked-to-main.
 
 **Test plan**: descriptor tests ×6 (15.8), incomplete-line ×2 (15.9),

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -31,6 +31,7 @@ import { Tenants } from './paginas/Tenants'
 import { Tesoreria } from './paginas/Tesoreria'
 import { Transferencias } from './paginas/Transferencias'
 import { Usuarios } from './paginas/Usuarios'
+import { Vencimientos } from './paginas/Vencimientos'
 import { descriptorListasPrecio } from './api/catalogos'
 import { ROL } from './api/tipos'
 
@@ -136,6 +137,18 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
                   <Existencias />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-12-lotes-vencimientos (Slice 15, design: Web Composition): mismo gate que
+                /reportes/existencias (Politicas.LecturaDeReportes) — vista de gestión sobre
+                lotes con saldo positivo, no el picker del POS (Politicas.OperacionDePos de
+                GET /api/stock/lotes). */}
+            <Route
+              path="/reportes/stock/vencimientos"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <Vencimientos />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/parametros.ts
+++ b/src/Ways.Web/src/api/parametros.ts
@@ -1,0 +1,16 @@
+/**
+ * Cliente HTTP de `parametros` (ADR-13, `GET /api/parametros/{clave}`): resolución punto de
+ * venta > empresa > default declarado — espejo de `ServicioDeParametros.ResolverAsync`. Usado por
+ * pantallas operativas (no solo `Parametros.tsx`, admin-only) que necesitan el valor EFECTIVO de
+ * un parámetro para una empresa/punto de venta puntual — `GET /api/parametros/{clave}` solo exige
+ * `Politicas.OperacionDePos`, no `GestionDeCatalogo` (ver `ParametrosEndpoints`).
+ */
+import { api } from './cliente'
+import type { ParametroResuelto } from './tipos'
+
+export const clienteDeParametros = {
+  resolver: (clave: string, idEmpresa: number, idPuntoVenta: number | null) =>
+    api.get<ParametroResuelto>(
+      `/parametros/${clave}?idEmpresa=${idEmpresa}${idPuntoVenta !== null ? `&idPuntoVenta=${idPuntoVenta}` : ''}`,
+    ),
+}

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -14,8 +14,10 @@ import type {
   PaginaDeMovimientosTesoreria,
   Rentabilidad,
   ResumenDeGastos,
+  ResumenDeVencimientos,
   ResumenDeVentas,
   TopArticulos,
+  Vencimientos,
   VentasPorMedioPago,
   VentasPorPuntoVenta,
   VentasPorVendedor,
@@ -107,6 +109,16 @@ export const clienteDeReportes = {
     api.get<PaginaDeMovimientosTesoreria>(`/reportes/tesoreria${construirQueryDeTesoreria(filtros)}`),
   existencias: (idPuntoVenta: number) =>
     api.get<Existencias>(`/reportes/stock/existencias?idPuntoVenta=${idPuntoVenta}`),
+  /** stage-12-lotes-vencimientos (Slice 15): `dias` es opcional — omitido, el servidor resuelve
+   * `dias_alerta_vencimiento` (PV → empresa → default), mismo criterio que el resto de los
+   * parámetros del backend con default declarado (dto-contract-honesty: no se manda un valor
+   * inventado del lado del cliente cuando el servidor ya sabe resolverlo). */
+  vencimientos: (idPuntoVenta: number, dias: number | null) =>
+    api.get<Vencimientos>(
+      `/reportes/stock/vencimientos?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}`,
+    ),
+  vencimientosResumen: (idPuntoVenta: number) =>
+    api.get<ResumenDeVencimientos>(`/reportes/stock/vencimientos/resumen?idPuntoVenta=${idPuntoVenta}`),
 }
 
 // ---- Offset local para desde/hasta de /cajas y /tesoreria (stage-11-exportacion-reportes,
@@ -212,6 +224,10 @@ export const rutasDeExportacion = {
   /** Sin `desde`/`hasta`: el stock no tiene rango, el nombre de archivo se fecha con el día del
    * servidor (mismo criterio que la ruta JSON hermana). */
   existencias: (idPuntoVenta: number) => `/reportes/stock/existencias/export?idPuntoVenta=${idPuntoVenta}&formato=xlsx`,
+  /** stage-12-lotes-vencimientos (Slice 15): mismo query string que la ruta JSON hermana +
+   * `formato=xlsx`, mismo criterio que `existencias`. */
+  vencimientos: (idPuntoVenta: number, dias: number | null) =>
+    `/reportes/stock/vencimientos/export?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}&formato=xlsx`,
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/stock.test.ts
+++ b/src/Ways.Web/src/api/stock.test.ts
@@ -1,22 +1,45 @@
 import { describe, expect, it } from 'vitest'
 import {
+  aConteoDeLotes,
   aLineasDeTransferencia,
   aSolicitudDeConteo,
+  aSolicitudDeConteoPorLote,
   aSolicitudDeTransferencia,
   articulosRepetidosEnTransferencia,
   contadaValida,
+  lineaDeConteoDeLoteVacia,
   lineaDeTransferenciaVacia,
   lineaTransferenciaCompleta,
+  lineasDeConteoDeLoteCompletas,
+  type LineaDeConteoDeLoteFormulario,
   type LineaDeTransferenciaFormulario,
 } from './stock'
+import type { LoteListado } from './tipos'
 
 function lineaFixture(sobrescribir: Partial<LineaDeTransferenciaFormulario> = {}): LineaDeTransferenciaFormulario {
-  return { clave: 1, idArticulo: 10, descripcion: 'Fideos 500g', cantidad: '5', ...sobrescribir }
+  return {
+    clave: 1,
+    idArticulo: 10,
+    descripcion: 'Fideos 500g',
+    cantidad: '5',
+    idLote: '',
+    codigoLote: '',
+    controlaLote: false,
+    ...sobrescribir,
+  }
 }
 
 describe('lineaDeTransferenciaVacia', () => {
-  it('arranca sin artículo ni cantidad tipeados', () => {
-    expect(lineaDeTransferenciaVacia(7)).toEqual({ clave: 7, idArticulo: '', descripcion: '', cantidad: '' })
+  it('arranca sin artículo, cantidad ni lote elegidos', () => {
+    expect(lineaDeTransferenciaVacia(7)).toEqual({
+      clave: 7,
+      idArticulo: '',
+      descripcion: '',
+      cantidad: '',
+      idLote: '',
+      codigoLote: '',
+      controlaLote: false,
+    })
   })
 })
 
@@ -66,7 +89,12 @@ describe('articulosRepetidosEnTransferencia', () => {
 describe('aLineasDeTransferencia', () => {
   it('mapea las líneas completas a número y filtra las incompletas', () => {
     const lineas = aLineasDeTransferencia([lineaFixture({ idArticulo: 10, cantidad: '5' }), lineaFixture({ clave: 2, idArticulo: '' })])
-    expect(lineas).toEqual([{ idArticulo: 10, cantidad: 5 }])
+    expect(lineas).toEqual([{ idArticulo: 10, cantidad: 5, idLote: null }])
+  })
+
+  it('un idLote elegido viaja como número; sin elegir viaja como null (el servidor resuelve FEFO)', () => {
+    const lineas = aLineasDeTransferencia([lineaFixture({ idArticulo: 10, cantidad: '5', idLote: 41 })])
+    expect(lineas).toEqual([{ idArticulo: 10, cantidad: 5, idLote: 41 }])
   })
 })
 
@@ -80,7 +108,7 @@ describe('aSolicitudDeTransferencia', () => {
       idPuntoVentaOrigen: 1,
       idPuntoVentaDestino: 2,
       observaciones: 'Reposición de sucursal',
-      lineas: [{ idArticulo: 10, cantidad: 5 }],
+      lineas: [{ idArticulo: 10, cantidad: 5, idLote: null }],
     })
   })
 
@@ -114,5 +142,71 @@ describe('aSolicitudDeConteo', () => {
     const solicitud = aSolicitudDeConteo('', '', '10', 'obs')
     expect(solicitud.idPuntoVenta).toBe(0)
     expect(solicitud.idArticulo).toBe(0)
+  })
+})
+
+// ---- Conteo por lote (stage-12-lotes-vencimientos, Slice 15) -----------------------------------
+
+function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+  return {
+    idLote: 41,
+    idArticulo: 10,
+    codigo: '2026-08-20',
+    fechaVencimiento: '2026-08-20',
+    esSinIdentificar: false,
+    cantidad: 12,
+    estado: 'Vigente',
+    sugerido: true,
+    ...sobrescribir,
+  }
+}
+
+function lineaDeLoteFixture(sobrescribir: Partial<LineaDeConteoDeLoteFormulario> = {}): LineaDeConteoDeLoteFormulario {
+  return { idLote: 41, codigo: '2026-08-20', contada: '10', ...sobrescribir }
+}
+
+describe('lineaDeConteoDeLoteVacia', () => {
+  it('arranca con el idLote/código del lote y sin contada tipeada', () => {
+    expect(lineaDeConteoDeLoteVacia(loteFixture())).toEqual({ idLote: 41, codigo: '2026-08-20', contada: '' })
+  })
+})
+
+describe('lineasDeConteoDeLoteCompletas', () => {
+  it('solo cuentan las líneas con una contada válida', () => {
+    const completas = lineasDeConteoDeLoteCompletas([
+      lineaDeLoteFixture({ idLote: 1, contada: '10' }),
+      lineaDeLoteFixture({ idLote: 2, contada: '' }),
+      lineaDeLoteFixture({ idLote: 3, contada: '-1' }),
+    ])
+    expect(completas.map((l) => l.idLote)).toEqual([1])
+  })
+})
+
+describe('aConteoDeLotes', () => {
+  it('mapea las líneas completas a número y filtra las incompletas', () => {
+    const lotes = aConteoDeLotes([
+      lineaDeLoteFixture({ idLote: 1, contada: '10' }),
+      lineaDeLoteFixture({ idLote: 2, contada: '' }),
+    ])
+    expect(lotes).toEqual([{ idLote: 1, contada: 10 }])
+  })
+})
+
+describe('aSolicitudDeConteoPorLote', () => {
+  it('arma la rama exactly-one-of por lote: contada null, lotes con las líneas completas', () => {
+    const solicitud = aSolicitudDeConteoPorLote(2, 10, [lineaDeLoteFixture({ idLote: 41, contada: '15' })], '  Recuento por lote  ')
+    expect(solicitud).toEqual({
+      idPuntoVenta: 2,
+      idArticulo: 10,
+      contada: null,
+      observaciones: 'Recuento por lote',
+      lotes: [{ idLote: 41, contada: 15 }],
+    })
+  })
+
+  it('nunca arma las dos formas a la vez — contada siempre null en la rama por lote', () => {
+    const solicitud = aSolicitudDeConteoPorLote(2, 10, [lineaDeLoteFixture()], 'obs')
+    expect(solicitud.contada).toBeNull()
+    expect(solicitud.lotes).not.toHaveLength(0)
   })
 })

--- a/src/Ways.Web/src/api/stock.test.ts
+++ b/src/Ways.Web/src/api/stock.test.ts
@@ -63,13 +63,16 @@ describe('lineaTransferenciaCompleta', () => {
 })
 
 describe('articulosRepetidosEnTransferencia', () => {
-  it('detecta un artículo que aparece en más de una línea completa', () => {
+  // stage-12-lotes-vencimientos (Slice 15, judgment-day fix): el Set devuelto ahora es de
+  // `clave` (identidad de la fila), no de `idArticulo` — dos líneas del mismo artículo pueden
+  // coexistir sin conflicto (caso c), así que "repetido" ya no puede marcarse por artículo a secas.
+  it('detecta un artículo sin control de lote (ambas líneas en Auto) que aparece en más de una línea completa', () => {
     const repetidos = articulosRepetidosEnTransferencia([
       lineaFixture({ clave: 1, idArticulo: 10 }),
       lineaFixture({ clave: 2, idArticulo: 10 }),
       lineaFixture({ clave: 3, idArticulo: 20 }),
     ])
-    expect(repetidos).toEqual(new Set([10]))
+    expect(repetidos).toEqual(new Set([1, 2]))
   })
 
   it('ignora las líneas incompletas al detectar repetidos', () => {
@@ -82,6 +85,48 @@ describe('articulosRepetidosEnTransferencia', () => {
 
   it('sin repetidos devuelve un set vacío', () => {
     const repetidos = articulosRepetidosEnTransferencia([lineaFixture({ idArticulo: 10 }), lineaFixture({ clave: 2, idArticulo: 20 })])
+    expect(repetidos.size).toBe(0)
+  })
+
+  // (a) mismo (idArticulo, idLote explícito) en dos líneas → repetido — choca contra la
+  // restricción real del backend `(idArticulo, idLote)` (decisión 11).
+  it('(a) dos líneas del mismo artículo con el MISMO lote explícito se marcan repetidas', () => {
+    const repetidos = articulosRepetidosEnTransferencia([
+      lineaFixture({ clave: 1, idArticulo: 10, idLote: 41 }),
+      lineaFixture({ clave: 2, idArticulo: 10, idLote: 41 }),
+    ])
+    expect(repetidos).toEqual(new Set([1, 2]))
+  })
+
+  // (b) mismo artículo, ambas líneas en Auto/FEFO → repetido — el cliente no puede saber si el
+  // servidor las resolvería al mismo lote; bloquear acá es honesto.
+  it('(b) dos líneas del mismo artículo AMBAS en Auto (FEFO) se marcan repetidas', () => {
+    const repetidos = articulosRepetidosEnTransferencia([
+      lineaFixture({ clave: 1, idArticulo: 10, idLote: '' }),
+      lineaFixture({ clave: 2, idArticulo: 10, idLote: '' }),
+    ])
+    expect(repetidos).toEqual(new Set([1, 2]))
+  })
+
+  // (c) mismo artículo con lotes explícitos DISTINTOS → PERMITIDO — operación real de depósito
+  // que el picker de lote existe para habilitar (el MAJOR original: la UI bloqueaba esto).
+  it('(c) dos líneas del mismo artículo con lotes explícitos DISTINTOS NO se marcan repetidas', () => {
+    const repetidos = articulosRepetidosEnTransferencia([
+      lineaFixture({ clave: 1, idArticulo: 10, idLote: 41 }),
+      lineaFixture({ clave: 2, idArticulo: 10, idLote: 42 }),
+    ])
+    expect(repetidos.size).toBe(0)
+  })
+
+  // (d) mismo artículo, una línea con lote explícito y otra en Auto → PERMITIDO client-side — el
+  // cliente no puede computar el pick FEFO de la línea Auto para compararlo; si el servidor
+  // resuelve al mismo lote, arbitra con un 400 `articulo_repetido` (verificado en
+  // Transferencias.test.tsx: el funnel de error existente lo muestra, no se traga).
+  it('(d) mismo artículo, una línea con lote explícito y otra en Auto (FEFO) NO se marcan repetidas', () => {
+    const repetidos = articulosRepetidosEnTransferencia([
+      lineaFixture({ clave: 1, idArticulo: 10, idLote: 41 }),
+      lineaFixture({ clave: 2, idArticulo: 10, idLote: '' }),
+    ])
     expect(repetidos.size).toBe(0)
   })
 })

--- a/src/Ways.Web/src/api/stock.ts
+++ b/src/Ways.Web/src/api/stock.ts
@@ -70,23 +70,59 @@ export function lineaTransferenciaCompleta(l: LineaDeTransferenciaFormulario): b
  * repetido en un mismo request") — feedback instantáneo, nunca autoritativo: el servidor vuelve a
  * validarlo. Solo mira las líneas completas — una fila a medio llenar nunca cuenta como repetida.
  *
- * stage-12-lotes-vencimientos (Slice 15): la clave de detección sigue siendo SOLO `idArticulo` —
- * la restricción real de unicidad del backend es por `(idArticulo, idLote)` (decisión 11), pero
- * dos líneas del mismo artículo con lotes DISTINTOS explícitos son válidas del lado del servidor;
- * acá se preserva el comportamiento previo (un artículo repetido siempre se avisa) porque dos
- * líneas del mismo artículo sin lote explícito (ambas dejando que el servidor FEFO-resuelva)
- * competirían por el mismo lote sugerido en la práctica. */
+ * stage-12-lotes-vencimientos (Slice 15, judgment-day fix): la clave real de unicidad del backend
+ * es `(idArticulo, idLote)` (decisión 11) — dedupear por `idArticulo` a secas bloqueaba una
+ * transferencia legal (dos líneas del mismo artículo con lotes explícitos DISTINTOS, la operación
+ * real que el picker de lote existe para habilitar). Acá se espeja esa clave con lo único que el
+ * cliente PUEDE saber sin adivinar el FEFO del servidor (decisión 19: "el server manda"):
+ * - Dos líneas completas con el MISMO `(idArticulo, idLote explícito)` → repetido (choca contra la
+ *   restricción real del backend).
+ * - Dos o más líneas del mismo artículo, TODAS con lote en "Auto (FEFO)" → repetido: el cliente no
+ *   puede saber si el servidor las resolvería al mismo lote, pero bloquear acá es honesto — el
+ *   servidor las rechazaría igual con `400 articulo_repetido` en el caso más probable.
+ * - Mismo artículo con lotes explícitos DISTINTOS → PERMITIDO (válido en el backend).
+ * - Mismo artículo, una línea con lote explícito y otra en Auto → PERMITIDO client-side (el
+ *   cliente no puede computar el pick FEFO de la línea Auto para compararlo); si el servidor
+ *   resuelve al mismo lote igual, arbitra con un `400 articulo_repetido` que el funnel de error
+ *   existente (`ErrorApi.message` en el catch de `transferir`) muestra tal cual, sin tragarlo.
+ *
+ * Devuelve las `clave` (no los `idArticulo`) de las líneas efectivamente en conflicto — a
+ * diferencia del `idArticulo` a secas, dos líneas del mismo artículo pueden coexistir sin
+ * conflicto (lotes distintos), así que marcar por artículo ya no alcanza para decidir qué fila
+ * mostrar en rojo. */
 export function articulosRepetidosEnTransferencia(lineas: LineaDeTransferenciaFormulario[]): Set<number> {
-  const conteoPorArticulo = new Map<number, number>()
+  const porArticulo = new Map<number, LineaDeTransferenciaFormulario[]>()
   for (const l of lineas.filter(lineaTransferenciaCompleta)) {
     const id = Number(l.idArticulo)
-    conteoPorArticulo.set(id, (conteoPorArticulo.get(id) ?? 0) + 1)
+    const grupo = porArticulo.get(id) ?? []
+    grupo.push(l)
+    porArticulo.set(id, grupo)
   }
-  const repetidos = new Set<number>()
-  for (const [id, cantidad] of conteoPorArticulo) {
-    if (cantidad > 1) repetidos.add(id)
+
+  const repetidas = new Set<number>()
+  for (const grupo of porArticulo.values()) {
+    if (grupo.length < 2) continue
+
+    const autoFefo = grupo.filter((l) => l.idLote === '')
+    if (autoFefo.length > 1) {
+      for (const l of autoFefo) repetidas.add(l.clave)
+    }
+
+    const porLoteExplicito = new Map<number, LineaDeTransferenciaFormulario[]>()
+    for (const l of grupo) {
+      if (l.idLote === '') continue
+      const idLote = Number(l.idLote)
+      const g = porLoteExplicito.get(idLote) ?? []
+      g.push(l)
+      porLoteExplicito.set(idLote, g)
+    }
+    for (const g of porLoteExplicito.values()) {
+      if (g.length > 1) {
+        for (const l of g) repetidas.add(l.clave)
+      }
+    }
   }
-  return repetidos
+  return repetidas
 }
 
 export function aLineasDeTransferencia(lineas: LineaDeTransferenciaFormulario[]): LineaDeTransferencia[] {

--- a/src/Ways.Web/src/api/stock.ts
+++ b/src/Ways.Web/src/api/stock.ts
@@ -77,9 +77,11 @@ export function lineaTransferenciaCompleta(l: LineaDeTransferenciaFormulario): b
  * cliente PUEDE saber sin adivinar el FEFO del servidor (decisión 19: "el server manda"):
  * - Dos líneas completas con el MISMO `(idArticulo, idLote explícito)` → repetido (choca contra la
  *   restricción real del backend).
- * - Dos o más líneas del mismo artículo, TODAS con lote en "Auto (FEFO)" → repetido: el cliente no
- *   puede saber si el servidor las resolvería al mismo lote, pero bloquear acá es honesto — el
- *   servidor las rechazaría igual con `400 articulo_repetido` en el caso más probable.
+ * - Dos o más líneas del mismo artículo, TODAS con lote en "Auto (FEFO)" → repetido: el servidor
+ *   lee los saldos UNA sola vez antes de resolver todas las líneas (`LeerSaldosAsync`, snapshot
+ *   único pre-transacción) y `ElegirFefo` es una función pura sobre ese mismo snapshot — dos
+ *   líneas Auto del mismo artículo SIEMPRE resuelven al mismo lote, nunca "probablemente"; el
+ *   servidor las rechaza con `400 articulo_repetido` de forma determinística.
  * - Mismo artículo con lotes explícitos DISTINTOS → PERMITIDO (válido en el backend).
  * - Mismo artículo, una línea con lote explícito y otra en Auto → PERMITIDO client-side (el
  *   cliente no puede computar el pick FEFO de la línea Auto para compararlo); si el servidor

--- a/src/Ways.Web/src/api/stock.ts
+++ b/src/Ways.Web/src/api/stock.ts
@@ -8,7 +8,9 @@
  */
 import { api } from './cliente'
 import type {
+  ConteoDeLote,
   LineaDeTransferencia,
+  LoteListado,
   ResultadoConteo,
   ResultadoTransferencia,
   SolicitudDeConteo,
@@ -27,6 +29,12 @@ export const clienteDeStock = {
    * de lo que se escribió; el `GET /api/stock` previo es solo un dato de referencia en pantalla,
    * nunca lo que decide qué se renderiza después de un submit. */
   contar: (solicitud: SolicitudDeConteo) => api.post<ResultadoConteo>('/stock/conteos', solicitud),
+  /** stage-12-lotes-vencimientos (Slice 15, espejo de `GET /api/stock/lotes`): feed del picker de
+   * lote, con `sugerido` (FEFO server-computed) — el picker lo pre-selecciona, nunca lo
+   * recalcula del lado del cliente (design decisión 19). Sin `idComprobanteAsociado` acá: esa
+   * variante (sugerencia desde el snapshot de una devolución) es del picker del POS, Slice 14. */
+  lotes: (idPuntoVenta: number, idArticulo: number) =>
+    api.get<LoteListado[]>(`/stock/lotes?idPuntoVenta=${idPuntoVenta}&idArticulo=${idArticulo}`),
 }
 
 // ---- Formulario de transferencia: una línea editable por fila (mismo patrón que compras.ts) --
@@ -37,10 +45,20 @@ export type LineaDeTransferenciaFormulario = {
   idArticulo: number | ''
   descripcion: string
   cantidad: string
+  /** stage-12-lotes-vencimientos (Slice 15): opcional incluso para un artículo lote-efectivo —
+   * `''` deja que el servidor resuelva el lote vía FEFO (design decisión 19: "el server manda"),
+   * mismo criterio que el picker del POS. */
+  idLote: number | ''
+  /** Código del lote elegido, solo para mostrarlo en el `<select>` — nunca viaja al backend
+   * (el servidor ya conoce el código a partir de `idLote`). */
+  codigoLote: string
+  /** `ArticuloListado.controlaLote` del artículo elegido — campo solo de UI (decide si esta fila
+   * muestra el picker de lote), nunca viaja al backend: no es parte de `LineaDeTransferencia`. */
+  controlaLote: boolean
 }
 
 export function lineaDeTransferenciaVacia(clave: number): LineaDeTransferenciaFormulario {
-  return { clave, idArticulo: '', descripcion: '', cantidad: '' }
+  return { clave, idArticulo: '', descripcion: '', cantidad: '', idLote: '', codigoLote: '', controlaLote: false }
 }
 
 export function lineaTransferenciaCompleta(l: LineaDeTransferenciaFormulario): boolean {
@@ -50,7 +68,14 @@ export function lineaTransferenciaCompleta(l: LineaDeTransferenciaFormulario): b
 
 /** Espejo de `ExigirLineasDeTransferenciaValidas` (design decisión 9: "rechaza un artículo
  * repetido en un mismo request") — feedback instantáneo, nunca autoritativo: el servidor vuelve a
- * validarlo. Solo mira las líneas completas — una fila a medio llenar nunca cuenta como repetida. */
+ * validarlo. Solo mira las líneas completas — una fila a medio llenar nunca cuenta como repetida.
+ *
+ * stage-12-lotes-vencimientos (Slice 15): la clave de detección sigue siendo SOLO `idArticulo` —
+ * la restricción real de unicidad del backend es por `(idArticulo, idLote)` (decisión 11), pero
+ * dos líneas del mismo artículo con lotes DISTINTOS explícitos son válidas del lado del servidor;
+ * acá se preserva el comportamiento previo (un artículo repetido siempre se avisa) porque dos
+ * líneas del mismo artículo sin lote explícito (ambas dejando que el servidor FEFO-resuelva)
+ * competirían por el mismo lote sugerido en la práctica. */
 export function articulosRepetidosEnTransferencia(lineas: LineaDeTransferenciaFormulario[]): Set<number> {
   const conteoPorArticulo = new Map<number, number>()
   for (const l of lineas.filter(lineaTransferenciaCompleta)) {
@@ -65,7 +90,13 @@ export function articulosRepetidosEnTransferencia(lineas: LineaDeTransferenciaFo
 }
 
 export function aLineasDeTransferencia(lineas: LineaDeTransferenciaFormulario[]): LineaDeTransferencia[] {
-  return lineas.filter(lineaTransferenciaCompleta).map((l) => ({ idArticulo: Number(l.idArticulo), cantidad: Number(l.cantidad) }))
+  return lineas
+    .filter(lineaTransferenciaCompleta)
+    .map((l) => ({
+      idArticulo: Number(l.idArticulo),
+      cantidad: Number(l.cantidad),
+      idLote: l.idLote === '' ? null : Number(l.idLote),
+    }))
 }
 
 export function aSolicitudDeTransferencia(
@@ -102,4 +133,45 @@ export function contadaValida(contada: string): boolean {
   if (contada.trim() === '') return false
   const n = Number(contada)
   return Number.isFinite(n) && n >= 0
+}
+
+// ---- Conteo por lote (stage-12-lotes-vencimientos, Slice 15, design decisión 12/18) ------------
+// Un artículo lote-efectivo cuenta por lote — nunca el total agregado (`400
+// conteo_no_aplica_lotes` del lado del servidor si se manda `contada`) — exactly-one-of espejado
+// client-side: la pantalla decide QUÉ forma armar según `ArticuloListado.controlaLote`, nunca
+// arma ambas ni ninguna.
+
+export type LineaDeConteoDeLoteFormulario = { idLote: number; codigo: string; contada: string }
+
+export function lineaDeConteoDeLoteVacia(lote: LoteListado): LineaDeConteoDeLoteFormulario {
+  return { idLote: lote.idLote, codigo: lote.codigo, contada: '' }
+}
+
+/** Solo cuentan como "completas" las líneas con una `contada` tipeada — un lote listado pero sin
+ * tocar por el operador se omite del request (mismo criterio que `ContarAsync`: no hace falta
+ * recontar cada lote existente para actualizar uno solo). */
+export function lineasDeConteoDeLoteCompletas(lineas: LineaDeConteoDeLoteFormulario[]): LineaDeConteoDeLoteFormulario[] {
+  return lineas.filter((l) => contadaValida(l.contada))
+}
+
+export function aConteoDeLotes(lineas: LineaDeConteoDeLoteFormulario[]): ConteoDeLote[] {
+  return lineasDeConteoDeLoteCompletas(lineas).map((l) => ({ idLote: l.idLote, contada: Number(l.contada) }))
+}
+
+/** Rama por-lote de `SolicitudDeConteo` — `contada: null`, `lotes` con al menos una línea
+ * completa (dto-contract-honesty: nunca se manda `lotes: []`, el backend lo rechazaría igual que
+ * "ninguna de las dos formas"). */
+export function aSolicitudDeConteoPorLote(
+  idPuntoVenta: number | '',
+  idArticulo: number | '',
+  lineas: LineaDeConteoDeLoteFormulario[],
+  observaciones: string,
+): SolicitudDeConteo {
+  return {
+    idPuntoVenta: idPuntoVenta === '' ? 0 : idPuntoVenta,
+    idArticulo: idArticulo === '' ? 0 : idArticulo,
+    contada: null,
+    observaciones: observaciones.trim(),
+    lotes: aConteoDeLotes(lineas),
+  }
 }

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -216,11 +216,14 @@ export type ParametroResuelto = { clave: string; valor: string }
 
 /** Espejo de `ParametroConocido` (Ways.Domain.Catalogos): clave, tipo declarado y default
  * documentado — el editor solo acepta estas claves, igual que el backend. `zona_horaria` es
- * el primer tipo `'texto'`: el backend lo guarda como string JSON-quoteado (stage-10). */
+ * el primer tipo `'texto'`: el backend lo guarda como string JSON-quoteado (stage-10).
+ * `'booleano'` (stage-12-lotes-vencimientos, Slice 15) es el primer tipo `bool` del registro —
+ * `lotes_habilitado`, viaja como `true`/`false` JSON crudo, sin comillas (mismo criterio de
+ * `JsonSerializer.Deserialize<bool>` que el resto de los lectores tipados del backend). */
 export const PARAMETROS_CONOCIDOS: {
   clave: string
   etiqueta: string
-  tipo: 'entero' | 'decimal' | 'texto'
+  tipo: 'entero' | 'decimal' | 'texto' | 'booleano'
   porDefecto: string
 }[] = [
   { clave: 'tolerancia_pago', etiqueta: 'Tolerancia de pago ($)', tipo: 'decimal', porDefecto: '10' },
@@ -239,6 +242,16 @@ export const PARAMETROS_CONOCIDOS: {
     porDefecto: 'America/Argentina/Buenos_Aires',
   },
   { clave: 'comision_porcentaje', etiqueta: 'Comisión (%)', tipo: 'decimal', porDefecto: '0' },
+  // stage-12-lotes-vencimientos (Slice 15, espejo de `ParametroConocido.LotesHabilitado`/
+  // `.DiasAlertaVencimiento`): interruptor del módulo de lotes a nivel empresa + horizonte de
+  // alerta del reporte de vencimientos.
+  { clave: 'lotes_habilitado', etiqueta: 'Control de lotes habilitado', tipo: 'booleano', porDefecto: 'false' },
+  {
+    clave: 'dias_alerta_vencimiento',
+    etiqueta: 'Días de alerta de vencimiento',
+    tipo: 'entero',
+    porDefecto: '30',
+  },
 ]
 
 /** Zonas IANA ofrecidas en el editor de `zona_horaria` (design decisión 12): un `<select>`
@@ -470,6 +483,10 @@ export type ArticuloListado = {
   disponibleParaTodas: boolean
   idsEmpresas: number[]
   activo: boolean
+  /** stage-12-lotes-vencimientos (Slice 15, espejo de `Articulo.ControlaLote`): control efectivo
+   * de lote de este artículo es este flag AND `lotes_habilitado` de la empresa
+   * (`ReglaDeLotes.ControlEfectivo`) — acá viaja solo el flag propio del artículo. */
+  controlaLote: boolean
 }
 
 /** `codigoInterno: null` deja que el servidor lo autogenere desde el contador atómico del
@@ -494,6 +511,7 @@ export type AltaArticulo = {
   disponibleParaTodas: boolean
   idsEmpresas: number[] | null
   activo: boolean
+  controlaLote: boolean
 }
 
 /** Sin `codigoInterno`: no es editable por este ABM (valor asignado en el alta, mismo criterio
@@ -1144,7 +1162,13 @@ export type StockActual = { idPuntoVenta: number; idArticulo: number; cantidad: 
  * calculó bajo el mismo lock de fila que derivó el ajuste — `movimientoRegistrado` distingue el
  * no-op de diferencia cero de la rama que sí escribió un movimiento, sin que el cliente tenga que
  * releer `GET /api/stock` (esa segunda lectura puede correr después de una venta concurrente y
- * mentir en cualquiera de las dos direcciones). */
+ * mentir en cualquiera de las dos direcciones).
+ *
+ * stage-12-lotes-vencimientos (Slice 15, espejo de `Ways.Application.Stock.Contratos.
+ * ResultadoConteo`): `lotes` lleva el resultado POR LOTE cuando el conteo llegó vía
+ * `SolicitudDeConteo.lotes` — `null`/ausente para un conteo agregado. `cantidad`/
+ * `cantidadAnterior`/`delta` siguen siendo el AGREGADO (la suma de los deltas por lote cuando
+ * `lotes` está presente) — el cliente nunca necesita sumar a mano. */
 export type ResultadoConteo = {
   idPuntoVenta: number
   idArticulo: number
@@ -1152,11 +1176,30 @@ export type ResultadoConteo = {
   cantidadAnterior: number
   delta: number
   movimientoRegistrado: boolean
+  lotes?: LoteContado[] | null
 }
 
+/** Resultado por lote de un conteo (stage-12-lotes-vencimientos, Slice 15, espejo de
+ * `Ways.Application.Stock.Contratos.LoteContado`) — una fila por cada `ConteoDeLote` del
+ * request, incluidos los lotes sin diferencia (`movimientoRegistrado` en `false`). */
+export type LoteContado = {
+  idLote: number
+  cantidad: number
+  cantidadAnterior: number
+  delta: number
+  movimientoRegistrado: boolean
+}
+
+/** Una línea del desglose por lote de un conteo (stage-12-lotes-vencimientos, Slice 15, espejo
+ * de `Ways.Application.Stock.Contratos.ConteoDeLote`) — `contada` es el total físicamente
+ * contado de ESE lote, misma disciplina que el agregado: nunca un delta. */
+export type ConteoDeLote = { idLote: number; contada: number }
+
 /** Una línea del cuerpo de `POST /api/stock/transferencias` — `cantidad` siempre positiva
- * (espejo de `LineaDeTransferencia`). */
-export type LineaDeTransferencia = { idArticulo: number; cantidad: number }
+ * (espejo de `LineaDeTransferencia`). stage-12-lotes-vencimientos (Slice 15, misma forma exacta
+ * que agrega el Slice 14): `idLote` es opcional para un artículo lote-efectivo — omitido, el
+ * servidor lo resuelve vía FEFO. */
+export type LineaDeTransferencia = { idArticulo: number; cantidad: number; idLote?: number | null }
 
 /** Cuerpo de `POST /api/stock/transferencias` (espejo de `SolicitudDeTransferencia`).
  * `observaciones` es obligatoria, mismo criterio que el ajuste manual. */
@@ -1168,8 +1211,11 @@ export type SolicitudDeTransferencia = {
 }
 
 /** El stock resultante de un artículo en AMBOS puntos de venta tras la transacción (espejo de
- * `LineaTransferida`). */
-export type LineaTransferida = { idArticulo: number; cantidadOrigen: number; cantidadDestino: number }
+ * `LineaTransferida`). stage-12-lotes-vencimientos (Slice 15, misma forma exacta que agrega el
+ * Slice 14): `idLote` viaja igual que `ItemEmitido.idLote` — la clave de agregación del backend
+ * es `(idArticulo, idLote)`, no solo `idArticulo`: dos líneas del mismo artículo con lotes
+ * distintos son filas separadas. */
+export type LineaTransferida = { idArticulo: number; idLote: number | null; cantidadOrigen: number; cantidadDestino: number }
 
 /** Respuesta de `POST /api/stock/transferencias` (espejo de `ResultadoTransferencia`). */
 export type ResultadoTransferencia = {
@@ -1180,8 +1226,76 @@ export type ResultadoTransferencia = {
 
 /** Cuerpo de `POST /api/stock/conteos` — `contada` es el TOTAL físicamente contado, nunca un
  * delta (espejo de `SolicitudDeConteo`; spec: conteo-de-inventario / Conteo Input Is The Counted
- * Total, Never A Delta). */
-export type SolicitudDeConteo = { idPuntoVenta: number; idArticulo: number; contada: number; observaciones: string }
+ * Total, Never A Delta).
+ *
+ * stage-12-lotes-vencimientos (Slice 15, espejo de `Ways.Application.Stock.Contratos.
+ * SolicitudDeConteo`, design decisión 18): `contada` se ensancha a `number | null` — el contrato
+ * pasa a EXACTLY-ONE-OF `contada`/`lotes` (`400 conteo_contada_y_lotes` si vienen ambos o
+ * ninguno). Un artículo lote-efectivo cuenta por lote (`lotes`, un total contado por cada
+ * `idLote`); uno sin lote efectivo sigue mandando el total agregado (`contada`). */
+export type SolicitudDeConteo = {
+  idPuntoVenta: number
+  idArticulo: number
+  contada: number | null
+  observaciones: string
+  lotes?: ConteoDeLote[] | null
+}
+
+// --- Lotes y vencimientos (stage-12-lotes-vencimientos) --------------------------------------
+// Espejo de `Ways.Application.Stock.Contratos`/`Ways.Application.Reportes.Contratos` — mismos
+// nombres de campo que el backend serializa en camelCase. `EstadoDeVencimiento` viaja como texto
+// (`JsonStringEnumConverter` sin política de naming en `Program.cs`, mismo criterio que
+// `Granularidad`/`EstadoPago`) — los NOMBRES de los miembros de C#, no una variante snake_case.
+
+/** Espejo del enum `EstadoDeVencimiento` (Ways.Domain.Stock) — clasificación de un lote respecto
+ * de "hoy". `SinFecha` es el lote sin identificar: se incluye en el reporte, nunca se excluye. */
+export type EstadoDeVencimiento = 'Vencido' | 'PorVencer' | 'Vigente' | 'SinFecha'
+
+/** Fila de `GET /api/stock/lotes` y resultado de `POST /api/stock/lotes` (espejo de
+ * `LoteListado`, design decisión 19). `sugerido` es el pick FEFO server-computed
+ * (`ReglaDeLotes.ElegirFefo`) — el picker lo renderiza, nunca lo recalcula. Misma forma exacta
+ * que agrega el Slice 14. */
+export type LoteListado = {
+  idLote: number
+  idArticulo: number
+  codigo: string
+  fechaVencimiento: string | null
+  esSinIdentificar: boolean
+  cantidad: number
+  estado: EstadoDeVencimiento
+  sugerido: boolean
+}
+
+/** Fila de `GET /api/reportes/stock/vencimientos` (espejo de `FilaDeVencimiento`) — solo lotes
+ * con `stock_lotes.cantidad` positivo. `fechaVencimiento` es `null` exactamente para el lote sin
+ * identificar, que clasifica `SinFecha` y SE INCLUYE en el reporte. */
+export type FilaDeVencimiento = {
+  idArticulo: number
+  articulo: string
+  idLote: number
+  codigoLote: string
+  fechaVencimiento: string | null
+  cantidad: number
+  estado: EstadoDeVencimiento
+}
+
+/** Respuesta de `GET /api/reportes/stock/vencimientos` (espejo de `Vencimientos`). `hoy`/
+ * `zonaHoraria` son la fecha y la zona efectivamente resueltas para clasificar cada fila — "hoy"
+ * se calcula en la zona horaria del punto de venta, NUNCA en UTC. `diasDeAlerta` es el horizonte
+ * efectivamente aplicado: el parámetro `dias` de la query si vino, si no el
+ * `dias_alerta_vencimiento` resuelto (PV → empresa → default). */
+export type Vencimientos = {
+  idPuntoVenta: number
+  hoy: string
+  diasDeAlerta: number
+  zonaHoraria: string
+  filas: FilaDeVencimiento[]
+}
+
+/** Respuesta de `GET /api/reportes/stock/vencimientos/resumen` (espejo de
+ * `ResumenDeVencimientos`) — el tile de Tablero. Mismos tres conteos que `Vencimientos.filas`
+ * agrupados por `FilaDeVencimiento.estado` — nunca una query de agregación separada. */
+export type ResumenDeVencimientos = { idPuntoVenta: number; vencidos: number; porVencer: number; sinFecha: number }
 
 // --- Reportes (stage-10-agregacion-dashboard, Slice 7): G1 parity — ventas/resumen y
 // gastos/resumen. Espejo de `Ways.Application.Reportes.Contratos` — mismos nombres de campo que

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -100,6 +100,15 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-12-lotes-vencimientos (Slice 15): mismo gate que Existencias
+                    (puedeVerReportes). */}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/reportes/stock/vencimientos">
+                      Vencimientos
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/Articulos.test.tsx
+++ b/src/Ways.Web/src/paginas/Articulos.test.tsx
@@ -40,6 +40,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }
@@ -67,12 +68,13 @@ function mockearApiGet() {
     if (/^\/articulos\/\d+\/codigos-barra$/.test(ruta)) return Promise.resolve([])
     if (/^\/articulos\/\d+\/precios$/.test(ruta)) return Promise.resolve([])
     if (/^\/articulos\/\d+\/sugerencia-precio$/.test(ruta)) return Promise.resolve({ precioSugerido: 55.5 })
-    if (ruta === '/catalogos/areas') return Promise.resolve([])
+    if (ruta === '/catalogos/areas') return Promise.resolve([{ id: 1, nombre: 'Almacén', activo: true }])
     if (ruta === '/catalogos/categorias') return Promise.resolve([])
     if (ruta === '/catalogos/marcas') return Promise.resolve([])
     if (ruta === '/catalogos/grupos') return Promise.resolve([])
     if (ruta.startsWith('/proveedores')) return Promise.resolve({ items: [], total: 0, pagina: 1, tamanio: 200 })
-    if (ruta === '/catalogos-fiscales/alicuotas-iva') return Promise.resolve([])
+    if (ruta === '/catalogos-fiscales/alicuotas-iva')
+      return Promise.resolve([{ id: 1, nombre: 'IVA 21%', porcentaje: 21, codigoAfip: 5, activo: true }])
     if (ruta === '/empresas') return Promise.resolve([])
     if (ruta === '/catalogos/listas-precio') return Promise.resolve([])
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
@@ -109,5 +111,55 @@ describe('Articulos — reseteo de estado por artículo (key de FormularioArticu
     await waitFor(() => {
       expect(screen.queryByText(/Precio sugerido a partir de costo y margen/)).not.toBeInTheDocument()
     })
+  })
+})
+
+// ---- controlaLote (stage-12-lotes-vencimientos, Slice 15) ---------------------------------------
+
+describe('Articulos — toggle controlaLote (coerción boolean, dto-contract-honesty)', () => {
+  it('un artículo con controlaLote:false arranca con el checkbox destildado', async () => {
+    render(<Articulos />)
+
+    const filaUno = (await screen.findByText('Articulo Uno')).closest('tr')
+    if (!filaUno) throw new Error('No se encontró la fila del artículo uno')
+    await userEvent.click(within(filaUno).getByRole('button', { name: 'Editar' }))
+
+    await screen.findByText('Editando artículo A0001')
+    expect(screen.getByLabelText('Controla lote / vencimiento')).not.toBeChecked()
+  })
+
+  it('tildar el checkbox y guardar manda controlaLote:true — nunca un string ni "on"', async () => {
+    mockearApiGet()
+    apiPutMock.mockResolvedValue(articuloFixture({ id: 1, controlaLote: true }))
+    render(<Articulos />)
+
+    const filaUno = (await screen.findByText('Articulo Uno')).closest('tr')
+    if (!filaUno) throw new Error('No se encontró la fila del artículo uno')
+    await userEvent.click(within(filaUno).getByRole('button', { name: 'Editar' }))
+
+    await screen.findByText('Editando artículo A0001')
+    await userEvent.click(screen.getByLabelText('Controla lote / vencimiento'))
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, cuerpo] = apiPutMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(cuerpo.controlaLote).toBe(true)
+  })
+
+  it('sin tocar el checkbox, guarda controlaLote:false — el valor previo del artículo, no un default inventado', async () => {
+    mockearApiGet()
+    apiPutMock.mockResolvedValue(articuloFixture({ id: 1, controlaLote: false }))
+    render(<Articulos />)
+
+    const filaUno = (await screen.findByText('Articulo Uno')).closest('tr')
+    if (!filaUno) throw new Error('No se encontró la fila del artículo uno')
+    await userEvent.click(within(filaUno).getByRole('button', { name: 'Editar' }))
+
+    await screen.findByText('Editando artículo A0001')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, cuerpo] = apiPutMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(cuerpo.controlaLote).toBe(false)
   })
 })

--- a/src/Ways.Web/src/paginas/Articulos.tsx
+++ b/src/Ways.Web/src/paginas/Articulos.tsx
@@ -49,6 +49,7 @@ type Formulario = {
   disponibleParaTodas: boolean
   idsEmpresas: number[]
   activo: boolean
+  controlaLote: boolean
 }
 
 function formularioVacio(): Formulario {
@@ -72,6 +73,7 @@ function formularioVacio(): Formulario {
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
   }
 }
 
@@ -96,6 +98,7 @@ function aFormulario(a: ArticuloListado): Formulario {
     disponibleParaTodas: a.disponibleParaTodas,
     idsEmpresas: a.idsEmpresas,
     activo: a.activo,
+    controlaLote: a.controlaLote,
   }
 }
 
@@ -128,6 +131,7 @@ function camposComunes(f: Formulario) {
     disponibleParaTodas: f.disponibleParaTodas,
     idsEmpresas: f.disponibleParaTodas ? null : f.idsEmpresas,
     activo: f.activo,
+    controlaLote: f.controlaLote,
   }
 }
 
@@ -898,6 +902,24 @@ function FormularioArticulo({
               />
               <label className="form-check-label" htmlFor="art-activo">
                 Activo
+              </label>
+            </div>
+          </div>
+
+          {/* stage-12-lotes-vencimientos (Slice 15, espejo de `Articulo.ControlaLote`): control
+              efectivo de lote es este flag AND `lotes_habilitado` de la empresa (Parámetros) —
+              acá solo se edita el flag propio del artículo, el servidor resuelve el AND. */}
+          <div className="col-md-3 d-flex align-items-end">
+            <div className="form-check">
+              <input
+                id="art-controla-lote"
+                type="checkbox"
+                className="form-check-input rounded-0"
+                checked={valor.controlaLote}
+                onChange={(e) => onCambio({ ...valor, controlaLote: e.target.checked })}
+              />
+              <label className="form-check-label" htmlFor="art-controla-lote">
+                Controla lote / vencimiento
               </label>
             </div>
           </div>

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
@@ -137,16 +137,22 @@ function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
 }
 
 /** stage-12-lotes-vencimientos (Slice 15) — variante lote-efectiva de `mockearBase`: el artículo
- * mockeado tiene `controlaLote: true` y `GET /api/stock/lotes` devuelve una lista fija de lotes. */
+ * mockeado tiene `controlaLote: true` y `GET /api/stock/lotes` devuelve una lista fija de lotes.
+ *
+ * judgment-day (ronda juez A): el control EFECTIVO ahora es el AND con `lotes_habilitado` de la
+ * empresa (`GET /api/parametros/lotes_habilitado`) — acá se mockea resuelto en `"true"` (el
+ * módulo está ON), que es el escenario que estos tests ya asumían implícitamente. */
 function mockearBaseConLote(
   stockActual: StockActual,
   lotes: LoteListado[] = [loteFixture({ idLote: 41 }), loteFixture({ idLote: 42, codigo: '2026-09-01' })],
+  lotesHabilitado = 'true',
 ) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
     if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture({ controlaLote: true })], total: 1, pagina: 1, tamanio: 25 })
     if (ruta.startsWith('/stock?')) return Promise.resolve(stockActual)
     if (ruta.startsWith('/stock/lotes?')) return Promise.resolve(lotes)
+    if (ruta.startsWith('/parametros/lotes_habilitado')) return Promise.resolve({ clave: 'lotes_habilitado', valor: lotesHabilitado })
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -416,5 +422,74 @@ describe('ConteoDeInventario — conteo por lote (exactly-one-of)', () => {
 
     expect(screen.queryByText('Conteo por lote')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Cantidad contada')).toBeInTheDocument()
+  })
+})
+
+// ---- Control efectivo de lote — AND con `lotes_habilitado` (judgment-day, Slice 15, ronda A) ---
+
+describe('ConteoDeInventario — control efectivo de lote (judgment-day fix, ronda juez A)', () => {
+  it('(a) artículo con controlaLote pero módulo de lotes apagado (lotes_habilitado=false): cae al formulario agregado, usable, submit OK — sin dead-end', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 }, [], 'false')
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/conteos')
+        return Promise.resolve({ idPuntoVenta: 1, idArticulo: 10, cantidad: 45, cantidadAnterior: 40, delta: 5, movimientoRegistrado: true })
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+
+    // el AND con `lotes_habilitado=false` cae al agregado: nunca la grilla por lote, aunque el
+    // artículo tenga `controlaLote: true` — antes del fix, esto quedaba en un grid vacío sin
+    // ninguna línea completable (dead-end permanente).
+    await waitFor(() => expect(screen.getByLabelText('Cantidad contada')).toBeInTheDocument())
+    expect(screen.queryByText('Conteo por lote')).not.toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Cantidad contada'), '45')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'Recuento con módulo apagado')
+
+    expect(screen.getByRole('button', { name: 'Contar' })).not.toBeDisabled()
+    await usuario.click(screen.getByRole('button', { name: 'Contar' }))
+
+    expect(await screen.findByText('Diferencia registrada: +5 (antes 40 → ahora 45).')).toBeInTheDocument()
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/conteos')
+    expect(llamadas).toHaveLength(1)
+    const [, cuerpo] = llamadas[0] as [string, Record<string, unknown>]
+    expect(cuerpo).toEqual({ idPuntoVenta: 1, idArticulo: 10, contada: 45, observaciones: 'Recuento con módulo apagado' })
+  })
+
+  it('(b) artículo con controlaLote y módulo de lotes prendido (lotes_habilitado=true): muestra la grilla por lote, como antes del fix', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+
+    await screen.findByText('2026-08-20')
+    expect(screen.queryByLabelText('Cantidad contada')).not.toBeInTheDocument()
+  })
+
+  it('(c) caso borde elegido: si la resolución de lotes_habilitado falla (red caída), cae al agregado en vez de bloquear al operador', async () => {
+    // `mockearBaseConLote` con la ruta de `lotes_habilitado` sobrescrita a un reject.
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture({ controlaLote: true })], total: 1, pagina: 1, tamanio: 25 })
+      if (ruta.startsWith('/stock?')) return Promise.resolve({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+      if (ruta.startsWith('/parametros/lotes_habilitado')) return Promise.reject(new Error('caído'))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+
+    // Fetch fallido → `lotesHabilitado` se queda en `null` → default agregado (honesto, mismo
+    // default que el servidor), nunca un dead-end.
+    await waitFor(() => expect(screen.getByLabelText('Cantidad contada')).toBeInTheDocument())
+    expect(screen.queryByText('Conteo por lote')).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConteoDeInventario } from './ConteoDeInventario'
 import { RutaProtegida } from '../auth/RutaProtegida'
 import { ROL } from '../api/tipos'
-import type { ArticuloListado, PuntoVentaListado, ResultadoConteo, StockActual, UsuarioAutenticado } from '../api/tipos'
+import type { ArticuloListado, LoteListado, PuntoVentaListado, ResultadoConteo, StockActual, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
@@ -84,6 +84,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }
@@ -117,6 +118,35 @@ function mockearBase(stockActual: StockActual, sobrescribirGet?: (ruta: string) 
     if (ruta.startsWith('/stock?')) return Promise.resolve(stockActual)
     const propia = sobrescribirGet?.(ruta)
     if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+  return {
+    idLote: 41,
+    idArticulo: 10,
+    codigo: '2026-08-20',
+    fechaVencimiento: '2026-08-20',
+    esSinIdentificar: false,
+    cantidad: 12,
+    estado: 'Vigente',
+    sugerido: true,
+    ...sobrescribir,
+  }
+}
+
+/** stage-12-lotes-vencimientos (Slice 15) — variante lote-efectiva de `mockearBase`: el artículo
+ * mockeado tiene `controlaLote: true` y `GET /api/stock/lotes` devuelve una lista fija de lotes. */
+function mockearBaseConLote(
+  stockActual: StockActual,
+  lotes: LoteListado[] = [loteFixture({ idLote: 41 }), loteFixture({ idLote: 42, codigo: '2026-09-01' })],
+) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture({ controlaLote: true })], total: 1, pagina: 1, tamanio: 25 })
+    if (ruta.startsWith('/stock?')) return Promise.resolve(stockActual)
+    if (ruta.startsWith('/stock/lotes?')) return Promise.resolve(lotes)
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -283,5 +313,108 @@ describe('ConteoDeInventario — role gating', () => {
     renderConteoProtegido()
 
     await waitFor(() => expect(screen.getByText('Inicio (redirigido)')).toBeInTheDocument())
+  })
+})
+
+// ---- Conteo por lote (stage-12-lotes-vencimientos, Slice 15) -----------------------------------
+
+describe('ConteoDeInventario — conteo por lote (exactly-one-of)', () => {
+  it('un artículo lote-efectivo muestra el grid por lote, nunca el campo agregado — exactly-one-of', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+
+    await screen.findByText('2026-08-20')
+    expect(screen.getByText('2026-09-01')).toBeInTheDocument()
+    // Nunca las dos formas a la vez: el campo agregado desaparece cuando el grid por lote está.
+    expect(screen.queryByLabelText('Cantidad contada')).not.toBeInTheDocument()
+  })
+
+  it('el botón queda deshabilitado hasta contar al menos un lote', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+    await screen.findByText('2026-08-20')
+
+    await usuario.type(screen.getByLabelText('Observaciones'), 'Recuento por lote')
+    expect(screen.getByRole('button', { name: 'Contar' })).toBeDisabled()
+
+    await usuario.type(screen.getByLabelText('Contada del lote 2026-08-20'), '10')
+    expect(screen.getByRole('button', { name: 'Contar' })).not.toBeDisabled()
+  })
+
+  it('contador de lotes incompletos: baja a medida que se cuentan lotes (mirror de Transferencias.tsx)', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+    await screen.findByText('2026-08-20')
+
+    expect(screen.getByText('2 lote(s) sin contar — no se van a incluir en el conteo.')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Contada del lote 2026-08-20'), '10')
+    expect(screen.getByText('1 lote(s) sin contar — no se van a incluir en el conteo.')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Contada del lote 2026-09-01'), '5')
+    expect(screen.queryByText(/lote\(s\) sin contar/)).not.toBeInTheDocument()
+  })
+
+  it('envía la rama por lote — contada:null, lotes solo con los completos, exactamente un lote sin tocar queda afuera', async () => {
+    mockearBaseConLote({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/conteos')
+        return Promise.resolve({
+          idPuntoVenta: 1,
+          idArticulo: 10,
+          cantidad: 22,
+          cantidadAnterior: 12,
+          delta: 10,
+          movimientoRegistrado: true,
+          lotes: [{ idLote: 41, cantidad: 22, cantidadAnterior: 12, delta: 10, movimientoRegistrado: true }],
+        })
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+    await screen.findByText('2026-08-20')
+
+    await usuario.type(screen.getByLabelText('Contada del lote 2026-08-20'), '22')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'Recuento por lote')
+    await usuario.click(screen.getByRole('button', { name: 'Contar' }))
+
+    expect(await screen.findByText('Diferencia registrada: +10 (antes 12 → ahora 22).')).toBeInTheDocument()
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/conteos')
+    expect(llamadas).toHaveLength(1)
+    const [, cuerpo] = llamadas[0] as [string, Record<string, unknown>]
+    expect(cuerpo).toEqual({
+      idPuntoVenta: 1,
+      idArticulo: 10,
+      contada: null,
+      observaciones: 'Recuento por lote',
+      lotes: [{ idLote: 41, contada: 22 }],
+    })
+  })
+
+  it('un artículo SIN control de lote nunca muestra el grid por lote', async () => {
+    mockearBase({ idPuntoVenta: 1, idArticulo: 10, cantidad: 40 })
+    const usuario = userEvent.setup()
+
+    renderConteo()
+    await screen.findByLabelText('Punto de venta')
+    await elegirPuntoVentaYArticulo(usuario)
+
+    expect(screen.queryByText('Conteo por lote')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Cantidad contada')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
-import { aSolicitudDeConteo, clienteDeStock, contadaValida } from '../api/stock'
+import {
+  aSolicitudDeConteo,
+  aSolicitudDeConteoPorLote,
+  clienteDeStock,
+  contadaValida,
+  lineaDeConteoDeLoteVacia,
+  lineasDeConteoDeLoteCompletas,
+  type LineaDeConteoDeLoteFormulario,
+} from '../api/stock'
 import { clienteDeArticulos } from '../api/articulos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
@@ -97,6 +105,12 @@ function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDe
  * pantalla: el resultado que se renderiza después de un submit sale ÍNTEGRO de la respuesta de
  * `POST /api/stock/conteos` (`ResultadoConteo`), nunca de ese pre-fetch — que puede haber quedado
  * desactualizado por una venta concurrente (judgment-day stage-8 Slice 6).
+ *
+ * stage-12-lotes-vencimientos (Slice 15, design decisión 12/18 — exactly-one-of espejado
+ * client-side): un artículo lote-efectivo (`ArticuloListado.controlaLote`) cambia la pantalla a
+ * un grid de "contada por lote" — nunca muestra el campo agregado a la vez. Un artículo sin
+ * control de lote sigue el flujo agregado de siempre. La pantalla arma UNA de las dos formas del
+ * contrato, nunca ambas ni ninguna, mismo criterio que el backend (`400 conteo_contada_y_lotes`).
  */
 export function ConteoDeInventario() {
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
@@ -125,8 +139,11 @@ export function ConteoDeInventario() {
   const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
   const [idArticulo, setIdArticulo] = useState<number | ''>('')
   const [descripcionArticulo, setDescripcionArticulo] = useState('')
+  const [articuloSeleccionado, setArticuloSeleccionado] = useState<ArticuloListado | null>(null)
   const [contada, setContada] = useState('')
   const [observaciones, setObservaciones] = useState('')
+
+  const esLoteEfectivo = articuloSeleccionado?.controlaLote === true
 
   // ---- stock actual conocido (el "antes" honesto) — token-gated, se reconsulta cada vez que
   // cambia el par (punto de venta, artículo). ----------------------------------------------------
@@ -162,18 +179,70 @@ export function ConteoDeInventario() {
     }
   }, [idPuntoVenta, idArticulo])
 
+  // ---- lotes del artículo (solo para uno lote-efectivo) — token-gated, mismo patrón que
+  // `actual` arriba. Cada lote listado arranca sin contada tipeada (regla 8: subárbol reseteado
+  // por artículo — este efecto corre de nuevo ante cualquier cambio de (PV, artículo)). ----------
+  const [lineasDeLote, setLineasDeLote] = useState<LineaDeConteoDeLoteFormulario[]>([])
+  const [cargandoLotes, setCargandoLotes] = useState(false)
+  const [errorLotes, setErrorLotes] = useState('')
+  const generacionLotesRef = useRef(0)
+
+  useEffect(() => {
+    setLineasDeLote([])
+    setErrorLotes('')
+    if (idPuntoVenta === '' || idArticulo === '' || !esLoteEfectivo) return
+
+    let vigente = true
+    const miGeneracion = (generacionLotesRef.current += 1)
+    setCargandoLotes(true)
+
+    clienteDeStock
+      .lotes(idPuntoVenta, idArticulo)
+      .then((lista) => {
+        if (!vigente || generacionLotesRef.current !== miGeneracion) return
+        setLineasDeLote(lista.map(lineaDeConteoDeLoteVacia))
+      })
+      .catch((e) => {
+        if (!vigente || generacionLotesRef.current !== miGeneracion) return
+        setLineasDeLote([])
+        setErrorLotes(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
+      })
+      .finally(() => {
+        if (!vigente || generacionLotesRef.current !== miGeneracion) return
+        setCargandoLotes(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idPuntoVenta, idArticulo, esLoteEfectivo])
+
+  function cambiarLineaDeLote(idLote: number, contadaLote: string) {
+    // regla 1: updater funcional, nunca lee `lineasDeLote` del cierre.
+    setLineasDeLote((prev) => prev.map((l) => (l.idLote === idLote ? { ...l, contada: contadaLote } : l)))
+  }
+
+  const lineasDeLoteCompletas = lineasDeConteoDeLoteCompletas(lineasDeLote)
+  const lineasDeLoteIncompletas = lineasDeLote.length - lineasDeLoteCompletas.length
+
   const [contando, setContando] = useState(false)
   const contandoRef = useRef(false)
   const [error, setError] = useState('')
   const [resultado, setResultado] = useState<ResultadoConteo | null>(null)
 
-  const puedeContar =
-    referenciaOk &&
-    !contando &&
-    idPuntoVenta !== '' &&
-    idArticulo !== '' &&
-    contadaValida(contada) &&
-    observaciones.trim() !== ''
+  const puedeContar = esLoteEfectivo
+    ? referenciaOk &&
+      !contando &&
+      idPuntoVenta !== '' &&
+      idArticulo !== '' &&
+      lineasDeLoteCompletas.length > 0 &&
+      observaciones.trim() !== ''
+    : referenciaOk &&
+      !contando &&
+      idPuntoVenta !== '' &&
+      idArticulo !== '' &&
+      contadaValida(contada) &&
+      observaciones.trim() !== ''
 
   async function contar() {
     // regla 9: guard de reentrancia de primera línea.
@@ -187,7 +256,9 @@ export function ConteoDeInventario() {
     generacionActualRef.current += 1
 
     try {
-      const solicitud = aSolicitudDeConteo(idPuntoVenta, idArticulo, contada, observaciones)
+      const solicitud = esLoteEfectivo
+        ? aSolicitudDeConteoPorLote(idPuntoVenta, idArticulo, lineasDeLoteCompletas, observaciones)
+        : aSolicitudDeConteo(idPuntoVenta, idArticulo, contada, observaciones)
       const respuesta = await clienteDeStock.contar(solicitud)
       contandoRef.current = false
       setContando(false)
@@ -199,6 +270,7 @@ export function ConteoDeInventario() {
       setActual(respuesta.cantidad)
       setContada('')
       setObservaciones('')
+      setLineasDeLote((prev) => prev.map((l) => ({ ...l, contada: '' })))
     } catch (e) {
       contandoRef.current = false
       setContando(false)
@@ -221,6 +293,30 @@ export function ConteoDeInventario() {
             {!resultado.movimientoRegistrado
               ? 'Sin diferencia — no se registró ningún movimiento.'
               : `Diferencia registrada: ${resultado.delta > 0 ? '+' : ''}${resultado.delta} (antes ${resultado.cantidadAnterior} → ahora ${resultado.cantidad}).`}
+            {resultado.lotes && resultado.lotes.length > 0 && (
+              <table className="table table-sm table-bordered mt-2 mb-0 bg-white">
+                <thead>
+                  <tr>
+                    <th>Lote</th>
+                    <th className="text-end">Anterior</th>
+                    <th className="text-end">Nueva</th>
+                    <th className="text-end">Delta</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resultado.lotes.map((l) => (
+                    <tr key={l.idLote}>
+                      <td>{l.idLote}</td>
+                      <td className="text-end">{l.cantidadAnterior}</td>
+                      <td className="text-end">{l.cantidad}</td>
+                      <td className="text-end">
+                        {l.movimientoRegistrado ? `${l.delta > 0 ? '+' : ''}${l.delta}` : 'sin diferencia'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
         )}
 
@@ -254,6 +350,8 @@ export function ConteoDeInventario() {
               onElegir={(a) => {
                 setIdArticulo(a.id)
                 setDescripcionArticulo(a.nombre)
+                setArticuloSeleccionado(a)
+                setContada('')
               }}
             />
           </div>
@@ -261,21 +359,23 @@ export function ConteoDeInventario() {
             <div className="small text-muted">Stock actual</div>
             <div>{idPuntoVenta === '' || idArticulo === '' ? '—' : cargandoActual ? 'Cargando…' : (actual ?? '—')}</div>
           </div>
-          <div className="col-md-3">
-            <label className="form-label" htmlFor="conteo-contada">
-              Cantidad contada
-            </label>
-            <input
-              id="conteo-contada"
-              type="number"
-              step="0.001"
-              min="0"
-              className="form-control rounded-0"
-              value={contada}
-              disabled={contando || !referenciaOk}
-              onChange={(e) => setContada(e.target.value)}
-            />
-          </div>
+          {!esLoteEfectivo && (
+            <div className="col-md-3">
+              <label className="form-label" htmlFor="conteo-contada">
+                Cantidad contada
+              </label>
+              <input
+                id="conteo-contada"
+                type="number"
+                step="0.001"
+                min="0"
+                className="form-control rounded-0"
+                value={contada}
+                disabled={contando || !referenciaOk}
+                onChange={(e) => setContada(e.target.value)}
+              />
+            </div>
+          )}
           <div className="col-12">
             <label className="form-label" htmlFor="conteo-observaciones">
               Observaciones
@@ -290,6 +390,53 @@ export function ConteoDeInventario() {
             />
           </div>
         </div>
+
+        {esLoteEfectivo && (
+          <div className="mb-3">
+            <strong className="text-muted small text-uppercase">Conteo por lote</strong>
+            {errorLotes && <div className="alert alert-danger rounded-0 py-1 px-2 small mt-2">{errorLotes}</div>}
+            {cargandoLotes && lineasDeLote.length === 0 ? (
+              <p className="text-muted small mt-2">Cargando lotes…</p>
+            ) : lineasDeLote.length === 0 && !errorLotes ? (
+              <p className="text-muted small mt-2">Este artículo no tiene lotes cargados en este punto de venta.</p>
+            ) : (
+              <div className="table-responsive mt-2">
+                <table className="table table-sm table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Lote</th>
+                      <th style={{ width: 160 }}>Contada</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {lineasDeLote.map((l) => (
+                      <tr key={l.idLote} className={contadaValida(l.contada) ? undefined : 'table-warning text-muted'}>
+                        <td>{l.codigo}</td>
+                        <td>
+                          <input
+                            type="number"
+                            step="0.001"
+                            min="0"
+                            className="form-control form-control-sm rounded-0"
+                            aria-label={`Contada del lote ${l.codigo}`}
+                            value={l.contada}
+                            disabled={contando || !referenciaOk}
+                            onChange={(e) => cambiarLineaDeLote(l.idLote, e.target.value)}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {lineasDeLote.length > 0 && lineasDeLoteIncompletas > 0 && (
+              <div className="alert alert-warning rounded-0 py-1 px-2 small mb-0">
+                {lineasDeLoteIncompletas} lote(s) sin contar — no se van a incluir en el conteo.
+              </div>
+            )}
+          </div>
+        )}
 
         <button type="button" className="btn btn-primary rounded-0" disabled={!puedeContar} onClick={contar}>
           {contando ? 'Contando…' : 'Contar'}

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.tsx
@@ -11,6 +11,7 @@ import {
 import { clienteDeArticulos } from '../api/articulos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeParametros } from '../api/parametros'
 import type { ArticuloListado, PuntoVentaListado, ResultadoConteo } from '../api/tipos'
 import { Box } from '../componentes/Box'
 
@@ -111,6 +112,19 @@ function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDe
  * un grid de "contada por lote" — nunca muestra el campo agregado a la vez. Un artículo sin
  * control de lote sigue el flujo agregado de siempre. La pantalla arma UNA de las dos formas del
  * contrato, nunca ambas ni ninguna, mismo criterio que el backend (`400 conteo_contada_y_lotes`).
+ *
+ * judgment-day (Slice 15, ronda juez A): el control EFECTIVO no es solo `controlaLote` — es el AND
+ * con `lotes_habilitado` de la empresa, espejo de `ReglaDeLotes.ControlEfectivo` (Domain). Con el
+ * flag propio en `true` pero el módulo apagado (`lotes_habilitado = false`), `GET /api/stock/lotes`
+ * jamás tuvo reconciliación y devuelve cero lotes — mostrar igual el grid por lote dejaba al
+ * operador sin ninguna forma de contar ese artículo (dead-end permanente, `puedeContar` exigía
+ * ≥1 línea que nunca podía existir). Acá se resuelve `lotes_habilitado` vía
+ * `GET /api/parametros/lotes_habilitado` (mismo endpoint que prueba `Parametros.tsx`, con
+ * `Politicas.OperacionDePos` — no hace falta ser admin) antes de decidir la forma del formulario;
+ * mientras no resuelve, o si el fetch falla, el default es agregado (mismo default del parámetro
+ * en el servidor, `"false"`) — nunca un dead-end: si el módulo está realmente ON, el servidor
+ * rechaza el envío agregado con `400 conteo_requiere_lotes`, error que el funnel ya muestra tal
+ * cual — el server manda, honesto y sin bloquear al operador silenciosamente.
  */
 export function ConteoDeInventario() {
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
@@ -143,7 +157,46 @@ export function ConteoDeInventario() {
   const [contada, setContada] = useState('')
   const [observaciones, setObservaciones] = useState('')
 
-  const esLoteEfectivo = articuloSeleccionado?.controlaLote === true
+  const articuloControlaLote = articuloSeleccionado?.controlaLote === true
+  const idEmpresaSeleccionada = (puntosVenta ?? []).find((pv) => pv.id === idPuntoVenta)?.idEmpresa ?? null
+
+  // ---- `lotes_habilitado` de la empresa (judgment-day, Slice 15) — solo se resuelve cuando hace
+  // falta (el artículo elegido tiene `controlaLote`): mismo patrón token-gated que `actual`/
+  // `lineasDeLote` de abajo. `null` = sin resolver todavía (o fetch fallido) — el default es
+  // agregado, nunca el grid por lote, hasta tener una respuesta positiva explícita del servidor.
+  const [lotesHabilitado, setLotesHabilitado] = useState<boolean | null>(null)
+  const generacionLotesHabilitadoRef = useRef(0)
+
+  useEffect(() => {
+    setLotesHabilitado(null)
+    if (idEmpresaSeleccionada === null || idPuntoVenta === '' || !articuloControlaLote) return
+
+    let vigente = true
+    const miGeneracion = (generacionLotesHabilitadoRef.current += 1)
+
+    clienteDeParametros
+      .resolver('lotes_habilitado', idEmpresaSeleccionada, idPuntoVenta)
+      .then((resuelto) => {
+        if (!vigente || generacionLotesHabilitadoRef.current !== miGeneracion) return
+        setLotesHabilitado(resuelto.valor === 'true')
+      })
+      .catch(() => {
+        if (!vigente || generacionLotesHabilitadoRef.current !== miGeneracion) return
+        // Fetch fallido: se queda en `null` → `esLoteEfectivo` cae a agregado (default honesto,
+        // mismo criterio que el default del parámetro en el servidor). Nunca un dead-end: si el
+        // módulo está realmente ON, el servidor rechaza el envío agregado y ese error se ve.
+        setLotesHabilitado(null)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idEmpresaSeleccionada, idPuntoVenta, articuloControlaLote])
+
+  // Control EFECTIVO — espejo de `ReglaDeLotes.ControlEfectivo` (Domain): el AND de ambos flags,
+  // nunca `controlaLote` a secas (ese era el dead-end del judgment-day: con el módulo apagado, la
+  // grilla por lote se mostraba igual y nunca tenía líneas para completar).
+  const esLoteEfectivo = articuloControlaLote && lotesHabilitado === true
 
   // ---- stock actual conocido (el "antes" honesto) — token-gated, se reconsulta cada vez que
   // cambia el par (punto de venta, artículo). ----------------------------------------------------

--- a/src/Ways.Web/src/paginas/Ofertas.test.tsx
+++ b/src/Ways.Web/src/paginas/Ofertas.test.tsx
@@ -58,6 +58,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Parametros.test.tsx
+++ b/src/Ways.Web/src/paginas/Parametros.test.tsx
@@ -125,3 +125,91 @@ describe('Parametros — claves numéricas existentes (flujo sin cambios)', () =
     expect(datos.valor).toBe('12')
   })
 })
+
+// ---- Claves nuevas de stage-12-lotes-vencimientos (Slice 15) -----------------------------------
+
+describe('Parametros — clave lotes_habilitado (tipo booleano, nuevo en el registro)', () => {
+  it('renderiza un checkbox — nunca un <input type="number"> ni un <select> — y arranca deshabilitado', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'lotes_habilitado')
+
+    const selectorDeValor = screen.getByLabelText('Valor')
+    expect(selectorDeValor.tagName).toBe('INPUT')
+    expect((selectorDeValor as HTMLInputElement).type).toBe('checkbox')
+    expect(selectorDeValor).not.toBeChecked()
+  })
+
+  it('coerción boolean: tildarlo y guardar manda el JSON crudo `true`, no `"true"` ni `1`', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'lotes_habilitado')
+    await usuario.click(screen.getByLabelText('Valor'))
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.clave).toBe('lotes_habilitado')
+    expect(datos.valor).toBe('true')
+  })
+
+  it('sin tildar, guarda el JSON crudo `false`', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'lotes_habilitado')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.valor).toBe('false')
+  })
+
+  it('cambiar de clave a otra numérica resetea el checkbox — nunca queda pisado un "true" residual', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'lotes_habilitado')
+    await usuario.click(screen.getByLabelText('Valor'))
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'dias_alerta_vencimiento')
+
+    expect(screen.getByLabelText('Valor').tagName).toBe('INPUT')
+    expect((screen.getByLabelText('Valor') as HTMLInputElement).type).toBe('number')
+    expect(screen.getByLabelText('Valor')).toHaveValue(null)
+  })
+})
+
+describe('Parametros — clave dias_alerta_vencimiento (entero, nuevo en el registro)', () => {
+  it('envía un número entero JSON, con el default 30 en el placeholder', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+
+    render(<Parametros />)
+    await screen.findByText('Empresa Uno SA')
+
+    await usuario.selectOptions(screen.getByLabelText('Clave'), 'dias_alerta_vencimiento')
+    expect(screen.getByPlaceholderText('Default: 30')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Valor'), '45')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    const [, datos] = apiPutMock.mock.calls[0] as [string, { clave: string; valor: string }]
+    expect(datos.clave).toBe('dias_alerta_vencimiento')
+    expect(datos.valor).toBe('45')
+  })
+})

--- a/src/Ways.Web/src/paginas/Parametros.tsx
+++ b/src/Ways.Web/src/paginas/Parametros.tsx
@@ -74,11 +74,14 @@ export function Parametros() {
   }, [idEmpresa, cargarListado])
 
   // Cambiar de clave resetea el valor tipeado: un `<select>` de zona horaria no puede arrancar
-  // en '' (no matchea ninguna opción), y un numérico arranca limpio para que el placeholder con
-  // el default declarado sea visible.
+  // en '' (no matchea ninguna opción), un checkbox arranca en 'false' (mismo criterio: no puede
+  // quedar en un estado sin mapeo), y un numérico arranca limpio para que el placeholder con el
+  // default declarado sea visible.
   useEffect(() => {
     const conocido = PARAMETROS_CONOCIDOS.find((p) => p.clave === clave)
-    setValorTexto(conocido?.tipo === 'texto' ? ZONAS_HORARIAS_OFRECIDAS[0].id : '')
+    if (conocido?.tipo === 'texto') setValorTexto(ZONAS_HORARIAS_OFRECIDAS[0].id)
+    else if (conocido?.tipo === 'booleano') setValorTexto('false')
+    else setValorTexto('')
   }, [clave])
 
   const puntosVentaDeLaEmpresa = puntosVenta.filter((p) => p.idEmpresa === idEmpresa)
@@ -96,9 +99,11 @@ export function Parametros() {
       const valor =
         conocidoSeleccionado?.tipo === 'texto'
           ? JSON.stringify(valorTexto)
-          : JSON.stringify(
-              conocidoSeleccionado?.tipo === 'entero' ? Math.trunc(Number(valorTexto)) : Number(valorTexto),
-            )
+          : conocidoSeleccionado?.tipo === 'booleano'
+            ? JSON.stringify(valorTexto === 'true')
+            : JSON.stringify(
+                conocidoSeleccionado?.tipo === 'entero' ? Math.trunc(Number(valorTexto)) : Number(valorTexto),
+              )
 
       const datos: ParametroAlta = {
         clave,
@@ -108,7 +113,13 @@ export function Parametros() {
 
       await api.put(`/parametros?idEmpresa=${idEmpresa}`, datos)
       setAviso(`Se guardó "${clave}".`)
-      setValorTexto(conocidoSeleccionado?.tipo === 'texto' ? ZONAS_HORARIAS_OFRECIDAS[0].id : '')
+      setValorTexto(
+        conocidoSeleccionado?.tipo === 'texto'
+          ? ZONAS_HORARIAS_OFRECIDAS[0].id
+          : conocidoSeleccionado?.tipo === 'booleano'
+            ? 'false'
+            : '',
+      )
       await cargarListado(idEmpresa)
     } catch (e) {
       setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el parámetro.')
@@ -213,6 +224,17 @@ export function Parametros() {
                       </option>
                     ))}
                   </select>
+                ) : conocidoSeleccionado?.tipo === 'booleano' ? (
+                  <div className="form-check form-switch mt-2">
+                    <input
+                      id="p-valor"
+                      type="checkbox"
+                      className="form-check-input"
+                      checked={valorTexto === 'true'}
+                      onChange={(e) => setValorTexto(e.target.checked ? 'true' : 'false')}
+                    />
+                    <span className="small text-muted ms-1">{valorTexto === 'true' ? 'Habilitado' : 'Deshabilitado'}</span>
+                  </div>
                 ) : (
                   <input
                     id="p-valor"

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tablero } from './Tablero'
@@ -11,6 +11,7 @@ import type {
   PuntoVentaListado,
   Rentabilidad,
   ResumenDeGastos,
+  ResumenDeVencimientos,
   ResumenDeVentas,
   TopArticulos,
   UsuarioAutenticado,
@@ -223,6 +224,10 @@ function comisionesFixture(sobrescribir: Partial<Comisiones> = {}): Comisiones {
   }
 }
 
+function vencimientosResumenFixture(sobrescribir: Partial<ResumenDeVencimientos> = {}): ResumenDeVencimientos {
+  return { idPuntoVenta: 10, vencidos: 2, porVencer: 5, sinFecha: 1, ...sobrescribir }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
@@ -238,6 +243,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     if (ruta.startsWith('/reportes/articulos/top?')) return Promise.resolve(topArticulosFixture())
     if (ruta.startsWith('/reportes/rentabilidad?')) return Promise.resolve(rentabilidadFixture())
     if (ruta.startsWith('/reportes/comisiones?')) return Promise.resolve(comisionesFixture())
+    if (ruta.startsWith('/reportes/stock/vencimientos/resumen?')) return Promise.resolve(vencimientosResumenFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -1137,6 +1143,63 @@ describe('Tablero — Descarga de reportes (stage-11 slice 4)', () => {
     fireEvent.click(boton)
     await waitFor(() => {
       expect(screen.queryByText('Sin permiso para exportar.')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('Tablero — tile de vencimientos (stage-12-lotes-vencimientos, Slice 15)', () => {
+  it('sin punto de venta elegido ("Todos") muestra un aviso neutro, nunca dispara el fetch', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await screen.findByText('Vencimientos')
+
+    expect(screen.getByText('Elegí un punto de venta para ver el resumen de vencimientos.')).toBeInTheDocument()
+    const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+    expect(rutas.some((r) => r.startsWith('/reportes/stock/vencimientos/resumen'))).toBe(false)
+  })
+
+  it('con un punto de venta elegido, muestra los tres conteos del resumen y un link al reporte', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
+
+    await waitFor(() => {
+      const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+      expect(rutas.some((r) => r.startsWith('/reportes/stock/vencimientos/resumen?') && r.includes('idPuntoVenta=10'))).toBe(true)
+    })
+
+    // Query acotado al tile — varios paneles hermanos ya muestran '5'/'1' sueltos en sus propias
+    // tablas, así que un `getByText` global colisionaría.
+    const titulo = await screen.findByText('Vencimientos')
+    const tile = titulo.closest('div.border')
+    if (!tile) throw new Error('No se encontró el tile de vencimientos')
+    await waitFor(() => {
+      expect(within(tile as HTMLElement).getByText('2')).toBeInTheDocument() // vencidos
+      expect(within(tile as HTMLElement).getByText('5')).toBeInTheDocument() // por vencer
+      expect(within(tile as HTMLElement).getByText('1')).toBeInTheDocument() // sin fecha
+    })
+    expect(screen.getByRole('link', { name: 'Ver reporte' })).toHaveAttribute('href', '/reportes/stock/vencimientos')
+  })
+
+  it('un error del panel de vencimientos no contamina a sus paneles hermanos', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/vencimientos/resumen?')) return Promise.reject(new Error('boom'))
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
+
+    expect(await screen.findByText('No se pudo cargar el resumen de vencimientos.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Vendedor #9')).toBeInTheDocument()
+      expect(screen.getByText('Efectivo')).toBeInTheDocument()
+      expect(screen.getByText('Producto Estrella')).toBeInTheDocument()
     })
   })
 })

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tablero } from './Tablero'
@@ -1172,15 +1172,13 @@ describe('Tablero — tile de vencimientos (stage-12-lotes-vencimientos, Slice 1
       expect(rutas.some((r) => r.startsWith('/reportes/stock/vencimientos/resumen?') && r.includes('idPuntoVenta=10'))).toBe(true)
     })
 
-    // Query acotado al tile — varios paneles hermanos ya muestran '5'/'1' sueltos en sus propias
-    // tablas, así que un `getByText` global colisionaría.
-    const titulo = await screen.findByText('Vencimientos')
-    const tile = titulo.closest('div.border')
-    if (!tile) throw new Error('No se encontró el tile de vencimientos')
+    // Cada valor atado a SU métrica por `data-testid` (no por presencia suelta en el tile):
+    // un swap vencidos↔porVencer en `PanelDeVencimientos` debe hacer fallar este test, no pasarlo
+    // por accidente porque ambos valores están "en algún lado" del tile.
     await waitFor(() => {
-      expect(within(tile as HTMLElement).getByText('2')).toBeInTheDocument() // vencidos
-      expect(within(tile as HTMLElement).getByText('5')).toBeInTheDocument() // por vencer
-      expect(within(tile as HTMLElement).getByText('1')).toBeInTheDocument() // sin fecha
+      expect(screen.getByTestId('vencimientos-tile-vencidos')).toHaveTextContent('2')
+      expect(screen.getByTestId('vencimientos-tile-por-vencer')).toHaveTextContent('5')
+      expect(screen.getByTestId('vencimientos-tile-sin-fecha')).toHaveTextContent('1')
     })
     expect(screen.getByRole('link', { name: 'Ver reporte' })).toHaveAttribute('href', '/reportes/stock/vencimientos')
   })

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -379,15 +379,21 @@ function PanelDeVencimientos({ idPuntoVenta }: PropsPanelDeVencimientos) {
           <div className="row g-2 text-center">
             <div className="col-4">
               <div className="text-muted small">Vencidos</div>
-              <div className="fs-5 text-danger">{datos.vencidos}</div>
+              <div className="fs-5 text-danger" data-testid="vencimientos-tile-vencidos">
+                {datos.vencidos}
+              </div>
             </div>
             <div className="col-4">
               <div className="text-muted small">Por vencer</div>
-              <div className="fs-5 text-warning-emphasis">{datos.porVencer}</div>
+              <div className="fs-5 text-warning-emphasis" data-testid="vencimientos-tile-por-vencer">
+                {datos.porVencer}
+              </div>
             </div>
             <div className="col-4">
               <div className="text-muted small">Sin fecha</div>
-              <div className="fs-5 text-secondary">{datos.sinFecha}</div>
+              <div className="fs-5 text-secondary" data-testid="vencimientos-tile-sin-fecha">
+                {datos.sinFecha}
+              </div>
             </div>
           </div>
         )

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
@@ -13,6 +14,7 @@ import type {
   PuntoVentaListado,
   Rentabilidad,
   ResumenDeGastos,
+  ResumenDeVencimientos,
   ResumenDeVentas,
   TopArticulos,
   VentasPorMedioPago,
@@ -335,6 +337,63 @@ function bannerDeCobertura(cobertura: CoberturaDeCosto): string {
   if (pctDesconocido > 0) partes.push(`${pctDesconocido.toFixed(0)}% de costo desconocido`)
 
   return partes.length === 0 ? 'Cobertura de costo: 100% de la venta con costo real considerado.' : partes.join(', ')
+}
+
+type PropsPanelDeVencimientos = { idPuntoVenta: number | null }
+
+/**
+ * Tile de vencimientos (stage-12-lotes-vencimientos, Slice 15 — completa el groundwork del
+ * Slice 13): reusa `GET /api/reportes/stock/vencimientos/resumen`, que a su vez reusa la MISMA
+ * clasificación que `ObtenerVencimientosAsync` — nunca una segunda query de agregación, el tile
+ * no puede divergir del reporte. Requiere un punto de venta CONCRETO (el endpoint no acepta
+ * "Todos" — es un balance por PV, mismo criterio que `/stock/existencias`); con "Todos" elegido
+ * muestra un aviso neutro en vez de una cifra inventada o de sumar PVs a mano. Sin filtro de
+ * rango propio (a diferencia de los paneles de venta): el balance de lotes no tiene dimensión
+ * temporal, mismo criterio que `Existencias.tsx`.
+ */
+function PanelDeVencimientos({ idPuntoVenta }: PropsPanelDeVencimientos) {
+  const cargarDatos = useCallback(
+    () => (idPuntoVenta === null ? Promise.resolve(null) : clienteDeReportes.vencimientosResumen(idPuntoVenta)),
+    [idPuntoVenta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<ResumenDeVencimientos | null>(
+    cargarDatos,
+    'No se pudo cargar el resumen de vencimientos.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <div className="d-flex align-items-center justify-content-between mb-2">
+        <h6 className="mb-0">Vencimientos</h6>
+        <Link to="/reportes/stock/vencimientos" className="small">
+          Ver reporte
+        </Link>
+      </div>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {idPuntoVenta === null ? (
+        <p className="text-muted small mb-0">Elegí un punto de venta para ver el resumen de vencimientos.</p>
+      ) : cargando && !datos ? (
+        <Cargando />
+      ) : (
+        datos && (
+          <div className="row g-2 text-center">
+            <div className="col-4">
+              <div className="text-muted small">Vencidos</div>
+              <div className="fs-5 text-danger">{datos.vencidos}</div>
+            </div>
+            <div className="col-4">
+              <div className="text-muted small">Por vencer</div>
+              <div className="fs-5 text-warning-emphasis">{datos.porVencer}</div>
+            </div>
+            <div className="col-4">
+              <div className="text-muted small">Sin fecha</div>
+              <div className="fs-5 text-secondary">{datos.sinFecha}</div>
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  )
 }
 
 type PropsPanelDeRentabilidad = { idEmpresa: number; desde: string; hasta: string; idPuntoVenta: number | null }
@@ -761,6 +820,9 @@ export function Tablero() {
                 </div>
                 <div className="col-md-3">
                   <PanelTopArticulos idEmpresa={idEmpresa} desde={desde} hasta={hasta} idPuntoVenta={idPuntoVenta} />
+                </div>
+                <div className="col-md-3">
+                  <PanelDeVencimientos idPuntoVenta={idPuntoVenta} />
                 </div>
               </div>
             )}

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -483,3 +483,88 @@ describe('Transferencias — picker de lote', () => {
     errorSpy.mockRestore()
   })
 })
+
+describe('Transferencias — repetidos por lote (judgment-day fix, Slice 15)', () => {
+  // Helper: arma dos filas del MISMO artículo lote-efectivo con `clave` propia y distinta.
+  // NO usa "+ Agregar línea" sobre la fila inicial: `proximaClaveRef` arranca en `1`, el mismo
+  // valor que `lineaDeTransferenciaVacia(1)` de la fila inicial (bug preexistente en HEAD, ajeno
+  // a este fix — detectado durante el apply, fuera de alcance de esta ronda) — la primera línea
+  // agregada colisionaría de clave con la inicial. Se arranca quitando la fila inicial y agregando
+  // dos filas frescas, así cada una recibe una `clave` realmente distinta.
+  async function completarDosLineasMismoArticulo(usuario: ReturnType<typeof userEvent.setup>) {
+    await usuario.click(screen.getByRole('button', { name: 'Quitar' }))
+    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
+    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
+
+    const buscadores = screen.getAllByPlaceholderText('Buscar artículo…')
+    await usuario.type(buscadores[0], 'fideos')
+    await screen.findByText('ART-10 — Fideos 500g')
+    await usuario.click(screen.getByText('ART-10 — Fideos 500g'))
+    await usuario.type(screen.getAllByLabelText('Cantidad')[0], '8')
+
+    await usuario.type(buscadores[1], 'fideos')
+    await screen.findByText('ART-10 — Fideos 500g')
+    await usuario.click(screen.getByText('ART-10 — Fideos 500g'))
+    await usuario.type(screen.getAllByLabelText('Cantidad')[1], '3')
+  }
+
+  // (c) — el MAJOR original: la UI bloqueaba una transferencia legal (dos líneas del mismo
+  // artículo con lotes explícitos DISTINTOS, la operación real de depósito que el picker existe
+  // para habilitar). Espeja `(idArticulo, idLote)` — la clave real de unicidad del backend
+  // (decisión 11) — en vez de `idArticulo` a secas.
+  it('(c) dos líneas del mismo artículo con lotes explícitos DISTINTOS no bloquean el envío', async () => {
+    mockearPuntosVentaConLote()
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'obs')
+    await completarDosLineasMismoArticulo(usuario)
+
+    const lotes = await waitFor(() => screen.getAllByLabelText('Lote'))
+    await waitFor(() => expect(lotes[0]).toHaveValue('41'))
+    await waitFor(() => expect(lotes[1]).toHaveValue('41'))
+    await usuario.selectOptions(lotes[1], '42') // segunda línea con un lote explícito DISTINTO
+
+    expect(screen.queryByText('Artículo repetido en la transferencia.')).not.toBeInTheDocument()
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
+    expect(screen.getByRole('button', { name: 'Transferir' })).not.toBeDisabled()
+  })
+
+  // (d) — mismo artículo, una línea con lote explícito y otra en Auto (FEFO): el cliente no
+  // bloquea (no puede computar el pick FEFO de la línea Auto para compararlo, decisión 19), pero
+  // si el servidor los resuelve al mismo lote arbitra con un 400 `articulo_repetido` — este test
+  // prueba que ese refusal aparece en el aviso existente, nunca se traga.
+  it('(d) mismo artículo con lote explícito + Auto pasa el gate cliente; un 400 articulo_repetido del servidor se muestra, no se traga', async () => {
+    mockearPuntosVentaConLote()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/transferencias') {
+        return Promise.reject(new ErrorApi(400, 'articulo_repetido', 'El artículo 10 aparece más de una vez en la transferencia.'))
+      }
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'obs')
+    await completarDosLineasMismoArticulo(usuario)
+
+    const lotes = await waitFor(() => screen.getAllByLabelText('Lote'))
+    await waitFor(() => expect(lotes[0]).toHaveValue('41'))
+    await waitFor(() => expect(lotes[1]).toHaveValue('41'))
+    await usuario.selectOptions(lotes[1], '') // segunda línea vuelve a "Auto (FEFO)"
+
+    expect(screen.queryByText('Artículo repetido en la transferencia.')).not.toBeInTheDocument()
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
+    expect(screen.getByRole('button', { name: 'Transferir' })).not.toBeDisabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
+
+    expect(await screen.findByText('El artículo 10 aparece más de una vez en la transferencia.')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -423,6 +423,19 @@ describe('Transferencias — picker de lote', () => {
   })
 
   it('mutation-proof: dos filas del resultado con el mismo artículo y lotes distintos NUNCA colisionan (clave compuesta)', async () => {
+    // La clave discriminante real de esta mutación es el warning de React de claves duplicadas
+    // en un `.map` — un `key={l.idArticulo}` a secas NO produce contenido visiblemente erróneo
+    // en un primer render controlado (cada `<tr>` sigue derivando su texto de sus propias
+    // props), así que un assert de solo-contenido pasa igual con la mutación aplicada — el
+    // confound que `mutation-proof-tests` regla 3 exige rodear. Acá se espía `console.error` y
+    // se afirma la AUSENCIA del warning "Encountered two children with the same key", que SÍ es
+    // la señal que React emite exclusivamente cuando la clave colisiona.
+    // *(Mutación aplicada→observada→revertida en este apply run: revertir la clave compuesta a
+    // `key={l.idArticulo}` deja pasar el assert de contenido de abajo intacto, pero el spy de
+    // `console.error` capta el warning "Encountered two children with the same key" que este
+    // test existe para prevenir — confirmado localmente, revertido, verde de nuevo.)*
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
     mockearPuntosVentaConLote()
     apiPostMock.mockImplementation((ruta: string) => {
       if (ruta === '/stock/transferencias')
@@ -449,8 +462,7 @@ describe('Transferencias — picker de lote', () => {
 
     await screen.findByText(/Transferencia registrada/)
 
-    // Con `key={l.idArticulo}` a secas, React colapsaría estas dos filas del mismo artículo en
-    // una — acá deben coexistir las DOS, con sus cantidades propias intactas.
+    // Contenido: las DOS filas coexisten, con sus cantidades propias intactas.
     const filas = screen.getAllByRole('row').filter((fila) => fila.textContent?.includes('Fideos 500g'))
     expect(filas).toHaveLength(2)
     expect(filas[0].textContent).toContain('41')
@@ -459,5 +471,15 @@ describe('Transferencias — picker de lote', () => {
     expect(filas[1].textContent).toContain('42')
     expect(filas[1].textContent).toContain('7')
     expect(filas[1].textContent).toContain('8')
+
+    // La señal discriminante real: React NUNCA advierte de claves duplicadas con la clave
+    // compuesta — esta es la aserción que la mutación (revertir a `key={l.idArticulo}`) hace
+    // fallar.
+    const huboWarningDeClave = errorSpy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes('same key')),
+    )
+    expect(huboWarningDeClave).toBe(false)
+
+    errorSpy.mockRestore()
   })
 })

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -208,6 +208,41 @@ describe('Transferencias — flujo feliz', () => {
   })
 })
 
+describe('Transferencias — clave de línea (judgment-day fix, Slice 15)', () => {
+  it('agregar una línea inmediatamente tras el mount no colisiona de clave con la fila inicial', async () => {
+    // `proximaClaveRef` arrancaba en `1`, el mismo valor que la fila inicial: la primera línea
+    // agregada recibía una `clave` duplicada (colisión de key de React; `cambiarLinea`/`quitarLinea`,
+    // que matchean por `clave`, tocarían ambas filas). Igual criterio de "señal discriminante" que
+    // el test de arriba: se espía `console.error` y se afirma la ausencia del warning de React.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockearPuntosVenta()
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
+
+    const buscadores = screen.getAllByPlaceholderText('Buscar artículo…')
+    expect(buscadores).toHaveLength(2)
+    await usuario.type(buscadores[1], 'fideos')
+    await screen.findByText('ART-10 — Fideos 500g')
+    await usuario.click(screen.getByText('ART-10 — Fideos 500g'))
+    await usuario.type(screen.getAllByLabelText('Cantidad')[1], '3')
+
+    // Comportamiento observable: si la `clave` colisionara, editar la fila nueva también
+    // habría tocado la fila inicial (mismo `clave` en el `.map` de `cambiarLinea`).
+    expect(buscadores[0]).toHaveValue('')
+    expect(screen.getAllByLabelText('Cantidad')[0]).toHaveValue(null)
+
+    const huboWarningDeClave = errorSpy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes('same key')),
+    )
+    expect(huboWarningDeClave).toBe(false)
+
+    errorSpy.mockRestore()
+  })
+})
+
 describe('Transferencias — líneas incompletas', () => {
   it('una línea a medio llenar se marca en amarillo, suma al contador y el request la excluye', async () => {
     mockearPuntosVenta()
@@ -485,15 +520,10 @@ describe('Transferencias — picker de lote', () => {
 })
 
 describe('Transferencias — repetidos por lote (judgment-day fix, Slice 15)', () => {
-  // Helper: arma dos filas del MISMO artículo lote-efectivo con `clave` propia y distinta.
-  // NO usa "+ Agregar línea" sobre la fila inicial: `proximaClaveRef` arranca en `1`, el mismo
-  // valor que `lineaDeTransferenciaVacia(1)` de la fila inicial (bug preexistente en HEAD, ajeno
-  // a este fix — detectado durante el apply, fuera de alcance de esta ronda) — la primera línea
-  // agregada colisionaría de clave con la inicial. Se arranca quitando la fila inicial y agregando
-  // dos filas frescas, así cada una recibe una `clave` realmente distinta.
+  // Helper: arma dos filas del MISMO artículo lote-efectivo con `clave` propia y distinta —
+  // la fila inicial y la agregada con "+ Agregar línea" (el `proximaClaveRef` arranca ya
+  // consumido por la fila inicial, ver fix del judgment-day de este slice).
   async function completarDosLineasMismoArticulo(usuario: ReturnType<typeof userEvent.setup>) {
-    await usuario.click(screen.getByRole('button', { name: 'Quitar' }))
-    await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
     await usuario.click(screen.getByRole('button', { name: '+ Agregar línea' }))
 
     const buscadores = screen.getAllByPlaceholderText('Buscar artículo…')

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -519,6 +519,67 @@ describe('Transferencias — picker de lote', () => {
   })
 })
 
+describe('Transferencias — lote explícito stale al cambiar Origen (judgment-day fix, Slice 15)', () => {
+  it('elegir un lote explícito y cambiar el Origen resetea la selección a Auto (FEFO) — nunca viaja el idLote del PV anterior', async () => {
+    const puntos = [
+      puntoVentaFixture({ id: 1, nombre: 'Casa Central' }),
+      puntoVentaFixture({ id: 2, nombre: 'Sucursal Norte' }),
+    ]
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve(puntos)
+      if (ruta.startsWith('/articulos'))
+        return Promise.resolve({ items: [articuloFixture({ controlaLote: true })], total: 1, pagina: 1, tamanio: 25 })
+      if (ruta.startsWith('/stock/lotes?') && ruta.includes('idPuntoVenta=1'))
+        return Promise.resolve([loteFixture({ idLote: 41, sugerido: true }), loteFixture({ idLote: 42, codigo: '2026-09-01', sugerido: false })])
+      if (ruta.startsWith('/stock/lotes?') && ruta.includes('idPuntoVenta=2')) return Promise.resolve([])
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+    let resolverTransferir: (valor: ResultadoTransferencia) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/transferencias') return new Promise((resolve) => (resolverTransferir = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'obs')
+    await completarLinea(usuario)
+
+    await waitFor(() => expect(screen.getByLabelText('Lote')).toHaveValue('41'))
+    await usuario.selectOptions(screen.getByLabelText('Lote'), '42')
+    expect(screen.getByLabelText('Lote')).toHaveValue('42')
+
+    // cambia el Origen — el lote 42 pertenecía al PV 1, ahora es stale.
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '2')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '1')
+
+    await waitFor(() => expect(screen.getByLabelText('Lote')).toHaveValue(''))
+
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
+    await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
+
+    resolverTransferir({
+      idPuntoVentaOrigen: 2,
+      idPuntoVentaDestino: 1,
+      lineas: [{ idArticulo: 10, idLote: null, cantidadOrigen: 12, cantidadDestino: 13 }],
+    })
+    await screen.findByText(/Transferencia registrada/)
+
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/transferencias')
+    const [, cuerpo] = llamadas[0] as [string, Record<string, unknown>]
+    // nunca viaja el idLote 42 (stale, del PV de origen anterior).
+    expect(cuerpo).toEqual({
+      idPuntoVentaOrigen: 2,
+      idPuntoVentaDestino: 1,
+      observaciones: 'obs',
+      lineas: [{ idArticulo: 10, cantidad: 8, idLote: null }],
+    })
+  })
+})
+
 describe('Transferencias — repetidos por lote (judgment-day fix, Slice 15)', () => {
   // Helper: arma dos filas del MISMO artículo lote-efectivo con `clave` propia y distinta —
   // la fila inicial y la agregada con "+ Agregar línea" (el `proximaClaveRef` arranca ya

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -6,7 +6,7 @@ import { Transferencias } from './Transferencias'
 import { RutaProtegida } from '../auth/RutaProtegida'
 import { ErrorApi } from '../api/cliente'
 import { ROL } from '../api/tipos'
-import type { ArticuloListado, PuntoVentaListado, ResultadoTransferencia, UsuarioAutenticado } from '../api/tipos'
+import type { ArticuloListado, LoteListado, PuntoVentaListado, ResultadoTransferencia, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
@@ -85,6 +85,7 @@ function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloL
     disponibleParaTodas: true,
     idsEmpresas: [],
     activo: true,
+    controlaLote: false,
     ...sobrescribir,
   }
 }
@@ -115,6 +116,34 @@ function mockearPuntosVenta(puntos: PuntoVentaListado[] = [puntoVentaFixture({ i
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/puntos-venta') return Promise.resolve(puntos)
     if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+  return {
+    idLote: 41,
+    idArticulo: 10,
+    codigo: '2026-08-20',
+    fechaVencimiento: '2026-08-20',
+    esSinIdentificar: false,
+    cantidad: 12,
+    estado: 'Vigente',
+    sugerido: true,
+    ...sobrescribir,
+  }
+}
+
+/** Variante lote-efectiva de `mockearPuntosVenta` — mismo artículo pero con `controlaLote: true`
+ * y `GET /api/stock/lotes` mockeado (stage-12-lotes-vencimientos, Slice 15). */
+function mockearPuntosVentaConLote(
+  lotes: LoteListado[] = [loteFixture({ idLote: 41, sugerido: true }), loteFixture({ idLote: 42, codigo: '2026-09-01', sugerido: false })],
+) {
+  const puntos = [puntoVentaFixture({ id: 1, nombre: 'Casa Central' }), puntoVentaFixture({ id: 2, nombre: 'Sucursal Norte' })]
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve(puntos)
+    if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture({ controlaLote: true })], total: 1, pagina: 1, tamanio: 25 })
+    if (ruta.startsWith('/stock/lotes?')) return Promise.resolve(lotes)
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -158,7 +187,7 @@ describe('Transferencias — flujo feliz', () => {
     resolverTransferir({
       idPuntoVentaOrigen: 1,
       idPuntoVentaDestino: 2,
-      lineas: [{ idArticulo: 10, cantidadOrigen: 12, cantidadDestino: 13 }],
+      lineas: [{ idArticulo: 10, idLote: null, cantidadOrigen: 12, cantidadDestino: 13 }],
     })
 
     expect(await screen.findByText(/Transferencia registrada: Casa Central → Sucursal Norte/)).toBeInTheDocument()
@@ -174,7 +203,7 @@ describe('Transferencias — flujo feliz', () => {
       idPuntoVentaOrigen: 1,
       idPuntoVentaDestino: 2,
       observaciones: 'Reposición de sucursal',
-      lineas: [{ idArticulo: 10, cantidad: 8 }],
+      lineas: [{ idArticulo: 10, cantidad: 8, idLote: null }],
     })
   })
 })
@@ -209,7 +238,7 @@ describe('Transferencias — líneas incompletas', () => {
     await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
     await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
 
-    resolverTransferir({ idPuntoVentaOrigen: 1, idPuntoVentaDestino: 2, lineas: [{ idArticulo: 10, cantidadOrigen: 12, cantidadDestino: 13 }] })
+    resolverTransferir({ idPuntoVentaOrigen: 1, idPuntoVentaDestino: 2, lineas: [{ idArticulo: 10, idLote: null, cantidadOrigen: 12, cantidadDestino: 13 }] })
     await screen.findByText(/Transferencia registrada/)
 
     const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/transferencias')
@@ -219,7 +248,7 @@ describe('Transferencias — líneas incompletas', () => {
       idPuntoVentaOrigen: 1,
       idPuntoVentaDestino: 2,
       observaciones: 'obs',
-      lineas: [{ idArticulo: 10, cantidad: 8 }],
+      lineas: [{ idArticulo: 10, cantidad: 8, idLote: null }],
     })
   })
 })
@@ -320,5 +349,115 @@ describe('Transferencias — role gating', () => {
 
     await screen.findByLabelText('Origen')
     expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+})
+
+// ---- Lotes (stage-12-lotes-vencimientos, Slice 15) ----------------------------------------------
+
+describe('Transferencias — picker de lote', () => {
+  it('un artículo lote-efectivo muestra el picker de lote, pre-seleccionado con el sugerido, y lo manda en el request', async () => {
+    mockearPuntosVentaConLote()
+    let resolverTransferir: (valor: ResultadoTransferencia) => void = () => {}
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/transferencias') return new Promise((resolve) => (resolverTransferir = resolve))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'obs')
+    await completarLinea(usuario)
+
+    // Pre-selección FEFO (decisión 19): el picker de lote arranca en el sugerido, sin que el
+    // operador haga nada.
+    await waitFor(() => expect(screen.getByLabelText('Lote')).toHaveValue('41'))
+
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
+    await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
+
+    resolverTransferir({
+      idPuntoVentaOrigen: 1,
+      idPuntoVentaDestino: 2,
+      lineas: [{ idArticulo: 10, idLote: 41, cantidadOrigen: 12, cantidadDestino: 13 }],
+    })
+    await screen.findByText(/Transferencia registrada/)
+
+    const llamadas = apiPostMock.mock.calls.filter((call: unknown[]) => call[0] === '/stock/transferencias')
+    const [, cuerpo] = llamadas[0] as [string, Record<string, unknown>]
+    expect(cuerpo).toEqual({
+      idPuntoVentaOrigen: 1,
+      idPuntoVentaDestino: 2,
+      observaciones: 'obs',
+      lineas: [{ idArticulo: 10, cantidad: 8, idLote: 41 }],
+    })
+  })
+
+  it('el operador puede vaciar la selección de lote — el servidor resuelve FEFO ("Auto (FEFO)")', async () => {
+    mockearPuntosVentaConLote()
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await completarLinea(usuario)
+
+    await waitFor(() => expect(screen.getByLabelText('Lote')).toHaveValue('41'))
+    await usuario.selectOptions(screen.getByLabelText('Lote'), '')
+    expect(screen.getByLabelText('Lote')).toHaveValue('')
+  })
+
+  it('un artículo SIN control de lote nunca muestra el picker', async () => {
+    mockearPuntosVenta()
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await completarLinea(usuario)
+
+    expect(screen.queryByLabelText('Lote')).not.toBeInTheDocument()
+  })
+
+  it('mutation-proof: dos filas del resultado con el mismo artículo y lotes distintos NUNCA colisionan (clave compuesta)', async () => {
+    mockearPuntosVentaConLote()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/transferencias')
+        return Promise.resolve({
+          idPuntoVentaOrigen: 1,
+          idPuntoVentaDestino: 2,
+          lineas: [
+            { idArticulo: 10, idLote: 41, cantidadOrigen: 3, cantidadDestino: 4 },
+            { idArticulo: 10, idLote: 42, cantidadOrigen: 7, cantidadDestino: 8 },
+          ],
+        })
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+    const usuario = userEvent.setup()
+
+    renderTransferencias()
+    await screen.findByLabelText('Origen')
+    await usuario.selectOptions(screen.getByLabelText('Origen'), '1')
+    await usuario.selectOptions(screen.getByLabelText('Destino'), '2')
+    await usuario.type(screen.getByLabelText('Observaciones'), 'obs')
+    await completarLinea(usuario)
+    await usuario.click(screen.getByLabelText(/Confirmo que quiero mover este stock/))
+    await usuario.click(screen.getByRole('button', { name: 'Transferir' }))
+
+    await screen.findByText(/Transferencia registrada/)
+
+    // Con `key={l.idArticulo}` a secas, React colapsaría estas dos filas del mismo artículo en
+    // una — acá deben coexistir las DOS, con sus cantidades propias intactas.
+    const filas = screen.getAllByRole('row').filter((fila) => fila.textContent?.includes('Fideos 500g'))
+    expect(filas).toHaveLength(2)
+    expect(filas[0].textContent).toContain('41')
+    expect(filas[0].textContent).toContain('3')
+    expect(filas[0].textContent).toContain('4')
+    expect(filas[1].textContent).toContain('42')
+    expect(filas[1].textContent).toContain('7')
+    expect(filas[1].textContent).toContain('8')
   })
 })

--- a/src/Ways.Web/src/paginas/Transferencias.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.tsx
@@ -488,7 +488,7 @@ export function Transferencias() {
                   linea={l}
                   idPuntoVentaOrigen={idPuntoVentaOrigen}
                   disabled={ocupado || !referenciaOk}
-                  repetida={l.idArticulo !== '' && repetidos.has(Number(l.idArticulo))}
+                  repetida={repetidos.has(l.clave)}
                   incompleta={!lineaTransferenciaCompleta(l)}
                   onCambio={cambiarLinea}
                   onQuitar={quitarLinea}

--- a/src/Ways.Web/src/paginas/Transferencias.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.tsx
@@ -10,7 +10,7 @@ import {
 import { clienteDeArticulos } from '../api/articulos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
-import type { ArticuloListado, PuntoVentaListado, ResultadoTransferencia } from '../api/tipos'
+import type { ArticuloListado, LoteListado, PuntoVentaListado, ResultadoTransferencia } from '../api/tipos'
 import { Box } from '../componentes/Box'
 
 // ---- Selector de artículo por búsqueda (search-as-you-type) — duplicado de CompraEditor.tsx:
@@ -96,10 +96,101 @@ function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDe
   )
 }
 
+// ---- Picker de lote por línea (stage-12-lotes-vencimientos, Slice 15) ---------------------------
+// `GET /api/stock/lotes` con `sugerido` — el server manda (design decisión 19): el picker
+// PRE-SELECCIONA el lote sugerido (FEFO), nunca lo recalcula del lado del cliente. El operador
+// puede vaciar la selección: un `idLote` omitido deja que el servidor resuelva FEFO en el
+// momento de la transferencia (mismo criterio del picker del POS, Slice 14).
+
+type PropsSelectorDeLote = {
+  idPuntoVenta: number | ''
+  idArticulo: number | ''
+  idLote: number | ''
+  disabled: boolean
+  onCambio: (idLote: number | '', codigoLote: string) => void
+}
+
+function SelectorDeLote({ idPuntoVenta, idArticulo, idLote, disabled, onCambio }: PropsSelectorDeLote) {
+  const [lotes, setLotes] = useState<LoteListado[]>([])
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+  const idLoteRef = useRef(idLote)
+  idLoteRef.current = idLote
+
+  useEffect(() => {
+    setLotes([])
+    if (idPuntoVenta === '' || idArticulo === '') return
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeStock
+      .lotes(idPuntoVenta, idArticulo)
+      .then((lista) => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setLotes(lista)
+        // Pre-selección FEFO (decisión 19) — solo si la línea todavía no tiene un lote elegido
+        // al momento en que esta respuesta aterriza (token-gated, regla 2/3 de react-async-state).
+        if (idLoteRef.current === '') {
+          const sugerido = lista.find((l) => l.sugerido)
+          if (sugerido) onCambio(sugerido.idLote, sugerido.codigo)
+        }
+      })
+      .catch((e) => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setLotes([])
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
+      })
+      .finally(() => {
+        if (!vigente || generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idPuntoVenta, idArticulo])
+
+  if (idPuntoVenta === '' || idArticulo === '') return <span className="text-muted small">—</span>
+  if (cargando && lotes.length === 0) return <span className="text-muted small">Cargando lotes…</span>
+  if (error) return <span className="text-danger small">{error}</span>
+
+  return (
+    <select
+      className="form-select form-select-sm rounded-0"
+      aria-label="Lote"
+      value={idLote}
+      disabled={disabled}
+      onChange={(e) => {
+        const valor = e.target.value
+        if (valor === '') {
+          onCambio('', '')
+          return
+        }
+        const elegido = lotes.find((l) => l.idLote === Number(valor))
+        onCambio(Number(valor), elegido?.codigo ?? '')
+      }}
+    >
+      <option value="">Auto (FEFO)</option>
+      {lotes.map((l) => (
+        <option key={l.idLote} value={l.idLote}>
+          {l.codigo} — saldo {l.cantidad}
+          {l.sugerido ? ' (sugerido)' : ''}
+        </option>
+      ))}
+    </select>
+  )
+}
+
 // ---- Fila editable del grid de líneas ----------------------------------------------------------
 
 type PropsFilaDeLinea = {
   linea: LineaDeTransferenciaFormulario
+  idPuntoVentaOrigen: number | ''
   disabled: boolean
   repetida: boolean
   incompleta: boolean
@@ -107,14 +198,22 @@ type PropsFilaDeLinea = {
   onQuitar: (clave: number) => void
 }
 
-function FilaDeLinea({ linea, disabled, repetida, incompleta, onCambio, onQuitar }: PropsFilaDeLinea) {
+function FilaDeLinea({ linea, idPuntoVentaOrigen, disabled, repetida, incompleta, onCambio, onQuitar }: PropsFilaDeLinea) {
   return (
     <tr className={repetida ? 'table-danger' : incompleta ? 'table-warning text-muted' : undefined}>
       <td style={{ minWidth: 220 }}>
         <SelectorDeArticulo
           descripcion={linea.descripcion}
           disabled={disabled}
-          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
+          onElegir={(a) =>
+            onCambio(linea.clave, {
+              idArticulo: a.id,
+              descripcion: a.nombre,
+              controlaLote: a.controlaLote,
+              idLote: '',
+              codigoLote: '',
+            })
+          }
         />
         {repetida && <div className="small text-danger">Artículo repetido en la transferencia.</div>}
         {incompleta && !repetida && <div className="small text-warning-emphasis">Línea incompleta — no se va a transferir.</div>}
@@ -130,6 +229,19 @@ function FilaDeLinea({ linea, disabled, repetida, incompleta, onCambio, onQuitar
           disabled={disabled}
           onChange={(e) => onCambio(linea.clave, { cantidad: e.target.value })}
         />
+      </td>
+      <td style={{ minWidth: 180 }}>
+        {linea.controlaLote && linea.idArticulo !== '' ? (
+          <SelectorDeLote
+            idPuntoVenta={idPuntoVentaOrigen}
+            idArticulo={linea.idArticulo}
+            idLote={linea.idLote}
+            disabled={disabled}
+            onCambio={(idLote, codigoLote) => onCambio(linea.clave, { idLote, codigoLote })}
+          />
+        ) : (
+          <span className="text-muted small">—</span>
+        )}
       </td>
       <td>
         <button type="button" className="btn btn-outline-danger btn-sm rounded-0" disabled={disabled} onClick={() => onQuitar(linea.clave)}>
@@ -279,14 +391,20 @@ export function Transferencias() {
               <thead>
                 <tr>
                   <th>Artículo</th>
+                  <th>Lote</th>
                   <th className="text-end">Stock en origen</th>
                   <th className="text-end">Stock en destino</th>
                 </tr>
               </thead>
               <tbody>
+                {/* stage-12-lotes-vencimientos (Slice 15): DEUDA del slice 10 cerrada acá — con
+                    lote, dos filas del MISMO artículo pueden coexistir (`(idArticulo, idLote)` es
+                    la clave de agregación real del backend), así que `key={l.idArticulo}` solo
+                    colisionaba silenciosamente entre ellas. Clave compuesta. */}
                 {resultado.lineas.map((l) => (
-                  <tr key={l.idArticulo}>
+                  <tr key={`${l.idArticulo}-${l.idLote ?? 'sin-lote'}`}>
                     <td>{descripcionesTransferidas[l.idArticulo] ?? `Artículo #${l.idArticulo}`} (#{l.idArticulo})</td>
+                    <td>{l.idLote ?? '—'}</td>
                     <td className="text-end">{l.cantidadOrigen}</td>
                     <td className="text-end">{l.cantidadDestino}</td>
                   </tr>
@@ -359,6 +477,7 @@ export function Transferencias() {
               <tr>
                 <th>Artículo</th>
                 <th>Cantidad</th>
+                <th>Lote</th>
                 <th></th>
               </tr>
             </thead>
@@ -367,6 +486,7 @@ export function Transferencias() {
                 <FilaDeLinea
                   key={l.clave}
                   linea={l}
+                  idPuntoVentaOrigen={idPuntoVentaOrigen}
                   disabled={ocupado || !referenciaOk}
                   repetida={l.idArticulo !== '' && repetidos.has(Number(l.idArticulo))}
                   incompleta={!lineaTransferenciaCompleta(l)}

--- a/src/Ways.Web/src/paginas/Transferencias.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.tsx
@@ -117,9 +117,21 @@ function SelectorDeLote({ idPuntoVenta, idArticulo, idLote, disabled, onCambio }
   const generacionRef = useRef(0)
   const idLoteRef = useRef(idLote)
   idLoteRef.current = idLote
+  const idPuntoVentaAnteriorRef = useRef(idPuntoVenta)
 
   useEffect(() => {
     setLotes([])
+
+    // stage-12-lotes-vencimientos (judgment-day fix, Slice 15): un lote explícito elegido viaja
+    // contra el PV de origen — si el origen cambia, ese `idLote` queda referido al PV anterior
+    // (stale). Se resetea acá, junto con el refetch de abajo, para que nunca viaje un lote de otro
+    // punto de venta; un cambio de `idArticulo` no necesita este reset porque `onElegir` en
+    // `FilaDeLinea` ya limpia `idLote` en el mismo `setLineas`.
+    if (idPuntoVentaAnteriorRef.current !== idPuntoVenta) {
+      idPuntoVentaAnteriorRef.current = idPuntoVenta
+      if (idLoteRef.current !== '') onCambio('', '')
+    }
+
     if (idPuntoVenta === '' || idArticulo === '') return
 
     let vigente = true

--- a/src/Ways.Web/src/paginas/Transferencias.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.tsx
@@ -287,7 +287,11 @@ export function Transferencias() {
   const [idPuntoVentaDestino, setIdPuntoVentaDestino] = useState<number | ''>('')
   const [observaciones, setObservaciones] = useState('')
   const proximaClaveRef = useRef(1)
-  const [lineas, setLineas] = useState<LineaDeTransferenciaFormulario[]>([lineaDeTransferenciaVacia(1)])
+  // Inicializador perezoso que consume el ref (mismo patrón que CuentaCorriente.tsx y Pos.tsx):
+  // evita que la fila inicial y la primera agregada compartan `clave` (colisión de key de React).
+  const [lineas, setLineas] = useState<LineaDeTransferenciaFormulario[]>(() => [
+    lineaDeTransferenciaVacia(proximaClaveRef.current++),
+  ])
 
   const [transfiriendo, setTransfiriendo] = useState(false)
   const transfiriendoRef = useRef(false)

--- a/src/Ways.Web/src/paginas/Vencimientos.test.tsx
+++ b/src/Ways.Web/src/paginas/Vencimientos.test.tsx
@@ -1,0 +1,281 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Vencimientos } from './Vencimientos'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { FilaDeVencimiento, PuntoVentaListado, UsuarioAutenticado, Vencimientos as VencimientosRespuesta } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const puntoVentaNorte: PuntoVentaListado = {
+  id: 11,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Norte',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function filaFixture(sobrescribir: Partial<FilaDeVencimiento> = {}): FilaDeVencimiento {
+  return {
+    idArticulo: 100,
+    articulo: 'Yogur bebible 1L',
+    idLote: 41,
+    codigoLote: '2026-08-20',
+    fechaVencimiento: '2026-08-20',
+    cantidad: 12,
+    estado: 'Vigente',
+    ...sobrescribir,
+  }
+}
+
+function vencimientosFixture(filas: FilaDeVencimiento[] = [filaFixture()], idPuntoVenta = 10): VencimientosRespuesta {
+  return { idPuntoVenta, hoy: '2026-08-14', diasDeAlerta: 30, zonaHoraria: 'America/Argentina/Buenos_Aires', filas }
+}
+
+function renderVencimientos() {
+  return render(<Vencimientos />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para
+ * `/reportes/stock/vencimientos` (`Politicas.LecturaDeReportes`). */
+function renderVencimientosProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/reportes/stock/vencimientos']}>
+      <Routes>
+        <Route
+          path="/reportes/stock/vencimientos"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <Vencimientos />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro, puntoVentaNorte])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/reportes/stock/vencimientos?')) return Promise.resolve(vencimientosFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
+})
+
+describe('Vencimientos — reporte (stage-12-lotes-vencimientos, Slice 15 — web)', () => {
+  it('arranca con el primer punto de venta cargado y sin dias forzado (el servidor resuelve el default)', async () => {
+    mockearRutasBase()
+    renderVencimientos()
+
+    await screen.findByLabelText('Punto de venta')
+    expect(screen.getByLabelText('Punto de venta')).toHaveValue('10')
+
+    const llamada = apiGetMock.mock.calls.find((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/vencimientos?'))!
+    expect(llamada[0] as string).not.toContain('dias=')
+  })
+
+  it('un valor tipeado en "Días de alerta" viaja como dias en la query', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderVencimientos()
+
+    await screen.findByLabelText('Punto de venta')
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.type(screen.getByLabelText('Días de alerta'), '45')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/vencimientos?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('dias=45'))).toBe(true)
+    })
+  })
+
+  it('renderiza las cuatro badges de estado, incluido sin_fecha para el lote sin identificar', async () => {
+    const filaVencida = filaFixture({ idLote: 1, articulo: 'Art A', estado: 'Vencido' })
+    const filaPorVencer = filaFixture({ idLote: 2, articulo: 'Art B', estado: 'PorVencer' })
+    const filaVigente = filaFixture({ idLote: 3, articulo: 'Art C', estado: 'Vigente' })
+    const filaSinFecha = filaFixture({ idLote: 4, articulo: 'Art D', estado: 'SinFecha', fechaVencimiento: null, codigoLote: 'SIN-IDENTIFICAR' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/vencimientos?')) {
+        return Promise.resolve(vencimientosFixture([filaVencida, filaPorVencer, filaVigente, filaSinFecha]))
+      }
+      return undefined
+    })
+    renderVencimientos()
+
+    await screen.findByText('Art A')
+    const filas = screen.getAllByRole('row').slice(1)
+    expect(within(filas[0]).getByText('Vencido')).toBeInTheDocument()
+    expect(within(filas[1]).getByText('Por vencer')).toBeInTheDocument()
+    expect(within(filas[2]).getByText('Vigente')).toBeInTheDocument()
+    expect(within(filas[3]).getByText('Sin fecha')).toBeInTheDocument()
+    // el lote sin identificar SE INCLUYE en el reporte — nunca "—" silencioso en el código.
+    expect(within(filas[3]).getByText('SIN-IDENTIFICAR')).toBeInTheDocument()
+    expect(within(filas[3]).getByText('—')).toBeInTheDocument() // fecha de vencimiento null
+  })
+
+  it('sin lotes con saldo positivo muestra un estado vacío, no un re-query', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/vencimientos?')) return Promise.resolve(vencimientosFixture([]))
+      return undefined
+    })
+    renderVencimientos()
+
+    expect(await screen.findByText('No hay lotes con saldo positivo para este punto de venta.')).toBeInTheDocument()
+    const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/vencimientos?'))
+    expect(llamadas).toHaveLength(1)
+  })
+
+  it('cambiar el punto de venta dispara una nueva consulta con el idPuntoVenta elegido', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderVencimientos()
+
+    await screen.findByText('Yogur bebible 1L')
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/vencimientos?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('idPuntoVenta=11'))).toBe(true)
+    })
+  })
+
+  it('el botón de descarga apunta a /reportes/stock/vencimientos/export con el idPuntoVenta elegido', async () => {
+    mockearRutasBase()
+    apiDescargarMock.mockRejectedValueOnce(new Error('no se pudo descargar'))
+    const usuario = userEvent.setup()
+    renderVencimientos()
+
+    await screen.findByText('Yogur bebible 1L')
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(await screen.findByText('No se pudo descargar el archivo.')).toBeInTheDocument()
+    expect(apiDescargarMock.mock.calls[0][0]).toMatch(/^\/reportes\/stock\/vencimientos\/export\?idPuntoVenta=10/)
+  })
+
+  it('una respuesta desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: VencimientosRespuesta) => void = () => {}
+    const primera = new Promise<VencimientosRespuesta>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/vencimientos?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(vencimientosFixture([filaFixture({ idLote: 999, articulo: 'segunda-respuesta' })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderVencimientos()
+    await screen.findByLabelText('Punto de venta')
+
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
+
+    // El flush del microtask va DENTRO de act (mutation-proof-tests regla 7): un waitFor solo
+    // pasaría en su primer tick, antes de que el .then stale aterrice.
+    const { act } = await import('@testing-library/react')
+    await act(async () => {
+      resolverPrimera(vencimientosFixture([filaFixture({ idLote: 1, articulo: 'primera-respuesta-vieja' })]))
+      await primera
+    })
+    expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument()
+    expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Vencimientos — role gating (mismo gate que Existencias: Politicas.LecturaDeReportes)', () => {
+  it('un Supervisor llega a /reportes/stock/vencimientos', async () => {
+    mockearRutasBase()
+    renderVencimientosProtegido()
+
+    await screen.findByText('Yogur bebible 1L')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /reportes/stock/vencimientos: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+
+    renderVencimientosProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Vencimientos')).not.toBeInTheDocument())
+  })
+})

--- a/src/Ways.Web/src/paginas/Vencimientos.tsx
+++ b/src/Ways.Web/src/paginas/Vencimientos.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
+import type { EstadoDeVencimiento, PuntoVentaListado, Vencimientos as VencimientosRespuesta } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearCantidad(valor: number): string {
+  return valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
+}
+
+/** Espejo de la clasificación en cuatro estados del reporte — badge por fila (spec
+ * lotes-y-vencimientos: "vencido si ya pasó, por_vencer si entra dentro del horizonte de alerta,
+ * vigente más allá del horizonte, sin_fecha para el lote sin identificar"). */
+const BADGE_POR_ESTADO: Record<EstadoDeVencimiento, { etiqueta: string; clase: string }> = {
+  Vencido: { etiqueta: 'Vencido', clase: 'text-bg-danger' },
+  PorVencer: { etiqueta: 'Por vencer', clase: 'text-bg-warning' },
+  Vigente: { etiqueta: 'Vigente', clase: 'text-bg-success' },
+  SinFecha: { etiqueta: 'Sin fecha', clase: 'text-bg-secondary' },
+}
+
+function BadgeDeEstado({ estado }: { estado: EstadoDeVencimiento }) {
+  const { etiqueta, clase } = BADGE_POR_ESTADO[estado]
+  return <span className={`badge rounded-0 ${clase}`}>{etiqueta}</span>
+}
+
+/**
+ * Vencimientos (stage-12-lotes-vencimientos, Slice 15 — web; design decisión 15/16/17, spec
+ * lotes-y-vencimientos: "Vencimientos Report Resolves 'Hoy' In The Punto De Venta's Own Zona
+ * Horaria, With An Export Sibling"): lotes con saldo positivo de un punto de venta, clasificados
+ * en las cuatro categorías del reporte. Mismo patrón que `Existencias.tsx` (selector de punto de
+ * venta + botón de descarga + tabla, sin paginado — listado acotado por construcción salvo el
+ * tope del export) más un filtro propio de `dias` (horizonte de alerta, opcional — el servidor
+ * resuelve `dias_alerta_vencimiento` cuando se omite). Misma política que `/tablero`/
+ * `/reportes/existencias` (`Politicas.LecturaDeReportes`: Supervisor + Admin).
+ */
+export function Vencimientos() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | null>(null)
+  const [dias, setDias] = useState('')
+  const [vencimientos, setVencimientos] = useState<VencimientosRespuesta | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        if (lista.length > 0) setIdPuntoVenta(lista[0].id)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // `dias` vacío ⇒ `null` — deja que el servidor resuelva `dias_alerta_vencimiento` (nunca se
+  // manda un valor inventado del lado del cliente cuando el servidor ya sabe resolverlo).
+  const diasNumero = dias.trim() === '' ? null : Number(dias)
+
+  const cargar = useCallback(() => {
+    if (idPuntoVenta === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeReportes
+      .vencimientos(idPuntoVenta, diasNumero)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setVencimientos(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setVencimientos(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los vencimientos.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idPuntoVenta, diasNumero])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Vencimientos" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        {puntosVenta === null ? (
+          <Cargando />
+        ) : puntosVenta.length === 0 ? (
+          <p className="text-muted text-center py-4">No hay puntos de venta visibles para los vencimientos.</p>
+        ) : idPuntoVenta === null ? (
+          <Cargando />
+        ) : (
+          <>
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="vencimientos-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="vencimientos-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  onChange={(e) => setIdPuntoVenta(Number(e.target.value))}
+                >
+                  {puntosVenta.map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="vencimientos-dias">
+                  Días de alerta
+                </label>
+                <input
+                  id="vencimientos-dias"
+                  type="number"
+                  step="1"
+                  min="0"
+                  className="form-control rounded-0"
+                  placeholder="Default de la empresa"
+                  value={dias}
+                  onChange={(e) => setDias(e.target.value)}
+                />
+              </div>
+              <div className="col-auto">
+                <BotonDeDescarga
+                  ruta={rutasDeExportacion.vencimientos(idPuntoVenta, diasNumero)}
+                  etiqueta="Descargar"
+                  onError={setErrorDescarga}
+                  onInicio={() => setErrorDescarga('')}
+                />
+              </div>
+            </div>
+
+            {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+            {cargando && !vencimientos && <Cargando />}
+
+            {vencimientos && (
+              <>
+                <p className="text-muted small">
+                  Vencimientos al {vencimientos.hoy} ({vencimientos.zonaHoraria}) — horizonte de alerta:{' '}
+                  {vencimientos.diasDeAlerta} día(s).
+                </p>
+                <div className="table-responsive">
+                  <table className="table table-sm table-striped table-bordered align-middle">
+                    <thead>
+                      <tr>
+                        <th>Artículo</th>
+                        <th>Lote</th>
+                        <th>Vencimiento</th>
+                        <th className="text-end">Cantidad</th>
+                        <th>Estado</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {vencimientos.filas.map((fila) => (
+                        <tr key={fila.idLote}>
+                          <td>{fila.articulo}</td>
+                          <td>{fila.codigoLote}</td>
+                          <td>{fila.fechaVencimiento ?? '—'}</td>
+                          <td className="text-end">{formatearCantidad(fila.cantidad)}</td>
+                          <td>
+                            <BadgeDeEstado estado={fila.estado} />
+                          </td>
+                        </tr>
+                      ))}
+                      {vencimientos.filas.length === 0 && (
+                        <tr>
+                          <td colSpan={5} className="text-center text-muted py-4">
+                            No hay lotes con saldo positivo para este punto de venta.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}


### PR DESCRIPTION
## Etapa 12 — Slice 15: Web Back-Office (último slice de la etapa)

- **\`Vencimientos.tsx\`**: pantalla del reporte con 4 badges (incl. \`sin_fecha\`), filtros PV/\`dias\`, descarga por el funnel de la etapa 11; ruta + nav bajo LecturaDeReportes.
- **\`controlaLote\`** en el editor de artículos; **\`lotes_habilitado\` + \`dias_alerta_vencimiento\`** en Parámetros (tipo \`'booleano'\` nuevo: literal JSON, no string).
- **Transferencias**: picker de lote por línea (sugerido server-authored), dedupe espejando la clave del backend — (mismo artículo + mismo lote explícito) o (ambas Auto) bloquean; **lotes explícitos distintos PERMITIDOS** (la operación real de depósito); key compuesta (deuda del slice 10 saldada) + fix de la colisión de clave pre-existente de main (etapa 8); reset del lote explícito al cambiar el Origen.
- **Conteo**: grid por lote exactly-one-of; \`esLoteEfectivo\` espeja \`ReglaDeLotes.ControlEfectivo\` (controlaLote AND \`lotes_habilitado\` resuelto vía \`GET /api/parametros/{clave}\`) — cierra el **dead-end del módulo apagado** que el juez A cazó como CRITICAL determinista.
- **Tablero**: tile de vencimientos con testids por métrica.

### Tests
vitest **612/612** post-merge con el slice 14 (35 archivos). 10+ rondas de evidencia de mutación.

### Judgment-day (3 rondas de findings reales)
Juez B: tile swap sobrevivía 41 tests (aserción por presencia) + la UI bloqueaba transferencias multi-lote que el backend acepta. Juez A: **CRITICAL** — \`esLoteEfectivo\` ignoraba \`lotes_habilitado\`: con módulo off y artículo flaggeado, grilla vacía + submit imposible = dead-end permanente (el escenario que el spec manda comportarse agregado); + lote stale al cambiar Origen + hedge del comentario. Todos corregidos con evidencia por fix; rondas finales doble APPROVE. Merge con main resuelto por identidad (dedup de LoteListado, unificación \`listarLotes\`), certificado por el orquestador: tsc limpio + 612/612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)