### PR TITLE
feat(stage-13): slice 7 tile-y-sugerencia — resumen de reposicion en el Tablero y columna Sugerido

### DIFF
--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -1464,6 +1464,29 @@ rather than retracting a published DTO field.
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files).
 - [ ] 7.13 Run `judgment-day`; fix; re-judge until clean.
+  **Ronda 1, juez B**: 3 hallazgos confirmados, los 3 cerrados — (MAJOR)
+  `ReposicionReporteTests.SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente`
+  (7.9) tenía cardinalidades simétricas (1 fila sin proveedor, 1 fila sin
+  sugerido) — mutar el fold `IdProveedor is null` → `Sugerido is null`
+  sobrevivía; fix: tercera fila bajo mínimo con proveedor asignado y
+  `reposicion` null (grupo "sin sugerido" pasa a 2, "sin proveedor" queda
+  en 1), más los otros dos counts del resumen (`bajoMinimo`/`sinStock`)
+  asertados con magnitudes distintas entre sí. (WARNING, autorizado con
+  extensión de matriz) `/reportes/stock/reposicion/resumen` no tenía test
+  de autorización — `.AllowAnonymous()` sobrevivía 9/9 en
+  `ReportesAutorizacionTests`; fix test-only: sumadas las DOS rutas de
+  resumen de stock (`stock/reposicion/resumen`, `stock/vencimientos/resumen`)
+  a `TodasLasRutas`, con un `RutaCon` que arma `?idPuntoVenta=` para ellas en
+  vez de `idEmpresa`/`desde`/`hasta`/`granularidad`. El sibling
+  `stock/vencimientos/resumen` tenía el MISMO gap preexistente desde la
+  slice 6 — cerrado de paso, también test-only. (WARNING)
+  `Existencias.test.tsx` el fixture de rotación traía una sola fila —
+  mutar la clave del map a "siempre `rotacion.filas[0].idArticulo`" era
+  indistinguible del fold correcto; fix: segunda fila presente en la
+  grilla y en `/rotacion` (otro artículo, `minimoSugerido` distinto),
+  ambas celdas de Sugerido asertadas con valores distintos por fila.
+  Evidencia de mutación real por hallazgo (mutar → build/test falla →
+  revert → verde) en los commits de esta ronda.
 - [ ] 7.14 Branch `feat/stage13-slice7-tile-y-sugerencia` off `main`
   (parent: slices 3+4+5); PR; merge stacked-to-main. **If the slice
   overflows at apply time, drop tasks 7.6/7.11 (the `Sugerido` column) per

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -1375,7 +1375,7 @@ the `Sugerido` column** (i.e. drop `GET /rotacion`'s web consumer, tasks
 its own endpoint and column, so dropping it removes code never shipped
 rather than retracting a published DTO field.
 
-- [ ] 7.1 Modify `ServicioDeReportesDeStock.cs`:
+- [x] 7.1 Modify `ServicioDeReportesDeStock.cs`:
   `ObtenerResumenDeReposicionAsync(idPuntoVenta, ct)` — calls the **same**
   `ObtenerReposicionAsync` method and folds its own rows: `bajoMinimo :=
   filas.Count`, `sinStock := filas.Count(f => f.Cantidad <= 0)`,
@@ -1383,47 +1383,72 @@ rather than retracting a published DTO field.
   aggregation query.** *(design decision 8, 9 — with the field name
   correction recorded in Orchestrator Decision #5 above: `sinProveedor`,
   not design.md's stale `sinSugerencia`)*
-- [ ] 7.2 Modify `Contratos.cs`: `ResumenDeReposicion(IdPuntoVenta,
+- [x] 7.2 Modify `Contratos.cs`: `ResumenDeReposicion(IdPuntoVenta,
   BajoMinimo, SinStock, SinProveedor)`. `dto-contract-honesty`:
   doc-comment `SinProveedor` as the *Sin proveedor* group count — distinct
   from, and never conflated with, "no `sugerido`" (`reposicion` unset).
-- [ ] 7.3 Modify `ReportesEndpoints.cs`:
+- [x] 7.3 Modify `ReportesEndpoints.cs`:
   `GET /reportes/stock/reposicion/resumen?idPuntoVenta`, `Politicas.LecturaDeReportes`.
-- [ ] 7.4 Modify `src/Ways.Web/src/api/{tipos,reportes}.ts`: mirror
+- [x] 7.4 Modify `src/Ways.Web/src/api/{tipos,reportes}.ts`: mirror
   `ResumenDeReposicion` (`sinProveedor`, not `sinSugerencia`);
   `clienteDeReportes.reposicionResumen`.
-- [ ] 7.5 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: `PanelDeReposicion`
+- [x] 7.5 Modify `src/Ways.Web/src/paginas/Tablero.tsx`: `PanelDeReposicion`
   cloned from `PanelDeVencimientos` — `usePanelDeReporte`, requires a
   concrete `idPuntoVenta` (neutral copy otherwise), `PanelDeError` + retry,
   `Link` to the report, and **one `data-testid` per metric**:
   `reposicion-tile-bajo-minimo`, `reposicion-tile-sin-stock`,
   `reposicion-tile-sin-proveedor` — the stage-12 slice-15 lesson: a blob
   assertion cannot catch two swapped counts.
+  **APPLY NOTE**: both `PanelDeVencimientos` and `PanelDeReposicion` render
+  a "Ver reporte" link with identical text, so the two pre-existing
+  `screen.getByRole('link', { name: 'Ver reporte' })` assertions (one in
+  the vencimientos tile describe block, one new in the reposición block)
+  became ambiguous once both panels render together. Both scoped with
+  `within(screen.getByText(<título>).closest('div')!)` — not a task,
+  recorded per the instruction to never silently deviate.
 - [ ] 7.6 Modify `src/Ways.Web/src/paginas/Existencias.tsx`: add the
   `Sugerido` column, fed by `clienteDeReportes.rotacion(idPuntoVenta)`
   fetched alongside the report and indexed by `idArticulo`; an articulo
   absent from that map renders `—`, never `0`.
-- [ ] 7.7 [P] **Mutation target**: the fold of `sinStock`
+- [x] 7.7 [P] **Mutation target**: the fold of `sinStock`
   (`f.Cantidad <= 0`) — change to `< 0` — the tile test seeded with an
   articulo at exactly `0` (7.8) must fail. *(mutation-proof-tests)*
-- [ ] 7.8 [P] Integration: the tile's three counts equal the report's
+  **EVIDENCE**: mutated `ObtenerResumenDeReposicionAsync`'s `sinStock` fold
+  to `f.Cantidad < 0 /* MUTATION 7.7 */`, ran `dotnet test --filter
+  FullyQualifiedName~LosTresConteosDelTileIgualanElFoldeoDelReporte` →
+  **FAILED** (`Assert.Equal() Failure: Expected: 2 Actual: 1` — the
+  exactly-zero articulo stopped counting as `sinStock`); reverted, ran
+  `--filter FullyQualifiedName~ReposicionReporteTests` → 9/9 green,
+  `grep -rn "MUTATION"` on the touched files left only the pre-existing
+  "MUTATION TARGET" comment headers from slice 4, no inline marker.
+- [x] 7.8 [P] Integration: the tile's three counts equal the report's
   folded values over a seed with **all three metrics distinct**
   (`bajoMinimo = 7, sinStock = 2, sinProveedor = 1`), so no two counts can
   be swapped without detection. *(spec `reposicion-de-stock`: "The Tablero
   Tile Reuses The Report Method, Never A Second Aggregation Query",
   scenario "The tile's three counts equal the report's folded values")*
-- [ ] 7.9 [P] Integration, discrimination: two rows below minimo — one with
+  Implemented as `ReposicionReporteTests.LosTresConteosDelTileIgualanElFoldeoDelReporte`
+  (also the 7.7 mutation-target test — same seed serves both purposes).
+- [x] 7.9 [P] Integration, discrimination: two rows below minimo — one with
   no `id_proveedor_habitual` and `sugerido = 30`, another with a proveedor
   assigned but `sugerido = null` (`reposicion` unset) — `sinProveedor = 1`,
   counting only the row missing a proveedor, independent of `sugerido`.
   *(spec: "sinProveedor counts the Sin proveedor group, not a missing
-  suggestion")*
-- [ ] 7.10 [P] Component test: the three `data-testid`s asserted
+  suggestion")* Implemented as
+  `ReposicionReporteTests.SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente`.
+- [x] 7.10 [P] Component test: the three `data-testid`s asserted
   individually, not as one blob — the stage-12 slice-15 lesson applied.
+  Implemented in `Tablero.test.tsx`, describe block "Tablero — tile de
+  reposición (stage-13-stock-inteligente, Slice 7)".
 - [ ] 7.11 [P] Component test: the `Existencias.tsx` `Sugerido` column
   renders `—` for an articulo absent from the rotation map, never `0`.
-- [ ] 7.12 Gate guard: `has-pending-model-changes` clean, zero migration
-  files in the diff.
+- [x] 7.12 Gate guard: `has-pending-model-changes` clean, zero migration
+  files in the diff. **VERIFIED**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made
+  to the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
+  files).
 - [ ] 7.13 Run `judgment-day`; fix; re-judge until clean.
 - [ ] 7.14 Branch `feat/stage13-slice7-tile-y-sugerencia` off `main`
   (parent: slices 3+4+5); PR; merge stacked-to-main. **If the slice
@@ -1435,7 +1460,18 @@ rather than retracting a published DTO field.
 (7.8), sinProveedor discrimination (7.9), per-testid assertions (7.10),
 column null-render (7.11).
 
-**Verify**: `dotnet test --filter FullyQualifiedName~ResumenDeReposicion` && `npm run test -- Tablero Existencias`
+**APPLY NOTE (Verify line filter mismatch, same class as slice 2's)**: this
+slice's `Verify` line below reads `FullyQualifiedName~ResumenDeReposicion`,
+but no test method matches that substring — the two new tests are
+`ReposicionReporteTests.LosTresConteosDelTileIgualanElFoldeoDelReporte` and
+`.SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente` (named for what
+they prove, per this repo's convention, not for the endpoint under test).
+Ran `--filter FullyQualifiedName~ReposicionReporteTests` instead, which
+matches the whole class (9 tests: the 7 pre-existing slice-4 tests plus
+these 2, all green) — recorded per instruction to never silently deviate;
+not a task, so not re-numbered.
+
+**Verify**: `dotnet test --filter FullyQualifiedName~ReposicionReporteTests` && `npm run test -- Tablero Existencias`
 
 ---
 

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -1463,7 +1463,13 @@ rather than retracting a published DTO field.
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty output (zero
   files).
-- [ ] 7.13 Run `judgment-day`; fix; re-judge until clean.
+- [x] 7.13 Run `judgment-day`; fix; re-judge until clean. *(CLEAN
+  2026-08-16: re-ronda B aprobada — 3 re-mutaciones muertas, incluida la
+  verificación en vivo del cierre del sibling vencimientos/resumen; juez A
+  fresh: 0 severos, 1 WARNING (matriz Supervisor-aceptado sin las rutas
+  nuevas) + 1 SUGGESTION (nombres "NueveRutas" caducos) cerrados test-only
+  en `9507f8f` con evidencia de mutación de política apilada. JUDGMENT:
+  APPROVED.)*
   **Ronda 1, juez B**: 3 hallazgos confirmados, los 3 cerrados — (MAJOR)
   `ReposicionReporteTests.SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente`
   (7.9) tenía cardinalidades simétricas (1 fila sin proveedor, 1 fila sin
@@ -1503,8 +1509,10 @@ rather than retracting a published DTO field.
   describían las 11/9 entradas reales; renombrados sin el numeral
   (`...EnTodasLasRutasDeReportes`,
   `UnSupervisorEsAceptadoEnLasRutasSinLecturaDeRentabilidad`).
-- [ ] 7.14 Branch `feat/stage13-slice7-tile-y-sugerencia` off `main`
-  (parent: slices 3+4+5); PR; merge stacked-to-main. **If the slice
+- [x] 7.14 Branch `feat/stage13-slice7-tile-y-sugerencia` off `main`
+  (parent: slices 3+4+5); PR; merge stacked-to-main. *(Degradation NOT
+  exercised — the slice landed under budget with 7.6/7.11 shipped.)*
+  **If the slice
   overflows at apply time, drop tasks 7.6/7.11 (the `Sugerido` column) per
   the pre-approved degradation above and record the reduction in the PR
   body — never a silent cut.**

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -1406,10 +1406,18 @@ rather than retracting a published DTO field.
   became ambiguous once both panels render together. Both scoped with
   `within(screen.getByText(<título>).closest('div')!)` — not a task,
   recorded per the instruction to never silently deviate.
-- [ ] 7.6 Modify `src/Ways.Web/src/paginas/Existencias.tsx`: add the
+- [x] 7.6 Modify `src/Ways.Web/src/paginas/Existencias.tsx`: add the
   `Sugerido` column, fed by `clienteDeReportes.rotacion(idPuntoVenta)`
   fetched alongside the report and indexed by `idArticulo`; an articulo
   absent from that map renders `—`, never `0`.
+  **APPLY NOTE**: `/rotacion` is fetched via `Promise.all` alongside
+  `/existencias` in the same `cargar()` call, same generation token — but
+  with its OWN `.catch` that degrades to an empty `Map` rather than
+  rejecting the combined promise (`react-async-state` rule 6: a secondary
+  feed's failure never turns a successful primary load into an error).
+  `agregarFila`'s new local row is naturally absent from the rotation map
+  fetched at load time, so it renders `—` until the next reload — no
+  special-casing needed.
 - [x] 7.7 [P] **Mutation target**: the fold of `sinStock`
   (`f.Cantidad <= 0`) — change to `< 0` — the tile test seeded with an
   articulo at exactly `0` (7.8) must fail. *(mutation-proof-tests)*
@@ -1440,8 +1448,14 @@ rather than retracting a published DTO field.
   individually, not as one blob — the stage-12 slice-15 lesson applied.
   Implemented in `Tablero.test.tsx`, describe block "Tablero — tile de
   reposición (stage-13-stock-inteligente, Slice 7)".
-- [ ] 7.11 [P] Component test: the `Existencias.tsx` `Sugerido` column
+- [x] 7.11 [P] Component test: the `Existencias.tsx` `Sugerido` column
   renders `—` for an articulo absent from the rotation map, never `0`.
+  Implemented in `Existencias.test.tsx`, describe block "Existencias —
+  columna Sugerido (stage-13-stock-inteligente, Slice 7)": one test
+  discriminates present-vs-absent (`minimoSugerido` value vs. `—`,
+  indexed by cell position — `Mínimo`/`Reposición` also render `—` on
+  the same rows, so a text-only query would be ambiguous); a second
+  proves the `/rotacion`-failure degradation from 7.6's APPLY NOTE.
 - [x] 7.12 Gate guard: `has-pending-model-changes` clean, zero migration
   files in the diff. **VERIFIED**: `dotnet ef migrations
   has-pending-model-changes --project src/Ways.Infrastructure

--- a/openspec/changes/stage-13-stock-inteligente/tasks.md
+++ b/openspec/changes/stage-13-stock-inteligente/tasks.md
@@ -1487,6 +1487,22 @@ rather than retracting a published DTO field.
   ambas celdas de Sugerido asertadas con valores distintos por fila.
   Evidencia de mutación real por hallazgo (mutar → build/test falla →
   revert → verde) en los commits de esta ronda.
+  **Ronda 1, juez A**: 0 hallazgos severos. (WARNING, autorizado, cerrado
+  test-only) `RutasSinLecturaDeRentabilidad` (la `TheoryData` del único
+  test Supervisor-aceptado) no había sido extendida con
+  `stock/reposicion/resumen` ni `stock/vencimientos/resumen` — una
+  regresión que hiciera `Forbidden` al Supervisor en esas rutas pasaría
+  inadvertida; fix: sumadas las dos rutas a la lista. Evidencia de
+  mutación real: stackear `.RequireAuthorization(Politicas.LecturaDeRentabilidad)`
+  sobre el `MapGet` de `reposicion/resumen` → build → el test
+  Supervisor-aceptado FALLA para esa ruta (`Expected: OK / Actual:
+  Forbidden`) → `git checkout --` → 44/44 verde. (SUGGESTION, autorizado,
+  cerrado test-only) los nombres `UnVendedorEsRechazadoEnLasNueveRutas` /
+  `UnRootEsRechazadoEnLasNueveRutas` / `UnAdminEsAceptadoEnLasNueveRutas`
+  / `UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad` ya no
+  describían las 11/9 entradas reales; renombrados sin el numeral
+  (`...EnTodasLasRutasDeReportes`,
+  `UnSupervisorEsAceptadoEnLasRutasSinLecturaDeRentabilidad`).
 - [ ] 7.14 Branch `feat/stage13-slice7-tile-y-sugerencia` off `main`
   (parent: slices 3+4+5); PR; merge stacked-to-main. **If the slice
   overflows at apply time, drop tasks 7.6/7.11 (the `Sugerido` column) per

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -469,6 +469,17 @@ public static class ReportesEndpoints
             "de filas exigido tras mapear — agregado acotado por catálogo, mismo criterio que " +
             "/stock/existencias/export.");
 
+        // Tile de Tablero (stage-13-stock-inteligente, Slice 7; design decisión 8/9, spec
+        // reposicion-de-stock: "The Tablero Tile Reuses The Report Method, Never A Second
+        // Aggregation Query"): gate heredado del grupo. Reusa la misma clasificación que el JSON
+        // de arriba, nunca una segunda query de agregación (ObtenerResumenDeReposicionAsync).
+        grupo.MapGet("/stock/reposicion/resumen", (
+            ServicioDeReportesDeStock servicio, int idPuntoVenta, CancellationToken ct) =>
+            servicio.ObtenerResumenDeReposicionAsync(idPuntoVenta, ct))
+        .WithSummary(
+            "Tile de Tablero: conteos de bajoMinimo/sinStock/sinProveedor del punto de venta — " +
+            "sinProveedor cuenta el grupo Sin proveedor, nunca conflado con sugerido ausente.");
+
         // stage-13-stock-inteligente, Slice 5 (design decisión 14, spec reposicion-de-stock:
         // "GET /api/reportes/stock/rotacion Feeds The Suggested-Minimo Column..."): gate heredado
         // del grupo. Feed INDEPENDIENTE de minimoSugerido — no depende de minimo, agrega sobre

--- a/src/Ways.Application/Reportes/Contratos.cs
+++ b/src/Ways.Application/Reportes/Contratos.cs
@@ -219,6 +219,21 @@ public sealed record Reposicion(
     int IdPuntoVenta, DateOnly Hoy, int DiasDeRotacion, string ZonaHoraria,
     IReadOnlyList<FilaDeReposicion> Filas);
 
+/// <summary>Respuesta de <c>GET /api/reportes/stock/reposicion/resumen</c> — el tile de Tablero
+/// (stage-13-stock-inteligente, Slice 7; design decisión 8/9, con la corrección de nombre del
+/// tercer campo registrada en orchestrator decision 5, tasks.md: <c>SinProveedor</c>, no la
+/// <c>SinSugerencia</c> vieja de design.md). Los tres conteos salen de <see cref="Reposicion.Filas"/>
+/// vía <c>ObtenerResumenDeReposicionAsync</c>, que reusa <c>ObtenerReposicionAsync</c> — nunca una
+/// segunda query de agregación, mismo criterio que <see cref="ResumenDeVencimientos"/>.
+/// <c>dto-contract-honesty</c>: <see cref="SinProveedor"/> cuenta el grupo <c>"Sin proveedor"</c>
+/// (<see cref="FilaDeReposicion.IdProveedor"/> <c>null</c>) — NUNCA conflado con "sin sugerido"
+/// (<see cref="FilaDeReposicion.Sugerido"/> <c>null</c>, <c>reposicion</c> sin configurar): son dos
+/// causas distintas (falta cargar un proveedor vs. falta configurar un <c>reposicion</c>) detrás de
+/// un número, y confundirlas es exactamente lo que esta doc-comment y la spec ratificada
+/// (reposicion-de-stock: "sinProveedor counts the Sin proveedor group, not a missing suggestion")
+/// prohíben.</summary>
+public sealed record ResumenDeReposicion(int IdPuntoVenta, int BajoMinimo, int SinStock, int SinProveedor);
+
 /// <summary>Fila de <c>GET /api/reportes/stock/rotacion</c> (stage-13-stock-inteligente, Slice 5;
 /// design: Interfaces / Contracts, decisión 14). Solo existe porque el artículo tiene AL MENOS UN
 /// movimiento calificado (<c>venta</c> o <c>anulacion</c> de venta) en la ventana — un artículo sin

--- a/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
+++ b/src/Ways.Application/Reportes/ServicioDeReportesDeStock.cs
@@ -173,6 +173,27 @@ public class ServicioDeReportesDeStock(IWaysDbContext db, ServicioDeParametros p
         return new Reposicion(idPuntoVenta, hoy, diasDeRotacion, zonaId, filas);
     }
 
+    /// <summary>Tile de Tablero (stage-13-stock-inteligente, Slice 7; design decisión 8/9; tarea
+    /// 7.1) — reusa <see cref="ObtenerReposicionAsync"/> con <c>dias</c> nulo (el horizonte
+    /// default, mismo criterio que <see cref="ObtenerResumenDeVencimientosAsync"/>) y foldea sus
+    /// propias filas: el tile nunca puede divergir del reporte porque no hay una segunda query de
+    /// agregación. <c>SinProveedor</c> cuenta el grupo "Sin proveedor" (<c>IdProveedor is null</c>)
+    /// — orchestrator decision 5 (tasks.md): NUNCA "sin sugerido" (<c>Sugerido is null</c>), el
+    /// nombre que design.md usaba antes de la corrección de la spec ratificada.</summary>
+    public async Task<ResumenDeReposicion> ObtenerResumenDeReposicionAsync(
+        int idPuntoVenta, CancellationToken ct = default)
+    {
+        var reposicion = await ObtenerReposicionAsync(idPuntoVenta, dias: null, ct);
+
+        // Cláusula bajo prueba (mutation-proof-tests, tarea 7.7): f.Cantidad <= 0 — con < 0, el
+        // artículo EXACTAMENTE en cero (agotado, el caso más urgente) deja de contar como sinStock.
+        return new ResumenDeReposicion(
+            idPuntoVenta,
+            reposicion.Filas.Count,
+            reposicion.Filas.Count(f => f.Cantidad <= 0),
+            reposicion.Filas.Count(f => f.IdProveedor is null));
+    }
+
     /// <summary>stage-13-stock-inteligente, Slice 5 (design decisión 14; task 5.4): el feed
     /// independiente de <c>minimoSugerido</c> para el editor — a diferencia de <see
     /// cref="ObtenerReposicionAsync"/>, NO depende de <c>minimo</c>: agrega sobre TODO el catálogo

--- a/src/Ways.Web/src/api/reportes.ts
+++ b/src/Ways.Web/src/api/reportes.ts
@@ -15,6 +15,7 @@ import type {
   Rentabilidad,
   Reposicion,
   ResumenDeGastos,
+  ResumenDeReposicion,
   ResumenDeVencimientos,
   ResumenDeVentas,
   Rotacion,
@@ -131,6 +132,9 @@ export const clienteDeReportes = {
    * opcional de `dias`. */
   rotacion: (idPuntoVenta: number, dias: number | null) =>
     api.get<Rotacion>(`/reportes/stock/rotacion?idPuntoVenta=${idPuntoVenta}${dias !== null ? `&dias=${dias}` : ''}`),
+  /** stage-13-stock-inteligente (Slice 7): tile de Tablero, mismo criterio que `vencimientosResumen`. */
+  reposicionResumen: (idPuntoVenta: number) =>
+    api.get<ResumenDeReposicion>(`/reportes/stock/reposicion/resumen?idPuntoVenta=${idPuntoVenta}`),
 }
 
 // ---- Offset local para desde/hasta de /cajas y /tesoreria (stage-11-exportacion-reportes,

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1390,6 +1390,14 @@ export type Reposicion = {
   filas: FilaDeReposicion[]
 }
 
+/** Respuesta de `GET /api/reportes/stock/reposicion/resumen` (stage-13-stock-inteligente, Slice 7)
+ * — espejo de `ResumenDeReposicion`, el tile de Tablero. Mismos tres conteos que `Reposicion.filas`
+ * foldeados por `ObtenerResumenDeReposicionAsync` — nunca una query de agregación separada.
+ * `sinProveedor` cuenta el grupo "Sin proveedor" (`idProveedor` nulo en `FilaDeReposicion`) — NUNCA
+ * conflado con "sin sugerido" (`sugerido` nulo, `reposicion` sin configurar): orchestrator decision
+ * 5 (tasks.md) corrigió este nombre sobre la `sinSugerencia` vieja de design.md. */
+export type ResumenDeReposicion = { idPuntoVenta: number; bajoMinimo: number; sinStock: number; sinProveedor: number }
+
 /** Fila de `GET /api/reportes/stock/rotacion` — espejo de `FilaDeRotacion`. Solo existe porque el
  * artículo tuvo AL MENOS UN movimiento calificado (venta o su anulación, nunca la anulación de
  * una compra) en la ventana — un artículo sin historia NO ES UNA FILA de esta lista, nunca una

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -274,12 +274,24 @@ describe('Existencias — reporte (stage-11-exportacion-reportes, Slice 9 — we
 describe('Existencias — columna Sugerido (stage-13-stock-inteligente, Slice 7)', () => {
   it('un artículo presente en /rotacion muestra su minimoSugerido; uno ausente muestra "—", nunca "0"', async () => {
     const filaConRotacion = filaFixture({ idArticulo: 1, nombre: 'Aceite de girasol 900ml', cantidad: 12 })
+    // Judgment-day slice 7 juez B (ronda 1, WARNING): SEGUNDA fila presente en /rotacion, con
+    // idArticulo y minimoSugerido DISTINTOS de la primera — con un solo par en el fixture, mutar
+    // la clave del map a "siempre rotacion.filas[0].idArticulo" es indistinguible del fold correcto
+    // (un solo par no expone el swap de clave). Con dos pares, el mutante pisa ambas entradas bajo
+    // la clave 1, así que la búsqueda por idArticulo 3 falla y la de idArticulo 1 muestra 15 en vez
+    // de 7.
+    const filaOtraConRotacion = filaFixture({ idArticulo: 3, nombre: 'Detergente 750ml', cantidad: 20 })
     const filaSinRotacion = filaFixture({ idArticulo: 2, nombre: 'Fideos guiseros 500g', cantidad: 87.5 })
     mockearRutasBase((ruta) => {
-      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture([filaConRotacion, filaSinRotacion]))
+      if (ruta.startsWith('/reportes/stock/existencias?')) {
+        return Promise.resolve(existenciasFixture([filaConRotacion, filaOtraConRotacion, filaSinRotacion]))
+      }
       if (ruta.startsWith('/reportes/stock/rotacion?')) {
         return Promise.resolve(
-          rotacionFixture([{ idArticulo: 1, articulo: 'Aceite de girasol 900ml', consumoEnVentana: 30, consumoDiarioPromedio: 1, minimoSugerido: 7 }]),
+          rotacionFixture([
+            { idArticulo: 1, articulo: 'Aceite de girasol 900ml', consumoEnVentana: 30, consumoDiarioPromedio: 1, minimoSugerido: 7 },
+            { idArticulo: 3, articulo: 'Detergente 750ml', consumoEnVentana: 45, consumoDiarioPromedio: 1.5, minimoSugerido: 15 },
+          ]),
         )
       }
       return undefined
@@ -293,10 +305,13 @@ describe('Existencias — columna Sugerido (stage-13-stock-inteligente, Slice 7)
     // renderizan "—" en estas filas (ambos null en filaFixture), así que un `getByText('—')` sin
     // ámbito de columna sería ambiguo.
     const sugeridoAceite = within(filas[0]).getAllByRole('cell')[6]
-    const sugeridoFideos = within(filas[1]).getAllByRole('cell')[6]
-    // task 7.11: idArticulo 1 está en el mapa de rotación ⇒ muestra minimoSugerido (7); idArticulo
-    // 2 está AUSENTE ⇒ "—", nunca "0" — la ausencia es la respuesta honesta (design decisión 14).
+    const sugeridoDetergente = within(filas[1]).getAllByRole('cell')[6]
+    const sugeridoFideos = within(filas[2]).getAllByRole('cell')[6]
+    // task 7.11: idArticulo 1 y 3 están en el mapa de rotación ⇒ muestran su propio minimoSugerido
+    // (7 y 15, distintos entre sí); idArticulo 2 está AUSENTE ⇒ "—", nunca "0" — la ausencia es la
+    // respuesta honesta (design decisión 14).
     expect(sugeridoAceite).toHaveTextContent('7')
+    expect(sugeridoDetergente).toHaveTextContent('15')
     expect(sugeridoFideos).toHaveTextContent('—')
   })
 

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Existencias } from './Existencias'
 import { RutaProtegida } from '../auth/RutaProtegida'
 import { ROL } from '../api/tipos'
-import type { ArticuloListado, Existencias as ExistenciasRespuesta, FilaExistencia, MinimosDeStock, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import type { ArticuloListado, Existencias as ExistenciasRespuesta, FilaExistencia, MinimosDeStock, PuntoVentaListado, Rotacion, UsuarioAutenticado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
 const apiPutMock = vi.fn()
@@ -87,6 +87,13 @@ function existenciasFixture(filas: FilaExistencia[] = [filaFixture()], idPuntoVe
   return { idPuntoVenta, filas }
 }
 
+// stage-13-stock-inteligente, Slice 7 (tarea 7.6): feed de `minimoSugerido` — vacío por default
+// (todas las filas de existencias muestran `—` en Sugerido), sobrescrito puntualmente por los tests
+// de la columna.
+function rotacionFixture(filas: Rotacion['filas'] = [], idPuntoVenta = 10): Rotacion {
+  return { idPuntoVenta, hoy: '2026-08-14', diasDeRotacion: 30, diasCoberturaObjetivo: 7, zonaHoraria: 'America/Argentina/Buenos_Aires', filas }
+}
+
 function minimosFixture(sobrescribir: Partial<MinimosDeStock> = {}): MinimosDeStock {
   return { idPuntoVenta: 10, idArticulo: 1, cantidad: 12, minimo: 5, reposicion: null, estado: 'Bajo', ...sobrescribir }
 }
@@ -147,6 +154,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     const propia = sobrescribir?.(ruta)
     if (propia) return propia
     if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture())
+    if (ruta.startsWith('/reportes/stock/rotacion?')) return Promise.resolve(rotacionFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -260,6 +268,50 @@ describe('Existencias — reporte (stage-11-exportacion-reportes, Slice 9 — we
     })
     expect(screen.queryByText('primera-respuesta-vieja')).not.toBeInTheDocument()
     expect(screen.getByText('segunda-respuesta')).toBeInTheDocument()
+  })
+})
+
+describe('Existencias — columna Sugerido (stage-13-stock-inteligente, Slice 7)', () => {
+  it('un artículo presente en /rotacion muestra su minimoSugerido; uno ausente muestra "—", nunca "0"', async () => {
+    const filaConRotacion = filaFixture({ idArticulo: 1, nombre: 'Aceite de girasol 900ml', cantidad: 12 })
+    const filaSinRotacion = filaFixture({ idArticulo: 2, nombre: 'Fideos guiseros 500g', cantidad: 87.5 })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/existencias?')) return Promise.resolve(existenciasFixture([filaConRotacion, filaSinRotacion]))
+      if (ruta.startsWith('/reportes/stock/rotacion?')) {
+        return Promise.resolve(
+          rotacionFixture([{ idArticulo: 1, articulo: 'Aceite de girasol 900ml', consumoEnVentana: 30, consumoDiarioPromedio: 1, minimoSugerido: 7 }]),
+        )
+      }
+      return undefined
+    })
+    renderExistencias()
+
+    await screen.findByText('Aceite de girasol 900ml')
+    const filas = screen.getAllByRole('row').slice(1) // sin la fila de encabezado
+    // Columnas: Artículo/Nombre/Cantidad/Mínimo/Reposición/Estado/Sugerido/Acciones — índice 6
+    // (0-based) es Sugerido. Indexado por celda, no por texto: Mínimo y Reposición también
+    // renderizan "—" en estas filas (ambos null en filaFixture), así que un `getByText('—')` sin
+    // ámbito de columna sería ambiguo.
+    const sugeridoAceite = within(filas[0]).getAllByRole('cell')[6]
+    const sugeridoFideos = within(filas[1]).getAllByRole('cell')[6]
+    // task 7.11: idArticulo 1 está en el mapa de rotación ⇒ muestra minimoSugerido (7); idArticulo
+    // 2 está AUSENTE ⇒ "—", nunca "0" — la ausencia es la respuesta honesta (design decisión 14).
+    expect(sugeridoAceite).toHaveTextContent('7')
+    expect(sugeridoFideos).toHaveTextContent('—')
+  })
+
+  it('si /rotacion falla, la columna Sugerido degrada a "—" en toda la grilla sin romper el reporte', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/rotacion?')) return Promise.reject(new Error('boom'))
+      return undefined
+    })
+    renderExistencias()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.queryByText('No se pudieron cargar las existencias.')).not.toBeInTheDocument()
+    const fila = screen.getAllByRole('row')[1]
+    const sugerido = within(fila).getAllByRole('cell')[6]
+    expect(sugerido).toHaveTextContent('—')
   })
 })
 

--- a/src/Ways.Web/src/paginas/Existencias.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.tsx
@@ -11,7 +11,7 @@ import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 
-const CANTIDAD_DE_COLUMNAS = 7
+const CANTIDAD_DE_COLUMNAS = 8
 
 const ETIQUETA_ESTADO: Record<EstadoDeReposicion, string> = {
   SinMinimo: 'Sin mínimo',
@@ -130,6 +130,13 @@ export function Existencias() {
 
   const [idPuntoVenta, setIdPuntoVenta] = useState<number | null>(null)
   const [existencias, setExistencias] = useState<ExistenciasRespuesta | null>(null)
+  // stage-13-stock-inteligente, Slice 7 (tarea 7.6): mapa idArticulo → minimoSugerido de
+  // `GET /rotacion`, fetcheado JUNTO con el reporte (Promise.all, misma generación) — un artículo
+  // AUSENTE del mapa renderiza `—`, nunca `0` (design decisión 14: la ausencia es la respuesta
+  // honesta). Si `/rotacion` falla, degrada a mapa vacío (`—` en toda la columna) SIN romper la
+  // pantalla — el reporte de existencias sigue siendo la fuente de verdad de esta grilla
+  // (`react-async-state` regla 6: un fallo de un feed secundario nunca reporta el load como fallido).
+  const [mapaSugeridos, setMapaSugeridos] = useState<Map<number, number>>(new Map())
   const [cargando, setCargando] = useState(false)
   const [error, setError] = useState('')
   const [errorDescarga, setErrorDescarga] = useState('')
@@ -193,11 +200,19 @@ export function Existencias() {
     setCargando(true)
     setError('')
 
-    clienteDeReportes
-      .existencias(idPuntoVenta)
-      .then((datos) => {
+    // tarea 7.6: `/rotacion` se pide JUNTO con `/existencias` (mismo disparo, misma generación),
+    // pero con su propio `.catch` — un fallo del feed de sugerencia nunca convierte el load de
+    // existencias en un error (degrada a mapa vacío, `—` en toda la columna).
+    const cargaSugeridos = clienteDeReportes
+      .rotacion(idPuntoVenta, null)
+      .then((rotacion) => new Map(rotacion.filas.map((f) => [f.idArticulo, f.minimoSugerido])))
+      .catch(() => new Map<number, number>())
+
+    Promise.all([clienteDeReportes.existencias(idPuntoVenta), cargaSugeridos])
+      .then(([datos, mapa]) => {
         if (generacionRef.current !== miGeneracion) return
         setExistencias(datos)
+        setMapaSugeridos(mapa)
       })
       .catch((e) => {
         if (generacionRef.current !== miGeneracion) return
@@ -387,6 +402,7 @@ export function Existencias() {
                       <th className="text-end">Mínimo</th>
                       <th className="text-end">Reposición</th>
                       <th>Estado</th>
+                      <th className="text-end">Sugerido</th>
                       <th></th>
                     </tr>
                   </thead>
@@ -440,6 +456,7 @@ export function Existencias() {
                               )}
                             </td>
                             <td>{ETIQUETA_ESTADO[fila.estado]}</td>
+                            <td className="text-end">{formatearUmbral(mapaSugeridos.get(fila.idArticulo) ?? null)}</td>
                             <td className="text-end" style={{ minWidth: 170 }}>
                               {puedeEscribir &&
                                 (enEdicion ? (

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tablero } from './Tablero'
@@ -11,6 +11,7 @@ import type {
   PuntoVentaListado,
   Rentabilidad,
   ResumenDeGastos,
+  ResumenDeReposicion,
   ResumenDeVencimientos,
   ResumenDeVentas,
   TopArticulos,
@@ -228,6 +229,13 @@ function vencimientosResumenFixture(sobrescribir: Partial<ResumenDeVencimientos>
   return { idPuntoVenta: 10, vencidos: 2, porVencer: 5, sinFecha: 1, ...sobrescribir }
 }
 
+// stage-13-stock-inteligente (Slice 7): tres conteos DISTINTOS entre sí (mismo criterio que
+// vencimientosResumenFixture) — ningún swap entre bajoMinimo/sinStock/sinProveedor pasa
+// desapercibido si un test lee el testid equivocado.
+function reposicionResumenFixture(sobrescribir: Partial<ResumenDeReposicion> = {}): ResumenDeReposicion {
+  return { idPuntoVenta: 10, bajoMinimo: 7, sinStock: 3, sinProveedor: 1, ...sobrescribir }
+}
+
 function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/empresas') return Promise.resolve([empresaUno])
@@ -244,6 +252,7 @@ function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | un
     if (ruta.startsWith('/reportes/rentabilidad?')) return Promise.resolve(rentabilidadFixture())
     if (ruta.startsWith('/reportes/comisiones?')) return Promise.resolve(comisionesFixture())
     if (ruta.startsWith('/reportes/stock/vencimientos/resumen?')) return Promise.resolve(vencimientosResumenFixture())
+    if (ruta.startsWith('/reportes/stock/reposicion/resumen?')) return Promise.resolve(reposicionResumenFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
   })
 }
@@ -1180,7 +1189,13 @@ describe('Tablero — tile de vencimientos (stage-12-lotes-vencimientos, Slice 1
       expect(screen.getByTestId('vencimientos-tile-por-vencer')).toHaveTextContent('5')
       expect(screen.getByTestId('vencimientos-tile-sin-fecha')).toHaveTextContent('1')
     })
-    expect(screen.getByRole('link', { name: 'Ver reporte' })).toHaveAttribute('href', '/reportes/stock/vencimientos')
+    // APPLY NOTE (Slice 7): scoped al panel — desde Slice 7, PanelDeReposicion también renderiza un
+    // link "Ver reporte" en pantalla; `getByRole` sin ámbito quedaría ambiguo entre ambos paneles.
+    const panelVencimientos = screen.getByText('Vencimientos').closest('div')!
+    expect(within(panelVencimientos).getByRole('link', { name: 'Ver reporte' })).toHaveAttribute(
+      'href',
+      '/reportes/stock/vencimientos',
+    )
   })
 
   it('un error del panel de vencimientos no contamina a sus paneles hermanos', async () => {
@@ -1194,6 +1209,65 @@ describe('Tablero — tile de vencimientos (stage-12-lotes-vencimientos, Slice 1
     fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
 
     expect(await screen.findByText('No se pudo cargar el resumen de vencimientos.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Vendedor #9')).toBeInTheDocument()
+      expect(screen.getByText('Efectivo')).toBeInTheDocument()
+      expect(screen.getByText('Producto Estrella')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('Tablero — tile de reposición (stage-13-stock-inteligente, Slice 7)', () => {
+  it('sin punto de venta elegido ("Todos") muestra un aviso neutro, nunca dispara el fetch', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    await screen.findByText('Reposición')
+
+    expect(screen.getByText('Elegí un punto de venta para ver el resumen de reposición.')).toBeInTheDocument()
+    const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+    expect(rutas.some((r) => r.startsWith('/reportes/stock/reposicion/resumen'))).toBe(false)
+  })
+
+  it('con un punto de venta elegido, muestra los tres conteos del resumen y un link al reporte', async () => {
+    mockearRutasBase()
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
+
+    await waitFor(() => {
+      const rutas = apiGetMock.mock.calls.map((llamada) => llamada[0] as string)
+      expect(rutas.some((r) => r.startsWith('/reportes/stock/reposicion/resumen?') && r.includes('idPuntoVenta=10'))).toBe(true)
+    })
+
+    // task 7.10: los tres testid asertados INDIVIDUALMENTE — la lección del stage-12 slice 15
+    // aplicada acá también: un swap bajoMinimo↔sinStock↔sinProveedor debe hacer fallar este test,
+    // nunca pasar por accidente porque los tres valores están "en algún lado" del tile.
+    await waitFor(() => {
+      expect(screen.getByTestId('reposicion-tile-bajo-minimo')).toHaveTextContent('7')
+      expect(screen.getByTestId('reposicion-tile-sin-stock')).toHaveTextContent('3')
+      expect(screen.getByTestId('reposicion-tile-sin-proveedor')).toHaveTextContent('1')
+    })
+    const panelReposicion = screen.getByText('Reposición').closest('div')!
+    expect(within(panelReposicion).getByRole('link', { name: 'Ver reporte' })).toHaveAttribute(
+      'href',
+      '/reportes/stock/reposicion',
+    )
+  })
+
+  it('un error del panel de reposición no contamina a sus paneles hermanos', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion/resumen?')) return Promise.reject(new Error('boom'))
+      return undefined
+    })
+    renderTablero()
+
+    await screen.findByText('Empresa Uno SA')
+    fireEvent.change(screen.getByLabelText('Punto de venta'), { target: { value: '10' } })
+
+    expect(await screen.findByText('No se pudo cargar el resumen de reposición.')).toBeInTheDocument()
     await waitFor(() => {
       expect(screen.getByText('Vendedor #9')).toBeInTheDocument()
       expect(screen.getByText('Efectivo')).toBeInTheDocument()

--- a/src/Ways.Web/src/paginas/Tablero.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.tsx
@@ -14,6 +14,7 @@ import type {
   PuntoVentaListado,
   Rentabilidad,
   ResumenDeGastos,
+  ResumenDeReposicion,
   ResumenDeVencimientos,
   ResumenDeVentas,
   TopArticulos,
@@ -393,6 +394,67 @@ function PanelDeVencimientos({ idPuntoVenta }: PropsPanelDeVencimientos) {
               <div className="text-muted small">Sin fecha</div>
               <div className="fs-5 text-secondary" data-testid="vencimientos-tile-sin-fecha">
                 {datos.sinFecha}
+              </div>
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  )
+}
+
+type PropsPanelDeReposicion = { idPuntoVenta: number | null }
+
+/**
+ * Tile de reposición (stage-13-stock-inteligente, Slice 7) — clonado de `PanelDeVencimientos`:
+ * reusa `GET /api/reportes/stock/reposicion/resumen`, que a su vez reusa `ObtenerReposicionAsync`
+ * (design decisión 8/9) — el tile no puede divergir del reporte porque no hay una segunda query de
+ * agregación. Requiere un punto de venta CONCRETO, mismo criterio que `PanelDeVencimientos`. Un
+ * `data-testid` POR MÉTRICA (`reposicion-tile-bajo-minimo`/`-sin-stock`/`-sin-proveedor`) — la
+ * lección del stage-12 slice 15: un blob no caza dos conteos swapeados.
+ */
+function PanelDeReposicion({ idPuntoVenta }: PropsPanelDeReposicion) {
+  const cargarDatos = useCallback(
+    () => (idPuntoVenta === null ? Promise.resolve(null) : clienteDeReportes.reposicionResumen(idPuntoVenta)),
+    [idPuntoVenta],
+  )
+  const { datos, cargando, error, reintentar } = usePanelDeReporte<ResumenDeReposicion | null>(
+    cargarDatos,
+    'No se pudo cargar el resumen de reposición.',
+  )
+
+  return (
+    <div className="border p-3 bg-white h-100">
+      <div className="d-flex align-items-center justify-content-between mb-2">
+        <h6 className="mb-0">Reposición</h6>
+        <Link to="/reportes/stock/reposicion" className="small">
+          Ver reporte
+        </Link>
+      </div>
+      {error && <PanelDeError error={error} onReintentar={reintentar} />}
+      {idPuntoVenta === null ? (
+        <p className="text-muted small mb-0">Elegí un punto de venta para ver el resumen de reposición.</p>
+      ) : cargando && !datos ? (
+        <Cargando />
+      ) : (
+        datos && (
+          <div className="row g-2 text-center">
+            <div className="col-4">
+              <div className="text-muted small">Bajo mínimo</div>
+              <div className="fs-5 text-danger" data-testid="reposicion-tile-bajo-minimo">
+                {datos.bajoMinimo}
+              </div>
+            </div>
+            <div className="col-4">
+              <div className="text-muted small">Sin stock</div>
+              <div className="fs-5 text-warning-emphasis" data-testid="reposicion-tile-sin-stock">
+                {datos.sinStock}
+              </div>
+            </div>
+            <div className="col-4">
+              <div className="text-muted small">Sin proveedor</div>
+              <div className="fs-5 text-secondary" data-testid="reposicion-tile-sin-proveedor">
+                {datos.sinProveedor}
               </div>
             </div>
           </div>
@@ -829,6 +891,9 @@ export function Tablero() {
                 </div>
                 <div className="col-md-3">
                   <PanelDeVencimientos idPuntoVenta={idPuntoVenta} />
+                </div>
+                <div className="col-md-3">
+                  <PanelDeReposicion idPuntoVenta={idPuntoVenta} />
                 </div>
               </div>
             )}

--- a/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
@@ -46,7 +46,8 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
     public static readonly TheoryData<string> RutasSinLecturaDeRentabilidad = new()
     {
         "ventas/resumen", "compras/por-proveedor", "gastos/resumen", "articulos/top",
-        "ventas/por-punto-venta", "ventas/por-vendedor", "ventas/por-medio-pago"
+        "ventas/por-punto-venta", "ventas/por-vendedor", "ventas/por-medio-pago",
+        "stock/reposicion/resumen", "stock/vencimientos/resumen"
     };
 
     public static readonly TheoryData<string> RutasConLecturaDeRentabilidad = new() { "rentabilidad", "comisiones" };
@@ -99,9 +100,9 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
 
     [Theory]
     [MemberData(nameof(TodasLasRutas))]
-    public async Task UnVendedorEsRechazadoEnLasNueveRutas(string ruta)
+    public async Task UnVendedorEsRechazadoEnTodasLasRutasDeReportes(string ruta)
     {
-        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnTodasLasRutasDeReportes) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
         var respuesta = await ctx.Vendedor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
@@ -111,9 +112,9 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
 
     [Theory]
     [MemberData(nameof(TodasLasRutas))]
-    public async Task UnRootEsRechazadoEnLasNueveRutas(string ruta)
+    public async Task UnRootEsRechazadoEnTodasLasRutasDeReportes(string ruta)
     {
-        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoEnTodasLasRutasDeReportes) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
         var respuesta = await ctx.Root.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
@@ -123,9 +124,9 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
 
     [Theory]
     [MemberData(nameof(TodasLasRutas))]
-    public async Task UnAdminEsAceptadoEnLasNueveRutas(string ruta)
+    public async Task UnAdminEsAceptadoEnTodasLasRutasDeReportes(string ruta)
     {
-        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoEnLasNueveRutas) + ruta.Replace("/", "-"));
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoEnTodasLasRutasDeReportes) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
         var respuesta = await ctx.Admin.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
@@ -135,9 +136,9 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
 
     [Theory]
     [MemberData(nameof(RutasSinLecturaDeRentabilidad))]
-    public async Task UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad(string ruta)
+    public async Task UnSupervisorEsAceptadoEnLasRutasSinLecturaDeRentabilidad(string ruta)
     {
-        var ctx = await PrepararAsync(nameof(UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad) + ruta.Replace("/", "-"));
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsAceptadoEnLasRutasSinLecturaDeRentabilidad) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
         var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));

--- a/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesAutorizacionTests.cs
@@ -7,15 +7,18 @@ using Ways.Domain.Usuarios;
 namespace Ways.IntegrationTests;
 
 /// <summary>
-/// stage-10-agregacion-dashboard, Slice 10 (task 10.6): la matriz de roles completa de las nueve
+/// stage-10-agregacion-dashboard, Slice 10 (task 10.6): la matriz de roles completa de las
 /// rutas de <c>/api/reportes/*</c> (spec rentabilidad-y-comisiones / reportes-de-gestion) en un
 /// único archivo dedicado — hasta esta slice cada endpoint probaba su propia matriz de roles por
 /// separado (<c>ReportesVentasResumenTests</c>, <c>ReportesEgresosTests</c>,
-/// <c>RentabilidadTests</c>); esto consolida las nueve en un solo lugar, parametrizado sobre la
-/// lista de rutas (design: Testing Strategy, "Integration — role matrix"). La composición de
-/// políticas en sí (AND de <c>LecturaDeReportes</c> + <c>LecturaDeRentabilidad</c>) ya está probada
-/// a nivel unitario en <c>PoliticasTests</c> — acá solo se prueba el <em>wiring</em> del grupo de
-/// endpoints completo.
+/// <c>RentabilidadTests</c>); esto consolida las nueve originales en un solo lugar, parametrizado
+/// sobre la lista de rutas (design: Testing Strategy, "Integration — role matrix"). La composición
+/// de políticas en sí (AND de <c>LecturaDeReportes</c> + <c>LecturaDeRentabilidad</c>) ya está
+/// probada a nivel unitario en <c>PoliticasTests</c> — acá solo se prueba el <em>wiring</em> del
+/// grupo de endpoints completo. Judgment-day slice 7 juez B (ronda 1, WARNING autorizado): sumadas
+/// las dos rutas de resumen de stock (<c>reposicion/resumen</c>, <c>vencimientos/resumen</c>) —
+/// ninguna tenía cobertura de autorización, el gap de <c>vencimientos/resumen</c> era preexistente
+/// (desde slice 6) y se cerró de paso, test-only.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -24,15 +27,20 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
     private const string MailRoot = "test@test.com";
     private const string PasswordOtroRol = "otro-rol-password-larga";
 
-    private sealed record Contexto(int IdEmpresa, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor, HttpClient Root);
+    private sealed record Contexto(
+        int IdEmpresa, int IdPuntoVenta, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor, HttpClient Root);
 
-    /// <summary>Las nueve rutas de <c>ReportesEndpoints.cs</c> — <c>rentabilidad</c> y
-    /// <c>comisiones</c> son las dos que apilan <c>LecturaDeRentabilidad</c> (design decisión 7).</summary>
+    /// <summary>Las nueve rutas originales de <c>ReportesEndpoints.cs</c> — <c>rentabilidad</c> y
+    /// <c>comisiones</c> son las dos que apilan <c>LecturaDeRentabilidad</c> (design decisión 7) —
+    /// más las dos rutas de resumen de stock (<c>stock/reposicion/resumen</c>,
+    /// <c>stock/vencimientos/resumen</c>, ambas <c>LecturaDeReportes</c> sola, sin rentabilidad),
+    /// que no tenían test de autorización propio.</summary>
     public static readonly TheoryData<string> TodasLasRutas = new()
     {
         "ventas/resumen", "compras/por-proveedor", "gastos/resumen", "articulos/top",
         "ventas/por-punto-venta", "ventas/por-vendedor", "ventas/por-medio-pago",
-        "rentabilidad", "comisiones"
+        "rentabilidad", "comisiones",
+        "stock/reposicion/resumen", "stock/vencimientos/resumen"
     };
 
     public static readonly TheoryData<string> RutasSinLecturaDeRentabilidad = new()
@@ -63,7 +71,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
         var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
 
-        return new Contexto(resultado.IdEmpresa, admin, supervisor, vendedor, root);
+        return new Contexto(resultado.IdEmpresa, resultado.IdPuntoVenta, admin, supervisor, vendedor, root);
     }
 
     private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
@@ -81,9 +89,13 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
 
     /// <summary>`ventas/resumen`/`gastos/resumen` exigen `granularidad`; el resto no lo lee
     /// (dto-contract-honesty) — agregarlo de más no rompe nada, así que viaja siempre para
-    /// simplificar la matriz.</summary>
-    private static string RutaCon(string ruta, int idEmpresa, DateOnly hoy) =>
-        $"/api/reportes/{ruta}?idEmpresa={idEmpresa}&desde={hoy:yyyy-MM-dd}&hasta={hoy:yyyy-MM-dd}&granularidad=Dia";
+    /// simplificar la matriz. Las dos rutas de resumen de stock (<c>stock/*/resumen</c>) no leen
+    /// ninguno de esos campos, solo <c>idPuntoVenta</c> (judgment-day slice 7 juez B, WARNING
+    /// autorizado) — build separado para no mandarles query params que no existen en su firma.</summary>
+    private static string RutaCon(string ruta, int idEmpresa, int idPuntoVenta, DateOnly hoy) =>
+        ruta.StartsWith("stock/", StringComparison.Ordinal)
+            ? $"/api/reportes/{ruta}?idPuntoVenta={idPuntoVenta}"
+            : $"/api/reportes/{ruta}?idEmpresa={idEmpresa}&desde={hoy:yyyy-MM-dd}&hasta={hoy:yyyy-MM-dd}&granularidad=Dia";
 
     [Theory]
     [MemberData(nameof(TodasLasRutas))]
@@ -92,7 +104,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var respuesta = await ctx.Vendedor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+        var respuesta = await ctx.Vendedor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
@@ -104,7 +116,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnRootEsRechazadoEnLasNueveRutas) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var respuesta = await ctx.Root.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+        var respuesta = await ctx.Root.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
@@ -116,7 +128,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoEnLasNueveRutas) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var respuesta = await ctx.Admin.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+        var respuesta = await ctx.Admin.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
@@ -128,7 +140,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnSupervisorEsAceptadoEnLasSieteRutasSinLecturaDeRentabilidad) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
     }
@@ -144,7 +156,7 @@ public class ReportesAutorizacionTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnRentabilidadYComisiones) + ruta.Replace("/", "-"));
         var hoy = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, hoy));
+        var respuesta = await ctx.Supervisor.GetAsync(RutaCon(ruta, ctx.IdEmpresa, ctx.IdPuntoVenta, hoy));
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }

--- a/tests/Ways.IntegrationTests/ReposicionReporteTests.cs
+++ b/tests/Ways.IntegrationTests/ReposicionReporteTests.cs
@@ -463,8 +463,12 @@ public class ReposicionReporteTests(WaysApiFixture fixture) : IClassFixture<Ways
     // ---- task 7.9: discriminación — sinProveedor cuenta el grupo Sin proveedor, no "sin sugerido" --
 
     /// <summary>spec reposicion-de-stock: "sinProveedor counts the Sin proveedor group, not a missing
-    /// suggestion" — dos filas bajo mínimo, una sin proveedor CON sugerido, otra con proveedor SIN
-    /// sugerido: <c>sinProveedor</c> cuenta solo la primera, independiente de <c>sugerido</c>.</summary>
+    /// suggestion" — tres filas bajo mínimo, con cardinalidades DISCRIMINANTES para que el mutante
+    /// <c>f.IdProveedor is null</c> → <c>f.Sugerido is null</c> no sobreviva: una sin proveedor CON
+    /// sugerido (grupo sinProveedor = 1), y DOS con proveedor SIN sugerido (grupo "sin sugerido" = 2,
+    /// asimétrico respecto de sinProveedor). Las magnitudes de cantidad/mínimo también son distintas
+    /// entre sí para que <c>bajoMinimo</c>/<c>sinStock</c>/<c>sinProveedor</c> (3/0/1) no colisionen y
+    /// ningún swap entre los tres campos del resumen sobreviva.</summary>
     [Fact]
     public async Task SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente()
     {
@@ -479,13 +483,22 @@ public class ReposicionReporteTests(WaysApiFixture fixture) : IClassFixture<Ways
         var artConProveedorSinSugerido = await SembrarArticuloAsync(ctx, "discriminacion-con-proveedor", provedor);
         await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artConProveedorSinSugerido, cantidad: 3m, minimo: 10m, reposicion: null);
 
+        // TERCERA fila (rompe la simetría 1/1): también con proveedor, también SIN sugerido, pero
+        // con cantidad/mínimo distintos y sin agotar stock — hace que "sin sugerido" (2) diverja de
+        // sinProveedor (1); si el fold se equivoca de campo, el resumen da 2 en vez de 1.
+        var artConProveedorSinSugeridoDos = await SembrarArticuloAsync(ctx, "discriminacion-con-proveedor-dos", provedor);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artConProveedorSinSugeridoDos, cantidad: 4m, minimo: 6m, reposicion: null);
+
         var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
-        Assert.Equal(2, reposicion.Filas.Count);
+        Assert.Equal(3, reposicion.Filas.Count);
         Assert.Equal(30m, reposicion.Filas.Single(f => f.IdArticulo == artSinProveedorConSugerido).Sugerido);
         Assert.Null(reposicion.Filas.Single(f => f.IdArticulo == artConProveedorSinSugerido).Sugerido);
+        Assert.Null(reposicion.Filas.Single(f => f.IdArticulo == artConProveedorSinSugeridoDos).Sugerido);
 
         var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdPuntoVenta);
 
+        Assert.Equal(3, resumen.BajoMinimo);
+        Assert.Equal(0, resumen.SinStock);
         Assert.Equal(1, resumen.SinProveedor);
     }
 }

--- a/tests/Ways.IntegrationTests/ReposicionReporteTests.cs
+++ b/tests/Ways.IntegrationTests/ReposicionReporteTests.cs
@@ -396,4 +396,96 @@ public class ReposicionReporteTests(WaysApiFixture fixture) : IClassFixture<Ways
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
+
+    // ---- Slice 7 (tasks 7.7-7.9): GET /api/reportes/stock/reposicion/resumen — el tile de Tablero
+    // reusa ObtenerReposicionAsync y foldea sus propias filas (design decisión 8/9), tercer campo
+    // sinProveedor (orchestrator decision 5, tasks.md — nunca la sinSugerencia vieja de design.md).
+
+    private static async Task<ResumenDeReposicion> ObtenerResumenAsync(HttpClient cliente, int idPuntoVenta)
+    {
+        var respuesta = await cliente.GetAsync($"/api/reportes/stock/reposicion/resumen?idPuntoVenta={idPuntoVenta}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<ResumenDeReposicion>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 7.7: MUTATION TARGET — el fold de sinStock (f.Cantidad <= 0) ------------------------
+
+    /// <summary>Nombra la cláusula bajo prueba (mutation-proof-tests): el fold <c>f.Cantidad &lt;= 0</c>
+    /// de <c>ObtenerResumenDeReposicionAsync</c> — con <c>&lt; 0</c>, el artículo EXACTAMENTE en cero
+    /// (el caso más urgente: la góndola está vacía AHORA) deja de contar como <c>sinStock</c>. También
+    /// cubre task 7.8 (spec reposicion-de-stock: "The tile's three counts equal the report's folded
+    /// values"): los tres conteos DISTINTOS entre sí (7/2/1) para que ningún swap pase desapercibido
+    /// (mutation-proof-tests regla 6). EVIDENCIA (mutación aplicada durante el apply de esta slice):
+    /// mutar <c>f.Cantidad &lt;= 0</c> a <c>f.Cantidad &lt; 0</c> en <c>ServicioDeReportesDeStock.cs</c>
+    /// y correr este test AISLADO (<c>--filter FullyQualifiedName~LosTresConteosDelTileIgualanElFoldeoDelReporte</c>)
+    /// hace fallar el <c>Assert.Equal(2, resumen.SinStock)</c> (el artículo en cantidad exactamente 0
+    /// deja de contarse, <c>SinStock</c> pasa a 1); revertida la mutación, el test vuelve a
+    /// verde.</summary>
+    [Fact]
+    public async Task LosTresConteosDelTileIgualanElFoldeoDelReporte()
+    {
+        var ctx = await PrepararAsync(nameof(LosTresConteosDelTileIgualanElFoldeoDelReporte));
+
+        var provUno = await SembrarProveedorAsync(ctx, "Proveedor resumen 1");
+        var provDos = await SembrarProveedorAsync(ctx, "Proveedor resumen 2");
+        var provTres = await SembrarProveedorAsync(ctx, "Proveedor resumen 3");
+
+        // Seis filas CON proveedor — dos de ellas sinStock (una en cantidad EXACTAMENTE 0, el
+        // mutation target; otra en saldo negativo, legal per ReglaDeReposicion).
+        var artA = await SembrarArticuloAsync(ctx, "resumen-a", provUno);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artA, cantidad: 3m, minimo: 5m, reposicion: null);
+        var artB = await SembrarArticuloAsync(ctx, "resumen-b-cero", provUno);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artB, cantidad: 0m, minimo: 2m, reposicion: null);
+        var artC = await SembrarArticuloAsync(ctx, "resumen-c-negativo", provDos);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artC, cantidad: -1m, minimo: 1m, reposicion: null);
+        var artD = await SembrarArticuloAsync(ctx, "resumen-d", provDos);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artD, cantidad: 4m, minimo: 6m, reposicion: null);
+        var artE = await SembrarArticuloAsync(ctx, "resumen-e", provTres);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artE, cantidad: 1m, minimo: 10m, reposicion: null);
+        var artF = await SembrarArticuloAsync(ctx, "resumen-f", provTres);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artF, cantidad: 2m, minimo: 3m, reposicion: null);
+
+        // Séptima fila SIN proveedor — la única que cuenta en sinProveedor.
+        var artG = await SembrarArticuloAsync(ctx, "resumen-g-sin-proveedor");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artG, cantidad: 5m, minimo: 8m, reposicion: null);
+
+        var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(7, reposicion.Filas.Count);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Equal(7, resumen.BajoMinimo);
+        Assert.Equal(2, resumen.SinStock);
+        Assert.Equal(1, resumen.SinProveedor);
+    }
+
+    // ---- task 7.9: discriminación — sinProveedor cuenta el grupo Sin proveedor, no "sin sugerido" --
+
+    /// <summary>spec reposicion-de-stock: "sinProveedor counts the Sin proveedor group, not a missing
+    /// suggestion" — dos filas bajo mínimo, una sin proveedor CON sugerido, otra con proveedor SIN
+    /// sugerido: <c>sinProveedor</c> cuenta solo la primera, independiente de <c>sugerido</c>.</summary>
+    [Fact]
+    public async Task SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente()
+    {
+        var ctx = await PrepararAsync(nameof(SinProveedorCuentaElGrupoSinProveedorNoElSugeridoAusente));
+
+        // Sin proveedor, CON sugerido (reposicion = 32 ⇒ sugerido = 30) — cuenta en sinProveedor.
+        var artSinProveedorConSugerido = await SembrarArticuloAsync(ctx, "discriminacion-sin-proveedor");
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artSinProveedorConSugerido, cantidad: 2m, minimo: 10m, reposicion: 32m);
+
+        // Con proveedor, SIN sugerido (reposicion sin configurar) — NO cuenta en sinProveedor.
+        var provedor = await SembrarProveedorAsync(ctx, "Proveedor discriminación");
+        var artConProveedorSinSugerido = await SembrarArticuloAsync(ctx, "discriminacion-con-proveedor", provedor);
+        await SembrarStockAsync(ctx, ctx.IdPuntoVenta, artConProveedorSinSugerido, cantidad: 3m, minimo: 10m, reposicion: null);
+
+        var reposicion = await ObtenerReposicionAsync(ctx.Admin, ctx.IdPuntoVenta);
+        Assert.Equal(2, reposicion.Filas.Count);
+        Assert.Equal(30m, reposicion.Filas.Single(f => f.IdArticulo == artSinProveedorConSugerido).Sugerido);
+        Assert.Null(reposicion.Filas.Single(f => f.IdArticulo == artConProveedorSinSugerido).Sugerido);
+
+        var resumen = await ObtenerResumenAsync(ctx.Admin, ctx.IdPuntoVenta);
+
+        Assert.Equal(1, resumen.SinProveedor);
+    }
 }


### PR DESCRIPTION
## Etapa 13 — Stock inteligente · Slice 7 (Tile Y Sugerencia) — cierre de la etapa

- `ObtenerResumenDeReposicionAsync`: fold sobre el MISMO `ObtenerReposicionAsync` (cero segunda query de agregación — decisiones 8/9): `bajoMinimo`, `sinStock` (cantidad ≤ 0), `sinProveedor` (grupo *Sin proveedor* — decisión de orquestador #5: jamás conflado con "sin sugerido"; la #12 hace que incluya soft-deleted).
- `GET /reportes/stock/reposicion/resumen` bajo `LecturaDeReportes`; tile `PanelDeReposicion` clonado de `PanelDeVencimientos` con UN `data-testid` POR métrica (lección del slice 15 de la etapa 12).
- Columna `Sugerido` en Existencias alimentada por `/rotacion` indexada por `idArticulo`; ausencia ⇒ `—` nunca `0` (decisión 14); fetch con `.catch` que degrada a mapa vacío sin romper la pantalla; contrato de estado del slice 3 intocado.
- Degradación pre-aprobada NO ejercida (el slice entró en presupuesto con 7.6/7.11 completos).
- Gates sostenidos: SIN-CAMBIOS-DE-SCHEMA (cero migraciones) y protección del checkout (cero archivos de Ventas/Compras/ServicioDeStock).

## Tests
Tile≡report con 3 counts distintos (7/2/1), discriminación asimétrica de `sinProveedor` (grupo sugerido-null=2 vs sin-proveedor=1), testids individuales, dos celdas de Sugerido con valores distintos + `—`, degradación ante fallo de rotación, matriz de autorización extendida a los DOS resúmenes de stock (cerró de paso el gap preexistente del sibling de vencimientos) con Supervisor-aceptado incluido y nombres sin numerales caducos. Mutation target 7.7 + 10 mutaciones del juez B con evidencia. Filtrados: 9/9 + 44/44; vitest full 660/660.

## Judgment-day
Juez B ronda 1: 1 MAJOR (7.9 con cardinalidades simétricas — el mutante sobrevivía a su killer declarado) + 2 WARNINGs → fix `2098d2f`. Re-ronda B: 3 re-mutaciones muertas + verificación en vivo del cierre del sibling. Juez A: 0 severos, WARNING+SUGGESTION cerrados test-only con evidencia. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)