### PR TITLE
feat(stage-14): slice 5 consulta — GET /api/auditoria con LecturaDeAuditoria Admin-only

### DIFF
--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1090,13 +1090,15 @@ depends on it.
 — `5a` (policy + route with date/`accion`/actor filters + 403s) and `5b`
 (`entidad`/`idEntidad`/PV filters + pagination).
 
-- [ ] 5.1 Modify `src/Ways.Api/Seguridad/Politicas.cs`: `const string
+- [x] 5.1 Modify `src/Ways.Api/Seguridad/Politicas.cs`: `const string
   LecturaDeAuditoria = "lectura_auditoria"`; `.AddPolicy(LecturaDeAuditoria,
   p => p.RequireAuthenticatedUser().RequireClaim(ClaimsWays.RolId,
   ((int)RolConocido.Admin).ToString()))` — the exact shape of
   `LecturaDeRentabilidad`, **not** stacked over `LecturaDeReportes`.
-  *(design decision 6)*
-- [ ] 5.2 Create `src/Ways.Application/Auditoria/Contratos.cs`:
+  *(design decision 6)* Covered at the policy-composition level too:
+  `PoliticasTests.LecturaDeAuditoriaAdmiteSoloAdmin` (Theory, 4 roles, no
+  Docker — same shape as `LecturaDeRentabilidadAdmiteSoloAdmin`).
+- [x] 5.2 Create `src/Ways.Application/Auditoria/Contratos.cs`:
   `FiltrosDeAuditoria(Desde, Hasta, Accion, IdActor, Entidad, IdEntidad,
   IdPuntoVenta)`, `FilaDeAuditoria(IdAuditoria, CreadoEl, Accion, Entidad,
   IdEntidad, IdActor, Actor, IdPuntoVenta, ValorAnterior, ValorNuevo)`,
@@ -1105,7 +1107,7 @@ depends on it.
   `ConstruirQuery`, no field accepted and silently discarded; doc-comment
   `Actor == null` as "not visible to this session", never "no actor"
   (`IdActor` always travels).
-- [ ] 5.3 Create
+- [x] 5.3 Create
   `src/Ways.Application/Auditoria/ServicioDeConsultaDeAuditoria.cs`:
   `ConstruirQuery(filtros)` — `LEFT JOIN` to `db.Usuarios.IgnoreQueryFilters(
   ["BajaLogica"])` via `DefaultIfEmpty()`, `orderby CreadoEl descending,
@@ -1114,70 +1116,193 @@ depends on it.
   `Skip((pagina-1)*tamanio).Take(tamanio)` with `pagina = Math.Max(pagina,
   1)`, `tamanio = Math.Clamp(tamanio, 1, 200)`; `idEntidad` without
   `entidad` → `400 entidad_requerida`.
-- [ ] 5.4 Create `src/Ways.Api/Endpoints/AuditoriaEndpoints.cs`: `GET
+  **DEVIATION (registered):** the entity's real PK property is `Id`
+  (`Auditoria.cs`, `AuditoriaConfiguration.cs` — slice 1), not the
+  `IdAuditoria` design/task prose used before the entity landed — the
+  tiebreaker is `orderby ... a.Id descending`, same underlying column
+  (`id_auditoria`). `idEntidad`-without-`entidad` validation lives at the
+  TOP of `ConstruirQuery` (not a separate step in `ConsultarAsync`) so
+  slice 6's `ConsultarParaExportacionAsync` — not declared yet — inherits
+  it automatically by reusing the same private method, per design decision
+  13 ("one `ConstruirQuery`, two consumers").
+- [x] 5.4 Create `src/Ways.Api/Endpoints/AuditoriaEndpoints.cs`: `GET
   /api/auditoria?desde&hasta&accion&idActor&entidad&idEntidad&idPuntoVenta&pagina&tamanio`
   under `.RequireAuthorization(Politicas.LecturaDeAuditoria)`.
-- [ ] 5.5 [P] **Mutation target**: `ThenByDescending(a.IdAuditoria)` on the
+  **Note (plumbing, not a scope deviation):** wiring this route required
+  two mechanical additions the task/design prose didn't spell out
+  line-by-line but every prior `MapearX()` slice needed the same way:
+  `app.MapearAuditoria();` in `Program.cs` and
+  `services.AddScoped<ServicioDeConsultaDeAuditoria>();` in
+  `Ways.Application/DependencyInjection.cs` — without either, the route
+  404s / DI throws at first request.
+- [x] 5.5 [P] **Mutation target**: `ThenByDescending(a.IdAuditoria)` on the
   ordering — delete it — the tied-`creado_el` pagination test (5.9) must
-  fail. *(slice 5 row 1)*
-- [ ] 5.6 [P] **Mutation target**: `candidatos.DefaultIfEmpty()` (the LEFT
+  fail. *(slice 5 row 1)* **Evidence**: mutated (`orderby a.CreadoEl
+  descending, a.Id descending` → `orderby a.CreadoEl descending`) →
+  `dotnet build --no-incremental` → `--filter
+  FullyQualifiedName~PaginacionConCreadoElEmpatadoNoRepiteNiSalteaYRespetaElOrdenDescendentePorId`
+  → FAILED (`Expected: [5,4,3,2,1], Actual: [2,1,3,4,5]` — the concatenated
+  3-page sequence stopped matching the expected strict descending-id order)
+  → reverted → green.
+- [x] 5.6 [P] **Mutation target**: `candidatos.DefaultIfEmpty()` (the LEFT
   JOIN) → an inner join — the root-actor/soft-deleted-actor visibility test
-  (5.10) must fail. *(slice 5 row 2)*
-- [ ] 5.7 [P] **Mutation target**: `IgnoreQueryFilters(["BajaLogica"])` —
+  (5.10) must fail. *(slice 5 row 2)* **Evidence**: mutated (`join u in
+  ... into actores from u in actores.DefaultIfEmpty()` → plain `join u in
+  ... on a.IdActor equals u.Id`, no `into`/`DefaultIfEmpty`) → build →
+  `--filter
+  FullyQualifiedName~UnActorSoftDeletedSigueMostrandoElNombreYUnActorRootApareceConActorNuloEIdActorPresente`
+  → FAILED (`InvalidOperationException: Sequence contains no matching
+  element` — the root-actor row vanished from the result set entirely,
+  `.Single()` found nothing) → reverted → green.
+- [x] 5.7 [P] **Mutation target**: `IgnoreQueryFilters(["BajaLogica"])` —
   remove it — the soft-deleted-actor-name half of 5.10 must fail. *(slice 5
-  row 3)*
-- [ ] 5.8 [P] **Mutation target**: each `if (filtro is { } x)` clause in
+  row 3)* **Evidence**: mutated (`db.Usuarios.IgnoreQueryFilters(["BajaLogica"])`
+  → `db.Usuarios`) → build → same filter as 5.6 → FAILED
+  (`Expected: "vendedor-de-baja", Actual: null` — the soft-deleted actor's
+  row survived the LEFT JOIN but its name disappeared, as predicted) →
+  reverted → green.
+- [x] 5.8 [P] **Mutation target**: each `if (filtro is { } x)` clause in
   `ConstruirQuery` — delete one at a time — the matching filter's dedicated
   test (5.11-5.16, asymmetric seeds per filter) must fail, with no other
   clause producing the same subset. *(slice 5 row 4; mutation-proof-tests
-  rules 4/6)*
-- [ ] 5.9 [P] Integration: pagination with `creado_el` tied across every
+  rules 4/6)* Implemented as one combined `where (... || ...) && (... ||
+  ...) && ...` (design's own snippet shape), so each mutation replaces one
+  AND-term with `true`. **Evidence, one clause at a time, `dotnet build
+  --no-incremental` between each**: `Desde` → true →
+  `FiltroDeFechaDevuelveElSubconjuntoEsperado` FAILED (`Expected: 3, Actual:
+  5`) → reverted; `Hasta` → true → same test FAILED (`Expected: 3, Actual:
+  6`) → reverted; `Accion` → true →
+  `FiltroDeAccionDevuelveElSubconjuntoEsperado` FAILED (`Expected: 2,
+  Actual: 8`) → reverted; `IdActor` → true →
+  `FiltroDeActorDevuelveElSubconjuntoEsperado` FAILED (`Expected: 3, Actual:
+  8`) → reverted; `Entidad` → true →
+  `FiltroDeEntidadMasIdEntidadDevuelveSoloLaHistoriaDeEseAgregado` FAILED
+  (`Expected: 3, Actual: 4`) → reverted; `IdEntidad` → true → same test
+  FAILED (`Expected: 3, Actual: 5`) → reverted; `IdPuntoVenta` → true →
+  `FiltroDePuntoDeVentaDevuelveElSubconjuntoEsperado` FAILED (`Expected: 3,
+  Actual: 8`) → reverted → 16/16 green.
+  **DEVIATION (registered, mutation-proof-tests rule 3):** the `Entidad`/
+  `IdEntidad` pair was originally UNDISCRIMINATING — the fixture's
+  `idEntidad` values never collided across different `entidad`s, so
+  `idEntidad=41` alone already identified the same 3-row subset regardless
+  of the `entidad` clause (an overdetermined confound, same defect class
+  the skill documents). Fixed by making R2 (`comprobante_venta`) carry
+  `idEntidad=41` too — colliding with the `articulo`/41 rows — which is
+  what actually makes the `Entidad` mutation observable (see the 4-vs-3
+  evidence above).
+- [x] 5.9 [P] Integration: pagination with `creado_el` tied across every
   row (RelojFijo) — page 2 neither repeats nor skips a row, resolving 5.5's
   evidence.
-- [ ] 5.10 [P] Integration — actor visibility: a row whose actor is
+  `AuditoriaConsultaTests.PaginacionConCreadoElEmpatadoNoRepiteNiSalteaYRespetaElOrdenDescendentePorId`
+  — asserts the concatenated 3-page sequence (tamanio=2) equals the full
+  expected strictly-descending-by-id order (design Testing Strategy:
+  "order as a sequence, not a set"), not merely "no dup/skip" as a set.
+- [x] 5.10 [P] Integration — actor visibility: a row whose actor is
   soft-deleted still shows the actor's name; a row whose actor is a
   root/platform user, read by a tenant Admin, appears with `actor: null`
   and `idActor` present — resolving 5.6 and 5.7's evidence. *(design
   decision 14)*
-- [ ] 5.11 [P] Integration: `desde`/`hasta` returns its expected subset
+  `AuditoriaConsultaTests.UnActorSoftDeletedSigueMostrandoElNombreYUnActorRootApareceConActorNuloEIdActorPresente`.
+- [x] 5.11 [P] Integration: `desde`/`hasta` returns its expected subset
   (asymmetric seeds — every date, actor, entidad and PV distinct).
-- [ ] 5.12 [P] Integration: `accion` returns its expected subset; an
+  `AuditoriaConsultaTests.FiltroDeFechaDevuelveElSubconjuntoEsperado` — 8-row
+  fixture (`SembrarEscenarioDeFiltrosAsync`), every row's date/accion/actor/
+  entidad+id/PV mutually distinct (mutation-proof-tests rule 6).
+- [x] 5.12 [P] Integration: `accion` returns its expected subset; an
   unknown `accion` returns `200` with zero rows. *(design decision 15)*
-- [ ] 5.13 [P] Integration: `idActor` returns its expected subset.
-- [ ] 5.14 [P] Integration: `entidad` + `idEntidad` returns exactly that
+  `FiltroDeAccionDevuelveElSubconjuntoEsperado` +
+  `UnaAccionDesconocidaDevuelve200ConCeroFilas`.
+- [x] 5.13 [P] Integration: `idActor` returns its expected subset.
+  `FiltroDeActorDevuelveElSubconjuntoEsperado`.
+- [x] 5.14 [P] Integration: `entidad` + `idEntidad` returns exactly that
   aggregate's rows — 3 rows for articulo 41, 2 for articulo 42. *(spec:
   "Filtering by entidad + id_entidad returns only that aggregate's
   history")*
-- [ ] 5.15 [P] Integration: `idPuntoVenta` returns its expected subset;
+  `FiltroDeEntidadMasIdEntidadDevuelveSoloLaHistoriaDeEseAgregado` — asserts
+  both aggregates (41 and 42), not just the spec's literal one.
+- [x] 5.15 [P] Integration: `idPuntoVenta` returns its expected subset;
   unset ("todos") includes `id_punto_venta IS NULL` rows. *(spec:
   "Tenant-wide rows appear under 'todos' punto de venta")*
-- [ ] 5.16 [P] Integration: `idEntidad` without `entidad` → `400
+  `FiltroDePuntoDeVentaDevuelveElSubconjuntoEsperado` (both PVs) +
+  `SinFiltroDePuntoDeVentaTodosIncluyeLasTenantWideYAmbosPuntosDeVenta`
+  (also resolves 5.18's "Admin reads across every punto de venta" scenario
+  in the same assertion: both PVs' rows AND the PV-null rows present in one
+  response).
+- [x] 5.16 [P] Integration: `idEntidad` without `entidad` → `400
   entidad_requerida`. *(design decision 16)*
-- [ ] 5.17 [P] **Mutation target**:
+  `IdEntidadSinEntidadRechazaCon400EntidadRequerida` — asserts the status
+  code AND the `codigo` field of the ProblemDetails body.
+- [x] 5.17 [P] **Mutation target**:
   `.RequireAuthorization(Politicas.LecturaDeAuditoria)` on `GET
   /api/auditoria` — delete the line — the Supervisor-403 test (5.18) must
-  fail. *(slice 5 row 5)*
-- [ ] 5.18 [P] Integration — authorization: Supervisor → `403`; Vendedor →
+  fail. *(slice 5 row 5)* **Evidence**: mutated (`.RequireAuthorization(...)`
+  line deleted from the `MapGroup`) → build → `--filter
+  FullyQualifiedName~UnSupervisorEsRechazado` → FAILED (`Expected:
+  Forbidden, Actual: OK` — the group fell back to `Program.cs`'s
+  authenticated-only fallback policy, letting any logged-in role through) →
+  reverted → green.
+- [x] 5.18 [P] Integration — authorization: Supervisor → `403`; Vendedor →
   `403`; Root → `403`; Admin → `200`, sees rows from **every** punto de
   venta of the tenant. *(spec: "Admin reads across every punto de venta of
   the tenant", "A Supervisor is rejected", "A Vendedor is rejected")*
-- [ ] 5.19 [P] **Mutation target**: the tenant/RLS filter of the query —
+  `UnSupervisorEsRechazado`, `UnVendedorEsRechazado`, `UnRootEsRechazado`,
+  `UnAdminEsAceptado` (+ the cross-PV assertion inside 5.15's
+  `SinFiltroDePuntoDeVentaTodosIncluyeLasTenantWideYAmbosPuntosDeVenta`).
+  Supervisor/Vendedor clients are created ONLY inside these two tests (via
+  `CrearYLoguearAsync`, a real `POST /api/usuarios`) — deliberately kept
+  OUT of the shared `PrepararAsync` scaffolding, because a real alta writes
+  its own `usuario.alta` audit row (slice 2) that would otherwise pollute
+  every exact-count assertion in 5.11-5.16/5.9 (caught this exact
+  contamination on first run: `Expected: 8, Actual: 10` — fixed by moving
+  role-client creation out of the shared setup).
+- [x] 5.19 [P] **Mutation target**: the tenant/RLS filter of the query —
   read with another tenant's GUC — the tenant-isolation test (5.20) must
   fail. *(slice 5 row 6)*
-- [ ] 5.20 [P] Integration — tenant isolation over `ways_app`
+  **DEVIATION (registered, mutation-proof-tests rule 3 — the exact
+  `LotesRlsTests` precedent):** over `ways_app`, RLS alone already isolates
+  regardless of the EF tenant filter — mutating/removing
+  `AplicarFiltroDeTenantEnAuditoria` would NOT make an `ways_app`-based
+  isolation test fail (confound, not a real proof). Routed BELOW the
+  confound, same as `LotesRlsTests.CrearContextoDeOwner`: a dedicated test
+  runs `ServicioDeConsultaDeAuditoria.ConsultarAsync` over a
+  `WaysDbContext` built on the OWNER connection (`ways_owner`, bypasses
+  RLS) — the ONLY mechanism left able to isolate is the EF query filter
+  itself. **Evidence**: mutated (commented out
+  `AplicarFiltroDeTenantEnAuditoria(modelBuilder);` in
+  `WaysDbContext.OnModelCreating`) → `dotnet build --no-incremental` →
+  `--filter
+  FullyQualifiedName~ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls`
+  → FAILED (`Assert.DoesNotContain() Failure: Item found in set` — tenant
+  A's row leaked into tenant B's owner-connection session) → reverted →
+  green.
+- [x] 5.20 [P] Integration — tenant isolation over `ways_app`
   (`mutation-proof-tests` rule 5): row-count isolation, plus an Admin of
   tenant B never seeing tenant A's rows through the endpoint.
-- [ ] 5.21 Gate guard: `has-pending-model-changes` clean; zero new files in
-  `Migraciones/`.
+  `UnAdminDeOtroTenantNuncaVeFilasDelTenantAjenoATravesDelEndpoint` (HTTP,
+  full stack, `ways_app`) +
+  `ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls` (the
+  genuinely discriminating half, 5.19's evidence — see its DEVIATION note).
+- [x] 5.21 Gate guard: `has-pending-model-changes` clean; zero new files in
+  `Migraciones/`. **Confirmed**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made
+  to the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
 - [ ] 5.22 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  *(orchestrator — out of `sdd-apply`'s scope per the launch prompt)*
 - [ ] 5.23 Branch `feat/stage14-slice5-consulta` off `main` (parent:
-  slice 1); PR; merge stacked-to-main.
+  slice 1); PR; merge stacked-to-main. *(branch already exists — this
+  worktree runs on it, created off `main` at `5fe20f1` per the launch
+  prompt; PR creation/merge is orchestrator work)*
 
 **Test plan**: 6 mutation targets (5.5-5.8, 5.17, 5.19), per-filter tests
 ×6 (5.11-5.16), tied-pagination (5.9), actor visibility (5.10),
 authorization ×4 roles (5.18), tenant isolation (5.20).
 
-**Verify**: `dotnet test --filter FullyQualifiedName~Auditoria`
+**Verify**: `dotnet test --filter FullyQualifiedName~Auditoria` → **60/60
+green** (16 new `AuditoriaConsultaTests` + 4 new `PoliticasTests` theory
+cases + 40 pre-existing Auditoria-filtered tests from slices 1-4,
+unaffected).
 
 ---
 

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1310,9 +1310,9 @@ depends on it.
      Slice 6 will reuse it too.
   All four mutations verified: mutated → `dotnet build --no-incremental`
   → targeted test FAILED → reverted → green.
-- [ ] 5.22 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 5.22 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator — out of `sdd-apply`'s scope per the launch prompt)*
-- [ ] 5.23 Branch `feat/stage14-slice5-consulta` off `main` (parent:
+- [x] 5.23 Branch `feat/stage14-slice5-consulta` off `main` (parent: *(CLEAN 2026-08-16: juez B ronda 1 — 0 severos, 3 WARNINGs cerrados (borde hasta pinneado con fila AL instante; clamps de pagina/tamanio con 3 tests; contenido del payload asertado en ambos lados + null-ness) + sugerencia aplicada (CrearContextoDeOwner hoisteado a WaysApiFixture, 15 MapEnum verificados 1:1 contra produccion); re-ronda B aprobada con 3 re-mutantes muertos y el hoist re-verificado EN VIVO (drop del filtro EF de StockLote → solo el test owner falla); juez A fresh: CERO hallazgos — verifico la cadena de aprovisionamiento sin polucion de auditoria, la aritmetica del fixture de 8 filas filtro por filtro, y la politica Admin-only contra RolConocido. JUDGMENT: APPROVED.)*
   slice 1); PR; merge stacked-to-main. *(branch already exists — this
   worktree runs on it, created off `main` at `5fe20f1` per the launch
   prompt; PR creation/merge is orchestrator work)*

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1288,6 +1288,28 @@ depends on it.
   --startup-project src/Ways.Infrastructure` → "No changes have been made
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
+  **Judgment-day slice 5 (round 1, judge B — closed, 0 severos, 3
+  WARNINGs + 1 sugerencia):**
+  1. `Hasta`'s inclusive upper bound (`:90`) was unpinned — no seeded row
+     landed EXACTLY on the `hasta` instant, so `<=`→`<` survived 16/16.
+     `FiltroDeFechaDevuelveElSubconjuntoEsperado` now seeds a row exactly
+     at `hasta` and asserts it's included.
+  2. `Math.Clamp(tamanio, 1, 200)`/`Math.Max(pagina, 1)` (`:38-39`) had no
+     test at all — deleting the clamp survived. Added
+     `TamanioCeroSeTrataComoElMinimoUnaFila`,
+     `TamanioQuinientosSeTopeaEnDoscientos`,
+     `PaginaCeroSeTrataComoLaPrimera`.
+  3. The log's payload CONTENT was never asserted — projecting
+     `ValorAnterior` from `a.ValorNuevo` survived 16/16. Added
+     `ElContenidoDeAmbosPayloadsCoincideConLoSembradoYLaNullNessDeValorAnteriorSeRespeta`
+     (R2's real emitido→anulado content on both sides, R1's null
+     `ValorAnterior`).
+  4. Sugerencia: `LotesRlsTests`' 15-line owner-context `MapEnum` helper,
+     duplicated verbatim in `AuditoriaConsultaTests`, hoisted to
+     `WaysApiFixture.CrearContextoDeOwner` and reused by both files —
+     Slice 6 will reuse it too.
+  All four mutations verified: mutated → `dotnet build --no-incremental`
+  → targeted test FAILED → reverted → green.
 - [ ] 5.22 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator — out of `sdd-apply`'s scope per the launch prompt)*
 - [ ] 5.23 Branch `feat/stage14-slice5-consulta` off `main` (parent:

--- a/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
@@ -1,0 +1,32 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Auditoria;
+
+namespace Ways.Api.Endpoints;
+
+public static class AuditoriaEndpoints
+{
+    public static IEndpointRouteBuilder MapearAuditoria(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/auditoria")
+            .WithTags("Auditoria")
+            .RequireAuthorization(Politicas.LecturaDeAuditoria);
+
+        grupo.MapGet("/", (
+            ServicioDeConsultaDeAuditoria servicio,
+            DateTimeOffset? desde, DateTimeOffset? hasta, string? accion, int? idActor,
+            string? entidad, int? idEntidad, int? idPuntoVenta, int? pagina, int? tamanio,
+            CancellationToken ct) =>
+        {
+            var filtros = new FiltrosDeAuditoria(desde, hasta, accion, idActor, entidad, idEntidad, idPuntoVenta);
+            return servicio.ConsultarAsync(filtros, pagina ?? 1, tamanio ?? 25, ct);
+        })
+        .WithSummary(
+            "Log de auditoría filtrado y paginado — Admin-only (LecturaDeAuditoria), sin apilar " +
+            "sobre LecturaDeReportes: dentro de un tenant, un Admin ve filas de TODOS los puntos " +
+            "de venta (idPuntoVenta es un filtro, no un alcance). idEntidad exige entidad (400 " +
+            "entidad_requerida) — accion/entidad desconocidas no rechazan, devuelven 0 filas " +
+            "(design decisión 15: una acción retirada deja rastro consultable).");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -175,6 +175,7 @@ app.MapearGastos();
 app.MapearCuentaCorriente();
 app.MapearCompras();
 app.MapearReportes();
+app.MapearAuditoria();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -70,6 +70,14 @@ public static class Politicas
     /// <see cref="LecturaDeReportes"/> en <c>/rentabilidad</c> y <c>/comisiones</c>.</summary>
     public const string LecturaDeRentabilidad = "lectura_rentabilidad";
 
+    /// <summary>Solo admin — la puerta de <c>GET /api/auditoria</c> (y su export sibling)
+    /// (stage-14-auditoria-trazabilidad, Slice 5; spec auditoria-de-operaciones: "GET /api/auditoria
+    /// Is Filtered, Paginated, And Admin-Only"; design decisión 6). Misma forma exacta que
+    /// <see cref="LecturaDeRentabilidad"/>, pero SIN apilar sobre <see cref="LecturaDeReportes"/>
+    /// — el log de auditoría no es un reporte de gestión, es la puerta de un dato distinto.
+    /// Supervisor, Vendedor y Root quedan afuera.</summary>
+    public const string LecturaDeAuditoria = "lectura_auditoria";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -119,6 +127,9 @@ public static class Politicas
                             ((int)RolConocido.Supervisor).ToString(),
                             ((int)RolConocido.Admin).ToString()))
             .AddPolicy(LecturaDeRentabilidad, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(LecturaDeAuditoria, politica =>
                 politica.RequireAuthenticatedUser()
                         .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()));
     }

--- a/src/Ways.Application/Auditoria/Contratos.cs
+++ b/src/Ways.Application/Auditoria/Contratos.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+
+namespace Ways.Application.Auditoria;
+
+/// <summary>
+/// Los 7 filtros de <c>GET /api/auditoria</c> (design: Interfaces/Contracts, decisiones 12-16).
+/// <c>dto-contract-honesty</c>: cada campo se lee EXCLUSIVAMENTE dentro de
+/// <see cref="ServicioDeConsultaDeAuditoria.ConstruirQuery"/> — ningún filtro se acepta acá y se
+/// descarta en silencio. <see cref="IdEntidad"/> sin <see cref="Entidad"/> es un `400
+/// entidad_requerida` (design decisión 16): `id_entidad` es polimórfico, así que solo tiene
+/// sentido junto con la entidad que lo desambigua.
+/// </summary>
+public sealed record FiltrosDeAuditoria(
+    DateTimeOffset? Desde,
+    DateTimeOffset? Hasta,
+    string? Accion,
+    int? IdActor,
+    string? Entidad,
+    int? IdEntidad,
+    int? IdPuntoVenta);
+
+/// <summary>
+/// Una fila del log de auditoría tal como la ve la lectura (design decisiones 12/14).
+/// <see cref="Actor"/> <c>null</c> significa "el nombre no es visible para esta sesión" (un
+/// actor de plataforma, excluido por el filtro de tenant/RLS de <c>usuarios</c> bajo el LEFT
+/// JOIN) — NUNCA "sin actor": <see cref="IdActor"/> siempre viaja, la pantalla lo muestra como
+/// <c>#idActor</c>. <see cref="ValorAnterior"/>/<see cref="ValorNuevo"/> viajan como JSON crudo
+/// — el cliente decide cómo mostrarlos, esta capa no los reinterpreta.
+/// </summary>
+public sealed record FilaDeAuditoria(
+    long IdAuditoria,
+    DateTimeOffset CreadoEl,
+    string Accion,
+    string Entidad,
+    int IdEntidad,
+    int IdActor,
+    string? Actor,
+    int? IdPuntoVenta,
+    JsonElement? ValorAnterior,
+    JsonElement ValorNuevo);
+
+/// <summary>Página offset (design decisión 12: 7 precedentes de <c>PaginaDe*</c> en el repo, cero
+/// keyset) — <c>Total</c> es lo que habilita "Página N de M" en el pager web (Slice 7).</summary>
+public sealed record PaginaDeAuditoria(IReadOnlyList<FilaDeAuditoria> Items, int Total, int Pagina, int Tamanio);

--- a/src/Ways.Application/Auditoria/ServicioDeConsultaDeAuditoria.cs
+++ b/src/Ways.Application/Auditoria/ServicioDeConsultaDeAuditoria.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+
+namespace Ways.Application.Auditoria;
+
+/// <summary>
+/// El lado de lectura del log de auditoría (design decisiones 12-16). Un único
+/// <see cref="ConstruirQuery"/>, pensado para ser reusado tal cual por el sibling de export
+/// (Slice 6, <c>ConsultarParaExportacionAsync</c> — no declarado todavía en esta slice) —
+/// <c>accion</c>/<c>entidad</c> NO se validan contra el catálogo acá (design decisión 15): una
+/// acción retirada deja filas consultables, la base es la parte permisiva, la aplicación es la
+/// estricta solo en ESCRITURA.
+/// </summary>
+public sealed class ServicioDeConsultaDeAuditoria(IWaysDbContext db)
+{
+    /// <summary>Forma cruda de una fila mientras todavía es <c>IQueryable</c> — los dos payloads
+    /// viajan como <c>string?</c>/<c>string</c> (el shape de columna real, <c>jsonb</c> ya
+    /// serializado por <see cref="SerializadorDeAuditoria"/>) y se parsean a
+    /// <see cref="JsonElement"/> recién DESPUÉS de materializar (<see cref="Materializar"/>) — EF
+    /// no puede traducir <c>JsonSerializer.Deserialize</c> a SQL.</summary>
+    private sealed record FilaCrudaDeAuditoria(
+        long IdAuditoria,
+        DateTimeOffset CreadoEl,
+        string Accion,
+        string Entidad,
+        int IdEntidad,
+        int IdActor,
+        string? Actor,
+        int? IdPuntoVenta,
+        string? ValorAnterior,
+        string ValorNuevo);
+
+    public async Task<PaginaDeAuditoria> ConsultarAsync(
+        FiltrosDeAuditoria filtros, int pagina = 1, int tamanio = 25, CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = ConstruirQuery(filtros);
+
+        var total = await query.CountAsync(ct);
+
+        var crudas = await query
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .ToListAsync(ct);
+
+        var items = crudas.Select(Materializar).ToList();
+
+        return new PaginaDeAuditoria(items, total, pagina, tamanio);
+    }
+
+    private static FilaDeAuditoria Materializar(FilaCrudaDeAuditoria f) =>
+        new(
+            f.IdAuditoria, f.CreadoEl, f.Accion, f.Entidad, f.IdEntidad, f.IdActor, f.Actor, f.IdPuntoVenta,
+            f.ValorAnterior is null ? null : JsonSerializer.Deserialize<JsonElement>(f.ValorAnterior),
+            JsonSerializer.Deserialize<JsonElement>(f.ValorNuevo));
+
+    /// <summary>
+    /// Cláusulas bajo prueba (<c>mutation-proof-tests</c>), en orden de daño si se pierden:
+    ///   <c>idEntidad</c> sin <c>entidad</c>       → un filtro polimórfico sin desambiguar
+    ///                                                mezclaría articulo 7, usuario 7 y
+    ///                                                comprobante 7 en una sola respuesta
+    ///                                                (design decisión 16) — 400 antes de armar
+    ///                                                el query.
+    ///   LEFT JOIN sobre usuarios                  → un INNER JOIN borra del log las filas de
+    ///                                                un actor root o de un usuario dado de baja
+    ///                                                (design decisión 14).
+    ///   <c>IgnoreQueryFilters(["BajaLogica"])</c> → sin él, el nombre del actor eliminado
+    ///                                                desaparece.
+    ///   <c>ThenByDescending(a.Id)</c>              → sin él, con <c>creado_el</c> empatado
+    ///                                                (RelojFijo, o varias filas de la misma
+    ///                                                operación) la paginación duplica y saltea
+    ///                                                filas (design decisión 12).
+    ///   cada <c>if (filtro is { } x)</c>           → un filtro ignorado devuelve de más, en
+    ///                                                silencio.
+    /// </summary>
+    private IQueryable<FilaCrudaDeAuditoria> ConstruirQuery(FiltrosDeAuditoria f)
+    {
+        if (f.IdEntidad is not null && f.Entidad is null)
+        {
+            throw new ErrorDominio("entidad_requerida", "idEntidad requiere entidad.", 400);
+        }
+
+        var query =
+            from a in db.Auditoria
+            where (f.Desde == null || a.CreadoEl >= f.Desde)
+               && (f.Hasta == null || a.CreadoEl <= f.Hasta)
+               && (f.Accion == null || a.Accion == f.Accion)
+               && (f.IdActor == null || a.IdActor == f.IdActor)
+               && (f.Entidad == null || a.Entidad == f.Entidad)
+               && (f.IdEntidad == null || a.IdEntidad == f.IdEntidad)
+               && (f.IdPuntoVenta == null || a.IdPuntoVenta == f.IdPuntoVenta)
+            join u in db.Usuarios.IgnoreQueryFilters(["BajaLogica"]) on a.IdActor equals u.Id into actores
+            from u in actores.DefaultIfEmpty()
+            orderby a.CreadoEl descending, a.Id descending
+            select new FilaCrudaDeAuditoria(
+                a.Id, a.CreadoEl, a.Accion, a.Entidad, a.IdEntidad, a.IdActor,
+                u == null ? null : u.NombreUsuario, a.IdPuntoVenta, a.ValorAnterior, a.ValorNuevo);
+
+        return query;
+    }
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -29,6 +29,8 @@ public static class DependencyInjection
         // stage-14-auditoria-trazabilidad, Slice 1: el writer se registra completo desde esta
         // slice, aunque sin call sites todavía (slices 2-4 lo inyectan recién ahí).
         services.AddScoped<ServicioDeAuditoria>();
+        // stage-14-auditoria-trazabilidad, Slice 5: el lado de lectura — GET /api/auditoria.
+        services.AddScoped<ServicioDeConsultaDeAuditoria>();
 
         // AsignadorDeNumeroCliente (Ways.Application.Clientes) es estática, sin ciclo de
         // vida de DI que registrar — el IWaysDbContext llega por parámetro en cada llamada.

--- a/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
@@ -188,7 +188,12 @@ public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<Ways
             ctx.IdTenant, null, ctx.IdActorAdmin, "precio.cambio", "articulo", 41,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), null, "{\"monto\":100}");
         ids["R2"] = await SembrarFilaAsync(
-            ctx.IdTenant, ctx.IdPuntoVenta1, ctx.IdActorX, "venta.anulacion", "comprobante_venta", 501,
+            // idEntidad = 41 a propósito, COLISIONANDO con R1/R4/R5 (articulo 41) bajo una
+            // entidad distinta — sin esto, el clon entidad==null||... es indistinguible de
+            // idEntidad==null||... (mutation-proof-tests regla 3: sin la colisión, idEntidad=41
+            // ya identifica el mismo subconjunto por sí solo, así que mutar la cláusula de
+            // entidad no cambiaría nada observable).
+            ctx.IdTenant, ctx.IdPuntoVenta1, ctx.IdActorX, "venta.anulacion", "comprobante_venta", 41,
             new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero), "{\"estado\":\"emitido\"}", "{\"estado\":\"anulado\"}");
         ids["R3"] = await SembrarFilaAsync(
             ctx.IdTenant, ctx.IdPuntoVenta2, ctx.IdActorY, "compra.anulacion", "comprobante_compra", 601,

--- a/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
@@ -226,18 +226,26 @@ public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<Ways
 
     // ---- 5.11: desde/hasta ----------------------------------------------------------------------
 
+    /// <summary>Judgment-day fix (juez B, slice 5 ronda 1, WARNING): el borde superior inclusivo
+    /// de <c>Hasta</c> no estaba pinneado — ninguna fila caía EXACTAMENTE en el instante
+    /// <c>hasta</c>, así que <c>&lt;=</c>→<c>&lt;</c> sobrevivía. La fila agregada acá cae justo
+    /// en <c>hasta</c> y tiene que seguir contando.</summary>
     [Fact]
     public async Task FiltroDeFechaDevuelveElSubconjuntoEsperado()
     {
         var ctx = await PrepararAsync(nameof(FiltroDeFechaDevuelveElSubconjuntoEsperado));
         var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
 
+        var idFilaEnElBordeHasta = await SembrarFilaAsync(
+            ctx.IdTenant, null, ctx.IdActorAdmin, "precio.cambio", "articulo", 999,
+            new DateTimeOffset(2026, 5, 31, 0, 0, 0, TimeSpan.Zero), null, "{\"monto\":999}");
+
         var pagina = await ConsultarAsync(
             ctx.Admin, "?desde=2026-03-01T00:00:00Z&hasta=2026-05-31T00:00:00Z&tamanio=50");
 
-        Assert.Equal(3, pagina.Total);
+        Assert.Equal(4, pagina.Total);
         var idsDevueltos = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
-        Assert.Equal(new HashSet<long> { ids["R3"], ids["R4"], ids["R5"] }, idsDevueltos);
+        Assert.Equal(new HashSet<long> { ids["R3"], ids["R4"], ids["R5"], idFilaEnElBordeHasta }, idsDevueltos);
     }
 
     // ---- 5.12: accion -----------------------------------------------------------------------------
@@ -360,6 +368,81 @@ public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
         var cuerpo = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("entidad_requerida", cuerpo.GetProperty("codigo").GetString());
+    }
+
+    // ---- contenido de los payloads (Judgment-day, juez B, slice 5 ronda 1, WARNING) --------------
+
+    /// <summary>Mutation target (slice 5, juez B ronda 1, WARNING): el contenido de
+    /// <c>ValorAnterior</c>/<c>ValorNuevo</c> nunca se comparaba contra lo sembrado — proyectar
+    /// <c>ValorAnterior</c> desde <c>a.ValorNuevo</c> sobrevivía 16/16. R2 (estado
+    /// emitido→anulado) discrimina el contenido REAL de ambos payloads; R1 (<c>ValorAnterior</c>
+    /// null) discrimina la null-ness.</summary>
+    [Fact]
+    public async Task ElContenidoDeAmbosPayloadsCoincideConLoSembradoYLaNullNessDeValorAnteriorSeRespeta()
+    {
+        var ctx = await PrepararAsync(nameof(ElContenidoDeAmbosPayloadsCoincideConLoSembradoYLaNullNessDeValorAnteriorSeRespeta));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?tamanio=50");
+
+        var filaR2 = pagina.Items.Single(f => f.IdAuditoria == ids["R2"]);
+        Assert.Equal("emitido", filaR2.ValorAnterior!.Value.GetProperty("estado").GetString());
+        Assert.Equal("anulado", filaR2.ValorNuevo.GetProperty("estado").GetString());
+
+        var filaR1 = pagina.Items.Single(f => f.IdAuditoria == ids["R1"]);
+        Assert.Null(filaR1.ValorAnterior);
+        Assert.Equal(100, filaR1.ValorNuevo.GetProperty("monto").GetInt32());
+    }
+
+    // ---- clamp de pagina/tamanio (Judgment-day, juez B, slice 5 ronda 1, WARNING) -----------------
+
+    /// <summary>Mutation target (slice 5, juez B ronda 1, WARNING): <c>Math.Clamp(tamanio, 1,
+    /// 200)</c> sin ningún test — borrar el clamp sobrevivía (<c>tamanio=0</c> se traduciría en
+    /// <c>Take(0)</c>, cero filas, en vez de la mínima página de 1).</summary>
+    [Fact]
+    public async Task TamanioCeroSeTrataComoElMinimoUnaFila()
+    {
+        var ctx = await PrepararAsync(nameof(TamanioCeroSeTrataComoElMinimoUnaFila));
+        await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?tamanio=0");
+
+        Assert.Equal(8, pagina.Total);
+        Assert.Equal(1, pagina.Tamanio);
+        Assert.Single(pagina.Items);
+    }
+
+    /// <summary>Mutation target (slice 5, juez B ronda 1, WARNING): mismo <c>Math.Clamp</c>, borde
+    /// superior — sin el clamp, <c>tamanio=500</c> viajaría tal cual en vez de topearse en
+    /// 200.</summary>
+    [Fact]
+    public async Task TamanioQuinientosSeTopeaEnDoscientos()
+    {
+        var ctx = await PrepararAsync(nameof(TamanioQuinientosSeTopeaEnDoscientos));
+        await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?tamanio=500");
+
+        Assert.Equal(200, pagina.Tamanio);
+    }
+
+    /// <summary>Mutation target (slice 5, juez B ronda 1, WARNING): <c>Math.Max(pagina, 1)</c> sin
+    /// ningún test — borrar el clamp sobrevivía. <c>pagina=0</c> tiene que tratarse igual que
+    /// <c>pagina=1</c>.</summary>
+    [Fact]
+    public async Task PaginaCeroSeTrataComoLaPrimera()
+    {
+        var ctx = await PrepararAsync(nameof(PaginaCeroSeTrataComoLaPrimera));
+        await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var paginaConCero = await ConsultarAsync(ctx.Admin, "?tamanio=50&pagina=0");
+        var paginaConUno = await ConsultarAsync(ctx.Admin, "?tamanio=50&pagina=1");
+
+        Assert.Equal(1, paginaConCero.Pagina);
+        Assert.Equal(8, paginaConCero.Total);
+        Assert.Equal(
+            paginaConUno.Items.Select(f => f.IdAuditoria).ToList(),
+            paginaConCero.Items.Select(f => f.IdAuditoria).ToList());
     }
 
     // ---- 5.5/5.9: tiebreaker id_auditoria DESC bajo creado_el empatado ---------------------------
@@ -528,7 +611,7 @@ public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<Ways
             ctxB.IdTenant, null, ctxB.IdActorAdmin, "precio.cambio", "articulo", 42,
             MomentoFijo, null, "{\"monto\":200}");
 
-        await using var sesionOwnerDeB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, ctxB.IdTenant));
+        await using var sesionOwnerDeB = fixture.CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, ctxB.IdTenant));
         var servicio = new ServicioDeConsultaDeAuditoria(sesionOwnerDeB);
 
         var pagina = await servicio.ConsultarAsync(
@@ -537,36 +620,5 @@ public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<Ways
         var idsVisibles = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
         Assert.DoesNotContain(idFilaA, idsVisibles);
         Assert.Contains(idFilaB, idsVisibles);
-    }
-
-    /// <summary>Mismo criterio que <c>LotesRlsTests.CrearContextoDeOwner</c>: un
-    /// <see cref="WaysDbContext"/> sobre <c>ways_owner</c> (bypassea RLS) para que la prueba de
-    /// arriba pruebe genuinamente el query filter de EF, no la política RLS (ya cubierta por
-    /// <c>AuditoriaEscrituraTests</c>, Slice 1).</summary>
-    private WaysDbContext CrearContextoDeOwner(ITenantActual tenantActual)
-    {
-        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
-            .UseNpgsql(fixture.OwnerConnectionString, npgsql =>
-            {
-                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
-                npgsql.MapEnum<EstadoTenant>("estado_tenant");
-                npgsql.MapEnum<Domain.Catalogos.ComportamientoMedioPago>("comportamiento_medio_pago");
-                npgsql.MapEnum<Domain.Catalogos.ClaseComprobante>("clase_comprobante");
-                npgsql.MapEnum<Domain.Clientes.TipoDocumento>("tipo_documento");
-                npgsql.MapEnum<Domain.Catalogos.ModoLista>("modo_lista");
-                npgsql.MapEnum<Domain.Articulos.UnidadVenta>("unidad_venta");
-                npgsql.MapEnum<Domain.Ventas.EstadoComprobante>("estado_comprobante");
-                npgsql.MapEnum<Domain.Stock.MotivoStock>("motivo_stock");
-                npgsql.MapEnum<Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
-                npgsql.MapEnum<Domain.Caja.EstadoTurno>("estado_turno");
-                npgsql.MapEnum<Domain.Caja.TipoMovimientoCaja>("tipo_movimiento_caja");
-                npgsql.MapEnum<Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
-                npgsql.MapEnum<Domain.Gastos.CategoriaGasto>("categoria_gasto");
-                npgsql.MapEnum<Domain.Compras.EstadoCompra>("estado_compra");
-            })
-            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
-            .Options;
-
-        return new WaysDbContext(opciones, tenantActual);
     }
 }

--- a/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaConsultaTests.cs
@@ -1,0 +1,567 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Auditoria;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 5 (tasks 5.5-5.20): el lado de lectura —
+/// <c>GET /api/auditoria</c> — contra Postgres real. Las filas de <c>auditoria</c> se siembran
+/// DIRECTO por <c>db.Auditoria.Add</c> (design: "5 needs only 1 — the table and the writer's
+/// read-side symmetry, not any call site — its integration tests seed auditoria rows directly"),
+/// nunca vía los servicios de negocio de las slices 2-4: esta slice prueba el filtro/paginado/
+/// autorización, no la escritura (ya cubierta en <c>AuditoriaEscrituraTests</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AuditoriaConsultaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string MailRoot = "test@test.com";
+    private const string PasswordRoot = "root";
+    private const string PasswordUsuario = "una-contraseña-larga";
+    private static readonly DateTimeOffset MomentoFijo = new(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta1, int IdPuntoVenta2,
+        int IdActorAdmin, int IdActorX, int IdActorY,
+        HttpClient Admin, HttpClient Root);
+
+    private sealed record FilaRespuesta(
+        long IdAuditoria, DateTimeOffset CreadoEl, string Accion, string Entidad, int IdEntidad,
+        int IdActor, string? Actor, int? IdPuntoVenta, JsonElement? ValorAnterior, JsonElement ValorNuevo);
+
+    private sealed record PaginaRespuesta(List<FilaRespuesta> Items, int Total, int Pagina, int Tamanio);
+
+    // ---- provisioning -------------------------------------------------------------------------
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        // idActorX/idActorY se siembran DIRECTO por DB (no vía POST /api/usuarios): un alta real
+        // dispararía su propia fila usuario.alta auditada (slice 2, ya mergeada) y contaminaría
+        // los conteos exactos que esta slice verifica. Lo mismo aplica a Supervisor/Vendedor — se
+        // crean vía HTTP SOLO en los tests de autorización que los necesitan (5.17/5.18), nunca acá.
+        var idActorX = await SembrarUsuarioAsync(resultado.IdTenant, $"{nombre}-x", $"{nombre}-x@ways.test".ToLowerInvariant());
+        var idActorY = await SembrarUsuarioAsync(resultado.IdTenant, $"{nombre}-y", $"{nombre}-y@ways.test".ToLowerInvariant());
+
+        var idPuntoVenta2 = await SembrarSegundoPuntoVentaAsync(resultado.IdTenant, resultado.IdEmpresa, nombre);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, idPuntoVenta2,
+            resultado.IdUsuarioAdmin, idActorX, idActorY,
+            admin, root);
+    }
+
+    /// <summary>Usado SOLO por los tests de autorización (5.17/5.18): un alta real vía HTTP
+    /// dispara su propia fila <c>usuario.alta</c> auditada — evitarlo en <see cref="PrepararAsync"/>
+    /// es lo que mantiene los conteos exactos del resto de los tests sin ruido.</summary>
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<int> SembrarSegundoPuntoVentaAsync(int idTenant, int idEmpresa, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, idTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = idTenant, IdEmpresa = idEmpresa, Nombre = $"{nombre}-pv2", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return puntoVenta.Id;
+    }
+
+    private async Task<int> SembrarUsuarioAsync(
+        int? idTenant, string usuario, string mail, RolConocido rol = RolConocido.Vendedor, DateTimeOffset? deletedAt = null)
+    {
+        var tenantActual = idTenant is int id
+            ? new TenantActualFijo(ModoDeAcceso.Tenant, id)
+            : TenantActualFijo.Plataforma;
+
+        await using var db = fixture.CrearContextoDeAplicacion(tenantActual);
+        var hasheador = new HasheadorPbkdf2();
+        var ahora = DateTimeOffset.UtcNow;
+
+        var entidad = new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = usuario,
+            Mail = mail,
+            RolId = (int)rol,
+            Estado = EstadoUsuario.Activo,
+            PasswordHash = hasheador.Hashear(PasswordUsuario),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora,
+            DeletedAt = deletedAt
+        };
+        db.Usuarios.Add(entidad);
+        await db.SaveChangesAsync();
+
+        return entidad.Id;
+    }
+
+    /// <summary>El id de un usuario existente de plataforma (root) — el actor de plataforma que
+    /// ejercita el escenario "root leído por un Admin de tenant" (task 5.10).</summary>
+    private async Task<int> ObtenerIdDeUsuarioRootAsync()
+    {
+        using var _ = fixture.CreateClient(); // arranca el host (siembra root)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        return await db.Usuarios.Where(u => u.Mail == MailRoot).Select(u => u.Id).FirstAsync();
+    }
+
+    private async Task<long> SembrarFilaAsync(
+        int idTenant, int? idPuntoVenta, int idActor, string accion, string entidad, int idEntidad,
+        DateTimeOffset creadoEl, string? valorAnterior, string valorNuevo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var fila = new Domain.Auditoria.Auditoria
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = idPuntoVenta,
+            IdActor = idActor,
+            Accion = accion,
+            Entidad = entidad,
+            IdEntidad = idEntidad,
+            ValorAnterior = valorAnterior,
+            ValorNuevo = valorNuevo,
+            CreadoEl = creadoEl
+        };
+        db.Auditoria.Add(fila);
+        await db.SaveChangesAsync();
+
+        return fila.Id;
+    }
+
+    /// <summary>
+    /// Escenario de filtros (tasks 5.11-5.16, 5.18): 8 filas, TODAS con fecha, acción, actor,
+    /// entidad/id_entidad y PV distintos entre sí (<c>mutation-proof-tests</c> regla 6) — así
+    /// ningún filtro puede devolver "de más" sin que el test lo note. Coincide con el escenario
+    /// del spec (auditoria-de-operaciones: "Filtering by entidad + id_entidad..."): exactamente 3
+    /// filas de articulo 41 (R1, R4, R5) y 2 de articulo 42 (R6, R7).
+    /// </summary>
+    private async Task<Dictionary<string, long>> SembrarEscenarioDeFiltrosAsync(Contexto ctx)
+    {
+        var ids = new Dictionary<string, long>();
+
+        ids["R1"] = await SembrarFilaAsync(
+            ctx.IdTenant, null, ctx.IdActorAdmin, "precio.cambio", "articulo", 41,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), null, "{\"monto\":100}");
+        ids["R2"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta1, ctx.IdActorX, "venta.anulacion", "comprobante_venta", 501,
+            new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero), "{\"estado\":\"emitido\"}", "{\"estado\":\"anulado\"}");
+        ids["R3"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta2, ctx.IdActorY, "compra.anulacion", "comprobante_compra", 601,
+            new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero), "{\"estado\":\"confirmada\"}", "{\"estado\":\"anulada\"}");
+        ids["R4"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta1, ctx.IdActorX, "stock.ajuste", "articulo", 41,
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero), "{\"cantidad\":5}", "{\"cantidad\":8}");
+        ids["R5"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta2, ctx.IdActorY, "stock.decomiso", "articulo", 41,
+            new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero), "{\"cantidad\":8}", "{\"cantidad\":6}");
+        ids["R6"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta1, ctx.IdActorAdmin, "stock.ajuste", "articulo", 42,
+            new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero), "{\"cantidad\":1}", "{\"cantidad\":3}");
+        ids["R7"] = await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta2, ctx.IdActorX, "stock.conteo", "articulo", 42,
+            new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero), "{\"cantidad\":3}", "{\"cantidad\":3,\"movimientos_generados\":[]}");
+        ids["R8"] = await SembrarFilaAsync(
+            ctx.IdTenant, null, ctx.IdActorAdmin, "usuario.actualizacion", "usuario", 999,
+            new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero), "{\"estado\":\"activo\"}", "{\"estado\":\"bloqueado\"}");
+
+        return ids;
+    }
+
+    private static async Task<PaginaRespuesta> ConsultarAsync(HttpClient cliente, string queryString)
+    {
+        var respuesta = await cliente.GetAsync($"/api/auditoria{queryString}");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        return (await respuesta.Content.ReadFromJsonAsync<PaginaRespuesta>())!;
+    }
+
+    // ---- 5.11: desde/hasta ----------------------------------------------------------------------
+
+    [Fact]
+    public async Task FiltroDeFechaDevuelveElSubconjuntoEsperado()
+    {
+        var ctx = await PrepararAsync(nameof(FiltroDeFechaDevuelveElSubconjuntoEsperado));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(
+            ctx.Admin, "?desde=2026-03-01T00:00:00Z&hasta=2026-05-31T00:00:00Z&tamanio=50");
+
+        Assert.Equal(3, pagina.Total);
+        var idsDevueltos = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
+        Assert.Equal(new HashSet<long> { ids["R3"], ids["R4"], ids["R5"] }, idsDevueltos);
+    }
+
+    // ---- 5.12: accion -----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task FiltroDeAccionDevuelveElSubconjuntoEsperado()
+    {
+        var ctx = await PrepararAsync(nameof(FiltroDeAccionDevuelveElSubconjuntoEsperado));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?accion=stock.ajuste&tamanio=50");
+
+        Assert.Equal(2, pagina.Total);
+        var idsDevueltos = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
+        Assert.Equal(new HashSet<long> { ids["R4"], ids["R6"] }, idsDevueltos);
+    }
+
+    [Fact]
+    public async Task UnaAccionDesconocidaDevuelve200ConCeroFilas()
+    {
+        var ctx = await PrepararAsync(nameof(UnaAccionDesconocidaDevuelve200ConCeroFilas));
+        await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?accion=accion.retirada.no.existe&tamanio=50");
+
+        Assert.Equal(0, pagina.Total);
+        Assert.Empty(pagina.Items);
+    }
+
+    // ---- 5.13: idActor ------------------------------------------------------------------------
+
+    [Fact]
+    public async Task FiltroDeActorDevuelveElSubconjuntoEsperado()
+    {
+        var ctx = await PrepararAsync(nameof(FiltroDeActorDevuelveElSubconjuntoEsperado));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, $"?idActor={ctx.IdActorX}&tamanio=50");
+
+        Assert.Equal(3, pagina.Total);
+        var idsDevueltos = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
+        Assert.Equal(new HashSet<long> { ids["R2"], ids["R4"], ids["R7"] }, idsDevueltos);
+    }
+
+    // ---- 5.14: entidad + idEntidad --------------------------------------------------------------
+
+    [Fact]
+    public async Task FiltroDeEntidadMasIdEntidadDevuelveSoloLaHistoriaDeEseAgregado()
+    {
+        var ctx = await PrepararAsync(nameof(FiltroDeEntidadMasIdEntidadDevuelveSoloLaHistoriaDeEseAgregado));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina41 = await ConsultarAsync(ctx.Admin, "?entidad=articulo&idEntidad=41&tamanio=50");
+        Assert.Equal(3, pagina41.Total);
+        Assert.Equal(
+            new HashSet<long> { ids["R1"], ids["R4"], ids["R5"] },
+            pagina41.Items.Select(f => f.IdAuditoria).ToHashSet());
+
+        var pagina42 = await ConsultarAsync(ctx.Admin, "?entidad=articulo&idEntidad=42&tamanio=50");
+        Assert.Equal(2, pagina42.Total);
+        Assert.Equal(
+            new HashSet<long> { ids["R6"], ids["R7"] },
+            pagina42.Items.Select(f => f.IdAuditoria).ToHashSet());
+    }
+
+    // ---- 5.15/5.18: idPuntoVenta + "todos" (Admin cross-PV) --------------------------------------
+
+    [Fact]
+    public async Task FiltroDePuntoDeVentaDevuelveElSubconjuntoEsperado()
+    {
+        var ctx = await PrepararAsync(nameof(FiltroDePuntoDeVentaDevuelveElSubconjuntoEsperado));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var paginaPv1 = await ConsultarAsync(ctx.Admin, $"?idPuntoVenta={ctx.IdPuntoVenta1}&tamanio=50");
+        Assert.Equal(3, paginaPv1.Total);
+        Assert.Equal(
+            new HashSet<long> { ids["R2"], ids["R4"], ids["R6"] },
+            paginaPv1.Items.Select(f => f.IdAuditoria).ToHashSet());
+
+        var paginaPv2 = await ConsultarAsync(ctx.Admin, $"?idPuntoVenta={ctx.IdPuntoVenta2}&tamanio=50");
+        Assert.Equal(3, paginaPv2.Total);
+        Assert.Equal(
+            new HashSet<long> { ids["R3"], ids["R5"], ids["R7"] },
+            paginaPv2.Items.Select(f => f.IdAuditoria).ToHashSet());
+    }
+
+    /// <summary>Spec "Tenant-wide rows appear under 'todos' punto de venta" y "Admin reads across
+    /// every punto de venta of the tenant" (task 5.18): sin <c>idPuntoVenta</c>, la respuesta
+    /// incluye las 8 filas — las tenant-wide (<c>id_punto_venta IS NULL</c>, R1/R8) Y las de AMBOS
+    /// puntos de venta (R2/R4/R6 de PV1, R3/R5/R7 de PV2) en la MISMA respuesta.</summary>
+    [Fact]
+    public async Task SinFiltroDePuntoDeVentaTodosIncluyeLasTenantWideYAmbosPuntosDeVenta()
+    {
+        var ctx = await PrepararAsync(nameof(SinFiltroDePuntoDeVentaTodosIncluyeLasTenantWideYAmbosPuntosDeVenta));
+        var ids = await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?tamanio=50");
+
+        Assert.Equal(8, pagina.Total);
+        var idsDevueltos = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
+        Assert.Equal(ids.Values.ToHashSet(), idsDevueltos);
+
+        // Tenant-wide (PV NULL) presente entre las devueltas.
+        Assert.Contains(pagina.Items, f => f.IdAuditoria == ids["R1"] && f.IdPuntoVenta is null);
+        // Ambos puntos de venta presentes en la MISMA respuesta.
+        Assert.Contains(pagina.Items, f => f.IdAuditoria == ids["R2"] && f.IdPuntoVenta == ctx.IdPuntoVenta1);
+        Assert.Contains(pagina.Items, f => f.IdAuditoria == ids["R3"] && f.IdPuntoVenta == ctx.IdPuntoVenta2);
+    }
+
+    // ---- 5.16: idEntidad sin entidad → 400 -------------------------------------------------------
+
+    /// <summary>Mutation target (slice 5, row 4 — validación 400): design decisión 16.</summary>
+    [Fact]
+    public async Task IdEntidadSinEntidadRechazaCon400EntidadRequerida()
+    {
+        var ctx = await PrepararAsync(nameof(IdEntidadSinEntidadRechazaCon400EntidadRequerida));
+
+        var respuesta = await ctx.Admin.GetAsync("/api/auditoria?idEntidad=41");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var cuerpo = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("entidad_requerida", cuerpo.GetProperty("codigo").GetString());
+    }
+
+    // ---- 5.5/5.9: tiebreaker id_auditoria DESC bajo creado_el empatado ---------------------------
+
+    /// <summary>Mutation target (slice 5, row 1): <c>ThenByDescending(a.Id)</c>. Todas las filas
+    /// comparten el MISMO <c>creado_el</c> (RelojFijo, decisión 12: "under RelojFijo an entire
+    /// fixture ties") — el orden esperado, por diseño, es EXACTAMENTE descendente por id, nunca
+    /// solo "sin duplicar ni saltear" (design Testing Strategy: "orden como secuencia, no como
+    /// conjunto"; <c>mutation-proof-tests</c> regla 6). Sin el tiebreaker, Postgres no está
+    /// obligado a devolver los empates en ese orden entre dos SELECTs con OFFSET distintos.</summary>
+    [Fact]
+    public async Task PaginacionConCreadoElEmpatadoNoRepiteNiSalteaYRespetaElOrdenDescendentePorId()
+    {
+        var ctx = await PrepararAsync(nameof(PaginacionConCreadoElEmpatadoNoRepiteNiSalteaYRespetaElOrdenDescendentePorId));
+
+        var idsEnOrdenDeInsercion = new List<long>();
+        for (var i = 0; i < 5; i++)
+        {
+            var id = await SembrarFilaAsync(
+                ctx.IdTenant, null, ctx.IdActorAdmin, "precio.cambio", "articulo", 100 + i,
+                MomentoFijo, null, $"{{\"monto\":{100 + i}}}");
+            idsEnOrdenDeInsercion.Add(id);
+        }
+
+        var esperadoDescendente = idsEnOrdenDeInsercion.OrderByDescending(x => x).ToList();
+
+        var pagina1 = await ConsultarAsync(ctx.Admin, "?tamanio=2&pagina=1");
+        var pagina2 = await ConsultarAsync(ctx.Admin, "?tamanio=2&pagina=2");
+        var pagina3 = await ConsultarAsync(ctx.Admin, "?tamanio=2&pagina=3");
+
+        Assert.Equal(5, pagina1.Total);
+        var secuenciaCompleta = pagina1.Items.Select(f => f.IdAuditoria)
+            .Concat(pagina2.Items.Select(f => f.IdAuditoria))
+            .Concat(pagina3.Items.Select(f => f.IdAuditoria))
+            .ToList();
+
+        Assert.Equal(esperadoDescendente, secuenciaCompleta);
+    }
+
+    // ---- 5.6/5.7/5.10: visibilidad del actor -----------------------------------------------------
+
+    /// <summary>Mutation targets (slice 5, rows 2 y 3): <c>DefaultIfEmpty()</c> (LEFT JOIN) e
+    /// <c>IgnoreQueryFilters(["BajaLogica"])</c> — un actor root (invisible por el filtro de
+    /// tenant/RLS propio de <c>usuarios</c>) y un actor dado de baja (invisible por
+    /// <c>BajaLogica</c> si no se lo ignora) son los dos casos que un INNER JOIN o un filtro sin
+    /// ignorar borrarían del log — justo las dos filas que un auditor más necesita leer (design
+    /// decisión 14).</summary>
+    [Fact]
+    public async Task UnActorSoftDeletedSigueMostrandoElNombreYUnActorRootApareceConActorNuloEIdActorPresente()
+    {
+        var ctx = await PrepararAsync(nameof(UnActorSoftDeletedSigueMostrandoElNombreYUnActorRootApareceConActorNuloEIdActorPresente));
+
+        var idActorBaja = await SembrarUsuarioAsync(
+            ctx.IdTenant, "vendedor-de-baja", "de-baja@ways.test", deletedAt: DateTimeOffset.UtcNow);
+        var idActorRoot = await ObtenerIdDeUsuarioRootAsync();
+
+        var idFilaBaja = await SembrarFilaAsync(
+            ctx.IdTenant, null, idActorBaja, "usuario.password", "usuario", 777,
+            MomentoFijo, null, "{\"por_el_propio_usuario\":true}");
+        var idFilaRoot = await SembrarFilaAsync(
+            ctx.IdTenant, null, idActorRoot, "usuario.actualizacion", "usuario", 778,
+            MomentoFijo, "{\"estado\":\"activo\"}", "{\"estado\":\"bloqueado\"}");
+
+        var pagina = await ConsultarAsync(ctx.Admin, "?tamanio=50");
+
+        var filaBaja = pagina.Items.Single(f => f.IdAuditoria == idFilaBaja);
+        Assert.Equal("vendedor-de-baja", filaBaja.Actor);
+
+        var filaRoot = pagina.Items.Single(f => f.IdAuditoria == idFilaRoot);
+        Assert.Null(filaRoot.Actor);
+        Assert.Equal(idActorRoot, filaRoot.IdActor);
+    }
+
+    // ---- 5.17/5.18: autorización ------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnSupervisorEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazado));
+        var supervisor = await CrearYLoguearAsync(ctx.Admin, nameof(UnSupervisorEsRechazado), "supervisor", RolConocido.Supervisor);
+
+        var respuesta = await supervisor.GetAsync("/api/auditoria");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazado));
+        var vendedor = await CrearYLoguearAsync(ctx.Admin, nameof(UnVendedorEsRechazado), "vendedor", RolConocido.Vendedor);
+
+        var respuesta = await vendedor.GetAsync("/api/auditoria");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazado));
+
+        var respuesta = await ctx.Root.GetAsync("/api/auditoria");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptado));
+        await SembrarEscenarioDeFiltrosAsync(ctx);
+
+        var respuesta = await ctx.Admin.GetAsync("/api/auditoria?tamanio=50");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var pagina = await respuesta.Content.ReadFromJsonAsync<PaginaRespuesta>();
+        Assert.Equal(8, pagina!.Total);
+    }
+
+    // ---- 5.19/5.20: aislamiento de tenant -----------------------------------------------------
+
+    /// <summary>Mitad HTTP (task 5.20): un Admin del tenant B nunca ve las filas del tenant A a
+    /// través del endpoint completo (EF filter + RLS + policy, la pila real).</summary>
+    [Fact]
+    public async Task UnAdminDeOtroTenantNuncaVeFilasDelTenantAjenoATravesDelEndpoint()
+    {
+        var ctxA = await PrepararAsync(nameof(UnAdminDeOtroTenantNuncaVeFilasDelTenantAjenoATravesDelEndpoint) + "-A");
+        await SembrarEscenarioDeFiltrosAsync(ctxA);
+
+        var ctxB = await PrepararAsync(nameof(UnAdminDeOtroTenantNuncaVeFilasDelTenantAjenoATravesDelEndpoint) + "-B");
+
+        var paginaB = await ConsultarAsync(ctxB.Admin, "?tamanio=50");
+
+        Assert.Equal(0, paginaB.Total);
+        Assert.Empty(paginaB.Items);
+    }
+
+    /// <summary>
+    /// Mutation target (slice 5, row 6): el filtro de tenant/RLS de la consulta. Sobre
+    /// <c>ways_app</c> (usado por el test de arriba), RLS por sí sola ya aísla — mutar/quitar el
+    /// filtro de EF de <c>ConstruirQuery</c> no haría fallar ese test (confound documentado en
+    /// <c>mutation-proof-tests</c> regla 3, mismo defecto que <c>LotesRlsTests</c> ya resolvió
+    /// para <c>lotes</c>/<c>stock_lotes</c>). Este test corre <see cref="ServicioDeConsultaDeAuditoria"/>
+    /// sobre una conexión DUEÑA de las tablas (<c>ways_owner</c>, bypassea RLS) — así el ÚNICO
+    /// mecanismo que puede aislar es el query filter de EF que <see cref="ServicioDeConsultaDeAuditoria.ConstruirQuery"/>
+    /// hereda de <c>db.Auditoria</c> (<c>WaysDbContext.AplicarFiltroDeTenantEnAuditoria</c>,
+    /// Slice 1) — genuinamente discriminante.
+    ///
+    /// Evidencia de mutación: comentando <c>AplicarFiltroDeTenantEnAuditoria(modelBuilder);</c> en
+    /// <c>WaysDbContext.AplicarFiltrosDeTenant</c> y corriendo
+    /// <c>--filter "FullyQualifiedName~ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls"</c>,
+    /// este test FALLÓ (<c>visibleAjena</c> pasó a <c>true</c> — la fila del tenant A quedó
+    /// visible para la sesión del tenant B) — revertida la mutación, vuelve a estar verde.
+    /// </summary>
+    [Fact]
+    public async Task ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls()
+    {
+        var ctxA = await PrepararAsync(nameof(ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls) + "-A");
+        var idFilaA = await SembrarFilaAsync(
+            ctxA.IdTenant, null, ctxA.IdActorAdmin, "precio.cambio", "articulo", 41,
+            MomentoFijo, null, "{\"monto\":100}");
+
+        var ctxB = await PrepararAsync(nameof(ElFiltroDeTenantDeLaConsultaAislaAunSobreUnaConexionQueBypaseaRls) + "-B");
+        var idFilaB = await SembrarFilaAsync(
+            ctxB.IdTenant, null, ctxB.IdActorAdmin, "precio.cambio", "articulo", 42,
+            MomentoFijo, null, "{\"monto\":200}");
+
+        await using var sesionOwnerDeB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, ctxB.IdTenant));
+        var servicio = new ServicioDeConsultaDeAuditoria(sesionOwnerDeB);
+
+        var pagina = await servicio.ConsultarAsync(
+            new FiltrosDeAuditoria(null, null, null, null, null, null, null), pagina: 1, tamanio: 50, CancellationToken.None);
+
+        var idsVisibles = pagina.Items.Select(f => f.IdAuditoria).ToHashSet();
+        Assert.DoesNotContain(idFilaA, idsVisibles);
+        Assert.Contains(idFilaB, idsVisibles);
+    }
+
+    /// <summary>Mismo criterio que <c>LotesRlsTests.CrearContextoDeOwner</c>: un
+    /// <see cref="WaysDbContext"/> sobre <c>ways_owner</c> (bypassea RLS) para que la prueba de
+    /// arriba pruebe genuinamente el query filter de EF, no la política RLS (ya cubierta por
+    /// <c>AuditoriaEscrituraTests</c>, Slice 1).</summary>
+    private WaysDbContext CrearContextoDeOwner(ITenantActual tenantActual)
+    {
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.OwnerConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<Domain.Catalogos.ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<Domain.Catalogos.ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<Domain.Catalogos.ModoLista>("modo_lista");
+                npgsql.MapEnum<Domain.Articulos.UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<Domain.Ventas.EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Domain.Caja.TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<Domain.Gastos.CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<Domain.Compras.EstadoCompra>("estado_compra");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        return new WaysDbContext(opciones, tenantActual);
+    }
+}

--- a/tests/Ways.IntegrationTests/LotesRlsTests.cs
+++ b/tests/Ways.IntegrationTests/LotesRlsTests.cs
@@ -31,39 +31,6 @@ public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtur
 {
     private sealed record Escenario(int IdTenant, int IdArticulo, int IdPuntoVenta, int IdLote);
 
-    /// <summary>Judgment-day fix (juez B, MAJOR): un <see cref="WaysDbContext"/> sobre
-    /// <c>ways_owner</c> (bypassea RLS) para que las dos pruebas de "el filtro de EF nunca
-    /// devuelve filas ajenas" prueben genuinamente el query filter — sobre <c>ways_app</c>
-    /// RLS filtra igual aunque el filtro de EF no exista, así esas pruebas no distinguían
-    /// nada (comprobado comentando <c>SetQueryFilter</c> y viendo los 8 tests pasar
-    /// igual).</summary>
-    private WaysDbContext CrearContextoDeOwner(ITenantActual tenantActual)
-    {
-        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
-            .UseNpgsql(fixture.OwnerConnectionString, npgsql =>
-            {
-                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
-                npgsql.MapEnum<EstadoTenant>("estado_tenant");
-                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
-                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
-                npgsql.MapEnum<TipoDocumento>("tipo_documento");
-                npgsql.MapEnum<ModoLista>("modo_lista");
-                npgsql.MapEnum<UnidadVenta>("unidad_venta");
-                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
-                npgsql.MapEnum<MotivoStock>("motivo_stock");
-                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
-                npgsql.MapEnum<EstadoTurno>("estado_turno");
-                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
-                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
-                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
-                npgsql.MapEnum<EstadoCompra>("estado_compra");
-            })
-            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
-            .Options;
-
-        return new WaysDbContext(opciones, tenantActual);
-    }
-
     private async Task<Escenario> SembrarEscenarioAsync(string nombre)
     {
         using var _ = fixture.CreateClient(); // arranca el host (siembra roles, alícuotas)
@@ -223,7 +190,7 @@ public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtur
         var escenarioA = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-A");
         var escenarioB = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveLotesDeOtroTenant) + "-B");
 
-        await using var sesionB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
+        await using var sesionB = fixture.CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
 
         var visibleAjeno = await sesionB.Lotes.AnyAsync(l => l.Id == escenarioA.IdLote);
         Assert.False(visibleAjeno);
@@ -328,7 +295,7 @@ public class LotesRlsTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixtur
         var escenarioA = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-A");
         var escenarioB = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveStockLotesDeOtroTenant) + "-B");
 
-        await using var sesionB = CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
+        await using var sesionB = fixture.CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, escenarioB.IdTenant));
 
         var visibleAjeno = await sesionB.StockLotes.AnyAsync(s =>
             s.IdArticulo == escenarioA.IdArticulo && s.IdPuntoVenta == escenarioA.IdPuntoVenta && s.IdLote == escenarioA.IdLote);

--- a/tests/Ways.IntegrationTests/PoliticasTests.cs
+++ b/tests/Ways.IntegrationTests/PoliticasTests.cs
@@ -84,4 +84,22 @@ public class PoliticasTests
 
         Assert.Equal(admitido, resultado.Succeeded);
     }
+
+    /// <summary>stage-14-auditoria-trazabilidad, Slice 5 (task 5.1; design decisión 6): misma
+    /// forma exacta que <see cref="LecturaDeRentabilidadAdmiteSoloAdmin"/> — Admin-only, sin
+    /// apilar sobre <see cref="Politicas.LecturaDeReportes"/> (el log de auditoría no es un
+    /// reporte de gestión).</summary>
+    [Theory]
+    [InlineData(RolConocido.Vendedor, false)]
+    [InlineData(RolConocido.Supervisor, false)]
+    [InlineData(RolConocido.Root, false)]
+    [InlineData(RolConocido.Admin, true)]
+    public async Task LecturaDeAuditoriaAdmiteSoloAdmin(RolConocido rol, bool admitido)
+    {
+        var servicio = ConstruirServicioDeAutorizacion();
+
+        var resultado = await servicio.AuthorizeAsync(Usuario(rol), Politicas.LecturaDeAuditoria);
+
+        Assert.Equal(admitido, resultado.Succeeded);
+    }
 }

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -255,6 +255,41 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
         return new WaysDbContext(opciones, tenantActual);
     }
 
+    /// <summary>Un <see cref="WaysDbContext"/> sobre <c>ways_owner</c> (bypassea RLS) — el único
+    /// mecanismo que puede aislar sobre esta conexión es el query filter de EF, nunca RLS. Usado
+    /// por las pruebas que necesitan probar genuinamente el filtro de EF de tenant, no la
+    /// política RLS (ya cubierta por las pruebas sobre <c>ways_app</c>).
+    ///
+    /// Judgment-day (juez B, slice 5, sugerencia): hoisteado desde <c>LotesRlsTests</c> —
+    /// duplicaba 15 líneas de <c>MapEnum</c> con <c>AuditoriaConsultaTests</c>, y crecía con cada
+    /// enum nuevo. El slice 6 lo va a reusar también.</summary>
+    public WaysDbContext CrearContextoDeOwner(ITenantActual tenantActual)
+    {
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(OwnerConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        return new WaysDbContext(opciones, tenantActual);
+    }
+
     /// <summary>Conexión cruda como <c>ways_app</c> con el GUC de tenant seteado a mano
     /// —lo mismo que hace <c>InterceptorDeContextoDeTenant</c>, pero sin pasar por EF: es
     /// la prueba de que la capa 2 (RLS) no depende del ORM.</summary>


### PR DESCRIPTION
## Etapa 14 — Auditoría · Slice 5 (Consulta + Policy)

- Policy nueva `LecturaDeAuditoria` Admin-only, SIN apilar (un Supervisor no lee el log que registra Supervisores — precedente LecturaDeRentabilidad).
- `GET /api/auditoria`: 7 filtros (fecha con bordes inclusivos PINNEADOS, acción, actor, entidad+idEntidad con 400 `entidad_requerida`, punto de venta), paginación OFFSET con tiebreaker OBLIGATORIO `id DESC` (creado_el empata por construcción — un reloj por operación), clamps de página/tamaño testeados, total pre-paginado.
- `ConstruirQuery` ÚNICO sin acoplamiento HTTP (el slice 6 lo reusa); LEFT JOIN a usuarios con `IgnoreQueryFilters(["BajaLogica"])" — el actor root y el soft-deleted siguen visibles en el log; payloads como JSON crudo materializados post-query, con CONTENIDO asertado.
- Filtro EF de tenant probado POR DEBAJO del confound de RLS (contexto owner — helper hoisteado a WaysApiFixture, MapEnum 1:1 contra producción, re-verificado en vivo).
- Cero migraciones; db-error-backstops N/A declarado.

## Tests (filtro combinado 76 integración + Politicas, todos verdes)
16 de consulta + 3 de clamps + contenido de payloads + secuencia exacta de paginación con empates + autorización a dos niveles (policy y endpoint) + aislamiento owner. 6 targets del apply + 10 mutaciones del juez B + 3 re-mutaciones, todas con evidencia.

## Judgment-day
Juez B: 0 severos, 3 WARNINGs + 1 sugerencia → fix `d81640a`. Re-ronda B: aprobada con verificación en vivo del hoist. Juez A: cero hallazgos. Ronda limpia. (El juez murió una vez por error de API a mitad de ronda — revivido por SendMessage con el worktree verificado limpio, cuarta recuperación exitosa del patrón.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)