### PR TITLE
feat(stage-13): slice 2 existencias-minimos — minimo/reposicion/estado en /existencias y su export

### DIFF
--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -253,52 +253,91 @@ already exercises — never a second definition. **Rollback**: revert the
 branch — the report reverts to silent on the two columns, exactly its
 pre-stage-13 shape.
 
-- [ ] 2.1 Modify `src/Ways.Application/Reportes/Contratos.cs`:
+- [x] 2.1 Modify `src/Ways.Application/Reportes/Contratos.cs`:
   `FilaExistencia` gains `Minimo`, `Reposicion`, `Estado`. `dto-contract-honesty`:
   doc-comment each — read straight off the `stock` row already joined,
   `Estado` derived via `ReglaDeReposicion.Clasificar`, never a report-local
   reimplementation of the boundary.
-- [ ] 2.2 Modify `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
+- [x] 2.2 Modify `src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs`:
   `ObtenerExistenciasAsync`'s projection calls `ReglaDeReposicion.Clasificar(
   s.Cantidad, s.Minimo)` for `Estado`, and includes `s.Minimo`/`s.Reposicion`
   in the existing row shape. *(design decision 2 — existencias classifies
   **every** stocked row; reposición, slice 4, returns **only** `Bajo`)*
-- [ ] 2.3 Modify `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
+  **APPLY NOTE**: `Clasificar` is a C# static method, not SQL-translatable —
+  the LINQ query now materializes the raw join (`ToListAsync`) first and
+  classifies in a second, in-memory `Select` (LINQ-to-Objects). No behavior
+  deviation: still one query, no second round trip, matches design's "the
+  comparison never leaves C#" principle (design §Technical Approach, point 2).
+- [x] 2.3 Modify `src/Ways.Application/Reportes/ExportacionDeReportes.cs`:
   `ColumnasExistencias` gains the same 3 columns, same order as the JSON.
-- [ ] 2.4 [P] **Mutation target**: the `ReglaDeReposicion.Clasificar` call
+- [x] 2.4 [P] **Mutation target**: the `ReglaDeReposicion.Clasificar` call
   in the existencias projection — hard-code `EstadoDeReposicion.Ok` — the
   `SinMinimo`/`Bajo`/`Ok` row assertions (2.5) must fail.
-  *(mutation-proof-tests)*
-- [ ] 2.5 [P] Three-state row assertions: `cantidad = minimo` classifies
+  *(mutation-proof-tests)* **EVIDENCE**: mutated to
+  `EstadoDeReposicion.Ok /* MUTATION 2.4 */`, ran
+  `LosTresEstadosDeReposicionClasificanCorrectamenteEnExistencias` →
+  FAILED (`Assert.Equal() Failure: Values differ Expected: Bajo Actual: Ok`
+  at `ExistenciasTests.cs:258`), reverted, ran the full `~Existencias`
+  filter → 14/14 green, `git status`/`git diff --stat` clean (revert matched
+  committed bytes exactly).
+- [x] 2.5 [P] Three-state row assertions: `cantidad = minimo` classifies
   `bajo`; `minimo = null, cantidad = 0` classifies `sin_minimo` (never
   `bajo`); `cantidad` above `minimo` classifies `ok`. *(spec
   `reportes-de-gestion`: scenarios "An articulo at or below its minimo
   classifies bajo", "…classifies sin_minimo, never bajo", "…classifies ok")*
-- [ ] 2.6 [P] Integration: existencias needs no `idArticulo` (regression,
+  Implemented as `ExistenciasTests.LosTresEstadosDeReposicionClasificanCorrectamenteEnExistencias`
+  (three articulos, all fields distinct — mutation-proof-tests rule 6).
+- [x] 2.6 [P] Integration: existencias needs no `idArticulo` (regression,
   re-asserted with the three new columns present). *(spec
   `reportes-de-gestion`: scenario "Existencias needs no idArticulo")*
-- [ ] 2.7 [P] Integration: a Supervisor exports existencias with the
+  `LasExistenciasDe40ArticulosVuelvenSinPedirIdArticulo` extended with
+  `Assert.All(...)` over the 40 rows: `Minimo`/`Reposicion` null, `Estado
+  == SinMinimo`.
+- [x] 2.7 [P] Integration: a Supervisor exports existencias with the
   widened table (regression). *(spec `reportes-de-gestion`: scenario "A
   Supervisor exports existencias")*
-- [ ] 2.8 [P] Integration: a Supervisor **reads** the reorder columns on
+  Pre-existing `UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico`
+  still green unmodified — 200 + deterministic filename regression confirmed
+  under the widened `FilaExistencia`/export mapper; the cell-level widened
+  assertions live in 2.9.
+- [x] 2.8 [P] Integration: a Supervisor **reads** the reorder columns on
   `GET /existencias` (`200`, columns present) and gets `403` re-confirmed
   on `PUT /minimos` from this route's vantage point. *(spec
   `reportes-de-gestion`: scenario "A Supervisor reads the reorder columns
   but cannot write them" — closes the read half left open by slice 1's
-  1.17)*
-- [ ] 2.9 [P] Export equality: the widened workbook carries the same
+  1.17)* Implemented as
+  `ExistenciasTests.UnSupervisorLeeLasColumnasDeReposicionYEsRechazadoDeEscribirlas`.
+- [x] 2.9 [P] Export equality: the widened workbook carries the same
   `minimo`/`reposicion`/`estado` values as the JSON, cell by cell. *(spec
   `reportes-de-gestion`: scenario "The existencias export carries the same
-  reorder columns"; `mutation-proof-tests` rule 6)*
-- [ ] 2.10 [P] Round-trip: `PUT /api/stock/minimos` then
+  reorder columns"; `mutation-proof-tests` rule 6)* Extended the existing
+  `ElExportEsIgualAlEndpointJsonParaLasDosFilas` (rather than a new test) —
+  same two-row equality test now compares all 6 columns per row, with one
+  row `SinMinimo` (both new fields null → blank cell) and one `Bajo` (both
+  populated), so both `Celda.Cantidad(decimal?)` branches are exercised.
+- [x] 2.10 [P] Round-trip: `PUT /api/stock/minimos` then
   `GET /existencias` returns the same persisted pair — the first end-to-end
   test that can exercise both routes together, now that the report exposes
-  the fields.
-- [ ] 2.11 Gate guard: `has-pending-model-changes` clean, zero migration
-  files in the diff.
+  the fields. Implemented as
+  `ExistenciasTests.UnRoundTripDeEscrituraYLecturaDevuelveElParPersistido`.
+- [x] 2.11 Gate guard: `has-pending-model-changes` clean, zero migration
+  files in the diff. **VERIFIED**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure --startup-project
+  src/Ways.Infrastructure` → "No changes have been made to the model since
+  the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
+  files).
 - [ ] 2.12 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 2.13 Branch `feat/stage13-slice2-existencias-minimos` off `main`
   (parent: slice 1); PR; merge stacked-to-main.
+
+**APPLY NOTE (Verify line filter mismatch)**: this slice's `Verify` line
+below reads `FullyQualifiedName~ExistenciasReport`, but no test class named
+`ExistenciasReport*` exists — the actual classes are `ExistenciasTests` and
+`ExistenciasExportTests` (same names stage-11 slice 9 already used). Ran
+`FullyQualifiedName~Existencias` instead, which matches both real classes
+(14 tests, all green) — recorded per instruction to never silently deviate;
+not a task, so not re-numbered.
 
 **Test plan**: mutation target (2.4), three-state assertions (2.5),
 regressions ×2 (2.6-2.7), Supervisor read (2.8), export equality (2.9),

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -315,6 +315,14 @@ pre-stage-13 shape.
   same two-row equality test now compares all 6 columns per row, with one
   row `SinMinimo` (both new fields null → blank cell) and one `Bajo` (both
   populated), so both `Celda.Cantidad(decimal?)` branches are exercised.
+  **judgment-day round 1**: a surviving header-label mutant was found —
+  swapping the `"Mínimo"`/`"Reposición"` header titles in `ColumnasExistencias`
+  still passed the suite because the equality test only read data cells by
+  position from `primeraFilaDeDatos`, never the header row. Closed by adding
+  one assert in `ElExportEsIgualAlEndpointJsonParaLasDosFilas` that reads all
+  six header texts from the header row (`filaDeEncabezados = 6`) in exact
+  order; confirmed the header-swap mutation now fails the suite, reverted,
+  suite green again.
 - [x] 2.10 [P] Round-trip: `PUT /api/stock/minimos` then
   `GET /existencias` returns the same persisted pair — the first end-to-end
   test that can exercise both routes together, now that the report exposes

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -335,8 +335,19 @@ pre-stage-13 shape.
   the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files).
-- [ ] 2.12 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 2.13 Branch `feat/stage13-slice2-existencias-minimos` off `main`
+- [x] 2.12 Run `judgment-day`; fix; re-judge until clean. *(CLEAN ROUND 2
+  2026-08-14. Round 1: judge B static + LIVE mutation pass — 9 mutations,
+  8 killed, 1 SURVIVOR (header-label swap in `ColumnasExistencias`, MAJOR)
+  plus a WARNING (seed doc-comment overclaiming all-distinct values). Fix
+  commit `067e95c`: six-header-text assert at `filaDeEncabezados = 6` +
+  genuinely all-distinct classification seed (minimo {5,null,7}, reposicion
+  {20,null,30}), mutation evidence re-recorded. Scoped re-judgment by judge
+  B: re-applied the exact mutant → suite FAILS at the new assert; adjacent
+  hard-coded-label probe also killed; zero fix-caused defects. Judge A fresh
+  read-only pass over the corrected frozen diff at `067e95c`: ZERO findings.
+  JUDGMENT: APPROVED — 1 confirmed-and-fixed MAJOR, 1 fixed WARNING, 0
+  contradictions.)*
+- [x] 2.13 Branch `feat/stage13-slice2-existencias-minimos` off `main`
   (parent: slice 1); PR; merge stacked-to-main.
 
 **APPLY NOTE (Verify line filter mismatch)**: this slice's `Verify` line

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -132,14 +132,24 @@ public sealed record Comisiones(
 /// construcción). A diferencia de <see cref="ArticuloTop"/> (que etiqueta con el snapshot congelado
 /// de una línea de venta), acá NO hay línea histórica que congelar — <c>stock</c> es estado
 /// ACTUAL, así que <see cref="Nombre"/> sale del join en vivo contra <c>articulos</c> (spec:
-/// Existencias Report Joins Stock To Artículos Under The Same Gate), nunca de un snapshot.</summary>
-public sealed record FilaExistencia(int IdArticulo, string Nombre, decimal Cantidad);
+/// Existencias Report Joins Stock To Artículos Under The Same Gate), nunca de un snapshot.
+///
+/// stage-13-stock-inteligente, Slice 2 (dto-contract-honesty — destino de cada campo nuevo):
+/// <see cref="Minimo"/> y <see cref="Reposicion"/> se leen directo de la fila <c>stock</c> ya
+/// unida (el mismo par que <c>PUT /api/stock/minimos</c> persiste, nunca re-derivado). Ambos
+/// son de solo lectura acá — escribirlos es <c>PUT /api/stock/minimos</c>, bajo
+/// <c>Politicas.GestionDeCatalogo</c>, una policy distinta de la de este reporte. <see
+/// cref="Estado"/> se deriva vía <see cref="ReglaDeReposicion.Clasificar"/> sobre
+/// <see cref="Cantidad"/>/<see cref="Minimo"/> — nunca una segunda definición del borde
+/// <c>bajo</c>/<c>sin_minimo</c>/<c>ok</c> (design decisión 2, spec reportes-de-gestion: "Existencias
+/// Report Joins Stock To Artículos Under The Same Gate").</summary>
+public sealed record FilaExistencia(
+    int IdArticulo, string Nombre, decimal Cantidad,
+    decimal? Minimo, decimal? Reposicion, EstadoDeReposicion Estado);
 
 /// <summary>Respuesta de <c>GET /api/reportes/stock/existencias</c>. Sin <c>desde</c>/<c>hasta</c>
 /// ni <c>ZonaHoraria</c> (a diferencia del resto de los reportes de esta etapa): el stock no tiene
-/// dimensión temporal, es una foto del estado actual — mínimos, punto de pedido y reposición
-/// quedan fuera de esta slice (proposal decisión 10: "give it the context it lacks here", reservado
-/// para Etapa 13).</summary>
+/// dimensión temporal, es una foto del estado actual.</summary>
 public sealed record Existencias(int IdPuntoVenta, IReadOnlyList<FilaExistencia> Filas);
 
 /// <summary>Fila de <c>GET /api/reportes/stock/vencimientos</c> (stage-12-lotes-vencimientos,

--- a/src/Ways.Application/Reportes/ExportacionDeReportes.cs
+++ b/src/Ways.Application/Reportes/ExportacionDeReportes.cs
@@ -281,12 +281,19 @@ public static class ExportacionDeReportes
     [
         new ColumnaExportable("Artículo", TipoDeColumna.Entero),
         new ColumnaExportable("Nombre", TipoDeColumna.Texto),
-        new ColumnaExportable("Cantidad", TipoDeColumna.Cantidad)
+        new ColumnaExportable("Cantidad", TipoDeColumna.Cantidad),
+        new ColumnaExportable("Mínimo", TipoDeColumna.Cantidad),
+        new ColumnaExportable("Reposición", TipoDeColumna.Cantidad),
+        new ColumnaExportable("Estado", TipoDeColumna.Texto)
     ];
 
     /// <summary>Slice 9 (proposal decisión 10): sin fila de totales — a diferencia de
     /// <c>ventas/resumen</c>/<c>compras/por-proveedor</c>, sumar cantidades de artículos distintos
-    /// no produce una figura con significado propio.</summary>
+    /// no produce una figura con significado propio. stage-13-stock-inteligente, Slice 2: mismo
+    /// orden de columnas que el JSON — <c>minimo</c>/<c>reposicion</c> nulos quedan como celda
+    /// vacía (nunca <c>0</c>, <c>Celda.Cantidad</c> ya acepta <c>decimal?</c>), <c>Estado</c> se
+    /// escribe como texto del nombre de miembro del enum (mismo criterio que <c>Vencimientos</c>
+    /// con <see cref="FilaDeVencimiento.Estado"/>).</summary>
     public static TablaExportable De(Existencias respuesta, ContextoDeExportacion ctx) =>
         new(
             "Existencias", ctx, ColumnasExistencias,
@@ -295,7 +302,10 @@ public static class ExportacionDeReportes
                 [
                     Celda.Entero(f.IdArticulo),
                     Celda.Texto(f.Nombre),
-                    Celda.Cantidad(f.Cantidad)
+                    Celda.Cantidad(f.Cantidad),
+                    Celda.Cantidad(f.Minimo),
+                    Celda.Cantidad(f.Reposicion),
+                    Celda.Texto(f.Estado.ToString())
                 ])
                 .ToList());
 

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -41,12 +41,22 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
         // es lo único que discrimina un punto de venta del otro — mezclar dos PVs del mismo tenant
         // en una sola respuesta rompería el significado del reporte tanto como en
         // ServicioDeTesoreria (design decisión 11, misma familia de bug).
-        var filas = await db.Stock
+        var crudas = await db.Stock
             .Where(s => s.IdPuntoVenta == idPuntoVenta)
-            .Join(db.Articulos, s => s.IdArticulo, a => a.Id, (s, a) => new { a.Id, a.Nombre, s.Cantidad })
+            .Join(
+                db.Articulos, s => s.IdArticulo, a => a.Id,
+                (s, a) => new { a.Id, a.Nombre, s.Cantidad, s.Minimo, s.Reposicion })
             .OrderBy(x => x.Id)
-            .Select(x => new FilaExistencia(x.Id, x.Nombre, x.Cantidad))
             .ToListAsync(ct);
+
+        // stage-13-stock-inteligente, Slice 2 (design decisión 2): existencias clasifica TODA fila
+        // stockeada vía ReglaDeReposicion.Clasificar — el mismo borde que reposición (slice 4) y el
+        // write path (slice 1) ya usan, nunca una segunda definición del boundary bajo/sin_minimo/ok.
+        var filas = crudas
+            .Select(x => new FilaExistencia(
+                x.Id, x.Nombre, x.Cantidad, x.Minimo, x.Reposicion,
+                ReglaDeReposicion.Clasificar(x.Cantidad, x.Minimo)))
+            .ToList();
 
         return new Existencias(idPuntoVenta, filas);
     }

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -12,6 +12,7 @@ using Ways.Application.Reportes;
 using Ways.Application.Usuarios;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
+using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
 
@@ -24,6 +25,10 @@ namespace Ways.IntegrationTests;
 /// deja pasar mutaciones de mapeo, hallazgo repetido cinco veces en esta misma etapa), más el rol
 /// un escalón debajo del gate y el nombre de archivo determinístico del spec (A Supervisor Exports
 /// Existencias).
+///
+/// stage-13-stock-inteligente, Slice 2 (task 2.9, spec: "The existencias export carries the same
+/// reorder columns"): agrega la igualdad de las tres columnas nuevas — mínimo, reposición y estado
+/// — celda por celda contra el JSON.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -34,7 +39,11 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
     private const string ContentTypeXlsx =
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
 
     private sealed record Contexto(
         int IdTenant, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
@@ -103,12 +112,14 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         return articulo.Id;
     }
 
-    private async Task SembrarStockAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    private async Task SembrarStockAsync(
+        Contexto ctx, int idArticulo, decimal cantidad, decimal? minimo = null, decimal? reposicion = null)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         db.Stock.Add(new Ways.Domain.Stock.Stock
         {
-            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad,
+            Minimo = minimo, Reposicion = reposicion
         });
         await db.SaveChangesAsync();
     }
@@ -120,13 +131,19 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
 
     /// <summary>Nombra el objetivo de mutación (mutation-proof-tests regla 6): el call site de
     /// <c>ExportacionDeReportes.De(Existencias, ContextoDeExportacion)</c> dentro del endpoint
-    /// <c>/stock/existencias/export</c>. Dos artículos con nombre Y cantidad distintos, ambas filas
-    /// comparadas contra el workbook — un test de una sola fila (el patrón que
-    /// <c>ExportacionDeReportesTests</c> usa para los otros ocho mappers de la Slice 2) no habría
-    /// detectado un <c>.Reverse()</c> ni un swap de columnas. Mutación aplicada
-    /// (<c>.Reverse()</c> antes del <c>.Select</c> en el mapper de <c>Existencias</c>): este test
-    /// pasó de FALLAR (fila 7 esperada = artículo A, fila 7 real = artículo B) a pasar al revertir
-    /// — evidencia registrada en el resumen de apply.</summary>
+    /// <c>/stock/existencias/export</c>. Dos artículos con TODOS los campos distintos (nombre,
+    /// cantidad, mínimo, reposición, estado), ambas filas con las SEIS columnas comparadas contra
+    /// el workbook — un test de una sola fila o de columnas salteadas no habría detectado un
+    /// <c>.Reverse()</c> ni un swap de columnas. Mutación aplicada (<c>.Reverse()</c> antes del
+    /// <c>.Select</c> en el mapper de <c>Existencias</c>): este test pasó de FALLAR (fila 7
+    /// esperada = artículo A, fila 7 real = artículo B) a pasar al revertir — evidencia registrada
+    /// en el resumen de apply.
+    ///
+    /// stage-13-stock-inteligente, Slice 2 (task 2.9, spec: "The existencias export carries the
+    /// same reorder columns"): el artículo A queda <c>SinMinimo</c> (mínimo/reposición ambos
+    /// <c>null</c> — celda vacía, nunca <c>0</c>) y el artículo B queda <c>Bajo</c> con ambos
+    /// campos poblados, así que las dos ramas de <c>Celda.Cantidad(decimal?)</c> quedan
+    /// ejercidas.</summary>
     [Fact]
     public async Task ElExportEsIgualAlEndpointJsonParaLasDosFilas()
     {
@@ -135,7 +152,7 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         var idArticuloA = await SembrarArticuloAsync(ctx, "Aceite de girasol 900ml");
         await SembrarStockAsync(ctx, idArticuloA, 12m);
         var idArticuloB = await SembrarArticuloAsync(ctx, "Fideos guiseros 500g");
-        await SembrarStockAsync(ctx, idArticuloB, 87.5m);
+        await SembrarStockAsync(ctx, idArticuloB, 87.5m, minimo: 90m, reposicion: 150m);
 
         var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/existencias?idPuntoVenta={ctx.IdPuntoVenta}");
         Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
@@ -160,11 +177,27 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
             Assert.Equal(esperado.IdArticulo, fila.Cell(1).GetValue<int>());
             Assert.Equal(esperado.Nombre, fila.Cell(2).GetString());
             Assert.Equal(esperado.Cantidad, fila.Cell(3).GetValue<decimal>());
+            AssertCeldaDecimalNullable(fila.Cell(4), esperado.Minimo);
+            AssertCeldaDecimalNullable(fila.Cell(5), esperado.Reposicion);
+            Assert.Equal(esperado.Estado.ToString(), fila.Cell(6).GetString());
         }
 
         // Sin fila de totales (design: existencias no suma cantidades de artículos distintos) — la
         // fila siguiente a la última fila de datos tiene que estar vacía.
         Assert.True(hoja.Cell(primeraFilaDeDatos + existencias.Filas.Count, 1).Value.IsBlank);
+    }
+
+    /// <summary>Celda vacía para <c>null</c> (nunca <c>0</c> — design decisión 2), valor exacto en
+    /// caso contrario.</summary>
+    private static void AssertCeldaDecimalNullable(IXLCell celda, decimal? esperado)
+    {
+        if (esperado is null)
+        {
+            Assert.True(celda.Value.IsBlank);
+            return;
+        }
+
+        Assert.Equal(esperado.Value, celda.GetValue<decimal>());
     }
 
     // ---- spec: A Supervisor Exports Existencias — 200 con nombre de archivo determinístico -------

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -167,8 +167,16 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
-        // Fila 6 = título de tabla, los datos empiezan en la fila 7 — EN ORDEN (OrderBy(IdArticulo)
-        // del lado del servicio), ambas filas con TODAS sus columnas comparadas.
+        // Fila 6 = título de tabla (headers), los datos empiezan en la fila 7 — EN ORDEN
+        // (OrderBy(IdArticulo) del lado del servicio), ambas filas con TODAS sus columnas
+        // comparadas. El header es lo que ata cada celda de datos a su columna: sin este assert un
+        // swap de labels ("Mínimo"/"Reposición") pasa inadvertido porque el test de igualdad de
+        // abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Artículo", "Nombre", "Cantidad", "Mínimo", "Reposición", "Estado"],
+            Enumerable.Range(1, 6).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < existencias.Filas.Count; i++)
         {

--- a/tests/Ways.IntegrationTests/ExistenciasTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasTests.cs
@@ -5,10 +5,12 @@ using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Application.Organizacion;
 using Ways.Application.Reportes;
+using Ways.Application.Stock;
 using Ways.Application.Usuarios;
 using Ways.Domain.Articulos;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
 
@@ -22,6 +24,12 @@ namespace Ways.IntegrationTests;
 /// <c>IWaysDbContext.Stock</c>/<c>Articulos</c> (nunca a través de <c>ServicioDeStock</c>, que
 /// exige un movimiento): esta clase prueba la LECTURA del reporte, no la escritura del caché de
 /// stock — ya cubierta por las pruebas de stage-5/8.
+///
+/// stage-13-stock-inteligente, Slice 2 (tasks 2.4-2.10): agrega las tres columnas de reposición —
+/// la clasificación de tres estados (2.4/2.5, mutation target sobre la llamada a
+/// <c>ReglaDeReposicion.Clasificar</c> en la proyección), la regresión de "sin idArticulo" con las
+/// columnas nuevas presentes (2.6), la lectura de Supervisor confirmando el 403 de escritura desde
+/// este vantage point (2.8) y el round-trip PUT→GET (2.10).
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -30,7 +38,11 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
     private const string MailRoot = "test@test.com";
     private const string PasswordOtroRol = "otro-rol-password-larga";
 
-    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
 
     private sealed record Contexto(
         int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
@@ -110,12 +122,15 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
         return articulo.Id;
     }
 
-    private async Task SembrarStockAsync(Contexto ctx, int idPuntoVenta, int idArticulo, decimal cantidad)
+    private async Task SembrarStockAsync(
+        Contexto ctx, int idPuntoVenta, int idArticulo, decimal cantidad,
+        decimal? minimo = null, decimal? reposicion = null)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         db.Stock.Add(new Ways.Domain.Stock.Stock
         {
-            IdTenant = ctx.IdTenant, IdPuntoVenta = idPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad
+            IdTenant = ctx.IdTenant, IdPuntoVenta = idPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad,
+            Minimo = minimo, Reposicion = reposicion
         });
         await db.SaveChangesAsync();
     }
@@ -209,7 +224,51 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
         Assert.Equal(42.5m, fila.Cantidad);
     }
 
-    // ---- task 9.11: no-idArticulo-required (spec: Existencias Needs No idArticulo) --------------
+    // ---- task 2.4/2.5: los tres estados de ReglaDeReposicion.Clasificar en la proyección ---------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests, task 2.4): la llamada a
+    /// <c>ReglaDeReposicion.Clasificar(x.Cantidad, x.Minimo)</c> dentro de la proyección de
+    /// <c>ObtenerExistenciasAsync</c>. Mutación aplicada (hard-code <c>EstadoDeReposicion.Ok</c> en
+    /// vez de la llamada real): esta prueba pasó de FALLAR (las tres filas clasifican <c>Ok</c> en
+    /// vez de <c>Bajo</c>/<c>SinMinimo</c>/<c>Ok</c> respectivamente) a pasar al revertir —
+    /// evidencia registrada en el resumen de apply. Tres artículos con valores de
+    /// cantidad/mínimo/reposición TODOS distintos (mutation-proof-tests regla 6), así que un swap
+    /// de fila también sería detectable. (spec reportes-de-gestion: "An articulo at or below its
+    /// minimo classifies bajo" / "…classifies sin_minimo, never bajo" / "…classifies ok")</summary>
+    [Fact]
+    public async Task LosTresEstadosDeReposicionClasificanCorrectamenteEnExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(LosTresEstadosDeReposicionClasificanCorrectamenteEnExistencias));
+
+        var idBajo = await SembrarArticuloAsync(ctx, "articulo-bajo");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idBajo, cantidad: 5m, minimo: 5m, reposicion: 20m);
+
+        var idSinMinimo = await SembrarArticuloAsync(ctx, "articulo-sin-minimo");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idSinMinimo, cantidad: 0m, minimo: null, reposicion: null);
+
+        var idOk = await SembrarArticuloAsync(ctx, "articulo-ok");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idOk, cantidad: 20m, minimo: 5m, reposicion: null);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(3, existencias.Filas.Count);
+
+        var filaBajo = existencias.Filas.Single(f => f.IdArticulo == idBajo);
+        Assert.Equal(5m, filaBajo.Minimo);
+        Assert.Equal(20m, filaBajo.Reposicion);
+        Assert.Equal(EstadoDeReposicion.Bajo, filaBajo.Estado);
+
+        var filaSinMinimo = existencias.Filas.Single(f => f.IdArticulo == idSinMinimo);
+        Assert.Null(filaSinMinimo.Minimo);
+        Assert.Null(filaSinMinimo.Reposicion);
+        Assert.Equal(EstadoDeReposicion.SinMinimo, filaSinMinimo.Estado);
+
+        var filaOk = existencias.Filas.Single(f => f.IdArticulo == idOk);
+        Assert.Equal(5m, filaOk.Minimo);
+        Assert.Null(filaOk.Reposicion);
+        Assert.Equal(EstadoDeReposicion.Ok, filaOk.Estado);
+    }
+
+    // ---- task 9.11 / 2.6: no-idArticulo-required, regresión con las tres columnas nuevas ---------
 
     [Fact]
     public async Task LasExistenciasDe40ArticulosVuelvenSinPedirIdArticulo()
@@ -228,6 +287,56 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
 
         var existencias = JsonSerializer.Deserialize<Existencias>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
         Assert.Equal(40, existencias.Filas.Count);
+        // Slice 2 (task 2.6): las 40 filas quedan sin mínimo configurado — cada una clasifica
+        // SinMinimo, nunca Bajo (spec: "An articulo with no minimo classifies sin_minimo, never bajo").
+        Assert.All(existencias.Filas, f =>
+        {
+            Assert.Null(f.Minimo);
+            Assert.Null(f.Reposicion);
+            Assert.Equal(EstadoDeReposicion.SinMinimo, f.Estado);
+        });
+    }
+
+    // ---- task 2.8: Supervisor lee las columnas de reposición y confirma el 403 de escritura -------
+
+    [Fact]
+    public async Task UnSupervisorLeeLasColumnasDeReposicionYEsRechazadoDeEscribirlas()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorLeeLasColumnasDeReposicionYEsRechazadoDeEscribirlas));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-supervisor-lectura");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idArticulo, cantidad: 3m, minimo: 5m, reposicion: 25m);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Supervisor, ctx.IdPuntoVenta);
+        var fila = Assert.Single(existencias.Filas);
+        Assert.Equal(5m, fila.Minimo);
+        Assert.Equal(25m, fila.Reposicion);
+        Assert.Equal(EstadoDeReposicion.Bajo, fila.Estado);
+
+        var escritura = await ctx.Supervisor.PutAsJsonAsync(
+            "/api/stock/minimos", new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 10m, null));
+        Assert.Equal(HttpStatusCode.Forbidden, escritura.StatusCode);
+    }
+
+    // ---- task 2.10: round-trip PUT /api/stock/minimos → GET /existencias devuelve el par persistido
+
+    [Fact]
+    public async Task UnRoundTripDeEscrituraYLecturaDevuelveElParPersistido()
+    {
+        var ctx = await PrepararAsync(nameof(UnRoundTripDeEscrituraYLecturaDevuelveElParPersistido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "articulo-round-trip");
+
+        var escritura = await ctx.Admin.PutAsJsonAsync(
+            "/api/stock/minimos", new SolicitudDeMinimos(ctx.IdPuntoVenta, idArticulo, 8m, 30m));
+        Assert.Equal(HttpStatusCode.OK, escritura.StatusCode);
+
+        var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var fila = Assert.Single(existencias.Filas);
+        Assert.Equal(idArticulo, fila.IdArticulo);
+        Assert.Equal(0m, fila.Cantidad);
+        Assert.Equal(8m, fila.Minimo);
+        Assert.Equal(30m, fila.Reposicion);
+        // cantidad queda en 0 (create-at-zero) y 0 <= 8 ⇒ Bajo, no Ok.
+        Assert.Equal(EstadoDeReposicion.Bajo, fila.Estado);
     }
 
     // ---- task 9.10: rol un escalón debajo del gate ------------------------------------------------

--- a/tests/Ways.IntegrationTests/ExistenciasTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasTests.cs
@@ -247,7 +247,7 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
         await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idSinMinimo, cantidad: 0m, minimo: null, reposicion: null);
 
         var idOk = await SembrarArticuloAsync(ctx, "articulo-ok");
-        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idOk, cantidad: 20m, minimo: 5m, reposicion: null);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, idOk, cantidad: 20m, minimo: 7m, reposicion: 30m);
 
         var existencias = await ObtenerExistenciasAsync(ctx.Admin, ctx.IdPuntoVenta);
         Assert.Equal(3, existencias.Filas.Count);
@@ -263,8 +263,8 @@ public class ExistenciasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFix
         Assert.Equal(EstadoDeReposicion.SinMinimo, filaSinMinimo.Estado);
 
         var filaOk = existencias.Filas.Single(f => f.IdArticulo == idOk);
-        Assert.Equal(5m, filaOk.Minimo);
-        Assert.Null(filaOk.Reposicion);
+        Assert.Equal(7m, filaOk.Minimo);
+        Assert.Equal(30m, filaOk.Reposicion);
         Assert.Equal(EstadoDeReposicion.Ok, filaOk.Estado);
     }
 


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 2 (Existencias Minimos)

- `FilaExistencia` gana `minimo`, `reposicion` y `estado` (derivado vía `ReglaDeReposicion.Clasificar` — nunca una segunda definición del boundary, decisión 2 del design).
- La proyección materializa el join y clasifica en memoria (Clasificar no es traducible a SQL); una sola ida a la base, nota de apply registrada en tasks.md.
- `ColumnasExistencias` del export gana las mismas 3 columnas en el mismo orden que el JSON; `Celda.Cantidad(decimal?)` renderiza null como celda vacía, nunca 0.
- Gate SIN-CAMBIOS-DE-SCHEMA sostenido: cero archivos bajo `Migraciones/`.

## Tests
- Clasificación de tres estados con seed todo-distinto por columna (mutation target 2.4 con evidencia registrada), regresión sin-idArticulo, Supervisor lee-pero-no-escribe (cierra la mitad de lectura del escenario 6 del slice 1), round-trip PUT→GET, igualdad JSON↔XLSX de las 6 columnas incluidos los DOS branches de celda nullable. Filtro ~Existencias: 14/14.

## Judgment-day
Ronda 1: juez B (estática + 9 mutaciones vivas) encontró 1 mutante sobreviviente MAJOR — el swap de headers Mínimo/Reposición del workbook pasaba la suite porque ningún test leía la fila de headers. Fix: assert de los 6 textos de header en orden exacto en la fila real (6); re-ronda del juez B mata el mutante original y el probe adyacente. Juez A read-only sobre el diff corregido: cero hallazgos. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)