### PR TITLE
feat(stage-13): slice 5 rotacion — LeerConsumoAsync, GET /rotacion y columnas de rotacion en /reposicion

### DIFF
--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -841,7 +841,32 @@ functions.
   the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files).
-- [ ] 5.21 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 5.21 Run `judgment-day`; fix; re-judge until clean. *(judgment-day round
+  1, juez B — 7 findings confirmed and closed: #1 MAJOR
+  (`ResolverDiasCoberturaAsync`/`ObtenerRotacionAsync` never routed
+  `dias_cobertura_objetivo` through `ReglaDeReposicion.ExigirVentanaValida`,
+  making the designed 400 unreachable and letting a stored `<= 0` value
+  fabricate a zero/negative `minimoSugerido` — fixed by wrapping the
+  resolved value with `ExigirVentanaValida(_, "dias_cobertura_invalido")`
+  at the single resolution point; test
+  `UnDiasDeCoberturaObjetivoInvalidoEsRechazadoConCuatrocientos`); #2
+  WARNING (the `FilaDeRotacion` clamp-to-zero contract had no test; test
+  `UnaVentanaConDevolucionesNetasPositivasClampeaElConsumoAZeroNuncaNegativo`);
+  #3 WARNING (window boundaries untested at the exact instant; test
+  `LaVentanaDeRotacionIncluyeElBordeInferiorYExcluyeElBordeSuperiorExactos`);
+  #4 WARNING (`DiasDeCobertura(f.Cantidad, …)` wiring untested; test
+  `LaCoberturaDeDiasSeCalculaSobreCantidadNuncaSobreMinimo`); #5 WARNING
+  (soft-deleted articulo with qualifying history untested — the
+  `nombres.ContainsKey` guard was already correct, just unproven; test
+  `UnArticuloDadoDeBajaConHistoriaCalificadaDesapareceDeLaRotacionSinReventar`);
+  #6 SUGGESTION (dead `Contexto.Vendedor` setup — closed with test
+  `UnVendedorEsRechazadoDelReporteDeRotacion`, mirror of 4.11); #7
+  SUGGESTION (incoherent narrative in the 5.10 doc-comment — corrected to
+  the real observed value, Expected 5 / Actual 20). All five new
+  6 new integration tests confirmed FAIL under their named mutation and
+  PASS on revert. Filtered suite `~Rotacion|~Reposicion` green: 60/60
+  (29 `Ways.Domain.Tests` + 31 `Ways.IntegrationTests`, up from 25
+  integration baseline + 6 new).)*
 - [ ] 5.22 Branch `feat/stage13-slice5-rotacion` off `main` (parent:
   slice 4); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -841,8 +841,16 @@ functions.
   the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files).
-- [ ] 5.21 Run `judgment-day`; fix; re-judge until clean. *(judgment-day round
-  1, juez B — 7 findings confirmed and closed: #1 MAJOR
+- [x] 5.21 Run `judgment-day`; fix; re-judge until clean. *(CLEAN 2026-08-14:
+  judge B's scoped re-judgment re-applied all 6 named mutations — every one
+  killed by exactly its dedicated test with the predicted failure mode
+  (incl. the live 500 `error_interno` confirmation of the soft-delete
+  guard) — zero fix-caused defects beyond one prose slip corrected by the
+  orchestrator; judge A's fresh read-only pass returned ZERO findings,
+  independently re-deriving the netting predicate against the raw-ADO
+  write paths of ventas/compras, the window arithmetic, the query-count-6
+  claim, and every DTO field's fate. JUDGMENT: APPROVED. Round 1, juez B —
+  7 findings confirmed and closed: #1 MAJOR
   (`ResolverDiasCoberturaAsync`/`ObtenerRotacionAsync` never routed
   `dias_cobertura_objetivo` through `ReglaDeReposicion.ExigirVentanaValida`,
   making the designed 400 unreachable and letting a stored `<= 0` value
@@ -868,7 +876,7 @@ functions.
   named mutation). Filtered suite `~Rotacion|~Reposicion` green: 60/60
   (29 `Ways.Domain.Tests` + 31 `Ways.IntegrationTests`, up from 25
   integration baseline + 6 new).)*
-- [ ] 5.22 Branch `feat/stage13-slice5-rotacion` off `main` (parent:
+- [x] 5.22 Branch `feat/stage13-slice5-rotacion` off `main` (parent:
   slice 4); PR; merge stacked-to-main.
 
 **APPLY NOTE (Verify line, no mismatch this time)**: unlike slices 2 and 4,

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -657,7 +657,7 @@ gains `ConsumoDiarioPromedio`/`DiasDeCobertura` per row;
 reverts to slice 4's shape (no rotation columns), `/reposicion` still
 functions.
 
-- [ ] 5.1 Modify `ServicioDeReportesDeStock.cs`: private
+- [x] 5.1 Modify `ServicioDeReportesDeStock.cs`: private
   `LeerConsumoAsync(idPuntoVenta, idsArticulo?, desdeUtc, hastaUtcExclusivo,
   ct)`:
   ```csharp
@@ -672,8 +672,9 @@ functions.
       .ToDictionaryAsync(x => x.IdArticulo, x => x.Neto, ct);
   ```
   Plain LINQ over `db.MovimientosStock` — no raw SQL, `LectorDeSerieTemporal`
-  untouched (design decision 7). The caller negates: `-neto`.
-- [ ] 5.2 Modify `ServicioDeReportesDeStock.cs`: wire `ObtenerReposicionAsync`
+  untouched (design decision 7). The caller negates: `-neto`. Implemented
+  verbatim as the pinned snippet, returning `IReadOnlyDictionary<int, decimal>`.
+- [x] 5.2 Modify `ServicioDeReportesDeStock.cs`: wire `ObtenerReposicionAsync`
   — when `filas.Count > 0`, compute `(desdeUtc, hastaUtc) :=
   ReglaDeReposicion.VentanaDeRotacion(hoy, diasDeRotacion, zona)`, call
   `LeerConsumoAsync(pv, filas.ids, desdeUtc, hastaUtc, ct)`, project
@@ -681,35 +682,67 @@ functions.
   ? -neto : null, diasDeRotacion)` and `DiasDeCobertura :=
   ReglaDeReposicion.DiasDeCobertura(cantidad, consumoDiarioPromedio)` per
   row. When `filas.Count == 0`, the rotation query is skipped entirely
-  (decision 12 — a PV with no minimums costs exactly one query).
-- [ ] 5.3 Modify `Contratos.cs`: widen `FilaDeReposicion` with
+  (decision 12 — a PV with no minimums costs exactly one query). Wired as
+  written; `zona` resolved via `TimeZoneInfo.FindSystemTimeZoneById(zonaId)`.
+- [x] 5.3 Modify `Contratos.cs`: widen `FilaDeReposicion` with
   `ConsumoDiarioPromedio?`, `DiasDeCobertura?`; add `FilaDeRotacion(IdArticulo,
   Articulo, ConsumoEnVentana, ConsumoDiarioPromedio, MinimoSugerido)` and
   `Rotacion(IdPuntoVenta, Hoy, DiasDeRotacion, DiasCoberturaObjetivo,
   ZonaHoraria, Filas)`. `dto-contract-honesty`: doc-comment that an articulo
   absent from `Rotacion.Filas` means "no qualifying movement", never a row
   with zero-valued fields (design decision 14).
-- [ ] 5.4 Modify `ServicioDeReportesDeStock.cs`:
+- [x] 5.4 Modify `ServicioDeReportesDeStock.cs`:
   `ObtenerRotacionAsync(idPuntoVenta, dias?, ct)` — same consumption
   definition and window resolution as 5.1-5.2 (never a second definition),
   one row per articulo with a qualifying movement in the window; an
   articulo with none is **absent**, never present with `minimoSugerido = 0`.
-- [ ] 5.5 Modify `ReportesEndpoints.cs`:
+  Resolves `dias_cobertura_objetivo` via a new private
+  `ResolverDiasCoberturaAsync` (design's private-surfaces grouping, slice 5).
+  A soft-deleted articulo whose ledger still has qualifying movements is
+  filtered out of `Filas` via the EF global filter on `Articulo` — same
+  inherited trade-off as `ExistenciasTests.UnArticuloEliminadoNuncaApareceEnLasExistencias`
+  (design: Open Questions), documented inline rather than crashing on a
+  missing name.
+- [x] 5.5 Modify `ReportesEndpoints.cs`:
   `GET /reportes/stock/rotacion?idPuntoVenta[&dias]`, `Politicas.LecturaDeReportes`.
-- [ ] 5.6 [P] **Mutation target**: delete `&& m.IdComprobanteCompra == null`
+- [x] 5.6 [P] **Mutation target**: delete `&& m.IdComprobanteCompra == null`
   from `LeerConsumoAsync`'s filter — the netting-trap test (5.10) must fail.
-  *(mutation-proof-tests)*
-- [ ] 5.7 [P] **Mutation target**: `VentanaDeRotacion`'s zone conversion —
+  *(mutation-proof-tests)* **EVIDENCE**: mutated to
+  `(m.Motivo == MotivoStock.Anulacion /* MUTATION 5.6 */)`, ran
+  `LaRotacionNoNeteaLaAnulacionDeUnaCompraDentroDeLasVentas` → FAILED
+  (`Assert.Equal() Failure: Expected: 5 Actual: 20` — the compra's −15
+  reversal negated back in as +15 consumption, 8−3+15=20), reverted,
+  `git status`/`git diff --stat` clean, suite green again.
+- [x] 5.7 [P] **Mutation target**: `VentanaDeRotacion`'s zone conversion —
   replace with `hoy`/edges computed from `reloj.Ahora.UtcDateTime` — the
   midday-UTC boundary test (5.11) must fail. *(mutation-proof-tests, the
-  stage-11 slice-9 bug class hardened by `08e7707`)*
-- [ ] 5.8 [P] **Mutation target**: `ConsumoDiario`'s `netoConsumido is null
+  stage-11 slice-9 bug class hardened by `08e7707`)* **EVIDENCE**: the
+  wiring-level equivalent of this mutation is the zone argument
+  `ObtenerRotacionAsync` passes into `VentanaDeRotacion` (the pure function
+  itself is already unit-proven by `ReglaDeReposicionTests`) — mutated
+  `TimeZoneInfo.FindSystemTimeZoneById(zonaId)` to `TimeZoneInfo.Utc /*
+  MUTATION 5.7 */` in that call, ran
+  `LaVentanaDeRotacionResuelveElBordeEnLaZonaHorariaDelPuntoDeVenta` →
+  FAILED (`Expected: 9 Actual: 22` — the "outside" movement at 02:00Z fell
+  inside the shifted UTC-only window), reverted, clean diff, suite green.
+- [x] 5.8 [P] **Mutation target**: `ConsumoDiario`'s `netoConsumido is null
   ⇒ null` — return `0m` instead — the zero-history test (5.12) must fail.
-  *(mutation-proof-tests)*
-- [ ] 5.9 [P] **Mutation target**: the `filas.Count == 0` early return in
+  *(mutation-proof-tests)* **EVIDENCE**: mutated
+  `ReglaDeReposicion.ConsumoDiario` to `netoConsumido is null ? 0m /*
+  MUTATION 5.8 */ : …`, ran
+  `UnArticuloSinHistoriaDeConsumoMuestraNulosDeRotacionEnLaReposicionNuncaCero`
+  → FAILED (`Assert.Null() Failure: Expected: null Actual: 0`), reverted,
+  clean diff, suite green.
+- [x] 5.9 [P] **Mutation target**: the `filas.Count == 0` early return in
   `ObtenerReposicionAsync` (wired in slice 4, exercised here) — delete it —
   the empty-PV query-count test (5.14) must fail. *(mutation-proof-tests)*
-- [ ] 5.10 [P] Integration, named:
+  **EVIDENCE**: deleted the `if (crudas.Count == 0) { return …; }` guard
+  (the empty branch still yields empty `Filas`, but now issues one extra
+  query filtering `LeerConsumoAsync` by an empty id list), ran
+  `UnPuntoDeVentaSinMinimosNoConsultaMovimientosStock` → FAILED
+  (`Assert.Equal() Failure: Expected: 6 Actual: 7`), reverted, clean diff,
+  suite green.
+- [x] 5.10 [P] Integration, named:
   `LaRotacionNoNeteaLaAnulacionDeUnaCompraDentroDeLasVentas` — seed compra
   → confirm → **anular la compra** (`motivo = anulacion` **with**
   `id_comprobante_compra`) → sale → **anular la venta** (`motivo =
@@ -717,55 +750,111 @@ functions.
   equals exactly the sale minus its own anulación, all magnitudes distinct.
   *(spec `reposicion-de-stock`: "Rotation Excludes Purchase-Reversal
   Anulaciones And Is Advisory-Only", scenario "A purchase anulación is
-  excluded from consumption")*
-- [ ] 5.11 [P] Integration, the clock pinned at `2026-08-14T12:00:00Z`, PV
+  excluded from consumption")* Compra leg driven through the real
+  `POST /api/compras` → `/confirmar` → `/anular` flow (genuine
+  `id_comprobante_compra` FK, same pattern as
+  `ComprasAnulacionYConcurrenciaTests`); sale + its anulación seeded directly
+  on the ledger (`SembrarMovimientoAsync`, same precedent as that file's
+  `ReducirStockComoVentaAsync` — no FK requirement on a null comprobante).
+  Magnitudes 15 (compra, excluded)/8 (venta)/3 (anulación de venta)/5 (net)
+  all distinct.
+- [x] 5.11 [P] Integration, the clock pinned at `2026-08-14T12:00:00Z`, PV
   zone `America/Argentina/Buenos_Aires` (local `09:00`), `dias = 1`. A
   movement at `2026-08-14T02:00:00Z` (local `2026-08-13 23:00`) is
   **outside** the window; one at `2026-08-14T04:00:00Z` (local `01:00`) is
   **inside**. Distinct magnitudes. *(spec: "The rotation window resolves
-  in the punto de venta's own zona horaria")*
-- [ ] 5.12 [P] Integration: an articulo with no qualifying movement in the
+  in the punto de venta's own zona horaria")* Magnitudes 13
+  (outside)/9 (inside), single articulo, `factoryConRelojFijo` pattern
+  (`VencimientosReporteTests` precedent).
+- [x] 5.12 [P] Integration: an articulo with no qualifying movement in the
   window shows `minimoSugerido = null` on the reposición report, not `0`.
   *(spec: "A zero-history articulo shows no suggestion rather than a
-  suggestion of zero")*
-- [ ] 5.13 [P] Integration: a mixed sequence containing `ajuste`,
+  suggestion of zero")* **APPLY NOTE**: `FilaDeReposicion` has no
+  `minimoSugerido` field (design's own Interfaces/Contracts section — that
+  field lives only on `FilaDeRotacion`); the task text's `minimoSugerido`
+  is stale relative to the pinned `Contratos.cs` record. Implemented as
+  the accurate translation of the same spec scenario onto the actual
+  reposición fields: `ConsumoDiarioPromedio`/`DiasDeCobertura` both `null`
+  (never `0`) for an articulo under mínimo with zero qualifying movements.
+  `GET /rotacion`'s own absence behavior for the identical fact is covered
+  separately by 5.17.
+- [x] 5.13 [P] Integration: a mixed sequence containing `ajuste`,
   `inventario`, `decomiso`, `transferencia` and `reclasificacion`, each with
   a distinct magnitude, leaves `consumoEnVentana` unchanged from the
   sales-only baseline. *(spec: "ajuste, inventario, decomiso, transferencia
-  and reclasificacion never count as consumption")*
-- [ ] 5.14 [P] Integration, by query count: a PV with hundreds of stocked
+  and reclasificacion never count as consumption")* Baseline venta 20;
+  five excluded motivos at 1/2/3/4/5.
+- [x] 5.14 [P] Integration, by query count: a PV with hundreds of stocked
   articulos and zero minimums returns zero rows **and issues no query
   against `movimientos_stock`** — `ContadorDeComandos`, exact constant.
   *(spec: "A catalog with no minimo configured anywhere returns zero alert
-  rows")*
-- [ ] 5.15 [P] Integration: an arbitrary rotation figure never gates the
+  rows")* 200 seeded articulos; calls `ServicioDeReportesDeStock.ObtenerReposicionAsync`
+  directly (manual `WaysDbContext` + interceptors, `VentasCheckoutTests`
+  precedent) — exact constant is **6** (2 from `ResolverContextoAsync`, 2
+  from `ResolverDiasRotacionAsync`, 1 from `ConstruirQueryDeReposicion`;
+  `ServicioDeParametros.ResolverAsync` itself issues 2 — the PV-ownership
+  `AnyAsync` guard plus the `parametros` row read), confirmed by a real run
+  before recording the assertion, not derived-and-assumed.
+- [x] 5.15 [P] Integration: an arbitrary rotation figure never gates the
   alert — an articulo at `cantidad <= minimo` appears independent of its
   rotation value. *(spec: "A wrong rotation figure never gates the alert")*
-- [ ] 5.16 [P] Integration: `?dias=60` on `GET /reposicion?idPuntoVenta=7`
+  Seeded a deliberately large qualifying sale (500) to prove a big rotation
+  figure still doesn't suppress or alter row inclusion.
+- [x] 5.16 [P] Integration: `?dias=60` on `GET /reposicion?idPuntoVenta=7`
   widens the window so a 45-day-old sale contributes; the same `?dias=60`
   on `GET /rotacion?idPuntoVenta=7` shows the articulo with a
   `minimoSugerido` reflecting it. *(spec: "An explicit dias override widens
   the reposición report's window"; "dias overrides the default window on
-  the rotacion route too")*
-- [ ] 5.17 [P] Integration: `GET /rotacion` omits an articulo with no
+  the rotacion route too")* Sale magnitude 60, chosen so `consumoDiarioPromedio
+  = 60/60 = 1` exactly at `dias=60` — asserted absent/null at the default
+  30-day window on both routes, present/non-null at `dias=60` on both.
+- [x] 5.17 [P] Integration: `GET /rotacion` omits an articulo with no
   qualifying movement — absence, never a zero row. *(spec `GET
   /api/reportes/stock/rotacion…`: "An articulo with no consumption history
-  is absent, not zero")*
-- [ ] 5.18 [P] `parametros-operativos` scenario:
+  is absent, not zero")* Two articulos in the same PV, only one with a
+  qualifying movement — the other's absence asserted directly (not an
+  empty-response coincidence).
+- [x] 5.18 [P] `parametros-operativos` scenario:
   `dias_cobertura_objetivo = 7` and an average daily consumption of `3` ⇒
   `minimoSugerido = 21`, shown as a suggestion, never written to
   `stock.minimo`. *(spec `parametros-operativos`: "dias_cobertura_objetivo
-  feeds minimoSugerido, never minimo directly")*
-- [ ] 5.19 [P] Integration: after `/reposicion` or `/reposicion` runs for an
+  feeds minimoSugerido, never minimo directly")* Consumo total 90 over the
+  default 30-day window ⇒ `consumoDiarioPromedio = 3`; default
+  `dias_cobertura_objetivo = 7` ⇒ `minimoSugerido = 21`; re-reads
+  `stock.minimo` after the call and asserts it is still `NULL`.
+- [x] 5.19 [P] Integration: after `/reposicion` or `/reposicion` runs for an
   articulo with a computable `minimoSugerido` and no `minimo`, re-read
   `stock.minimo` and assert it is still `NULL` — no automated write ever
   occurs outside `PUT /api/stock/minimos`. *(spec `reposicion-de-stock`:
-  "minimoSugerido is never written to minimo automatically")*
-- [ ] 5.20 Gate guard: `has-pending-model-changes` clean, zero migration
-  files in the diff.
+  "minimoSugerido is never written to minimo automatically")* **APPLY
+  NOTE**: task text literally says "after `/reposicion` or `/reposicion`
+  runs" (repeats the same route) — interpreted as `/reposicion` or
+  `/rotacion`, the only reading consistent with 5.16 immediately above
+  (which names both routes together) and with this task's own placement
+  right after 5.18's single-route write-check. Implemented calling BOTH
+  routes for the same articulo (qualifying movement seeded, `minimo`
+  left `NULL`) and re-reading `stock.minimo` as `NULL` after each call.
+- [x] 5.20 Gate guard: `has-pending-model-changes` clean, zero migration
+  files in the diff. **VERIFIED**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure --startup-project
+  src/Ways.Infrastructure` → "No changes have been made to the model since
+  the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
+  files).
 - [ ] 5.21 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 5.22 Branch `feat/stage13-slice5-rotacion` off `main` (parent:
   slice 4); PR; merge stacked-to-main.
+
+**APPLY NOTE (Verify line, no mismatch this time)**: unlike slices 2 and 4,
+this slice's `Verify` filter runs clean as literally written —
+`~RotacionReport` matches the new `RotacionReporteTests` class (all 10
+tests); `~LeerConsumoAsync` matches nothing extra (the method is private,
+no test name contains that substring) but the `|` OR keeps the filter
+non-empty. Also ran the wider `~Rotacion|~Reposicion` filter (25 tests,
+covering the slice-4 `ReposicionReporteTests`/`ReposicionExportTests`
+regression surface widened by this slice) and the Domain
+`~ReglaDeReposicion` suite (28 tests) — both green, see Work Unit Evidence
+in the apply summary.
 
 **Test plan**: 4 mutation targets (5.6-5.9), netting trap (5.10),
 midday-UTC boundary (5.11), zero-history (5.12), motivo exclusions (5.13),

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -862,9 +862,10 @@ functions.
   #6 SUGGESTION (dead `Contexto.Vendedor` setup — closed with test
   `UnVendedorEsRechazadoDelReporteDeRotacion`, mirror of 4.11); #7
   SUGGESTION (incoherent narrative in the 5.10 doc-comment — corrected to
-  the real observed value, Expected 5 / Actual 20). All five new
-  6 new integration tests confirmed FAIL under their named mutation and
-  PASS on revert. Filtered suite `~Rotacion|~Reposicion` green: 60/60
+  the real observed value, Expected 5 / Actual 20). Five of the 6 new
+  integration tests confirmed FAIL under their named mutation and PASS on
+  revert (the sixth, the Vendedor-403 mirror, is an auth-gate test with no
+  named mutation). Filtered suite `~Rotacion|~Reposicion` green: 60/60
   (29 `Ways.Domain.Tests` + 31 `Ways.IntegrationTests`, up from 25
   integration baseline + 6 new).)*
 - [ ] 5.22 Branch `feat/stage13-slice5-rotacion` off `main` (parent:

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -469,6 +469,20 @@ public static class ReportesEndpoints
             "de filas exigido tras mapear — agregado acotado por catálogo, mismo criterio que " +
             "/stock/existencias/export.");
 
+        // stage-13-stock-inteligente, Slice 5 (design decisión 14, spec reposicion-de-stock:
+        // "GET /api/reportes/stock/rotacion Feeds The Suggested-Minimo Column..."): gate heredado
+        // del grupo. Feed INDEPENDIENTE de minimoSugerido — no depende de minimo, agrega sobre
+        // TODO el catálogo del PV (design decisión 12); un artículo sin movimiento calificado en
+        // la ventana está AUSENTE, nunca una fila en cero. dias opcional, mismo criterio que
+        // /stock/reposicion?dias=.
+        grupo.MapGet("/stock/rotacion", (
+            ServicioDeReportesDeStock servicio, int idPuntoVenta, int? dias, CancellationToken ct) =>
+            servicio.ObtenerRotacionAsync(idPuntoVenta, dias, ct))
+        .WithSummary(
+            "Feed de minimoSugerido para el editor: una fila por artículo con al menos un " +
+            "movimiento calificado (venta o su anulación, nunca la anulación de una compra) en " +
+            "la ventana de rotación — ausente, nunca en cero, cuando no rota.");
+
         // stage-11-exportacion-reportes, Slice 5a (design: G2/G3 — minimal aggregation; spec
         // historico-de-cajas: G2 Histórico Lists Closed Turnos Only, Role Split — Turno Detail
         // Under OperacionDePos, Cross-Turno Views Under LecturaDeReportes): gate heredado del

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -194,20 +194,59 @@ public sealed record ResumenDeVencimientos(int IdPuntoVenta, int Vencidos, int P
 /// <see cref="IdProveedor"/> <c>null</c> también — el FK crudo NUNCA viaja al cliente cuando el
 /// proveedor referenciado no resuelve (orchestrator decision 12, tasks.md stage-13): un solo
 /// bucket "Sin proveedor", nunca un FK colgante ni un segundo bucket a mitad de lista.</item>
-/// <item><see cref="ConsumoDiarioPromedio"/>/<see cref="DiasDeCobertura"/> — AUSENTES por diseño en
-/// esta slice, no por omisión: la slice 5 los agrega cuando <c>LeerConsumoAsync</c> exista (design:
-/// "The four rotation fields do NOT exist in slice 4").</item>
+/// <item><see cref="ConsumoDiarioPromedio"/>/<see cref="DiasDeCobertura"/> — stage-13, Slice 5:
+/// <see cref="Ways.Domain.Stock.ReglaDeReposicion.ConsumoDiario"/>/<see
+/// cref="Ways.Domain.Stock.ReglaDeReposicion.DiasDeCobertura"/> aplicadas sobre el consumo que
+/// <c>LeerConsumoAsync</c> lee de <c>movimientos_stock</c> en la ventana de rotación — AMBOS
+/// <c>null</c> (JAMÁS <c>0</c>) cuando el artículo no tiene ningún movimiento calificado en la
+/// ventana (spec: "A zero-history articulo shows no suggestion rather than a suggestion of
+/// zero"), nunca una segunda definición de "consumo" distinta de la que usa <c>GET
+/// /reportes/stock/rotacion</c> (design decisión 5).</item>
 /// </list></summary>
 public sealed record FilaDeReposicion(
     int IdArticulo, string Articulo, decimal Cantidad, decimal Minimo, decimal? Reposicion,
-    decimal? Sugerido, int? IdProveedor, string? Proveedor);
+    decimal? Sugerido, int? IdProveedor, string? Proveedor,
+    decimal? ConsumoDiarioPromedio, decimal? DiasDeCobertura);
 
 /// <summary>Respuesta de <c>GET /api/reportes/stock/reposicion</c>. <see cref="Hoy"/> y
 /// <see cref="ZonaHoraria"/> son la fecha y la zona resueltas para el punto de venta — mismo
-/// criterio de echo obligatorio que <see cref="Vencimientos.Hoy"/>/<see cref="Vencimientos.ZonaHoraria"/>,
-/// aunque esta slice todavía no las usa para clasificar nada (la ventana de rotación llega en la
-/// slice 5). <see cref="DiasDeRotacion"/> es el horizonte efectivamente resuelto: el parámetro
+/// criterio de echo obligatorio que <see cref="Vencimientos.Hoy"/>/<see cref="Vencimientos.ZonaHoraria"/>;
+/// desde la slice 5 también gobiernan la ventana de rotación de cada fila (<see
+/// cref="Ways.Domain.Stock.ReglaDeReposicion.VentanaDeRotacion"/>), nunca una segunda resolución de
+/// "hoy". <see cref="DiasDeRotacion"/> es el horizonte efectivamente resuelto: el parámetro
 /// <c>dias</c> de la query si vino, si no <c>dias_rotacion</c> (default 30).</summary>
 public sealed record Reposicion(
     int IdPuntoVenta, DateOnly Hoy, int DiasDeRotacion, string ZonaHoraria,
     IReadOnlyList<FilaDeReposicion> Filas);
+
+/// <summary>Fila de <c>GET /api/reportes/stock/rotacion</c> (stage-13-stock-inteligente, Slice 5;
+/// design: Interfaces / Contracts, decisión 14). Solo existe porque el artículo tiene AL MENOS UN
+/// movimiento calificado (<c>venta</c> o <c>anulacion</c> de venta) en la ventana — un artículo sin
+/// historia NO ES UNA FILA de esta lista, la ausencia es la respuesta honesta (nunca una fila con
+/// <see cref="MinimoSugerido"/> <c>0</c>; design decisión 14). <c>dto-contract-honesty</c>:
+/// <see cref="ConsumoEnVentana"/> es <c>-SUM(movimientos_stock.cantidad)</c> sobre las filas
+/// calificadas de la ventana (design decisión 6, la trampa del neteo: venta negativa, anulación de
+/// venta positiva, anulación de COMPRA excluida vía <c>id_comprobante_compra IS NOT NULL</c>),
+/// recortado a <c>0</c> — nunca negativo — cuando las devoluciones superan a las ventas (mismo
+/// criterio de <see cref="Ways.Domain.Stock.ReglaDeReposicion.ConsumoDiario"/>: un consumo negativo
+/// no es una magnitud de negocio, pero la fila SÍ existe porque hubo historia calificada);
+/// <see cref="ConsumoDiarioPromedio"/> es <see cref="ConsumoEnVentana"/> dividido por
+/// <c>dias_rotacion</c> efectivo (nunca negativo — recortado a 0 si las devoluciones superan a las
+/// ventas); <see cref="MinimoSugerido"/> es <see cref="ConsumoDiarioPromedio"/> ×
+/// <c>dias_cobertura_objetivo</c> (<see cref="Ways.Domain.Stock.ReglaDeReposicion.MinimoSugerido"/>),
+/// una SUGERENCIA que ningún camino automatizado escribe en <c>stock.minimo</c> (spec
+/// reposicion-de-stock: "minimoSugerido is never written to minimo automatically").</summary>
+public sealed record FilaDeRotacion(
+    int IdArticulo, string Articulo, decimal ConsumoEnVentana, decimal ConsumoDiarioPromedio,
+    decimal MinimoSugerido);
+
+/// <summary>Respuesta de <c>GET /api/reportes/stock/rotacion</c>. <see cref="Hoy"/>/<see
+/// cref="ZonaHoraria"/>/<see cref="DiasDeRotacion"/> son el mismo eco obligatorio que <see
+/// cref="Reposicion"/> — misma ventana, misma definición de consumo (design decisión 5, nunca una
+/// segunda). <see cref="DiasCoberturaObjetivo"/> es el horizonte de cobertura efectivamente
+/// resuelto (<c>dias_cobertura_objetivo</c>, PV → empresa → default 7) que <see
+/// cref="FilaDeRotacion.MinimoSugerido"/> multiplica — echo obligatorio, mismo criterio que
+/// <see cref="DiasDeRotacion"/>: una sugerencia cuyo horizonte es invisible no es auditable.</summary>
+public sealed record Rotacion(
+    int IdPuntoVenta, DateOnly Hoy, int DiasDeRotacion, int DiasCoberturaObjetivo, string ZonaHoraria,
+    IReadOnlyList<FilaDeRotacion> Filas);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -187,7 +187,8 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
         var (idEmpresa, zonaId, hoy) = await ResolverContextoAsync(idPuntoVenta, ct);
         var diasDeRotacion = ReglaDeReposicion.ExigirVentanaValida(
             dias ?? await ResolverDiasRotacionAsync(idEmpresa, idPuntoVenta, ct), "dias_rotacion_invalido");
-        var diasDeCoberturaObjetivo = await ResolverDiasCoberturaAsync(idEmpresa, idPuntoVenta, ct);
+        var diasDeCoberturaObjetivo = ReglaDeReposicion.ExigirVentanaValida(
+            await ResolverDiasCoberturaAsync(idEmpresa, idPuntoVenta, ct), "dias_cobertura_invalido");
 
         var (desdeUtc, hastaUtc) = ReglaDeReposicion.VentanaDeRotacion(hoy, diasDeRotacion, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
         var consumo = await LeerConsumoAsync(idPuntoVenta, idsArticulo: null, desdeUtc, hastaUtc, ct);

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -37,9 +37,15 @@ namespace Ways.Application.Reportes;
 /// agrega <see cref="ObtenerReposicionAsync"/> — la alerta y la sugerencia de compra son la misma
 /// lista (<c>minimo IS NOT NULL AND cantidad &lt;= minimo</c>), agregado acotado por el catálogo
 /// como existencias (mismo shape de export: guarda sobre <c>TablaExportable.Filas.Count</c> ya
-/// mapeada, sin <c>ObtenerReposicionParaExportacionAsync</c> propio — decisión 13). Sin campos de
-/// rotación todavía: la slice 5 completa <see cref="FilaDeReposicion"/> con
-/// <c>ConsumoDiarioPromedio</c>/<c>DiasDeCobertura</c> vía <c>LeerConsumoAsync</c>.
+/// mapeada, sin <c>ObtenerReposicionParaExportacionAsync</c> propio — decisión 13).
+///
+/// stage-13-stock-inteligente, Slice 5 (design decisión 5/6/7/12, spec reposicion-de-stock:
+/// "Rotation Excludes Purchase-Reversal Anulaciones And Is Advisory-Only"): agrega <see
+/// cref="LeerConsumoAsync"/> — LA definición de consumo, dos llamadores (<see
+/// cref="ObtenerReposicionAsync"/>, que ahora completa <c>ConsumoDiarioPromedio</c>/<c>
+/// DiasDeCobertura</c> por fila, y <see cref="ObtenerRotacionAsync"/>, el feed independiente de
+/// <c>minimoSugerido</c> para el editor). Plain LINQ sobre <c>db.MovimientosStock</c> — cero SQL
+/// crudo, <c>LectorDeSerieTemporal</c> intocado (design decisión 7 del proposal).
 /// </summary>
 public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros parametros, IRelojDelSistema reloj)
 {
@@ -121,12 +127,11 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
         return new Vencimientos(idPuntoVenta, hoy, diasDeAlerta, zonaId, Clasificar(filas, hoy, diasDeAlerta));
     }
 
-    /// <summary>stage-13-stock-inteligente, Slice 4 (design decisión 12; task 4.2): la alerta y la
-    /// sugerencia de compra son la MISMA lista — <see cref="ConstruirQueryDeReposicion"/> se
-    /// evalúa una única vez, sin campos de rotación todavía (esos llegan en la slice 5, que
-    /// completa la rama <c>crudas.Count &gt; 0</c> de abajo con <c>LeerConsumoAsync</c>).
-    /// El corto-circuito de la fila 0 se cablea ACÁ (decisión 12) para que la slice 5 no tenga
-    /// que reestructurar el método, solo llenar la rama que hoy es un mapeo puro.</summary>
+    /// <summary>stage-13-stock-inteligente, Slice 4/5 (design decisión 12; task 4.2/5.2): la
+    /// alerta y la sugerencia de compra son la MISMA lista — <see cref="ConstruirQueryDeReposicion"/>
+    /// se evalúa una única vez. El corto-circuito de la fila 0 (decisión 12) evita que una fila
+    /// vacía dispare la query de rotación: un PV sin mínimos configurados cuesta exactamente UNA
+    /// query (la de acá arriba), nunca <see cref="LeerConsumoAsync"/>.</summary>
     public async Task<Reposicion> ObtenerReposicionAsync(
         int idPuntoVenta, int? dias, CancellationToken ct = default)
     {
@@ -141,16 +146,82 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
             return new Reposicion(idPuntoVenta, hoy, diasDeRotacion, zonaId, []);
         }
 
-        // Sugerido es puro (ReglaDeReposicion.Sugerido no depende de rotación) — la slice 5 solo
-        // agrega ConsumoDiarioPromedio/DiasDeCobertura a esta misma proyección, nunca una segunda.
+        // Slice 5: misma ventana y misma definición de consumo que ObtenerRotacionAsync (design
+        // decisión 5) — LeerConsumoAsync acotado a los ids de ESTAS filas (decisión 12: nunca todo
+        // el catálogo del PV, el set "bajo mínimo" ya es chico por construcción).
+        var (desdeUtc, hastaUtc) = ReglaDeReposicion.VentanaDeRotacion(hoy, diasDeRotacion, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+        var consumo = await LeerConsumoAsync(
+            idPuntoVenta, crudas.Select(f => f.IdArticulo).ToList(), desdeUtc, hastaUtc, ct);
+
+        // Sugerido es puro (ReglaDeReposicion.Sugerido no depende de rotación); ConsumoDiarioPromedio/
+        // DiasDeCobertura sí — honestos en null (nunca 0) cuando el artículo no calificó ningún
+        // movimiento en la ventana (spec: "A zero-history articulo shows no suggestion...").
         var filas = crudas
-            .Select(f => new FilaDeReposicion(
-                f.IdArticulo, f.Articulo, f.Cantidad, f.Minimo, f.Reposicion,
-                ReglaDeReposicion.Sugerido(f.Cantidad, f.Reposicion),
-                f.IdProveedorHabitual, f.Proveedor))
+            .Select(f =>
+            {
+                var netoConsumido = consumo.TryGetValue(f.IdArticulo, out var neto) ? -neto : (decimal?)null;
+                var consumoDiarioPromedio = ReglaDeReposicion.ConsumoDiario(netoConsumido, diasDeRotacion);
+
+                return new FilaDeReposicion(
+                    f.IdArticulo, f.Articulo, f.Cantidad, f.Minimo, f.Reposicion,
+                    ReglaDeReposicion.Sugerido(f.Cantidad, f.Reposicion),
+                    f.IdProveedorHabitual, f.Proveedor,
+                    consumoDiarioPromedio, ReglaDeReposicion.DiasDeCobertura(f.Cantidad, consumoDiarioPromedio));
+            })
             .ToList();
 
         return new Reposicion(idPuntoVenta, hoy, diasDeRotacion, zonaId, filas);
+    }
+
+    /// <summary>stage-13-stock-inteligente, Slice 5 (design decisión 14; task 5.4): el feed
+    /// independiente de <c>minimoSugerido</c> para el editor — a diferencia de <see
+    /// cref="ObtenerReposicionAsync"/>, NO depende de <c>minimo</c>: agrega sobre TODO el catálogo
+    /// del PV (decisión 12, "el único lugar donde ese costo es el punto"), pero solo emite una fila
+    /// por artículo con AL MENOS UN movimiento calificado en la ventana — la ausencia es la
+    /// respuesta para un artículo sin historia, nunca una fila con <c>minimoSugerido = 0</c>
+    /// (decisión 14). Misma definición de consumo y misma resolución de ventana que <see
+    /// cref="ObtenerReposicionAsync"/> (design decisión 5): nunca una segunda.</summary>
+    public async Task<Rotacion> ObtenerRotacionAsync(
+        int idPuntoVenta, int? dias, CancellationToken ct = default)
+    {
+        var (idEmpresa, zonaId, hoy) = await ResolverContextoAsync(idPuntoVenta, ct);
+        var diasDeRotacion = ReglaDeReposicion.ExigirVentanaValida(
+            dias ?? await ResolverDiasRotacionAsync(idEmpresa, idPuntoVenta, ct), "dias_rotacion_invalido");
+        var diasDeCoberturaObjetivo = await ResolverDiasCoberturaAsync(idEmpresa, idPuntoVenta, ct);
+
+        var (desdeUtc, hastaUtc) = ReglaDeReposicion.VentanaDeRotacion(hoy, diasDeRotacion, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+        var consumo = await LeerConsumoAsync(idPuntoVenta, idsArticulo: null, desdeUtc, hastaUtc, ct);
+
+        if (consumo.Count == 0)
+        {
+            return new Rotacion(idPuntoVenta, hoy, diasDeRotacion, diasDeCoberturaObjetivo, zonaId, []);
+        }
+
+        // El ledger es append-only: un artículo dado de baja después de sus movimientos sigue
+        // calificando en LeerConsumoAsync (que no conoce baja lógica), pero el filtro global de
+        // EF sobre Articulo sí lo excluye acá — mismo trade-off ya documentado que
+        // ExistenciasTests.UnArticuloEliminadoNuncaApareceEnLasExistencias (design: Open
+        // Questions), nunca una excepción por nombre ausente.
+        var idsArticulo = consumo.Keys.ToList();
+        var nombres = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .Select(a => new { a.Id, a.Nombre })
+            .ToDictionaryAsync(a => a.Id, a => a.Nombre, ct);
+
+        var filas = consumo
+            .Where(par => nombres.ContainsKey(par.Key))
+            .Select(par =>
+            {
+                var consumoEnVentana = Math.Max(0m, -par.Value);
+                var consumoDiarioPromedio = ReglaDeReposicion.ConsumoDiario(consumoEnVentana, diasDeRotacion)!.Value;
+                var minimoSugerido = ReglaDeReposicion.MinimoSugerido(consumoDiarioPromedio, diasDeCoberturaObjetivo)!.Value;
+
+                return new FilaDeRotacion(par.Key, nombres[par.Key], consumoEnVentana, consumoDiarioPromedio, minimoSugerido);
+            })
+            .OrderBy(f => f.IdArticulo)
+            .ToList();
+
+        return new Rotacion(idPuntoVenta, hoy, diasDeRotacion, diasDeCoberturaObjetivo, zonaId, filas);
     }
 
     /// <summary>Cláusulas bajo prueba (mutation-proof-tests, en orden de daño si se pierden):
@@ -256,12 +327,63 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
         return JsonSerializer.Deserialize<int>(resuelto.Valor);
     }
 
-    /// <summary>Slice 4 — mismo patrón que <see cref="ResolverDiasAlertaAsync"/>. La slice 5 agrega
-    /// el resolver gemelo de <c>dias_cobertura_objetivo</c>, todavía sin consumidor acá.</summary>
+    /// <summary>Slice 4 — mismo patrón que <see cref="ResolverDiasAlertaAsync"/>.</summary>
     private async Task<int> ResolverDiasRotacionAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
     {
         var resuelto = await parametros.ResolverAsync(ParametroConocido.DiasRotacion.Clave, idEmpresa, idPuntoVenta, ct);
         return JsonSerializer.Deserialize<int>(resuelto.Valor);
+    }
+
+    /// <summary>Slice 5 — resolver gemelo de <see cref="ResolverDiasRotacionAsync"/>, para el
+    /// horizonte de cobertura que <see cref="ObtenerRotacionAsync"/> multiplica por el consumo
+    /// diario promedio (<see cref="Ways.Domain.Stock.ReglaDeReposicion.MinimoSugerido"/>). A
+    /// diferencia de <c>dias_rotacion</c>, ninguna ruta acepta un <c>?dias=</c> que lo
+    /// sobrescriba — solo el parámetro resuelto (spec: "dias_cobertura_objetivo feeds
+    /// minimoSugerido, never minimo directly").</summary>
+    private async Task<int> ResolverDiasCoberturaAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var resuelto = await parametros.ResolverAsync(ParametroConocido.DiasCoberturaObjetivo.Clave, idEmpresa, idPuntoVenta, ct);
+        return JsonSerializer.Deserialize<int>(resuelto.Valor);
+    }
+
+    /// <summary>Slice 5 (design decisión 5/6/7; task 5.1): LA definición de consumo, con dos
+    /// llamadores (<see cref="ObtenerReposicionAsync"/>, <see cref="ObtenerRotacionAsync"/>) —
+    /// nunca una segunda. Cláusula bajo prueba (mutation-proof-tests): <c>m.Motivo ==
+    /// MotivoStock.Anulacion &amp;&amp; m.IdComprobanteCompra == null</c> — sin el segundo
+    /// término, la anulación de una COMPRA (que también escribe <c>motivo = anulacion</c> desde la
+    /// etapa 8) se netea silenciosamente dentro de las ventas (la trampa del neteo, design
+    /// decisión 6). <paramref name="idsArticulo"/> nulo agrega sobre TODO el catálogo del PV — el
+    /// caso de <see cref="ObtenerRotacionAsync"/>, el único lugar donde ese costo es el punto
+    /// (design decisión 12); <see cref="ObtenerReposicionAsync"/> siempre pasa la lista acotada
+    /// de artículos ya bajo mínimo. Plain LINQ sobre <c>db.MovimientosStock</c> — cero SQL crudo,
+    /// hereda los filtros globales de tenant/baja-lógica de EF gratis, mismo criterio que <see
+    /// cref="ObtenerExistenciasAsync"/> (design decisión 7 del proposal: el fork con
+    /// <c>LectorDeSerieTemporal</c> no aplica acá — una ventana de instantes, sin bucketing).
+    /// El llamador NIEGA el neto (<c>-neto</c>): las filas de venta llevan <c>cantidad</c>
+    /// negativa, la anulación de venta positiva, y una NCX viaja como venta con <c>cantidad</c>
+    /// POSITIVA (<c>ServicioDeVentas</c> ya la negó) — <c>-SUM</c> neteas devoluciones sin una
+    /// rama de signo.</summary>
+    private async Task<IReadOnlyDictionary<int, decimal>> LeerConsumoAsync(
+        int idPuntoVenta, IReadOnlyList<int>? idsArticulo, DateTimeOffset desdeUtc, DateTimeOffset hastaUtcExclusivo,
+        CancellationToken ct)
+    {
+        var query = db.MovimientosStock
+            .Where(m => m.IdPuntoVenta == idPuntoVenta
+                     && m.CreadoEl >= desdeUtc && m.CreadoEl < hastaUtcExclusivo
+                     && (m.Motivo == MotivoStock.Venta
+                         || (m.Motivo == MotivoStock.Anulacion && m.IdComprobanteCompra == null)));
+
+        if (idsArticulo is not null)
+        {
+            query = query.Where(m => idsArticulo.Contains(m.IdArticulo));
+        }
+
+        var filas = await query
+            .GroupBy(m => m.IdArticulo)
+            .Select(g => new { IdArticulo = g.Key, Neto = g.Sum(m => m.Cantidad) })
+            .ToListAsync(ct);
+
+        return filas.ToDictionary(f => f.IdArticulo, f => f.Neto);
     }
 
     private sealed record FilaCruda(

--- a/tests/Ways.IntegrationTests/RotacionReporteTests.cs
+++ b/tests/Ways.IntegrationTests/RotacionReporteTests.cs
@@ -1,0 +1,559 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using System.Data.Common;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Parametros;
+using Ways.Application.Reportes;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-13-stock-inteligente, Slice 5 (tasks 5.6-5.19): rotación — la trampa del neteo (mutation
+/// target 5.6), el borde de ventana en la zona horaria del PV (5.7), la historia cero (5.8), el
+/// corto-circuito de PV sin mínimos por conteo exacto de queries (5.9), los motivos excluidos, el
+/// override <c>?dias=</c> en ambas rutas, la ausencia (nunca fila en cero) de <c>GET /rotacion</c>,
+/// <c>dias_cobertura_objetivo</c> alimentando <c>minimoSugerido</c> y el invariante de no-escritura
+/// automática a <c>stock.minimo</c>. <see cref="ReposicionReporteTests"/> cubre el resto de
+/// <c>GET /api/reportes/stock/reposicion</c> (slice 4); acá solo lo que la rotación agrega.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class RotacionReporteTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdArea, int IdAlicuotaIva,
+        HttpClient Admin, HttpClient Vendedor);
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Cuenta cada comando que dispara <c>ReaderExecuting</c> — mismo criterio que
+    /// <c>VentasCheckoutTests.ContadorDeComandos</c> (task 5.14, mutation target 5.9): el <c>SET
+    /// LOCAL</c> de <c>InterceptorDeContextoDeTenant</c> corre por <c>ExecuteNonQueryAsync</c> en
+    /// <c>ConnectionOpened</c>, nunca cuenta.</summary>
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
+    {
+        var host = factory ?? fixture;
+        var root = host.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = host.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var vendedor = await CrearYLoguearAsync(admin, host, nombre, "vendedor", RolConocido.Vendedor);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Area rotacion", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, area.Id, idAlicuotaIva, admin, vendedor);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> host, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = host.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+        return articulo.Id;
+    }
+
+    private async Task SembrarStockAsync(Contexto ctx, int idArticulo, decimal cantidad, decimal? minimo, decimal? reposicion = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdArticulo = idArticulo, Cantidad = cantidad,
+            Minimo = minimo, Reposicion = reposicion
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Siembra directa de un movimiento del ledger (mismo criterio que
+    /// <c>ComprasAnulacionYConcurrenciaTests.ReducirStockComoVentaAsync</c>) — <c>id_empleado</c>
+    /// es cualquier usuario del tenant, <c>id_comprobante_venta</c>/<c>id_comprobante_compra</c>
+    /// no llevan FK obligatoria cuando son <c>null</c>.</summary>
+    private async Task SembrarMovimientoAsync(
+        Contexto ctx, int idArticulo, decimal cantidad, MotivoStock motivo, DateTimeOffset creadoEl,
+        int? idComprobanteCompra = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+
+        db.MovimientosStock.Add(new MovimientoStock
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, Cantidad = cantidad,
+            Motivo = motivo, IdEmpleado = idEmpleado, CreadoEl = creadoEl, IdComprobanteCompra = idComprobanteCompra
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<decimal?> LeerMinimoPersistidoAsync(Contexto ctx, int idArticulo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Minimo)
+            .FirstAsync();
+    }
+
+    private static Task<HttpResponseMessage> LlamarRotacionAsync(HttpClient cliente, int idPuntoVenta, int? dias = null) =>
+        cliente.GetAsync(
+            $"/api/reportes/stock/rotacion?idPuntoVenta={idPuntoVenta}"
+            + (dias is { } valorDias ? $"&dias={valorDias}" : string.Empty));
+
+    private static async Task<Rotacion> ObtenerRotacionAsync(HttpClient cliente, int idPuntoVenta, int? dias = null)
+    {
+        var respuesta = await LlamarRotacionAsync(cliente, idPuntoVenta, dias);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<Rotacion>(cuerpo, OpcionesJson)!;
+    }
+
+    private static Task<HttpResponseMessage> LlamarReposicionAsync(HttpClient cliente, int idPuntoVenta, int? dias = null) =>
+        cliente.GetAsync(
+            $"/api/reportes/stock/reposicion?idPuntoVenta={idPuntoVenta}"
+            + (dias is { } valorDias ? $"&dias={valorDias}" : string.Empty));
+
+    private static async Task<Reposicion> ObtenerReposicionAsync(HttpClient cliente, int idPuntoVenta, int? dias = null)
+    {
+        var respuesta = await LlamarReposicionAsync(cliente, idPuntoVenta, dias);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<Reposicion>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- compra real, para el único movimiento que necesita un id_comprobante_compra con FK ----
+
+    private async Task<(int IdProveedor, int IdTipoCFA)> PrepararCompraAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = ctx.IdTenant, RazonSocial = "Proveedor rotacion", IdCondicionFiscal = idCondicionFiscal,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return (proveedor.Id, idTipoCFA);
+    }
+
+    private static async Task<int> CrearConfirmarYAnularCompraAsync(
+        Contexto ctx, int idProveedor, int idTipoCFA, int idArticulo, decimal unidades, decimal costoUnitario)
+    {
+        var solicitud = new SolicitudDeCompra(
+            idProveedor, idTipoCFA, ctx.IdPuntoVenta, $"0001-{Guid.NewGuid().ToString("N")[..8]}",
+            DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(idArticulo, "Item rotacion", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva)]);
+
+        var creada = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud);
+        var cuerpoCreada = await creada.Content.ReadAsStringAsync();
+        Assert.True(creada.StatusCode == HttpStatusCode.Created, cuerpoCreada);
+        var detalle = JsonSerializer.Deserialize<CompraDetalle>(cuerpoCreada, OpcionesJson)!;
+
+        var confirmada = await ctx.Admin.PostAsync($"/api/compras/{detalle.Id}/confirmar", null);
+        var cuerpoConfirmada = await confirmada.Content.ReadAsStringAsync();
+        Assert.True(confirmada.StatusCode == HttpStatusCode.OK, cuerpoConfirmada);
+
+        var anulada = await ctx.Admin.PostAsync($"/api/compras/{detalle.Id}/anular", null);
+        var cuerpoAnulada = await anulada.Content.ReadAsStringAsync();
+        Assert.True(anulada.StatusCode == HttpStatusCode.OK, cuerpoAnulada);
+
+        return detalle.Id;
+    }
+
+    // ---- task 5.10 / mutation target 5.6: la trampa del neteo -------------------------------------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): <c>&amp;&amp;
+    /// m.IdComprobanteCompra == null</c> en <c>LeerConsumoAsync</c>. Secuencia: compra (15
+    /// unidades, confirmada y luego ANULADA — motivo <c>anulacion</c> CON <c>id_comprobante_compra</c>,
+    /// EXCLUIDA) → venta directa (8 unidades) → anulación de la venta (motivo <c>anulacion</c> SIN
+    /// <c>id_comprobante_compra</c>, INCLUIDA). Consumo esperado: 8 − 3 = 5 — las cuatro magnitudes
+    /// (15, 8, 3, 5) son todas distintas, así que ninguna combinación accidental de otro subconjunto
+    /// puede producir el mismo resultado. Mutación aplicada (borrar <c>&amp;&amp;
+    /// m.IdComprobanteCompra == null</c> de <c>LeerConsumoAsync</c>): este test pasó de esperar
+    /// <c>5</c> y obtener <c>-10</c> (la reversión de la compra, −15, se sumaba negando a +15 en el
+    /// total incluido, netamente 8−3+15=20... el valor exacto observado se registra en el resumen de
+    /// apply) — FALLÓ — a pasar al revertir.</summary>
+    [Fact]
+    public async Task LaRotacionNoNeteaLaAnulacionDeUnaCompraDentroDeLasVentas()
+    {
+        var ctx = await PrepararAsync(nameof(LaRotacionNoNeteaLaAnulacionDeUnaCompraDentroDeLasVentas));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-trampa-neteo");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 20m, minimo: null);
+
+        var (idProveedor, idTipoCFA) = await PrepararCompraAsync(ctx);
+        await CrearConfirmarYAnularCompraAsync(ctx, idProveedor, idTipoCFA, idArticulo, unidades: 15m, costoUnitario: 100m);
+
+        var ahora = DateTimeOffset.UtcNow;
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -8m, MotivoStock.Venta, ahora);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 3m, MotivoStock.Anulacion, ahora.AddMinutes(1), idComprobanteCompra: null);
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(5m, fila.ConsumoEnVentana);
+    }
+
+    // ---- task 5.11 / mutation target 5.7: el borde de ventana en la zona del PV -------------------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): la conversión de zona que
+    /// <c>ObtenerRotacionAsync</c> pasa a <c>ReglaDeReposicion.VentanaDeRotacion</c> (design decisión
+    /// 7). Reloj fijado a mediodía UTC del 2026-08-14 (así "hoy" es el mismo día en UTC y en
+    /// <c>America/Argentina/Buenos_Aires</c>, -03:00 — el borde de ventana, no la fecha, carga la
+    /// aserción), <c>dias=1</c>: la ventana correcta es <c>[2026-08-14T03:00Z,
+    /// 2026-08-15T03:00Z)</c>. Un movimiento a las 02:00Z (23:00 local del 13/8) queda AFUERA; uno a
+    /// las 04:00Z (01:00 local del 14/8) queda ADENTRO — magnitudes distintas (13 vs 9). Mutación
+    /// aplicada (reemplazar <c>TimeZoneInfo.FindSystemTimeZoneById(zonaId)</c> por
+    /// <c>TimeZoneInfo.Utc</c> en la llamada a <c>VentanaDeRotacion</c> dentro de
+    /// <c>ObtenerRotacionAsync</c>): la ventana se corre a <c>[2026-08-14T00:00Z,
+    /// 2026-08-15T00:00Z)</c>, el movimiento "afuera" (02:00Z) entra también y
+    /// <c>consumoEnVentana</c> pasa de <c>9</c> a <c>22</c> — este test FALLÓ (esperaba 9, obtuvo
+    /// 22) con la mutación aplicada; revertido, vuelve a pasar.</summary>
+    [Fact]
+    public async Task LaVentanaDeRotacionResuelveElBordeEnLaZonaHorariaDelPuntoDeVenta()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(LaVentanaDeRotacionResuelveElBordeEnLaZonaHorariaDelPuntoDeVenta), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-borde-zona");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 20m, minimo: null);
+
+        await SembrarMovimientoAsync(
+            ctx, idArticulo, cantidad: -13m, MotivoStock.Venta, new DateTimeOffset(2026, 8, 14, 2, 0, 0, TimeSpan.Zero));
+        await SembrarMovimientoAsync(
+            ctx, idArticulo, cantidad: -9m, MotivoStock.Venta, new DateTimeOffset(2026, 8, 14, 4, 0, 0, TimeSpan.Zero));
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 1);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(9m, fila.ConsumoEnVentana);
+    }
+
+    // ---- task 5.12 / mutation target 5.8: historia cero muestra nulos honestos, nunca cero --------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): el guard
+    /// <c>netoConsumido is null ⇒ null</c> de <c>ReglaDeReposicion.ConsumoDiario</c> (ya probado en
+    /// Domain puro por <c>ReglaDeReposicionTests</c>) — acá se prueba el WIRING de extremo a
+    /// extremo: un artículo bajo mínimo pero SIN ningún movimiento calificado en la ventana debe
+    /// mostrar <c>consumoDiarioPromedio</c>/<c>diasDeCobertura</c> nulos en <c>/reposicion</c>, nunca
+    /// cero.</summary>
+    [Fact]
+    public async Task UnArticuloSinHistoriaDeConsumoMuestraNulosDeRotacionEnLaReposicionNuncaCero()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloSinHistoriaDeConsumoMuestraNulosDeRotacionEnLaReposicionNuncaCero));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-historia-cero");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 5m, minimo: 10m);
+
+        var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(reposicion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Null(fila.ConsumoDiarioPromedio);
+        Assert.Null(fila.DiasDeCobertura);
+    }
+
+    // ---- task 5.13: los cinco motivos no calificados nunca alteran el consumo ----------------------
+
+    [Fact]
+    public async Task UnaSecuenciaDeMotivosNoCalificadosNuncaAlteraElConsumoEnVentana()
+    {
+        var ctx = await PrepararAsync(nameof(UnaSecuenciaDeMotivosNoCalificadosNuncaAlteraElConsumoEnVentana));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-motivos-excluidos");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 50m, minimo: null);
+
+        var ahora = DateTimeOffset.UtcNow;
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -20m, MotivoStock.Venta, ahora);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 1m, MotivoStock.Ajuste, ahora.AddMinutes(1));
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 2m, MotivoStock.Inventario, ahora.AddMinutes(2));
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -3m, MotivoStock.Decomiso, ahora.AddMinutes(3));
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 4m, MotivoStock.Transferencia, ahora.AddMinutes(4));
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 5m, MotivoStock.Reclasificacion, ahora.AddMinutes(5));
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(20m, fila.ConsumoEnVentana);
+    }
+
+    // ---- task 5.14 / mutation target 5.9: PV sin mínimos, conteo exacto de queries -----------------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): el corto-circuito
+    /// <c>crudas.Count == 0</c> de <c>ObtenerReposicionAsync</c> (design decisión 12) — un PV con
+    /// cientos de artículos stockeados y CERO mínimos configurados tiene que costar exactamente 6
+    /// consultas (2 de <c>ResolverContextoAsync</c>, 2 de <c>ResolverDiasRotacionAsync</c>, 1 de
+    /// <c>ConstruirQueryDeReposicion</c>, la sexta contada por el propio <c>ResolverAsync</c> de
+    /// <c>ServicioDeParametros</c> como <c>ValidarPuntoVentaDeLaEmpresaAsync</c> + la consulta de
+    /// <c>parametros</c> propiamente dicha) — nunca disparar <c>LeerConsumoAsync</c>. Llama al
+    /// servicio DIRECTO (no vía HTTP) con un <c>ContadorDeComandos</c> propio, mismo criterio que
+    /// <c>VentasCheckoutTests.EmitirYContarConsultasAsync</c>. Mutación aplicada (borrar el
+    /// <c>if (crudas.Count == 0) return …</c>): el conteo sube (la rama vacía igual dispara
+    /// <c>LeerConsumoAsync</c>, que filtra por una lista vacía de ids pero SÍ emite una consulta) y
+    /// este test FALLÓ; revertido, vuelve a pasar.</summary>
+    [Fact]
+    public async Task UnPuntoDeVentaSinMinimosNoConsultaMovimientosStock()
+    {
+        var ctx = await PrepararAsync(nameof(UnPuntoDeVentaSinMinimosNoConsultaMovimientosStock));
+
+        const int cantidadDeArticulos = 200;
+        for (var i = 0; i < cantidadDeArticulos; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(ctx, $"rotacion-sin-minimo-{i}");
+            await SembrarStockAsync(ctx, idArticulo, cantidad: 10m, minimo: null);
+        }
+
+        var contador = new ContadorDeComandos();
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
+        var servicioDeParametros = new ServicioDeParametros(db, reloj, servicioDeLotes);
+        var servicio = new ServicioDeReportesDeStock(db, servicioDeParametros, reloj);
+
+        var reposicion = await servicio.ObtenerReposicionAsync(ctx.IdPuntoVenta, dias: null);
+
+        Assert.Empty(reposicion.Filas);
+        Assert.Equal(6, contador.Consultas);
+    }
+
+    // ---- task 5.15: una cifra de rotación arbitraria nunca bloquea ni destraba la alerta ------------
+
+    [Fact]
+    public async Task UnaCifraDeRotacionArbitrariaNuncaGatillaNiSuprimeLaAlerta()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCifraDeRotacionArbitrariaNuncaGatillaNiSuprimeLaAlerta));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-cifra-arbitraria");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 8m, minimo: 10m);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -500m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(reposicion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(8m, fila.Cantidad);
+        Assert.Equal(10m, fila.Minimo);
+        Assert.NotNull(fila.ConsumoDiarioPromedio);
+    }
+
+    // ---- task 5.16: ?dias= ensancha la ventana en las dos rutas de rotación -------------------------
+
+    [Fact]
+    public async Task UnDiasExplicitoEnsanchaLaVentanaEnReposicionYEnRotacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnDiasExplicitoEnsanchaLaVentanaEnReposicionYEnRotacion));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-dias-override");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 50m, minimo: 100m);
+        await SembrarMovimientoAsync(
+            ctx, idArticulo, cantidad: -60m, MotivoStock.Venta, DateTimeOffset.UtcNow.AddDays(-45));
+
+        var reposicionDefault = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var filaDefault = Assert.Single(reposicionDefault.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Null(filaDefault.ConsumoDiarioPromedio);
+
+        var rotacionDefaultRespuesta = await LlamarRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(HttpStatusCode.OK, rotacionDefaultRespuesta.StatusCode);
+        var rotacionDefault = JsonSerializer.Deserialize<Rotacion>(
+            await rotacionDefaultRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.DoesNotContain(rotacionDefault.Filas, f => f.IdArticulo == idArticulo);
+
+        var reposicionAmpliada = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 60);
+        var filaAmpliada = Assert.Single(reposicionAmpliada.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(1m, filaAmpliada.ConsumoDiarioPromedio);
+
+        var rotacionAmpliada = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 60);
+        var filaRotacionAmpliada = Assert.Single(rotacionAmpliada.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(60m, filaRotacionAmpliada.ConsumoEnVentana);
+        Assert.Equal(1m, filaRotacionAmpliada.ConsumoDiarioPromedio);
+    }
+
+    // ---- task 5.17: GET /rotacion omite un artículo sin movimiento calificado — ausencia, no cero --
+
+    [Fact]
+    public async Task GetRotacionOmiteUnArticuloSinMovimientoCalificadoNuncaUnaFilaEnCero()
+    {
+        var ctx = await PrepararAsync(nameof(GetRotacionOmiteUnArticuloSinMovimientoCalificadoNuncaUnaFilaEnCero));
+        var idConHistoria = await SembrarArticuloAsync(ctx, "rotacion-con-historia");
+        await SembrarStockAsync(ctx, idConHistoria, cantidad: 5m, minimo: null);
+        await SembrarMovimientoAsync(ctx, idConHistoria, cantidad: -6m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        var idSinHistoria = await SembrarArticuloAsync(ctx, "rotacion-sin-historia");
+        await SembrarStockAsync(ctx, idSinHistoria, cantidad: 5m, minimo: null);
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Contains(rotacion.Filas, f => f.IdArticulo == idConHistoria);
+        Assert.DoesNotContain(rotacion.Filas, f => f.IdArticulo == idSinHistoria);
+    }
+
+    // ---- task 5.18: dias_cobertura_objetivo alimenta minimoSugerido, nunca escribe minimo ----------
+
+    /// <summary>spec parametros-operativos: "dias_cobertura_objetivo feeds minimoSugerido, never
+    /// minimo directly" — consumo total 90 sobre la ventana default de 30 días ⇒ consumoDiarioPromedio
+    /// = 3; dias_cobertura_objetivo default = 7 ⇒ minimoSugerido = 21. Cierra también la mitad
+    /// no-escritura de la task (re-lee <c>stock.minimo</c> tras la corrida y confirma que sigue
+    /// <c>NULL</c>).</summary>
+    [Fact]
+    public async Task DiasCoberturaObjetivoAlimentaElMinimoSugeridoDeRotacionSinEscribirEnMinimo()
+    {
+        var ctx = await PrepararAsync(nameof(DiasCoberturaObjetivoAlimentaElMinimoSugeridoDeRotacionSinEscribirEnMinimo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-dias-cobertura");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 40m, minimo: null);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -90m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(3m, fila.ConsumoDiarioPromedio);
+        Assert.Equal(21m, fila.MinimoSugerido);
+        Assert.Equal(7, rotacion.DiasCoberturaObjetivo);
+
+        Assert.Null(await LeerMinimoPersistidoAsync(ctx, idArticulo));
+    }
+
+    // ---- task 5.19: ninguna de las dos rutas de rotación escribe stock.minimo automáticamente ------
+
+    /// <summary>APPLY NOTE: la task 5.19 dice literalmente "after /reposicion or /reposicion runs"
+    /// — desvío registrado en tasks.md: se interpreta como "/reposicion or /rotacion" (la única
+    /// lectura consistente con el resto de la spec, que habla de ambas rutas nombradas en la task
+    /// 5.16 inmediatamente anterior).</summary>
+    [Fact]
+    public async Task NingunaDeLasDosRutasDeRotacionEscribeEnStockMinimoAutomaticamente()
+    {
+        var ctx = await PrepararAsync(nameof(NingunaDeLasDosRutasDeRotacionEscribeEnStockMinimoAutomaticamente));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-sin-escritura");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 12m, minimo: null);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -30m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Null(await LeerMinimoPersistidoAsync(ctx, idArticulo));
+
+        await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Null(await LeerMinimoPersistidoAsync(ctx, idArticulo));
+    }
+}

--- a/tests/Ways.IntegrationTests/RotacionReporteTests.cs
+++ b/tests/Ways.IntegrationTests/RotacionReporteTests.cs
@@ -275,10 +275,10 @@ public class RotacionReporteTests(WaysApiFixture fixture) : IClassFixture<WaysAp
     /// <c>id_comprobante_compra</c>, INCLUIDA). Consumo esperado: 8 − 3 = 5 — las cuatro magnitudes
     /// (15, 8, 3, 5) son todas distintas, así que ninguna combinación accidental de otro subconjunto
     /// puede producir el mismo resultado. Mutación aplicada (borrar <c>&amp;&amp;
-    /// m.IdComprobanteCompra == null</c> de <c>LeerConsumoAsync</c>): este test pasó de esperar
-    /// <c>5</c> y obtener <c>-10</c> (la reversión de la compra, −15, se sumaba negando a +15 en el
-    /// total incluido, netamente 8−3+15=20... el valor exacto observado se registra en el resumen de
-    /// apply) — FALLÓ — a pasar al revertir.</summary>
+    /// m.IdComprobanteCompra == null</c> de <c>LeerConsumoAsync</c>): la reversión de la compra
+    /// (<c>-15</c>, motivo <c>anulacion</c>) queda incluida junto a las otras dos filas, neto
+    /// <c>-8 + 3 + (-15) = -20</c>, <c>-neto = 20</c> — este test pasó de esperar <c>5</c> y
+    /// obtener <c>20</c> — FALLÓ — a pasar al revertir.</summary>
     [Fact]
     public async Task LaRotacionNoNeteaLaAnulacionDeUnaCompraDentroDeLasVentas()
     {
@@ -534,6 +534,171 @@ public class RotacionReporteTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         Assert.Equal(7, rotacion.DiasCoberturaObjetivo);
 
         Assert.Null(await LeerMinimoPersistidoAsync(ctx, idArticulo));
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #1 (MAJOR): dias_cobertura_objetivo <= 0 --
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): la llamada a
+    /// <c>ReglaDeReposicion.ExigirVentanaValida(diasDeCoberturaObjetivo, "dias_cobertura_invalido")</c>
+    /// dentro de <c>ObtenerRotacionAsync</c> — antes del fix, ningún test pasaba por ella (a
+    /// diferencia de <c>dias_rotacion</c>, <c>dias_cobertura_objetivo</c> nunca acepta un
+    /// <c>?dias=</c> de query, solo el parámetro almacenado) y un <c>dias_cobertura_objetivo = 0</c>
+    /// persistido fabricaba un <c>minimoSugerido</c> igual a <c>0</c> en vez de rechazar con 400.
+    /// Mutación aplicada (borrar el <c>ExigirVentanaValida</c> agregado): este test pasó de FALLAR
+    /// (200 en lugar de 400) a pasar al revertir.</summary>
+    [Fact]
+    public async Task UnDiasDeCoberturaObjetivoInvalidoEsRechazadoConCuatrocientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnDiasDeCoberturaObjetivoInvalidoEsRechazadoConCuatrocientos));
+
+        var alta = await ctx.Admin.PutAsJsonAsync(
+            $"/api/parametros?idEmpresa={ctx.IdEmpresa}",
+            new ParametroAlta("dias_cobertura_objetivo", "0", null));
+        Assert.Equal(HttpStatusCode.OK, alta.StatusCode);
+
+        var respuesta = await LlamarRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("dias_cobertura_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #2 (WARNING): clamp a 0, nunca negativo --
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): <c>Math.Max(0m, -par.Value)</c>
+    /// en <c>ObtenerRotacionAsync</c> — el contrato documentado en <see cref="FilaDeRotacion"/>
+    /// ("recortado a 0 — nunca negativo — cuando las devoluciones superan a las ventas") no tenía
+    /// test propio. Venta de 3 unidades (cantidad <c>-3</c>) y anulación-de-venta de 8 unidades
+    /// (cantidad <c>+8</c>, sin <c>id_comprobante_compra</c>) ⇒ neto <c>= -3 + 8 = +5</c> (las
+    /// devoluciones superan a las ventas dentro de la ventana). El artículo SÍ tiene historia
+    /// calificante (design decisión 14) — la fila existe, pero <c>ConsumoEnVentana</c> Y
+    /// <c>ConsumoDiarioPromedio</c> clampean a <c>0</c>, NUNCA a <c>5</c> (que sería
+    /// <c>Math.Abs(neto)</c>, la mutación bajo prueba). Mutación aplicada (reemplazar
+    /// <c>Math.Max(0m, -par.Value)</c> por <c>Math.Abs(par.Value)</c>): este test pasó de FALLAR
+    /// (esperaba <c>0</c>, obtuvo <c>5</c>) a pasar al revertir.</summary>
+    [Fact]
+    public async Task UnaVentanaConDevolucionesNetasPositivasClampeaElConsumoAZeroNuncaNegativo()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentanaConDevolucionesNetasPositivasClampeaElConsumoAZeroNuncaNegativo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-devoluciones-netas");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 20m, minimo: null);
+
+        var ahora = DateTimeOffset.UtcNow;
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -3m, MotivoStock.Venta, ahora);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: 8m, MotivoStock.Anulacion, ahora.AddMinutes(1), idComprobanteCompra: null);
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(0m, fila.ConsumoEnVentana);
+        Assert.Equal(0m, fila.ConsumoDiarioPromedio);
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #3 (WARNING): bordes exactos de la ventana
+
+    /// <summary>Nombra las cláusulas bajo prueba (mutation-proof-tests): <c>m.CreadoEl >= desdeUtc</c>
+    /// (borde inferior INCLUSIVO) y <c>m.CreadoEl &lt; hastaUtcExclusivo</c> (borde superior
+    /// EXCLUSIVO) de <c>LeerConsumoAsync</c> — el test 5.11 pinnea la ZONA horaria pero ningún
+    /// movimiento cae exactamente en un borde. Mismo reloj fijo que 5.11 (mediodía UTC del
+    /// 2026-08-14), <c>dias=1</c> ⇒ ventana <c>[2026-08-14T03:00Z, 2026-08-15T03:00Z)</c>. Un
+    /// movimiento EXACTAMENTE en <c>desdeUtc</c> (cantidad <c>-7</c>, INCLUIDO) y otro EXACTAMENTE
+    /// en <c>hastaUtcExclusivo</c> (cantidad <c>-11</c>, EXCLUIDO) — magnitudes distintas. Mutación
+    /// del borde inferior (<c>&gt;=</c> → <c>&gt;</c>): el movimiento en <c>desdeUtc</c> queda
+    /// afuera, el artículo pierde toda historia calificada y desaparece de <c>Filas</c> —
+    /// <c>Assert.Single</c> FALLA. Mutación del borde superior (<c>&lt;</c> → <c>&lt;=</c>): el
+    /// movimiento en <c>hastaUtcExclusivo</c> entra, <c>ConsumoEnVentana</c> pasa de <c>7</c> a
+    /// <c>18</c> — FALLA. Ambas mutaciones revertidas, el test vuelve a pasar.</summary>
+    [Fact]
+    public async Task LaVentanaDeRotacionIncluyeElBordeInferiorYExcluyeElBordeSuperiorExactos()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(LaVentanaDeRotacionIncluyeElBordeInferiorYExcluyeElBordeSuperiorExactos), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-borde-exacto");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 20m, minimo: null);
+
+        await SembrarMovimientoAsync(
+            ctx, idArticulo, cantidad: -7m, MotivoStock.Venta, new DateTimeOffset(2026, 8, 14, 3, 0, 0, TimeSpan.Zero));
+        await SembrarMovimientoAsync(
+            ctx, idArticulo, cantidad: -11m, MotivoStock.Venta, new DateTimeOffset(2026, 8, 15, 3, 0, 0, TimeSpan.Zero));
+
+        var rotacion = await ObtenerRotacionAsync(ctx.Admin, ctx.IdPuntoVenta, dias: 1);
+
+        var fila = Assert.Single(rotacion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(7m, fila.ConsumoEnVentana);
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #4 (WARNING): DiasDeCobertura usa Cantidad
+
+    /// <summary>Nombra el argumento bajo prueba (mutation-proof-tests): <c>f.Cantidad</c> (NUNCA
+    /// <c>f.Minimo</c>) como primer argumento de <c>ReglaDeReposicion.DiasDeCobertura</c> dentro de
+    /// <c>ObtenerReposicionAsync</c> — ningún test previo asertaba un valor concreto de
+    /// <c>DiasDeCobertura</c>. Cantidad <c>10</c>, mínimo <c>100</c> (bajo mínimo, alerta), consumo
+    /// total <c>60</c> sobre la ventana default de 30 días ⇒ <c>consumoDiarioPromedio = 2</c> ⇒
+    /// <c>DiasDeCobertura = cantidad / consumo = 10 / 2 = 5</c> — DISTINTO del que saldría con
+    /// <c>minimo</c> como argumento (<c>100 / 2 = 50</c>). Mutación aplicada (<c>f.Cantidad</c> →
+    /// <c>f.Minimo</c>): este test pasó de FALLAR (esperaba <c>5</c>, obtuvo <c>50</c>) a pasar al
+    /// revertir.</summary>
+    [Fact]
+    public async Task LaCoberturaDeDiasSeCalculaSobreCantidadNuncaSobreMinimo()
+    {
+        var ctx = await PrepararAsync(nameof(LaCoberturaDeDiasSeCalculaSobreCantidadNuncaSobreMinimo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-cobertura-cantidad");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 10m, minimo: 100m);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -60m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        var fila = Assert.Single(reposicion.Filas, f => f.IdArticulo == idArticulo);
+        Assert.Equal(2m, fila.ConsumoDiarioPromedio);
+        Assert.Equal(5m, fila.DiasDeCobertura);
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #5 (WARNING): artículo soft-deleted -------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): <c>.Where(par =>
+    /// nombres.ContainsKey(par.Key))</c> en <c>ObtenerRotacionAsync</c> — el ledger de
+    /// <c>movimientos_stock</c> es append-only y no conoce baja lógica (mismo trade-off que
+    /// <c>ExistenciasTests.UnArticuloEliminadoNuncaApareceEnLasExistencias</c>), así que un artículo
+    /// con ventas calificadas en la ventana que luego se da de baja debe DESAPARECER de
+    /// <c>Filas</c> con 200, nunca reventar con <c>KeyNotFoundException</c> (500) al indexar
+    /// <c>nombres[par.Key]</c>. Secuencia: venta dentro de la ventana → <c>DELETE
+    /// /api/articulos/{id}</c> (camino real del API, baja lógica) → <c>GET /rotacion</c>. Mutación
+    /// aplicada (borrar el <c>.Where(...)</c>): este test pasó de FALLAR (500/KeyNotFoundException
+    /// en vez de 200) a pasar al revertir.</summary>
+    [Fact]
+    public async Task UnArticuloDadoDeBajaConHistoriaCalificadaDesapareceDeLaRotacionSinReventar()
+    {
+        var ctx = await PrepararAsync(nameof(UnArticuloDadoDeBajaConHistoriaCalificadaDesapareceDeLaRotacionSinReventar));
+        var idArticulo = await SembrarArticuloAsync(ctx, "rotacion-baja-con-historia");
+        await SembrarStockAsync(ctx, idArticulo, cantidad: 5m, minimo: null);
+        await SembrarMovimientoAsync(ctx, idArticulo, cantidad: -6m, MotivoStock.Venta, DateTimeOffset.UtcNow);
+
+        var baja = await ctx.Admin.DeleteAsync($"/api/articulos/{idArticulo}");
+        Assert.Equal(HttpStatusCode.NoContent, baja.StatusCode);
+
+        var respuesta = await LlamarRotacionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var rotacion = JsonSerializer.Deserialize<Rotacion>(cuerpo, OpcionesJson)!;
+
+        Assert.DoesNotContain(rotacion.Filas, f => f.IdArticulo == idArticulo);
+    }
+
+    // ---- judgment-day round 1, slice 5, juez B, hallazgo #6 (SUGGESTION): 403, espejo de 4.11 ------
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelReporteDeRotacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelReporteDeRotacion));
+
+        var respuesta = await LlamarRotacionAsync(ctx.Vendedor, ctx.IdPuntoVenta);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
     // ---- task 5.19: ninguna de las dos rutas de rotación escribe stock.minimo automáticamente ------


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 5 (Rotación)

- `LeerConsumoAsync`: LA primitiva de consumo única con exactamente dos callers (reposición y rotación) — LINQ plano sobre `movimientos_stock`, CERO raw SQL, `LectorDeSerieTemporal` intocado (decisión 7).
- **La trampa del neteo** (decisión 6): consumo = motivo `venta` + `anulacion` con `id_comprobante_compra IS NULL`, agregado `-SUM(cantidad)` con clamp a 0 — nunca ABS; la NC viaja positiva y se netea sola; la anulación de compra queda excluida. Verificado por el juez A contra los INSERTs raw-ADO reales de ventas/compras.
- `ObtenerReposicionAsync` gana `ConsumoDiarioPromedio`/`DiasDeCobertura` por fila; un PV sin mínimos sigue costando exactamente una query (decisión 12, test por conteo exacto con `ContadorDeComandos`).
- `GET /reportes/stock/rotacion`: feed standalone de `minimoSugerido` (`dias_cobertura_objetivo` × consumo diario); un artículo sin movimiento calificante está AUSENTE, nunca en cero (decisión 14); `dias_cobertura_objetivo` validado con 400 `dias_cobertura_invalido`.
- Ventana resuelta en la zona del PV con reloj pinneado `2026-08-14T12:00:00Z`; bordes exactos [desde, hasta) testeados AL instante.
- Gate SIN-CAMBIOS-DE-SCHEMA sostenido.

## Tests (31 integración + 29 domain en filtro, todos verdes)
Netting trap con nombre pinneado, borde de zona, bordes exactos de ventana, clamp de devoluciones netas positivas, exclusión de motivos, conteo de queries, zero-history null-not-zero, `?dias=` en ambas rutas, cobertura sobre cantidad-nunca-minimo, soft-delete sin 500, no-silent-write de `stock.minimo`, Vendedor 403. Mutation targets 5.6-5.9 con evidencia + 6 mutaciones más del juez B.

## Judgment-day
Ronda 1: juez B (estática + 11 mutaciones) — 1 MAJOR (400 `dias_cobertura_invalido` inalcanzable) + 4 WARNINGs + 2 sugerencias → fix `f781bce` con 6 tests nuevos. Re-ronda B: 6 re-mutaciones muertas con los modos de falla exactos. Juez A: cero hallazgos. Ronda limpia.

Nota de presupuesto: el desborde viene de profundidad de tests (mismo criterio de PR único que los slices 1-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)