### PR TITLE
feat(stage-13): slice 6 web-reposicion — pantalla de reposicion agrupada por proveedor

### DIFF
--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -977,6 +977,16 @@ depends on it.
   queda sin test unitario en ningún sibling de esta suite; no se agregó
   cobertura Layout-level para Reposición porque ningún sibling la tiene
   (no es una regresión de este slice).
+  **Ronda 2, juez A**: 0 severos, 1 WARNING cerrado (test-only) —
+  `Reposicion.test.tsx:151-169` ('sugerido renderiza — cuando es null,
+  nunca 0') solo contrastaba `null` ('—') contra `8` ('8'), nunca un
+  `sugerido = 0` genuino: un regression a `!valor ? '—' : ...` en
+  `formatearCantidadNullable` (Reposicion.tsx) habría pasado la suite
+  renderizando '—' para un 0 real (fix: test hermano nuevo, fixture
+  `idArticulo: 3, sugerido: 0`, assert `getByText('0')` +
+  `queryByText('—')` ausente; evidencia: mutado `valor === null` →
+  `!valor`, el nuevo assert falló solo; revertido, suite completa verde
+  otra vez — 626/626).
 - [ ] 6.9 Branch `feat/stage13-slice6-web-reposicion` off `main` (parent:
   slices 4+5); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -955,7 +955,10 @@ depends on it.
   the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files). Web-only slice, as expected.
-- [ ] 6.8 Run `judgment-day`; fix; re-judge until clean.
+- [x] 6.8 Run `judgment-day`; fix; re-judge until clean. *(CLEAN
+  2026-08-15: re-ronda B aprobada — 4 re-mutaciones muertas, mocks sin
+  fugas; juez A fresh: 0 severos, 1 WARNING cerrado test-only con
+  evidencia de mutación falsy-coercion. JUDGMENT: APPROVED.)*
   **Ronda 1, juez B**: 4 hallazgos confirmados, los 4 cerrados —
   (MAJOR) `Reposicion.test.tsx` el test del botón de descarga no clickeaba
   ni asertaba la ruta, solo existencia (fix: replica el precedente
@@ -987,7 +990,7 @@ depends on it.
   `queryByText('—')` ausente; evidencia: mutado `valor === null` →
   `!valor`, el nuevo assert falló solo; revertido, suite completa verde
   otra vez — 626/626).
-- [ ] 6.9 Branch `feat/stage13-slice6-web-reposicion` off `main` (parent:
+- [x] 6.9 Branch `feat/stage13-slice6-web-reposicion` off `main` (parent:
   slices 4+5); PR; merge stacked-to-main.
 
 **Test plan**: grouping descriptors (6.5), null-sugerido render (6.6).

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -956,6 +956,27 @@ depends on it.
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files). Web-only slice, as expected.
 - [ ] 6.8 Run `judgment-day`; fix; re-judge until clean.
+  **Ronda 1, juez B**: 4 hallazgos confirmados, los 4 cerrados —
+  (MAJOR) `Reposicion.test.tsx` el test del botón de descarga no clickeaba
+  ni asertaba la ruta, solo existencia (fix: replica el precedente
+  `Vencimientos.test.tsx` — click + `apiDescargarMock` matchea
+  `/reportes/stock/reposicion/export?idPuntoVenta=`); (WARNING)
+  `agruparPorProveedor.test.ts` ningún test discriminaba la clave del fold
+  (`idProveedor` vs. nombre) por fixtures biyectivos (fix: test nuevo con
+  dos proveedores de igual nombre e id distinto, consecutivos → dos
+  grupos); (WARNING) el gate de generación de `Reposicion.tsx` (stale
+  response) sin cobertura (fix: test de respuesta desactualizada, mismo
+  patrón que `Vencimientos.test.tsx` — promesa diferida + `act` síncrono,
+  mutation-proof-tests regla 7); (WARNING) sin tests de rol/ruta para
+  `/reportes/stock/reposicion` (fix: replica los dos tests de rol de
+  `Vencimientos.test.tsx` — Supervisor llega, Vendedor redirige a Inicio).
+  **Limitación de suite registrada** (igual que en `Vencimientos.test.tsx`
+  y demás siblings): los tests de rol montan `RutaProtegida` directo en un
+  `MemoryRouter` propio del test, no a través de `App.tsx` — la
+  invisibilidad de la entrada de nav en `Layout.tsx` para roles sin acceso
+  queda sin test unitario en ningún sibling de esta suite; no se agregó
+  cobertura Layout-level para Reposición porque ningún sibling la tiene
+  (no es una regresión de este slice).
 - [ ] 6.9 Branch `feat/stage13-slice6-web-reposicion` off `main` (parent:
   slices 4+5); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -907,29 +907,54 @@ by proveedor habitual, with a download button and a nav entry.
 **Rollback**: revert the branch — a new, additive screen; nothing else
 depends on it.
 
-- [ ] 6.1 Modify `src/Ways.Web/src/api/{tipos,reportes}.ts`: mirror
+- [x] 6.1 Modify `src/Ways.Web/src/api/{tipos,reportes}.ts`: mirror
   `FilaDeReposicion` (with the two rotation fields), `Reposicion`,
   `FilaDeRotacion`, `Rotacion`; `clienteDeReportes.reposicion`,
   `clienteDeReportes.rotacion`; `rutasDeExportacion.reposicion`.
-- [ ] 6.2 Create the pure helper `agruparPorProveedor(filas) →
+- [x] 6.2 Create the pure helper `agruparPorProveedor(filas) →
   { idProveedor, proveedor, filas }[]` — a **fold over the already-ordered
-  list** (no client-side sort — decision 4).
-- [ ] 6.3 Create `src/Ways.Web/src/paginas/Reposicion.tsx`: PV selector,
+  list** (no client-side sort — decision 4). *(colocated at
+  `src/Ways.Web/src/paginas/agruparPorProveedor.ts` — same "standalone pure
+  helper module in `paginas/`" precedent as `etiquetaParaValorFaltante.ts`;
+  groups CONSECUTIVE rows sharing `idProveedor`, never a second sort, since
+  the server already guarantees a single trailing *Sin proveedor* run)*
+- [x] 6.3 Create `src/Ways.Web/src/paginas/Reposicion.tsx`: PV selector,
   fetches `clienteDeReportes.reposicion(idPuntoVenta, null)`,
   `BotonDeDescarga` pointing at `rutasDeExportacion.reposicion(idPuntoVenta)`
   (the `Existencias.tsx` shape verbatim). Header per group shows the
   proveedor and its row count; `sugerido` renders `—` when null, never `0`.
-- [ ] 6.4 Modify `src/Ways.Web/src/App.tsx` and
+  **APPLY NOTE**: `rutasDeExportacion.reposicion` takes `(idPuntoVenta,
+  dias)` (mirroring `vencimientos`'s signature, since the backend route
+  accepts `dias` too) — the page always calls it with `dias = null`, exactly
+  like `clienteDeReportes.reposicion(idPuntoVenta, null)`; no `dias` control
+  is exposed in this slice's UI (design's Reposicion.tsx composition note
+  never asks for one). Columns shipped: Artículo, Cantidad, Mínimo,
+  Reposición, Sugerido — the two rotation fields
+  (`consumoDiarioPromedio`/`diasDeCobertura`) are on the DTO for slice 7's
+  `Sugerido` column on `Existencias.tsx`, never displayed here (design's
+  Reposicion.tsx section only asks for `sugerido`).
+- [x] 6.4 Modify `src/Ways.Web/src/App.tsx` and
   `src/Ways.Web/src/componentes/Layout.tsx`: one route, one nav entry
-  alongside `/reportes/stock/vencimientos`.
-- [ ] 6.5 [P] Descriptor tests for `agruparPorProveedor`: two proveedores
+  alongside `/reportes/stock/vencimientos`. Route `/reportes/stock/reposicion`,
+  same `RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}` gate as
+  `/reportes/stock/vencimientos`; nav entry "Reposición" placed immediately
+  after "Vencimientos" under the same `puedeVerReportes` gate.
+- [x] 6.5 [P] Descriptor tests for `agruparPorProveedor`: two proveedores
   in server order, a *Sin proveedor* bucket landing **last**, a single row,
-  the empty list. *(web-descriptor-tests)*
-- [ ] 6.6 [P] Component test: `sugerido` renders `—` for a null value,
+  the empty list. *(web-descriptor-tests)* Implemented in
+  `agruparPorProveedor.test.ts` — 4 tests, all four scenarios covered.
+- [x] 6.6 [P] Component test: `sugerido` renders `—` for a null value,
   never `0` — the cell an operator would otherwise misread as "buy
-  nothing".
-- [ ] 6.7 Gate guard: `has-pending-model-changes` clean, zero migration
-  files in the diff.
+  nothing". Implemented in `Reposicion.test.tsx` (`'sugerido renderiza —
+  cuando es null, nunca 0'`), plus 4 more component tests (first-PV load
+  with no `?dias=`, group header text, download button wiring, empty state).
+- [x] 6.7 Gate guard: `has-pending-model-changes` clean, zero migration
+  files in the diff. **VERIFIED**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made to
+  the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
+  files). Web-only slice, as expected.
 - [ ] 6.8 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 6.9 Branch `feat/stage13-slice6-web-reposicion` off `main` (parent:
   slices 4+5); PR; merge stacked-to-main.

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -25,6 +25,7 @@ import { Parametros } from './paginas/Parametros'
 import { Pos } from './paginas/Pos'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
+import { Reposicion } from './paginas/Reposicion'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
 import { Tablero } from './paginas/Tablero'
 import { Tenants } from './paginas/Tenants'
@@ -149,6 +150,18 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
                   <Vencimientos />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-13-stock-inteligente (Slice 6, design: "Reposicion.tsx — grouped by
+                proveedor"): mismo gate que /reportes/stock/vencimientos
+                (Politicas.LecturaDeReportes) — vista de gestión, agrupada por proveedor
+                habitual. */}
+            <Route
+              path="/reportes/stock/reposicion"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+                  <Reposicion />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -13,9 +13,11 @@ import type {
   PaginaDeHistoricoDeCajas,
   PaginaDeMovimientosTesoreria,
   Rentabilidad,
+  Reposicion,
   ResumenDeGastos,
   ResumenDeVencimientos,
   ResumenDeVentas,
+  Rotacion,
   TopArticulos,
   Vencimientos,
   VentasPorMedioPago,
@@ -119,6 +121,16 @@ export const clienteDeReportes = {
     ),
   vencimientosResumen: (idPuntoVenta: number) =>
     api.get<ResumenDeVencimientos>(`/reportes/stock/vencimientos/resumen?idPuntoVenta=${idPuntoVenta}`),
+  /** stage-13-stock-inteligente (Slice 6): mismo criterio opcional de `dias` que `vencimientos` —
+   * omitido, el servidor resuelve `dias_rotacion` (PV → empresa → default). */
+  reposicion: (idPuntoVenta: number, dias: number | null) =>
+    api.get<Reposicion>(
+      `/reportes/stock/reposicion?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}`,
+    ),
+  /** stage-13-stock-inteligente (Slice 6): feed independiente de `minimoSugerido`, mismo criterio
+   * opcional de `dias`. */
+  rotacion: (idPuntoVenta: number, dias: number | null) =>
+    api.get<Rotacion>(`/reportes/stock/rotacion?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}`),
 }
 
 // ---- Offset local para desde/hasta de /cajas y /tesoreria (stage-11-exportacion-reportes,
@@ -228,6 +240,11 @@ export const rutasDeExportacion = {
    * `formato=xlsx`, mismo criterio que `existencias`. */
   vencimientos: (idPuntoVenta: number, dias: number | null) =>
     `/reportes/stock/vencimientos/export?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}&formato=xlsx`,
+  /** stage-13-stock-inteligente (Slice 6): mismo query string que la ruta JSON hermana +
+   * `formato=xlsx`, mismo criterio que `vencimientos`. Sin sibling propio para `/rotacion` — esa
+   * ruta no tiene export (`ReportesEndpoints.cs`). */
+  reposicion: (idPuntoVenta: number, dias: number | null) =>
+    `/reportes/stock/reposicion/export?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}&formato=xlsx`,
 }
 
 function aFechaIso(fecha: Date): string {

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1319,6 +1319,67 @@ export type Vencimientos = {
  * agrupados por `FilaDeVencimiento.estado` — nunca una query de agregación separada. */
 export type ResumenDeVencimientos = { idPuntoVenta: number; vencidos: number; porVencer: number; sinFecha: number }
 
+// --- Reposición de stock (stage-13-stock-inteligente, Slices 4/5) ----------------------------
+// Espejo de `Ways.Application.Reportes.Contratos` — alerta y sugerencia de compra
+// (`minimo IS NOT NULL AND cantidad <= minimo`), agrupable por proveedor habitual, más el feed
+// independiente de rotación que alimenta `minimoSugerido` (Slice 5).
+
+/** Fila de `GET /api/reportes/stock/reposicion` — espejo de `FilaDeReposicion`. `sugerido` es
+ * `null`, NUNCA `0`, cuando `reposicion` no está configurado. `idProveedor`/`proveedor` viajan
+ * `null` en conjunto para la fila que cae en el grupo "Sin proveedor" — un `idProveedorHabitual`
+ * que apunta a un proveedor soft-deleted también proyecta `null` acá (orchestrator decision 12,
+ * tasks.md stage-13): un solo bucket "Sin proveedor", nunca un FK colgante ni un segundo bucket.
+ * `consumoDiarioPromedio`/`diasDeCobertura` son `null`, NUNCA `0`, cuando el artículo no tiene
+ * historia calificada en la ventana de rotación. */
+export type FilaDeReposicion = {
+  idArticulo: number
+  articulo: string
+  cantidad: number
+  minimo: number
+  reposicion: number | null
+  sugerido: number | null
+  idProveedor: number | null
+  proveedor: string | null
+  consumoDiarioPromedio: number | null
+  diasDeCobertura: number | null
+}
+
+/** Respuesta de `GET /api/reportes/stock/reposicion` — espejo de `Reposicion`. `hoy`/
+ * `zonaHoraria` son la fecha y la zona efectivamente resueltas (echo obligatorio, mismo criterio
+ * que `Vencimientos.hoy`/`Vencimientos.zonaHoraria`); `diasDeRotacion` es el horizonte efectivo —
+ * el parámetro `dias` de la query si vino, si no `dias_rotacion` (default 30). */
+export type Reposicion = {
+  idPuntoVenta: number
+  hoy: string
+  diasDeRotacion: number
+  zonaHoraria: string
+  filas: FilaDeReposicion[]
+}
+
+/** Fila de `GET /api/reportes/stock/rotacion` — espejo de `FilaDeRotacion`. Solo existe porque el
+ * artículo tuvo AL MENOS UN movimiento calificado (venta o su anulación, nunca la anulación de
+ * una compra) en la ventana — un artículo sin historia NO ES UNA FILA de esta lista, nunca una
+ * fila con `minimoSugerido` en `0`. */
+export type FilaDeRotacion = {
+  idArticulo: number
+  articulo: string
+  consumoEnVentana: number
+  consumoDiarioPromedio: number
+  minimoSugerido: number
+}
+
+/** Respuesta de `GET /api/reportes/stock/rotacion` — espejo de `Rotacion`. `diasCoberturaObjetivo`
+ * es el horizonte de cobertura efectivamente resuelto que multiplica `minimoSugerido` — mismo
+ * criterio de echo obligatorio que `diasDeRotacion`. */
+export type Rotacion = {
+  idPuntoVenta: number
+  hoy: string
+  diasDeRotacion: number
+  diasCoberturaObjetivo: number
+  zonaHoraria: string
+  filas: FilaDeRotacion[]
+}
+
 // --- Reportes (stage-10-agregacion-dashboard, Slice 7): G1 parity — ventas/resumen y
 // gastos/resumen. Espejo de `Ways.Application.Reportes.Contratos` — mismos nombres de campo que
 // el backend serializa en camelCase, ningún dato de negocio recalculado en el cliente.

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -109,6 +109,15 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-13-stock-inteligente (Slice 6): mismo gate que Vencimientos
+                    (puedeVerReportes). */}
+                {usuario && puedeVerReportes(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/reportes/stock/reposicion">
+                      Reposición
+                    </NavLink>
+                  </li>
+                )}
                 {usuario && puedeGestionarUsuarios(usuario.rolId) && (
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/usuarios">

--- a/src/Ways.Web/src/paginas/Reposicion.test.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen, within } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Reposicion } from './Reposicion'
-import type { FilaDeReposicion, PuntoVentaListado, Reposicion as ReposicionRespuesta } from '../api/tipos'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { FilaDeReposicion, PuntoVentaListado, Reposicion as ReposicionRespuesta, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
 const apiDescargarMock = vi.fn()
@@ -26,11 +29,43 @@ vi.mock('../api/cliente', () => ({
   },
 }))
 
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
 const puntoVentaCentro: PuntoVentaListado = {
   id: 10,
   idTenant: 1,
   idEmpresa: 1,
   nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+const puntoVentaNorte: PuntoVentaListado = {
+  id: 11,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Norte',
   domicilio: null,
   horario: null,
   whatsapp: null,
@@ -61,7 +96,7 @@ function reposicionFixture(filas: FilaDeReposicion[], idPuntoVenta = 10): Reposi
 
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
-    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro])
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro, puntoVentaNorte])
     const propia = sobrescribir?.(ruta)
     if (propia) return propia
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
@@ -72,10 +107,31 @@ function renderReposicion() {
   return render(<Reposicion />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
 }
 
+/** Monta detrás del mismo gate de rol que `App.tsx` usa para
+ * `/reportes/stock/reposicion` (`Politicas.LecturaDeReportes`). */
+function renderReposicionProtegido() {
+  return render(
+    <MemoryRouter initialEntries={['/reportes/stock/reposicion']}>
+      <Routes>
+        <Route
+          path="/reportes/stock/reposicion"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
+              <Reposicion />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   apiGetMock.mockReset()
   apiDescargarMock.mockReset()
   apiDescargarMock.mockResolvedValue(undefined)
+  usuarioActual = usuarioFixture()
 })
 
 describe('Reposicion (stage-13-stock-inteligente, Slice 6 — web)', () => {
@@ -133,10 +189,13 @@ describe('Reposicion (stage-13-stock-inteligente, Slice 6 — web)', () => {
       if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaFixture()]))
       return undefined
     })
+    const usuario = userEvent.setup()
     renderReposicion()
 
     await screen.findByText('Yerba mate 1kg')
-    expect(await screen.findByRole('button', { name: 'Descargar' })).toBeInTheDocument()
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(apiDescargarMock.mock.calls[0][0]).toMatch(/^\/reportes\/stock\/reposicion\/export\?idPuntoVenta=10/)
   })
 
   it('sin filas bajo el mínimo muestra un estado vacío', async () => {
@@ -147,5 +206,65 @@ describe('Reposicion (stage-13-stock-inteligente, Slice 6 — web)', () => {
     renderReposicion()
 
     expect(await screen.findByText('No hay artículos bajo el mínimo para este punto de venta.')).toBeInTheDocument()
+  })
+
+  it('una respuesta desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: ReposicionRespuesta) => void = () => {}
+    const primera = new Promise<ReposicionRespuesta>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(reposicionFixture([filaFixture({ idArticulo: 999, articulo: 'segunda-respuesta' })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderReposicion()
+    await screen.findByLabelText('Punto de venta')
+
+    await usuario.selectOptions(screen.getByLabelText('Punto de venta'), '11')
+    expect(await screen.findByText('segunda-respuesta')).toBeInTheDocument()
+
+    // El flush del microtask va DENTRO de act (mutation-proof-tests regla 7): un waitFor solo
+    // pasaría en su primer tick, antes de que el .then stale aterrice.
+    const { act } = await import('@testing-library/react')
+    await act(async () => {
+      resolverPrimera(reposicionFixture([filaFixture({ idArticulo: 1, articulo: 'primera-respuesta-vieja' })]))
+      await primera
+    })
+    expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument()
+    expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Reposicion — role gating (mismo gate que Vencimientos: Politicas.LecturaDeReportes)', () => {
+  it('un Supervisor llega a /reportes/stock/reposicion', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaFixture()]))
+      return undefined
+    })
+    renderReposicionProtegido()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor nunca llega a /reportes/stock/reposicion: redirige a Inicio', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'vendedor', rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaFixture()]))
+      return undefined
+    })
+
+    renderReposicionProtegido()
+
+    expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Reposición')).not.toBeInTheDocument())
   })
 })

--- a/src/Ways.Web/src/paginas/Reposicion.test.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.test.tsx
@@ -168,6 +168,25 @@ describe('Reposicion (stage-13-stock-inteligente, Slice 6 — web)', () => {
     expect(within(filaDos).getByText('8')).toBeInTheDocument()
   })
 
+  it('sugerido renderiza 0 cuando es un sugerido genuino de 0 — nunca —', async () => {
+    // Regression guard: un `!valor ? '—' : ...` en formatearCantidadNullable trataría
+    // sugerido: 0 como falsy y renderizaría '—' (lectura "comprar nada" que la spec prohíbe).
+    const filaConSugeridoCero = filaFixture({ idArticulo: 3, sugerido: 0 })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) {
+        return Promise.resolve(reposicionFixture([filaConSugeridoCero]))
+      }
+      return undefined
+    })
+    renderReposicion()
+
+    const filas = await screen.findAllByRole('row')
+    // fila 0 = encabezado, fila 1 = header del grupo de proveedor, fila 2 = dato.
+    const filaDato = filas[2]
+    expect(within(filaDato).queryByText('—')).not.toBeInTheDocument()
+    expect(within(filaDato).getByText('0')).toBeInTheDocument()
+  })
+
   it('agrupa por proveedor mostrando el nombre y la cantidad de filas en el encabezado del grupo', async () => {
     const filaUno = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Uno' })
     const filaDos = filaFixture({ idArticulo: 2, idProveedor: 1, proveedor: 'Proveedor Uno' })

--- a/src/Ways.Web/src/paginas/Reposicion.test.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Reposicion } from './Reposicion'
+import type { FilaDeReposicion, PuntoVentaListado, Reposicion as ReposicionRespuesta } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function filaFixture(sobrescribir: Partial<FilaDeReposicion> = {}): FilaDeReposicion {
+  return {
+    idArticulo: 100,
+    articulo: 'Yerba mate 1kg',
+    cantidad: 3,
+    minimo: 10,
+    reposicion: 20,
+    sugerido: 17,
+    idProveedor: 1,
+    proveedor: 'Proveedor Uno',
+    consumoDiarioPromedio: null,
+    diasDeCobertura: null,
+    ...sobrescribir,
+  }
+}
+
+function reposicionFixture(filas: FilaDeReposicion[], idPuntoVenta = 10): ReposicionRespuesta {
+  return { idPuntoVenta, hoy: '2026-08-14', diasDeRotacion: 30, zonaHoraria: 'America/Argentina/Buenos_Aires', filas }
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderReposicion() {
+  return render(<Reposicion />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+})
+
+describe('Reposicion (stage-13-stock-inteligente, Slice 6 — web)', () => {
+  it('arranca con el primer punto de venta cargado, sin ?dias= en la consulta', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaFixture()]))
+      return undefined
+    })
+    renderReposicion()
+
+    await screen.findByLabelText('Punto de venta')
+    expect(screen.getByLabelText('Punto de venta')).toHaveValue('10')
+    const llamada = apiGetMock.mock.calls.find((call: unknown[]) => (call[0] as string).startsWith('/reportes/stock/reposicion?'))!
+    expect(llamada[0] as string).toBe('/reportes/stock/reposicion?idPuntoVenta=10')
+  })
+
+  it('sugerido renderiza — cuando es null, nunca 0', async () => {
+    const filaSinReposicionConfigurada = filaFixture({ idArticulo: 1, sugerido: null })
+    const filaConSugerido = filaFixture({ idArticulo: 2, sugerido: 8 })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) {
+        return Promise.resolve(reposicionFixture([filaSinReposicionConfigurada, filaConSugerido]))
+      }
+      return undefined
+    })
+    renderReposicion()
+
+    const filas = await screen.findAllByRole('row')
+    // fila 0 = encabezado, fila 1 = header del grupo de proveedor, filas 2/3 = datos.
+    const filaUno = filas[2]
+    const filaDos = filas[3]
+    expect(within(filaUno).getByText('—')).toBeInTheDocument()
+    expect(within(filaDos).queryByText('—')).not.toBeInTheDocument()
+    expect(within(filaDos).getByText('8')).toBeInTheDocument()
+  })
+
+  it('agrupa por proveedor mostrando el nombre y la cantidad de filas en el encabezado del grupo', async () => {
+    const filaUno = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaDos = filaFixture({ idArticulo: 2, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaSinProveedor = filaFixture({ idArticulo: 3, idProveedor: null, proveedor: null })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) {
+        return Promise.resolve(reposicionFixture([filaUno, filaDos, filaSinProveedor]))
+      }
+      return undefined
+    })
+    renderReposicion()
+
+    expect(await screen.findByText('Proveedor Uno (2)')).toBeInTheDocument()
+    expect(screen.getByText('Sin proveedor (1)')).toBeInTheDocument()
+  })
+
+  it('el botón de descarga apunta a /reportes/stock/reposicion/export con el idPuntoVenta elegido', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaFixture()]))
+      return undefined
+    })
+    renderReposicion()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(await screen.findByRole('button', { name: 'Descargar' })).toBeInTheDocument()
+  })
+
+  it('sin filas bajo el mínimo muestra un estado vacío', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([]))
+      return undefined
+    })
+    renderReposicion()
+
+    expect(await screen.findByText('No hay artículos bajo el mínimo para este punto de venta.')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Reposicion.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.tsx
@@ -1,0 +1,191 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
+import type { PuntoVentaListado, Reposicion as ReposicionRespuesta } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+import { agruparPorProveedor } from './agruparPorProveedor'
+
+function formatearCantidad(valor: number): string {
+  return valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
+}
+
+/** `sugerido` (y cualquier otro campo nullable de la fila) renderiza `—`, NUNCA `0` — la celda
+ * que un operador leería como "no comprar nada" cuando en realidad el dato no existe (spec
+ * reposicion-de-stock: sugerido Is Null, Never Zero, When Reposicion Is Unset). */
+function formatearCantidadNullable(valor: number | null): string {
+  return valor === null ? '—' : formatearCantidad(valor)
+}
+
+/**
+ * Reposición (stage-13-stock-inteligente, Slice 6 — web; design: "Reposicion.tsx — grouped by
+ * proveedor (slice 6)"): artículos bajo su mínimo de un punto de venta, agrupados por proveedor
+ * habitual — mismo shape que `Existencias.tsx` (selector de punto de venta + botón de descarga +
+ * tabla, sin paginado). El agrupamiento es un FOLD puro sobre la lista ya ordenada que devuelve
+ * el servidor (`agruparPorProveedor`, design decisión 4) — nunca un sort del lado del cliente.
+ * Misma política que `/tablero`/`/reportes/existencias` (`Politicas.LecturaDeReportes`:
+ * Supervisor + Admin).
+ */
+export function Reposicion() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | null>(null)
+  const [reposicion, setReposicion] = useState<ReposicionRespuesta | null>(null)
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+        if (lista.length > 0) setIdPuntoVenta(lista[0].id)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    if (idPuntoVenta === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeReportes
+      .reposicion(idPuntoVenta, null)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setReposicion(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setReposicion(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar la reposición.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [idPuntoVenta])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const grupos = reposicion ? agruparPorProveedor(reposicion.filas) : []
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Reposición" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        {puntosVenta === null ? (
+          <Cargando />
+        ) : puntosVenta.length === 0 ? (
+          <p className="text-muted text-center py-4">No hay puntos de venta visibles para la reposición.</p>
+        ) : idPuntoVenta === null ? (
+          <Cargando />
+        ) : (
+          <>
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="reposicion-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="reposicion-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  onChange={(e) => setIdPuntoVenta(Number(e.target.value))}
+                >
+                  {puntosVenta.map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-auto">
+                <BotonDeDescarga
+                  ruta={rutasDeExportacion.reposicion(idPuntoVenta, null)}
+                  etiqueta="Descargar"
+                  onError={setErrorDescarga}
+                  onInicio={() => setErrorDescarga('')}
+                />
+              </div>
+            </div>
+
+            {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+            {cargando && !reposicion && <Cargando />}
+
+            {reposicion && (
+              <div className="table-responsive">
+                <table className="table table-sm table-striped table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Artículo</th>
+                      <th className="text-end">Cantidad</th>
+                      <th className="text-end">Mínimo</th>
+                      <th className="text-end">Reposición</th>
+                      <th className="text-end">Sugerido</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {grupos.map((grupo) => (
+                      <Fragment key={grupo.idProveedor ?? 'sin-proveedor'}>
+                        <tr className="table-secondary">
+                          <td colSpan={5}>
+                            {grupo.proveedor ?? 'Sin proveedor'} ({grupo.filas.length})
+                          </td>
+                        </tr>
+                        {grupo.filas.map((fila) => (
+                          <tr key={fila.idArticulo}>
+                            <td>{fila.articulo}</td>
+                            <td className="text-end">{formatearCantidad(fila.cantidad)}</td>
+                            <td className="text-end">{formatearCantidad(fila.minimo)}</td>
+                            <td className="text-end">{formatearCantidadNullable(fila.reposicion)}</td>
+                            <td className="text-end">{formatearCantidadNullable(fila.sugerido)}</td>
+                          </tr>
+                        ))}
+                      </Fragment>
+                    ))}
+                    {reposicion.filas.length === 0 && (
+                      <tr>
+                        <td colSpan={5} className="text-center text-muted py-4">
+                          No hay artículos bajo el mínimo para este punto de venta.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/agruparPorProveedor.test.ts
+++ b/src/Ways.Web/src/paginas/agruparPorProveedor.test.ts
@@ -55,4 +55,16 @@ describe('agruparPorProveedor (stage-13-stock-inteligente, Slice 6 — fold sobr
   it('la lista vacía produce cero grupos', () => {
     expect(agruparPorProveedor([])).toEqual([])
   })
+
+  it('dos proveedores con ids distintos y el mismo nombre visible producen DOS grupos, no uno fusionado', () => {
+    const filaProveedorUno = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Homónimo' })
+    const filaProveedorDos = filaFixture({ idArticulo: 2, idProveedor: 2, proveedor: 'Proveedor Homónimo' })
+
+    const grupos = agruparPorProveedor([filaProveedorUno, filaProveedorDos])
+
+    expect(grupos).toEqual([
+      { idProveedor: 1, proveedor: 'Proveedor Homónimo', filas: [filaProveedorUno] },
+      { idProveedor: 2, proveedor: 'Proveedor Homónimo', filas: [filaProveedorDos] },
+    ])
+  })
 })

--- a/src/Ways.Web/src/paginas/agruparPorProveedor.test.ts
+++ b/src/Ways.Web/src/paginas/agruparPorProveedor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { agruparPorProveedor } from './agruparPorProveedor'
+import type { FilaDeReposicion } from '../api/tipos'
+
+function filaFixture(sobrescribir: Partial<FilaDeReposicion> = {}): FilaDeReposicion {
+  return {
+    idArticulo: 1,
+    articulo: 'Artículo genérico',
+    cantidad: 5,
+    minimo: 10,
+    reposicion: 20,
+    sugerido: 15,
+    idProveedor: 1,
+    proveedor: 'Proveedor Uno',
+    consumoDiarioPromedio: null,
+    diasDeCobertura: null,
+    ...sobrescribir,
+  }
+}
+
+describe('agruparPorProveedor (stage-13-stock-inteligente, Slice 6 — fold sobre la lista ya ordenada)', () => {
+  it('agrupa dos proveedores en el orden que ya trae el servidor', () => {
+    const filaA = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaB = filaFixture({ idArticulo: 2, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaC = filaFixture({ idArticulo: 3, idProveedor: 2, proveedor: 'Proveedor Dos' })
+
+    const grupos = agruparPorProveedor([filaA, filaB, filaC])
+
+    expect(grupos).toEqual([
+      { idProveedor: 1, proveedor: 'Proveedor Uno', filas: [filaA, filaB] },
+      { idProveedor: 2, proveedor: 'Proveedor Dos', filas: [filaC] },
+    ])
+  })
+
+  it('el bucket "Sin proveedor" (idProveedor null) aterriza último, tal como lo ordena el servidor', () => {
+    const filaConProveedor = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaSinProveedorUno = filaFixture({ idArticulo: 2, idProveedor: null, proveedor: null })
+    const filaSinProveedorDos = filaFixture({ idArticulo: 3, idProveedor: null, proveedor: null })
+
+    const grupos = agruparPorProveedor([filaConProveedor, filaSinProveedorUno, filaSinProveedorDos])
+
+    expect(grupos).toHaveLength(2)
+    expect(grupos[grupos.length - 1]).toEqual({
+      idProveedor: null,
+      proveedor: null,
+      filas: [filaSinProveedorUno, filaSinProveedorDos],
+    })
+  })
+
+  it('una única fila produce un único grupo con esa fila', () => {
+    const fila = filaFixture()
+    expect(agruparPorProveedor([fila])).toEqual([{ idProveedor: 1, proveedor: 'Proveedor Uno', filas: [fila] }])
+  })
+
+  it('la lista vacía produce cero grupos', () => {
+    expect(agruparPorProveedor([])).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/paginas/agruparPorProveedor.ts
+++ b/src/Ways.Web/src/paginas/agruparPorProveedor.ts
@@ -1,0 +1,31 @@
+import type { FilaDeReposicion } from '../api/tipos'
+
+/** Un bucket de `Reposicion.tsx`: todas las filas consecutivas que comparten `idProveedor`. */
+export type GrupoDeReposicion = {
+  idProveedor: number | null
+  proveedor: string | null
+  filas: FilaDeReposicion[]
+}
+
+/**
+ * Agrupa las filas de `GET /api/reportes/stock/reposicion` por proveedor habitual — un FOLD sobre
+ * la lista YA ORDENADA que devuelve el servidor (design decisión 4), NUNCA un sort del lado del
+ * cliente. El servidor ya garantiza un único bucket "Sin proveedor" al final (proveedor
+ * soft-deleted proyecta `idProveedor: null` y ordena por presencia primero — orchestrator
+ * decision 12, tasks.md stage-13), así que agrupar filas CONSECUTIVAS que comparten `idProveedor`
+ * alcanza: nunca puede haber dos runs separados del mismo proveedor en la lista que llega acá.
+ */
+export function agruparPorProveedor(filas: FilaDeReposicion[]): GrupoDeReposicion[] {
+  const grupos: GrupoDeReposicion[] = []
+
+  for (const fila of filas) {
+    const grupoActual = grupos[grupos.length - 1]
+    if (grupoActual && grupoActual.idProveedor === fila.idProveedor) {
+      grupoActual.filas.push(fila)
+      continue
+    }
+    grupos.push({ idProveedor: fila.idProveedor, proveedor: fila.proveedor, filas: [fila] })
+  }
+
+  return grupos
+}


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 6 (Web Reposición)

- `Reposicion.tsx`: selector de PV, reporte agrupado por proveedor habitual con header por grupo (proveedor + count), `BotonDeDescarga` al export sibling, `sugerido` renderiza `—` cuando null — NUNCA `0` — y `0` cuando es un cero genuino.
- `agruparPorProveedor`: FOLD puro sobre la lista YA ordenada por el server (decisión 4, jamás sort client-side); hereda el bucket único *Sin proveedor* trailing garantizado por la decisión #12.
- Espejos TS exactos de `FilaDeReposicion`/`Reposicion`/`FilaDeRotacion`/`Rotacion`; `clienteDeReportes.reposicion/rotacion`; ruta + nav junto a Vencimientos con el mismo gate de roles.
- Fetch con gate de generación (respuesta stale jamás pisa la reciente).
- Gate SIN-CAMBIOS-DE-SCHEMA: cero archivos .NET.

## Tests
10 del fold + componente (orden server, homónimos con ids distintos = DOS grupos, Sin proveedor último, stale dentro de act, URL del export clickeada y asertada, roles Supervisor/Vendedor, null-vs-0 con cero genuino). Vitest full post-merge con slice 3: **655/655**; tsc limpio.

## Judgment-day
Juez B ronda 1: 1 MAJOR (el test del download no clickeaba ni asertaba la ruta — mutarla a vencimientos pasaba 5/5) + 3 WARNINGs → fix por copia del precedente Vencimientos. Re-ronda B: 4 re-mutaciones muertas. Juez A: 0 severos, 1 WARNING (sin fixture de sugerido=0 genuino) cerrado test-only con evidencia falsy-coercion. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)