### PR TITLE
test(exportacion): assert de headers de tabla en todos los tests de igualdad JSON-XLSX preexistentes

### DIFF
--- a/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
@@ -152,6 +152,14 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Comprobante", "Proveedor", "Fecha de recepción", "Estado", "Total"],
+            Enumerable.Range(1, 5).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
         var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < pagina.Items.Count; i++)

--- a/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
+++ b/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
@@ -313,6 +313,12 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         // PV que abrió/cerró el turno.
         Assert.Contains($"PV {ctx.IdPuntoVenta}", hoja.Cell(2, 1).GetString());
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Sección", "Detalle", "Fecha", "Importe"],
+            Enumerable.Range(1, 4).Select(c => hoja.Cell(6, c).GetString()));
+
         const int primeraFilaDeDatos = 7;
         var filas = new List<(string Seccion, string Detalle, decimal Importe)>();
         for (var fila = primeraFilaDeDatos; !hoja.Cell(fila, 1).Value.IsBlank; fila++)

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
@@ -125,6 +125,14 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Fecha", "Tipo", "Importe", "Saldo", "Detalle"],
+            Enumerable.Range(1, 5).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
         var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < estado.Movimientos.Count; i++)

--- a/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
+++ b/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
@@ -324,6 +324,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
             ctx.Admin, $"/api/reportes/ventas/por-punto-venta/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Punto de venta", "Neto", "TX", "Ticket promedio"],
+            Enumerable.Range(1, 4).Select(c => hoja.Cell(6, c).GetString()));
+
         Assert.Equal(fila.IdPuntoVenta, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
         Assert.Equal(fila.CantidadTx, hoja.Cell(7, 3).GetValue<int>());
@@ -344,6 +350,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         using var libro = await DescargarLibroAsync(
             ctx.Admin, $"/api/reportes/ventas/por-vendedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Vendedor", "Neto", "TX", "Ticket promedio"],
+            Enumerable.Range(1, 4).Select(c => hoja.Cell(6, c).GetString()));
 
         Assert.Equal(fila.IdEmpleado, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
@@ -367,6 +379,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
             ctx.Admin, $"/api/reportes/ventas/por-medio-pago/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Medio de pago", "Neto", "Cantidad de pagos"],
+            Enumerable.Range(1, 3).Select(c => hoja.Cell(6, c).GetString()));
+
         Assert.Equal(fila.IdMedioPago, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.Neto, hoja.Cell(7, 2).GetValue<decimal>());
         Assert.Equal(fila.CantidadPagos, hoja.Cell(7, 3).GetValue<int>());
@@ -388,6 +406,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
             ctx.Admin, $"/api/reportes/articulos/top/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Artículo", "Descripción", "Cantidad", "Total"],
+            Enumerable.Range(1, 4).Select(c => hoja.Cell(6, c).GetString()));
+
         Assert.Equal(fila.IdArticulo, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.Descripcion, hoja.Cell(7, 2).GetString());
         Assert.Equal(fila.Cantidad, hoja.Cell(7, 3).GetValue<decimal>());
@@ -408,6 +432,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         using var libro = await DescargarLibroAsync(
             ctx.Admin, $"/api/reportes/compras/por-proveedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Proveedor", "Total", "Cantidad de compras"],
+            Enumerable.Range(1, 3).Select(c => hoja.Cell(6, c).GetString()));
 
         Assert.Equal(fila.NombreProveedor, hoja.Cell(7, 1).GetString());
         Assert.Equal(fila.Total, hoja.Cell(7, 2).GetValue<decimal>());
@@ -431,6 +461,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
             ctx.Admin, $"/api/reportes/gastos/resumen/export?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Período", "Importe"],
+            Enumerable.Range(1, 2).Select(c => hoja.Cell(6, c).GetString()));
+
         Assert.Equal(reporte.Serie[0].Etiqueta, hoja.Cell(7, 1).GetString());
         Assert.Equal(reporte.Serie[0].Importe, hoja.Cell(7, 2).GetValue<decimal>());
         Assert.Equal(reporte.ImporteTotal, hoja.Cell(8, 2).GetValue<decimal>());
@@ -451,6 +487,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         using var libro = await DescargarLibroAsync(
             ctx.Admin, $"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Artículo", "Descripción", "Venta considerada", "Costo considerado", "Margen", "Margen %"],
+            Enumerable.Range(1, 6).Select(c => hoja.Cell(6, c).GetString()));
 
         Assert.Equal(fila.IdArticulo, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.Descripcion, hoja.Cell(7, 2).GetString());
@@ -476,6 +518,12 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         using var libro = await DescargarLibroAsync(
             ctx.Admin, $"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
         var hoja = libro.Worksheets.First();
+
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Vendedor", "Neto vendido", "Comisión"],
+            Enumerable.Range(1, 3).Select(c => hoja.Cell(6, c).GetString()));
 
         Assert.Equal(fila.IdEmpleado, hoja.Cell(7, 1).GetValue<int>());
         Assert.Equal(fila.NetoVendido, hoja.Cell(7, 2).GetValue<decimal>());

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -332,6 +332,12 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
         using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido.
+        Assert.Equal(
+            ["Turno", "Punto de venta", "Apertura", "Cierre", "Esperado", "Declarado", "Diferencia", "Retiros"],
+            Enumerable.Range(1, 8).Select(c => hoja.Cell(6, c).GetString()));
+
         // Las 8 columnas completas, no solo Diferencia — Apertura/Cierre se comparan
         // zone-converted (mismo patrón que VentasListadoExportTests) porque el mapper convierte
         // el DateTimeOffset a America/Argentina/Buenos_Aires antes de escribir la celda.

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
@@ -180,6 +180,14 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Período", "Neto", "TX", "Ticket promedio"],
+            Enumerable.Range(1, 4).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
         // Primera fila de datos es la 7 (fila 6 = título de tabla) — una fila por bucket, EN
         // ORDEN, seguida de la fila de totales.
         const int primeraFilaDeDatos = 7;

--- a/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
@@ -146,8 +146,16 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         using var libroXlsx = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libroXlsx.Worksheets.First();
 
-        // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden de cadena que el
-        // libro JSON (inicio/ingreso/egreso/final/concepto/empleado/fecha, design: Slice 7 task 7.5).
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Inicio", "Ingreso", "Egreso", "Final", "Concepto", "Empleado", "Fecha"],
+            Enumerable.Range(1, 7).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
+        // Los datos empiezan en la fila 7, mismo orden de cadena que el libro JSON
+        // (inicio/ingreso/egreso/final/concepto/empleado/fecha, design: Slice 7 task 7.5).
         var zonaArgentina = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < libro.Items.Count; i++)

--- a/tests/Ways.IntegrationTests/VencimientosExportTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosExportTests.cs
@@ -172,8 +172,16 @@ public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<Way
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
-        // Fila 6 = título de tabla, los datos empiezan en la fila 7 — orden fecha_vencimiento ASC
-        // NULLS LAST del lado del servicio, ambas filas con TODAS sus columnas comparadas.
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Artículo", "Nombre", "Lote", "Código de lote", "Vencimiento", "Cantidad", "Estado"],
+            Enumerable.Range(1, 7).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
+        // Los datos empiezan en la fila 7 — orden fecha_vencimiento ASC NULLS LAST del lado del
+        // servicio, ambas filas con TODAS sus columnas comparadas.
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < vencimientos.Filas.Count; i++)
         {

--- a/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
@@ -149,8 +149,16 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();
 
-        // Fila 6 = título de tabla; los datos empiezan en la fila 7, mismo orden que el listado
-        // JSON (newest-first, ver ServicioDeVentas.ConstruirQuery).
+        // Fila 6 = título de tabla (mutation-proof-tests regla 8): el header es lo que ata cada
+        // celda de datos a su columna, sin este assert un swap de labels pasa inadvertido porque
+        // el test de igualdad de abajo solo lee celdas por posición.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Número", "Fecha", "Punto de venta", "Cliente", "Estado", "Total"],
+            Enumerable.Range(1, 6).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
+        // Los datos empiezan en la fila 7, mismo orden que el listado JSON (newest-first, ver
+        // ServicioDeVentas.ConstruirQuery).
         var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
         const int primeraFilaDeDatos = 7;
         for (var i = 0; i < pagina.Items.Count; i++)


### PR DESCRIPTION
## Cierre del gap de headers (regla 8 de mutation-proof-tests)

Los tests de igualdad JSON↔XLSX anteriores a la etapa 13 leían solo filas de datos desde la fila 7 y jamás asertaban la fila de headers (fila 6, `ExportadorXlsx.FilaDeTituloDeTabla`): un swap de títulos de columna pasaba toda la suite — la clase de mutante que el judgment-day de la etapa 13 cazó dos veces (slices 2 y 4) y que la regla 8 nueva de la skill ya exige.

- **17 tests de igualdad cubiertos** en 9 archivos: 6 archivos `*ExportTests.cs` (Compras, EstadoDeCuenta, VentasResumen, Tesoreria, Vencimientos, VentasListado) + 3 archivos que el glob inicial no veía (ExportacionDeReportesTests ×8 mappers, HistoricoDeCajas, DetalleDeTurno — hallazgo de completitud del juez A).
- Cada assert lee las celdas (6,1..N) y compara la colección contra los títulos EXACTOS de la `ColumnasX` de producción correspondiente (verificado mapper por mapper).
- Ya cumplían y no se tocaron: ExistenciasExportTests y ReposicionExportTests (etapa 13). El test de filtro de estado de VentasListado quedó correctamente excluido (no es test de igualdad).
- **Test-only**: cero archivos de producción, cero migraciones.

## Evidencia de mutación
Por archivo/shape: swap de dos títulos en la ColumnasX → build → la suite filtrada FALLA en el assert nuevo → revert → verde. 12 mutaciones registradas cubriendo todos los shapes de columnas presentes (2/3/4/6/8).

## Judgment-day
Juez A ronda 1: 6 archivos limpios + hallazgo de completitud (los 3 archivos faltantes) → completado. Re-ronda A: los 10 asserts nuevos verificados exactos contra producción, barrido XLWorkbook completo sin residuales. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)