### PR TITLE
feat(stage-13): slice 1 minimos-api — ReglaDeReposicion pura, 2 parametros y PUT /api/stock/minimos

### DIFF
--- a/docs/11-programa-post-paridad.md
+++ b/docs/11-programa-post-paridad.md
@@ -364,7 +364,7 @@ notas de etapas ya archivadas.
 |---|---|
 | Las 4 sugerencias de cobertura del verify de la Etapa 8 | Se resuelven dentro de la etapa que toque el código correspondiente |
 | Recargo por medio de pago (la columna existe, la lógica está dormida) | Etapa 10 lo expone en los agregados; su activación es un cambio menor previo |
-| Conteo de inventario completo (la Etapa 8 entregó una versión mínima, sin workflow de snapshot/variance) | Etapa 13 |
+| Conteo de inventario completo (la Etapa 8 entregó una versión mínima, sin workflow de snapshot/variance) | `stage-13b-conteo-por-planilla` (re-registrado desde la Etapa 13 — proposal decisión 5: necesita migración propia, incompatible con el gate sin-cambios-de-schema que la Etapa 13 ratificó; secuenciado después de la Etapa 13, cerca de la Etapa 14) |
 | Cuenta corriente de proveedores con ledger propio | Etapa 15 |
 | Órdenes de compra | Etapa 16 |
 | Libro IVA compras | Etapa 19 |

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -105,12 +105,12 @@ rows, Admin-only; doc-11's backlog row 367 is re-registered.
 been since Etapa 5, no other slice depends on this write path's *code*
 existing (only on its *contract*).
 
-- [ ] 1.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
+- [x] 1.1 Modify `src/Ways.Domain/Catalogos/ParametroConocido.cs`: add
   `DiasRotacion` (`int`, default `30`) and `DiasCoberturaObjetivo` (`int`,
   default `7`), both registered in `PorClave` — without that, `Buscar()`
   rejects them as unknown. *(no migration — stage-10/12 pattern; spec
   `parametros-operativos`)*
-- [ ] 1.2 Create `src/Ways.Domain/Stock/ReglaDeReposicion.cs`:
+- [x] 1.2 Create `src/Ways.Domain/Stock/ReglaDeReposicion.cs`:
   `EstadoDeReposicion` enum (`SinMinimo`/`Bajo`/`Ok`, wire values are the
   C# member names — the `EstadoDeVencimiento` precedent, no naming
   policy); `Clasificar(cantidad, minimo?)` — `minimo is null ⇒ SinMinimo`,
@@ -126,14 +126,14 @@ existing (only on its *contract*).
   (takes the standard offset); `ExigirVentanaValida(dias, codigo)` —
   rejects `dias <= 0`. *(design decision 1, 7; `PoliticaDeRoles` pattern —
   no `IWaysDbContext` anywhere in this file)*
-- [ ] 1.3 Modify `src/Ways.Application/Stock/Contratos.cs`: add
+- [x] 1.3 Modify `src/Ways.Application/Stock/Contratos.cs`: add
   `SolicitudDeMinimos(IdPuntoVenta, IdArticulo, Minimo?, Reposicion?)` and
   `MinimosDeStock(IdPuntoVenta, IdArticulo, Cantidad, Minimo?, Reposicion?,
   Estado)`. `dto-contract-honesty`: doc-comment each field's fate —
   `Minimo`/`Reposicion` on the request go straight to the upsert's `$4`/`$5`;
   on the response they are read back from the same statement's `RETURNING`,
   never re-derived.
-- [ ] 1.4 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
+- [x] 1.4 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
   `EscribirMinimosAsync(SolicitudDeMinimos, ct)` — in-memory validation
   first (`ExigirUmbralValido` on both fields: `>= 0` → `400
   minimo_negativo`; at most 3 decimals → `400 minimo_invalido`;
@@ -152,17 +152,17 @@ existing (only on its *contract*).
   `movimientos_stock` insert anywhere in this method. Response classifies
   `Estado` via `ReglaDeReposicion.Clasificar` on the returned row. *(design
   decision 10, 11)*
-- [ ] 1.5 Modify `src/Ways.Api/Endpoints/StockEndpoints.cs`:
+- [x] 1.5 Modify `src/Ways.Api/Endpoints/StockEndpoints.cs`:
   `PUT /api/stock/minimos`, `.RequireAuthorization(Politicas.GestionDeCatalogo)`
   stacked over the group's `OperacionDePos` — the `/ajustes`,
   `/transferencias`, `/conteos`, `/decomiso` precedent.
-- [ ] 1.6 Modify `docs/11-programa-post-paridad.md`: re-register the backlog
+- [x] 1.6 Modify `docs/11-programa-post-paridad.md`: re-register the backlog
   row at line 367 (the full conteo snapshot/freeze/variance workflow) to its
   new owner `stage-13b-conteo-por-planilla`, citing proposal decision 5 —
   the carve-out is not complete until the registration is. *(proposal
   decision 5, binding — "a carve-out recorded only in a proposal is a
   carve-out that disappears at the next archive")*
-- [ ] 1.7 [P] Domain unit suite (`PoliticaDeRoles` pattern, no DB, no
+- [x] 1.7 [P] Domain unit suite (`PoliticaDeRoles` pattern, no DB, no
   fixture): `Clasificar` at `cantidad = minimo - 1 / = minimo / = minimo +
   1`, at `minimo = 0` with `cantidad = 0` and `= -1` (negative balances are
   legal), and `minimo = null`; `Sugerido` null-vs-0 and with negative
@@ -172,50 +172,50 @@ existing (only on its *contract*).
   `VentanaDeRotacion` for a UTC zone, a `-03:00` zone, `dias = 1`, and an
   invalid-local-midnight zone. *(spec: none — pure Domain arithmetic, the
   contract every downstream scenario relies on)*
-- [ ] 1.8 [P] Application unit: `ExigirVentanaValida` rejects `0` and `-1`
+- [x] 1.8 [P] Application unit: `ExigirVentanaValida` rejects `0` and `-1`
   with their two distinct codes.
-- [ ] 1.9 [P] **Mutation target**: the `SET` list of the upsert — add
+- [x] 1.9 [P] **Mutation target**: the `SET` list of the upsert — add
   `cantidad = EXCLUDED.cantidad` → a write over a row with `cantidad = 5`
   must leave the balance unchanged; the mutation must make it change.
   *(spec `stock`: "Writing Reorder Parameters Creates The Stock Row Without
   A Movement", scenario 2; mutation-proof-tests)*
-- [ ] 1.10 [P] **Mutation target**: `ReglaDeReposicion.Clasificar`'s `<=` →
+- [x] 1.10 [P] **Mutation target**: `ReglaDeReposicion.Clasificar`'s `<=` →
   `<` — the exact-boundary Domain fact from 1.7 must fail.
   *(mutation-proof-tests)*
-- [ ] 1.11 [P] **Mutation target**: `Sugerido`'s `reposicion is null` guard
+- [x] 1.11 [P] **Mutation target**: `Sugerido`'s `reposicion is null` guard
   — return `0m` instead of `null` — the null-vs-zero Domain fact from 1.7
   must fail. *(mutation-proof-tests)*
-- [ ] 1.12 [P] **Mutation target**: delete
+- [x] 1.12 [P] **Mutation target**: delete
   `.RequireAuthorization(Politicas.GestionDeCatalogo)` on `PUT /minimos` —
   the Supervisor-`403` test (1.16) must fail once the line is gone, because
   the group's `OperacionDePos` alone admits Supervisor **and** Vendedor.
   *(mutation-proof-tests)*
-- [ ] 1.13 [P] Integration: a minimo write for an articulo with **no**
+- [x] 1.13 [P] Integration: a minimo write for an articulo with **no**
   `stock` row creates it at `cantidad = 0` with zero `movimientos_stock`
   rows, asserted before and after by `SELECT COUNT(*)`. *(spec `stock`:
   scenario 1; spec `reposicion-de-stock`: PUT requirement, scenario 1)*
-- [ ] 1.14 [P] Integration: a minimo write over `cantidad = 45` leaves
+- [x] 1.14 [P] Integration: a minimo write over `cantidad = 45` leaves
   `cantidad` unchanged and inserts zero movements. *(spec `stock`: scenario
   2)*
-- [ ] 1.15 [P] Integration: both fields `null` clears a previously-set pair
+- [x] 1.15 [P] Integration: both fields `null` clears a previously-set pair
   (the unmanage operation).
-- [ ] 1.16 [P] Integration: the five refusal paths with their HTTP status —
+- [x] 1.16 [P] Integration: the five refusal paths with their HTTP status —
   `400 minimo_negativo`, `400 reposicion_menor_que_minimo`, `400
   minimo_invalido` (both on `minimo` and on `reposicion`, > 3 decimals),
   `400 referencia_invalida` (unknown articulo), `404` (unknown/foreign-tenant
   punto de venta). *(spec `reposicion-de-stock`: PUT requirement, scenarios
   2-5)*
-- [ ] 1.17 [P] Authorization: Supervisor gets `403` on `PUT /minimos`;
+- [x] 1.17 [P] Authorization: Supervisor gets `403` on `PUT /minimos`;
   Vendedor gets `403` on `PUT /minimos`. *(spec `reposicion-de-stock`: PUT
   requirement, scenarios 6-7 — the write half; the read half of scenario 6
   is slice 2's task, once `/existencias` exposes the columns)*
-- [ ] 1.18 [P] RLS over the **`ways_app`** connection (NOSUPERUSER
+- [x] 1.18 [P] RLS over the **`ways_app`** connection (NOSUPERUSER
   NOBYPASSRLS, `mutation-proof-tests` rule 5): cross-tenant `SELECT`/`UPDATE`
   of `stock.minimo` and a cross-tenant `INSERT` through the upsert, asserting
   row counts for the silent 0-row cases and `42501` where an error is
   actually raised — proves the *new statement* respects `stock`'s existing
   policy, not the schema.
-- [ ] 1.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
+- [x] 1.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
   reports no pending changes; `git diff --stat` against `main` shows zero
   files under `Migraciones/`.
 - [ ] 1.20 Run `judgment-day` on the slice diff; fix confirmed issues;

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -219,7 +219,16 @@ existing (only on its *contract*).
   reports no pending changes; `git diff --stat` against `main` shows zero
   files under `Migraciones/`.
 - [ ] 1.20 Run `judgment-day` on the slice diff; fix confirmed issues;
-  re-judge until clean.
+  re-judge until clean. *(IN PROGRESS at session handoff 2026-08-14: judge B
+  ran in TWO passes because the jd-judge-* agent types lost Bash in the
+  environment — (1) full STATIC read-only trace, zero findings; (2) LIVE
+  mutation pass via a general-purpose agent under the B-bis mandate: 11
+  mutations, ZERO survivors (clamp, rounding, window exclusivity,
+  invalid-midnight zone proven non-decorative, all 3 validation arms,
+  COALESCE full-replace, create-at-zero, SET-with-cantidad sample), sweep
+  28+15+25 green, HEAD 83f651f intact. BOTH judge-B passes APPROVE.
+  PENDING: judge A (fresh read-only pass) → then close 1.20/1.21, PR,
+  merge, full suite.)*
 - [ ] 1.21 Branch `feat/stage13-slice1-minimos-api` off `main`; PR; merge
   stacked-to-main.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -218,18 +218,22 @@ existing (only on its *contract*).
 - [x] 1.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
   reports no pending changes; `git diff --stat` against `main` shows zero
   files under `Migraciones/`.
-- [ ] 1.20 Run `judgment-day` on the slice diff; fix confirmed issues;
-  re-judge until clean. *(IN PROGRESS at session handoff 2026-08-14: judge B
-  ran in TWO passes because the jd-judge-* agent types lost Bash in the
-  environment — (1) full STATIC read-only trace, zero findings; (2) LIVE
-  mutation pass via a general-purpose agent under the B-bis mandate: 11
-  mutations, ZERO survivors (clamp, rounding, window exclusivity,
-  invalid-midnight zone proven non-decorative, all 3 validation arms,
-  COALESCE full-replace, create-at-zero, SET-with-cantidad sample), sweep
-  28+15+25 green, HEAD 83f651f intact. BOTH judge-B passes APPROVE.
-  PENDING: judge A (fresh read-only pass) → then close 1.20/1.21, PR,
-  merge, full suite.)*
-- [ ] 1.21 Branch `feat/stage13-slice1-minimos-api` off `main`; PR; merge
+- [x] 1.20 Run `judgment-day` on the slice diff; fix confirmed issues;
+  re-judge until clean. *(CLEAN ROUND 2026-08-14. Judge B ran in TWO passes
+  because the jd-judge-* agent types lost Bash in the environment —
+  (1) full STATIC read-only trace, zero findings; (2) LIVE mutation pass
+  via a general-purpose agent under the B-bis mandate: 11 mutations, ZERO
+  survivors (clamp, rounding, window exclusivity, invalid-midnight zone
+  proven non-decorative, all 3 validation arms, COALESCE full-replace,
+  create-at-zero, SET-with-cantidad sample), sweep 28+15+25 green, HEAD
+  83f651f intact. Judge A fresh read-only pass over the frozen diff at
+  f282081: ZERO findings — verified upsert parameter ordering and SET list
+  against sibling upserts, no-schema gate (newest migration still Etapa
+  12's), DST arithmetic of VentanaDeRotacion re-derived, dto-contract
+  field fates, RLS tests over ways_app with 42501, auth stacking vs the
+  /ajustes precedent. BOTH judges APPROVE — JUDGMENT: APPROVED, round 1,
+  0 confirmed / 0 suspect / 0 contradictions.)*
+- [x] 1.21 Branch `feat/stage13-slice1-minimos-api` off `main`; PR; merge
   stacked-to-main.
 
 **Test plan**: Domain suite (1.7-1.8), 3 mutation targets (1.9-1.12),

--- a/src/Ways.Api/Endpoints/StockEndpoints.cs
+++ b/src/Ways.Api/Endpoints/StockEndpoints.cs
@@ -96,6 +96,18 @@ public static class StockEndpoints
         .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Decomiso de stock (admin-only) — motivo = decomiso, nunca negativo.");
 
+        // stage-13-stock-inteligente (Slice 1, task 1.5, design: API Surface): reemplazo completo
+        // del par minimo/reposicion — mismo apilado GestionDeCatalogo sobre OperacionDePos que
+        // /ajustes, /transferencias, /conteos y /decomiso. Un Supervisor lee el par en
+        // /api/reportes/stock/existencias (LecturaDeReportes) pero no puede escribirlo acá.
+        grupo.MapPut("/minimos", async (ServicioDeStock servicio, SolicitudDeMinimos solicitud, CancellationToken ct) =>
+        {
+            var resultado = await servicio.EscribirMinimosAsync(solicitud, ct);
+            return Results.Ok(resultado);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Reemplazo completo de minimo/reposicion (admin-only) — sin movimiento, sin transacción.");
+
         return app;
     }
 }

--- a/src/Ways.Application/Stock/Contratos.cs
+++ b/src/Ways.Application/Stock/Contratos.cs
@@ -159,3 +159,26 @@ public sealed record ResultadoDeReconciliacion(int ParesReconciliados, int Pares
 /// proposal) — la merma real (rotura, pérdida) entra en el mismo cajón.
 /// </summary>
 public sealed record SolicitudDeDecomiso(int IdPuntoVenta, int IdArticulo, int? IdLote, decimal Cantidad, string Observaciones);
+
+/// <summary>
+/// Cuerpo de <c>PUT /api/stock/minimos</c> (stage-13-stock-inteligente, Slice 1; design:
+/// Interfaces/Contracts; decisión 11). REEMPLAZO COMPLETO de ambos umbrales — no PATCH: <see
+/// cref="Minimo"/>/<see cref="Reposicion"/> en <c>null</c> limpian el campo (la operación de
+/// "unmanage"), y un valor presente siempre pisa el anterior. <c>dto-contract-honesty</c>:
+/// ningún campo queda sin destino — los cuatro se leen en
+/// <c>ServicioDeStock.EscribirMinimosAsync</c>, <see cref="Minimo"/>/<see cref="Reposicion"/>
+/// van directo al <c>$4</c>/<c>$5</c> del upsert crudo tras la validación en memoria.
+/// </summary>
+public sealed record SolicitudDeMinimos(int IdPuntoVenta, int IdArticulo, decimal? Minimo, decimal? Reposicion);
+
+/// <summary>
+/// Resultado de <c>PUT /api/stock/minimos</c> (design decisión 11). <see cref="Cantidad"/>/<see
+/// cref="Minimo"/>/<see cref="Reposicion"/> se leen del <c>RETURNING</c> del MISMO statement que
+/// escribió — nunca re-derivados ni releídos por una segunda consulta — para que la grilla
+/// renderice la fila persistida sin refetch (design decisión 16). <see cref="Estado"/> es
+/// derivado en memoria vía <see cref="Ways.Domain.Stock.ReglaDeReposicion.Clasificar"/> sobre
+/// esa misma fila, nunca una segunda definición del borde.
+/// </summary>
+public sealed record MinimosDeStock(
+    int IdPuntoVenta, int IdArticulo, decimal Cantidad, decimal? Minimo, decimal? Reposicion,
+    EstadoDeReposicion Estado);

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -31,6 +31,11 @@ namespace Ways.Application.Stock;
 /// <c>AjustarAsync</c>, con la cantidad positiva del cliente negada server-side (disciplina de
 /// <c>ContarAsync</c>) y el único rechazo de negatividad que este servicio conoce
 /// (<c>409 stock_insuficiente_para_decomiso</c>). No restringido a lotes vencidos.
+///
+/// Etapa 13, slice 1 (design decisión 10/11): <c>EscribirMinimosAsync</c> gana el par
+/// <c>minimo</c>/<c>reposicion</c> de <c>PUT /api/stock/minimos</c> — a diferencia de todo lo de
+/// arriba, NO abre transacción ni escribe <c>movimientos_stock</c>: un parámetro de reposición
+/// no es un hecho del ledger, es un umbral configurado sobre la misma fila de caché.
 /// </summary>
 public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeLotes servicioDeLotes)
 {
@@ -97,6 +102,99 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         await transaccion.CommitAsync(ct);
 
         return nuevaCantidad;
+    }
+
+    // ---- mínimos de reposición (stage-13-stock-inteligente, Slice 1; design decisión 10/11) -----
+
+    /// <summary>Design decisión 10/11: <c>PUT /api/stock/minimos</c> — validación EN MEMORIA
+    /// primero, dos pre-checks de existencia/tenant, y UN statement crudo (<see
+    /// cref="UpsertParametrosDeReposicionAsync"/>) que crea la fila en <c>cantidad = 0</c> si
+    /// falta y jamás la toca si existe. Sin transacción, sin lock explícito, sin fila de
+    /// <c>movimientos_stock</c> — un parámetro de reposición no es un hecho del ledger.</summary>
+    public async Task<MinimosDeStock> EscribirMinimosAsync(SolicitudDeMinimos solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+
+        ExigirUmbralValido(solicitud.Minimo, "mínimo");
+        ExigirUmbralValido(solicitud.Reposicion, "reposición");
+
+        if (solicitud.Minimo is { } minimo && solicitud.Reposicion is { } reposicion && reposicion < minimo)
+        {
+            throw new ErrorDominio(
+                "reposicion_menor_que_minimo",
+                "La reposición no puede ser menor que el mínimo cuando ambos están definidos.",
+                400);
+        }
+
+        // Pre-checks de existencia/tenant ANTES del statement — mismo criterio que AjustarAsync:
+        // la referencia se valida sobre una lectura simple, nunca dejando que la FK real de la
+        // base la rechace con un 500 crudo dentro del INSERT de abajo.
+        await ResolverArticuloAsync(solicitud.IdArticulo, ct);
+        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var fila = await UpsertParametrosDeReposicionAsync(conexion, idTenant, solicitud, ct);
+
+        return new MinimosDeStock(
+            solicitud.IdPuntoVenta, solicitud.IdArticulo, fila.Cantidad, fila.Minimo, fila.Reposicion,
+            ReglaDeReposicion.Clasificar(fila.Cantidad, fila.Minimo));
+    }
+
+    /// <summary>Design decisión 10 — el mutation target nombrado del slice: <c>cantidad</c> ESTÁ
+    /// en el <c>VALUES</c> (crea la fila en <c>0</c> cuando falta) y está AUSENTE del <c>SET</c>
+    /// (jamás pisa un saldo existente) — la asimetría es la decisión entera, no una omisión. Sin
+    /// transacción: un único statement con <c>RETURNING</c> ya es atómico por sí mismo.</summary>
+    private static async Task<(decimal Cantidad, decimal? Minimo, decimal? Reposicion)> UpsertParametrosDeReposicionAsync(
+        DbConnection conexion, int idTenant, SolicitudDeMinimos solicitud, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO stock (id_articulo, id_punto_venta, id_tenant, cantidad, minimo, reposicion) " +
+            "VALUES ($1, $2, $3, 0, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta) DO UPDATE " +
+            "SET minimo = EXCLUDED.minimo, reposicion = EXCLUDED.reposicion " +
+            "RETURNING cantidad, minimo, reposicion";
+
+        AgregarParametro(comando, solicitud.IdArticulo);
+        AgregarParametro(comando, solicitud.IdPuntoVenta);
+        AgregarParametro(comando, idTenant);
+        AgregarParametroNulo(comando, solicitud.Minimo);
+        AgregarParametroNulo(comando, solicitud.Reposicion);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            throw new InvalidOperationException("El upsert de mínimos de reposición no devolvió ninguna fila.");
+        }
+
+        return (
+            lector.GetDecimal(0),
+            lector.IsDBNull(1) ? null : lector.GetDecimal(1),
+            lector.IsDBNull(2) ? null : lector.GetDecimal(2));
+    }
+
+    /// <summary>Design: New Domain error codes — familia <c>minimo_negativo</c>/<c>
+    /// minimo_invalido</c> (un código, el mensaje nombra el campo ofendido — mismo criterio que
+    /// <c>cantidad_de_ajuste_invalida</c> en ajuste/decomiso). Valida EN MEMORIA, antes de
+    /// resolver cualquier referencia: <c>&gt;= 0</c> y hasta 3 decimales — sin el segundo
+    /// chequeo, Postgres redondearía en silencio el valor que el operador tipeó al truncar a
+    /// <c>numeric(12,3)</c>. <c>null</c> pasa sin validar (campo sin gestionar).</summary>
+    private static void ExigirUmbralValido(decimal? valor, string campo)
+    {
+        if (valor is not { } numero)
+        {
+            return;
+        }
+
+        if (numero < 0m)
+        {
+            throw new ErrorDominio("minimo_negativo", $"El {campo} no puede ser negativo.", 400);
+        }
+
+        if (decimal.Round(numero, 3, MidpointRounding.AwayFromZero) != numero)
+        {
+            throw new ErrorDominio("minimo_invalido", $"El {campo} admite hasta 3 decimales.", 400);
+        }
     }
 
     // ---- decomiso (design: Write site 3 — "EjecutarDecomisoAsync, structurally EjecutarAjusteAsync

--- a/src/Ways.Domain/Catalogos/ParametroConocido.cs
+++ b/src/Ways.Domain/Catalogos/ParametroConocido.cs
@@ -53,11 +53,27 @@ public sealed record ParametroConocido(string Clave, Type TipoClr, string ValorP
     public static readonly ParametroConocido DiasAlertaVencimiento =
         new("dias_alerta_vencimiento", typeof(int), "30");
 
+    /// <summary>Ventana de días que el cálculo de rotación agrega para producir el consumo
+    /// diario promedio (stage-13, design decisión 7). Sin migración — mismo patrón que <see
+    /// cref="ZonaHoraria"/>/<see cref="ComisionPorcentaje"/> (stage-10) y <see
+    /// cref="LotesHabilitado"/>/<see cref="DiasAlertaVencimiento"/> (stage-12). Default
+    /// <c>30</c> días.</summary>
+    public static readonly ParametroConocido DiasRotacion =
+        new("dias_rotacion", typeof(int), "30");
+
+    /// <summary>Días de cobertura objetivo que <c>minimoSugerido</c> multiplica sobre el
+    /// consumo diario promedio (stage-13, design decisión 1). Nunca se escribe a
+    /// <c>stock.minimo</c> automáticamente — solo alimenta la sugerencia. Default <c>7</c>
+    /// días.</summary>
+    public static readonly ParametroConocido DiasCoberturaObjetivo =
+        new("dias_cobertura_objetivo", typeof(int), "7");
+
     private static readonly IReadOnlyDictionary<string, ParametroConocido> PorClave =
         new[]
         {
             ToleranciaPago, VueltoMaximo, ImporteAdicionalRecarga, SlotsTicketsEspera,
-            ZonaHoraria, ComisionPorcentaje, LotesHabilitado, DiasAlertaVencimiento
+            ZonaHoraria, ComisionPorcentaje, LotesHabilitado, DiasAlertaVencimiento,
+            DiasRotacion, DiasCoberturaObjetivo
         }.ToDictionary(p => p.Clave, p => p, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Devuelve el registro de <paramref name="clave"/>, o rechaza con un error de

--- a/src/Ways.Domain/Stock/ReglaDeReposicion.cs
+++ b/src/Ways.Domain/Stock/ReglaDeReposicion.cs
@@ -1,0 +1,120 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Stock;
+
+/// <summary>
+/// Estado de reposición de un artículo en un punto de venta, derivado en <see
+/// cref="ReglaDeReposicion.Clasificar"/> — nunca persistido (proposal decisión 1: <c>minimo</c>
+/// es el valor fijo que el dueño setea; este enum es una LECTURA sobre él, nunca un campo
+/// propio). Wire values son los nombres de miembro de C# (<c>JsonStringEnumConverter</c>, sin
+/// naming policy) — mismo criterio que <see cref="EstadoDeVencimiento"/> (stage-12).
+/// </summary>
+public enum EstadoDeReposicion
+{
+    SinMinimo,
+    Bajo,
+    Ok
+}
+
+/// <summary>
+/// La regla de reposición, pura y sin base de datos (design decisión 1, patrón
+/// <c>PoliticaDeRoles</c>/<c>ReglaDeLotes</c>): clasificación por umbral, sugerencia de compra,
+/// consumo diario promedio, cobertura y la ventana de rotación con su resolución de zona
+/// horaria. El write path de <c>PUT /api/stock/minimos</c> y los tres reportes de gestión
+/// (existencias, reposición, rotación) la consumen igual — la regla se testea UNA vez acá,
+/// nunca reimplementada (proposal, riesgo 2: "una cifra plausible y equivocada").
+/// </summary>
+public static class ReglaDeReposicion
+{
+    /// <summary>Proposal decisión 1(b): <c>minimo IS NULL</c> ⇒ no gestionado, nunca alerta —
+    /// lo que vuelve el día uno silencioso en vez de catastrófico. El borde es <c>cantidad
+    /// &lt;= minimo</c>, NUNCA <c>&lt;</c>: alcanzar el punto de pedido ES la señal, y así
+    /// <c>minimo = 0</c> también es útil ("avisame cuando llegue a cero") en vez de inútil.
+    /// </summary>
+    public static EstadoDeReposicion Clasificar(decimal cantidad, decimal? minimo) =>
+        minimo is null ? EstadoDeReposicion.SinMinimo
+        : cantidad <= minimo.Value ? EstadoDeReposicion.Bajo
+        : EstadoDeReposicion.Ok;
+
+    /// <summary>Proposal decisión 1(c)/3/4: <c>null</c> (JAMÁS <c>0</c>) cuando no hay nivel
+    /// objetivo (<paramref name="reposicion"/>) — un cero en "cuánto comprar" es una respuesta
+    /// fabricada a una pregunta que el sistema no puede responder. <c>Math.Max(0, …)</c> evita
+    /// una sugerencia negativa cuando <paramref name="cantidad"/> ya superó el objetivo. Sin
+    /// término "en tránsito": ese sustraendo lo agrega la etapa 16.</summary>
+    public static decimal? Sugerido(decimal cantidad, decimal? reposicion) =>
+        reposicion is null ? null : Math.Max(0m, reposicion.Value - cantidad);
+
+    /// <summary><paramref name="netoConsumido"/> <c>null</c> ⇒ ningún movimiento de consumo
+    /// calificado en la ventana: no hay historia que promediar, y la respuesta honesta es "no
+    /// sé" (<c>null</c>), nunca "cero" (proposal, riesgo 3). Un neto negativo (devoluciones
+    /// superan a las ventas dentro de la ventana) se recorta a <c>0</c> — nunca <c>null</c>,
+    /// porque SÍ hubo historia calificada, y nunca negativo, porque un consumo diario negativo
+    /// no es una magnitud de negocio. <paramref name="diasVentana"/> &gt;= 1 lo garantiza el
+    /// llamador vía <see cref="ExigirVentanaValida"/> — nunca una división por cero acá.
+    /// </summary>
+    public static decimal? ConsumoDiario(decimal? netoConsumido, int diasVentana) =>
+        netoConsumido is null ? null : Math.Max(0m, netoConsumido.Value) / diasVentana;
+
+    /// <summary>Consumo diario promedio × <paramref name="diasCoberturaObjetivo"/>, redondeado
+    /// a 3 decimales — la precisión de <c>numeric(12,3)</c> que <c>stock.minimo</c>/<c>
+    /// reposicion</c> ya usan. <c>null</c> se propaga desde <paramref name="consumoDiario"/>
+    /// (sin historia ⇒ sin sugerencia, nunca una sugerencia de cero).</summary>
+    public static decimal? MinimoSugerido(decimal? consumoDiario, int diasCoberturaObjetivo) =>
+        consumoDiario is null
+            ? null
+            : Math.Round(consumoDiario.Value * diasCoberturaObjetivo, 3, MidpointRounding.AwayFromZero);
+
+    /// <summary><c>null</c> cuando el consumo diario es <c>null</c> (sin historia) O <c>0</c>
+    /// (el artículo no rota) — "infinito" no es un número de días, y tampoco lo es <c>0</c>:
+    /// ninguna de las dos respuestas es honesta, así que ninguna se devuelve.</summary>
+    public static decimal? DiasDeCobertura(decimal cantidad, decimal? consumoDiario) =>
+        consumoDiario is null or 0m ? null : cantidad / consumoDiario.Value;
+
+    /// <summary>
+    /// Proposal decisión 7 / design decisión 7: la ventana <c>[hoy - (dias-1) .. hoy]</c>,
+    /// resuelta en <paramref name="zona"/> y devuelta como instantes UTC — <c>
+    /// HastaUtcExclusivo</c> es la medianoche local del día SIGUIENTE a <paramref
+    /// name="hoy"/>, exclusiva (mismo criterio que <c>RangoDeReporte.HastaUtcExclusivo</c>).
+    ///
+    /// <see cref="TimeZoneInfo.GetUtcOffset(DateTime)"/> — nunca <c>ConvertTimeToUtc</c>, que
+    /// TIRA <c>ArgumentException</c> sobre un local inválido — ya resuelve los dos bordes que
+    /// un naive <c>ConvertTimeToUtc</c> revienta o contesta mal, sin código especial acá: una
+    /// medianoche local INVÁLIDA (una zona que salta hacia adelante exactamente a las 24:00)
+    /// devuelve el offset ANTERIOR a la transición, así que el instante calculado avanza
+    /// exactamente al instante del salto; una medianoche AMBIGUA (una zona que retrocede el
+    /// reloj exactamente a las 24:00) devuelve el offset ESTÁNDAR por diseño de la BCL. El
+    /// mismo patrón que <c>RangoDeReporte.InstanteLocal</c> ya prueba en producción.
+    /// </summary>
+    public static (DateTimeOffset DesdeUtc, DateTimeOffset HastaUtcExclusivo) VentanaDeRotacion(
+        DateOnly hoy, int dias, TimeZoneInfo zona)
+    {
+        var desde = hoy.AddDays(-(dias - 1));
+        var hastaExclusivo = hoy.AddDays(1);
+
+        return (InstanteLocal(desde, zona), InstanteLocal(hastaExclusivo, zona));
+    }
+
+    private static DateTimeOffset InstanteLocal(DateOnly fecha, TimeZoneInfo zona)
+    {
+        var local = fecha.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
+        var offset = zona.GetUtcOffset(local);
+
+        return new DateTimeOffset(local, offset).ToUniversalTime();
+    }
+
+    /// <summary>400 <paramref name="codigo"/> (<c>dias_rotacion_invalido</c> / <c>
+    /// dias_cobertura_invalido</c>, según el llamador) — un parámetro <c>&lt;= 0</c> dividiría
+    /// por cero en <see cref="ConsumoDiario"/> o produciría una ventana invertida en <see
+    /// cref="VentanaDeRotacion"/>. Refinamiento sobre el proposal (decisión de sdd-design).
+    /// </summary>
+    public static int ExigirVentanaValida(int dias, string codigo)
+    {
+        if (dias <= 0)
+        {
+            throw new ErrorDominio(
+                codigo, $"El parámetro de días tiene que ser mayor a cero (recibido: {dias}).", 400);
+        }
+
+        return dias;
+    }
+}

--- a/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
+++ b/tests/Ways.Domain.Tests/Catalogos/ParametroConocidoTests.cs
@@ -14,7 +14,9 @@ public class ParametroConocidoTests
     [InlineData("comision_porcentaje")]
     [InlineData("lotes_habilitado")]
     [InlineData("dias_alerta_vencimiento")]
-    public void LasOchoClavesConocidasEstanRegistradas(string clave)
+    [InlineData("dias_rotacion")]
+    [InlineData("dias_cobertura_objetivo")]
+    public void LasDiezClavesConocidasEstanRegistradas(string clave)
     {
         var conocido = ParametroConocido.Buscar(clave);
 
@@ -33,6 +35,20 @@ public class ParametroConocidoTests
     {
         Assert.Equal(typeof(int), ParametroConocido.DiasAlertaVencimiento.TipoClr);
         Assert.Equal("30", ParametroConocido.DiasAlertaVencimiento.ValorPorDefecto);
+    }
+
+    [Fact]
+    public void DiasRotacionDeclaraElDefaultEn30()
+    {
+        Assert.Equal(typeof(int), ParametroConocido.DiasRotacion.TipoClr);
+        Assert.Equal("30", ParametroConocido.DiasRotacion.ValorPorDefecto);
+    }
+
+    [Fact]
+    public void DiasCoberturaObjetivoDeclaraElDefaultEn7()
+    {
+        Assert.Equal(typeof(int), ParametroConocido.DiasCoberturaObjetivo.TipoClr);
+        Assert.Equal("7", ParametroConocido.DiasCoberturaObjetivo.ValorPorDefecto);
     }
 
     [Fact]

--- a/tests/Ways.Domain.Tests/Stock/ReglaDeReposicionTests.cs
+++ b/tests/Ways.Domain.Tests/Stock/ReglaDeReposicionTests.cs
@@ -1,0 +1,261 @@
+using Ways.Domain.Common;
+using Ways.Domain.Stock;
+
+namespace Ways.Domain.Tests.Stock;
+
+/// <summary>
+/// stage-13-stock-inteligente, Slice 1 (design decisión 1, patrón <c>PoliticaDeRoles</c>/<c>
+/// ReglaDeLotes</c>): <see cref="ReglaDeReposicion"/> es pura y sin base de datos — cada hecho de
+/// acá corre sin fixture. También cubre <see cref="ReglaDeReposicion.ExigirVentanaValida"/>
+/// (task 1.8 — nombrada "Application unit" en tasks.md, pero la función vive en Domain junto al
+/// resto de la regla; sin fixture ni DB, mismo criterio que todo lo demás de este archivo).
+/// </summary>
+public class ReglaDeReposicionTests
+{
+    // ---- Clasificar (spec reposicion-de-stock: "The Low-Stock Boundary Is Inclusive") ----------
+
+    [Theory]
+    [InlineData(9, 10, EstadoDeReposicion.Bajo)]   // cantidad = minimo - 1
+    [InlineData(10, 10, EstadoDeReposicion.Bajo)]  // cantidad = minimo (borde inclusivo)
+    [InlineData(11, 10, EstadoDeReposicion.Ok)]    // cantidad = minimo + 1
+    public void ClasificarEnLosTresBordesDelPuntoDePedido(decimal cantidad, decimal minimo, EstadoDeReposicion esperado)
+    {
+        Assert.Equal(esperado, ReglaDeReposicion.Clasificar(cantidad, minimo));
+    }
+
+    [Fact]
+    public void ClasificarConMinimoCeroAlertaSoloAlAgotarse()
+    {
+        Assert.Equal(EstadoDeReposicion.Bajo, ReglaDeReposicion.Clasificar(cantidad: 0m, minimo: 0m));
+        // Un saldo negativo es legal (paridad legacy) y también queda bajo el punto de pedido.
+        Assert.Equal(EstadoDeReposicion.Bajo, ReglaDeReposicion.Clasificar(cantidad: -1m, minimo: 0m));
+    }
+
+    [Fact]
+    public void ClasificarConMinimoNuloEsSinMinimoIndependienteDeLaCantidad()
+    {
+        Assert.Equal(EstadoDeReposicion.SinMinimo, ReglaDeReposicion.Clasificar(cantidad: 0m, minimo: null));
+        Assert.Equal(EstadoDeReposicion.SinMinimo, ReglaDeReposicion.Clasificar(cantidad: -50m, minimo: null));
+        Assert.Equal(EstadoDeReposicion.SinMinimo, ReglaDeReposicion.Clasificar(cantidad: 1000m, minimo: null));
+    }
+
+    // ---- Sugerido (spec: "sugerido is null, never zero, when reposicion is unset") --------------
+
+    [Fact]
+    public void SugeridoEsNuloCuandoReposicionNoEstaSeteada()
+    {
+        Assert.Null(ReglaDeReposicion.Sugerido(cantidad: 3m, reposicion: null));
+    }
+
+    [Fact]
+    public void SugeridoComputaLaBrechaAlObjetivo()
+    {
+        Assert.Equal(30m, ReglaDeReposicion.Sugerido(cantidad: 20m, reposicion: 50m));
+    }
+
+    [Fact]
+    public void SugeridoNuncaEsNegativoAunqueLaCantidadSuperonElObjetivo()
+    {
+        Assert.Equal(0m, ReglaDeReposicion.Sugerido(cantidad: 80m, reposicion: 50m));
+    }
+
+    [Fact]
+    public void SugeridoConCantidadNegativaSumaCorrectamenteALaBrecha()
+    {
+        Assert.Equal(60m, ReglaDeReposicion.Sugerido(cantidad: -10m, reposicion: 50m));
+    }
+
+    // ---- ConsumoDiario (spec: "A zero-history articulo shows no suggestion...") ------------------
+
+    [Fact]
+    public void ConsumoDiarioEsNuloCuandoNoHayHistoriaCalificada()
+    {
+        Assert.Null(ReglaDeReposicion.ConsumoDiario(netoConsumido: null, diasVentana: 30));
+    }
+
+    [Fact]
+    public void ConsumoDiarioEsCeroConNetoCeroPeroNoNulo()
+    {
+        Assert.Equal(0m, ReglaDeReposicion.ConsumoDiario(netoConsumido: 0m, diasVentana: 30));
+    }
+
+    [Fact]
+    public void ConsumoDiarioPositivoSeDivideEntreLosDiasDeLaVentana()
+    {
+        Assert.Equal(3m, ReglaDeReposicion.ConsumoDiario(netoConsumido: 90m, diasVentana: 30));
+    }
+
+    [Fact]
+    public void ConsumoDiarioConNetoNegativoSeRecortaACeroNuncaANulo()
+    {
+        var resultado = ReglaDeReposicion.ConsumoDiario(netoConsumido: -15m, diasVentana: 30);
+
+        Assert.NotNull(resultado);
+        Assert.Equal(0m, resultado);
+    }
+
+    // ---- MinimoSugerido (spec parametros-operativos: "dias_cobertura_objetivo feeds minimoSugerido") --
+
+    [Fact]
+    public void MinimoSugeridoMultiplicaConsumoDiarioPorDiasDeCobertura()
+    {
+        Assert.Equal(21m, ReglaDeReposicion.MinimoSugerido(consumoDiario: 3m, diasCoberturaObjetivo: 7));
+    }
+
+    [Fact]
+    public void MinimoSugeridoRedondeaATresDecimales()
+    {
+        // 1/3 * 7 = 2.3333... redondeado a 3 decimales (numeric(12,3)).
+        var consumoDiario = 1m / 3m;
+
+        Assert.Equal(2.333m, ReglaDeReposicion.MinimoSugerido(consumoDiario, diasCoberturaObjetivo: 7));
+    }
+
+    [Fact]
+    public void MinimoSugeridoEsNuloCuandoElConsumoDiarioEsNulo()
+    {
+        Assert.Null(ReglaDeReposicion.MinimoSugerido(consumoDiario: null, diasCoberturaObjetivo: 7));
+    }
+
+    // ---- DiasDeCobertura (design decisión 1: ni infinito ni cero son respuestas honestas) --------
+
+    [Fact]
+    public void DiasDeCoberturaEsNuloCuandoElConsumoDiarioEsNulo()
+    {
+        Assert.Null(ReglaDeReposicion.DiasDeCobertura(cantidad: 10m, consumoDiario: null));
+    }
+
+    [Fact]
+    public void DiasDeCoberturaEsNuloCuandoElConsumoDiarioEsCero()
+    {
+        Assert.Null(ReglaDeReposicion.DiasDeCobertura(cantidad: 10m, consumoDiario: 0m));
+    }
+
+    [Fact]
+    public void DiasDeCoberturaDivideLaCantidadPorElConsumoDiario()
+    {
+        Assert.Equal(5m, ReglaDeReposicion.DiasDeCobertura(cantidad: 10m, consumoDiario: 2m));
+    }
+
+    // ---- VentanaDeRotacion (design decisión 7: bordes de día local, medianoche inválida/ambigua) --
+
+    private static readonly DateOnly Hoy = new(2026, 8, 14);
+
+    [Fact]
+    public void VentanaDeRotacionEnUtcCubreLosDiasPedidosConBordeExclusivo()
+    {
+        var (desde, hasta) = ReglaDeReposicion.VentanaDeRotacion(Hoy, dias: 30, TimeZoneInfo.Utc);
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 16, 0, 0, 0, TimeSpan.Zero), desde);
+        Assert.Equal(new DateTimeOffset(2026, 8, 15, 0, 0, 0, TimeSpan.Zero), hasta);
+        Assert.Equal(30, (hasta - desde).TotalDays);
+    }
+
+    [Fact]
+    public void VentanaDeRotacionEnMenosTresCubreLosDiasPedidosConBordeExclusivo()
+    {
+        var zona = TimeZoneInfo.CreateCustomTimeZone("Fijo/-03:00", TimeSpan.FromHours(-3), "Fijo -03:00", "Fijo -03:00");
+
+        var (desde, hasta) = ReglaDeReposicion.VentanaDeRotacion(Hoy, dias: 30, zona);
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 16, 3, 0, 0, TimeSpan.Zero), desde);
+        Assert.Equal(new DateTimeOffset(2026, 8, 15, 3, 0, 0, TimeSpan.Zero), hasta);
+    }
+
+    [Fact]
+    public void VentanaDeRotacionConDiasUnoEsSoloElDiaDeHoy()
+    {
+        var (desde, hasta) = ReglaDeReposicion.VentanaDeRotacion(Hoy, dias: 1, TimeZoneInfo.Utc);
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 14, 0, 0, 0, TimeSpan.Zero), desde);
+        Assert.Equal(new DateTimeOffset(2026, 8, 15, 0, 0, 0, TimeSpan.Zero), hasta);
+    }
+
+    /// <summary>Zona sintética con una transición EXACTAMENTE a medianoche local (design decisión
+    /// 7: "zonas que saltan a las 24:00") — <c>2026-08-14T00:00</c> local no existe (el reloj
+    /// salta de 2026-08-13T23:59:59 -03:00 directo a 2026-08-14T01:00:00 -02:00). Un <c>
+    /// ConvertTimeToUtc</c> naive tira <c>ArgumentException</c> acá; <see
+    /// cref="ReglaDeReposicion.VentanaDeRotacion"/> avanza al instante del salto (design: "el
+    /// offset ANTERIOR a la transición").</summary>
+    private static TimeZoneInfo CrearZonaConMedianocheInvalida()
+    {
+        var inicioTransicion = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), 8, 14);
+        var finTransicion = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), 8, 20);
+        var regla = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(2026, 1, 1), new DateTime(2026, 12, 31), TimeSpan.FromHours(1), inicioTransicion, finTransicion);
+
+        return TimeZoneInfo.CreateCustomTimeZone(
+            "Prueba/MedianocheInvalida", TimeSpan.FromHours(-3), "Prueba", "Estándar", "Verano", [regla]);
+    }
+
+    [Fact]
+    public void VentanaDeRotacionSobreUnaMedianocheLocalInvalidaAvanzaAlInstanteDelSalto()
+    {
+        var zona = CrearZonaConMedianocheInvalida();
+        Assert.True(zona.IsInvalidTime(new DateTime(2026, 8, 14, 0, 0, 0)));
+
+        var (_, hastaExclusivo) = ReglaDeReposicion.VentanaDeRotacion(new DateOnly(2026, 8, 13), dias: 1, zona);
+
+        // La medianoche local del 14 no existe: el offset ANTERIOR a la transición (-03:00)
+        // aplicado a 2026-08-14T00:00 cae exactamente en el instante del salto — el mismo UTC que
+        // 2026-08-14T01:00 -02:00 (el primer instante local válido tras el salto).
+        Assert.Equal(new DateTimeOffset(2026, 8, 14, 3, 0, 0, TimeSpan.Zero), hastaExclusivo);
+    }
+
+    /// <summary>Zona sintética con una medianoche local AMBIGUA (design decisión 7): <c>
+    /// 2026-08-20T00:00</c>-<c>00:59:59</c> ocurre dos veces (el reloj retrocede de -02:00 a
+    /// -03:00). <see cref="ReglaDeReposicion.VentanaDeRotacion"/> toma el offset ESTÁNDAR por
+    /// diseño de la BCL, sin código especial.</summary>
+    [Fact]
+    public void VentanaDeRotacionSobreUnaMedianocheLocalAmbiguaTomaElOffsetEstandar()
+    {
+        var inicioTransicion = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 0, 0, 0), 8, 14);
+        var finTransicion = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 1, 0, 0), 8, 20);
+        var regla = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(2026, 1, 1), new DateTime(2026, 12, 31), TimeSpan.FromHours(1), inicioTransicion, finTransicion);
+        var zona = TimeZoneInfo.CreateCustomTimeZone(
+            "Prueba/MedianocheAmbigua", TimeSpan.FromHours(-3), "Prueba", "Estándar", "Verano", [regla]);
+        Assert.True(zona.IsAmbiguousTime(new DateTime(2026, 8, 20, 0, 0, 0)));
+
+        var (desde, _) = ReglaDeReposicion.VentanaDeRotacion(new DateOnly(2026, 8, 20), dias: 1, zona);
+
+        // Offset estándar (-03:00): 2026-08-20T00:00 -03:00 = 2026-08-20T03:00 UTC.
+        Assert.Equal(new DateTimeOffset(2026, 8, 20, 3, 0, 0, TimeSpan.Zero), desde);
+    }
+
+    // ---- ExigirVentanaValida (task 1.8) ------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ExigirVentanaValidaRechazaDiasNoPositivos(int dias)
+    {
+        var error = Assert.Throws<ErrorDominio>(() => ReglaDeReposicion.ExigirVentanaValida(dias, "dias_rotacion_invalido"));
+
+        Assert.Equal("dias_rotacion_invalido", error.Codigo);
+        Assert.Equal(400, error.EstadoHttp);
+    }
+
+    [Fact]
+    public void ExigirVentanaValidaPropagaElCodigoDelLlamador()
+    {
+        var error = Assert.Throws<ErrorDominio>(
+            () => ReglaDeReposicion.ExigirVentanaValida(-1, "dias_cobertura_invalido"));
+
+        Assert.Equal("dias_cobertura_invalido", error.Codigo);
+    }
+
+    [Fact]
+    public void ExigirVentanaValidaAceptaUnDiaPositivo()
+    {
+        Assert.Equal(1, ReglaDeReposicion.ExigirVentanaValida(1, "dias_rotacion_invalido"));
+    }
+
+    // ---- mutation targets 1.10/1.11 (mutation-proof-tests) ----------------------------------------
+    // Evidencia registrada en el resumen de apply (mutar → correr → falla → revertir → verde):
+    // 1.10 — Clasificar's "<=" mutado a "<": ClasificarEnLosTresBordesDelPuntoDePedido
+    //        (cantidad = minimo, esperado Bajo) FALLÓ (obtuvo Ok); revertido, vuelve a pasar.
+    // 1.11 — Sugerido's "reposicion is null ⇒ null" mutado a "⇒ 0m":
+    //        SugeridoEsNuloCuandoReposicionNoEstaSeteada FALLÓ (Assert.Null recibió 0m);
+    //        revertido, vuelve a pasar.
+}

--- a/tests/Ways.IntegrationTests/EscribirMinimosTests.cs
+++ b/tests/Ways.IntegrationTests/EscribirMinimosTests.cs
@@ -1,0 +1,328 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-13-stock-inteligente, Slice 1 (tasks 1.13-1.17): <c>PUT /api/stock/minimos</c> punta a
+/// punta — el mutation target del <c>SET</c> del upsert (1.9, spec stock: "Writing Reorder
+/// Parameters..." escenario 2), el create-at-zero sin movimiento (1.13, escenario 1), la
+/// operación de unmanage (1.15), los cinco códigos de refusal (1.16) y el rol (1.17 — el
+/// Supervisor lee en <c>ExistenciasTests</c>/futuras slices, acá solo se confirma que NO puede
+/// escribir).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class EscribirMinimosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area minimos", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, supervisor, vendedor);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private async Task SembrarStockAsync(Contexto ctx, int idArticulo, decimal cantidad, decimal? minimo = null, decimal? reposicion = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Ways.Domain.Stock.Stock
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad,
+            Minimo = minimo, Reposicion = reposicion
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<bool> ExisteFilaDeStockAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock.AnyAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+    }
+
+    private async Task<int> ContarMovimientosAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == ctx.IdPuntoVenta);
+    }
+
+    private static Task<HttpResponseMessage> EscribirAsync(HttpClient cliente, SolicitudDeMinimos solicitud) =>
+        cliente.PutAsJsonAsync("/api/stock/minimos", solicitud);
+
+    // ---- task 1.13 / spec stock escenario 1: crea la fila en cero, sin movimiento --------------
+
+    [Fact]
+    public async Task UnMinimoParaUnArticuloSinFilaDeStockLaCreaEnCeroSinMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnMinimoParaUnArticuloSinFilaDeStockLaCreaEnCeroSinMovimientos));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-sin-fila");
+
+        Assert.False(await ExisteFilaDeStockAsync(ctx, idArticulo));
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, idArticulo));
+
+        var solicitud = new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, Minimo: 10m, Reposicion: null);
+        var respuesta = await EscribirAsync(ctx.Admin, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<MinimosDeStock>(cuerpo, OpcionesJson)!;
+        Assert.Equal(0m, resultado.Cantidad);
+        Assert.Equal(10m, resultado.Minimo);
+        Assert.Null(resultado.Reposicion);
+        Assert.Equal(EstadoDeReposicion.Bajo, resultado.Estado);
+
+        Assert.True(await ExisteFilaDeStockAsync(ctx, idArticulo));
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, idArticulo));
+    }
+
+    // ---- task 1.14 / spec stock escenario 2 / mutation target 1.9: no toca cantidad ni movimiento --
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): la AUSENCIA de <c>
+    /// cantidad</c> en el <c>SET</c> de <c>UpsertParametrosDeReposicionAsync</c>. Mutación
+    /// aplicada (agregar <c>cantidad = EXCLUDED.cantidad</c> al SET, que con <c>VALUES (..., 0,
+    /// ...)</c> pisa cualquier saldo con cero) — esta prueba pasó de FALLAR (<c>cantidad</c>
+    /// resultante <c>0</c> en vez de <c>45</c>) a pasar al revertir. Evidencia registrada en el
+    /// resumen de apply.</summary>
+    [Fact]
+    public async Task UnMinimoSobreUnaFilaExistenteNoTocaLaCantidadNiInsertaMovimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnMinimoSobreUnaFilaExistenteNoTocaLaCantidadNiInsertaMovimientos));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-con-fila");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 45m);
+
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, idArticulo));
+
+        var solicitud = new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, Minimo: 10m, Reposicion: 60m);
+        var respuesta = await EscribirAsync(ctx.Admin, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<MinimosDeStock>(cuerpo, OpcionesJson)!;
+        Assert.Equal(45m, resultado.Cantidad);
+        Assert.Equal(10m, resultado.Minimo);
+        Assert.Equal(60m, resultado.Reposicion);
+
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, idArticulo));
+    }
+
+    // ---- task 1.15: ambos null limpia un par previamente seteado (unmanage) ---------------------
+
+    [Fact]
+    public async Task AmbosCamposNulosLimpianUnParPreviamenteSeteado()
+    {
+        var ctx = await PrepararAsync(nameof(AmbosCamposNulosLimpianUnParPreviamenteSeteado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-unmanage");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 12m, minimo: 5m, reposicion: 20m);
+
+        var solicitud = new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, Minimo: null, Reposicion: null);
+        var respuesta = await EscribirAsync(ctx.Admin, solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var resultado = JsonSerializer.Deserialize<MinimosDeStock>(cuerpo, OpcionesJson)!;
+        Assert.Equal(12m, resultado.Cantidad);
+        Assert.Null(resultado.Minimo);
+        Assert.Null(resultado.Reposicion);
+        Assert.Equal(EstadoDeReposicion.SinMinimo, resultado.Estado);
+    }
+
+    // ---- task 1.16: los cinco códigos de refusal, en memoria --------------------------------------
+
+    [Fact]
+    public async Task UnMinimoNegativoEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnMinimoNegativoEsRechazado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-minimo-negativo");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, -1m, null));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("minimo_negativo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaReposicionNegativaEsRechazadaConElMismoCodigoDeFamilia()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReposicionNegativaEsRechazadaConElMismoCodigoDeFamilia));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-reposicion-negativa");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, null, -5m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("minimo_negativo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnaReposicionMenorQueElMinimoEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReposicionMenorQueElMinimoEsRechazada));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-reposicion-menor");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 10m, 5m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("reposicion_menor_que_minimo", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnMinimoConMasDeTresDecimalesEsRechazadoNoRedondeadoEnSilencio()
+    {
+        var ctx = await PrepararAsync(nameof(UnMinimoConMasDeTresDecimalesEsRechazadoNoRedondeadoEnSilencio));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-minimo-decimales");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 10.1234m, null));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("minimo_invalido", problema.GetProperty("codigo").GetString());
+        Assert.False(await ExisteFilaDeStockAsync(ctx, idArticulo));
+    }
+
+    [Fact]
+    public async Task UnaReposicionConMasDeTresDecimalesTambienEsRechazada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReposicionConMasDeTresDecimalesTambienEsRechazada));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-reposicion-decimales");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, null, 50.5678m));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("minimo_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnArticuloInexistenteEsRechazadoCon400()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloInexistenteEsRechazadoCon400));
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(ctx.IdPuntoVenta, 999_999, 10m, null));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("referencia_invalida", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnPuntoDeVentaInexistenteEsRechazadoCon404()
+    {
+        var ctx = await PrepararAsync(nameof(UnPuntoDeVentaInexistenteEsRechazadoCon404));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-pv-inexistente");
+
+        var respuesta = await EscribirAsync(ctx.Admin, new SolicitudDeMinimos(999_999, idArticulo, 10m, null));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("no_encontrado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 1.17 / mutation target 1.12: Admin-only, apilado sobre OperacionDePos --------------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): <c>
+    /// .RequireAuthorization(Politicas.GestionDeCatalogo)</c> sobre <c>PUT /minimos</c> — sin
+    /// ella, el grupo solo exige <c>OperacionDePos</c>, que un Supervisor SÍ tiene. Mutación
+    /// aplicada (borrar la línea) — esta prueba pasó de FALLAR (<c>200</c> en vez de <c>403</c>)
+    /// a pasar al revertir. Evidencia registrada en el resumen de apply.</summary>
+    [Fact]
+    public async Task UnSupervisorEsRechazadoDeEscribirMinimos()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoDeEscribirMinimos));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-supervisor");
+
+        var respuesta = await EscribirAsync(ctx.Supervisor, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 10m, null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDeEscribirMinimos()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDeEscribirMinimos));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-vendedor");
+
+        var respuesta = await EscribirAsync(ctx.Vendedor, new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 10m, null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/MinimosRlsTests.cs
+++ b/tests/Ways.IntegrationTests/MinimosRlsTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-13-stock-inteligente, Slice 1 (task 1.18, mutation-proof-tests regla 5): cross-tenant
+/// sobre <c>stock.minimo</c>/<c>reposicion</c> y sobre el NUEVO statement de <c>PUT
+/// /api/stock/minimos</c> (<c>INSERT ... ON CONFLICT DO UPDATE</c>), corriendo sobre la conexión
+/// <c>ways_app</c> (NOSUPERUSER NOBYPASSRLS) — misma disciplina que <c>StockRlsTests</c>. Esto
+/// prueba que la fila y el statement NUEVOS respetan la política EXISTENTE de <c>stock</c>, no
+/// que la política existe (ya cubierto desde stage-5).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class MinimosRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private async Task<(int IdTenant, int IdArticulo, int IdPuntoVenta)> SembrarStockConMinimoAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = nombre,
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = articulo.Id, IdPuntoVenta = puntoVenta.Id, IdTenant = tenant.Id, Cantidad = 10m, Minimo = 5m
+        });
+        await db.SaveChangesAsync();
+
+        return (tenant.Id, articulo.Id, puntoVenta.Id);
+    }
+
+    private async Task<int> CrearTenantAjenoAsync(string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var tenant = new Tenant
+        {
+            Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+        return tenant.Id;
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeElMinimoDeLaFila()
+    {
+        var (idTenantA, idArticuloA, idPuntoVentaA) = await SembrarStockConMinimoAsync(nameof(UnaSesionDeOtroTenantNoVeElMinimoDeLaFila) + "-A");
+        var idTenantB = await CrearTenantAjenoAsync(nameof(UnaSesionDeOtroTenantNoVeElMinimoDeLaFila) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM stock WHERE id_articulo = $1 AND id_punto_venta = $2 AND minimo IS NOT NULL";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticuloA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+
+        Assert.Equal(0, total);
+        Assert.NotEqual(idTenantA, idTenantB);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoPuedeActualizarElMinimo()
+    {
+        var (_, idArticuloA, idPuntoVentaA) = await SembrarStockConMinimoAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElMinimo) + "-A");
+        var idTenantB = await CrearTenantAjenoAsync(nameof(UnaSesionDeOtroTenantNoPuedeActualizarElMinimo) + "-B");
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantB);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "UPDATE stock SET minimo = 999 WHERE id_articulo = $1 AND id_punto_venta = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idArticuloA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+
+        var filas = await comando.ExecuteNonQueryAsync();
+        Assert.Equal(0, filas);
+    }
+
+    /// <summary>Prueba el statement NUEVO de <c>PUT /api/stock/minimos</c> — el mismo <c>INSERT
+    /// ... ON CONFLICT DO UPDATE</c> que <c>ServicioDeStock.UpsertParametrosDeReposicionAsync</c>
+    /// ejecuta, corrido a mano con un <c>id_tenant</c> ajeno para probar el <c>WITH CHECK</c> del
+    /// <c>INSERT</c> — camino que un cruce de tenant vía <c>ResolverArticuloAsync</c>/<c>
+    /// ResolverPuntoVentaAsync</c> nunca alcanza (esos ya devuelven 400/404 antes), así que esta
+    /// es la única prueba que ejercita el <c>WITH CHECK</c> de este statement específico.</summary>
+    [Fact]
+    public async Task UnInsertDeMinimosConIdTenantAjenoSeRechaza()
+    {
+        var (idTenantA, idArticuloA, idPuntoVentaA) = await SembrarStockConMinimoAsync(nameof(UnInsertDeMinimosConIdTenantAjenoSeRechaza) + "-A");
+        var idTenantB = await CrearTenantAjenoAsync(nameof(UnInsertDeMinimosConIdTenantAjenoSeRechaza) + "-B");
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var otroArticulo = new Articulo
+        {
+            IdTenant = idTenantA,
+            CodigoInterno = nameof(UnInsertDeMinimosConIdTenantAjenoSeRechaza) + "-otro",
+            Nombre = "otro",
+            IdArea = await db.Articulos.Where(a => a.Id == idArticuloA).Select(a => a.IdArea).FirstAsync(),
+            IdAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync(),
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Articulos.Add(otroArticulo);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", idTenantA);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO stock (id_articulo, id_punto_venta, id_tenant, cantidad, minimo, reposicion) " +
+            "VALUES ($1, $2, $3, 0, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta) DO UPDATE " +
+            "SET minimo = EXCLUDED.minimo, reposicion = EXCLUDED.reposicion";
+        comando.Parameters.Add(new NpgsqlParameter { Value = otroArticulo.Id });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaA });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTenantB });
+        comando.Parameters.Add(new NpgsqlParameter { Value = 15m });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)DBNull.Value });
+
+        // 42501 = insufficient_privilege (violación de WITH CHECK) — se dispara antes de
+        // cualquier FK compuesta, mismo criterio que StockRlsTests.UnInsertConIdTenantAjenoSeRechaza.
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+}


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 1 (Minimos API)

- `ReglaDeReposicion` pura en Domain: `Clasificar` (SinMinimo/Bajo/Ok), `Sugerido` (null-vs-0 honesto), `VentanaDeRotacion` con zona del PV e InstanteLocal tolerante a medianoche local invalida.
- 2 parametros nuevos en `ParametroConocido`: `DiasRotacion` (30) y `DiasCoberturaObjetivo` (7) — sin migracion (patron etapa 10/12).
- `PUT /api/stock/minimos`: upsert con `cantidad` FUERA del SET (crea la fila de stock en 0 sin movimiento), respuesta desde `RETURNING`, 5 caminos de rechazo con codigos distintos, `GestionDeCatalogo` apilada sobre `OperacionDePos`.
- Re-registro de la fila 367 del doc 11 a `stage-13b-conteo-por-planilla` (decision 5 del proposal).
- Gate SIN-CAMBIOS-DE-SCHEMA sostenido: cero archivos bajo `Migraciones/`.

## Tests
- Domain: 28 nuevos (limites de Clasificar, null-vs-0, ventana DST/zona invalida). Filtro EscribirMinimos: 15. RLS: 25 (ways_app, 42501 + 0-row silencioso).
- 4 mutation targets de tasks.md + pasada viva del juez B: 11 mutaciones, cero sobrevivientes.

## Judgment-day
Ronda limpia: juez B (estatica + mutador vivo) y juez A (read-only sobre el diff congelado en f282081) — 0 hallazgos confirmados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)