### PR TITLE
feat(stage-14): slice 6 export — GET /api/auditoria/export con el contrato de la etapa 11

### DIFF
--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1444,6 +1444,19 @@ untouched.
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
 - [ ] 6.12 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator)*
+  - Ronda 1 (juez B): 0 severos; 3 WARNING (findings 1-3), pre-existentes-de-
+    patrón (mismos gaps que la etapa 11) cerrados en el código NUEVO de esta
+    slice. Fixed y con evidencia de mutación en `AuditoriaExportTests.cs`
+    (commit `08efd37`): finding 1 (seed subida a tope+2 filas y assert sobre
+    la cantidad REAL, discrimina el primer `GuardaDeTope.Exigir` de un `Take`
+    truncado con el mismo count), finding 2 (`UnFormatoNoSoportadoRechaza...`
+    — caso HTTP faltante para `FormatoDeExportacion.Parsear` en
+    `/api/auditoria/export`), finding 3
+    (`UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta` — borde
+    exacto del tope, discrimina el segundo `Exigir` del lado del éxito). Los
+    hermanos de la etapa 11 (mismos WARNINGs en `VentasListadoExportTests`/
+    `ReportesVentasResumenExportTests`) quedan FUERA de alcance de esta
+    ronda — chip aparte.
 - [ ] 6.13 Branch `feat/stage14-slice6-export` off `main` (parent:
   slice 5); PR; merge stacked-to-main. *(orchestrator)*
 

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1442,7 +1442,7 @@ untouched.
   --startup-project src/Ways.Infrastructure` → "No changes have been made
   to the model since the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
-- [ ] 6.12 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 6.12 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator)*
   - Ronda 1 (juez B): 0 severos; 3 WARNING (findings 1-3), pre-existentes-de-
     patrón (mismos gaps que la etapa 11) cerrados en el código NUEVO de esta
@@ -1457,7 +1457,7 @@ untouched.
     hermanos de la etapa 11 (mismos WARNINGs en `VentasListadoExportTests`/
     `ReportesVentasResumenExportTests`) quedan FUERA de alcance de esta
     ronda — chip aparte.
-- [ ] 6.13 Branch `feat/stage14-slice6-export` off `main` (parent:
+- [x] 6.13 Branch `feat/stage14-slice6-export` off `main` (parent: *(CLEAN 2026-08-16: juez B ronda 1 — 0 severos, 3 WARNINGs cerrados (seed tope+2 que discrimina el PRIMER Exigir por cantidad real; formato=pdf por ruta; borde exacto del tope del lado del EXITO con las filas asertadas presentes); re-ronda B aprobada con los 3 re-mutantes muertos. Juez A fresh: 0 severos, 1 WARNING PRE-EXISTENTE Y REPO-WIDE registrado sin fix: DateOnly.FromDateTime(hasta.UtcDateTime) corre el 'Periodo' del header y el nombre de archivo UN DIA para offsets UTC negativos (23:59:59.999-03:00 -> 02:59:59.999Z del dia siguiente); el filtrado de filas NO se afecta (usa el instante crudo). Patron byte-identico en VentasEndpoints, ReportesEndpoints, CuentaCorrienteEndpoints, ComprasEndpoints y CajaEndpoints — misma CLASE que el bug de produccion del 'hoy' UTC en el filename que cazo la etapa 11, sobreviviente en la cara desde/hasta. Fuera de alcance de este slice (arreglarlo solo aca desalinearia auditoria de sus 5 hermanos): chip de barrido repo-wide. JUDGMENT: APPROVED.)*
   slice 5); PR; merge stacked-to-main. *(orchestrator)*
 
 **Test plan**: 3 mutation targets (6.5, 6.6, 6.9), cap refusal (6.7),

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1335,59 +1335,128 @@ mirrors the JSON endpoint's figures cell by cell, refuses rather than
 truncates at cap. **Rollback**: revert the branch — the JSON endpoint is
 untouched.
 
-- [ ] 6.1 Create `src/Ways.Application/Exportacion/ExportacionDeAuditoria.cs`:
+- [x] 6.1 Create `src/Ways.Application/Exportacion/ExportacionDeAuditoria.cs`:
   `De(IReadOnlyList<FilaDeAuditoria> filas, ctx, zona)` mapping to
   `TablaExportable`, 8 columns in order: `Fecha · Acción · Entidad · Id
   entidad · Actor · Punto de venta · Valor anterior · Valor nuevo`.
   `Actor` null ⇒ `"#<idActor>"`; `Punto de venta` null ⇒ blank cell; both
   payload cells via `Celda.Texto(JsonSerializer.Serialize(elemento))`.
-- [ ] 6.2 Modify `ServicioDeConsultaDeAuditoria.cs`: add
+- [x] 6.2 Modify `ServicioDeConsultaDeAuditoria.cs`: add
   `ConsultarParaExportacionAsync(f, tope, ct)` = `Contar → GuardaDeTope.
   Exigir → Take(tope+1) → Exigir` (the stage-11 listing shape, decision 13),
   mapping from the **same** `FilaDeAuditoria` the JSON endpoint returns.
-- [ ] 6.3 Modify `src/Ways.Api/Endpoints/AuditoriaEndpoints.cs`: `GET
+- [x] 6.3 Modify `src/Ways.Api/Endpoints/AuditoriaEndpoints.cs`: `GET
   /api/auditoria/export?...&formato=xlsx`, `desde`/`hasta` mandatory
   (export house rule), `NombreDeArchivo.Construir("auditoria", alcance,
   desde, hasta)`. No separate `.RequireAuthorization` — inherited by
   co-location under the same route group as `LecturaDeAuditoria`.
-- [ ] 6.4 Modify `src/Ways.Web/src/api/{tipos,auditoria}.ts`: add
+- [x] 6.4 Modify `src/Ways.Web/src/api/{tipos,auditoria}.ts`: add
   `rutasDeExportacion.auditoria(filtros)` (route builder only — the screen
   is slice 7).
-- [ ] 6.5 [P] **Mutation target**: `GuardaDeTope.Exigir` (the second call,
+  **DEVIATION (registered):** `tipos.ts` was NOT modified — `auditoria.ts`
+  is new (Slice 6 is the first web-touching change of this stage; no
+  `clienteDeAuditoria` yet, that's Slice 7 per Suggested Work Units).
+  `tipos.ts` is reserved for genuinely cross-cutting shared types (`ROL`,
+  `EstadoUsuario`, `PaginaDe<T>`); domain-specific filter shapes live in
+  their own domain file — the established precedent is `reportes.ts`
+  itself, whose `FiltrosDeHistoricoDeCajas`/`FiltrosDeTesoreria` are
+  declared locally, not in `tipos.ts`. `auditoria.ts` follows that same
+  precedent with its own `FiltrosDeExportacionDeAuditoria` (narrower than
+  the eventual `dto-contract-honesty` `FiltrosDeAuditoria` mirror —
+  Orchestrator Decision 8 explicitly reserves that mirror for Slice 7's
+  `tipos.ts`, not this slice). `rutasDeExportacion` is its own local
+  object in `auditoria.ts` (same convention as `reportes.ts`'s own
+  `rutasDeExportacion`, not the same JS object — no cross-file coupling),
+  duplicating `fechaIsoConOffset`/`desplazamientoUtcLocal` per the
+  established "no shared date-utils module yet" convention. 3 colocated
+  unit tests (`auditoria.test.ts`) — `npx vitest run src/api/auditoria.test.ts`
+  → 3/3 green; full web suite (`npx vitest run`) → 38 files / 663 tests
+  green, no regressions.
+- [x] 6.5 [P] **Mutation target**: `GuardaDeTope.Exigir` (the second call,
   after `Take(tope+1)`) — delete it — the over-cap export test (6.7) must
   fail (truncates instead of rejecting). *(slice 6 row 1)*
-- [ ] 6.6 [P] **Mutation target**: `ExportacionDeAuditoria`'s header row —
+  **DEVIATION (registered):** the simple over-cap test (6.7 as originally
+  scoped — 4 seeded rows, `TopeDeFilas=3`) does NOT discriminate this
+  mutant: the first `Exigir` (over the real `COUNT(*)`) already rejects
+  before the second `Exigir` is ever reached, so deleting only the second
+  call is an equivalent mutant for that scenario — empirically confirmed
+  (mutated → `UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo`
+  stayed GREEN). A dedicated race test was added,
+  `UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion`
+  (same `DbCommandInterceptor` pattern as
+  `VentasListadoExportTests.UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion`
+  — the second query touching `auditoria` gets a row inserted just before
+  it runs, so `COUNT(*)` sees `tope` rows but the read brings `tope + 1`).
+  **Evidence**: mutated (second `Exigir` deleted) → `dotnet build
+  --no-incremental` → `UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion`
+  FAILED (`Expected: BadRequest, Actual: OK` — the extra row silently
+  reached the workbook) while `UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo`
+  stayed green as predicted (confirming it alone is not a valid
+  discriminator) → reverted → both green.
+- [x] 6.6 [P] **Mutation target**: `ExportacionDeAuditoria`'s header row —
   swap the `Valor anterior`/`Valor nuevo` titles — the full-header-row
   assertion (6.8) must fail. *(slice 6 row 2; `mutation-proof-tests` rule
-  8)*
-- [ ] 6.7 [P] Integration: with `TopeDeFilas` lowered below the seeded row
+  8)* **Evidence**: mutated (titles swapped in `Columnas`) → `dotnet build
+  --no-incremental` → `ElExportEsIgualAlListadoJsonCeldaPorCeldaConLosOchoEncabezadosEnOrden`
+  FAILED at the row-6 header assertion (position 6: expected `"Valor
+  anterior"`, got `"Valor nuevo"`) → reverted → green.
+- [x] 6.7 [P] Integration: with `TopeDeFilas` lowered below the seeded row
   count, the export is rejected `400 exportacion_demasiado_grande` and no
   file is generated, resolving 6.5's evidence. *(spec: "The export refuses
   rather than truncates at cap")*
-- [ ] 6.8 [P] Integration — export parity, cell by cell
+  `AuditoriaExportTests.UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo`.
+  See 6.5's note: this test alone does not discriminate the second
+  `Exigir` — `UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion`
+  (also under this task) closes that gap.
+- [x] 6.8 [P] Integration — export parity, cell by cell
   (`mutation-proof-tests` rule 8): the same query string on JSON and XLSX
   produce equal figures for every row **and** the complete 8-header-row
   text asserted in order; a tenant-wide row's PV cell is blank; both jsonb
   payload cells equal `JsonSerializer.Serialize` of the JSON endpoint's own
   `JsonElement`. *(spec: "Export figures equal the endpoint's for
   identical filters")*
-- [ ] 6.9 [P] **Mutation target**: `.RequireAuthorization` on `/export` —
+  `AuditoriaExportTests.ElExportEsIgualAlListadoJsonCeldaPorCeldaConLosOchoEncabezadosEnOrden`
+  — 3 seeded rows: one with PV + a resolvable actor name, one tenant-wide
+  (PV NULL, root actor ⇒ `#<idActor>` cell), one with distinct
+  `valorAnterior`/`valorNuevo` content.
+- [x] 6.9 [P] **Mutation target**: `.RequireAuthorization` on `/export` —
   delete the line — the Supervisor-403-on-export test (6.10) must fail.
   *(slice 6 row 3)*
-- [ ] 6.10 [P] Integration — authorization: Supervisor → `403` on
+  **Note**: there is no separate `.RequireAuthorization` line on `/export`
+  itself (design: inherited by co-location) — the ONE line that can be
+  deleted is the shared `.RequireAuthorization(Politicas.LecturaDeAuditoria)`
+  on `grupo`, which covers both routes. **Evidence**: mutated (that line
+  deleted) → `dotnet build --no-incremental` →
+  `UnSupervisorEsRechazadoDelExportDeAuditoriaSinPoliticaPropiaEnLaRuta`
+  FAILED (`Expected: Forbidden, Actual: OK` — the group fell back to
+  `Program.cs`'s `RequireAuthenticatedUser()` fallback policy, which any
+  authenticated Supervisor satisfies) → reverted → green.
+- [x] 6.10 [P] Integration — authorization: Supervisor → `403` on
   `/export`, with no separate policy declared on the route. *(spec: "A
   Supervisor is rejected on the export too, inherited from the source
   route")*
-- [ ] 6.11 Gate guard: `has-pending-model-changes` clean; zero new files in
-  `Migraciones/`.
+  `AuditoriaExportTests.UnSupervisorEsRechazadoDelExportDeAuditoriaSinPoliticaPropiaEnLaRuta`.
+- [x] 6.11 Gate guard: `has-pending-model-changes` clean; zero new files in
+  `Migraciones/`. **Confirmed**: `dotnet ef migrations
+  has-pending-model-changes --project src/Ways.Infrastructure
+  --startup-project src/Ways.Infrastructure` → "No changes have been made
+  to the model since the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty.
 - [ ] 6.12 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  *(orchestrator)*
 - [ ] 6.13 Branch `feat/stage14-slice6-export` off `main` (parent:
-  slice 5); PR; merge stacked-to-main.
+  slice 5); PR; merge stacked-to-main. *(orchestrator)*
 
 **Test plan**: 3 mutation targets (6.5, 6.6, 6.9), cap refusal (6.7),
-cell-by-cell parity + header row (6.8), Supervisor 403 (6.10).
+cell-by-cell parity + header row (6.8), Supervisor 403 (6.10). Plus one
+extra discriminator (6.5's note): the COUNT-vs-Take race test, added
+because the plain over-cap test is an equivalent mutant for the second
+`GuardaDeTope.Exigir`.
 
 **Verify**: `dotnet test --filter FullyQualifiedName~ExportacionDeAuditoria|FullyQualifiedName~Auditoria`
+→ **68/68 green** (`AuditoriaExportTests` 4 facts + the rest of the
+`~Auditoria` suite, unchanged). Web: `npx vitest run` → 38 files / 663
+tests green (3 new in `auditoria.test.ts`).
 
 ---
 

--- a/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
@@ -1,5 +1,10 @@
+using Microsoft.Extensions.Options;
+using Ways.Api.Exportacion;
 using Ways.Api.Seguridad;
+using Ways.Application.Abstracciones;
 using Ways.Application.Auditoria;
+using Ways.Application.Exportacion;
+using Ways.Application.Parametros;
 
 namespace Ways.Api.Endpoints;
 
@@ -26,6 +31,43 @@ public static class AuditoriaEndpoints
             "de venta (idPuntoVenta es un filtro, no un alcance). idEntidad exige entidad (400 " +
             "entidad_requerida) — accion/entidad desconocidas no rechazan, devuelven 0 filas " +
             "(design decisión 15: una acción retirada deja rastro consultable).");
+
+        // Slice 6 (design decisión 13): sibling declarado inmediatamente después de su ruta
+        // fuente, sin `.RequireAuthorization` propio — hereda `LecturaDeAuditoria` por
+        // co-locación bajo el mismo `grupo` (mutation target 6.9: borrar el `.RequireAuthorization`
+        // de ARRIBA es lo único que puede hacer fallar el 403 de Supervisor acá, no hay una
+        // segunda línea que borrar). `desde`/`hasta` OBLIGATORIOS (regla de la casa del export +
+        // nombre de archivo determinístico), a diferencia del listado JSON.
+        grupo.MapGet("/export", async (
+            ServicioDeConsultaDeAuditoria servicio, IExportadorDeTabla exportador, IOptions<OpcionesDeExportacion> opciones,
+            IContextoDeUsuario usuario, IRelojDelSistema reloj, ServicioDeParametros parametros, IWaysDbContext db,
+            DateTimeOffset desde, DateTimeOffset hasta, string? accion, int? idActor, string? entidad,
+            int? idEntidad, int? idPuntoVenta, string formato, CancellationToken ct) =>
+        {
+            FormatoDeExportacion.Parsear(formato);
+
+            var filtros = new FiltrosDeAuditoria(desde, hasta, accion, idActor, entidad, idEntidad, idPuntoVenta);
+            var filas = await servicio.ConsultarParaExportacionAsync(filtros, opciones.Value.TopeDeFilas, ct);
+
+            var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
+            var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
+            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
+            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+
+            var ctx = ContextoDeExportacionHttp.Construir(
+                usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);
+            var tabla = ExportacionDeAuditoria.De(filas, ctx, zona);
+
+            var bytes = exportador.Generar(tabla);
+            var alcance = idPuntoVenta is { } pv ? $"pv{pv}" : "todos";
+            var nombre = NombreDeArchivo.Construir("auditoria", alcance, desdeFecha, hastaFecha);
+
+            return ResultadoDeExportacion.Archivo(bytes, exportador.TipoDeContenido, nombre);
+        })
+        .WithSummary(
+            "Export XLSX de GET /api/auditoria: mismos filtros, desde/hasta obligatorios (regla " +
+            "de la casa del export), política LecturaDeAuditoria heredada por co-locación. " +
+            "Rechaza (400 exportacion_demasiado_grande) en vez de truncar al superar el tope.");
 
         return app;
     }

--- a/src/Ways.Application/Auditoria/ServicioDeConsultaDeAuditoria.cs
+++ b/src/Ways.Application/Auditoria/ServicioDeConsultaDeAuditoria.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
+using Ways.Application.Exportacion;
 using Ways.Domain.Common;
 
 namespace Ways.Application.Auditoria;
@@ -50,6 +51,31 @@ public sealed class ServicioDeConsultaDeAuditoria(IWaysDbContext db)
         var items = crudas.Select(Materializar).ToList();
 
         return new PaginaDeAuditoria(items, total, pagina, tamanio);
+    }
+
+    /// <summary>
+    /// Sibling de export (Slice 6, design decisión 13) — shape LISTADO: <c>Contar → GuardaDeTope.
+    /// Exigir → Take(tope+1) → segundo Exigir</c> (etapa 11, <c>ServicioDeVentas.
+    /// ListarParaExportacionAsync</c> verbatim), sobre el MISMO <see cref="ConstruirQuery"/> que
+    /// <see cref="ConsultarAsync"/> — nunca un predicado propio. El orden ya viene de
+    /// <see cref="ConstruirQuery"/> (<c>creado_el desc, id desc</c>), sin un <c>OrderBy</c>
+    /// adicional acá.
+    /// </summary>
+    public async Task<IReadOnlyList<FilaDeAuditoria>> ConsultarParaExportacionAsync(
+        FiltrosDeAuditoria filtros, int tope, CancellationToken ct = default)
+    {
+        var query = ConstruirQuery(filtros);
+
+        var cantidad = await query.CountAsync(ct);
+        GuardaDeTope.Exigir(cantidad, tope);
+
+        var crudas = await query
+            .Take(tope + 1)
+            .ToListAsync(ct);
+
+        GuardaDeTope.Exigir(crudas.Count, tope);
+
+        return crudas.Select(Materializar).ToList();
     }
 
     private static FilaDeAuditoria Materializar(FilaCrudaDeAuditoria f) =>

--- a/src/Ways.Application/Exportacion/ExportacionDeAuditoria.cs
+++ b/src/Ways.Application/Exportacion/ExportacionDeAuditoria.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Ways.Application.Auditoria;
+
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Mapper puro del sibling de export de auditoría (Slice 6, design decisión 13) — mapea desde la
+/// MISMA <see cref="FilaDeAuditoria"/> que <c>GET /api/auditoria</c> devuelve, nunca vuelve a
+/// consultar la base (design decisión 11, etapa 11) ni redeclara un predicado propio: la paridad
+/// JSON↔XLSX es estructural porque ambos consumen <c>ServicioDeConsultaDeAuditoria.ConstruirQuery</c>.
+/// </summary>
+public static class ExportacionDeAuditoria
+{
+    private static readonly IReadOnlyList<ColumnaExportable> Columnas =
+    [
+        new ColumnaExportable("Fecha", TipoDeColumna.FechaHora),
+        new ColumnaExportable("Acción", TipoDeColumna.Texto),
+        new ColumnaExportable("Entidad", TipoDeColumna.Texto),
+        new ColumnaExportable("Id entidad", TipoDeColumna.Entero),
+        new ColumnaExportable("Actor", TipoDeColumna.Texto),
+        new ColumnaExportable("Punto de venta", TipoDeColumna.Entero),
+        new ColumnaExportable("Valor anterior", TipoDeColumna.Texto),
+        new ColumnaExportable("Valor nuevo", TipoDeColumna.Texto)
+    ];
+
+    /// <summary>Una fila por evento de auditoría, mismo orden que <c>ConstruirQuery</c>
+    /// (newest-first). <see cref="FilaDeAuditoria.Actor"/> nulo (actor de plataforma, invisible
+    /// para esta sesión) cae a <c>"#idActor"</c> — nunca una celda vacía, que se confundiría con
+    /// "sin actor" (design decisión 14). <see cref="FilaDeAuditoria.IdPuntoVenta"/> nulo (evento
+    /// tenant-wide) sí queda vacío. Los dos payloads viajan como texto JSON crudo — el cliente
+    /// del export nunca reinterpreta el contenido, mismo criterio que la lectura JSON.</summary>
+    public static TablaExportable De(IReadOnlyList<FilaDeAuditoria> filas, ContextoDeExportacion ctx, TimeZoneInfo zona)
+    {
+        var celdas = filas
+            .Select(f => (IReadOnlyList<Celda>)
+            [
+                Celda.FechaHora(f.CreadoEl, zona),
+                Celda.Texto(f.Accion),
+                Celda.Texto(f.Entidad),
+                Celda.Entero(f.IdEntidad),
+                Celda.Texto(f.Actor ?? $"#{f.IdActor}"),
+                Celda.Entero(f.IdPuntoVenta),
+                Celda.Texto(JsonSerializer.Serialize(f.ValorAnterior)),
+                Celda.Texto(JsonSerializer.Serialize(f.ValorNuevo))
+            ])
+            .ToList();
+
+        return new TablaExportable("Auditoría", ctx, Columnas, celdas);
+    }
+}

--- a/src/Ways.Web/src/api/auditoria.test.ts
+++ b/src/Ways.Web/src/api/auditoria.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { FiltrosDeExportacionDeAuditoria } from './auditoria'
+
+const { rutasDeExportacion } = await import('./auditoria')
+
+function offsetEsperado(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function filtrosFixture(sobrescribir: Partial<FiltrosDeExportacionDeAuditoria> = {}): FiltrosDeExportacionDeAuditoria {
+  return {
+    desde: '2026-08-05',
+    hasta: '2026-08-11',
+    accion: null,
+    idActor: null,
+    entidad: null,
+    idEntidad: null,
+    idPuntoVenta: null,
+    ...sobrescribir,
+  }
+}
+
+describe('rutasDeExportacion.auditoria', () => {
+  it('aplica el mismo offset local que /cajas y /tesoreria, y suma formato=xlsx al final', () => {
+    const offsetDesde = offsetEsperado(2026, 8, 5)
+    const offsetHasta = offsetEsperado(2026, 8, 11)
+
+    const ruta = decodeURIComponent(rutasDeExportacion.auditoria(filtrosFixture()))
+
+    expect(ruta).toBe(
+      `/auditoria/export?desde=2026-08-05T00:00:00${offsetDesde}&hasta=2026-08-11T23:59:59.999${offsetHasta}&formato=xlsx`,
+    )
+  })
+
+  it('omite los 5 filtros opcionales cuando son null', () => {
+    const ruta = rutasDeExportacion.auditoria(filtrosFixture())
+
+    expect(ruta).not.toContain('accion=')
+    expect(ruta).not.toContain('idActor=')
+    expect(ruta).not.toContain('entidad=')
+    expect(ruta).not.toContain('idEntidad=')
+    expect(ruta).not.toContain('idPuntoVenta=')
+  })
+
+  it('agrega los 5 filtros opcionales solo cuando están seteados', () => {
+    const ruta = rutasDeExportacion.auditoria(
+      filtrosFixture({ accion: 'precio.cambio', idActor: 3, entidad: 'articulo', idEntidad: 41, idPuntoVenta: 7 }),
+    )
+
+    expect(ruta).toContain('accion=precio.cambio')
+    expect(ruta).toContain('idActor=3')
+    expect(ruta).toContain('entidad=articulo')
+    expect(ruta).toContain('idEntidad=41')
+    expect(ruta).toContain('idPuntoVenta=7')
+  })
+})

--- a/src/Ways.Web/src/api/auditoria.ts
+++ b/src/Ways.Web/src/api/auditoria.ts
@@ -1,0 +1,63 @@
+/**
+ * stage-14-auditoria-trazabilidad (Slice 6): SOLO el constructor de ruta de exportación —
+ * `rutasDeExportacion.auditoria(filtros)`. El cliente JSON (`clienteDeAuditoria`) y los espejos
+ * de tipos (`FiltrosDeAuditoria`/`FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`,
+ * design decisión 8) quedan para la Slice 7 (la pantalla `Auditoria.tsx`) — acá no hay ningún
+ * consumidor todavía.
+ *
+ * `tipos.ts` no se modifica en esta slice: es un módulo de tipos verdaderamente transversales
+ * (`ROL`, `EstadoUsuario`, `PaginaDe<T>`, …), y el precedente de `reportes.ts` es que los tipos de
+ * filtro propios de un dominio (`FiltrosDeHistoricoDeCajas`, `FiltrosDeTesoreria`, …) viven en el
+ * archivo del dominio, nunca en `tipos.ts` — `FiltrosDeExportacionDeAuditoria` sigue ese mismo
+ * criterio acá.
+ *
+ * Mismo criterio de offset local que `reportes.ts` (`fechaIsoConOffset`/`desplazamientoUtcLocal`,
+ * duplicado a propósito: no hay un módulo compartido de utilidades de fecha en esta web todavía) —
+ * `auditoria.creado_el` es `timestamptz`, igual que `cajas.fecha_cierre`.
+ */
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+/** Filtros del export de auditoría — `desde`/`hasta` son OBLIGATORIOS acá (a diferencia del
+ * futuro `GET /api/auditoria` JSON, Slice 7): regla de la casa del export + nombre de archivo
+ * determinístico (mismo criterio que `historicoDeCajas`/`tesoreria` en `reportes.ts`). El resto
+ * replica 1:1 los 5 filtros opcionales de `FiltrosDeAuditoria` (backend, Slice 5). */
+export type FiltrosDeExportacionDeAuditoria = {
+  desde: string
+  hasta: string
+  accion: string | null
+  idActor: number | null
+  entidad: string | null
+  idEntidad: number | null
+  idPuntoVenta: number | null
+}
+
+function construirQueryDeExportacionDeAuditoria(filtros: FiltrosDeExportacionDeAuditoria): string {
+  const parametros = new URLSearchParams()
+  parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  if (filtros.accion !== null) parametros.set('accion', filtros.accion)
+  if (filtros.idActor !== null) parametros.set('idActor', String(filtros.idActor))
+  if (filtros.entidad !== null) parametros.set('entidad', filtros.entidad)
+  if (filtros.idEntidad !== null) parametros.set('idEntidad', String(filtros.idEntidad))
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  return `?${parametros.toString()}`
+}
+
+/** Misma convención de `reportes.ts` (`rutasDeExportacion.<dominio>(filtros)`), en su propio
+ * módulo — `auditoria.ts` no depende de `reportes.ts` ni viceversa. */
+export const rutasDeExportacion = {
+  auditoria: (filtros: FiltrosDeExportacionDeAuditoria) =>
+    `/auditoria/export${construirQueryDeExportacionDeAuditoria(filtros)}&formato=xlsx`,
+}

--- a/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Exportacion;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-14-auditoria-trazabilidad, Slice 6: <c>GET /api/auditoria/export</c> — el sibling LISTADO
+/// (design decisión 13, mismo patrón que <c>VentasListadoExportTests</c>): <c>GuardaDeTope.Exigir</c>
+/// corre dos veces (sobre el <c>COUNT(*)</c> y sobre <c>.Take(tope + 1)</c>), mapeando desde la
+/// MISMA <c>FilaDeAuditoria</c> que <c>GET /api/auditoria</c> (Slice 5, <c>AuditoriaConsultaTests</c>)
+/// devuelve. Filas sembradas DIRECTO por <c>db.Auditoria.Add</c>, mismo criterio que Slice 5 — el
+/// contenido de la fila no importa para este sibling, solo su mapeo 1:1.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string MailRoot = "test@test.com";
+    private const string PasswordRoot = "root";
+    private const string PasswordUsuario = "una-contraseña-larga";
+    private const string ContentTypeXlsx =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new() { PropertyNameCaseInsensitive = true };
+
+    private sealed record Contexto(int IdTenant, int IdPuntoVenta, int IdActorAdmin, HttpClient Admin);
+
+    private sealed record FilaRespuesta(
+        long IdAuditoria, DateTimeOffset CreadoEl, string Accion, string Entidad, int IdEntidad,
+        int IdActor, string? Actor, int? IdPuntoVenta, JsonElement? ValorAnterior, JsonElement ValorNuevo);
+
+    private sealed record PaginaRespuesta(List<FilaRespuesta> Items, int Total, int Pagina, int Tamanio);
+
+    // ---- provisioning -------------------------------------------------------------------------
+
+    private static async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
+    {
+        var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, resultado.IdUsuarioAdmin, admin);
+    }
+
+    private static async Task<HttpClient> CrearYLoguearSupervisorAsync(Contexto ctx, string nombre, WebApplicationFactory<Program> factory)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-supervisor@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario($"supervisor-{corto}", mail, (int)RolConocido.Supervisor, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    /// <summary>El id de un usuario existente de plataforma (root) — usado para probar la celda
+    /// <c>"#idActor"</c> (design decisión 14: <c>Actor</c> nulo nunca es celda vacía).</summary>
+    private async Task<int> ObtenerIdDeUsuarioRootAsync(WebApplicationFactory<Program> factory)
+    {
+        using var _ = factory.CreateClient(); // arranca el host (siembra root)
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        return await db.Usuarios.Where(u => u.Mail == MailRoot).Select(u => u.Id).FirstAsync();
+    }
+
+    private async Task<long> SembrarFilaAsync(
+        int idTenant, int? idPuntoVenta, int idActor, string accion, string entidad, int idEntidad,
+        DateTimeOffset creadoEl, string? valorAnterior, string valorNuevo)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var fila = new Domain.Auditoria.Auditoria
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = idPuntoVenta,
+            IdActor = idActor,
+            Accion = accion,
+            Entidad = entidad,
+            IdEntidad = idEntidad,
+            ValorAnterior = valorAnterior,
+            ValorNuevo = valorNuevo,
+            CreadoEl = creadoEl
+        };
+        db.Auditoria.Add(fila);
+        await db.SaveChangesAsync();
+
+        return fila.Id;
+    }
+
+    private static string ConstruirQuery(DateOnly desde, DateOnly hasta, string? formato) =>
+        $"desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        (formato is null ? string.Empty : $"&formato={formato}");
+
+    private static Task<HttpResponseMessage> LlamarListadoAsync(HttpClient cliente, DateOnly desde, DateOnly hasta) =>
+        cliente.GetAsync($"/api/auditoria?{ConstruirQuery(desde, hasta, null)}&tamanio=50");
+
+    private static Task<HttpResponseMessage> LlamarExportAsync(HttpClient cliente, DateOnly desde, DateOnly hasta, string formato = "xlsx") =>
+        cliente.GetAsync($"/api/auditoria/export?{ConstruirQuery(desde, hasta, formato)}");
+
+    // ---- task 6.8: paridad JSON↔XLSX celda por celda + fila de encabezados completa ------------
+
+    [Fact]
+    public async Task ElExportEsIgualAlListadoJsonCeldaPorCeldaConLosOchoEncabezadosEnOrden()
+    {
+        var ctx = await PrepararAsync(nameof(ElExportEsIgualAlListadoJsonCeldaPorCeldaConLosOchoEncabezadosEnOrden), fixture);
+        var idActorRoot = await ObtenerIdDeUsuarioRootAsync(fixture);
+
+        var desde = new DateOnly(2026, 1, 1);
+        var hasta = new DateOnly(2026, 3, 31);
+
+        // R1: con PV, actor Admin (nombre visible), valorAnterior NULL.
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41,
+            new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero), null, "{\"monto\":100}");
+        // R2: tenant-wide (PV NULL) — celda de PV vacía; actor root — Actor null, celda "#idActor".
+        await SembrarFilaAsync(
+            ctx.IdTenant, null, idActorRoot, "usuario.actualizacion", "usuario", ctx.IdActorAdmin,
+            new DateTimeOffset(2026, 2, 1, 12, 0, 0, TimeSpan.Zero), "{\"estado\":\"activo\"}", "{\"estado\":\"bloqueado\"}");
+        // R3: con PV, actor Admin, valorAnterior/valorNuevo con contenido distinto entre sí.
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "stock.ajuste", "articulo", 42,
+            new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero), "{\"cantidad\":5}", "{\"cantidad\":8}");
+
+        var jsonRespuesta = await LlamarListadoAsync(ctx.Admin, desde, hasta);
+        Assert.Equal(HttpStatusCode.OK, jsonRespuesta.StatusCode);
+        var pagina = JsonSerializer.Deserialize<PaginaRespuesta>(await jsonRespuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(3, pagina.Items.Count);
+
+        var exportRespuesta = await LlamarExportAsync(ctx.Admin, desde, hasta);
+        var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
+        Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Fila 6 = encabezados (mutation-proof-tests regla 8): sin este assert, un swap de
+        // "Valor anterior"/"Valor nuevo" pasa inadvertido — el test de igualdad de abajo solo lee
+        // celdas por POSICIÓN, nunca por título.
+        const int filaDeEncabezados = 6;
+        Assert.Equal(
+            ["Fecha", "Acción", "Entidad", "Id entidad", "Actor", "Punto de venta", "Valor anterior", "Valor nuevo"],
+            Enumerable.Range(1, 8).Select(c => hoja.Cell(filaDeEncabezados, c).GetString()));
+
+        // Datos desde la fila 7, mismo orden que el JSON (newest-first, ConstruirQuery).
+        var zona = TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires");
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < pagina.Items.Count; i++)
+        {
+            var item = pagina.Items[i];
+            var fila = hoja.Row(primeraFilaDeDatos + i);
+
+            Assert.Equal(TimeZoneInfo.ConvertTime(item.CreadoEl, zona).DateTime, fila.Cell(1).GetValue<DateTime>());
+            Assert.Equal(item.Accion, fila.Cell(2).GetString());
+            Assert.Equal(item.Entidad, fila.Cell(3).GetString());
+            Assert.Equal(item.IdEntidad, fila.Cell(4).GetValue<int>());
+            Assert.Equal(item.Actor ?? $"#{item.IdActor}", fila.Cell(5).GetString());
+
+            if (item.IdPuntoVenta is { } pv)
+            {
+                Assert.Equal(pv, fila.Cell(6).GetValue<int>());
+            }
+            else
+            {
+                Assert.Empty(fila.Cell(6).GetString());
+            }
+
+            Assert.Equal(JsonSerializer.Serialize(item.ValorAnterior), fila.Cell(7).GetString());
+            Assert.Equal(JsonSerializer.Serialize(item.ValorNuevo), fila.Cell(8).GetString());
+        }
+    }
+
+    // ---- task 6.10: autorización — Supervisor rechazado en el export también --------------------
+
+    [Fact]
+    public async Task UnSupervisorEsRechazadoDelExportDeAuditoriaSinPoliticaPropiaEnLaRuta()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoDelExportDeAuditoriaSinPoliticaPropiaEnLaRuta), fixture);
+        var supervisor = await CrearYLoguearSupervisorAsync(
+            ctx, nameof(UnSupervisorEsRechazadoDelExportDeAuditoriaSinPoliticaPropiaEnLaRuta), fixture);
+
+        var hoy = new DateOnly(2026, 1, 1);
+        var respuesta = await LlamarExportAsync(supervisor, hoy, hoy);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- task 6.7: rechazo por tope (COUNT real, no una serie truncada) ---------------------------
+
+    [Fact]
+    public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo), factoryBajo);
+        var dia = new DateOnly(2026, 1, 1);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await SembrarFilaAsync(
+                ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41 + i,
+                new DateTimeOffset(2026, 1, 1, 12, 0, i, TimeSpan.Zero), null, $"{{\"monto\":{100 + i}}}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, dia, dia);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+}

--- a/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
@@ -223,7 +223,12 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo), factoryBajo);
         var dia = new DateOnly(2026, 1, 1);
 
-        for (var i = 0; i < 4; i++)
+        // tope+2 = 5 filas (no tope+1 = 4): con solo 4 filas, count real y count leído del
+        // Take(tope+1) coinciden, y borrar el PRIMER GuardaDeTope.Exigir sobrevive (el segundo
+        // Exigir, sobre crudas.Count, rechaza igual con el mismo "4"). Con 5 filas el Take(4)
+        // trunca: si el primer Exigir se borra, el mutante reporta "4" (el truncado) en vez de "5"
+        // (la cantidad REAL) y el assert de abajo lo discrimina.
+        for (var i = 0; i < 5; i++)
         {
             await SembrarFilaAsync(
                 ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41 + i,
@@ -237,7 +242,72 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("5", problema.GetProperty("title").GetString());
+    }
+
+    // ---- judgment-day slice 6 (juez B, finding 2): FormatoDeExportacion.Parsear en esta ruta -----
+
+    /// <summary>Complementa <c>FormatoDeExportacionTests</c> (unitaria, sin fixture) — mismo patrón
+    /// que <c>ReportesVentasResumenExportTests.UnFormatoNoSoportadoRechazaConProblemDetailsAtravesDelPipelineHttp</c>
+    /// (líneas 228-240): sin este test, borrar la llamada a <see cref="FormatoDeExportacion.Parsear"/>
+    /// en <c>/api/auditoria/export</c> sobrevive — un <c>formato=pdf</c> devolvería 200 XLSX.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeAuditoria()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeAuditoria), fixture);
+        var hoy = new DateOnly(2026, 1, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, hoy, hoy, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- judgment-day slice 6 (juez B, finding 3): borde EXACTO del tope (200, no 400) -----------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(crudas.Count, tope - 1)</c> sobrevive
+    /// — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadRealYNoGeneraArchivo</c> solo cubre
+    /// el rechazo por ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> filas y se espera
+    /// 200 con el workbook completo (design decisión 6: exportar exactamente el tope es
+    /// legítimo).</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var dia = new DateOnly(2026, 1, 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarFilaAsync(
+                ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41 + i,
+                new DateTimeOffset(2026, 1, 1, 12, 0, i, TimeSpan.Zero), null, $"{{\"monto\":{100 + i}}}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, dia, dia);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado de tabla en la fila 6 (mismo layout que ExportadorXlsx), datos desde la 7: las
+        // tope=3 filas ocupan 7-9, y la fila 10 debe quedar vacía — si el mutante rechazara de más
+        // (Exigir(count, tope-1)) esta sección de arriba ya devolvió 400 y el test corta antes.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 
     // ---- task 6.5: backstop de carrera del segundo GuardaDeTope.Exigir ---------------------------

--- a/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
@@ -1,15 +1,18 @@
+using System.Data.Common;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClosedXML.Excel;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Exportacion;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 
 namespace Ways.IntegrationTests;
 
@@ -235,5 +238,105 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
         Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    // ---- task 6.5: backstop de carrera del segundo GuardaDeTope.Exigir ---------------------------
+
+    /// <summary>
+    /// Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> (mutation target 6.5): con un
+    /// <c>COUNT(*)</c> ya consistente con el tope, la prueba de arriba (6.7) NO puede detectar
+    /// borrar el segundo <c>Exigir</c> — el primero ya rechaza antes de llegar a <c>Take</c>. Este
+    /// test recrea la carrera que el segundo <c>Exigir</c> existe para atrapar (mismo patrón que
+    /// <c>VentasListadoExportTests.UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion</c>):
+    /// un <c>DbCommandInterceptor</c> retiene la SEGUNDA consulta que toca <c>auditoria</c> (la
+    /// lectura <c>.Take(tope + 1)</c> — la primera es el <c>COUNT(*)</c>) e inserta una fila extra
+    /// JUSTO ANTES de dejarla correr, así el <c>COUNT(*)</c> pasa el primer <c>Exigir</c> con
+    /// exactamente <c>tope</c> filas pero la lectura trae <c>tope + 1</c>.
+    /// </summary>
+    [Fact]
+    public async Task UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion()
+    {
+        var gate = new SemaphoreSlim(0, 1);
+        Contexto? ctxRef = null;
+        DateOnly dia = default;
+
+        var interceptor = new InterceptorDeCarreraDeExportacion(async () =>
+        {
+            if (ctxRef is null)
+            {
+                return;
+            }
+
+            await SembrarFilaAsync(
+                ctxRef.IdTenant, ctxRef.IdPuntoVenta, ctxRef.IdActorAdmin, "precio.cambio", "articulo", 999,
+                new DateTimeOffset(dia.Year, dia.Month, dia.Day, 12, 0, 59, TimeSpan.Zero), null, "{\"monto\":999}");
+            gate.Release();
+        });
+
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+            {
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3);
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor));
+            }));
+
+        var ctx = await PrepararAsync(nameof(UnaFilaInsertadaEntreElConteoYLaLecturaSigueRechazandoLaExportacion), factoryBajo);
+        dia = new DateOnly(2026, 1, 1);
+        ctxRef = ctx;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarFilaAsync(
+                ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41 + i,
+                new DateTimeOffset(2026, 1, 1, 12, 0, i, TimeSpan.Zero), null, $"{{\"monto\":{100 + i}}}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, dia, dia);
+
+        Assert.True(await gate.WaitAsync(TimeSpan.FromSeconds(10)), "El interceptor de carrera nunca insertó la fila extra.");
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("4", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Retiene la SEGUNDA consulta que toca <c>auditoria</c> (la lectura <c>.Take(tope +
+    /// 1)</c> — la primera es el <c>COUNT(*)</c>) e inyecta <paramref name="alSegundaConsulta"/>
+    /// antes de dejarla correr. Cubre tanto <c>ReaderExecutingAsync</c> como
+    /// <c>ScalarExecutingAsync</c>: si <c>CountAsync</c> se traduce a un escalar en vez de un
+    /// reader, el contador compartido sigue contando en orden.</summary>
+    private sealed class InterceptorDeCarreraDeExportacion(Func<Task> alSegundaConsulta) : DbCommandInterceptor
+    {
+        private int _coincidencias;
+
+        public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            await ConsiderarAsync(command);
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            await ConsiderarAsync(command);
+            return await base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        private async Task ConsiderarAsync(DbCommand command)
+        {
+            if (!command.CommandText.Contains("auditoria", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _coincidencias) == 2)
+            {
+                await alSegundaConsulta();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Etapa 14 — Auditoría · Slice 6 (Export)

- `GET /api/auditoria/export?...&formato=xlsx` bajo la MISMA `LecturaDeAuditoria` (heredada por co-locación, sin línea propia — patrón hermano).
- Shape LISTADO del contrato de la etapa 11: count-first → `Exigir` → `Take(tope+1)` → segundo `Exigir`; **RECHAZA con la cantidad REAL, nunca trunca**.
- Paridad **estructural**: el mismo `ConstruirQuery` del slice 5 (mismos filtros, mismo orden, mismo tiebreaker) — el juez B verificó que una divergencia export-only es imposible de mutar porque no existe código export-only de orden ni de filtro.
- Mapper de 8 columnas; actor null → `#idActor` (decisión 14), PV null → celda vacía, payloads como JSON crudo en la celda.
- Cliente web `rutasDeExportacion.auditoria` con 3 tests colocados.

## Tests (6 de integración + 3 vitest, verdes)
Igualdad JSON↔XLSX celda por celda con **la fila de headers completa en orden** (regla 8), rechazo por tope con cantidad real (seed tope+2 que discrimina el primer guard), **carrera entre el COUNT y la lectura** (interceptor + inserción out-of-band), borde exacto del tope del lado del éxito, `formato=pdf` → 400, 403 heredado.

## Judgment-day
Juez B: 0 severos, 3 WARNINGs (gaps heredados del contrato hermano copiado verbatim) → fix `dbbde50`; re-ronda B con los 3 re-mutantes muertos. Juez A: 0 severos, 1 WARNING **pre-existente repo-wide** registrado sin fix (el `Período`/filename corridos un día para offsets negativos — misma clase que el bug de la etapa 11, presente en 5 endpoints; va a chip de barrido). Ronda limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)