### PR TITLE
feat(stage-13): slice 3 web-minimos — editor inline de minimo/reposicion en Existencias

### DIFF
--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -725,6 +725,45 @@ here, since 3.13 is explicitly the orchestrator's task.
   revert: `npx vitest run` → 35 files, 640/640 green (full repo suite,
   web-only change — no other file touched); `npm run build` (`tsc -b &&
   vite build`) → clean, 0 type errors.
+  **ROUND A-3 (judgment-day, judge A ledger, scoped fix-agent run,
+  additional round)**: 1 CRITICAL residual confirmed and closed — third
+  variant of the same class. Round A's structural fix (`filaEnEdicion ===
+  null` gates the picker) still leaves a path open: add X via the picker
+  (X opens for edit, `filaEnEdicion = X`, picker hidden) → `abrirFila` on
+  a persisted row Y only checks `guardandoRef`, not any ghost state, so
+  Editar on Y is allowed while X is still unsaved (`filaEnEdicion = Y`, X
+  benched) → Cancelar Y: the identity match against
+  `filaLocalSinGuardarRef` correctly fails (Y ≠ X), so nothing is removed,
+  and `filaEnEdicion` goes back to `null` → the picker's render condition
+  (`filaEnEdicion === null`) is now satisfied even though the unsaved
+  ghost X is still alive in the grid → the picker reappears → adding a
+  second row W lets `agregarFila` overwrite the ref's single slot →  X is
+  now permanently orphaned. **Root cause**: the correct render condition
+  is "no unsaved ghost exists", not "no row is being edited" — those are
+  different predicates, and round A's fix conflated them.
+  `filaLocalSinGuardarRef` (a `ref`) cannot govern render either way:
+  mutating a ref does not trigger a re-render, so any render-time
+  condition has to read committed React state. **Fix**: added
+  `filaFantasma` (`useState<number | null>`), an exact state mirror of
+  `filaLocalSinGuardarRef` — same pattern already used for
+  `guardando`/`guardandoRef` in this same component (the ref is for
+  synchronous guards, the state is for render). Every write to the ref
+  (`agregarFila`'s set, the identity-gated clear in `guardarFila`'s
+  success path, the removal in `cancelarEdicion`, and the reset in
+  `cargar`) now has an adjacent write to `filaFantasma`, each with a
+  one-line comment naming the mirror. Picker render condition became
+  `puedeEscribir && filaEnEdicion === null && filaFantasma === null`.
+  Added the judge's exact required sequence as a new test: add X via the
+  picker → Editar the persisted row Y → Cancelar Y → assert the picker is
+  still absent (`queryByLabelText` null) → reopen X → Cancelar X → X is
+  removed and the picker reappears. **EVIDENCE**: reverted the render
+  condition to `filaEnEdicion === null` only (leaving `filaFantasma`
+  unused), ran `npx vitest run Existencias -t "abrir y cancelar Y"` →
+  **FAILED** (picker present after cancelling Y); reverted via `git
+  checkout --` → clean working tree, fix restored from the prior commit.
+  Full suite after revert: `npx vitest run` → 35 files, 641/641 green
+  (full repo suite, web-only change — no other file touched); `npm run
+  build` (`tsc -b && vite build`) → clean, 0 type errors.
 - [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
   slices 1+2); PR; merge stacked-to-main.
 
@@ -734,9 +773,9 @@ phantom-ref-on-reload + saved-row-cancel + same-tick save guard (3.12 round
 2, FINDINGS 1/2/3), ghost-row-identity-gated-clear + write-role gate +
 result-button `disabled` attribute (3.12 round A, FINDINGS 1/2/3).
 
-**Verify**: `npm run test -- Existencias` — 24/24 green (full suite:
-`npx vitest run` → 35 files, 640/640 green — updated post-`judgment-day`
-round A final, see the apply notes on task 3.12). `npm run lint`
+**Verify**: `npm run test -- Existencias` — 25/25 green (full suite:
+`npx vitest run` → 35 files, 641/641 green — updated post-`judgment-day`
+round A-3, see the apply notes on task 3.12). `npm run lint`
 (oxlint) → clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
 `npm run build` (`tsc -b && vite build`) → clean.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -566,6 +566,19 @@ here, since 3.13 is explicitly the orchestrator's task.
   (row B's "Bajo"/"10" never landed — `filaB.getByText('Bajo')` found no
   match, the response was applied to row A instead); reverted via `git
   checkout --` → 17/17 green.
+  **APPLY NOTE — `judgment-day` round 2, slice 3 (FINDING 3)**: the
+  "doble click en Guardar" test above (`CompraEditor.test.tsx` awaited
+  double-click convention) proves the Guardar button's `disabled`
+  ATTRIBUTE, not `guardarFila`'s own first-line `guardandoRef` guard —
+  `userEvent.click` no-ops on an already-`disabled` button (same confound
+  documented in 3.6's evidence for `abrirFila`), so removing that guard
+  line still passed 17/17. Round 1's Finding 5 ("defense-in-depth,
+  unreachable by construction") was therefore an artifact of that gap, not
+  a settled fact. Closed with a dedicated same-tick test (two
+  `fireEvent.click`s on Guardar inside one `act()`, zero renders between
+  them — same pattern as the 3.6 mutation target) that exercises the guard
+  BEFORE the `disabled` attribute re-renders. See FINDING 3 evidence below
+  task 3.12.
 - [x] 3.11 Gate guard: `has-pending-model-changes` clean, zero migration
   files in the diff (web-only slice — confirms no accidental API/EF drift).
   **VERIFIED**: `dotnet ef migrations has-pending-model-changes --project
@@ -575,17 +588,74 @@ here, since 3.13 is explicitly the orchestrator's task.
   → empty output (zero files); `git status --porcelain` shows only 6
   `src/Ways.Web/**` files modified; `dotnet build --no-restore` → 0
   errors.
-- [ ] 3.12 Run `judgment-day`; fix; re-judge until clean.
+- [x] 3.12 Run `judgment-day`; fix; re-judge until clean.
+  **ROUND 2 (judgment-day, judge B re-round)**: 1 MAJOR (fix-caused, judge
+  B PROVED LIVE) + 2 WARNING confirmed and closed.
+  **CONFIRMED MAJOR (Finding 1, fix-caused by round 1's Finding 7 fix)**:
+  `cambiarPuntoVenta` cleared `filaEnEdicion` but never
+  `filaLocalSinGuardarRef` — `cargar()` replaces the grid wholesale
+  (mount, PV change, Reintentar) without touching that ref. Corruption
+  sequence proved live by the judge: add articulo X via the picker on PV A
+  (ref := X, unsaved) → switch PV before saving → the new PV happens to
+  have a PERSISTED row with the same idArticulo X → Editar + Cancelar on
+  that persisted row → `cancelarEdicion` matches the stale ref and DELETES
+  the real, persisted row. Fixed with a single clear point: `cargar()`
+  itself resets `filaLocalSinGuardarRef.current = null` right after its
+  `idPuntoVenta === null` guard — since `cargar` is the only function that
+  ever replaces `existencias.filas` wholesale (mount effect, PV switch via
+  `cambiarPuntoVenta`'s state change, and the Reintentar button), a single
+  clear there covers every path that can strand the ref, instead of
+  duplicating the clear at each call site. **EVIDENCE**: mutated `cargar`
+  to `/* MUTATION 1 */` (dropped the clear line), ran `npx vitest run
+  Existencias -t "FINDING 1"` → **FAILED** (`Arroz persistido en Norte`
+  gone from the grid — `getByText` found no match, replaced by "No hay
+  stock cargado para este punto de venta."); `git checkout --
+  src/Ways.Web/src/paginas/Existencias.tsx` → 20/20 green, no `MUTATION`
+  marker left.
+  **CONFIRMED WARNING (Finding 2, coverage gap on the pre-existing
+  success-path clear)**: the `filaLocalSinGuardarRef.current = null` line
+  already shipped in `guardarFila`'s success path (round 1, task 3.4/3.6)
+  had zero direct coverage of its own removal — dropping it still passed
+  17/17. Closed with a dedicated test: add a row via the picker, save it
+  (PUT resolves OK), then Editar + Cancelar the now-PERSISTED row — it
+  must stay in the grid. **EVIDENCE**: mutated the success-path clear to
+  `/* MUTATION 2 */`, ran `npx vitest run Existencias -t "FINDING 2"` →
+  **FAILED** (`Arroz largo fino 1kg` gone after Cancelar); reverted via
+  `git checkout --` → 20/20 green.
+  **CONFIRMED WARNING (Finding 3, stale mutation-proof claim on 3.10)**:
+  with Guardar now attribute-`disabled` while in flight, the existing
+  "doble click en Guardar" test (3.10) proves the `disabled` ATTRIBUTE,
+  not `guardarFila`'s own first-line `guardandoRef` guard — removing that
+  guard line still passed 17/17, because `userEvent.click` no-ops on an
+  already-disabled button before ever reaching the handler (same confound
+  as 3.6's `abrirFila` evidence). Round 1's Finding 5 ("unreachable by
+  construction") is retracted as stated: the guard IS reachable in a
+  genuine same-tick double click, where the `disabled` attribute has not
+  re-rendered yet. Closed with a same-tick test mirroring 3.6's mutation
+  target (two `fireEvent.click`s on Guardar inside one `act()`, zero
+  renders between them), asserting exactly one PUT. **EVIDENCE**: mutated
+  `guardarFila`'s first line to `/* MUTATION 3 */` (guard removed), ran
+  `npx vitest run Existencias -t "FINDING 3"` → **FAILED** (`expected
+  "vi.fn()" to be called 1 times, but got 2 times`); reverted via `git
+  checkout --` → 20/20 green. See the cross-reference note on task 3.10
+  above for the corrected framing of the double-click vs. same-tick tests.
+  Full suite after all reverts: `npx vitest run` → 20/20 in
+  `Existencias.test.tsx` (full repo suite unaffected — web-only change, no
+  other file touched). `npm run build` (`tsc -b && vite build`) → clean.
+  `git status --porcelain` clean, no stray `MUTATION` markers
+  (`grep -rn "MUTATION"` on both touched files → empty).
 - [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
   slices 1+2); PR; merge stacked-to-main.
 
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
-(3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10).
+(3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10),
+phantom-ref-on-reload + saved-row-cancel + same-tick save guard (3.12 round
+2, FINDINGS 1/2/3).
 
-**Verify**: `npm run test -- Existencias` — 17/17 green (full suite:
-`npx vitest run` → 35 files, 633/633 green — updated post-`judgment-day`
-round 1, see the apply notes on tasks 3.5/3.10). `npm run lint` (oxlint) →
-clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
+**Verify**: `npm run test -- Existencias` — 20/20 green (full suite:
+`npx vitest run` → 35 files, 636/636 green — updated post-`judgment-day`
+round 2, see the apply notes on tasks 3.5/3.10/3.12). `npm run lint`
+(oxlint) → clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
 `npm run build` (`tsc -b && vite build`) → clean.
 
 ---

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -432,6 +432,62 @@ here, since 3.13 is explicitly the orchestrator's task.
   JSX — this is a targeted refinement of the guard's storage, not a
   change to the disable surface. Same precedent already used in this repo
   (`transfiriendoRef` in `Transferencias.tsx`/`CompraEditor.tsx`).
+  **APPLY NOTE — `judgment-day` round 1, slice 3**: this task's disable
+  surface ("every row's Editar, the PV selector, the download button and
+  the add-row") was infalsifiable as originally shipped — no test asserted
+  the `disabled` ATTRIBUTE on any of those surfaces; mutating the Editar
+  button's guard from `guardando !== null` down to `guardandoEstaFila`
+  (a no-op for any OTHER row) still passed 13/13.
+  **CONFIRMED MAJOR (Finding 2)**: closed with a dedicated component test
+  that holds a `PUT` in flight and asserts `toBeDisabled()` on the OTHER
+  row's Editar button, the PV selector, the download button, the add-row
+  search input, and the in-flight row's own Guardar (Finding 6b — see
+  below); then resolves the `PUT` inside the test and asserts every one of
+  those surfaces re-enables (closes Finding 3's same-scope gap too).
+  **EVIDENCE**: mutated the Editar button's `disabled` to
+  `/* MUTATION 2 */ guardandoEstaFila`, ran `npx vitest run Existencias -t
+  "mientras una fila guarda"` → **FAILED** (`expected element to be
+  disabled` / `Received element is not disabled` on row B's Editar
+  button). `git checkout -- src/Ways.Web/src/paginas/Existencias.tsx` →
+  17/17 green, no `MUTATION` marker left (`grep -rn "MUTATION"` clean).
+  **CONFIRMED WARNING (Finding 6b)**: the Guardar button's own `disabled`
+  attribute (`!puedeGuardar`) never carried a `guardando` term, so the
+  in-flight row's own Guardar stayed clickable while its label read
+  "Guardando…". Fixed: `disabled={!puedeGuardar || guardandoEstaFila}`.
+  **EVIDENCE**: mutated back to `/* MUTATION 6b */ !puedeGuardar`, ran the
+  same "mientras una fila guarda" test → **FAILED** (`Guardando…` button
+  `Received element is not disabled`); reverted via `git checkout --` →
+  17/17 green.
+  **CONFIRMED WARNING (Finding 6a)**: `SelectorDeArticuloParaAlta`'s picker
+  effect reset `resultados` on its early-return branch (term < 2 chars) but
+  never `buscando` — "Buscando…" could get stuck visible after the term
+  shrank back below 2 chars. Fixed with `setBuscando(false)` in that
+  branch. **EVIDENCE**: mutated the branch to
+  `/* MUTATION 6a */` (dropped the `setBuscando(false)` line), ran
+  `npx vitest run Existencias -t "Buscando"` → **FAILED** (`expected
+  document not to contain element, found <div class="small text-muted">
+  Buscando…</div>`); reverted via `git checkout --` → 17/17 green.
+  **REGISTERED, not fixed (Finding 5, WARNING)**: `guardarFila`'s own
+  first-line `guardandoRef` re-entrancy guard is defense-in-depth
+  unreachable by construction — the window-wide `disabled` attribute this
+  task installs already prevents a second concurrent save from ever
+  dispatching. Left as-is (belt-and-suspenders, same precedent as
+  `transfiriendoRef`/`Transferencias.tsx`); recorded here as known phantom
+  coverage, honestly, per the instruction to never hide it.
+  **CONFIRMED SUGGESTION (Finding 7)**: `agregarFila` (task 3.4) appended
+  the new local row (`cantidad = 0`, unpersisted) BEFORE the `PUT`, and
+  `cancelarEdicion` never removed it on cancel — a ghost row stayed in the
+  grid. Fixed with `filaLocalSinGuardarRef` (tracks the pending local
+  row's `idArticulo`, cleared on a successful save); `cancelarEdicion` now
+  filters that row out of `existencias.filas` when it's the one being
+  cancelled. **EVIDENCE**: mutated `cancelarEdicion` to
+  `/* MUTATION 7 */` (dropped the filter block), ran `npx vitest run
+  Existencias -t "cancelar una fila agregada"` → **FAILED** (`expected
+  document not to contain element, found <td>Arroz largo fino 1kg</td>`);
+  reverted via `git checkout --` → 17/17 green.
+  Full suite after all reverts: `npx vitest run` → 633/633 green (35
+  files, +4 tests vs. the pre-round-1 629). `npm run build` (`tsc -b &&
+  vite build`) → clean.
 - [x] 3.6 [P] **Mutation target**: remove the `guardandoRef.current !== null`
   guard from the row-open handler (`abrirFila`) — the "open row B blocked
   while row A is saving, same tick" test must fail. *(mutation-proof-tests,
@@ -487,6 +543,29 @@ here, since 3.13 is explicitly the orchestrator's task.
   from 3.6 (single `act()`, two `fireEvent.click`s, no render between
   them — see 3.6 evidence for why the naive single-`fireEvent.click`
   variant does not exercise the mutation).
+  **APPLY NOTE — `judgment-day` round 1, slice 3, CONFIRMED WARNING
+  (Findings 3+4)**: the token-gated `finally` in `guardarFila`
+  (`if (tokenDeEscrituraRef.current === miToken) { guardandoRef.current =
+  null; setGuardando(null) }`) had zero coverage of its own reset — every
+  existing test only ever saved ONE row per render tree, so a permanent
+  lockup of the whole window after any single save (dropping
+  `setGuardando(null)`) passed 13/13 unnoticed. Closed with a sequential
+  test: save row A end-to-end, then open/edit/save row B — the SECOND row,
+  not the first — and assert the second `PUT`'s payload and the grid
+  update both target B (kills the "always-first-row" updater class too,
+  Finding 4, without a separate test). **EVIDENCE (a)**: dropped
+  `setGuardando(null)` from the `finally` (left `guardandoRef.current =
+  null`), ran `npx vitest run Existencias -t "guardar la fila A"` →
+  **FAILED** (row B's "Editar" query resolved to zero elements —
+  `getAllByLabelText` found nothing for "Mínimo de Fideos guiseros 500g",
+  the window stayed disabled after A's save); `git checkout --
+  src/Ways.Web/src/paginas/Existencias.tsx` → 17/17 green. **EVIDENCE
+  (b)**: hard-coded the save-response updater's row match to `i === 0`
+  (`prev.filas.map((f, i) => i === 0 ? ... : f)`) instead of
+  `f.idArticulo === resultado.idArticulo`, ran the same test → **FAILED**
+  (row B's "Bajo"/"10" never landed — `filaB.getByText('Bajo')` found no
+  match, the response was applied to row A instead); reverted via `git
+  checkout --` → 17/17 green.
 - [x] 3.11 Gate guard: `has-pending-model-changes` clean, zero migration
   files in the diff (web-only slice — confirms no accidental API/EF drift).
   **VERIFIED**: `dotnet ef migrations has-pending-model-changes --project
@@ -503,8 +582,9 @@ here, since 3.13 is explicitly the orchestrator's task.
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
 (3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10).
 
-**Verify**: `npm run test -- Existencias` — 13/13 green (full suite:
-`npx vitest run` → 35 files, 629/629 green). `npm run lint` (oxlint) →
+**Verify**: `npm run test -- Existencias` — 17/17 green (full suite:
+`npx vitest run` → 35 files, 633/633 green — updated post-`judgment-day`
+round 1, see the apply notes on tasks 3.5/3.10). `npm run lint` (oxlint) →
 clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
 `npm run build` (`tsc -b && vite build`) → clean.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -377,6 +377,26 @@ editing, blocked supersede, add-row, no post-write refetch.
 cut: ship the grid + inline edit first; the articulo add-row (3.4) is the
 cut point if the slice overflows during apply.
 
+**APPLY NOTE — budget overflow, cut point NOT exercised (deliberate, recorded
+per the instruction to never cut silently)**: the actual diff came in at 6
+files changed, **644 insertions(+), 23 deletions(-) = 667 authored changed
+lines** (`git diff --shortstat main..HEAD -- src/Ways.Web`), above both the
+~380-line estimate and the 400-line budget guard. The pre-identified cut
+(drop 3.4, the add-row) was NOT taken: by the time the overflow became
+measurable, 3.1-3.11 were already implemented as one cohesive, fully green,
+fully committed unit (35 test files, 629/629 vitest green; `dotnet build`
+clean; gate guard clean), and un-shipping a working, tested add-row would
+have discarded verified work rather than avoided writing it. A meaningful
+share of the overflow is test code (`Existencias.test.tsx` alone is +171/-13
+— five new tests plus the mutation-target evidence work in 3.6, which itself
+needed an extra probe-and-revert cycle once the naive test construction
+turned out not to exercise the named clause, per `mutation-proof-tests` rule
+3). This is flagged here for the orchestrator's PR-creation step (task
+3.13, out of `sdd-apply`'s scope): slice 3, as delivered, needs either a
+`size:exception` acknowledgment on this single PR, or a split into two
+child PRs (e.g., grid+edit vs. add-row) at PR-creation time — not decided
+here, since 3.13 is explicitly the orchestrator's task.
+
 - [x] 3.1 Modify `src/Ways.Web/src/api/{tipos,stock}.ts`: mirror
   `EstadoDeReposicion`, `FilaExistencia` (+3 fields), `SolicitudDeMinimos`,
   `MinimosDeStock`; `clienteDeStock.escribirMinimos`.

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -496,6 +496,9 @@ here, since 3.13 is explicitly the orchestrator's task.
   → empty output (zero files); `git status --porcelain` shows only 6
   `src/Ways.Web/**` files modified; `dotnet build --no-restore` → 0
   errors.
+- [ ] 3.12 Run `judgment-day`; fix; re-judge until clean.
+- [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
+  slices 1+2); PR; merge stacked-to-main.
 
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
 (3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10).

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -764,8 +764,20 @@ here, since 3.13 is explicitly the orchestrator's task.
   Full suite after revert: `npx vitest run` → 35 files, 641/641 green
   (full repo suite, web-only change — no other file touched); `npm run
   build` (`tsc -b && vite build`) → clean, 0 type errors.
-- [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
-  slices 1+2); PR; merge stacked-to-main.
+- [x] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
+  slices 1+2); PR; merge stacked-to-main. *(FINAL VERDICT 2026-08-14:
+  JUDGMENT: APPROVED at HEAD `678f1c2` after the longest judgment-day of
+  the program — judge B round 1 (2 MAJORs: deleted checklist items,
+  unfalsifiable full-window disable; +4 deterministic WARNINGs), two
+  scoped B re-judgments (round 2 caught a MAJOR fix-caused stale-ref
+  corruption LIVE), and three judge-A rounds on the ghost-row mechanism
+  (unconditional clear → picker unGated on filaEnEdicion → picker
+  reappearing with a benched ghost), closed structurally with the
+  filaFantasma state mirror (a ref never governs render). Judge B's final
+  hygiene pass over the post-approval delta: 4 re-mutations killed exactly
+  their tests, puedeEscribir hollowing ruled out empirically (16 failed
+  under a forced false — none vacuous). Both ledgers clean on the final
+  candidate.)*
 
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
 (3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10),

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -377,57 +377,113 @@ editing, blocked supersede, add-row, no post-write refetch.
 cut: ship the grid + inline edit first; the articulo add-row (3.4) is the
 cut point if the slice overflows during apply.
 
-- [ ] 3.1 Modify `src/Ways.Web/src/api/{tipos,stock}.ts`: mirror
+- [x] 3.1 Modify `src/Ways.Web/src/api/{tipos,stock}.ts`: mirror
   `EstadoDeReposicion`, `FilaExistencia` (+3 fields), `SolicitudDeMinimos`,
   `MinimosDeStock`; `clienteDeStock.escribirMinimos`.
-- [ ] 3.2 Create the pure helper `aSolicitudDeMinimos(idPv, idArticulo,
+- [x] 3.2 Create the pure helper `aSolicitudDeMinimos(idPv, idArticulo,
   minimoTexto, reposicionTexto)` in a colocated module — `'' → null`
   coercion for both inputs.
-- [ ] 3.3 Modify `src/Ways.Web/src/paginas/Existencias.tsx`: add columns
+- [x] 3.3 Modify `src/Ways.Web/src/paginas/Existencias.tsx`: add columns
   `Mínimo`/`Reposición`/`Estado`; state contract — `generacionRef` (existing,
   read staleness), `filaEnEdicion: number | null` (one `idArticulo`),
   `guardando: number | null` (one `idArticulo` in flight). Save applies the
   authoritative `MinimosDeStock` response via a functional updater from
   `prev` (no post-write refetch — decision 16), gated on its captured
   token, `guardando` reset in a token-gated `finally`.
-- [ ] 3.4 Modify `Existencias.tsx`: **add-row** — an articulo lookup over
+- [x] 3.4 Modify `Existencias.tsx`: **add-row** — an articulo lookup over
   `clienteDeArticulos` (the `Transferencias.tsx` picker pattern), appending
   a row with `cantidad = 0` locally, saved through the same `PUT`.
-- [ ] 3.5 Modify `Existencias.tsx`: `guardando !== null` disables **every**
+- [x] 3.5 Modify `Existencias.tsx`: `guardando !== null` disables **every**
   row's "Editar", the PV selector, the download button and the add-row; the
   handler's first line is `if (guardando !== null) return` (beats a
   same-tick double click ahead of the `disabled` re-render). Client-side
   pre-validation mirrors `reposicion_menor_que_minimo` and disables save
   while the aviso is visible — the copy never claims a block the UI does
-  not enforce (`react-async-state` rule 7).
-- [ ] 3.6 [P] **Mutation target**: remove the `guardando !== null` guard
-  from the row-open handler — the "open row B blocked while row A is
-  saving" test (3.10) must fail. *(mutation-proof-tests, design decision
-  15 — "supersede-during-write mutated across four consecutive review
-  rounds in this repo before blocking the window killed the class")*
-- [ ] 3.7 [P] Descriptor tests: `aSolicitudDeMinimos` coercion branches —
+  not enforce (`react-async-state` rule 7). **APPLY REFINEMENT**: the
+  first-line reentrancy guard is `guardandoRef.current !== null`
+  (`useRef<number|null>`, mirror of `guardando`), not the literal
+  `guardando` (`useState`) named above. Empirically verified with the
+  ScratchDisabled probe (see 3.6 evidence) that a `useState`-based guard
+  cannot survive a genuine same-tick double click, because React 18
+  batches the state commit — two `fireEvent.click`s issued inside one
+  `act()` with no render in between would both read the SAME stale
+  closure value even with the state check present. The `guardando` state
+  itself is kept, unchanged, driving every `disabled` attribute in the
+  JSX — this is a targeted refinement of the guard's storage, not a
+  change to the disable surface. Same precedent already used in this repo
+  (`transfiriendoRef` in `Transferencias.tsx`/`CompraEditor.tsx`).
+- [x] 3.6 [P] **Mutation target**: remove the `guardandoRef.current !== null`
+  guard from the row-open handler (`abrirFila`) — the "open row B blocked
+  while row A is saving, same tick" test must fail. *(mutation-proof-tests,
+  design decision 15 — "supersede-during-write mutated across four
+  consecutive review rounds in this repo before blocking the window killed
+  the class")* **EVIDENCE**: mutated `abrirFila` to
+  `/* MUTATION 3.6 */` (guard line removed), ran
+  `npx vitest run Existencias -t "abrir la fila B"` → **FAILED** (`expected
+  document not to contain element, found <input aria-label="Mínimo de
+  Fideos guiseros 500g" ...>` — row B's editor opened despite row A's
+  save being in flight, dispatched via two `fireEvent.click` calls inside
+  one `act()` so no render/`disabled` update lands between them). Reverted
+  the guard line; ran `npx vitest run Existencias` → 13/13 green;
+  `git diff --stat -- src/Ways.Web/src/paginas/Existencias.tsx` after
+  revert showed no `MUTATION` marker left in the file (`grep -rn
+  "MUTATION"` → clean). Full suite re-run after revert: 629/629 green.
+  A first attempt at this same test (dispatching the row-B click via a
+  single `fireEvent.click` after two AWAITED `userEvent.click`s on
+  "Guardar", mirroring `CompraEditor.test.tsx`'s double-click pattern)
+  **passed even with the guard removed** — confirmed via an isolated
+  probe (`ScratchDisabled.test.tsx`, discarded after use) that jsdom
+  silently no-ops `fireEvent.click` on a `disabled` button, so the
+  pre-existing `disabled={guardando !== null}` attribute was the actual
+  confound killing the mutation's observability, not the removed guard.
+  Per `mutation-proof-tests` rule 3 ("kill the confounds, not the
+  layers"), the test was re-routed below that confound: both clicks now
+  fire inside a single `act()` with zero renders between them, which also
+  revealed the `guardando`-state-vs-`guardandoRef` distinction recorded in
+  3.5 above.
+- [x] 3.7 [P] Descriptor tests: `aSolicitudDeMinimos` coercion branches —
   `''`, `'0'`, `'2.5'`, `'-1'`, `'1,5'`, both-empty (unmanage).
-  *(web-descriptor-tests)*
-- [ ] 3.8 [P] Component test: save applies the authoritative response
+  *(web-descriptor-tests)* Implemented in `stock.test.ts` alongside
+  `umbralTextoValido`/`reposicionMenorQueMinimo` (both new pure helpers
+  introduced by 3.5's client-side pre-validation).
+- [x] 3.8 [P] Component test: save applies the authoritative response
   **without** a refetch — assert no second `GET` fires after the `PUT`
   resolves.
-- [ ] 3.9 [P] Component test: a stale read landing after a save is
+- [x] 3.9 [P] Component test: a stale read landing after a save is
   discarded — a stale promise resolved **inside `act`**, asserted
   synchronously after the flush (`react-async-state` rule 7 — the "committed
   write reported as a failure" class this design's decision 16 exists to
-  prevent).
-- [ ] 3.10 [P] Component test: double-click on save ⇒ exactly one `fetch`;
+  prevent). Since decision 16 removes the natural read/write race on this
+  screen (a save never triggers a report refetch), the test constructs the
+  race via a PV round-trip (Centro → Norte, held pending → back to Centro,
+  resolved fast) to leave a genuinely stale, still-in-flight Norte read;
+  the save happens on the fresh Centro generation; the stale Norte
+  response is resolved last, inside `act`, and asserted to never land.
+- [x] 3.10 [P] Component test: double-click on save ⇒ exactly one `fetch`;
   open-row-B **blocked** while row A is saving (ties to the 3.6 mutation).
-- [ ] 3.11 Gate guard: `has-pending-model-changes` clean, zero migration
+  Implemented as two tests: the double-click case mirrors the
+  `CompraEditor.test.tsx` "await click twice" convention; the
+  same-tick supersede-blocked case is the dedicated mutation-target test
+  from 3.6 (single `act()`, two `fireEvent.click`s, no render between
+  them — see 3.6 evidence for why the naive single-`fireEvent.click`
+  variant does not exercise the mutation).
+- [x] 3.11 Gate guard: `has-pending-model-changes` clean, zero migration
   files in the diff (web-only slice — confirms no accidental API/EF drift).
-- [ ] 3.12 Run `judgment-day`; fix; re-judge until clean.
-- [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
-  slices 1+2); PR; merge stacked-to-main.
+  **VERIFIED**: `dotnet ef migrations has-pending-model-changes --project
+  src/Ways.Infrastructure --startup-project src/Ways.Infrastructure` →
+  "No changes have been made to the model since the last migration.";
+  `git diff --stat main -- src/Ways.Infrastructure/Persistencia/Migraciones/`
+  → empty output (zero files); `git status --porcelain` shows only 6
+  `src/Ways.Web/**` files modified; `dotnet build --no-restore` → 0
+  errors.
 
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
 (3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10).
 
-**Verify**: `npm run test -- Existencias`
+**Verify**: `npm run test -- Existencias` — 13/13 green (full suite:
+`npx vitest run` → 35 files, 629/629 green). `npm run lint` (oxlint) →
+clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
+`npm run build` (`tsc -b && vite build`) → clean.
 
 ---
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -644,17 +644,68 @@ here, since 3.13 is explicitly the orchestrator's task.
   other file touched). `npm run build` (`tsc -b && vite build`) → clean.
   `git status --porcelain` clean, no stray `MUTATION` markers
   (`grep -rn "MUTATION"` on both touched files → empty).
+  **ROUND A (judgment-day, judge A ledger, scoped fix-agent run)**: 1
+  CRITICAL + 2 WARNING confirmed and closed.
+  **CONFIRMED CRITICAL (Finding 1)**: `filaLocalSinGuardarRef`'s success-path
+  clear in `guardarFila` was unconditional — `agregarFila(X)` sets the ref to
+  X and appends the ghost row, then opening and saving a DIFFERENT
+  preexisting row Y (allowed: `abrirFila` only checks `guardandoRef`, not
+  `filaEnEdicion`) cleared the ref to `null` regardless of which row it just
+  saved, orphaning X (`cancelarEdicion` matches by identity against
+  `filaEnEdicion`, so it could no longer find X to remove it). Fixed by
+  gating the clear on identity: `if (fila.idArticulo ===
+  filaLocalSinGuardarRef.current) filaLocalSinGuardarRef.current = null`.
+  `cancelarEdicion`'s own removal already matched by identity, so no other
+  change was needed. **EVIDENCE**: mutated the clear back to unconditional
+  (`filaLocalSinGuardarRef.current = null`), ran `npx vitest run
+  Existencias -t "FINDING 1 CRITICAL"` → **FAILED** (`Arroz largo fino 1kg`
+  still in the document after Cancelar — the ghost survived, proving the
+  orphan); reverted via targeted edit (not `git checkout --`, to avoid
+  wiping the other two round-A fixes staged in the same uncommitted file) →
+  23/23 green in `Existencias.test.tsx`.
+  **CONFIRMED WARNING (Finding 2, precedent-matching write-role gate)**:
+  `Existencias.tsx` had no client-side write-role gate even though `PUT
+  /api/stock/minimos` is Admin-only server-side (`GestionDeCatalogo`) while
+  the route itself admits Supervisor+Admin (`Politicas.LecturaDeReportes`).
+  Replicated the exact `CompraEditor.tsx:492` precedent: `puedeEscribir =
+  usuario !== null && usuario.rolId === ROL.Admin`, hiding the Editar
+  buttons, Guardar/Cancelar, and the `SelectorDeArticuloParaAlta` add-row
+  when `false`; reading (all columns) stays open to Supervisor. Test
+  fixture default switched from Supervisor to Admin (same convention as
+  `CompraEditor.test.tsx`) since most of this file's tests exercise write
+  actions; the "role gating" describe's Supervisor test now sets the role
+  explicitly. **EVIDENCE**: mutated `puedeEscribir` to a hardcoded `true`,
+  ran `npx vitest run Existencias -t "FINDING 2"` → **FAILED** (the
+  Supervisor-render test found an "Editar" button that should have been
+  hidden); reverted via targeted edit → 23/23 green.
+  **CONFIRMED WARNING (Finding 3, `disabled` attribute missing on rendered
+  result buttons)**: `SelectorDeArticuloParaAlta`'s search-result buttons
+  never received the `disabled` prop (only the search input did) — the
+  click was stopped by `agregarFila`'s `guardandoRef` guard, but the
+  rendered attribute lied. Wired `disabled={disabled}` onto the result
+  buttons. Extended the existing full-window "TODA la ventana queda
+  attribute-disabled" test (task 3.5) to leave a result visible before
+  triggering an in-flight PUT, then assert that result button is
+  `toBeDisabled()`. **EVIDENCE**: removed the `disabled` prop from the
+  result buttons, ran `npx vitest run Existencias -t "TODA la ventana"` →
+  **FAILED** (`Received element is not disabled`); reverted via targeted
+  edit → 23/23 green.
+  Full suite after all reverts: `grep -rn "MUTATION"` on both touched files
+  → empty; `npx vitest run` → 35 files, 639/639 green (full repo suite,
+  web-only change — no other file touched); `npm run build` (`tsc -b &&
+  vite build`) → clean, 0 type errors.
 - [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
   slices 1+2); PR; merge stacked-to-main.
 
 **Test plan**: mutation target (3.6), coercion descriptors (3.7), no-refetch
 (3.8), stale-read-discarded (3.9), double-click + supersede-blocked (3.10),
 phantom-ref-on-reload + saved-row-cancel + same-tick save guard (3.12 round
-2, FINDINGS 1/2/3).
+2, FINDINGS 1/2/3), ghost-row-identity-gated-clear + write-role gate +
+result-button `disabled` attribute (3.12 round A, FINDINGS 1/2/3).
 
-**Verify**: `npm run test -- Existencias` — 20/20 green (full suite:
-`npx vitest run` → 35 files, 636/636 green — updated post-`judgment-day`
-round 2, see the apply notes on tasks 3.5/3.10/3.12). `npm run lint`
+**Verify**: `npm run test -- Existencias` — 23/23 green (full suite:
+`npx vitest run` → 35 files, 639/639 green — updated post-`judgment-day`
+round A, see the apply notes on task 3.12). `npm run lint`
 (oxlint) → clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
 `npm run build` (`tsc -b && vite build`) → clean.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -694,6 +694,37 @@ here, since 3.13 is explicitly the orchestrator's task.
   → empty; `npx vitest run` → 35 files, 639/639 green (full repo suite,
   web-only change — no other file touched); `npm run build` (`tsc -b &&
   vite build`) → clean, 0 type errors.
+  **ROUND A FINAL (judgment-day, judge A ledger, scoped fix-agent run)**: 1
+  CRITICAL residual confirmed and closed.
+  **CONFIRMED CRITICAL (residual of Finding 1)**: round A's identity-gated
+  clear in `guardarFila`'s success path fixed the *symptom* (a save on a
+  different row no longer orphans the ghost's ref) but not the *class* of
+  bug — `agregarFila` still overwrote the single-slot ref without checking
+  for a prior ghost, and `SelectorDeArticuloParaAlta` was never gated by
+  `filaEnEdicion`: it stayed visible and enabled as soon as the first ghost
+  was added (no PUT in flight needed). Sequence: add X via the picker (X
+  opens for edit) → without saving or cancelling, add Z via the still-visible
+  picker → the ref gets overwritten to Z → X is now permanently orphaned in
+  the grid (reopening X + Cancelar fails the identity match against the new
+  ref value). **Structural fix** (kills the class, not the symptom):
+  condition the picker's render on `filaEnEdicion === null` —
+  `{puedeEscribir && filaEnEdicion === null && (...)}`. With that, two
+  unsaved ghosts can never coexist: adding one opens it for edit and the
+  picker disappears until it is saved or cancelled. No extra ref logic
+  added. Rewrote the "TODA la ventana queda attribute-disabled" test (task
+  3.5): the picker is now *absent* (not merely `disabled`) as soon as any
+  row is in edit, which supersedes the old `disabled`-attribute assertion on
+  the picker's input/result buttons — reflected inline in the test's own
+  comments. Added the judge's exact required sequence as a new test: add X
+  via the picker → without saving/cancelling, assert the picker is gone →
+  Cancelar X → X is removed and the picker reappears. **EVIDENCE**: removed
+  the `filaEnEdicion === null` condition from the render, ran `npx vitest
+  run Existencias -t "agregar X por el picker sin guardar"` → **FAILED**
+  (picker still present with X in edit); reverted via `git checkout --` →
+  clean working tree, fix restored from the prior commit. Full suite after
+  revert: `npx vitest run` → 35 files, 640/640 green (full repo suite,
+  web-only change — no other file touched); `npm run build` (`tsc -b &&
+  vite build`) → clean, 0 type errors.
 - [ ] 3.13 Branch `feat/stage13-slice3-web-minimos` off `main` (parent:
   slices 1+2); PR; merge stacked-to-main.
 
@@ -703,9 +734,9 @@ phantom-ref-on-reload + saved-row-cancel + same-tick save guard (3.12 round
 2, FINDINGS 1/2/3), ghost-row-identity-gated-clear + write-role gate +
 result-button `disabled` attribute (3.12 round A, FINDINGS 1/2/3).
 
-**Verify**: `npm run test -- Existencias` — 23/23 green (full suite:
-`npx vitest run` → 35 files, 639/639 green — updated post-`judgment-day`
-round A, see the apply notes on task 3.12). `npm run lint`
+**Verify**: `npm run test -- Existencias` — 24/24 green (full suite:
+`npx vitest run` → 35 files, 640/640 green — updated post-`judgment-day`
+round A final, see the apply notes on task 3.12). `npm run lint`
 (oxlint) → clean (one pre-existing, unrelated warning in `AuthContext.tsx`).
 `npm run build` (`tsc -b && vite build`) → clean.
 

--- a/src/Ways.Web/src/api/stock.test.ts
+++ b/src/Ways.Web/src/api/stock.test.ts
@@ -4,6 +4,7 @@ import {
   aLineasDeTransferencia,
   aSolicitudDeConteo,
   aSolicitudDeConteoPorLote,
+  aSolicitudDeMinimos,
   aSolicitudDeTransferencia,
   articulosRepetidosEnTransferencia,
   contadaValida,
@@ -11,6 +12,8 @@ import {
   lineaDeTransferenciaVacia,
   lineaTransferenciaCompleta,
   lineasDeConteoDeLoteCompletas,
+  reposicionMenorQueMinimo,
+  umbralTextoValido,
   type LineaDeConteoDeLoteFormulario,
   type LineaDeTransferenciaFormulario,
 } from './stock'
@@ -253,5 +256,69 @@ describe('aSolicitudDeConteoPorLote', () => {
     const solicitud = aSolicitudDeConteoPorLote(2, 10, [lineaDeLoteFixture()], 'obs')
     expect(solicitud.contada).toBeNull()
     expect(solicitud.lotes).not.toHaveLength(0)
+  })
+})
+
+// ---- Mínimos y reposición (stage-13-stock-inteligente, Slice 3) --------------------------------
+
+describe('umbralTextoValido', () => {
+  it('vacío es válido (unmanage)', () => {
+    expect(umbralTextoValido('')).toBe(true)
+    expect(umbralTextoValido('   ')).toBe(true)
+  })
+
+  it('un entero, un cero y un negativo son válidos (la negatividad la rechaza el servidor, no el parseo)', () => {
+    expect(umbralTextoValido('0')).toBe(true)
+    expect(umbralTextoValido('2.5')).toBe(true)
+    expect(umbralTextoValido('-1')).toBe(true)
+  })
+
+  it('una coma decimal no parsea — inválido, nunca coercionado en silencio a null', () => {
+    expect(umbralTextoValido('1,5')).toBe(false)
+  })
+})
+
+describe('aSolicitudDeMinimos', () => {
+  it('cada campo vacío coerciona a null (unmanage de un solo campo)', () => {
+    expect(aSolicitudDeMinimos(2, 10, '', '20')).toEqual({ idPuntoVenta: 2, idArticulo: 10, minimo: null, reposicion: 20 })
+    expect(aSolicitudDeMinimos(2, 10, '5', '')).toEqual({ idPuntoVenta: 2, idArticulo: 10, minimo: 5, reposicion: null })
+  })
+
+  it('ambos vacíos limpia el par completo — la operación de unmanage', () => {
+    expect(aSolicitudDeMinimos(2, 10, '', '')).toEqual({ idPuntoVenta: 2, idArticulo: 10, minimo: null, reposicion: null })
+  })
+
+  it('"0" coerciona a 0, nunca a null', () => {
+    expect(aSolicitudDeMinimos(2, 10, '0', '0')).toEqual({ idPuntoVenta: 2, idArticulo: 10, minimo: 0, reposicion: 0 })
+  })
+
+  it('decimales y negativos viajan tal cual — la validación de rango es responsabilidad del servidor', () => {
+    expect(aSolicitudDeMinimos(2, 10, '2.5', '-1')).toEqual({ idPuntoVenta: 2, idArticulo: 10, minimo: 2.5, reposicion: -1 })
+  })
+
+  it('una coma decimal ("1,5") coerciona a NaN — nunca silenciosamente a null', () => {
+    const solicitud = aSolicitudDeMinimos(2, 10, '1,5', '')
+    expect(Number.isNaN(solicitud.minimo)).toBe(true)
+  })
+})
+
+describe('reposicionMenorQueMinimo', () => {
+  it('reposición por debajo del mínimo dispara el aviso', () => {
+    expect(reposicionMenorQueMinimo('10', '5')).toBe(true)
+  })
+
+  it('reposición igual o por encima del mínimo no dispara el aviso', () => {
+    expect(reposicionMenorQueMinimo('10', '10')).toBe(false)
+    expect(reposicionMenorQueMinimo('10', '20')).toBe(false)
+  })
+
+  it('un campo vacío nunca dispara el aviso — todavía no hay dos valores para comparar', () => {
+    expect(reposicionMenorQueMinimo('', '5')).toBe(false)
+    expect(reposicionMenorQueMinimo('10', '')).toBe(false)
+    expect(reposicionMenorQueMinimo('', '')).toBe(false)
+  })
+
+  it('un campo con formato inválido nunca dispara este aviso en particular', () => {
+    expect(reposicionMenorQueMinimo('1,5', '5')).toBe(false)
   })
 })

--- a/src/Ways.Web/src/api/stock.ts
+++ b/src/Ways.Web/src/api/stock.ts
@@ -11,9 +11,11 @@ import type {
   ConteoDeLote,
   LineaDeTransferencia,
   LoteListado,
+  MinimosDeStock,
   ResultadoConteo,
   ResultadoTransferencia,
   SolicitudDeConteo,
+  SolicitudDeMinimos,
   SolicitudDeTransferencia,
   StockActual,
 } from './tipos'
@@ -36,6 +38,10 @@ export const clienteDeStock = {
    * `idComprobanteAsociado` (sugerencia desde el snapshot de una devolución) vive en el POS. */
   listarLotes: (idPuntoVenta: number, idArticulo: number) =>
     api.get<LoteListado[]>(`/stock/lotes?idPuntoVenta=${idPuntoVenta}&idArticulo=${idArticulo}`),
+  /** `PUT /api/stock/minimos` (stage-13-stock-inteligente, Slice 1/3; design decisión 11/16): la
+   * respuesta es la fila PERSISTIDA leída del mismo `RETURNING` que escribió — `Existencias.tsx`
+   * la aplica con un updater funcional desde `prev`, sin volver a pedir el reporte. */
+  escribirMinimos: (solicitud: SolicitudDeMinimos) => api.put<MinimosDeStock>('/stock/minimos', solicitud),
 }
 
 // ---- Formulario de transferencia: una línea editable por fila (mismo patrón que compras.ts) --
@@ -212,5 +218,52 @@ export function aSolicitudDeConteoPorLote(
     contada: null,
     observaciones: observaciones.trim(),
     lotes: aConteoDeLotes(lineas),
+  }
+}
+
+// ---- Mínimos y reposición (stage-13-stock-inteligente, Slice 3) --------------------------------
+// Editor inline de fila única de `Existencias.tsx` (design: Web Composition, decisión 15/16): un
+// umbral vacío es "no gestionado" (unmanage), nunca 0 — el mismo criterio que ya usa
+// `SolicitudDeMinimos` del lado del servidor.
+
+function aUmbral(texto: string): number | null {
+  const limpio = texto.trim()
+  return limpio === '' ? null : Number(limpio)
+}
+
+/** Un campo vacío siempre es válido (unmanage); uno tipeado tiene que parsear a un número finito.
+ * `Number('1,5')` (coma decimal) es `NaN`, así que ese texto queda INVÁLIDO en vez de viajar como
+ * `null` en silencio — que es lo que `JSON.stringify` haría con un `NaN` sin este guard, la
+ * misma clase de "campo aceptado y descartado" que `dto-contract-honesty` prohíbe. */
+export function umbralTextoValido(texto: string): boolean {
+  const limpio = texto.trim()
+  return limpio === '' || Number.isFinite(Number(limpio))
+}
+
+/** Espejo cliente de `reposicion_menor_que_minimo` (design decisión 11) — feedback instantáneo
+ * que deshabilita el guardado; el servidor lo vuelve a validar igual (`react-async-state` regla
+ * 7: la copia nunca promete un bloqueo que la UI no aplica). Solo compara cuando AMBOS campos son
+ * números finitos — un campo vacío o con formato inválido no dispara este aviso en particular,
+ * eso ya lo bloquea `umbralTextoValido` por su propia razón. */
+export function reposicionMenorQueMinimo(minimoTexto: string, reposicionTexto: string): boolean {
+  if (!umbralTextoValido(minimoTexto) || !umbralTextoValido(reposicionTexto)) return false
+  const minimo = aUmbral(minimoTexto)
+  const reposicion = aUmbral(reposicionTexto)
+  return minimo !== null && reposicion !== null && reposicion < minimo
+}
+
+/** `SolicitudDeMinimos` completa desde el formulario de edición de una fila — REEMPLAZO completo
+ * (decisión 11): ambos campos vacíos limpia el par (unmanage). */
+export function aSolicitudDeMinimos(
+  idPuntoVenta: number,
+  idArticulo: number,
+  minimoTexto: string,
+  reposicionTexto: string,
+): SolicitudDeMinimos {
+  return {
+    idPuntoVenta,
+    idArticulo,
+    minimo: aUmbral(minimoTexto),
+    reposicion: aUmbral(reposicionTexto),
   }
 }

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -868,18 +868,52 @@ export type PaginaDeMovimientosTesoreria = {
 // --- Existencias (stage-11-exportacion-reportes, Slice 9 — droppable a Etapa 13) — espejo de
 // `Ways.Application.Reportes.Contratos`. Sin fecha/zona horaria: el stock es estado ACTUAL, no
 // tiene dimensión temporal (a diferencia del resto de los reportes de esta etapa).
+//
+// stage-13-stock-inteligente (Slice 2/3): `FilaExistencia` gana `minimo`/`reposicion`/`estado` —
+// espejo de `ReglaDeReposicion.EstadoDeReposicion` (nombres de miembro de C#, no snake_case:
+// mismo criterio que el resto de los enums de wire de esta web, p. ej. `EstadoDeVencimiento`).
+
+/** Espejo de `Ways.Domain.Stock.ReglaDeReposicion.EstadoDeReposicion` — `minimo` nulo nunca
+ * alerta (`SinMinimo`), el borde es `cantidad <= minimo` (`Bajo`), nunca `<`. */
+export type EstadoDeReposicion = 'SinMinimo' | 'Bajo' | 'Ok'
 
 /** Fila de `GET /api/reportes/stock/existencias` — espejo de `FilaExistencia`. */
 export type FilaExistencia = {
   idArticulo: number
   nombre: string
   cantidad: number
+  minimo: number | null
+  reposicion: number | null
+  estado: EstadoDeReposicion
 }
 
 /** Respuesta de `GET /api/reportes/stock/existencias` — espejo de `Existencias`. */
 export type Existencias = {
   idPuntoVenta: number
   filas: FilaExistencia[]
+}
+
+/** Cuerpo de `PUT /api/stock/minimos` — espejo de
+ * `Ways.Application.Stock.Contratos.SolicitudDeMinimos` (stage-13-stock-inteligente, Slice 1/3;
+ * design decisión 11). REEMPLAZO COMPLETO de ambos umbrales, no PATCH: `null` limpia el campo
+ * (la operación de "unmanage"). */
+export type SolicitudDeMinimos = {
+  idPuntoVenta: number
+  idArticulo: number
+  minimo: number | null
+  reposicion: number | null
+}
+
+/** Respuesta de `PUT /api/stock/minimos` — espejo de `MinimosDeStock`. La fila PERSISTIDA, leída
+ * del mismo `RETURNING` que escribió, con `estado` ya derivado — la grilla la aplica sin volver a
+ * pedir el reporte (design decisión 16). */
+export type MinimosDeStock = {
+  idPuntoVenta: number
+  idArticulo: number
+  cantidad: number
+  minimo: number | null
+  reposicion: number | null
+  estado: EstadoDeReposicion
 }
 
 // --- POS: checkout (stage-5-pos-ventas, Slice 6 → wireado en Slice 7) ---

--- a/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
+++ b/src/Ways.Web/src/componentes/BotonDeDescarga.tsx
@@ -8,6 +8,11 @@ type PropsBotonDeDescarga = {
   /** Se invoca al iniciar una descarga válida (tras la guarda) — limpia el error previo del caller. */
   onInicio?: () => void
   className?: string
+  /** stage-13-stock-inteligente (Slice 3): deshabilita el botón desde afuera cuando OTRA acción
+   * de la misma pantalla está en vuelo (`react-async-state` regla 5/9 — ventana completa
+   * deshabilitada mientras `Existencias.tsx` guarda una fila). No reemplaza el guard interno de
+   * re-entrancy del propio botón, que sigue cubriendo su propio doble click. */
+  disabled?: boolean
 }
 
 /**
@@ -18,7 +23,7 @@ type PropsBotonDeDescarga = {
  * navegan la SPA: se funnelean por `onError` al estado de la pantalla que monta el botón (proposal
  * decisión 8 — "a download that silently does nothing is this pattern's worst failure mode").
  */
-export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, onInicio, className }: PropsBotonDeDescarga) {
+export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, onInicio, className, disabled }: PropsBotonDeDescarga) {
   const [descargando, setDescargando] = useState(false)
   const enVueloRef = useRef(false)
 
@@ -42,7 +47,7 @@ export function BotonDeDescarga({ ruta, etiqueta = 'Descargar', onError, onInici
     <button
       type="button"
       className={className ?? 'btn btn-sm btn-outline-secondary rounded-0'}
-      disabled={descargando}
+      disabled={descargando || disabled}
       onClick={manejarClick}
     >
       {descargando ? 'Descargando…' : etiqueta}

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -1,20 +1,21 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Existencias } from './Existencias'
 import { RutaProtegida } from '../auth/RutaProtegida'
 import { ROL } from '../api/tipos'
-import type { Existencias as ExistenciasRespuesta, FilaExistencia, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import type { Existencias as ExistenciasRespuesta, FilaExistencia, MinimosDeStock, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
+const apiPutMock = vi.fn()
 const apiDescargarMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: vi.fn(),
-    put: vi.fn(),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
     delete: vi.fn(),
     descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
   },
@@ -75,11 +76,15 @@ const puntoVentaNorte: PuntoVentaListado = {
 }
 
 function filaFixture(sobrescribir: Partial<FilaExistencia> = {}): FilaExistencia {
-  return { idArticulo: 100, nombre: 'Yerba mate 1kg', cantidad: 42.5, ...sobrescribir }
+  return { idArticulo: 100, nombre: 'Yerba mate 1kg', cantidad: 42.5, minimo: null, reposicion: null, estado: 'SinMinimo', ...sobrescribir }
 }
 
 function existenciasFixture(filas: FilaExistencia[] = [filaFixture()], idPuntoVenta = 10): ExistenciasRespuesta {
   return { idPuntoVenta, filas }
+}
+
+function minimosFixture(sobrescribir: Partial<MinimosDeStock> = {}): MinimosDeStock {
+  return { idPuntoVenta: 10, idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo', ...sobrescribir }
 }
 
 function renderExistencias() {
@@ -118,6 +123,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
 
 beforeEach(() => {
   apiGetMock.mockReset()
+  apiPutMock.mockReset()
   apiDescargarMock.mockReset()
   apiDescargarMock.mockResolvedValue(undefined)
   usuarioActual = usuarioFixture()
@@ -224,6 +230,163 @@ describe('Existencias — reporte (stage-11-exportacion-reportes, Slice 9 — we
     })
     expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument()
     expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Existencias — editor de mínimos y reposición (stage-13-stock-inteligente, Slice 3)', () => {
+  function dosFilasFixture() {
+    return [
+      filaFixture({ idArticulo: 1, nombre: 'Aceite de girasol 900ml', cantidad: 12 }),
+      filaFixture({ idArticulo: 2, nombre: 'Fideos guiseros 500g', cantidad: 87.5 }),
+    ]
+  }
+
+  it('guardar aplica la respuesta autoritativa del PUT sin volver a pedir el reporte (decisión 16)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    apiPutMock.mockResolvedValue(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: 20, estado: 'Bajo' }))
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    apiGetMock.mockClear()
+
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+    await usuario.type(screen.getByLabelText('Reposición de Aceite de girasol 900ml'), '20')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    expect(await screen.findByText('Bajo')).toBeInTheDocument()
+    expect(apiPutMock).toHaveBeenCalledWith('/stock/minimos', { idPuntoVenta: 10, idArticulo: 1, minimo: 5, reposicion: 20 })
+    // Ningún GET nuevo desde que se limpió el mock — la fila se aplica desde el RETURNING del
+    // propio PUT, nunca desde un refetch del reporte.
+    expect(apiGetMock).not.toHaveBeenCalled()
+  })
+
+  it('una lectura desactualizada que llega recién después de guardar no pisa el valor recién guardado (regla 7)', async () => {
+    let resolverNorte: (valor: ExistenciasRespuesta) => void = () => {}
+    const norte = new Promise<ExistenciasRespuesta>((resolve) => {
+      resolverNorte = resolve
+    })
+    let llamadasCentro = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?idPuntoVenta=11')) return norte
+      if (ruta.startsWith('/reportes/stock/existencias?idPuntoVenta=10')) {
+        llamadasCentro += 1
+        return Promise.resolve(existenciasFixture(dosFilasFixture(), 10))
+      }
+      return undefined
+    })
+    apiPutMock.mockResolvedValue(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
+
+    const usuario = userEvent.setup()
+    renderExistencias()
+    await screen.findByText('Aceite de girasol 900ml')
+
+    // Cambia a Norte (queda pendiente) y vuelve a Centro (resuelve de nuevo, rápido) — deja una
+    // generación intermedia obsoleta que todavía no aterrizó.
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '10')
+    await screen.findByText('Aceite de girasol 900ml')
+    expect(llamadasCentro).toBe(2)
+
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await screen.findByText('Bajo')
+
+    // La lectura obsoleta de Norte llega RECIÉN ahora. El flush del microtask va DENTRO de act:
+    // un waitFor solo pasaría en su primer tick, antes de que el .then stale aterrice, y saldría
+    // verde sin probar nada (mutation-proof-tests regla 7).
+    await act(async () => {
+      resolverNorte(existenciasFixture([filaFixture({ idArticulo: 1, nombre: 'Aceite de girasol 900ml', cantidad: 999 })], 11))
+      await norte
+    })
+
+    expect(screen.getByText('Bajo')).toBeInTheDocument()
+    expect(screen.queryByText('999')).not.toBeInTheDocument()
+  })
+
+  it('doble click en Guardar manda un solo PUT; abrir la fila B queda bloqueado mientras la fila A se guarda (mutation target 3.6)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    let resolverPut: (valor: MinimosDeStock) => void = () => {}
+    apiPutMock.mockImplementation(
+      () =>
+        new Promise<MinimosDeStock>((resolve) => {
+          resolverPut = resolve
+        }),
+    )
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+
+    const botonGuardar = screen.getByRole('button', { name: 'Guardar' })
+    // Doble click rápido — mismo criterio que CompraEditor.test.tsx: el guard de reentrancia de
+    // primera línea evita un segundo PUT.
+    await usuario.click(botonGuardar)
+    await usuario.click(botonGuardar)
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+
+    resolverPut(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
+    await screen.findByText('Bajo')
+  })
+
+  it('abrir la fila B queda bloqueado en el MISMO tick que se dispara el guardado de la fila A — el guard sobrevive al re-render del `disabled` (mutation target 3.6)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    apiPutMock.mockImplementation(() => new Promise<MinimosDeStock>(() => {})) // nunca resuelve — no importa para este test
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0]) // abre A
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+
+    const botonGuardar = screen.getByRole('button', { name: 'Guardar' })
+    const botonEditarFilaB = screen.getByRole('button', { name: 'Editar' }) // solo B: A ya muestra Guardar/Cancelar
+
+    // Ambos clicks se despachan DENTRO del mismo `act`, sin ningún `await` (ni render) entre
+    // medio: el atributo `disabled` de B TODAVÍA no refleja `guardando`, así que solo un guard
+    // síncrono (el ref) puede bloquear esta carrera — `react-async-state` regla 9: "un doble
+    // click en el mismo tick vence al re-render del atributo `disabled`". Probar esto con clicks
+    // AWAITED (userEvent) no ejercitaría el guard removido por la mutación: para entonces el
+    // atributo `disabled` ya haría el trabajo por su cuenta.
+    act(() => {
+      fireEvent.click(botonGuardar)
+      fireEvent.click(botonEditarFilaB)
+    })
+
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+    expect(screen.queryByLabelText('Mínimo de Fideos guiseros 500g')).not.toBeInTheDocument()
+  })
+
+  it('reposición menor que el mínimo deshabilita Guardar con un aviso, sin llegar a mandar el PUT', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '10')
+    await usuario.type(screen.getByLabelText('Reposición de Aceite de girasol 900ml'), '5')
+
+    expect(await screen.findByText('La reposición no puede ser menor que el mínimo.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
+    expect(apiPutMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -397,6 +397,33 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     expect(screen.queryByLabelText('Mínimo de Fideos guiseros 500g')).not.toBeInTheDocument()
   })
 
+  it('dos clicks en Guardar en el MISMO tick mandan un solo PUT — el guard de reentrancia de `guardarFila` sobrevive al re-render del `disabled` (judgment-day round 2, FINDING 3)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    apiPutMock.mockImplementation(() => new Promise<MinimosDeStock>(() => {})) // nunca resuelve — no importa para este test
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+
+    const botonGuardar = screen.getByRole('button', { name: 'Guardar' })
+    // Mismo patrón del mutation target 3.6 ("abrir la fila B..."): dos `fireEvent.click` dentro de
+    // UN solo `act()`, sin `await` (ni render) entre medio — el atributo `disabled` de Guardar
+    // TODAVÍA no reflejó `guardando` cuando se despacha el segundo click, así que solo el guard
+    // síncrono de primera línea de `guardarFila` (no el atributo, que un `userEvent.click` awaited
+    // no-opea sobre un botón ya disabled) puede evitar el segundo PUT.
+    act(() => {
+      fireEvent.click(botonGuardar)
+      fireEvent.click(botonGuardar)
+    })
+
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+  })
+
   it('reposición menor que el mínimo deshabilita Guardar con un aviso, sin llegar a mandar el PUT', async () => {
     mockearRutasBase((ruta) => {
       if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
@@ -520,6 +547,63 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
 
     expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
+  })
+
+  it('cambiar de punto de venta sin guardar una fila agregada por el picker no deja el ref fantasma corrompiendo la grilla nueva (judgment-day round 2, FINDING 1, MAJOR fix-caused)', async () => {
+    const idArticuloFantasma = articuloFixture().id // 50 — coincide a propósito con la fila PERSISTIDA de PV Norte
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      if (ruta.startsWith('/reportes/stock/existencias?idPuntoVenta=11'))
+        return Promise.resolve(existenciasFixture([filaFixture({ idArticulo: idArticuloFantasma, nombre: 'Arroz persistido en Norte' })], 11))
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture())
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+    // Fila local sin guardar en PV Centro (idPuntoVenta 10) — `filaLocalSinGuardarRef.current := 50`.
+    expect(await screen.findByText('Arroz largo fino 1kg')).toBeInTheDocument()
+
+    // Cambia de PV SIN guardar: `cargar()` reemplaza la grilla entera con la de PV Norte, que trae
+    // una fila PERSISTIDA con el MISMO idArticulo (50) que el ref fantasma todavía recuerda.
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    expect(await screen.findByText('Arroz persistido en Norte')).toBeInTheDocument()
+
+    // Editar + Cancelar sobre esa fila PERSISTIDA: si el ref no se limpió al recargar, `cancelarEdicion`
+    // la matchea por idArticulo y la borra — corrompiendo una fila real del nuevo punto de venta.
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.getByText('Arroz persistido en Norte')).toBeInTheDocument()
+  })
+
+  it('cancelar Editar sobre una fila agregada por el picker y YA GUARDADA no la borra de la grilla (judgment-day round 2, FINDING 2)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    apiPutMock.mockResolvedValue(minimosFixture({ idArticulo: articuloFixture().id, cantidad: 0, minimo: null, reposicion: null, estado: 'SinMinimo' }))
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+    await screen.findByText('Arroz largo fino 1kg')
+
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Editar' })).toHaveLength(2)) // vuelve a modo lectura tras guardar
+
+    const filas = screen.getAllByRole('row')
+    const filaArroz = within(filas.find((f) => within(f).queryByText('Arroz largo fino 1kg') !== null)!)
+    await usuario.click(filaArroz.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.getByText('Arroz largo fino 1kg')).toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Existencias } from './Existencias'
 import { RutaProtegida } from '../auth/RutaProtegida'
 import { ROL } from '../api/tipos'
-import type { Existencias as ExistenciasRespuesta, FilaExistencia, MinimosDeStock, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import type { ArticuloListado, Existencias as ExistenciasRespuesta, FilaExistencia, MinimosDeStock, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
 const apiPutMock = vi.fn()
@@ -85,6 +85,32 @@ function existenciasFixture(filas: FilaExistencia[] = [filaFixture()], idPuntoVe
 
 function minimosFixture(sobrescribir: Partial<MinimosDeStock> = {}): MinimosDeStock {
   return { idPuntoVenta: 10, idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo', ...sobrescribir }
+}
+
+function articuloFixture(sobrescribir: Partial<ArticuloListado> = {}): ArticuloListado {
+  return {
+    id: 50,
+    codigoInterno: 'ART-50',
+    nombre: 'Arroz largo fino 1kg',
+    descripcion: null,
+    idArea: 1,
+    idCategoria: null,
+    idMarca: null,
+    idGrupo: null,
+    idProveedorHabitual: null,
+    idAlicuotaIva: 3,
+    unidadVenta: 'Unidad',
+    unidadesPorBulto: null,
+    esProducto: true,
+    costoLista: null,
+    descuentoProveedor: null,
+    costoNominal: null,
+    disponibleParaTodas: true,
+    idsEmpresas: [],
+    activo: true,
+    controlaLote: false,
+    ...sobrescribir,
+  }
 }
 
 function renderExistencias() {
@@ -387,6 +413,113 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     expect(await screen.findByText('La reposición no puede ser menor que el mínimo.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
     expect(apiPutMock).not.toHaveBeenCalled()
+  })
+
+  it('mientras una fila guarda, TODA la ventana queda attribute-disabled — no solo la fila en edición (decisión 15 / tarea 3.5)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    let resolverPut: (valor: MinimosDeStock) => void = () => {}
+    apiPutMock.mockImplementation(
+      () =>
+        new Promise<MinimosDeStock>((resolve) => {
+          resolverPut = resolve
+        }),
+    )
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0]) // abre A
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    // El PUT de la fila A quedó en vuelo (nunca resuelto todavía) — TODA superficie gobernada por
+    // `guardando` tiene que quedar attribute-disabled, no solo la fila que se está guardando
+    // (react-async-state regla 10: el mismo patrón de bloqueo se replica en cada superficie
+    // hermana de la ventana).
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeDisabled() // única "Editar" visible: fila B
+    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Guardando…' })).toBeDisabled() // el propio Guardar en vuelo
+
+    resolverPut(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
+    await screen.findByText('Bajo')
+
+    expect(screen.getAllByRole('button', { name: 'Editar' })[0]).not.toBeDisabled()
+    expect(screen.getByLabelText('Punto de venta')).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Descargar' })).not.toBeDisabled()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).not.toBeDisabled()
+  })
+
+  it('guardar la fila A y después editar y guardar la fila B aplica la respuesta a B — el `finally` token-gated reabre la ventana (tarea 3.5/3.10)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
+      return undefined
+    })
+    apiPutMock
+      .mockResolvedValueOnce(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
+      .mockResolvedValueOnce(minimosFixture({ idArticulo: 2, cantidad: 87.5, minimo: 10, reposicion: null, estado: 'Bajo' }))
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+
+    // Guarda la fila A (idArticulo 1) de punta a punta.
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await screen.findAllByText('Bajo') // A ya resolvió — si el `finally` quedara colgado, esto nunca abriría B
+
+    // Ahora edita y guarda la fila B (idArticulo 2) — la SEGUNDA fila, no la primera: si el updater
+    // aplicara siempre a la primera fila (o si la ventana siguiera bloqueada por un `finally` sin
+    // `setGuardando(null)`), este segundo guardado fallaría o pisaría la fila equivocada.
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[1]) // fila B — A ya volvió a mostrar "Editar" tras guardar
+    await usuario.type(screen.getByLabelText('Mínimo de Fideos guiseros 500g'), '10')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(2))
+    expect(apiPutMock).toHaveBeenNthCalledWith(2, '/stock/minimos', { idPuntoVenta: 10, idArticulo: 2, minimo: 10, reposicion: null })
+
+    const filas = await screen.findAllByRole('row')
+    const filaB = within(filas[2]) // [0] encabezado, [1] fila A, [2] fila B
+    expect(filaB.getByText('Bajo')).toBeInTheDocument()
+    expect(filaB.getByText('10')).toBeInTheDocument()
+  })
+
+  it('el indicador "Buscando…" del picker de alta desaparece si el término vuelve a quedar corto antes de que la búsqueda resuelva', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    const buscador = screen.getByLabelText('Buscar artículo para agregar')
+
+    await usuario.type(buscador, 'ye')
+    expect(screen.getByText('Buscando…')).toBeInTheDocument()
+
+    await usuario.type(buscador, '{Backspace}') // vuelve a 1 carácter, antes de que resuelva el debounce de 300ms
+    expect(screen.queryByText('Buscando…')).not.toBeInTheDocument()
+  })
+
+  it('cancelar una fila agregada por el picker y nunca guardada la saca de la grilla (fila fantasma, tarea 3.4)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+
+    expect(await screen.findByText('Arroz largo fino 1kg')).toBeInTheDocument()
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -686,6 +686,48 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
 
     expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
   })
+
+  it('agregar X, abrir y cancelar Y (fila persistida distinta) NO reaparece el picker con X vivo — reabrir y cancelar X sí lo reaparece (judgment-day ronda A-3, residual FINDING 1 CRITICAL, tercera variante)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+
+    // Agrega X (idArticulo 50, "Arroz largo fino 1kg") por el picker — fila fantasma benched:
+    // `filaLocalSinGuardarRef.current := 50`, `filaFantasma := 50`, `filaEnEdicion := 50`.
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+    expect(await screen.findByText('Arroz largo fino 1kg')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
+
+    // Con X todavía en edición sin guardar, abre Y — la fila PREEXISTENTE "Yerba mate 1kg"
+    // (idArticulo 100) — y la CANCELA (no la guarda): `abrirFila` solo chequea `guardandoRef`, así
+    // que X queda benched sin tocarse. `cancelarEdicion` no matchea (100 !== 50, el ref sigue en
+    // 50) y pone `filaEnEdicion := null`.
+    await usuario.click(screen.getByRole('button', { name: 'Editar' })) // única "Editar" visible: X muestra Guardar/Cancelar — abre Y
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' })) // única "Cancelar" visible: Y en edición — la cancela
+
+    // Regresión exacta de la tercera variante: `filaEnEdicion === null` ya no alcanza para mostrar
+    // el picker — el fantasma X sigue vivo (`filaFantasma` todavía en 50), así que el picker tiene
+    // que seguir AUSENTE del DOM.
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
+    expect(screen.getByText('Yerba mate 1kg')).toBeInTheDocument() // Y nunca se tocó
+    expect(screen.getByText('Arroz largo fino 1kg')).toBeInTheDocument() // X sigue vivo, sin guardar
+
+    // Reabre X y Cancelar: se remueve de la grilla, ref y estado del fantasma se limpian, y el
+    // picker por fin reaparece.
+    const filas = screen.getAllByRole('row')
+    const filaArroz = within(filas.find((f) => within(f).queryByText('Arroz largo fino 1kg') !== null)!)
+    await usuario.click(filaArroz.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument()
+  })
 })
 
 describe('Existencias — role gating (spec: A Supervisor Exports Existencias)', () => {

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -448,7 +448,6 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
 
   it('mientras una fila guarda, TODA la ventana queda attribute-disabled — no solo la fila en edición (decisión 15 / tarea 3.5)', async () => {
     mockearRutasBase((ruta) => {
-      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
       if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
       return undefined
     })
@@ -463,26 +462,28 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     renderExistencias()
 
     await screen.findByText('Aceite de girasol 900ml')
-    // Deja resultados del picker visibles (sin elegir ninguno) ANTES de disparar el guardado —
-    // judgment-day round A, FINDING 3: el `disabled` de esos botones de resultado, no solo el del
-    // input de búsqueda.
-    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
-    const botonResultado = await screen.findByText('ART-50 — Arroz largo fino 1kg')
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument()
 
     await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0]) // abre A
+    // Judgment-day ronda final A (residual del FINDING 1 CRITICAL): apenas hay una fila en
+    // edición el picker de alta DESAPARECE del DOM — la ausencia supersede al chequeo de
+    // `disabled` que este test hacía antes del fix estructural (no hace falta que haya un PUT
+    // en vuelo todavía, alcanza con `filaEnEdicion !== null`).
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
+
     await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
     await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
 
     // El PUT de la fila A quedó en vuelo (nunca resuelto todavía) — TODA superficie gobernada por
     // `guardando` tiene que quedar attribute-disabled, no solo la fila que se está guardando
     // (react-async-state regla 10: el mismo patrón de bloqueo se replica en cada superficie
-    // hermana de la ventana).
+    // hermana de la ventana). El picker de alta ya no forma parte de esa superficie: sigue
+    // ausente por `filaEnEdicion`, no por `disabled`.
     expect(screen.getByRole('button', { name: 'Editar' })).toBeDisabled() // única "Editar" visible: fila B
     expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
-    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeDisabled()
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Guardando…' })).toBeDisabled() // el propio Guardar en vuelo
-    expect(botonResultado.closest('button')).toBeDisabled() // FINDING 3: el atributo, no solo el guard de `agregarFila`
 
     resolverPut(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
     await screen.findByText('Bajo')
@@ -490,7 +491,7 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     expect(screen.getAllByRole('button', { name: 'Editar' })[0]).not.toBeDisabled()
     expect(screen.getByLabelText('Punto de venta')).not.toBeDisabled()
     expect(screen.getByRole('button', { name: 'Descargar' })).not.toBeDisabled()
-    expect(screen.getByLabelText('Buscar artículo para agregar')).not.toBeDisabled()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument() // reaparece al cerrar la edición
   })
 
   it('guardar la fila A y después editar y guardar la fila B aplica la respuesta a B — el `finally` token-gated reabre la ventana (tarea 3.5/3.10)', async () => {
@@ -559,6 +560,34 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
 
     expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
+  })
+
+  it('agregar X por el picker sin guardar ni cancelar esconde el picker — no hay forma de agregar Z hasta cerrar la edición (judgment-day ronda final A, residual FINDING 1 CRITICAL)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument()
+
+    // Agrega X por el picker — se abre sola para edición, sin guardar ni cancelar.
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+    expect(await screen.findByText('Arroz largo fino 1kg')).toBeInTheDocument()
+
+    // Fix estructural: mientras X siga en edición sin guardar, el picker entero está AUSENTE del
+    // DOM (no solo `disabled`) — no hay forma de agregar un segundo fantasma Z, que era la clase
+    // de bug que dejaba el ref de slot único huérfano.
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
+
+    // Cancelar X: se remueve de la grilla y el picker reaparece.
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument()
   })
 
   it('cambiar de punto de venta sin guardar una fila agregada por el picker no deja el ref fantasma corrompiendo la grilla nueva (judgment-day round 2, FINDING 1, MAJOR fix-caused)', async () => {

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -30,13 +30,17 @@ vi.mock('../api/cliente', () => ({
   },
 }))
 
+// Judgment-day round A (FINDING 2): el default es Admin porque la mayoría de los tests de este
+// archivo ejercitan las acciones de escritura (Editar/Guardar/agregar fila), gateadas por
+// `puedeEscribir` — mismo criterio que `CompraEditor.test.tsx`. Los tests de rol (`describe`
+// "role gating") sobrescriben `usuarioActual` explícitamente cuando necesitan otro rol.
 function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
   return {
     id: 9,
-    usuario: 'supervisor',
-    mail: 'supervisor@ways.test',
-    rolId: ROL.Supervisor,
-    rol: 'Supervisor',
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
     ultimaConexion: null,
     idTenant: 1,
     ...sobrescribir,
@@ -444,6 +448,7 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
 
   it('mientras una fila guarda, TODA la ventana queda attribute-disabled — no solo la fila en edición (decisión 15 / tarea 3.5)', async () => {
     mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
       if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture(dosFilasFixture()))
       return undefined
     })
@@ -458,6 +463,12 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     renderExistencias()
 
     await screen.findByText('Aceite de girasol 900ml')
+    // Deja resultados del picker visibles (sin elegir ninguno) ANTES de disparar el guardado —
+    // judgment-day round A, FINDING 3: el `disabled` de esos botones de resultado, no solo el del
+    // input de búsqueda.
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    const botonResultado = await screen.findByText('ART-50 — Arroz largo fino 1kg')
+
     await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0]) // abre A
     await usuario.type(screen.getByLabelText('Mínimo de Aceite de girasol 900ml'), '5')
     await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
@@ -471,6 +482,7 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
     expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
     expect(screen.getByLabelText('Buscar artículo para agregar')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Guardando…' })).toBeDisabled() // el propio Guardar en vuelo
+    expect(botonResultado.closest('button')).toBeDisabled() // FINDING 3: el atributo, no solo el guard de `agregarFila`
 
     resolverPut(minimosFixture({ idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo' }))
     await screen.findByText('Bajo')
@@ -605,10 +617,51 @@ describe('Existencias — editor de mínimos y reposición (stage-13-stock-intel
 
     expect(screen.getByText('Arroz largo fino 1kg')).toBeInTheDocument()
   })
+
+  it('agregar una fila fantasma X y guardar una fila Y preexistente distinta no la huerfaniza — Cancelar todavía la saca (judgment-day round A, FINDING 1 CRITICAL)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/articulos')) return Promise.resolve({ items: [articuloFixture()], total: 1, pagina: 1, tamanio: 25 })
+      return undefined
+    })
+    apiPutMock.mockResolvedValue(minimosFixture({ idArticulo: 100, cantidad: 42.5, minimo: 5, reposicion: null, estado: 'Bajo' }))
+    const usuario = userEvent.setup()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+
+    // Agrega X (idArticulo 50, "Arroz largo fino 1kg") por el picker — fila fantasma, se abre sola
+    // para edición: `filaLocalSinGuardarRef.current := 50`.
+    await usuario.type(screen.getByLabelText('Buscar artículo para agregar'), 'arroz')
+    await usuario.click(await screen.findByText('ART-50 — Arroz largo fino 1kg'))
+    expect(await screen.findByText('Arroz largo fino 1kg')).toBeInTheDocument()
+
+    // Con X todavía en edición (y sin guardar), abre Y — la fila PREEXISTENTE "Yerba mate 1kg"
+    // (idArticulo 100) — y la guarda de punta a punta. `abrirFila` no exige que ninguna otra fila
+    // esté cerrada, solo que no haya un guardado en vuelo.
+    await usuario.click(screen.getByRole('button', { name: 'Editar' })) // única "Editar" visible: X muestra Guardar/Cancelar
+    await usuario.type(screen.getByLabelText('Mínimo de Yerba mate 1kg'), '5')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalledTimes(1))
+    expect(apiPutMock).toHaveBeenCalledWith('/stock/minimos', { idPuntoVenta: 10, idArticulo: 100, minimo: 5, reposicion: null })
+    await screen.findByText('Bajo')
+
+    // El fantasma X NO se lo llevó el clear del success-path de Y: sigue renderizado.
+    expect(screen.getByText('Arroz largo fino 1kg')).toBeInTheDocument()
+
+    // Reabre X y Cancelar: como nunca se guardó, tiene que desaparecer de la grilla.
+    const filas = screen.getAllByRole('row')
+    const filaArroz = within(filas.find((f) => within(f).queryByText('Arroz largo fino 1kg') !== null)!)
+    await usuario.click(filaArroz.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByText('Arroz largo fino 1kg')).not.toBeInTheDocument()
+  })
 })
 
 describe('Existencias — role gating (spec: A Supervisor Exports Existencias)', () => {
   it('un Supervisor llega a /reportes/existencias', async () => {
+    usuarioActual = usuarioFixture({ id: 9, usuario: 'supervisor', mail: 'supervisor@ways.test', rolId: ROL.Supervisor, rol: 'Supervisor' })
     mockearRutasBase()
     renderExistenciasProtegido()
 
@@ -624,5 +677,28 @@ describe('Existencias — role gating (spec: A Supervisor Exports Existencias)',
 
     expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText('Existencias')).not.toBeInTheDocument())
+  })
+})
+
+describe('Existencias — gate de escritura (judgment-day round A, FINDING 2)', () => {
+  it('un Supervisor lee las columnas pero no ve ninguna acción de escritura: ni "Editar" ni el picker de alta', async () => {
+    usuarioActual = usuarioFixture({ id: 9, usuario: 'supervisor', mail: 'supervisor@ways.test', rolId: ROL.Supervisor, rol: 'Supervisor' })
+    mockearRutasBase()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.getByText('42,5')).toBeInTheDocument() // la lectura de columnas sigue intacta
+    expect(screen.queryByRole('button', { name: 'Editar' })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Buscar artículo para agregar')).not.toBeInTheDocument()
+  })
+
+  it('un Admin sí ve "Editar" y el picker de alta', async () => {
+    usuarioActual = usuarioFixture({ id: 1, usuario: 'admin', mail: 'admin@ways.test', rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Buscar artículo para agregar')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -169,6 +169,12 @@ export function Existencias() {
 
   const cargar = useCallback(() => {
     if (idPuntoVenta === null) return
+    // Judgment-day round 2 (FINDING 1, MAJOR fix-caused): `cargar` siempre reemplaza la grilla
+    // completa (mount inicial, cambio de punto de venta, botón Reintentar) — el `ref` de la fila
+    // local sin guardar de la carga ANTERIOR queda huérfano si no se limpia acá. Sin este clear,
+    // `cancelarEdicion` puede matchear por `idArticulo` una fila PERSISTIDA de la nueva grilla que
+    // coincide por casualidad con el `idArticulo` fantasma, y borrarla.
+    filaLocalSinGuardarRef.current = null
     const miGeneracion = (generacionRef.current += 1)
     setCargando(true)
     setError('')

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -1,22 +1,120 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { clienteDeArticulos } from '../api/articulos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
-import type { Existencias as ExistenciasRespuesta, PuntoVentaListado } from '../api/tipos'
+import { aSolicitudDeMinimos, clienteDeStock, reposicionMenorQueMinimo, umbralTextoValido } from '../api/stock'
+import type { ArticuloListado, EstadoDeReposicion, Existencias as ExistenciasRespuesta, FilaExistencia, PuntoVentaListado } from '../api/tipos'
 import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+
+const CANTIDAD_DE_COLUMNAS = 7
+
+const ETIQUETA_ESTADO: Record<EstadoDeReposicion, string> = {
+  SinMinimo: 'Sin mínimo',
+  Bajo: 'Bajo',
+  Ok: 'Ok',
+}
 
 function formatearCantidad(valor: number): string {
   return valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
 }
 
+function formatearUmbral(valor: number | null): string {
+  return valor === null ? '—' : formatearCantidad(valor)
+}
+
+// ---- Selector de artículo para agregar una fila (stage-13-stock-inteligente, Slice 3) ---------
+// Duplicado de `SelectorDeArticulo` en `Transferencias.tsx`: no hay un módulo compartido de
+// selectores todavía (mismo criterio ya documentado ahí). A diferencia de ese selector, este no
+// mantiene una "descripción elegida" en pantalla — el resultado se consume de inmediato
+// (`onElegir`) y la búsqueda se limpia sola.
+
+type PropsSelectorDeArticuloParaAlta = {
+  disabled: boolean
+  onElegir: (articulo: ArticuloListado) => void
+}
+
+function SelectorDeArticuloParaAlta({ disabled, onElegir }: PropsSelectorDeArticuloParaAlta) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (termino.trim().length < 2) {
+      setResultados([])
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setBuscando(true)
+
+    const temporizador = setTimeout(() => {
+      clienteDeArticulos
+        .listar(termino, false)
+        .then((pagina) => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados(pagina.items)
+        })
+        .catch(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados([])
+        })
+        .finally(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setBuscando(false)
+        })
+    }, 300)
+
+    return () => {
+      vigente = false
+      clearTimeout(temporizador)
+    }
+  }, [termino])
+
+  return (
+    <div className="position-relative" style={{ maxWidth: 320 }}>
+      <input
+        type="text"
+        className="form-control form-control-sm rounded-0"
+        placeholder="Buscar artículo para agregar…"
+        aria-label="Buscar artículo para agregar"
+        value={termino}
+        disabled={disabled}
+        onChange={(e) => setTermino(e.target.value)}
+      />
+      {buscando && <div className="small text-muted">Buscando…</div>}
+      {!buscando && resultados.length > 0 && (
+        <div className="list-group position-absolute w-100" style={{ zIndex: 10 }}>
+          {resultados.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="list-group-item list-group-item-action py-1 px-2 small"
+              onClick={() => {
+                onElegir(a)
+                setTermino('')
+                setResultados([])
+              }}
+            >
+              {a.codigoInterno} — {a.nombre}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /**
- * Existencias (stage-11-exportacion-reportes, Slice 9 — web, droppable a Etapa 13; design: Web
- * Composition; proposal decisión 10) — pantalla modesta: `stock` ⋈ `articulos` de UN punto de
- * venta, sin filtro de fecha (el stock no tiene dimensión temporal) y sin paginado (agregado
- * acotado por construcción, design decisión 6). Misma política que `/tablero`
- * (`Politicas.LecturaDeReportes`: Supervisor + Admin).
+ * Existencias (stage-11-exportacion-reportes, Slice 9 — web; ampliada en stage-13-stock-inteligente,
+ * Slice 3, design: Web Composition; decisiones 15/16) — pantalla del punto de venta: `stock` ⋈
+ * `articulos`, con edición inline de `minimo`/`reposicion` fila-por-fila y alta de artículos nuevos
+ * al grupo gestionado. Misma política que `/tablero` (`Politicas.LecturaDeReportes`: Supervisor +
+ * Admin en lectura; `PUT /api/stock/minimos` es Admin-only del lado del servidor).
  */
 export function Existencias() {
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
@@ -27,7 +125,22 @@ export function Existencias() {
   const [cargando, setCargando] = useState(false)
   const [error, setError] = useState('')
   const [errorDescarga, setErrorDescarga] = useState('')
-  const generacionRef = useRef(0)
+  const generacionRef = useRef(0) // staleness de LECTURAS (regla 2), sin tocar por esta slice
+
+  // ---- Editor inline de una sola fila (decisión 15: bloquear supersede-during-write, nunca
+  // reconciliar por token) --------------------------------------------------------------------
+  const [filaEnEdicion, setFilaEnEdicion] = useState<number | null>(null) // idArticulo, UNA sola
+  const [minimoTexto, setMinimoTexto] = useState('')
+  const [reposicionTexto, setReposicionTexto] = useState('')
+  const [guardando, setGuardando] = useState<number | null>(null) // idArticulo en vuelo — atributo `disabled`
+  // Espejo síncrono de `guardando`, mismo criterio que `transfiriendoRef` en Transferencias.tsx /
+  // CompraEditor.tsx: el `useState` de arriba solo maneja el render (`disabled`), pero React 18
+  // batchea su commit — dos clicks despachados en el MISMO tick (sin render entre medio) todavía
+  // leerían el `guardando` VIEJO del cierre. El guard de reentrancia de primera línea (regla 9)
+  // necesita una escritura/lectura SÍNCRONA, así que vive en este ref, no en el estado.
+  const guardandoRef = useRef<number | null>(null)
+  const [errorGuardado, setErrorGuardado] = useState('')
+  const tokenDeEscrituraRef = useRef(0) // gate de la respuesta/`finally` del propio guardado (regla 2/4)
 
   useEffect(() => {
     let vigente = true
@@ -76,6 +189,97 @@ export function Existencias() {
     cargar()
   }, [cargar])
 
+  function cambiarPuntoVenta(nuevoId: number) {
+    if (guardandoRef.current !== null) return
+    setIdPuntoVenta(nuevoId)
+    setFilaEnEdicion(null)
+    setErrorGuardado('')
+  }
+
+  /** Abre una fila para edición — mutation target nombrado (design decisión 15, tarea 3.6):
+   * sin este guard de primera línea, abrir la fila B mientras la fila A se guarda deja de estar
+   * bloqueado. Lee `guardandoRef` (no el estado `guardando`): un doble click en el MISMO tick
+   * vence tanto al re-render del atributo `disabled` COMO a un guard basado en estado — solo un
+   * ref, escrito/leído sincrónicamente, sobrevive esa carrera (`react-async-state` regla 9). */
+  function abrirFila(fila: FilaExistencia) {
+    if (guardandoRef.current !== null) return
+    setFilaEnEdicion(fila.idArticulo)
+    setMinimoTexto(fila.minimo === null ? '' : String(fila.minimo))
+    setReposicionTexto(fila.reposicion === null ? '' : String(fila.reposicion))
+    setErrorGuardado('')
+  }
+
+  function cancelarEdicion() {
+    if (guardandoRef.current !== null) return
+    setFilaEnEdicion(null)
+    setErrorGuardado('')
+  }
+
+  async function guardarFila(fila: FilaExistencia) {
+    if (guardandoRef.current !== null) return // regla 9: guard de reentrancia de primera línea (doble click)
+    if (idPuntoVenta === null) return
+    if (!umbralTextoValido(minimoTexto) || !umbralTextoValido(reposicionTexto)) return
+    if (reposicionMenorQueMinimo(minimoTexto, reposicionTexto)) return
+
+    const miToken = (tokenDeEscrituraRef.current += 1)
+    guardandoRef.current = fila.idArticulo
+    setGuardando(fila.idArticulo)
+    setErrorGuardado('')
+
+    try {
+      const solicitud = aSolicitudDeMinimos(idPuntoVenta, fila.idArticulo, minimoTexto, reposicionTexto)
+      const resultado = await clienteDeStock.escribirMinimos(solicitud)
+      if (tokenDeEscrituraRef.current !== miToken) return
+
+      // decisión 16: la respuesta AUTORITATIVA se aplica con un updater funcional desde `prev` —
+      // nunca un refetch del reporte completo (regla 1: nunca se lee `existencias` del cierre).
+      setExistencias((prev) => {
+        if (prev === null) return prev
+        return {
+          ...prev,
+          filas: prev.filas.map((f) =>
+            f.idArticulo === resultado.idArticulo
+              ? { ...f, cantidad: resultado.cantidad, minimo: resultado.minimo, reposicion: resultado.reposicion, estado: resultado.estado }
+              : f,
+          ),
+        }
+      })
+      setFilaEnEdicion(null)
+    } catch (e) {
+      if (tokenDeEscrituraRef.current === miToken) {
+        setErrorGuardado(e instanceof ErrorApi ? e.message : 'No se pudo guardar el mínimo.')
+      }
+    } finally {
+      if (tokenDeEscrituraRef.current === miToken) {
+        guardandoRef.current = null
+        setGuardando(null)
+      }
+    }
+  }
+
+  /** Alta de artículo (tarea 3.4): agrega una fila local en `cantidad = 0` (el mismo residuo que
+   * deja el upsert del servidor cuando no había fila de `stock` previa) y la abre para edición —
+   * la fila existe recién cuando el `PUT` la persiste. Si el artículo ya está en la grilla, abre
+   * la fila existente en vez de duplicarla. */
+  function agregarFila(articulo: ArticuloListado) {
+    if (guardandoRef.current !== null) return
+    const existente = existencias?.filas.find((f) => f.idArticulo === articulo.id)
+    if (existente) {
+      abrirFila(existente)
+      return
+    }
+    const nuevaFila: FilaExistencia = {
+      idArticulo: articulo.id,
+      nombre: articulo.nombre,
+      cantidad: 0,
+      minimo: null,
+      reposicion: null,
+      estado: 'SinMinimo',
+    }
+    setExistencias((prev) => (prev === null ? prev : { ...prev, filas: [...prev.filas, nuevaFila] }))
+    abrirFila(nuevaFila)
+  }
+
   return (
     <div className="container-fluid py-4">
       <Box titulo="Existencias" variante="inverse">
@@ -106,7 +310,8 @@ export function Existencias() {
                   id="existencias-punto-venta"
                   className="form-select rounded-0"
                   value={idPuntoVenta}
-                  onChange={(e) => setIdPuntoVenta(Number(e.target.value))}
+                  disabled={guardando !== null}
+                  onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
                 >
                   {puntosVenta.map((pv) => (
                     <option key={pv.id} value={pv.id}>
@@ -121,6 +326,7 @@ export function Existencias() {
                   etiqueta="Descargar"
                   onError={setErrorDescarga}
                   onInicio={() => setErrorDescarga('')}
+                  disabled={guardando !== null}
                 />
               </div>
             </div>
@@ -137,25 +343,118 @@ export function Existencias() {
                       <th>Artículo</th>
                       <th>Nombre</th>
                       <th className="text-end">Cantidad</th>
+                      <th className="text-end">Mínimo</th>
+                      <th className="text-end">Reposición</th>
+                      <th>Estado</th>
+                      <th></th>
                     </tr>
                   </thead>
                   <tbody>
-                    {existencias.filas.map((fila) => (
-                      <tr key={fila.idArticulo}>
-                        <td>{fila.idArticulo}</td>
-                        <td>{fila.nombre}</td>
-                        <td className="text-end">{formatearCantidad(fila.cantidad)}</td>
-                      </tr>
-                    ))}
+                    {existencias.filas.map((fila) => {
+                      const enEdicion = filaEnEdicion === fila.idArticulo
+                      const guardandoEstaFila = guardando === fila.idArticulo
+                      const minimoInvalido = enEdicion && !umbralTextoValido(minimoTexto)
+                      const reposicionInvalida = enEdicion && !umbralTextoValido(reposicionTexto)
+                      const violaReposicion = enEdicion && reposicionMenorQueMinimo(minimoTexto, reposicionTexto)
+                      const puedeGuardar = enEdicion && !minimoInvalido && !reposicionInvalida && !violaReposicion
+
+                      return (
+                        <Fragment key={fila.idArticulo}>
+                          <tr>
+                            <td>{fila.idArticulo}</td>
+                            <td>{fila.nombre}</td>
+                            <td className="text-end">{formatearCantidad(fila.cantidad)}</td>
+                            <td className="text-end" style={{ minWidth: 110 }}>
+                              {enEdicion ? (
+                                <input
+                                  type="text"
+                                  inputMode="decimal"
+                                  className="form-control form-control-sm rounded-0 text-end"
+                                  aria-label={`Mínimo de ${fila.nombre}`}
+                                  value={minimoTexto}
+                                  disabled={guardando !== null}
+                                  onChange={(e) => setMinimoTexto(e.target.value)}
+                                />
+                              ) : (
+                                formatearUmbral(fila.minimo)
+                              )}
+                            </td>
+                            <td className="text-end" style={{ minWidth: 110 }}>
+                              {enEdicion ? (
+                                <input
+                                  type="text"
+                                  inputMode="decimal"
+                                  className="form-control form-control-sm rounded-0 text-end"
+                                  aria-label={`Reposición de ${fila.nombre}`}
+                                  value={reposicionTexto}
+                                  disabled={guardando !== null}
+                                  onChange={(e) => setReposicionTexto(e.target.value)}
+                                />
+                              ) : (
+                                formatearUmbral(fila.reposicion)
+                              )}
+                              {violaReposicion && <div className="small text-danger">La reposición no puede ser menor que el mínimo.</div>}
+                              {(minimoInvalido || reposicionInvalida) && !violaReposicion && (
+                                <div className="small text-danger">Formato numérico inválido.</div>
+                              )}
+                            </td>
+                            <td>{ETIQUETA_ESTADO[fila.estado]}</td>
+                            <td className="text-end" style={{ minWidth: 170 }}>
+                              {enEdicion ? (
+                                <>
+                                  <button
+                                    type="button"
+                                    className="btn btn-primary btn-sm rounded-0 me-1"
+                                    disabled={!puedeGuardar}
+                                    onClick={() => guardarFila(fila)}
+                                  >
+                                    {guardandoEstaFila ? 'Guardando…' : 'Guardar'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="btn btn-outline-secondary btn-sm rounded-0"
+                                    disabled={guardando !== null}
+                                    onClick={cancelarEdicion}
+                                  >
+                                    Cancelar
+                                  </button>
+                                </>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="btn btn-outline-secondary btn-sm rounded-0"
+                                  disabled={guardando !== null}
+                                  onClick={() => abrirFila(fila)}
+                                >
+                                  Editar
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                          {enEdicion && errorGuardado && (
+                            <tr>
+                              <td colSpan={CANTIDAD_DE_COLUMNAS} className="text-danger small py-1">
+                                {errorGuardado}
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      )
+                    })}
                     {existencias.filas.length === 0 && (
                       <tr>
-                        <td colSpan={3} className="text-center text-muted py-4">
+                        <td colSpan={CANTIDAD_DE_COLUMNAS} className="text-center text-muted py-4">
                           No hay stock cargado para este punto de venta.
                         </td>
                       </tr>
                     )}
                   </tbody>
                 </table>
+
+                <div className="mt-2">
+                  <label className="form-label small text-muted d-block mb-1">Agregar artículo</label>
+                  <SelectorDeArticuloParaAlta disabled={guardando !== null} onElegir={agregarFila} />
+                </div>
               </div>
             )}
           </>

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -481,7 +481,13 @@ export function Existencias() {
                   </tbody>
                 </table>
 
-                {puedeEscribir && (
+                {/* Judgment-day ronda final A (residual del FINDING 1 CRITICAL): el gate por identidad
+                    del clear en `guardarFila` no alcanza — `agregarFila` sigue pisando el slot único
+                    del ref sin chequear un fantasma previo. Fix estructural: el picker desaparece
+                    mientras haya CUALQUIER fila en edición, así nunca puede coexistir un segundo
+                    fantasma sin guardar (agregar abre la fila en edición y el picker se esconde hasta
+                    guardar o cancelar). */}
+                {puedeEscribir && filaEnEdicion === null && (
                   <div className="mt-2">
                     <label className="form-label small text-muted d-block mb-1">Agregar artículo</label>
                     <SelectorDeArticuloParaAlta disabled={guardando !== null} onElegir={agregarFila} />

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -4,7 +4,9 @@ import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
 import { aSolicitudDeMinimos, clienteDeStock, reposicionMenorQueMinimo, umbralTextoValido } from '../api/stock'
+import { ROL } from '../api/tipos'
 import type { ArticuloListado, EstadoDeReposicion, Existencias as ExistenciasRespuesta, FilaExistencia, PuntoVentaListado } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
 import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -95,6 +97,7 @@ function SelectorDeArticuloParaAlta({ disabled, onElegir }: PropsSelectorDeArtic
               key={a.id}
               type="button"
               className="list-group-item list-group-item-action py-1 px-2 small"
+              disabled={disabled}
               onClick={() => {
                 onElegir(a)
                 setTermino('')
@@ -115,9 +118,13 @@ function SelectorDeArticuloParaAlta({ disabled, onElegir }: PropsSelectorDeArtic
  * Slice 3, design: Web Composition; decisiones 15/16) — pantalla del punto de venta: `stock` ⋈
  * `articulos`, con edición inline de `minimo`/`reposicion` fila-por-fila y alta de artículos nuevos
  * al grupo gestionado. Misma política que `/tablero` (`Politicas.LecturaDeReportes`: Supervisor +
- * Admin en lectura; `PUT /api/stock/minimos` es Admin-only del lado del servidor).
+ * Admin en lectura; `PUT /api/stock/minimos` es Admin-only del lado del servidor) —
+ * `puedeEscribir` oculta las acciones de escritura, `GestionDeCatalogo` es la autoridad real del
+ * lado del servidor (mismo patrón que `CompraEditor.tsx`).
  */
 export function Existencias() {
+  const { usuario } = useAuth()
+  const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
   const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
 
@@ -260,7 +267,11 @@ export function Existencias() {
           ),
         }
       })
-      filaLocalSinGuardarRef.current = null
+      // Judgment-day round A (FINDING 1, CRITICAL): este clear gatea por IDENTIDAD — si el
+      // usuario abrió OTRA fila (Y) mientras la fantasma (X) seguía sin guardar, guardar Y no
+      // puede pisar el ref de X: eso la huerfanizaría (`cancelarEdicion` matchea por identidad
+      // contra `filaEnEdicion`, así que ya no la encontraría para sacarla de la grilla).
+      if (fila.idArticulo === filaLocalSinGuardarRef.current) filaLocalSinGuardarRef.current = null
       setFilaEnEdicion(null)
     } catch (e) {
       if (tokenDeEscrituraRef.current === miToken) {
@@ -418,35 +429,36 @@ export function Existencias() {
                             </td>
                             <td>{ETIQUETA_ESTADO[fila.estado]}</td>
                             <td className="text-end" style={{ minWidth: 170 }}>
-                              {enEdicion ? (
-                                <>
-                                  <button
-                                    type="button"
-                                    className="btn btn-primary btn-sm rounded-0 me-1"
-                                    disabled={!puedeGuardar || guardandoEstaFila}
-                                    onClick={() => guardarFila(fila)}
-                                  >
-                                    {guardandoEstaFila ? 'Guardando…' : 'Guardar'}
-                                  </button>
+                              {puedeEscribir &&
+                                (enEdicion ? (
+                                  <>
+                                    <button
+                                      type="button"
+                                      className="btn btn-primary btn-sm rounded-0 me-1"
+                                      disabled={!puedeGuardar || guardandoEstaFila}
+                                      onClick={() => guardarFila(fila)}
+                                    >
+                                      {guardandoEstaFila ? 'Guardando…' : 'Guardar'}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="btn btn-outline-secondary btn-sm rounded-0"
+                                      disabled={guardando !== null}
+                                      onClick={cancelarEdicion}
+                                    >
+                                      Cancelar
+                                    </button>
+                                  </>
+                                ) : (
                                   <button
                                     type="button"
                                     className="btn btn-outline-secondary btn-sm rounded-0"
                                     disabled={guardando !== null}
-                                    onClick={cancelarEdicion}
+                                    onClick={() => abrirFila(fila)}
                                   >
-                                    Cancelar
+                                    Editar
                                   </button>
-                                </>
-                              ) : (
-                                <button
-                                  type="button"
-                                  className="btn btn-outline-secondary btn-sm rounded-0"
-                                  disabled={guardando !== null}
-                                  onClick={() => abrirFila(fila)}
-                                >
-                                  Editar
-                                </button>
-                              )}
+                                ))}
                             </td>
                           </tr>
                           {enEdicion && errorGuardado && (
@@ -469,10 +481,12 @@ export function Existencias() {
                   </tbody>
                 </table>
 
-                <div className="mt-2">
-                  <label className="form-label small text-muted d-block mb-1">Agregar artículo</label>
-                  <SelectorDeArticuloParaAlta disabled={guardando !== null} onElegir={agregarFila} />
-                </div>
+                {puedeEscribir && (
+                  <div className="mt-2">
+                    <label className="form-label small text-muted d-block mb-1">Agregar artículo</label>
+                    <SelectorDeArticuloParaAlta disabled={guardando !== null} onElegir={agregarFila} />
+                  </div>
+                )}
               </div>
             )}
           </>

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -45,6 +45,7 @@ function SelectorDeArticuloParaAlta({ disabled, onElegir }: PropsSelectorDeArtic
   useEffect(() => {
     if (termino.trim().length < 2) {
       setResultados([])
+      setBuscando(false)
       return
     }
 
@@ -130,6 +131,10 @@ export function Existencias() {
   // ---- Editor inline de una sola fila (decisión 15: bloquear supersede-during-write, nunca
   // reconciliar por token) --------------------------------------------------------------------
   const [filaEnEdicion, setFilaEnEdicion] = useState<number | null>(null) // idArticulo, UNA sola
+  // Tarea 3.4 / fila fantasma: `agregarFila` appenda la fila local ANTES del `PUT` que la
+  // persiste — este ref recuerda el `idArticulo` de esa fila local mientras sigue sin guardarse,
+  // para que `cancelarEdicion` pueda sacarla de la grilla en vez de dejarla huérfana.
+  const filaLocalSinGuardarRef = useRef<number | null>(null)
   const [minimoTexto, setMinimoTexto] = useState('')
   const [reposicionTexto, setReposicionTexto] = useState('')
   const [guardando, setGuardando] = useState<number | null>(null) // idArticulo en vuelo — atributo `disabled`
@@ -211,6 +216,11 @@ export function Existencias() {
 
   function cancelarEdicion() {
     if (guardandoRef.current !== null) return
+    if (filaLocalSinGuardarRef.current !== null && filaLocalSinGuardarRef.current === filaEnEdicion) {
+      const idALimpiar = filaLocalSinGuardarRef.current
+      setExistencias((prev) => (prev === null ? prev : { ...prev, filas: prev.filas.filter((f) => f.idArticulo !== idALimpiar) }))
+      filaLocalSinGuardarRef.current = null
+    }
     setFilaEnEdicion(null)
     setErrorGuardado('')
   }
@@ -244,6 +254,7 @@ export function Existencias() {
           ),
         }
       })
+      filaLocalSinGuardarRef.current = null
       setFilaEnEdicion(null)
     } catch (e) {
       if (tokenDeEscrituraRef.current === miToken) {
@@ -277,6 +288,7 @@ export function Existencias() {
       estado: 'SinMinimo',
     }
     setExistencias((prev) => (prev === null ? prev : { ...prev, filas: [...prev.filas, nuevaFila] }))
+    filaLocalSinGuardarRef.current = nuevaFila.idArticulo
     abrirFila(nuevaFila)
   }
 
@@ -405,7 +417,7 @@ export function Existencias() {
                                   <button
                                     type="button"
                                     className="btn btn-primary btn-sm rounded-0 me-1"
-                                    disabled={!puedeGuardar}
+                                    disabled={!puedeGuardar || guardandoEstaFila}
                                     onClick={() => guardarFila(fila)}
                                   >
                                     {guardandoEstaFila ? 'Guardando…' : 'Guardar'}

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -142,6 +142,12 @@ export function Existencias() {
   // persiste — este ref recuerda el `idArticulo` de esa fila local mientras sigue sin guardarse,
   // para que `cancelarEdicion` pueda sacarla de la grilla en vez de dejarla huérfana.
   const filaLocalSinGuardarRef = useRef<number | null>(null)
+  // Judgment-day ronda A-3 (residual del FINDING 1 CRITICAL): espejo de estado del ref de arriba,
+  // mismo patrón que `guardando`/`guardandoRef` — el ref sirve para guards síncronos, pero mutarlo
+  // NO re-renderiza, así que el picker no puede gatear su visibilidad por el ref solo. Este estado
+  // es la única fuente de verdad para el render: "existe un fantasma sin guardar" (a diferencia de
+  // `filaEnEdicion`, que solo dice cuál fila está abierta, no si quedó un fantasma benched).
+  const [filaFantasma, setFilaFantasma] = useState<number | null>(null)
   const [minimoTexto, setMinimoTexto] = useState('')
   const [reposicionTexto, setReposicionTexto] = useState('')
   const [guardando, setGuardando] = useState<number | null>(null) // idArticulo en vuelo — atributo `disabled`
@@ -182,6 +188,7 @@ export function Existencias() {
     // `cancelarEdicion` puede matchear por `idArticulo` una fila PERSISTIDA de la nueva grilla que
     // coincide por casualidad con el `idArticulo` fantasma, y borrarla.
     filaLocalSinGuardarRef.current = null
+    setFilaFantasma(null) // espejo de estado (patrón guardandoRef): sin esto el picker no reaparecería
     const miGeneracion = (generacionRef.current += 1)
     setCargando(true)
     setError('')
@@ -233,6 +240,7 @@ export function Existencias() {
       const idALimpiar = filaLocalSinGuardarRef.current
       setExistencias((prev) => (prev === null ? prev : { ...prev, filas: prev.filas.filter((f) => f.idArticulo !== idALimpiar) }))
       filaLocalSinGuardarRef.current = null
+      setFilaFantasma(null) // espejo de estado (patrón guardandoRef): sin esto el picker no reaparecería
     }
     setFilaEnEdicion(null)
     setErrorGuardado('')
@@ -271,7 +279,10 @@ export function Existencias() {
       // usuario abrió OTRA fila (Y) mientras la fantasma (X) seguía sin guardar, guardar Y no
       // puede pisar el ref de X: eso la huerfanizaría (`cancelarEdicion` matchea por identidad
       // contra `filaEnEdicion`, así que ya no la encontraría para sacarla de la grilla).
-      if (fila.idArticulo === filaLocalSinGuardarRef.current) filaLocalSinGuardarRef.current = null
+      if (fila.idArticulo === filaLocalSinGuardarRef.current) {
+        filaLocalSinGuardarRef.current = null
+        setFilaFantasma(null) // espejo de estado (patrón guardandoRef): sin esto el picker no reaparecería
+      }
       setFilaEnEdicion(null)
     } catch (e) {
       if (tokenDeEscrituraRef.current === miToken) {
@@ -306,6 +317,7 @@ export function Existencias() {
     }
     setExistencias((prev) => (prev === null ? prev : { ...prev, filas: [...prev.filas, nuevaFila] }))
     filaLocalSinGuardarRef.current = nuevaFila.idArticulo
+    setFilaFantasma(nuevaFila.idArticulo) // espejo de estado (patrón guardandoRef): gobierna el render del picker
     abrirFila(nuevaFila)
   }
 
@@ -481,13 +493,15 @@ export function Existencias() {
                   </tbody>
                 </table>
 
-                {/* Judgment-day ronda final A (residual del FINDING 1 CRITICAL): el gate por identidad
-                    del clear en `guardarFila` no alcanza — `agregarFila` sigue pisando el slot único
-                    del ref sin chequear un fantasma previo. Fix estructural: el picker desaparece
-                    mientras haya CUALQUIER fila en edición, así nunca puede coexistir un segundo
-                    fantasma sin guardar (agregar abre la fila en edición y el picker se esconde hasta
-                    guardar o cancelar). */}
-                {puedeEscribir && filaEnEdicion === null && (
+                {/* Judgment-day ronda A-3 (residual del FINDING 1 CRITICAL, tercera variante): gatear
+                    solo por `filaEnEdicion === null` no alcanza — un fantasma puede quedar "benched"
+                    (agregado pero sin guardar) mientras se abre y cancela OTRA fila persistida, y ese
+                    camino deja `filaEnEdicion` en `null` con el fantasma todavía vivo, reapareciendo
+                    el picker y permitiendo que un segundo alta pise el slot único del ref. La condición
+                    correcta es "no existe NINGÚN fantasma sin guardar" — no "no hay fila en edición" —,
+                    así que el render usa `filaFantasma` (estado), nunca el ref (mutar un ref no
+                    re-renderiza). */}
+                {puedeEscribir && filaEnEdicion === null && filaFantasma === null && (
                   <div className="mt-2">
                     <label className="form-label small text-muted d-block mb-1">Agregar artículo</label>
                     <SelectorDeArticuloParaAlta disabled={guardando !== null} onElegir={agregarFila} />


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 3 (Web Minimos)

- `Existencias.tsx` se vuelve la pantalla de stock por PV: columnas Mínimo/Reposición/Estado, edición inline de a una fila, add-row por picker de artículos (patrón Transferencias), guardado que aplica la respuesta autoritativa `MinimosDeStock` con functional updater keyed por idArticulo — SIN refetch post-write (decisión 16).
- Ventana de escritura bloqueada (decisión 15): `guardando`+`guardandoRef` (el ref para guards same-tick — un guard por useState no sobrevive el batching de React 18, precedente `transfiriendoRef`), TODA la ventana attribute-disabled, gate `puedeEscribir` Admin-only (precedente CompraEditor: la UI oculta, `GestionDeCatalogo` es la autoridad real).
- Fantasma de add-row con ciclo de vida cerrado estructuralmente: `filaFantasma` estado ESPEJO de `filaLocalSinGuardarRef` (el ref jamás gobierna render), picker visible solo sin fila en edición ni fantasma vivo, clear identity-gated.
- Espejos TS exactos de los contratos C#; `aSolicitudDeMinimos` con coerción `'' → null`; pre-validación cliente espejo de `reposicion_menor_que_minimo`.
- Gate SIN-CAMBIOS-DE-SCHEMA: cero archivos .NET en el diff.

## Tests
25 en Existencias.test.tsx + descriptores de coerción; vitest full 641/641; tsc limpio. Mutation targets con evidencia: guard same-tick de abrirFila Y de guardarFila, full-window por atributo, clear del finally, updater por identidad, fantasma en sus 3 variantes.

## Judgment-day (el más largo del programa)
Juez B ronda 1: 2 MAJORs (tasks 3.12/3.13 borradas del checklist; full-window infalsificable) + 4 WARNINGs deterministas (lockup invisible, updater sin identidad probada, Buscando… colgado, Guardar no inerte). Re-ronda B 1: cazó EN VIVO un MAJOR fix-caused (ref stale tras cambio de PV borraba una fila persistida). Re-ronda B 2: limpia. Juez A: CRITICAL del fantasma huérfano en TRES variantes sucesivas hasta el cierre estructural por espejo de estado, con walk exhaustivo de la máquina de estados. Pasada final de higiene de B sobre el delta post-approval: 4 re-mutaciones muertas, hollowing del gate de rol descartado empíricamente. Ambos ledgers limpios en `678f1c2`.

Nota de presupuesto: desborde por profundidad de tests (mismo criterio de PR único que los slices 1-5); el corte pre-identificado (add-row) no se ejerció.

🤖 Generated with [Claude Code](https://claude.com/claude-code)