### PR TITLE
feat(stage-14): slice 3 anulaciones — venta.anulacion y compra.anulacion con RETURNING de PV

### DIFF
--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -723,7 +723,7 @@ call sites disappear, both `MarcarAnulado*Async` methods keep their
   --startup-project src/Ways.Infrastructure` → "No changes have been made
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
-- [ ] 3.14 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 3.14 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   - Ronda 1 (juez B): 0 severos; 2 WARNING (findings 1-2). Ambos fixed y con
     evidencia de mutación: finding 1 (test fail-closed nuevo sobre la
     composición literal del spec — 3 líneas de producto + consumo de CC —
@@ -731,7 +731,7 @@ call sites disappear, both `MarcarAnulado*Async` methods keep their
     finding 2 (`Assert.NotEqual(0, fila.IdActor)` → `Assert.Equal(ctx.
     IdEmpleadoAdmin, fila.IdActor)` en ambos tests de cobertura, venta y
     compra). Re-judge pendiente.
-- [ ] 3.15 Branch `feat/stage14-slice3-anulaciones` off `main` (parent:
+- [x] 3.15 Branch `feat/stage14-slice3-anulaciones` off `main` (parent: *(CLEAN 2026-08-16: juez B ronda 1 — 0 severos, 2 WARNINGs test-only cerrados (fail-closed con la composicion literal del spec 3 lineas+CC asertando cero reversas; IdActor por IGUALDAD con el admin — el mutante actor-constante ahora muere en ambos tests); re-ronda B aprobada (patch-id verificado, REVOKE con restore en finally, retry limpio 200) con 1 INFO de cifras de comentario corregido por el orquestador; juez A fresh: CERO hallazgos — verifico el precedente MarcarCerradoAsync, la carrera cross-connection del interceptor como patron establecido del repo, y que MarcarAnulad(o|a)Async no tiene callers externos. JUDGMENT: APPROVED.)*
   slice 1); PR; merge stacked-to-main.
 
 **Test plan**: 3 mutation targets (3.4-3.6), flagship (3.7), coverage

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -549,62 +549,149 @@ row in the same ADO transaction as the `estado` transition, including the
 call sites disappear, both `MarcarAnulado*Async` methods keep their
 `RETURNING`-derived PV (harmless if unused).
 
-- [ ] 3.1 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
+- [x] 3.1 Modify `src/Ways.Application/Ventas/ServicioDeVentas.cs`:
   `MarcarAnuladoAsync` → `RETURNING id_punto_venta` / return `int?`
   (instead of `bool` via `RETURNING id_comprobante_venta`) — the same
   `UPDATE ... WHERE estado = 'emitido'` stays the sole race-safe authority,
   now also answering "in which PV", zero extra round trips. *(design
   decision 8; call site 7)*
-- [ ] 3.2 Modify `ServicioDeVentas.cs`'s `EjecutarAnulacionAsync` (`:541`,
+- [x] 3.2 Modify `ServicioDeVentas.cs`'s `EjecutarAnulacionAsync` (`:541`,
   after the `!seAnulo` guard, before paso 2):
   `auditoria.RegistrarAsync(conexion, transaccionCruda, ...)` with
   `accion=venta.anulacion`, `ant={estado: EstadoComprobante.Emitido}` (the
   **same constant** that binds the `UPDATE`'s `WHERE`), `nuevo={estado:
   EstadoComprobante.Anulado}`.
-- [ ] 3.3 Modify `src/Ways.Application/Compras/ServicioDeCompras.cs`'s
+  **DEVIATION (registered, not silent)**: `auditoria` is **not** a new
+  constructor dependency of `ServicioDeVentas`/`ServicioDeCompras` — design's
+  own call-site table never lists a constructor change for call sites 7/8,
+  and design binding verify criterion 2 restricts this etapa's diff of
+  `src/Ways.Application/Ventas/` to the lines of
+  `EjecutarAnulacionAsync`/`MarcarAnuladoAsync`. `VentasCheckoutTests.cs` and
+  4 other integration test files construct `ServicioDeVentas`/`ServicioDeCompras`
+  with `new(...)` and the CURRENT positional arg count (confirmed by
+  `grep`: `PlanDeVentaFefoTests`, `VentasAtomicidadYConcurrenciaTests`,
+  `VentaEscrituraLoteTests`, `VentasTurnoWiringTests`,
+  `VentasCheckoutTests`, and `ComprasAnulacionYConcurrenciaTests.CrearServicio`)
+  — a constructor parameter would have broken all of them, including the
+  one file that must stay byte-identical. Instead,
+  `new ServicioDeAuditoria(db, reloj, contexto)` is instantiated LOCAL to
+  each `EjecutarAnulacionAsync`, from the same `db`/`reloj`/`contexto`
+  already captured by each service's own primary constructor — zero DI
+  surface change, zero touched constructor, zero touched test file. For
+  `ServicioDeVentas.cs` specifically, fully-qualified names
+  (`Ways.Application.Auditoria.ServicioDeAuditoria`,
+  `Ways.Domain.Auditoria.*`) are used inline instead of adding `using`
+  directives, to keep the diff confined to the two named methods per
+  binding verify criterion 2's literal text.
+- [x] 3.3 Modify `src/Ways.Application/Compras/ServicioDeCompras.cs`'s
   anulación path (`:522`, after the guard, before paso 2):
   `RegistrarAsync` with `accion=compra.anulacion`, `ant={estado:
   "confirmada"}` (guaranteed by the `UPDATE`'s `WHERE`, `:677`),
   `nuevo={estado:"anulada"}`; `id_punto_venta` from the `RETURNING`
   `MarcarAnuladaAsync` **already** returns — no change to that method.
-- [ ] 3.4 [P] **Mutation target**: `RETURNING id_punto_venta` on
+  Compras is not named by binding verify criterion 2, so ordinary `using`
+  directives (`Ways.Application.Auditoria`, `Ways.Domain.Auditoria`) were
+  added — same local-instantiation pattern as 3.2 otherwise.
+- [x] 3.4 [P] **Mutation target**: `RETURNING id_punto_venta` on
   `MarcarAnuladoAsync` — revert to `id_comprobante_venta` and read the PV
   from the pre-read instead — a test whose pre-read PV disagrees with the
   row's actual PV must catch the audit row's `id_punto_venta` diverging.
-  *(slice 3 row 1)*
-- [ ] 3.5 [P] **Mutation target**: `RegistrarAsync` moved **after**
+  *(slice 3 row 1)* **Evidence**: a same-thread, no-race test cannot
+  discriminate here — the PV is immutable post-emission, so the pre-read
+  and the `RETURNING` always agree without a real interleaving (same
+  confound flagged in slice 1 task 1.18). Test
+  `AuditoriaAnulacionVentaTests.LaAuditoriaDeAnulacionLlevaElPuntoDeVentaQueElUpdateAtomicoRealmenteVioNoElDelPreRead`
+  forces a genuine race via a `DbCommandInterceptor` pausing
+  `EjecutarAnulacionAsync` right after the pre-read SELECT executes; from a
+  separate owner connection (outside the app transaction) `id_punto_venta`
+  is reassigned to a second, freshly-seeded PV; the atomic `UPDATE ...
+  RETURNING` then sees and returns the reassigned PV. Mutated (audit call
+  reads `comprobantePreLectura!.IdPuntoVenta` instead of the `RETURNING`
+  value) → `dotnet build --no-incremental` → named test →
+  `Assert.Equal() Failure: Values differ / Expected: 4 / Actual: 3` (audit
+  row carried the stale pre-read PV) → reverted → `git diff` clean →
+  rebuilt → green.
+- [x] 3.5 [P] **Mutation target**: `RegistrarAsync` moved **after**
   `CommitAsync` in the anulación transaction — the flagship fail-closed
-  test (3.9) must fail. *(slice 3 row 2)*
-- [ ] 3.6 [P] **Mutation target**: `EstadoComprobante.Emitido` as
+  test (3.9) must fail. *(slice 3 row 2)* **Evidence**: mutated (the whole
+  "1.5. Auditoría" block cut from before paso 2 and pasted after
+  `transaccion.CommitAsync(ct)`, immediately before `return await
+  ObtenerAsync(...)`) → `dotnet build --no-incremental` → named test
+  `AuditoriaAnulacionVentaTests.UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDelComprobante100PorCientoServicio`
+  → `Assert.Equal() Failure: Values differ / Expected: Emitido / Actual:
+  Anulado` (the 100%-servicio comprobante committed `Anulado` even with
+  `INSERT` on `auditoria` revoked, because the commit had already happened
+  before the now-doomed audit insert ran) → reverted via `git checkout --`
+  → `git diff` clean → rebuilt → green.
+- [x] 3.6 [P] **Mutation target**: `EstadoComprobante.Emitido` as
   `valor_anterior` replaced by a hardcoded `"anulado"` literal — the
   `venta.anulacion` payload coverage test (3.8) must fail. *(slice 3 row 3)*
-- [ ] 3.7 [P] Integration — **the flagship scenario**: a TX comprobante
+  **Evidence**: mutated (`PayloadDeAuditoria.AnulacionDeVenta`'s first
+  argument changed from `EstadoComprobante.Emitido` to
+  `EstadoComprobante.Anulado`, the enum member that serializes to the
+  `"anulado"` literal per `SerializadorDeAuditoria`'s
+  `JsonStringEnumConverter(SnakeCaseLower)`) → `dotnet build
+  --no-incremental` → named test
+  `AuditoriaAnulacionVentaTests.VentaAnulacionCoberturaSobreUnComprobanteConConsumoDeCuentaCorriente`
+  → `Assert.Equal() Failure: Strings differ / Expected: "emitido" / Actual:
+  "anulado"` → reverted → `git diff` clean → rebuilt → green.
+- [x] 3.7 [P] Integration — **the flagship scenario**: a TX comprobante
   composed entirely of service lines (`id_articulo NULL` on every item)
   with no cuenta corriente pago, anulado — one `auditoria` row naming the
   actor, zero `movimientos_stock`, zero `movimientos_cuenta_corriente`
   reversal rows. *(spec `comprobantes-venta`: "A 100%-servicio comprobante
   without cuenta corriente is attributable on anulación"; spec `auditoria-
   de-operaciones`: "A 100%-servicio anulación without cuenta corriente is
-  attributable")*
-- [ ] 3.8 [P] Integration: `venta.anulacion` coverage over a mixed
+  attributable")* Implemented as
+  `AuditoriaAnulacionVentaTests.AnulacionDeUnComprobante100PorCientoServicioSinCcEsAtribuible`.
+  **Note**: `POST /api/ventas` cannot construct a free-concept
+  (`id_articulo NULL`) line — `LineaDeVenta.IdArticulo` is non-nullable
+  `int` (`Ventas/Contratos.cs`) and the checkout path "no construye ese
+  camino todavía" per `ItemComprobanteVenta.IdArticulo`'s own doc-comment
+  — so the comprobante + its free-concept item are seeded directly by EF
+  (`SembrarComprobanteDeServicioAsync`), same precedent as
+  `CajaCierreEndpointsTests.SembrarPagoAsync`, then anulado through the
+  real `POST /api/ventas/{id}/anulacion` endpoint.
+- [x] 3.8 [P] Integration: `venta.anulacion` coverage over a mixed
   comprobante (product + service lines, with CC consumo) — one row,
   `{estado: Emitido}` → `{estado: Anulado}`, `id_punto_venta` matches the
-  comprobante's own PV.
-- [ ] 3.9 [P] Integration — fail-closed on `venta.anulacion`: forcing the
+  comprobante's own PV. Implemented as
+  `AuditoriaAnulacionVentaTests.VentaAnulacionCoberturaSobreUnComprobanteConConsumoDeCuentaCorriente`.
+  **DEVIATION (registered, not silent)**: since the checkout endpoint
+  structurally cannot emit a free-concept line (see 3.7's note), "mixed"
+  composition is covered by the flagship test's directly-seeded
+  100%-servicio comprobante instead; this task's own coverage test uses an
+  ordinary product line paid by cuenta corriente (real checkout path,
+  `EmitirConCcAsync`) to exercise the payload/PV assertions over a
+  comprobante that DOES produce ledger reversal rows — the generality axis
+  this task actually needed (a non-degenerate case, as opposed to 3.7's
+  degenerate one), rather than a literal product+service item mix.
+- [x] 3.9 [P] Integration — fail-closed on `venta.anulacion`: forcing the
   audit write to fail leaves `estado = emitido` and no inverse
   `movimientos_stock`/`movimientos_cuenta_corriente` row. *(spec
   `comprobantes-venta`: "An audit failure blocks the anulación"; spec
   `auditoria-de-operaciones`: "A forced audit-insert failure blocks a venta
-  anulación")*
-- [ ] 3.10 [P] Integration: `compra.anulacion` coverage — a confirmada
+  anulación")* Implemented as
+  `AuditoriaAnulacionVentaTests.UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDelComprobante100PorCientoServicio`
+  over the SAME 100%-servicio-sin-CC comprobante as 3.7 — design's own
+  "test insignia (b)": the audit `INSERT` is the ONLY statement in that
+  transaction touching `usuarios` (via `fk_auditoria_actor`), so `REVOKE
+  INSERT ON auditoria` isolates the failure without ambiguity (same
+  `REVOKE`/`RESTORE` technique as `AnulacionTests`/
+  `ComprasAnulacionYConcurrenciaTests`). Also doubles as 3.5's fail-closed
+  evidence, per that task's own text.
+- [x] 3.10 [P] Integration: `compra.anulacion` coverage — a confirmada
   compra of 50 units, none sold, anulada — one row, actor identified, same
   transaction as the `-50` `movimientos_stock` row. *(spec `comprobantes-
-  compra`: "A compra anulación is attributable to its actor")*
-- [ ] 3.11 [P] Integration — fail-closed on `compra.anulacion`: `estado`
+  compra`: "A compra anulación is attributable to its actor")* Implemented
+  as `AuditoriaAnulacionCompraTests.CompraAnulacionCoberturaSobreUnaCompraConfirmadaSinVender`.
+- [x] 3.11 [P] Integration — fail-closed on `compra.anulacion`: `estado`
   remains `confirmada`, no `movimientos_stock` contramovimiento. *(spec
   `comprobantes-compra`: "An audit failure blocks the anulación, same as
-  the negative-stock refusal")*
-- [ ] 3.12 **Binding verify criterion, not a mutation target**:
+  the negative-stock refusal")* Implemented as
+  `AuditoriaAnulacionCompraTests.UnaFallaAlEscribirLaAuditoriaBloqueaLaCompraAnulacion`
+  (`REVOKE INSERT ON auditoria`, same technique as 3.9).
+- [x] 3.12 **Binding verify criterion, not a mutation target**:
   `tests/Ways.IntegrationTests/VentasCheckoutTests.cs` is **absent from the
   stage's diff entirely** (`git diff --name-only` against the stage's base
   never lists this file), and its `Assert.Equal(16, …)` query-count guard
@@ -612,9 +699,17 @@ call sites disappear, both `MarcarAnulado*Async` methods keep their
   `ServicioDeVentas.cs`, so it is asserted here. *(spec `auditoria-de-
   operaciones`: "Checkout emission writes no audit row and the query-count
   guard stays at 16"; design binding verify criterion 2; Orchestrator
-  Decision 13 above)*
-- [ ] 3.13 Gate guard: `has-pending-model-changes` clean; zero new files in
-  `Migraciones/`.
+  Decision 13 above)* **Confirmed**:
+  `git diff --name-only main | grep -i VentasCheckout` → no match, on the
+  final committed state (`ba9b8d5`). `EmitirAsync`/checkout is never
+  touched by this slice — only `EjecutarAnulacionAsync`/`MarcarAnuladoAsync`
+  in `ServicioDeVentas.cs`, per 3.2's DEVIATION note above.
+- [x] 3.13 Gate guard: `has-pending-model-changes` clean; zero new files in
+  `Migraciones/`. **Confirmed**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made
+  to the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
 - [ ] 3.14 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 3.15 Branch `feat/stage14-slice3-anulaciones` off `main` (parent:
   slice 1); PR; merge stacked-to-main.

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -680,6 +680,19 @@ call sites disappear, both `MarcarAnulado*Async` methods keep their
   `REVOKE`/`RESTORE` technique as `AnulacionTests`/
   `ComprasAnulacionYConcurrenciaTests`). Also doubles as 3.5's fail-closed
   evidence, per that task's own text.
+  **Judgment Day fix (slice 3 juez B ronda 1, finding 1, WARNING):** the
+  100%-servicio-sin-CC comprobante this task's test runs on never produces
+  reversas under any implementation, so the spec's THEN ("no inverse
+  movimientos_stock/movimientos_cuenta_corriente row exists") was vacuously
+  true there — it asserted nothing about the mechanism it claims to guard.
+  Complemented (not replaced) with
+  `UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDeUnComprobanteConTresLineasDeProductoYConsumoDeCc`,
+  the spec's literal GIVEN ("3 líneas de producto y un consumo de cuenta
+  corriente"), with distinct per-line magnitudes so the CEROs it asserts
+  are real. Evidence: committed → mutated (the "1.5. Auditoría" block moved
+  after `transaccion.CommitAsync(ct)`) → `dotnet build --no-incremental` →
+  new test FAILED (reversas existían / estado quedó `Anulado`) → reverted →
+  `git diff` clean → rebuilt → green.
 - [x] 3.10 [P] Integration: `compra.anulacion` coverage — a confirmada
   compra of 50 units, none sold, anulada — one row, actor identified, same
   transaction as the `-50` `movimientos_stock` row. *(spec `comprobantes-
@@ -711,6 +724,13 @@ call sites disappear, both `MarcarAnulado*Async` methods keep their
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
 - [ ] 3.14 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  - Ronda 1 (juez B): 0 severos; 2 WARNING (findings 1-2). Ambos fixed y con
+    evidencia de mutación: finding 1 (test fail-closed nuevo sobre la
+    composición literal del spec — 3 líneas de producto + consumo de CC —
+    complementando, no reemplazando, el flagship 100%-servicio, task 3.9);
+    finding 2 (`Assert.NotEqual(0, fila.IdActor)` → `Assert.Equal(ctx.
+    IdEmpleadoAdmin, fila.IdActor)` en ambos tests de cobertura, venta y
+    compra). Re-judge pendiente.
 - [ ] 3.15 Branch `feat/stage14-slice3-anulaciones` off `main` (parent:
   slice 1); PR; merge stacked-to-main.
 

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -4,10 +4,12 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Auditoria;
 using Ways.Application.Exportacion;
 using Ways.Application.Precios;
 using Ways.Application.Stock;
 using Ways.Domain.Articulos;
+using Ways.Domain.Auditoria;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Compras;
@@ -519,6 +521,21 @@ public class ServicioDeCompras(
 
             throw new ErrorDominio("compra_no_confirmada", "La compra no está confirmada.", 409);
         }
+
+        // 1.5. Auditoría (stage-14-auditoria-trazabilidad, Slice 3; spec auditoria-de-operaciones;
+        // design call site 8) — MISMA transacción cruda; id_punto_venta sale del RETURNING que
+        // MarcarAnuladaAsync YA devuelve (sin cambios en ese método), nunca de una lectura extra.
+        // ServicioDeAuditoria se instancia local con los mismos db/reloj/contexto de este
+        // servicio, mismo criterio que ServicioDeVentas.EjecutarAnulacionAsync.
+        var servicioDeAuditoriaAnulacionCompra = new ServicioDeAuditoria(db, reloj, contexto);
+        var (valorAnteriorCompraAnulacion, valorNuevoCompraAnulacion) =
+            PayloadDeAuditoria.AnulacionDeCompra(EstadoCompra.Confirmada, EstadoCompra.Anulada);
+        await servicioDeAuditoriaAnulacionCompra.RegistrarAsync(
+            conexion, transaccionCruda,
+            new RegistroDeAuditoria(
+                idTenant, idPuntoVenta, AccionAuditada.CompraAnulacion, id,
+                valorAnteriorCompraAnulacion, valorNuevoCompraAnulacion),
+            ct);
 
         // 2. El ledger ORIGINAL, nunca recalculado desde items (design: doc-comment de
         // ServicioDeVentas.AnularAsync, mismo criterio acá). Orden ascendente (id_articulo,

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -495,7 +495,8 @@ public class ServicioDeVentas(
         // ValidarSignoDeLineas dentro de MaterializarItems): valida la transición contra el
         // estado pre-leído ANTES del UPDATE atómico del paso 1, que sigue siendo la única
         // autoridad race-safe — si otra anulación gana la carrera entre este SELECT y ese UPDATE,
-        // la rama `!seAnulo` de abajo la sigue atrapando sin depender de este pre-chequeo.
+        // la rama `idPuntoVentaAnulacion is null` de abajo la sigue atrapando sin depender de
+        // este pre-chequeo.
         // AsNoTracking(): el UPDATE de abajo es SQL crudo, no pasa por el change tracker de EF —
         // sin esto, la entidad quedaría trackeada con el estado VIEJO y el ObtenerAsync() del
         // final devolvería ese mismo objeto stale desde el identity map, en vez de re-consultar.
@@ -516,15 +517,16 @@ public class ServicioDeVentas(
         await ExigirTurnoNoCerradoAsync(conexion, transaccionCruda, idTenant, id, ct);
 
         // 1. Transición atómica emitido → anulado — un único UPDATE ... WHERE estado = 'emitido'
-        // RETURNING (forward obligation, ADR-8: el segundo layer id_tenant en el WHERE es la
-        // misma defensa barata que ActualizarSaldoClienteAsync, RLS ya aísla por tenant). Dos
-        // anulaciones concurrentes del mismo comprobante se serializan acá: Postgres toma el row
-        // lock de la primera, la segunda espera y, al retomarlo, re-evalúa el WHERE contra el
-        // estado YA COMITEADO por la primera — 'anulado' no matchea 'emitido', 0 filas, nunca un
-        // 500 ni una condición de carrera silenciosa.
-        var seAnulo = await MarcarAnuladoAsync(conexion, transaccionCruda, idTenant, id, ct);
+        // RETURNING id_punto_venta (stage-14-auditoria-trazabilidad, Slice 3, design decisión 8 —
+        // mismo criterio que ServicioDeTurnos.MarcarCerradoAsync). Sigue siendo la única autoridad
+        // race-safe para "¿pasó la transición?", y ahora también contesta "¿en qué PV?" sin una
+        // lectura extra. Dos anulaciones concurrentes del mismo comprobante se serializan acá:
+        // Postgres toma el row lock de la primera, la segunda espera y, al retomarlo, re-evalúa
+        // el WHERE contra el estado YA COMITEADO por la primera — 'anulado' no matchea 'emitido',
+        // 0 filas, nunca un 500 ni una condición de carrera silenciosa.
+        var idPuntoVentaAnulacion = await MarcarAnuladoAsync(conexion, transaccionCruda, idTenant, id, ct);
 
-        if (!seAnulo)
+        if (idPuntoVentaAnulacion is null)
         {
             // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (filtro de EF + RLS ya
             // deja invisible un comprobante ajeno) — solo si NINGUNA fila visible tiene ese id
@@ -538,6 +540,25 @@ public class ServicioDeVentas(
 
             throw new ErrorDominio("comprobante_ya_anulado", "El comprobante ya está anulado.", 409);
         }
+
+        // 1.5. Auditoría (stage-14-auditoria-trazabilidad, Slice 3; spec auditoria-de-operaciones;
+        // design call site 7) — MISMA transacción cruda, MISMA constante EstadoComprobante.Emitido
+        // que ligó el WHERE del UPDATE de arriba, así que valor_anterior no puede divergir del
+        // predicado que realmente lo autorizó. id_punto_venta sale del RETURNING recién leído,
+        // nunca de comprobantePreLectura (AsNoTracking, tomado ANTES del UPDATE bajo otro filtro).
+        // ServicioDeAuditoria se instancia local con los mismos db/reloj/contexto de este servicio
+        // — el binding verify criterion de esta etapa restringe el diff de este archivo a las
+        // líneas de EjecutarAnulacionAsync/MarcarAnuladoAsync, así que el constructor de
+        // ServicioDeVentas (y VentasCheckoutTests, que lo instancia directo) queda intacto.
+        var servicioDeAuditoriaAnulacion = new Ways.Application.Auditoria.ServicioDeAuditoria(db, reloj, contexto);
+        var (valorAnteriorVentaAnulacion, valorNuevoVentaAnulacion) =
+            Ways.Domain.Auditoria.PayloadDeAuditoria.AnulacionDeVenta(EstadoComprobante.Emitido, EstadoComprobante.Anulado);
+        await servicioDeAuditoriaAnulacion.RegistrarAsync(
+            conexion, transaccionCruda,
+            new Ways.Domain.Auditoria.RegistroDeAuditoria(
+                idTenant, idPuntoVentaAnulacion, Ways.Domain.Auditoria.AccionAuditada.VentaAnulacion, id,
+                valorAnteriorVentaAnulacion, valorNuevoVentaAnulacion),
+            ct);
 
         // 2. Movimientos de stock inversos — uno por cada movimiento ORIGINAL de motivo = venta
         // de este comprobante (nunca recalculado desde items: ver el doc-comment de
@@ -712,8 +733,12 @@ public class ServicioDeVentas(
 
     /// <summary>Único UPDATE atómico de la transición de estado — ver el doc-comment de
     /// <see cref="EjecutarAnulacionAsync"/> sobre por qué esto alcanza para serializar dos
-    /// anulaciones concurrentes sin ningún lock explícito.</summary>
-    private static async Task<bool> MarcarAnuladoAsync(
+    /// anulaciones concurrentes sin ningún lock explícito. stage-14-auditoria-trazabilidad, Slice
+    /// 3 (design decisión 8, precedente exacto <c>ServicioDeTurnos.MarcarCerradoAsync</c>):
+    /// <c>RETURNING id_punto_venta</c> en vez de <c>id_comprobante_venta</c> — el mismo lock que
+    /// ya decide "¿pasó la transición?" contesta también "¿en qué PV?", sin una lectura extra ni
+    /// confiar en el pre-read <c>AsNoTracking()</c>.</summary>
+    private static async Task<int?> MarcarAnuladoAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idComprobanteVenta, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
@@ -721,7 +746,7 @@ public class ServicioDeVentas(
         comando.CommandText =
             "UPDATE comprobantes_venta SET estado = $1 " +
             "WHERE id_comprobante_venta = $2 AND id_tenant = $3 AND estado = $4 " +
-            "RETURNING id_comprobante_venta";
+            "RETURNING id_punto_venta";
 
         AgregarParametro(comando, EstadoComprobante.Anulado);
         AgregarParametro(comando, idComprobanteVenta);
@@ -729,7 +754,7 @@ public class ServicioDeVentas(
         AgregarParametro(comando, EstadoComprobante.Emitido);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
-        return resultado is not null;
+        return resultado is null ? null : Convert.ToInt32(resultado);
     }
 
     // ---- La transacción (design: The Sale Transaction, orden de statements pineado) ----------

--- a/tests/Ways.IntegrationTests/AuditoriaAnulacionCompraTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaAnulacionCompraTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Stock;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 3: <c>compra.anulacion</c> — cobertura (task 3.10) y
+/// fail-closed (task 3.11). Espejo de <c>AuditoriaAnulacionVentaTests.cs</c>: archivo nuevo,
+/// dedicado a auditoría, para no tocar <c>ComprasAnulacionYConcurrenciaTests.cs</c> (esa clase
+/// además construye <c>ServicioDeCompras</c> directo con los 4 parámetros del constructor actual —
+/// esta slice lo deja intacto, ver el doc-comment de <c>ServicioDeCompras.EjecutarAnulacionAsync</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AuditoriaAnulacionCompraTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
+        int IdTipoCFA);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Auditoria-compras-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21, idTipoCFA);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(Contexto ctx, decimal unidades = 50m, decimal costoUnitario = 100m) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-00000001", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearBorradorAsync(Contexto ctx, SolicitudDeCompra? solicitud = null)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud ?? SolicitudSimple(ctx));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<CompraDetalle> ConfirmarAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 3.10: cobertura -----------------------------------------------------------------
+
+    /// <summary>Spec `comprobantes-compra`, "A compra anulación is attributable to its actor": una
+    /// compra confirmada de 50 unidades, ninguna vendida, anulada — una fila, actor identificado,
+    /// MISMA transacción que el <c>-50</c> de <c>movimientos_stock</c>.</summary>
+    [Fact]
+    public async Task CompraAnulacionCoberturaSobreUnaCompraConfirmadaSinVender()
+    {
+        var ctx = await PrepararAsync(nameof(CompraAnulacionCoberturaSobreUnaCompraConfirmadaSinVender));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 50m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "compra.anulacion" && a.IdEntidad == creada.Id);
+        Assert.Equal("comprobante_compra", fila.Entidad);
+        Assert.NotEqual(0, fila.IdActor);
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+
+        using var valorAnterior = JsonDocument.Parse(fila.ValorAnterior!);
+        using var valorNuevo = JsonDocument.Parse(fila.ValorNuevo);
+        Assert.Equal("confirmada", valorAnterior.RootElement.GetProperty("estado").GetString());
+        Assert.Equal("anulada", valorNuevo.RootElement.GetProperty("estado").GetString());
+
+        // MISMA transacción que la reversa real del ledger.
+        Assert.Equal(
+            1, await db.MovimientosStock.CountAsync(
+                m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion && m.Cantidad == -50m));
+    }
+
+    // ---- task 3.11: fail-closed ----------------------------------------------------------------
+
+    /// <summary>Spec `comprobantes-compra`, "An audit failure blocks the anulación, same as the
+    /// negative-stock refusal": <c>REVOKE INSERT ON auditoria</c> — mismo técnica de
+    /// <c>ComprasAnulacionYConcurrenciaTests</c>.</summary>
+    [Fact]
+    public async Task UnaFallaAlEscribirLaAuditoriaBloqueaLaCompraAnulacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirLaAuditoriaBloqueaLaCompraAnulacion));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 20m));
+        await ConfirmarAsync(ctx, creada.Id);
+
+        await RevocarAsync("auditoria", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        }
+        finally
+        {
+            await RestaurarAsync("auditoria", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Confirmada, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(
+            0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id && m.Motivo == MotivoStock.Anulacion));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.IdEntidad == creada.Id && a.Accion == "compra.anulacion"));
+
+        var cantidad = await db.Stock
+            .Where(s => s.IdArticulo == ctx.IdArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(20m, cantidad);
+
+        // Reintento limpio inmediatamente después tiene que funcionar.
+        var reintento = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, reintento.StatusCode);
+    }
+
+    // ---- REVOKE/RESTORE (mismo patrón que ComprasAnulacionYConcurrenciaTests) -------------------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/Ways.IntegrationTests/AuditoriaAnulacionCompraTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaAnulacionCompraTests.cs
@@ -39,7 +39,7 @@ public class AuditoriaAnulacionCompraTests(WaysApiFixture fixture) : IClassFixtu
 
     private sealed record Contexto(
         int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
-        int IdTipoCFA);
+        int IdTipoCFA, int IdEmpleadoAdmin);
 
     private async Task<Contexto> PrepararAsync(string nombre)
     {
@@ -90,7 +90,9 @@ public class AuditoriaAnulacionCompraTests(WaysApiFixture fixture) : IClassFixtu
 
         var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
 
-        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21, idTipoCFA);
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21, idTipoCFA,
+            resultado.IdUsuarioAdmin);
     }
 
     private static SolicitudDeCompra SolicitudSimple(Contexto ctx, decimal unidades = 50m, decimal costoUnitario = 100m) =>
@@ -134,7 +136,10 @@ public class AuditoriaAnulacionCompraTests(WaysApiFixture fixture) : IClassFixtu
 
         var fila = await db.Auditoria.SingleAsync(a => a.Accion == "compra.anulacion" && a.IdEntidad == creada.Id);
         Assert.Equal("comprobante_compra", fila.Entidad);
-        Assert.NotEqual(0, fila.IdActor);
+        // Judgment Day fix (slice 3 juez B ronda 1, finding 2): NotEqual(0, ...) no discrimina el
+        // actor — un mutante que estampa un actor constante (p. ej. 1) lo pasa igual. Igualdad
+        // exacta contra el admin real cierra ese hueco.
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdActor);
         Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
 
         using var valorAnterior = JsonDocument.Parse(fila.ValorAnterior!);

--- a/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
@@ -279,7 +279,7 @@ public class AuditoriaAnulacionVentaTests(WaysApiFixture fixture) : IClassFixtur
     /// composición no produce reversas bajo ninguna implementación, ni siquiera una que ignorara el
     /// fail-closed. El GIVEN literal del spec `comprobantes-venta` para este escenario es "3 líneas
     /// de producto y un consumo de cuenta corriente": este test lo cubre con magnitudes distintas
-    /// por línea (2/3/1 unidades, $100/$250/$400) para que el CERO de cada aserción sea real — si
+    /// por línea (2/3/1 unidades, $50/$100/$150) para que el CERO de cada aserción sea real — si
     /// el fail-closed fallara, habría 3 filas de <c>movimientos_stock</c> y 1 contramovimiento de
     /// CC que este test SÍ detectaría. Mismo técnica <c>REVOKE INSERT ON auditoria</c> que el test
     /// insignia de arriba (que se mantiene intacto: sigue siendo el flagship de la task 3.7).

--- a/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
@@ -223,7 +223,10 @@ public class AuditoriaAnulacionVentaTests(WaysApiFixture fixture) : IClassFixtur
 
         var fila = await db.Auditoria.SingleAsync(a => a.Accion == "venta.anulacion" && a.IdEntidad == idComprobante);
         Assert.Equal("comprobante_venta", fila.Entidad);
-        Assert.NotEqual(0, fila.IdActor);
+        // Judgment Day fix (slice 3 juez B ronda 1, finding 2): NotEqual(0, ...) no discrimina el
+        // actor — un mutante que estampa un actor constante (p. ej. 1) lo pasa igual. Igualdad
+        // exacta contra el admin real cierra ese hueco.
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdActor);
         Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
 
         Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == idComprobante));
@@ -267,6 +270,92 @@ public class AuditoriaAnulacionVentaTests(WaysApiFixture fixture) : IClassFixtur
         // Reintento limpio inmediatamente después tiene que funcionar (mismo criterio que
         // AnulacionTests: la anulación no consume ningún recurso de un solo uso).
         var reintento = await ctx.Admin.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+        Assert.Equal(HttpStatusCode.OK, reintento.StatusCode);
+    }
+
+    /// <summary>Judgment Day fix (slice 3 juez B ronda 1, finding 1, WARNING): el test de arriba
+    /// corre sobre el comprobante 100%-servicio, donde el THEN del spec ("no inverse
+    /// movimientos_stock/movimientos_cuenta_corriente row exists") es VACUAMENTE verdadero — esa
+    /// composición no produce reversas bajo ninguna implementación, ni siquiera una que ignorara el
+    /// fail-closed. El GIVEN literal del spec `comprobantes-venta` para este escenario es "3 líneas
+    /// de producto y un consumo de cuenta corriente": este test lo cubre con magnitudes distintas
+    /// por línea (2/3/1 unidades, $100/$250/$400) para que el CERO de cada aserción sea real — si
+    /// el fail-closed fallara, habría 3 filas de <c>movimientos_stock</c> y 1 contramovimiento de
+    /// CC que este test SÍ detectaría. Mismo técnica <c>REVOKE INSERT ON auditoria</c> que el test
+    /// insignia de arriba (que se mantiene intacto: sigue siendo el flagship de la task 3.7).
+    /// </summary>
+    [Fact]
+    public async Task UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDeUnComprobanteConTresLineasDeProductoYConsumoDeCc()
+    {
+        var ctx = await PrepararAsync(
+            nameof(UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDeUnComprobanteConTresLineasDeProductoYConsumoDeCc));
+
+        var idArticuloA = await SembrarArticuloConPrecioAsync(ctx, "articulo-fail-closed-a", 50m);
+        var idArticuloB = await SembrarArticuloConPrecioAsync(ctx, "articulo-fail-closed-b", 100m);
+        var idArticuloC = await SembrarArticuloConPrecioAsync(ctx, "articulo-fail-closed-c", 150m);
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [
+                new LineaDeVenta(idArticuloA, 2m, null),
+                new LineaDeVenta(idArticuloB, 3m, null),
+                new LineaDeVenta(idArticuloC, 1m, null)
+            ],
+            // 2*50 + 3*100 + 1*150 = 550 — bajo el LimiteCredito (1000m) de PrepararAsync.
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, 550m, null, 0m)],
+            null, null);
+
+        var emisionRespuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var emisionCuerpo = await emisionRespuesta.Content.ReadAsStringAsync();
+        Assert.True(emisionRespuesta.StatusCode == HttpStatusCode.Created, emisionCuerpo);
+        var emitido = (await JsonSerializer.DeserializeAsync<ComprobanteEmitido>(
+            new MemoryStream(System.Text.Encoding.UTF8.GetBytes(emisionCuerpo)), OpcionesJson))!;
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stockAAntes = await dbAntes.Stock
+            .Where(s => s.IdArticulo == idArticuloA && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        var stockBAntes = await dbAntes.Stock
+            .Where(s => s.IdArticulo == idArticuloB && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        var stockCAntes = await dbAntes.Stock
+            .Where(s => s.IdArticulo == idArticuloC && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+
+        await RevocarAsync("auditoria", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        }
+        finally
+        {
+            await RestaurarAsync("auditoria", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var estado = await db.ComprobantesVenta.Where(c => c.Id == emitido.Id).Select(c => c.Estado).FirstAsync();
+        Assert.Equal(EstadoComprobante.Emitido, estado);
+
+        Assert.Equal(
+            0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == emitido.Id && m.Motivo == MotivoStock.Anulacion));
+        Assert.Equal(
+            0, await db.MovimientosCuentaCorriente.CountAsync(
+                m => m.IdComprobanteVenta == emitido.Id && m.Tipo == Ways.Domain.CuentaCorriente.TipoMovimientoCc.Ajuste));
+        Assert.Equal(
+            0, await db.Auditoria.CountAsync(a => a.IdEntidad == emitido.Id && a.Accion == "venta.anulacion"));
+
+        var stockADespues = await db.Stock
+            .Where(s => s.IdArticulo == idArticuloA && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        var stockBDespues = await db.Stock
+            .Where(s => s.IdArticulo == idArticuloB && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        var stockCDespues = await db.Stock
+            .Where(s => s.IdArticulo == idArticuloC && s.IdPuntoVenta == ctx.IdPuntoVenta).Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(stockAAntes, stockADespues);
+        Assert.Equal(stockBAntes, stockBDespues);
+        Assert.Equal(stockCAntes, stockCDespues);
+
+        // Reintento limpio inmediatamente después tiene que funcionar.
+        var reintento = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
         Assert.Equal(HttpStatusCode.OK, reintento.StatusCode);
     }
 

--- a/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaAnulacionVentaTests.cs
@@ -1,0 +1,428 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 3: <c>venta.anulacion</c> — el caso insignia
+/// (100%-servicio sin cuenta corriente, tasks 3.7/3.9), la cobertura sobre un comprobante con
+/// consumo de cuenta corriente (task 3.8) y el mutation target de <c>id_punto_venta</c> (task 3.4,
+/// <c>RETURNING</c> vs pre-read). Archivo nuevo, dedicado a auditoría — mismo criterio que
+/// <c>AuditoriaEscrituraTests.cs</c> de Slice 1 — para no tocar <c>AnulacionTests.cs</c> ni,
+/// sobre todo, <c>VentasCheckoutTests.cs</c> (binding verify criterion de esta etapa: ausente del
+/// diff, constante 16 intacta — esta slice no abre <c>EmitirAsync</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AuditoriaAnulacionVentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva,
+        int IdListaPrecio, int IdMedioEfectivo, int IdMedioCuentaCorriente, int IdCliente, int IdTipoComprobanteTx,
+        int IdEmpleadoAdmin, string MailAdmin, string PasswordAdmin);
+
+    private long _numeroSecuencial = 500_000;
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Auditoria-anulacion-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Auditoria Anulacion", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        // stage-6-turnos-caja: el checkout exige un turno abierto (409 turno_no_abierto) — mismo
+        // criterio que AnulacionTests.PrepararAsync, sembrado directo por EF.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "Cliente auditoria anulacion",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 1000m,
+            CreditoIlimitado = false, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+        var idCliente = cliente.Id;
+
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, idMedioEfectivo, medioCc.Id, idCliente, idTipoComprobanteTx, resultado.IdUsuarioAdmin,
+            mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    /// <summary>Siembra DIRECTO (EF) un comprobante <c>emitido</c> 100%-servicio, con
+    /// <c>id_turno_caja NULL</c> ("Stage-5 NULL-turno comprobante stays anulable"): el checkout
+    /// HTTP no puede construir una línea de concepto libre —
+    /// <c>LineaDeVenta.IdArticulo</c> es <c>int</c> no-nullable (Ventas/Contratos.cs) — así que la
+    /// única forma honesta de sembrar el caso insignia (spec: "TX comprobante composed entirely of
+    /// service lines, id_articulo NULL on every item") es directo por EF, mismo criterio que
+    /// <c>CajaCierreEndpointsTests.SembrarPagoAsync</c>.</summary>
+    private async Task<int> SembrarComprobanteDeServicioAsync(Contexto ctx, decimal total = 500m)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var comprobante = new ComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant, IdTipoComprobante = ctx.IdTipoComprobanteTx,
+            Numero = Interlocked.Increment(ref _numeroSecuencial), Fecha = ahora, IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = null, IdEmpleado = ctx.IdEmpleadoAdmin, IdCliente = ctx.IdCliente, Subtotal = total,
+            DescuentoTotal = 0m, Total = total, Estado = EstadoComprobante.Emitido, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync();
+
+        db.ItemsComprobanteVenta.Add(new ItemComprobanteVenta
+        {
+            IdTenant = ctx.IdTenant, IdComprobanteVenta = comprobante.Id, Orden = 1, IdArticulo = null,
+            Descripcion = "Servicio de prueba (concepto libre)", IdArea = ctx.IdArea, IdListaPrecio = ctx.IdListaPrecio,
+            IdAlicuotaIva = ctx.IdAlicuotaIva, PorcentajeIva = 0m, Cantidad = 1m, PrecioUnitario = total, Descuento = 0m,
+            Total = total, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return comprobante.Id;
+    }
+
+    private static async Task<ComprobanteEmitido> EmitirConCcAsync(Contexto ctx, int idArticulo, decimal precio)
+    {
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, precio, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+
+        return (await JsonSerializer.DeserializeAsync<ComprobanteEmitido>(
+            new MemoryStream(System.Text.Encoding.UTF8.GetBytes(cuerpo)), OpcionesJson))!;
+    }
+
+    // ---- task 3.7 (flagship) + task 3.9 sobre el caso insignia (mutation target, slice 3 row 2) --
+
+    /// <summary>Spec `comprobantes-venta`/`auditoria-de-operaciones`, "A 100%-servicio comprobante
+    /// without cuenta corriente is attributable on anulación" — el caso insignia: antes de esta
+    /// etapa, el único rastro era <c>updated_at</c> sin actor.</summary>
+    [Fact]
+    public async Task AnulacionDeUnComprobante100PorCientoServicioSinCcEsAtribuible()
+    {
+        var ctx = await PrepararAsync(nameof(AnulacionDeUnComprobante100PorCientoServicioSinCcEsAtribuible));
+        var idComprobante = await SembrarComprobanteDeServicioAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "venta.anulacion" && a.IdEntidad == idComprobante);
+        Assert.Equal("comprobante_venta", fila.Entidad);
+        Assert.NotEqual(0, fila.IdActor);
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == idComprobante));
+        Assert.Equal(
+            0, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdComprobanteVenta == idComprobante));
+    }
+
+    /// <summary>Mutation target (slice 3, row 2): <c>RegistrarAsync</c> movido DESPUÉS de
+    /// <c>CommitAsync</c> en la transacción de anulación — este test DEBE fallar bajo esa mutación.
+    /// design decisión 10 / testing strategy, "el test insignia" (b): el 100%-servicio sin CC es el
+    /// ÚNICO caso donde el INSERT de auditoría es el ÚNICO statement de la transacción que toca
+    /// <c>usuarios</c> (vía <c>fk_auditoria_actor</c>) — revocar <c>INSERT</c> sobre
+    /// <c>auditoria</c> aísla la falla sin ambigüedad, mismo técnica de <c>REVOKE</c> que
+    /// <c>AnulacionTests.UnaFallaAlRevertirElStockDejaElComprobanteEmitidoYNadaCambiado</c>.</summary>
+    [Fact]
+    public async Task UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDelComprobante100PorCientoServicio()
+    {
+        var ctx = await PrepararAsync(
+            nameof(UnaFallaAlEscribirLaAuditoriaBloqueaLaAnulacionDelComprobante100PorCientoServicio));
+        var idComprobante = await SembrarComprobanteDeServicioAsync(ctx);
+
+        await RevocarAsync("auditoria", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+        }
+        finally
+        {
+            await RestaurarAsync("auditoria", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var estado = await db.ComprobantesVenta.Where(c => c.Id == idComprobante).Select(c => c.Estado).FirstAsync();
+        Assert.Equal(EstadoComprobante.Emitido, estado);
+        Assert.Equal(
+            0, await db.Auditoria.CountAsync(a => a.IdEntidad == idComprobante && a.Accion == "venta.anulacion"));
+
+        // Reintento limpio inmediatamente después tiene que funcionar (mismo criterio que
+        // AnulacionTests: la anulación no consume ningún recurso de un solo uso).
+        var reintento = await ctx.Admin.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+        Assert.Equal(HttpStatusCode.OK, reintento.StatusCode);
+    }
+
+    // ---- task 3.8: cobertura sobre un comprobante con consumo de cuenta corriente ------------------
+
+    /// <summary>Cobertura de <c>venta.anulacion</c> sobre un comprobante NO degenerado (con consumo
+    /// de cuenta corriente) — payload key por key, discriminando el mutation target de la fila 3
+    /// (<c>EstadoComprobante.Emitido</c> reemplazado por un literal <c>"anulado"</c> haría que
+    /// <c>valor_anterior.estado</c> leyera <c>"anulado"</c> en vez de <c>"emitido"</c>). El
+    /// checkout HTTP no puede construir una línea de concepto libre (ver el doc-comment de
+    /// <see cref="SembrarComprobanteDeServicioAsync"/>), así que la composición "mixta" de la spec
+    /// se cubre con el caso insignia (100%-servicio, arriba) — acá el eje es la generalidad del
+    /// payload sobre un comprobante CON reversas que sí escriben filas.</summary>
+    [Fact]
+    public async Task VentaAnulacionCoberturaSobreUnComprobanteConConsumoDeCuentaCorriente()
+    {
+        var ctx = await PrepararAsync(nameof(VentaAnulacionCoberturaSobreUnComprobanteConConsumoDeCuentaCorriente));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-auditoria-anulacion", 300m);
+        var emitido = await EmitirConCcAsync(ctx, idArticulo, 300m);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ventas/{emitido.Id}/anulacion", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var filas = await db.Auditoria.Where(a => a.Accion == "venta.anulacion" && a.IdEntidad == emitido.Id).ToListAsync();
+        var fila = Assert.Single(filas);
+
+        Assert.Equal("comprobante_venta", fila.Entidad);
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+
+        using var valorAnterior = JsonDocument.Parse(fila.ValorAnterior!);
+        using var valorNuevo = JsonDocument.Parse(fila.ValorNuevo);
+        Assert.Equal("emitido", valorAnterior.RootElement.GetProperty("estado").GetString());
+        Assert.Equal("anulado", valorNuevo.RootElement.GetProperty("estado").GetString());
+
+        // La reversa real sigue existiendo — la cobertura de auditoría no reemplaza al ledger.
+        Assert.Equal(
+            1, await db.MovimientosCuentaCorriente.CountAsync(
+                m => m.IdComprobanteVenta == emitido.Id && m.Tipo == Ways.Domain.CuentaCorriente.TipoMovimientoCc.Ajuste));
+    }
+
+    // ---- task 3.4: mutation target — RETURNING id_punto_venta vs pre-read -------------------------
+
+    /// <summary>Mutation target (slice 3, row 1): <c>MarcarAnuladoAsync</c> revertido a
+    /// <c>RETURNING id_comprobante_venta</c> + leer el PV desde <c>comprobantePreLectura</c> (el
+    /// pre-read <c>AsNoTracking()</c>, tomado ANTES del UPDATE atómico) — este test DEBE fallar
+    /// bajo esa mutación. En ejecución normal (sin carrera) el pre-read y el <c>RETURNING</c>
+    /// SIEMPRE coinciden (el PV es inmutable tras la emisión), así que un test sin carrera no
+    /// discrimina nada (mismo confound de <c>mutation-proof-tests</c> regla 3 que 1.18). Este test
+    /// fuerza el desacople: pausa <c>EjecutarAnulacionAsync</c> justo DESPUÉS de que el pre-read leyó
+    /// el PV original y ANTES de que el UPDATE atómico corra, y desde una conexión ajena (owner,
+    /// fuera de la transacción) reasigna <c>id_punto_venta</c> a un segundo PV del mismo tenant —
+    /// un "fix" de datos fuera de banda, el único actor legítimo que puede tocar esa columna hoy.
+    /// El UPDATE atómico, al retomar el lock, ve y devuelve el PV YA reasignado — si el código
+    /// leyera el PV del pre-read en cambio, la fila de auditoría llevaría el PV viejo.</summary>
+    [Fact]
+    public async Task LaAuditoriaDeAnulacionLlevaElPuntoDeVentaQueElUpdateAtomicoRealmenteVioNoElDelPreRead()
+    {
+        var ctx = await PrepararAsync(
+            nameof(LaAuditoriaDeAnulacionLlevaElPuntoDeVentaQueElUpdateAtomicoRealmenteVioNoElDelPreRead));
+        var idComprobante = await SembrarComprobanteDeServicioAsync(ctx);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var puntoVentaB = new PuntoVenta
+        {
+            IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, Nombre = "PV reasignado (race)",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVentaB);
+        await db.SaveChangesAsync();
+        var idPuntoVentaB = puntoVentaB.Id;
+
+        var preLecturaLista = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasElPreLecturaDeAnulacion(preLecturaLista, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaAnulacion = cliente.PostAsync($"/api/ventas/{idComprobante}/anulacion", null);
+
+        await preLecturaLista.Task;
+
+        // Reasignación fuera de banda, DESDE OTRA conexión, DESPUÉS de que el pre-read ya leyó el
+        // PV original — el único actor que hoy toca esta columna fuera de la emisión.
+        await using (var owner = new NpgsqlConnection(fixture.OwnerConnectionString))
+        {
+            await owner.OpenAsync();
+            await using var comando = owner.CreateCommand();
+            comando.CommandText = "UPDATE comprobantes_venta SET id_punto_venta = $1 WHERE id_comprobante_venta = $2";
+            comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVentaB });
+            comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        puedeContinuar.TrySetResult();
+
+        var respuesta = await tareaAnulacion;
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var dbDespues = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idPuntoVentaEnAuditoria = await dbDespues.Auditoria
+            .Where(a => a.Accion == "venta.anulacion" && a.IdEntidad == idComprobante)
+            .Select(a => a.IdPuntoVenta)
+            .SingleAsync();
+
+        Assert.Equal(idPuntoVentaB, idPuntoVentaEnAuditoria);
+        Assert.NotEqual(ctx.IdPuntoVenta, idPuntoVentaEnAuditoria);
+    }
+
+    /// <summary>Pausa la query LINQ del pre-read (<c>db.ComprobantesVenta.AsNoTracking()...</c>)
+    /// justo DESPUÉS de que ejecutó — el UPDATE atómico crudo de <c>MarcarAnuladoAsync</c> corre
+    /// sobre <c>DbConnection.CreateCommand()</c> directo, fuera del pipeline de interceptores de
+    /// EF, así que nunca dispara este hook.</summary>
+    private sealed class InterceptorDePausaTrasElPreLecturaDeAnulacion(
+        TaskCompletionSource preLecturaLista, TaskCompletionSource puedeContinuar) : DbCommandInterceptor
+    {
+        public override async ValueTask<DbDataReader> ReaderExecutedAsync(
+            DbCommand command, CommandExecutedEventData eventData, DbDataReader result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("comprobantes_venta", StringComparison.OrdinalIgnoreCase))
+            {
+                preLecturaLista.TrySetResult();
+                await puedeContinuar.Task;
+            }
+
+            return await base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    // ---- REVOKE/RESTORE (mismo patrón que AnulacionTests/ComprasAnulacionYConcurrenciaTests) ------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+}


### PR DESCRIPTION
## Etapa 14 — Auditoría · Slice 3 (Anulaciones, modo ADO)

- `venta.anulacion` en `EjecutarAnulacionAsync` SOLO (el checkout intocado POR ALCANCE — decisión 4): el INSERT de auditoría dentro de la misma transacción ADO, antes de las patas de reversa — fail-closed en ambas direcciones.
- Decisión 8: `MarcarAnuladoAsync` pasa a `UPDATE ... RETURNING id_punto_venta` (precedente exacto `MarcarCerradoAsync`) — la misma autoridad race-safe ahora entrega el PV, cero round-trips extra, sin confiar en el pre-read; carrera real discriminada con `DbCommandInterceptor` + conexión out-of-band.
- `compra.anulacion` espejo. Before-images desde el RETURNING autoritativo (decisión 9, jamás un segundo SELECT).
- Desvío registrado y ratificado por ambos jueces: `ServicioDeAuditoria` instanciado localmente (6 constructores posicionales preexistentes, incluido el intocable `VentasCheckoutTests`) — mismo db/reloj/contexto capturados, contrato del writer intacto.
- **Test insignia**: el comprobante 100% servicio SIN cuenta corriente anulado deja fila con actor — el caso que hoy no deja NINGÚN rastro.
- `VentasCheckoutTests.cs` AUSENTE del diff (byte-idéntico, constante 16 intacta). Cero migraciones.

## Tests (filtro combinado: Integration 54 · Domain 39 · Application 5, todos verdes)
Fail-closed en DOS composiciones (100%-servicio y la literal del spec: 3 líneas + CC, asertando cero reversas de stock, cero contramovimientos, cero auditoría y stock intacto ×3), carrera del PV, IdActor por igualdad, retry limpio post-REVOKE. 3 mutation targets del apply + 7 mutaciones del juez B con evidencia.

## Judgment-day
Juez B: 0 severos + 2 WARNINGs test-only → fix `4ca8161`. Re-ronda B: ambas re-mutaciones muertas (patch-id verificado). Juez A: cero hallazgos. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)