### PR TITLE
feat(stage-14): slice 4 stock-cc — auditoria de ajuste, decomiso, conteo y reliquidacion

### DIFF
--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -768,6 +768,20 @@ operation**, per Orchestrator Decision #1 above — never one per lote.
   src/Ways.Infrastructure/Persistencia/Migraciones/` and `git status
   --short` on that directory both empty.
 - [ ] 4.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  - Ronda 1 (juez B): 2 MAJOR cerrados con evidencia de mutación. Finding 1:
+    el conteo agregado con diferencia (`EjecutarConteoAsync`, delta ≠ 0) no
+    tenía ningún test — cubierto por
+    `StockAuditoriaTests.UnConteoAgregadoConDiferenciaEscribeUnaFilaDeAuditoriaConPayloadCompleto`
+    (payload clave por clave + actor por igualdad). Finding 2: el test de
+    ajuste no discriminaba `id_entidad` (coincidencia accidental con
+    `id_movimiento_stock` por alineación de secuencias en el entorno) —
+    desincronizado quemando filas descartables antes de sembrar la entidad
+    real (`QuemarArticulosDescartablesAsync`/`QuemarClientesDescartablesAsync`),
+    aplicado también a los hermanos `UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria`
+    y `ReliquidacionAuditoriaTests.UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo`.
+    La sugerencia equivalente para `stock.decomiso` quedó registrada como
+    survivor equivalente por rollback (mutar su call site no cambia el
+    resultado observable) — sin fix.
 - [ ] 4.17 Branch `feat/stage14-slice4-stock-cc` off `main` (parent:
   slice 1); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -636,75 +636,137 @@ operation**, per Orchestrator Decision #1 above — never one per lote.
 `InsertarMovimientoStockAsync`'s `Task<int>` signature can stay (harmless,
 `TransferirAsync` ignores the value) or revert with it.
 
-- [ ] 4.1 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
+- [x] 4.1 Modify `src/Ways.Application/Stock/ServicioDeStock.cs`:
   `InsertarMovimientoStockAsync` → `RETURNING id_movimiento_stock` /
   `ExecuteScalarAsync`, returning `int`. `TransferirAsync` ignores the
   returned value and stays byte-identical in behavior — still writes zero
   `auditoria` rows (proposal decision 5). *(Orchestrator Decision 15 above;
   design Open Questions)*
-- [ ] 4.2 Modify `ServicioDeStock.cs`'s ajuste path (`:101`, after the
+  **DEVIATION (registered, not silent):** the `RETURNING` clause reads
+  `id_movimiento`, not `id_movimiento_stock` — `movimientos_stock`'s actual
+  primary-key column is `id_movimiento` (confirmed against the etapa-5
+  migration and `MovimientoStock.Id`), not the name tasks.md/design.md use
+  for the SQL identifier. The payload dictionary KEY stays literally
+  `id_movimiento_stock` in every `PayloadDeAuditoria` factory (that name is
+  the audit contract's own field name, independent of the DB column) — only
+  the `RETURNING` SQL identifier differs from the task's prose. Verified
+  empirically: the literal task text fails with `column "id_movimiento_stock"
+  does not exist` against real Postgres.
+- [x] 4.2 Modify `ServicioDeStock.cs`'s ajuste path (after the
   aggregate **and** lote upserts, before commit): `RegistrarAsync(
   stock.ajuste, ant={cantidad: nueva − delta}, nuevo={cantidad: nueva,
   id_movimiento_stock, observaciones})`.
-- [ ] 4.3 Modify `ServicioDeStock.cs`'s decomiso path (`:276`, **after**
+- [x] 4.3 Modify `ServicioDeStock.cs`'s decomiso path (**after**
   both negative-stock refusals): `RegistrarAsync(stock.decomiso,
   ant={cantidad}, nuevo={cantidad, id_movimiento_stock, observaciones,
   id_lote})` — `id_lote` null = no lote-efectivo.
-- [ ] 4.4 Modify `ServicioDeStock.cs`'s conteo paths
-  (`EjecutarConteoAsync:743` and `EjecutarConteoPorLoteAsync:810`): **per
+- [x] 4.4 Modify `ServicioDeStock.cs`'s conteo paths
+  (`EjecutarConteoAsync` and `EjecutarConteoPorLoteAsync`): **per
   Orchestrator Decision #1 above** — accumulate `movimientos_generados`
   (the `id_movimiento_stock` list), `lotes_afectados` (count), and
   `delta_total` across the existing loop over lotes/agregado; write
   **exactly one** `RegistrarAsync(stock.conteo, ant={cantidad: cantidad al
   inicio}, nuevo={cantidad: cantidad final, movimientos_generados,
   lotes_afectados, delta_total})` **after** the loop, per counting
-  operation. The existing zero-difference early return (`:721-727`) is
+  operation. The existing zero-difference early return is
   untouched and now unambiguously produces zero ledger **and** zero audit
-  rows for the whole operation.
-- [ ] 4.5 Modify
+  rows for the whole operation. The single-lote/aggregate path
+  (`EjecutarConteoAsync`) uses the same `PayloadDeAuditoria.Conteo` factory
+  with `lotesAfectados: 0` (the aggregate path never touches a lote) and a
+  one-element `movimientos_generados`.
+- [x] 4.5 Modify
   `src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs`
-  (`:130`, after the marker + rowcount check, before commit):
-  `RegistrarAsync(cc.reliquidacion, ant={saldo} from the :174 SELECT …
+  (after the marker + rowcount check, before commit):
+  `RegistrarAsync(cc.reliquidacion, ant={saldo} from the SELECT …
   FOR UPDATE, nuevo={saldo: nuevoSaldo, id_movimiento, consumos_actualizados:
-  |ids|, diferencia: delta})`.
-- [ ] 4.6 [P] **Mutation target**: `cantidad − delta` as before-image — use
+  |ids|, diferencia: delta})`. `BloquearClienteAsync`'s previously-discarded
+  `Saldo` tuple element is now captured as `saldoInicial`.
+- [x] 4.6 [P] **Mutation target**: `cantidad − delta` as before-image — use
   `nueva` on both sides — the `stock.ajuste` coverage test (4.9) must fail.
-  *(slice 4 row 1)*
-- [ ] 4.7 [P] **Mutation target**: the delta-cero early return
-  (`ServicioDeStock.cs:721`) — remove it — the zero-difference conteo test
-  (4.10) must fail. *(slice 4 row 2)*
-- [ ] 4.8 [P] **Mutation target**: the `saldo` before-image taken from the
+  *(slice 4 row 1)* **Evidence**: mutated (`nuevaCantidad, nuevaCantidad`
+  on both sides) → `dotnet build --no-incremental` → `dotnet test
+  tests/Ways.IntegrationTests --no-build --filter FullyQualifiedName~Ajuste`
+  → `StockAuditoriaTests.UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo`
+  FAILED (`Assert.Equal` on `anterior.cantidad`: expected 50, actual 70 —
+  the mutated before-image collapsed to the after-image) → reverted →
+  44/44 green.
+- [x] 4.7 [P] **Mutation target**: the delta-cero early return
+  (`ServicioDeStock.cs`, `EjecutarConteoAsync`) — remove it — the
+  zero-difference conteo test (4.10) must fail. *(slice 4 row 2)*
+  **Evidence**: mutated (early-return block deleted) → `dotnet build
+  --no-incremental` → `dotnet test tests/Ways.IntegrationTests --no-build
+  --filter FullyQualifiedName~Conteo` →
+  `StockAuditoriaTests.UnConteoAgregadoSinDiferenciaNoEscribeFilaDeAuditoria`
+  FAILED (`400 movimiento_de_stock_sin_cantidad` — the mutated path reached
+  `InsertarMovimientoStockAsync` with `cantidad = 0`, tripping
+  `ck_movimientos_stock_cantidad_no_cero`), together with two pre-existing
+  zero-difference tests
+  (`TransferenciasYConteoDeInventarioTests.UnConteoQueCoincideConElCacheNoEscribeNadaYDevuelve200`,
+  `ConteoPorLoteTests.UnConteoAgregadoDeContadaIgualALaActualSigueSinEscribirNada`)
+  → reverted → 51/51 green.
+- [x] 4.8 [P] **Mutation target**: the `saldo` before-image taken from the
   `FOR UPDATE` — re-read it **after** the `UPDATE` instead — the
   `cc.reliquidacion` coverage test (4.13) must fail. *(slice 4 row 3)*
-- [ ] 4.9 [P] Integration: `stock.ajuste` coverage — one row, `{cantidad:
+  **Evidence**: mutated (`ReliquidacionDeCc(nuevoSaldo, nuevoSaldo, …)`,
+  simulating a post-`UPDATE` re-read) → `dotnet build --no-incremental` →
+  `dotnet test tests/Ways.IntegrationTests --no-build --filter
+  FullyQualifiedName~Reliquidacion` →
+  `ReliquidacionAuditoriaTests.UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo`
+  FAILED (`Assert.Equal` on `anterior.saldo`: expected 100, actual 150 —
+  the mutated before-image collapsed to the after-image) → reverted →
+  25/25 green.
+- [x] 4.9 [P] Integration: `stock.ajuste` coverage — one row, `{cantidad:
   anterior}` ≠ `{cantidad: nuevo}` with delta ≠ 0, `id_movimiento_stock`
-  and `observaciones` present, resolving 4.6's evidence.
-- [ ] 4.10 [P] Integration: `stock.conteo`, zero-difference — zero
+  and `observaciones` present, resolving 4.6's evidence. Implemented as
+  `StockAuditoriaTests.UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo`.
+- [x] 4.10 [P] Integration: `stock.conteo`, zero-difference — zero
   `movimientos_stock` rows **and** zero `auditoria` rows, resolving 4.7's
   evidence. *(spec `auditoria-de-operaciones`: "A zero-difference conteo
-  writes no audit row")*
-- [ ] 4.11 [P] Integration — **the reconciled scenario** (Orchestrator
+  writes no audit row")* Implemented as
+  `StockAuditoriaTests.UnConteoAgregadoSinDiferenciaNoEscribeFilaDeAuditoria`.
+- [x] 4.11 [P] Integration — **the reconciled scenario** (Orchestrator
   Decision #1): a conteo por lote over one articulo with 3 lotes, 2
   differing, writes **exactly one** `auditoria` row for the whole
   operation — not two — with `valor_nuevo.movimientos_generados` naming
   both `id_movimiento_stock` values and `lotes_afectados = 2`. This is the
   discriminating test that replaces design.md's stale per-lote call-site
   text. *(spec `auditoria-de-operaciones`: "Each operation MUST write
-  exactly one row")*
-- [ ] 4.12 [P] Integration: `stock.decomiso` coverage — one row, `id_lote`
+  exactly one row")* Implemented as
+  `StockAuditoriaTests.UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria`
+  (L1 10→15 and L3 5→3 differ, L2 20→20 matches; asserts exactly one
+  `auditoria` row, `lotes_afectados = 2`, and `movimientos_generados`
+  naming both real ledger row ids).
+- [x] 4.12 [P] Integration: `stock.decomiso` coverage — one row, `id_lote`
   present on a lote-efectivo decomiso and `NULL` on an aggregate-only one;
   both `409 stock_insuficiente_para_decomiso` refusal paths leave zero
-  rows.
-- [ ] 4.13 [P] Integration: `cc.reliquidacion` coverage — one row, `saldo`
+  rows. Implemented as four `StockAuditoriaTests` facts:
+  `UnDecomisoDeStockEscribeUnaFilaConIdLotePresenteCuandoEsLoteEfectivo`,
+  `UnDecomisoDeStockEscribeUnaFilaConIdLoteNuloCuandoNoEsLoteEfectivo`,
+  `UnDecomisoRechazadoPorStockInsuficienteEnElLoteNoEscribeFilaDeAuditoria`,
+  `UnDecomisoRechazadoPorStockInsuficienteEnElAgregadoNoEscribeFilaDeAuditoria`.
+- [x] 4.13 [P] Integration: `cc.reliquidacion` coverage — one row, `saldo`
   anterior ≠ nuevo with a known `diferencia`, `consumos_actualizados`
   matches the seeded consumos; the two no-op paths (sin elegibles, delta
   cero) commit without any ledger or audit row, resolving 4.8's evidence.
-- [ ] 4.14 [P] Integration — límite registrado: `TransferirAsync` writes
+  Implemented as three `ReliquidacionAuditoriaTests` facts:
+  `UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo`,
+  `UnaReliquidacionSinConsumosElegiblesNoEscribeFilaDeAuditoria`,
+  `UnaReliquidacionConDeltaCeroNoEscribeFilaDeAuditoria` (a consumo whose
+  price never changed — eligible, but a zero-delta re-pricing, distinct
+  from the "sin elegibles" no-op).
+- [x] 4.14 [P] Integration — límite registrado: `TransferirAsync` writes
   **zero** `auditoria` rows for either leg, and both `movimientos_stock`
   legs still carry their own `id_empleado`. *(spec `auditoria-de-
   operaciones`: "stock.transferencia is excluded by scope, not by defect")*
-- [ ] 4.15 Gate guard: `has-pending-model-changes` clean; zero new files in
-  `Migraciones/`.
+  Implemented as
+  `StockAuditoriaTests.UnaTransferenciaNoEscribeFilasDeAuditoriaParaNingunaDeLasDosPatas`.
+- [x] 4.15 Gate guard: `has-pending-model-changes` clean; zero new files in
+  `Migraciones/`. **Confirmed**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made
+  to the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` and `git status
+  --short` on that directory both empty.
 - [ ] 4.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 4.17 Branch `feat/stage14-slice4-stock-cc` off `main` (parent:
   slice 1); PR; merge stacked-to-main.

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -782,6 +782,16 @@ operation**, per Orchestrator Decision #1 above — never one per lote.
     La sugerencia equivalente para `stock.decomiso` quedó registrada como
     survivor equivalente por rollback (mutar su call site no cambia el
     resultado observable) — sin fix.
+  - Ronda 1 (juez A): 0 severos; 1 WARNING cerrado test-only. Los dos tests
+    de cobertura de `stock.decomiso` (`StockAuditoriaTests.cs:260-330`)
+    assertaban solo `cantidad`/`id_lote` y nunca `id_movimiento_stock` ni
+    `observaciones`, aunque `PayloadDeAuditoria.DecomisoDeStock` escribe las
+    4 claves — agregados los asserts de `observaciones` (igualdad con la
+    observación seedeada) e `id_movimiento_stock` (round-trip contra la fila
+    real de `movimientos_stock` del decomiso), mismo patrón del test de
+    ajuste del mismo archivo. Evidencia de mutación: call site de decomiso
+    en `ServicioDeStock.cs` mutado a `observaciones=""`/`idMovimientoStock=0`
+    → los 2 tests fallaron → revert → 23/23 verdes.
 - [ ] 4.17 Branch `feat/stage14-slice4-stock-cc` off `main` (parent:
   slice 1); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -767,7 +767,7 @@ operation**, per Orchestrator Decision #1 above — never one per lote.
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` and `git status
   --short` on that directory both empty.
-- [ ] 4.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 4.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   - Ronda 1 (juez B): 2 MAJOR cerrados con evidencia de mutación. Finding 1:
     el conteo agregado con diferencia (`EjecutarConteoAsync`, delta ≠ 0) no
     tenía ningún test — cubierto por
@@ -792,7 +792,7 @@ operation**, per Orchestrator Decision #1 above — never one per lote.
     ajuste del mismo archivo. Evidencia de mutación: call site de decomiso
     en `ServicioDeStock.cs` mutado a `observaciones=""`/`idMovimientoStock=0`
     → los 2 tests fallaron → revert → 23/23 verdes.
-- [ ] 4.17 Branch `feat/stage14-slice4-stock-cc` off `main` (parent:
+- [x] 4.17 Branch `feat/stage14-slice4-stock-cc` off `main` (parent: *(CLEAN 2026-08-16: juez B ronda 1 — 2 MAJORs cerrados (cobertura del conteo agregado clave-por-clave; id_entidad desincronizado de secuencias coincidentes con quemadores de filas) + survivor equivalente del decomiso registrado; re-ronda B aprobada con 4 re-mutantes muertos incl. el survivor de ronda 1 y el probe de reliquidacion; juez A fresh: 0 severos, 1 WARNING (payload de decomiso 2-de-4 claves) cerrado test-only en cf2a474 con evidencia. JUDGMENT: APPROVED.)*
   slice 1); PR; merge stacked-to-main.
 
 **Test plan**: 3 mutation targets (4.6-4.8), coverage ×3 (4.9, 4.12, 4.13),

--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -4,7 +4,9 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Auditoria;
 using Ways.Application.Precios;
+using Ways.Domain.Auditoria;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
 using Ways.Domain.CuentaCorriente;
@@ -27,7 +29,7 @@ namespace Ways.Application.CuentaCorriente;
 /// </summary>
 public class ServicioDeReliquidacion(
     IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, LectorDeConsumosReliquidables lector,
-    ServicioDePrecios servicioDePrecios)
+    ServicioDePrecios servicioDePrecios, ServicioDeAuditoria auditoria)
 {
     /// <summary>Preview — <c>GET</c>, sin lock, nunca autoritativo (design: API Surface). Un
     /// consumo que se marca ENTRE este preview y el commit siguiente simplemente deja de aparecer
@@ -77,8 +79,10 @@ public class ServicioDeReliquidacion(
     {
         await using var transaccion = await db.Database.BeginTransactionAsync(ct);
 
-        // 1. Lock del cliente — PRIMER statement, SIN turno (design decisión 4, pinned).
-        var (_, idListaPrecio) = await BloquearClienteAsync(idTenant, idCliente, ct);
+        // 1. Lock del cliente — PRIMER statement, SIN turno (design decisión 4, pinned). El saldo
+        // devuelto (etapa 14, slice 4) es el before-image autoritativo de cc.reliquidacion —
+        // decisión 9, JAMÁS un segundo SELECT después del UPDATE de saldo.
+        var (saldoInicial, idListaPrecio) = await BloquearClienteAsync(idTenant, idCliente, ct);
 
         // 2/3. Escaneo de elegibles + items — bajo el lock recién tomado (design: "scan runs
         // after it, inside the same transaction").
@@ -137,6 +141,18 @@ public class ServicioDeReliquidacion(
                 $"El marcador de reliquidación afectó {filasMarcadas} filas, se esperaban " +
                 $"{resultado.IdsMovimientosCubiertos.Count} — invariante de escritura violado.");
         }
+
+        // Etapa 14, slice 4 (design call site 12): después del marcador y su chequeo de rowcount,
+        // antes del commit. saldoInicial viene del FOR UPDATE ya tomado en el paso 1 — nunca un
+        // re-read tras el UPDATE de saldo (mutation target del slice, design mutation-targets,
+        // fila 3).
+        var (anteriorReliquidacion, nuevoReliquidacion) = PayloadDeAuditoria.ReliquidacionDeCc(
+            saldoInicial, nuevoSaldo, idMovimiento, resultado.IdsMovimientosCubiertos.Count, resultado.Delta);
+        await auditoria.RegistrarAsync(
+            conexion, transaccionCruda,
+            new RegistroDeAuditoria(
+                idTenant, idPuntoVenta, AccionAuditada.CcReliquidacion, idCliente, anteriorReliquidacion, nuevoReliquidacion),
+            ct);
 
         await transaccion.CommitAsync(ct);
         return resultado;

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -4,7 +4,9 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
+using Ways.Application.Auditoria;
 using Ways.Domain.Articulos;
+using Ways.Domain.Auditoria;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Organizacion;
@@ -37,7 +39,9 @@ namespace Ways.Application.Stock;
 /// arriba, NO abre transacción ni escribe <c>movimientos_stock</c>: un parámetro de reposición
 /// no es un hecho del ledger, es un umbral configurado sobre la misma fila de caché.
 /// </summary>
-public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeLotes servicioDeLotes)
+public class ServicioDeStock(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeLotes servicioDeLotes,
+    ServicioDeAuditoria auditoria)
 {
     public async Task<decimal> ObtenerCantidadAsync(int idPuntoVenta, int idArticulo, CancellationToken ct = default) =>
         await db.Stock
@@ -84,7 +88,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         var conexion = await ObtenerConexionAbiertaAsync(ct);
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
-        await InsertarMovimientoStockAsync(
+        var idMovimientoStock = await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, cantidad, MotivoStock.Ajuste, idEmpleado,
             observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote, ct);
 
@@ -98,6 +102,16 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         {
             await UpsertStockLoteAsync(conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, idLoteEfectivo, cantidad, ct);
         }
+
+        // Etapa 14, slice 4 (design decisión 9, call site 9): before-image derivado del RETURNING
+        // autoritativo del upsert (nueva − delta), JAMÁS un segundo SELECT — mutation target del
+        // slice (design mutation-targets, fila 1).
+        var (anteriorAjuste, nuevoAjuste) = PayloadDeAuditoria.AjusteDeStock(
+            nuevaCantidad - cantidad, nuevaCantidad, idMovimientoStock, observaciones);
+        await auditoria.RegistrarAsync(
+            conexion, transaccionCruda,
+            new RegistroDeAuditoria(idTenant, idPuntoVenta, AccionAuditada.StockAjuste, idArticulo, anteriorAjuste, nuevoAjuste),
+            ct);
 
         await transaccion.CommitAsync(ct);
 
@@ -243,7 +257,7 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         var conexion = await ObtenerConexionAbiertaAsync(ct);
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
-        await InsertarMovimientoStockAsync(
+        var idMovimientoStock = await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, MotivoStock.Decomiso, idEmpleado,
             observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote, ct);
 
@@ -273,6 +287,16 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
                 $"No hay stock suficiente del artículo {idArticulo} para decomisar.",
                 409);
         }
+
+        // Etapa 14, slice 4 (design call site 10): recién DESPUÉS de los dos rechazos de
+        // negatividad — un decomiso rechazado no deja fila de auditoría. Before-image sobre el
+        // AGREGADO (nueva − delta), mismo criterio de decisión 9 que el ajuste.
+        var (anteriorDecomiso, nuevoDecomiso) = PayloadDeAuditoria.DecomisoDeStock(
+            nuevaAgregada - delta, nuevaAgregada, idMovimientoStock, observaciones, idLote);
+        await auditoria.RegistrarAsync(
+            conexion, transaccionCruda,
+            new RegistroDeAuditoria(idTenant, idPuntoVenta, AccionAuditada.StockDecomiso, idArticulo, anteriorDecomiso, nuevoDecomiso),
+            ct);
 
         await transaccion.CommitAsync(ct);
 
@@ -720,13 +744,15 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
         if (delta == 0m)
         {
-            // spec: "Zero-Difference Conteo Writes No Ledger Row" — commit sin escribir nada,
-            // que además evita ck_movimientos_stock_cantidad_no_cero (nunca lo alcanza).
+            // spec: "Zero-Difference Conteo Writes No Ledger Row" — commit sin escribir nada, ni
+            // ledger NI auditoría (tasks.md, Orchestrator Decision #1: la operación entera queda
+            // muda) — mutation target del slice (design mutation-targets, fila 2); además evita
+            // ck_movimientos_stock_cantidad_no_cero (nunca lo alcanza).
             await transaccion.CommitAsync(ct);
             return new ResultadoConteo(idPuntoVenta, idArticulo, actual, actual, 0m, MovimientoRegistrado: false);
         }
 
-        await InsertarMovimientoStockAsync(
+        var idMovimientoStock = await InsertarMovimientoStockAsync(
             conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, delta, MotivoStock.Inventario, idEmpleado,
             observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, idLote: null, ct);
 
@@ -740,6 +766,16 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
             throw new InvalidOperationException(
                 $"El conteo de inventario produjo un resultado inconsistente: esperado {contada}, obtenido {final}.");
         }
+
+        // Etapa 14, slice 4 (design call site 11; tasks.md Orchestrator Decision #1): UNA fila
+        // por OPERACIÓN de conteo. El conteo agregado (sin desglose por lote) no toca ningún
+        // lote — lotesAfectados = 0, el único movimiento es el agregado.
+        var (anteriorConteo, nuevoConteo) = PayloadDeAuditoria.Conteo(
+            actual, final, [idMovimientoStock], lotesAfectados: 0, delta);
+        await auditoria.RegistrarAsync(
+            conexion, transaccionCruda,
+            new RegistroDeAuditoria(idTenant, idPuntoVenta, AccionAuditada.StockConteo, idArticulo, anteriorConteo, nuevoConteo),
+            ct);
 
         await transaccion.CommitAsync(ct);
 
@@ -784,6 +820,12 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         var deltaAgregado = 0m;
         var cantidadAgregadaFinal = actualAgregado;
 
+        // Etapa 14, slice 4 (tasks.md Orchestrator Decision #1, VINCULANTE — resuelve el
+        // conflicto entre design.md y spec.md a favor del spec): acumula acá, a través del loop,
+        // en vez de escribir una fila de auditoría por lote — la fila se escribe UNA sola vez,
+        // después del loop, por OPERACIÓN de conteo.
+        var movimientosGenerados = new List<int>();
+
         foreach (var lote in lotesAscendentes)
         {
             var actualDelLote = actualPorLote[lote.IdLote];
@@ -795,9 +837,10 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
                 continue;
             }
 
-            await InsertarMovimientoStockAsync(
+            var idMovimientoDelLote = await InsertarMovimientoStockAsync(
                 conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, deltaDelLote, MotivoStock.Inventario,
                 idEmpleado, observaciones, momento, idComprobanteCompra: null, idPuntoVentaDestino: null, lote.IdLote, ct);
+            movimientosGenerados.Add(idMovimientoDelLote);
 
             var finalDelLote = await UpsertStockLoteAsync(
                 conexion, transaccionCruda, idTenant, idArticulo, idPuntoVenta, lote.IdLote, deltaDelLote, ct);
@@ -810,6 +853,20 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
             deltaAgregado += deltaDelLote;
             resultadosPorLote.Add(new LoteContado(lote.IdLote, finalDelLote, actualDelLote, deltaDelLote, MovimientoRegistrado: true));
+        }
+
+        // Ningún lote difirió ⇒ cero filas de ledger Y cero de auditoría para la operación entera
+        // (mismo criterio que el early-return del conteo agregado, tasks.md Orchestrator Decision
+        // #1). Al menos un lote difirió ⇒ UNA fila, con la lista completa de movimientos y el
+        // conteo de lotes afectados — nunca una fila por lote.
+        if (movimientosGenerados.Count > 0)
+        {
+            var (anteriorConteo, nuevoConteo) = PayloadDeAuditoria.Conteo(
+                actualAgregado, cantidadAgregadaFinal, movimientosGenerados, movimientosGenerados.Count, deltaAgregado);
+            await auditoria.RegistrarAsync(
+                conexion, transaccionCruda,
+                new RegistroDeAuditoria(idTenant, idPuntoVenta, AccionAuditada.StockConteo, idArticulo, anteriorConteo, nuevoConteo),
+                ct);
         }
 
         await transaccion.CommitAsync(ct);
@@ -891,8 +948,15 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
     /// <summary>Etapa 12, slice 10: gana <paramref name="idLote"/> (design decisión 10 — en una
     /// transferencia, el ledger se escribe en el elemento AGREGADO de <c>ConstruirClavesOrdenadas</c>
     /// y lleva el <c>IdLoteDelMovimiento</c> de esa clave; <c>Ajustar</c>/<c>Contar</c> siguen
-    /// pasando <c>null</c>, sin cambio de comportamiento).</summary>
-    private static async Task InsertarMovimientoStockAsync(
+    /// pasando <c>null</c>, sin cambio de comportamiento).
+    ///
+    /// Etapa 14, slice 4 (tasks.md Orchestrator Decision #15; design Open Questions): gana
+    /// <c>RETURNING id_movimiento_stock</c> / <c>ExecuteScalarAsync</c>, devuelve <c>int</c> — el
+    /// único cambio fuera de los doce call sites nombrados, necesario para alimentar los payloads
+    /// de <c>stock.ajuste</c>/<c>stock.decomiso</c>/<c>stock.conteo</c>. <see
+    /// cref="EjecutarTransferenciaAsync"/> ignora el valor devuelto y su comportamiento queda
+    /// byte-idéntico — sigue sin escribir auditoría (proposal decisión 5).</summary>
+    private static async Task<int> InsertarMovimientoStockAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
         decimal cantidad, MotivoStock motivo, int idEmpleado, string? observaciones, DateTimeOffset creadoEl,
         int? idComprobanteCompra, int? idPuntoVentaDestino, int? idLote, CancellationToken ct)
@@ -903,7 +967,8 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "INSERT INTO movimientos_stock " +
             "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_empleado, observaciones, " +
             "id_comprobante_compra, id_punto_venta_destino, creado_el, id_lote) " +
-            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) " +
+            "RETURNING id_movimiento";
 
         AgregarParametro(comando, idTenant);
         AgregarParametro(comando, idArticulo);
@@ -917,7 +982,10 @@ public class ServicioDeStock(IWaysDbContext db, IRelojDelSistema reloj, IContext
         AgregarParametro(comando, creadoEl);
         AgregarParametroNulo(comando, idLote);
 
-        await comando.ExecuteNonQueryAsync(ct);
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("El INSERT de movimientos_stock no devolvió ninguna fila.");
+
+        return Convert.ToInt32(resultado);
     }
 
     private static async Task<decimal> UpsertStockAsync(

--- a/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
+++ b/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
@@ -585,7 +585,8 @@ public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         var reloj = new RelojFijo(DateTimeOffset.UtcNow);
         var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
         var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
-        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes);
+        var servicioDeAuditoria = new Ways.Application.Auditoria.ServicioDeAuditoria(db, reloj, contexto);
+        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes, servicioDeAuditoria);
 
         var solicitud = new SolicitudDeConteo(
             ctx.IdPuntoVenta, idArticulo, null, "Orden de locks",

--- a/tests/Ways.IntegrationTests/ReliquidacionAuditoriaTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionAuditoriaTests.cs
@@ -166,6 +166,30 @@ public class ReliquidacionAuditoriaTests(WaysApiFixture fixture) : IClassFixture
         await db.SaveChangesAsync();
     }
 
+    /// <summary>Judgment-day fix (juez B, slice 4, ronda 1, finding 2): mismo criterio que
+    /// <c>StockAuditoriaTests.QuemarArticulosDescartablesAsync</c> — sin este quemado previo,
+    /// <c>id_cliente</c> puede coincidir por casualidad con <c>id_movimiento</c> de
+    /// <c>movimientos_cuenta_corriente</c> en el entorno de test, escondiendo un call site mutado
+    /// que auditara con el id equivocado.</summary>
+    private async Task QuemarClientesDescartablesAsync(Contexto ctx, int cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        for (var i = 0; i < cantidad; i++)
+        {
+            db.Clientes.Add(new Cliente
+            {
+                IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = "quemado",
+                IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+                CreditoIlimitado = true, Saldo = 0m, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
     private static async Task<HttpResponseMessage> EjecutarAsync(Contexto ctx, int idCliente) =>
         await ctx.Admin.PostAsJsonAsync(
             $"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
@@ -180,6 +204,7 @@ public class ReliquidacionAuditoriaTests(WaysApiFixture fixture) : IClassFixture
     {
         var ctx = await PrepararAsync(nameof(UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo));
         var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-reliquidacion-auditoria", 100m);
+        await QuemarClientesDescartablesAsync(ctx, 2);
         var idCliente = await SembrarClienteAsync(ctx, "Cliente reliquidacion auditoria");
         await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
         await SubirPrecioAsync(ctx, idArticulo, 150m);

--- a/tests/Ways.IntegrationTests/ReliquidacionAuditoriaTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionAuditoriaTests.cs
@@ -1,0 +1,256 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 4 (task 4.13): <c>cc.reliquidacion</c> punta a punta
+/// contra Postgres real — before-image tomado del <c>SELECT … FOR UPDATE</c> ya lockeado (design
+/// decisión 9, mutation target de la slice, fila 3) y los dos caminos no-op (sin elegibles, delta
+/// cero) mudos tanto en el ledger como en la auditoría.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ReliquidacionAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
+        int IdMedioCuentaCorriente, int IdTipoComprobanteTx, HttpClient Admin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Auditoria-cc-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+        var idListaPrecio = await db.Clientes.Select(c => c.IdListaPrecio).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        var idTipoComprobanteTx = await db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.Id).FirstAsync();
+
+        // La reliquidación no exige turno (design decisión 4), pero el checkout que crea el
+        // Consumo sí — sembrado directo, mismo criterio que ReliquidacionTests.PrepararAsync.
+        db.TurnosCaja.Add(new Ways.Domain.Caja.TurnoCaja
+        {
+            IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+            IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+            Estado = Ways.Domain.Caja.EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, area.Id, idAlicuotaIva, idListaPrecio,
+            medioCc.Id, idTipoComprobanteTx, admin);
+    }
+
+    private async Task<int> SembrarArticuloConPrecioAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Ways.Domain.Articulos.Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = Ways.Domain.Articulos.UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio,
+            Monto = precio, VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = 0m,
+            CreditoIlimitado = true, Saldo = 0m, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    /// <summary>Un Consumo real, vía checkout — mismo criterio que
+    /// <c>ReliquidacionTests.RealizarConsumoAsync</c>.</summary>
+    private static async Task RealizarConsumoAsync(Contexto ctx, int idCliente, int idArticulo, decimal cantidad, decimal precio)
+    {
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null)],
+            [new PagoDeVenta(ctx.IdMedioCuentaCorriente, cantidad * precio, null, 0m)],
+            null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+    }
+
+    private async Task SubirPrecioAsync(Contexto ctx, int idArticulo, decimal nuevoPrecio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var vieja = await db.Precios
+            .Where(p => p.IdArticulo == idArticulo && p.IdListaPrecio == ctx.IdListaPrecio && p.VigenteHasta == null)
+            .SingleAsync();
+        vieja.VigenteHasta = ahora;
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdListaPrecio = ctx.IdListaPrecio, Monto = nuevoPrecio,
+            VigenteDesde = ahora, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<HttpResponseMessage> EjecutarAsync(Contexto ctx, int idCliente) =>
+        await ctx.Admin.PostAsJsonAsync(
+            $"/api/clientes/{idCliente}/cuenta-corriente/reliquidacion", new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
+
+    // ---- task 4.13 / mutation target 4.8 (design mutation-targets, slice 4, fila 3) ----------------
+
+    /// <summary>spec `auditoria-de-operaciones`: cobertura de `cc.reliquidacion`. Mutation target
+    /// (slice 4, fila 3): releer <c>saldo</c> DESPUÉS del <c>UPDATE</c> de saldo (en vez de usar el
+    /// del <c>FOR UPDATE</c> ya tomado) hace que <c>anterior</c> quede igual a <c>nuevo</c> acá.</summary>
+    [Fact]
+    public async Task UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReliquidacionConDiferenciaEscribeUnaFilaDeAuditoriaConSaldoAnteriorDistintoDeNuevo));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-reliquidacion-auditoria", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente reliquidacion auditoria");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        await SubirPrecioAsync(ctx, idArticulo, 150m);
+
+        var respuesta = await EjecutarAsync(ctx, idCliente);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        var resultado = JsonSerializer.Deserialize<ResultadoDeReliquidacion>(cuerpo, OpcionesJson)!;
+        Assert.Equal(50m, resultado.Delta);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "cc.reliquidacion" && a.IdEntidad == idCliente);
+
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+        Assert.Equal("cliente", fila.Entidad);
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdActor);
+
+        var anterior = JsonDocument.Parse(fila.ValorAnterior!).RootElement;
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(100m, anterior.GetProperty("saldo").GetDecimal());
+        Assert.Equal(150m, nuevo.GetProperty("saldo").GetDecimal());
+        Assert.NotEqual(anterior.GetProperty("saldo").GetDecimal(), nuevo.GetProperty("saldo").GetDecimal());
+        Assert.Equal(50m, nuevo.GetProperty("diferencia").GetDecimal());
+        Assert.Equal(1, nuevo.GetProperty("consumos_actualizados").GetInt32());
+
+        var movimiento = await db.MovimientosCuentaCorriente
+            .SingleAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios);
+        Assert.Equal(movimiento.Id, nuevo.GetProperty("id_movimiento").GetInt32());
+    }
+
+    // ---- task 4.13: los dos caminos no-op --------------------------------------------------------
+
+    /// <summary>spec `auditoria-de-operaciones`: el primero de los dos no-ops — sin consumos
+    /// elegibles, la transacción comitea sin escribir nada, ni ledger ni auditoría.</summary>
+    [Fact]
+    public async Task UnaReliquidacionSinConsumosElegiblesNoEscribeFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReliquidacionSinConsumosElegiblesNoEscribeFilaDeAuditoria));
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente reliquidacion sin elegibles");
+
+        var respuesta = await EjecutarAsync(ctx, idCliente);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        var resultado = JsonSerializer.Deserialize<ResultadoDeReliquidacion>(cuerpo, OpcionesJson)!;
+        Assert.Equal(0m, resultado.Delta);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "cc.reliquidacion" && a.IdEntidad == idCliente));
+    }
+
+    /// <summary>El segundo no-op — un consumo elegible cuyo precio nunca cambió (delta cero): la
+    /// transacción comitea sin escribir nada, mismo criterio que el camino "sin elegibles" aunque
+    /// la causa sea distinta.</summary>
+    [Fact]
+    public async Task UnaReliquidacionConDeltaCeroNoEscribeFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnaReliquidacionConDeltaCeroNoEscribeFilaDeAuditoria));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-reliquidacion-auditoria-delta-cero", 100m);
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente reliquidacion delta cero");
+        await RealizarConsumoAsync(ctx, idCliente, idArticulo, 1m, 100m);
+        // Precio SIN cambios — hay un consumo elegible, pero re-precificarlo da delta cero.
+
+        var respuesta = await EjecutarAsync(ctx, idCliente);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.IsSuccessStatusCode, cuerpo);
+        var resultado = JsonSerializer.Deserialize<ResultadoDeReliquidacion>(cuerpo, OpcionesJson)!;
+        Assert.Equal(0m, resultado.Delta);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "cc.reliquidacion" && a.IdEntidad == idCliente));
+        Assert.Equal(
+            0, await db.MovimientosCuentaCorriente.CountAsync(m => m.IdCliente == idCliente && m.Tipo == TipoMovimientoCc.ActualizacionPrecios));
+    }
+}

--- a/tests/Ways.IntegrationTests/ReliquidacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionTests.cs
@@ -698,7 +698,8 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: ctx.IdEmpleadoAdmin);
         var lector = new LectorDeConsumosReliquidables(db);
         var servicioDePrecios = new ServicioDePrecios(db, reloj, contexto);
-        var servicio = new ServicioDeReliquidacion(db, reloj, contexto, lector, servicioDePrecios);
+        var servicioDeAuditoria = new Ways.Application.Auditoria.ServicioDeAuditoria(db, reloj, contexto);
+        var servicio = new ServicioDeReliquidacion(db, reloj, contexto, lector, servicioDePrecios, servicioDeAuditoria);
 
         await servicio.EjecutarAsync(idCliente, new SolicitudDeReliquidacion(ctx.IdPuntoVenta));
 

--- a/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
+++ b/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
@@ -277,6 +277,10 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(40m, anterior.GetProperty("cantidad").GetDecimal());
         Assert.Equal(35m, nuevo.GetProperty("cantidad").GetDecimal());
         Assert.Equal(idLote, nuevo.GetProperty("id_lote").GetInt32());
+        Assert.Equal("Rotura auditada", nuevo.GetProperty("observaciones").GetString());
+
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso);
+        Assert.Equal(movimiento.Id, nuevo.GetProperty("id_movimiento_stock").GetInt32());
     }
 
     [Fact]
@@ -296,6 +300,10 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
 
         var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
         Assert.Equal(JsonValueKind.Null, nuevo.GetProperty("id_lote").ValueKind);
+        Assert.Equal("Rotura sin lote auditada", nuevo.GetProperty("observaciones").GetString());
+
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Decomiso);
+        Assert.Equal(movimiento.Id, nuevo.GetProperty("id_movimiento_stock").GetInt32());
     }
 
     /// <summary>Los dos caminos de rechazo <c>409 stock_insuficiente_para_decomiso</c> (lote y

--- a/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
+++ b/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
@@ -189,6 +189,32 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         return puntoVenta.Id;
     }
 
+    /// <summary>Judgment-day fix (juez B, slice 4, ronda 1, finding 2): sin este quemado previo,
+    /// <c>id_articulo</c> e <c>id_movimiento_stock</c> coinciden por alineación accidental de las
+    /// secuencias en el entorno de test — mutar el call site de auditoría a
+    /// <c>idMovimientoStock</c> en vez de <c>idArticulo</c> sobrevive porque ambos valores son
+    /// iguales por casualidad. Regla permanente (magnitudes discriminantes): ningún id usado por
+    /// una aserción de auditoría (articulo/punto de venta/actor/entidad/movimiento/cliente) puede
+    /// coincidir con otro por casualidad — se desincroniza a propósito quemando filas descartables
+    /// ANTES de sembrar la entidad real que el test audita.</summary>
+    private async Task QuemarArticulosDescartablesAsync(Contexto ctx, int cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < cantidad; i++)
+        {
+            db.Articulos.Add(new Articulo
+            {
+                IdTenant = ctx.IdTenant, CodigoInterno = $"quemado-{Guid.NewGuid():N}", Nombre = "quemado",
+                IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+                EsProducto = true, ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
     // ---- task 4.9 / mutation target 4.6 (design mutation-targets, slice 4, fila 1) ---------------
 
     /// <summary>spec `auditoria-de-operaciones`: catálogo de las doce acciones, cobertura de
@@ -199,6 +225,7 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     public async Task UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo()
     {
         var ctx = await PrepararAsync(nameof(UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo));
+        await QuemarArticulosDescartablesAsync(ctx, 2);
         var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-auditoria-ajuste", 10m);
         await SembrarStockAgregadoAsync(ctx, idArticulo, 50m);
 
@@ -328,6 +355,45 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "stock.conteo" && a.IdEntidad == idArticulo));
     }
 
+    /// <summary>Judgment-day fix (juez B, slice 4, ronda 1, finding 1): el conteo AGREGADO con
+    /// diferencia (delta ≠ 0, <c>EjecutarConteoAsync</c>) no tenía ningún test — hardcodear
+    /// <c>delta_total = 0</c> en el payload, o borrar el bloque <c>RegistrarAsync</c> entero,
+    /// sobrevivían los 66/66 tests previos (solo estaban cubiertos el camino sin diferencia y el
+    /// camino por-lote). Magnitudes discriminantes (88/61/-27, delta negativo — complementa el
+    /// +3 del escenario por-lote) y secuencias desincronizadas
+    /// (<see cref="QuemarArticulosDescartablesAsync"/>) — verifica el payload clave por clave.</summary>
+    [Fact]
+    public async Task UnConteoAgregadoConDiferenciaEscribeUnaFilaDeAuditoriaConPayloadCompleto()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoAgregadoConDiferenciaEscribeUnaFilaDeAuditoriaConPayloadCompleto));
+        await QuemarArticulosDescartablesAsync(ctx, 2);
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-conteo-auditoria-agregado-con-diferencia", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 88m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, 61m, "Conteo agregado con diferencia auditado");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario);
+
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "stock.conteo" && a.IdEntidad == idArticulo);
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+        Assert.Equal("articulo", fila.Entidad);
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdActor);
+
+        var anterior = JsonDocument.Parse(fila.ValorAnterior!).RootElement;
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(88m, anterior.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(61m, nuevo.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(-27m, nuevo.GetProperty("delta_total").GetDecimal());
+        Assert.Equal(0, nuevo.GetProperty("lotes_afectados").GetInt32());
+
+        var idsGenerados = nuevo.GetProperty("movimientos_generados").EnumerateArray().Select(e => e.GetInt32()).ToList();
+        Assert.Equal([movimiento.Id], idsGenerados);
+    }
+
     // ---- task 4.11: el escenario reconciliado (tasks.md Orchestrator Decision #1) -----------------
 
     /// <summary>spec `auditoria-de-operaciones`: "Each operation MUST write exactly one row" — el
@@ -338,6 +404,7 @@ public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     public async Task UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria()
     {
         var ctx = await PrepararAsync(nameof(UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria));
+        await QuemarArticulosDescartablesAsync(ctx, 2);
         var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-auditoria-reconciliado", 10m);
         var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-CONTEO-AUDITORIA", VencimientoLejanoFuturo);
         var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L2-CONTEO-AUDITORIA", VencimientoLejanoFuturo);

--- a/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
+++ b/tests/Ways.IntegrationTests/StockAuditoriaTests.cs
@@ -1,0 +1,409 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Stock;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 4 (tasks 4.9-4.14): <c>stock.ajuste</c>/
+/// <c>stock.decomiso</c>/<c>stock.conteo</c> punta a punta contra Postgres real — before-image
+/// derivado del <c>RETURNING</c> autoritativo (nunca un segundo <c>SELECT</c>, design decisión 9),
+/// el conteo sin diferencia mudo (ledger Y auditoría, tasks.md Orchestrator Decision #1), el
+/// escenario reconciliado de conteo por lote (UNA fila por operación, no por lote) y el límite
+/// estructural de <c>stock.transferencia</c> (proposal decisión 5).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class StockAuditoriaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    // Regla permanente 3: fechas fijas y lejanas — independientes del reloj de la corrida.
+    private static readonly DateOnly VencimientoLejanoFuturo = new(2099, 12, 31);
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdEmpleadoAdmin, HttpClient Admin, int IdArea,
+        int IdAlicuotaIva, int IdListaPrecio);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Auditoria-stock-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista Auditoria Stock", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        // Módulo de lotes ON a nivel empresa — mismo criterio que AjusteDecomisoLoteTests/ConteoPorLoteTests.
+        db.Parametros.Add(new Parametro
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+            Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, admin, area.Id,
+            idAlicuotaIva, lista.Id);
+    }
+
+    private async Task<int> SembrarArticuloLoteEfectivoAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarArticuloSinLoteAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, ControlaLote = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockLoteAsync(Contexto ctx, int idArticulo, int idLote, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = idLote, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> SembrarPuntoVentaAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return puntoVenta.Id;
+    }
+
+    // ---- task 4.9 / mutation target 4.6 (design mutation-targets, slice 4, fila 1) ---------------
+
+    /// <summary>spec `auditoria-de-operaciones`: catálogo de las doce acciones, cobertura de
+    /// `stock.ajuste`. Mutation target (slice 4, fila 1): mutar el before-image de
+    /// `nuevaCantidad - cantidad` a `nuevaCantidad` en los dos lados hace fallar el
+    /// <c>Assert.NotEqual</c> de acá.</summary>
+    [Fact]
+    public async Task UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteDeStockEscribeUnaFilaDeAuditoriaConAnteriorDistintoDeNuevo));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-auditoria-ajuste", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 50m);
+
+        var solicitud = new SolicitudDeAjusteDeStock(ctx.IdPuntoVenta, idArticulo, 20m, "Carga adicional auditada");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/ajustes", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "stock.ajuste" && a.IdEntidad == idArticulo);
+
+        Assert.Equal(ctx.IdPuntoVenta, fila.IdPuntoVenta);
+        Assert.Equal("articulo", fila.Entidad);
+        Assert.Equal(ctx.IdEmpleadoAdmin, fila.IdActor);
+
+        var anterior = JsonDocument.Parse(fila.ValorAnterior!).RootElement;
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(50m, anterior.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(70m, nuevo.GetProperty("cantidad").GetDecimal());
+        Assert.NotEqual(anterior.GetProperty("cantidad").GetDecimal(), nuevo.GetProperty("cantidad").GetDecimal());
+        Assert.Equal("Carga adicional auditada", nuevo.GetProperty("observaciones").GetString());
+        Assert.True(nuevo.TryGetProperty("id_movimiento_stock", out var idMovimiento));
+
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Ajuste);
+        Assert.Equal(movimiento.Id, idMovimiento.GetInt32());
+    }
+
+    // ---- task 4.12: stock.decomiso coverage --------------------------------------------------------
+
+    [Fact]
+    public async Task UnDecomisoDeStockEscribeUnaFilaConIdLotePresenteCuandoEsLoteEfectivo()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeStockEscribeUnaFilaConIdLotePresenteCuandoEsLoteEfectivo));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-auditoria-lote", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-DECOMISO-AUDITORIA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Rotura auditada");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "stock.decomiso" && a.IdEntidad == idArticulo);
+
+        var anterior = JsonDocument.Parse(fila.ValorAnterior!).RootElement;
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(40m, anterior.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(35m, nuevo.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(idLote, nuevo.GetProperty("id_lote").GetInt32());
+    }
+
+    [Fact]
+    public async Task UnDecomisoDeStockEscribeUnaFilaConIdLoteNuloCuandoNoEsLoteEfectivo()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoDeStockEscribeUnaFilaConIdLoteNuloCuandoNoEsLoteEfectivo));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-decomiso-auditoria-sin-lote", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, null, 5m, "Rotura sin lote auditada");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var fila = await db.Auditoria.SingleAsync(a => a.Accion == "stock.decomiso" && a.IdEntidad == idArticulo);
+
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(JsonValueKind.Null, nuevo.GetProperty("id_lote").ValueKind);
+    }
+
+    /// <summary>Los dos caminos de rechazo <c>409 stock_insuficiente_para_decomiso</c> (lote y
+    /// agregado) dejan cero filas de auditoría — el rechazo corre ANTES del
+    /// <c>RegistrarAsync</c>.</summary>
+    [Fact]
+    public async Task UnDecomisoRechazadoPorStockInsuficienteEnElLoteNoEscribeFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoRechazadoPorStockInsuficienteEnElLoteNoEscribeFilaDeAuditoria));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-decomiso-auditoria-insuf-lote", 10m);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-INSUF-AUDITORIA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote, 3m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 3m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, idLote, 5m, "Rotura mayor al saldo del lote");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "stock.decomiso" && a.IdEntidad == idArticulo));
+    }
+
+    [Fact]
+    public async Task UnDecomisoRechazadoPorStockInsuficienteEnElAgregadoNoEscribeFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnDecomisoRechazadoPorStockInsuficienteEnElAgregadoNoEscribeFilaDeAuditoria));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-decomiso-auditoria-insuf-agregado", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 3m);
+
+        var solicitud = new SolicitudDeDecomiso(ctx.IdPuntoVenta, idArticulo, null, 5m, "Rotura mayor al saldo agregado");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/decomiso", solicitud);
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "stock.decomiso" && a.IdEntidad == idArticulo));
+    }
+
+    // ---- task 4.10 / mutation target 4.7 (design mutation-targets, slice 4, fila 2) ---------------
+
+    /// <summary>spec `auditoria-de-operaciones`: "A zero-difference conteo writes no audit row".
+    /// Mutation target (slice 4, fila 2): borrar el early-return de delta cero hace que este test
+    /// falle (aparecería una fila de ledger Y una de auditoría).</summary>
+    [Fact]
+    public async Task UnConteoAgregadoSinDiferenciaNoEscribeFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoAgregadoSinDiferenciaNoEscribeFilaDeAuditoria));
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-conteo-auditoria-sin-diferencia", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var solicitud = new SolicitudDeConteo(ctx.IdPuntoVenta, idArticulo, 40m, "Conteo sin diferencia auditado");
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario));
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Accion == "stock.conteo" && a.IdEntidad == idArticulo));
+    }
+
+    // ---- task 4.11: el escenario reconciliado (tasks.md Orchestrator Decision #1) -----------------
+
+    /// <summary>spec `auditoria-de-operaciones`: "Each operation MUST write exactly one row" — el
+    /// test discriminante que reemplaza el texto per-lote obsoleto de design.md (call-site row 11):
+    /// un conteo por lote sobre un artículo con 3 lotes, 2 con diferencia, escribe UNA sola fila de
+    /// auditoría para la operación entera — no dos.</summary>
+    [Fact]
+    public async Task UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnConteoPorLoteConDosDeTresLotesDiferentesEscribeUnaSolaFilaDeAuditoria));
+        var idArticulo = await SembrarArticuloLoteEfectivoAsync(ctx, "articulo-conteo-auditoria-reconciliado", 10m);
+        var idLote1 = await SembrarLoteAsync(ctx, idArticulo, "L1-CONTEO-AUDITORIA", VencimientoLejanoFuturo);
+        var idLote2 = await SembrarLoteAsync(ctx, idArticulo, "L2-CONTEO-AUDITORIA", VencimientoLejanoFuturo);
+        var idLote3 = await SembrarLoteAsync(ctx, idArticulo, "L3-CONTEO-AUDITORIA", VencimientoLejanoFuturo);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote1, 10m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote2, 20m);
+        await SembrarStockLoteAsync(ctx, idArticulo, idLote3, 5m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 35m);
+
+        // L1 (10→15, +5) y L3 (5→3, -2) difieren; L2 (20→20) coincide — el escenario reconciliado
+        // exacto de tasks.md 4.11. Delta neto +3, deliberadamente no-cero para que anterior/nuevo
+        // del agregado también discriminen.
+        var solicitud = new SolicitudDeConteo(
+            ctx.IdPuntoVenta, idArticulo, null, "Conteo con dos de tres lotes con diferencia",
+            [new ConteoDeLote(idLote1, 15m), new ConteoDeLote(idLote2, 20m), new ConteoDeLote(idLote3, 3m)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/conteos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var movimientosDelLedger = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Inventario).ToListAsync();
+        Assert.Equal(2, movimientosDelLedger.Count);
+
+        var filas = await db.Auditoria.Where(a => a.Accion == "stock.conteo" && a.IdEntidad == idArticulo).ToListAsync();
+        var fila = Assert.Single(filas);
+
+        var anterior = JsonDocument.Parse(fila.ValorAnterior!).RootElement;
+        var nuevo = JsonDocument.Parse(fila.ValorNuevo).RootElement;
+        Assert.Equal(35m, anterior.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(38m, nuevo.GetProperty("cantidad").GetDecimal());
+        Assert.Equal(2, nuevo.GetProperty("lotes_afectados").GetInt32());
+        Assert.Equal(3m, nuevo.GetProperty("delta_total").GetDecimal());
+
+        var idsGenerados = nuevo.GetProperty("movimientos_generados").EnumerateArray().Select(e => e.GetInt32()).OrderBy(id => id).ToList();
+        var idsDelLedger = movimientosDelLedger.Select(m => m.Id).OrderBy(id => id).ToList();
+        Assert.Equal(idsDelLedger, idsGenerados);
+    }
+
+    // ---- task 4.14: stock.transferencia — límite estructural (proposal decisión 5) ----------------
+
+    /// <summary>spec `auditoria-de-operaciones`: "stock.transferencia is excluded by scope, not by
+    /// defect" — ninguna de las dos patas escribe una fila de auditoría, y ambas siguen cargando su
+    /// propio <c>id_empleado</c> en <c>movimientos_stock</c>.</summary>
+    [Fact]
+    public async Task UnaTransferenciaNoEscribeFilasDeAuditoriaParaNingunaDeLasDosPatas()
+    {
+        var ctx = await PrepararAsync(nameof(UnaTransferenciaNoEscribeFilasDeAuditoriaParaNingunaDeLasDosPatas));
+        var idPuntoVentaDestino = await SembrarPuntoVentaAsync(ctx, "Destino transferencia auditoria");
+        var idArticulo = await SembrarArticuloSinLoteAsync(ctx, "articulo-transferencia-auditoria", 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var solicitud = new SolicitudDeTransferencia(
+            ctx.IdPuntoVenta, idPuntoVentaDestino, "Transferencia auditada",
+            [new LineaDeTransferencia(idArticulo, 5m)]);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/stock/transferencias", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.Motivo == MotivoStock.Transferencia).ToListAsync();
+        Assert.Equal(2, movimientos.Count);
+        Assert.All(movimientos, m => Assert.Equal(ctx.IdEmpleadoAdmin, m.IdEmpleado));
+
+        Assert.Equal(0, await db.Auditoria.CountAsync(a => a.Entidad == "articulo" && a.IdEntidad == idArticulo));
+    }
+}

--- a/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
@@ -871,7 +871,8 @@ public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<Ways
         var reloj = new RelojFijo(DateTimeOffset.UtcNow);
         var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
         var servicioDeLotes = new ServicioDeLotes(db, reloj, contexto);
-        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes);
+        var servicioDeAuditoria = new Ways.Application.Auditoria.ServicioDeAuditoria(db, reloj, contexto);
+        var servicioDeStock = new ServicioDeStock(db, reloj, contexto, servicioDeLotes, servicioDeAuditoria);
 
         var solicitud = new SolicitudDeTransferencia(
             idPuntoVentaConIdMayor, idPuntoVentaConIdMenor, "Orden de locks",


### PR DESCRIPTION
## Etapa 14 — Auditoría · Slice 4 (Stock + Cuenta Corriente, modo ADO)

- `stock.ajuste`/`stock.decomiso`/`stock.conteo` dentro de las transacciones ADO existentes de `ServicioDeStock`: before-images desde `nueva − delta` del RETURNING autoritativo o el lock FOR UPDATE ya tomado (decisión 9, jamás un segundo SELECT); orden de locks, advisory-first, guard de turno y el split adquisición/aplicación del conteo por lote INTACTOS.
- **Decisión de orquestador #1 implementada**: el conteo escribe UNA fila por OPERACIÓN (payload agregado {cantidad, movimientos_generados, lotes_afectados, delta_total}); el conteo con diferencia cero no escribe NADA.
- `cc.reliquidacion` con `saldoInicial` capturado del FOR UPDATE; los dos no-ops (sin elegibles, delta cero) no auditan.
- `stock.transferencia` NO se audita (exclusión estructural, decisión 5) — probado por test de ausencia.
- `InsertarMovimientoStockAsync` → RETURNING `id_movimiento` (PK real; la clave del payload sigue siendo `id_movimiento_stock`, el nombre del contrato — desvío documentado y ratificado).
- Cero migraciones.

## Tests (filtro combinado 174/174 verdes post-merge con slice 3)
Cobertura por acción con payload clave-por-clave (incl. el conteo AGREGADO con delta negativo firmado), decomiso ×4 con las 4 claves asertadas, seeds DESINCRONIZADOS de secuencias coincidentes (quemadores de filas — la colisión id_articulo/id_movimiento cazada por el juez con la variante +1000000), no-ops probados, actor por igualdad. 3 targets del apply + 8 mutaciones del juez B + probe de reliquidación.

## Judgment-day
Juez B: 2 MAJORs (conteo agregado sin NINGÚN test del write — borrarlo pasaba 66/66; id_entidad indiscriminable por secuencias alineadas) → fix test-only `1cd20af`. Re-ronda B: 4 re-mutantes muertos. Juez A: 0 severos, 1 WARNING (decomiso 2-de-4 claves) cerrado con evidencia. Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)