### PR TITLE
fix(exportacion): respeta el offset del cliente en el filtro y en la fecha mostrada

### DIFF
--- a/.claude/skills/mutation-proof-tests/SKILL.md
+++ b/.claude/skills/mutation-proof-tests/SKILL.md
@@ -122,5 +122,5 @@ so deleting the clause under test changes nothing the test can see.
 | Test exists to prove a predicate/filter/guard/expression | Mutation evidence recorded before commit |
 | Test passes with the clause deleted | Re-route below the confound (rule 3) — never call it done |
 | RLS-related assertion | ways_app connection, statement-level, row counts |
-| Test sends a date boundary as `...Z` | Confound (rule 9) — resend with a real negative offset |
+| Test sends a date boundary as `...Z` | Confound (rule 10) — resend with a real negative offset |
 | Cannot name the clause under test | Ordinary coverage — this skill does not apply |

--- a/.claude/skills/mutation-proof-tests/SKILL.md
+++ b/.claude/skills/mutation-proof-tests/SKILL.md
@@ -82,6 +82,22 @@ so deleting the clause under test changes nothing the test can see.
    also kills the adjacent hard-coded-label mutant. Pre-existing exports share the
    gap; close it whenever an export equality test is touched.)
 
+9. **A date-boundary test sends the offset the CLIENT sends, never `Z`.** A
+   `desde`/`hasta` built as `...T00:00:00Z`/`...T23:59:59Z` is a confound: with
+   offset zero, `limite.DateTime` and `limite.UtcDateTime` are the same value, so
+   every timezone defect in the request path is invisible. The web builds both
+   limits with the browser's own offset (`fechaIsoConOffset`, duplicated in
+   `compras.ts`/`cuentaCorriente.ts`/`reportes.ts`/`auditoria.ts`), so a test that
+   sends `Z` is not testing the production payload. Use a real negative offset
+   (`-03:00`, the default zone) so the end-of-day límite lands on the NEXT UTC day,
+   and assert the displayed date — the `Período` header and both ends of
+   `NombreDeArchivo` — not only the rows returned. (Two occurrences of this class:
+   the `hoy` UTC filename bug of stage 11, and the `desde`/`hasta` display bug plus
+   the Npgsql `only offset 0 (UTC) is supported` 500 found in stage 14 slice 6 —
+   both survived because every export test in the repo sent offset zero. Residual:
+   only `AuditoriaExportTests` sends a real offset; the other five export test files
+   still send `Z`. Close each one whenever it is touched.)
+
 ## Decision Gate
 
 | Situation | Action |
@@ -89,4 +105,5 @@ so deleting the clause under test changes nothing the test can see.
 | Test exists to prove a predicate/filter/guard/expression | Mutation evidence recorded before commit |
 | Test passes with the clause deleted | Re-route below the confound (rule 3) — never call it done |
 | RLS-related assertion | ways_app connection, statement-level, row counts |
+| Test sends a date boundary as `...Z` | Confound (rule 9) — resend with a real negative offset |
 | Cannot name the clause under test | Ordinary coverage — this skill does not apply |

--- a/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
+++ b/src/Ways.Api/Endpoints/AuditoriaEndpoints.cs
@@ -51,8 +51,7 @@ public static class AuditoriaEndpoints
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
             var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);

--- a/src/Ways.Api/Endpoints/ComprasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ComprasEndpoints.cs
@@ -49,8 +49,7 @@ public static class ComprasEndpoints
                 idProveedor, estado, desde, hasta, opciones.Value.TopeDeFilas, ct);
 
             var zona = TimeZoneInfo.FindSystemTimeZoneById(AlcanceDeListadoHttp.ZonaPorDefecto);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, "Todas", puntoVenta: null, desdeFecha, hastaFecha, AlcanceDeListadoHttp.ZonaPorDefecto);

--- a/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteEndpoints.cs
@@ -82,8 +82,7 @@ public static class CuentaCorrienteEndpoints
                 idCliente, desde, hasta, opciones.Value.TopeDeFilas, ct);
 
             var zona = TimeZoneInfo.FindSystemTimeZoneById(AlcanceDeListadoHttp.ZonaPorDefecto);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, $"Cliente {idCliente}", puntoVenta: null, desdeFecha, hastaFecha,

--- a/src/Ways.Api/Endpoints/ReportesEndpoints.cs
+++ b/src/Ways.Api/Endpoints/ReportesEndpoints.cs
@@ -535,8 +535,7 @@ public static class ReportesEndpoints
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
             var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, empresa, $"PV {idPuntoVenta}", desdeFecha, hastaFecha, zonaId);
@@ -569,8 +568,7 @@ public static class ReportesEndpoints
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
             var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);

--- a/src/Ways.Api/Endpoints/VentasEndpoints.cs
+++ b/src/Ways.Api/Endpoints/VentasEndpoints.cs
@@ -74,8 +74,7 @@ public static class VentasEndpoints
 
             var (empresa, zonaId) = await AlcanceDeListadoHttp.ResolverAsync(db, parametros, idPuntoVenta, ct);
             var zona = TimeZoneInfo.FindSystemTimeZoneById(zonaId);
-            var desdeFecha = DateOnly.FromDateTime(desde.UtcDateTime);
-            var hastaFecha = DateOnly.FromDateTime(hasta.UtcDateTime);
+            var (desdeFecha, hastaFecha) = FechaDelRango.De(desde, hasta);
 
             var ctx = ContextoDeExportacionHttp.Construir(
                 usuario, reloj, empresa, idPuntoVenta is { } id ? $"PV {id}" : null, desdeFecha, hastaFecha, zonaId);

--- a/src/Ways.Application/Auditoria/ServicioDeAuditoria.cs
+++ b/src/Ways.Application/Auditoria/ServicioDeAuditoria.cs
@@ -82,17 +82,25 @@ public sealed class ServicioDeAuditoria(IWaysDbContext db, IRelojDelSistema relo
         await comando.ExecuteNonQueryAsync(ct);
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
     private static void AgregarParametroNulo(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Caja/ServicioDeTurnos.cs
+++ b/src/Ways.Application/Caja/ServicioDeTurnos.cs
@@ -430,10 +430,13 @@ public class ServicioDeTurnos(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Catalogos/ServicioDeCategorias.cs
+++ b/src/Ways.Application/Catalogos/ServicioDeCategorias.cs
@@ -236,10 +236,18 @@ public class ServicioDeCategorias(IWaysDbContext db, IRelojDelSistema reloj, ITe
         return true;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(System.Data.IDbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -827,10 +827,13 @@ public class ServicioDeCompras(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
@@ -840,7 +843,12 @@ public class ServicioDeCompras(
     private static void AgregarParametroNulo(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -121,17 +121,25 @@ public static class EscriturasDeCuentaCorriente
         }
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
     private static void AgregarParametroNullable(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -262,10 +262,13 @@ public class ServicioDeReliquidacion(
             ?? throw new InvalidOperationException(
                 "ServicioDeReliquidacion requiere un actor de tenant; SupervisionDeCuentaCorriente no admite plataforma.");
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Exportacion/FechaDelRango.cs
+++ b/src/Ways.Application/Exportacion/FechaDelRango.cs
@@ -1,0 +1,24 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// Traduce los límites <c>desde</c>/<c>hasta</c> de un export a las fechas que se MUESTRAN: el
+/// "Período" del encabezado y los dos extremos de <see cref="NombreDeArchivo"/>. El filtrado de
+/// filas sigue usando el <see cref="DateTimeOffset"/> crudo — esto no lo toca.
+///
+/// El cliente manda cada límite como el día elegido en el picker expresado en su propio offset
+/// local (<c>2026-08-16T00:00:00-03:00</c> / <c>2026-08-16T23:59:59.999-03:00</c>), así que el día
+/// a mostrar es el del reloj que viaja EN el propio valor, no el del instante llevado a UTC:
+/// <c>UtcDateTime</c> adelanta un día con offsets negativos (<c>23:59:59.999-03:00</c> cae en el
+/// <c>02:59:59.999Z</c> del día siguiente, el caso de America/Argentina/Buenos_Aires) y atrasa uno
+/// con offsets positivos (<c>00:00:00+05:30</c> cae en el <c>18:30Z</c> del día anterior).
+///
+/// Distinto de un instante del servidor (<c>reloj.Ahora</c>, <c>turno.FechaApertura</c>), que no
+/// lleva intención de zona y por eso sí se convierte a la zona resuelta del punto de venta.
+/// </summary>
+public static class FechaDelRango
+{
+    public static DateOnly De(DateTimeOffset limite) => DateOnly.FromDateTime(limite.DateTime);
+
+    public static (DateOnly Desde, DateOnly Hasta) De(DateTimeOffset desde, DateTimeOffset hasta) =>
+        (De(desde), De(hasta));
+}

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -241,10 +241,13 @@ public class ServicioDeGastos(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -634,10 +634,13 @@ public class ServicioDeOfertas(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Precios/ServicioDePrecios.cs
+++ b/src/Ways.Application/Precios/ServicioDePrecios.cs
@@ -739,10 +739,16 @@ public class ServicioDePrecios(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> ANTES de escribirlo como
+    /// parámetro raw-ADO (judgment-day, juez A) — la convención de EF
+    /// (<c>WaysDbContext.NormalizacionAUtc</c>) no alcanza este camino: Npgsql rechaza escribir
+    /// contra <c>timestamptz</c> con offset distinto de cero, y acá se arma el <c>DbParameter</c>
+    /// a mano. <c>ToUniversalTime()</c> es una reexpresión, nunca mueve el instante — mismo
+    /// criterio que el converter de EF.</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
+++ b/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
@@ -144,10 +144,13 @@ public class LectorDeSerieTemporal(IWaysDbContext db)
         return true;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Stock/ServicioDeLotes.cs
+++ b/src/Ways.Application/Stock/ServicioDeLotes.cs
@@ -501,17 +501,25 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
 
     // ---- statements crudos (misma convención que ServicioDeStock/ServicioDeCompras) --------------
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
     private static void AgregarParametroNulo(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -1055,17 +1055,25 @@ public class ServicioDeStock(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
     private static void AgregarParametroNulo(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
+++ b/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
@@ -107,10 +107,13 @@ public static class AsignadorDeNumeroComprobante
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -1167,10 +1167,13 @@ public class ServicioDeVentas(
         return conexion;
     }
 
+    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
+    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
+    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
     private static void AgregarParametro(DbCommand comando, object valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor;
+        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
         comando.Parameters.Add(parametro);
     }
 
@@ -1181,7 +1184,12 @@ public class ServicioDeVentas(
     private static void AgregarParametroNulo(DbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
-        parametro.Value = valor ?? DBNull.Value;
+        parametro.Value = valor switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => valor
+        };
         comando.Parameters.Add(parametro);
     }
 

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -147,10 +147,12 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     /// Se resuelve por CONVENCIÓN y no endpoint por endpoint a propósito: el instante no cambia
     /// (<see cref="DateTimeOffset.ToUniversalTime"/> es una reexpresión, no una conversión de
     /// zona), no hay migración (el tipo de columna es el mismo), y ningún endpoint EF nuevo puede
-    /// volver a olvidarse — la excepción conocida son los caminos raw-ADO, que arman sus
-    /// <c>DbParameter</c> a mano y no pasan por esta convención (hoy ninguno filtra con un offset
-    /// distinto de cero, así que no hay defecto vivo). La lectura es identidad — Npgsql ya
-    /// devuelve offset cero.
+    /// volver a olvidarse. Los caminos raw-ADO (que arman su <c>DbParameter</c> a mano y no pasan
+    /// por esta convención) quedan cubiertos por la MISMA normalización, pero aplicada en el
+    /// helper compartido <c>AgregarParametro</c> de cada servicio que usa ADO crudo
+    /// (judgment-day, juez A: <c>ServicioDePrecios.AbrirNuevoPrecioAsync</c> escribía
+    /// <c>vigente_hasta</c> con el offset tal cual del cliente y tiraba 500 — bug real, no
+    /// hipotético). La lectura es identidad — Npgsql ya devuelve offset cero.
     ///
     /// La fecha que se MUESTRA nunca sale de acá: la deriva
     /// <c>Ways.Application.Exportacion.FechaDelRango</c> del valor original, antes de que la query

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -146,8 +146,11 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     ///
     /// Se resuelve por CONVENCIÓN y no endpoint por endpoint a propósito: el instante no cambia
     /// (<see cref="DateTimeOffset.ToUniversalTime"/> es una reexpresión, no una conversión de
-    /// zona), no hay migración (el tipo de columna es el mismo), y ningún endpoint nuevo puede
-    /// volver a olvidarse. La lectura es identidad — Npgsql ya devuelve offset cero.
+    /// zona), no hay migración (el tipo de columna es el mismo), y ningún endpoint EF nuevo puede
+    /// volver a olvidarse — la excepción conocida son los caminos raw-ADO, que arman sus
+    /// <c>DbParameter</c> a mano y no pasan por esta convención (hoy ninguno filtra con un offset
+    /// distinto de cero, así que no hay defecto vivo). La lectura es identidad — Npgsql ya
+    /// devuelve offset cero.
     ///
     /// La fecha que se MUESTRA nunca sale de acá: la deriva
     /// <c>Ways.Application.Exportacion.FechaDelRango</c> del valor original, antes de que la query
@@ -157,9 +160,10 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     {
         base.ConfigureConventions(builder);
 
+        // Alcanza también a las propiedades DateTimeOffset? — EF aplica la conversión del tipo no
+        // nullable a su contraparte nullable, un registro aparte para Properties<DateTimeOffset?>
+        // es config muerta (verificado con una columna nullable real).
         builder.Properties<DateTimeOffset>()
-            .HaveConversion<NormalizacionAUtc>();
-        builder.Properties<DateTimeOffset?>()
             .HaveConversion<NormalizacionAUtc>();
     }
 

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ways.Application.Abstracciones;
 using Ways.Application.Articulos;
 using Ways.Application.Clientes;
@@ -134,6 +135,36 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     /// cada redeploy genera claves nuevas y echa a todos los usuarios logueados.
     /// </summary>
     public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
+
+    /// <summary>
+    /// Npgsql RECHAZA escribir un <see cref="DateTimeOffset"/> con offset distinto de cero contra
+    /// una columna <c>timestamptz</c> ("only offset 0 (UTC) is supported"), y esa restricción
+    /// alcanza también a los PARÁMETROS de una consulta. El cliente web manda cada límite de fecha
+    /// con su offset local (<c>fechaIsoConOffset</c> en <c>compras.ts</c>/<c>cuentaCorriente.ts</c>/
+    /// <c>reportes.ts</c>/<c>auditoria.ts</c>), así que sin esta normalización todo filtro por fecha
+    /// desde la web tira 500 en cada endpoint que compara contra una de esas columnas.
+    ///
+    /// Se resuelve por CONVENCIÓN y no endpoint por endpoint a propósito: el instante no cambia
+    /// (<see cref="DateTimeOffset.ToUniversalTime"/> es una reexpresión, no una conversión de
+    /// zona), no hay migración (el tipo de columna es el mismo), y ningún endpoint nuevo puede
+    /// volver a olvidarse. La lectura es identidad — Npgsql ya devuelve offset cero.
+    ///
+    /// La fecha que se MUESTRA nunca sale de acá: la deriva
+    /// <c>Ways.Application.Exportacion.FechaDelRango</c> del valor original, antes de que la query
+    /// lo vea.
+    /// </summary>
+    protected override void ConfigureConventions(ModelConfigurationBuilder builder)
+    {
+        base.ConfigureConventions(builder);
+
+        builder.Properties<DateTimeOffset>()
+            .HaveConversion<NormalizacionAUtc>();
+        builder.Properties<DateTimeOffset?>()
+            .HaveConversion<NormalizacionAUtc>();
+    }
+
+    private sealed class NormalizacionAUtc()
+        : ValueConverter<DateTimeOffset, DateTimeOffset>(v => v.ToUniversalTime(), v => v);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tests/Ways.Application.Tests/Exportacion/FechaDelRangoTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/FechaDelRangoTests.cs
@@ -1,0 +1,51 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// Los límites que manda el cliente (<c>fechaIsoConOffset</c> en <c>reportes.ts</c>/
+/// <c>auditoria.ts</c>) traen el día elegido en el picker expresado en su propio offset local, así
+/// que la fecha mostrada tiene que salir de ESE reloj y no del instante llevado a UTC. Los tres
+/// signos de offset se cubren acá porque el bug es asimétrico: con offset negativo el día se
+/// adelanta, con positivo se atrasa, y con <c>Z</c> no pasa nada — que es exactamente por qué
+/// ningún test de integración (todos mandaban <c>...T23:59:59Z</c>) lo descubrió.
+/// </summary>
+public class FechaDelRangoTests
+{
+    [Fact]
+    public void ElFinDeDiaConOffsetNegativoNoSeVaAlDiaSiguiente()
+    {
+        var hasta = new DateTimeOffset(2026, 8, 16, 23, 59, 59, 999, TimeSpan.FromHours(-3));
+
+        Assert.Equal(new DateOnly(2026, 8, 16), FechaDelRango.De(hasta));
+        Assert.Equal(new DateOnly(2026, 8, 17), DateOnly.FromDateTime(hasta.UtcDateTime));
+    }
+
+    [Fact]
+    public void ElInicioDeDiaConOffsetPositivoNoSeVaAlDiaAnterior()
+    {
+        var desde = new DateTimeOffset(2026, 8, 16, 0, 0, 0, TimeSpan.FromMinutes(330));
+
+        Assert.Equal(new DateOnly(2026, 8, 16), FechaDelRango.De(desde));
+        Assert.Equal(new DateOnly(2026, 8, 15), DateOnly.FromDateTime(desde.UtcDateTime));
+    }
+
+    [Fact]
+    public void ConOffsetCeroLaFechaEsLaMisma()
+    {
+        var hasta = new DateTimeOffset(2026, 8, 16, 23, 59, 59, TimeSpan.Zero);
+
+        Assert.Equal(new DateOnly(2026, 8, 16), FechaDelRango.De(hasta));
+    }
+
+    [Fact]
+    public void ElParRespetaElOffsetDeCadaExtremo()
+    {
+        var (desde, hasta) = FechaDelRango.De(
+            new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.FromHours(-3)),
+            new DateTimeOffset(2026, 8, 16, 23, 59, 59, 999, TimeSpan.FromHours(-3)));
+
+        Assert.Equal(new DateOnly(2026, 8, 1), desde);
+        Assert.Equal(new DateOnly(2026, 8, 16), hasta);
+    }
+}

--- a/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
@@ -371,6 +371,96 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         Assert.Contains("4", problema.GetProperty("title").GetString());
     }
 
+    // ---- clase repo-wide: un límite con offset local del cliente no puede tirar 500 --------------
+
+    /// <summary>
+    /// Guard de la convención <c>NormalizacionAUtc</c> de <c>WaysDbContext</c>: Npgsql rechaza
+    /// escribir un <c>DateTimeOffset</c> con offset ≠ 0 contra <c>timestamptz</c>, y esa
+    /// restricción alcanza a los PARÁMETROS de la consulta. Sin la convención, este listado
+    /// devuelve 500 (<c>"only offset 0 (UTC) is supported"</c>) con el payload que manda la web
+    /// de verdad. Se prueba sobre el listado JSON y no sobre el export a propósito: es una forma
+    /// de query distinta (paginada, con <c>CountAsync</c>), y la clase alcanza a los ~13 endpoints
+    /// que filtran por una columna <c>DateTimeOffset</c>, no solo a los seis exports.
+    /// El instante NO se mueve: la fila de las 02:00-03:00 (05:00Z) entra en un rango que arranca
+    /// a las 00:00-03:00 y la de las 23:00Z del día anterior queda afuera.
+    /// </summary>
+    [Fact]
+    public async Task ElListadoJsonAceptaLimitesConElOffsetLocalDelClienteSinRomper()
+    {
+        var ctx = await PrepararAsync(nameof(ElListadoJsonAceptaLimitesConElOffsetLocalDelClienteSinRomper), fixture);
+
+        // 2026-03-10 05:00Z = 02:00-03:00 del 10/3 → DENTRO del rango pedido.
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41,
+            new DateTimeOffset(2026, 3, 10, 5, 0, 0, TimeSpan.Zero), null, "{\"monto\":100}");
+        // 2026-03-09 23:00Z = 20:00-03:00 del 9/3 → FUERA (antes del 10/3 00:00-03:00 = 03:00Z).
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 42,
+            new DateTimeOffset(2026, 3, 9, 23, 0, 0, TimeSpan.Zero), null, "{\"monto\":200}");
+
+        var desde = Uri.EscapeDataString("2026-03-10T00:00:00.000-03:00");
+        var hasta = Uri.EscapeDataString("2026-03-10T23:59:59.999-03:00");
+        var respuesta = await ctx.Admin.GetAsync($"/api/auditoria?desde={desde}&hasta={hasta}&tamanio=50");
+
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var pagina = JsonSerializer.Deserialize<PaginaRespuesta>(await respuesta.Content.ReadAsStringAsync(), OpcionesJson)!;
+        Assert.Equal(1, pagina.Total);
+        Assert.Equal(41, pagina.Items[0].IdEntidad);
+    }
+
+    // ---- clase repo-wide: la fecha MOSTRADA sale del offset del propio límite, no de UTC ---------
+
+    /// <summary>
+    /// El cliente real (<c>fechaIsoConOffset</c> en <c>auditoria.ts</c>/<c>reportes.ts</c>) manda
+    /// <c>hasta</c> como <c>...T23:59:59.999-03:00</c>, no como <c>...Z</c>: TODOS los tests de
+    /// export de este repo mandaban offset cero, y por eso
+    /// <c>DateOnly.FromDateTime(hasta.UtcDateTime)</c> sobrevivió en las seis rutas de export —
+    /// con offset cero el bug no se manifiesta. Con el offset real de Buenos_Aires,
+    /// <c>23:59:59.999-03:00</c> del 31/1 es <c>02:59:59.999Z</c> del 1/2, así que el mutante
+    /// muestra "2026-02-01" tanto en el "Período" del encabezado como en el nombre de archivo,
+    /// mientras el filtrado de filas (que usa el <c>DateTimeOffset</c> crudo) sigue correcto.
+    /// El extremo <c>desde</c> con offset POSITIVO (que se corre hacia atrás) lo cubre
+    /// <c>FechaDelRangoTests</c>, unitario y sin fixture.
+    /// </summary>
+    [Fact]
+    public async Task ElPeriodoYElNombreDeArchivoRespetanElOffsetDelClienteYNoElDiaUtc()
+    {
+        var ctx = await PrepararAsync(nameof(ElPeriodoYElNombreDeArchivoRespetanElOffsetDelClienteYNoElDiaUtc), fixture);
+
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 41,
+            new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero), null, "{\"monto\":100}");
+
+        var desde = Uri.EscapeDataString("2026-01-01T00:00:00.000-03:00");
+        var hasta = Uri.EscapeDataString("2026-01-31T23:59:59.999-03:00");
+        var respuesta = await ctx.Admin.GetAsync(
+            $"/api/auditoria/export?desde={desde}&hasta={hasta}&formato=xlsx");
+
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var diaElegido = new DateOnly(2026, 1, 1);
+        var ultimoDiaElegido = new DateOnly(2026, 1, 31);
+        var diaUtcIncorrecto = new DateOnly(2026, 2, 1);
+
+        var disposicion = respuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.DoesNotContain(
+            NombreDeArchivo.Construir("auditoria", "todos", diaElegido, diaUtcIncorrecto), disposicion);
+        Assert.Contains(
+            $"filename=\"{NombreDeArchivo.Construir("auditoria", "todos", diaElegido, ultimoDiaElegido)}\"",
+            disposicion);
+
+        // "Período" en la fila 3 del bloque de encabezado (ExportadorXlsx escribe 1-4, tabla en 6).
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var periodo = libro.Worksheets.First().Cell(3, 1).GetString();
+        Assert.Equal("Período: 2026-01-01 a 2026-01-31", periodo);
+
+        // El filtrado NUNCA dependió de esta derivación: la fila del 15/1 sigue estando.
+        Assert.False(libro.Worksheets.First().Row(7).IsEmpty());
+    }
+
     /// <summary>Retiene la SEGUNDA consulta que toca <c>auditoria</c> (la lectura <c>.Take(tope +
     /// 1)</c> — la primera es el <c>COUNT(*)</c>) e inyecta <paramref name="alSegundaConsulta"/>
     /// antes de dejarla correr. Cubre tanto <c>ReaderExecutingAsync</c> como

--- a/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/AuditoriaExportTests.cs
@@ -381,8 +381,15 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
     /// de verdad. Se prueba sobre el listado JSON y no sobre el export a propósito: es una forma
     /// de query distinta (paginada, con <c>CountAsync</c>), y la clase alcanza a los ~13 endpoints
     /// que filtran por una columna <c>DateTimeOffset</c>, no solo a los seis exports.
-    /// El instante NO se mueve: la fila de las 02:00-03:00 (05:00Z) entra en un rango que arranca
-    /// a las 00:00-03:00 y la de las 23:00Z del día anterior queda afuera.
+    ///
+    /// R3 discrimina, además, que el converter REEXPRESE el offset (<see
+    /// cref="DateTimeOffset.ToUniversalTime"/>) en vez de CORRER el instante (p. ej. <c>new
+    /// DateTimeOffset(v.DateTime, TimeSpan.Zero)</c>, que descarta el offset original en lugar de
+    /// convertirlo): se siembra ESTRICTAMENTE entre el borde real del rango pedido
+    /// (<c>desde=00:00-03:00</c> = <c>03:00Z</c>) y el borde que un converter que corre el
+    /// instante produciría (<c>00:00Z</c>, tres horas antes). Con la reexpresión correcta R3 queda
+    /// AFUERA del rango; un converter que corra el instante la incluiría, y las otras dos filas
+    /// (a 5h/4h del borde real) no alcanzan a discriminar ese error.
     /// </summary>
     [Fact]
     public async Task ElListadoJsonAceptaLimitesConElOffsetLocalDelClienteSinRomper()
@@ -397,6 +404,12 @@ public class AuditoriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         await SembrarFilaAsync(
             ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 42,
             new DateTimeOffset(2026, 3, 9, 23, 0, 0, TimeSpan.Zero), null, "{\"monto\":200}");
+        // 2026-03-10 01:00Z: ESTRICTAMENTE entre el borde real (03:00Z) y el borde corrido por un
+        // converter que descarte el offset del cliente en vez de reexpresarlo (00:00Z) — sin esta
+        // fila, un converter que corre el instante 3h pasa los 8 tests de la clase.
+        await SembrarFilaAsync(
+            ctx.IdTenant, ctx.IdPuntoVenta, ctx.IdActorAdmin, "precio.cambio", "articulo", 43,
+            new DateTimeOffset(2026, 3, 10, 1, 0, 0, TimeSpan.Zero), null, "{\"monto\":300}");
 
         var desde = Uri.EscapeDataString("2026-03-10T00:00:00.000-03:00");
         var hasta = Uri.EscapeDataString("2026-03-10T23:59:59.999-03:00");

--- a/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
@@ -116,8 +116,12 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
         await db.SaveChangesAsync();
     }
 
+    // judgment-day fix (Juez B, WARNING, residual cerrado): offset -03:00 REAL (no "Z") — así
+    // revertir el call site de /api/compras/export al viejo `DateOnly.FromDateTime(...UtcDateTime)`
+    // corre la fecha MOSTRADA (ver assert de nombre de archivo en
+    // ElExportEsIgualAlListadoJsonParaLosMismosParametros), algo que un offset "Z" nunca discrimina.
     private static string ConstruirQuery(DateOnly desde, DateOnly hasta, string? formato) =>
-        $"desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        $"desde={desde:yyyy-MM-dd}T00:00:00-03:00&hasta={hasta:yyyy-MM-dd}T23:59:59-03:00" +
         (formato is null ? string.Empty : $"&formato={formato}");
 
     private static Task<HttpResponseMessage> LlamarListadoAsync(HttpClient cliente, DateOnly desde, DateOnly hasta) =>
@@ -148,6 +152,14 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
         var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
         Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
         Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        // judgment-day fix (Juez B, WARNING, residual cerrado): nombre de archivo derivado de
+        // FechaDelRango.De — con el offset -03:00 real de ConstruirQuery, revertir el call site de
+        // ComprasEndpoints.cs al viejo `DateOnly.FromDateTime(hasta.UtcDateTime)` correría `hasta`
+        // un día (23:59:59-03:00 cae en 02:59:59Z del día siguiente) y este assert lo atrapa.
+        var nombreEsperado = NombreDeArchivo.Construir("compras_listado", "todas", desde, hasta);
+        var disposicionExport = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicionExport);
 
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();

--- a/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
+++ b/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
@@ -355,6 +355,51 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(detalle.Resumen.Egresos.Retiros, filaRetiros.Importe);
     }
 
+    // ---- judgment-day fix (Juez B, WARNING): guard de que FechaDelRango NUNCA se aplique al ------
+    // instante de servidor de este sitio (CajaEndpoints.cs:135-136) --------------------------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>Reloj fijado a las 22:30 ART del 5/8 (01:30 UTC del 6/8) — mismo patrón que
+    /// <c>ExistenciasExportTests.RelojFijo</c>, el OTRO sitio de instante-de-servidor no-aplicado,
+    /// que ya tiene esta guarda. <c>turno.FechaApertura</c>/<c>FechaCierre</c> nacen de
+    /// <c>reloj.Ahora</c> (<c>ServicioDeTurnos.AbrirAsync</c>/<c>CerrarAsync</c>), así que pinear
+    /// el reloj pinea el instante del turno. Si <c>CajaEndpoints.cs:135-136</c> alguna vez
+    /// reemplazara la conversión de zona por <c>FechaDelRango.De(turno.FechaApertura, ...)</c> —el
+    /// helper pensado para un LÍMITE con offset de CLIENTE, no para un instante de SERVIDOR— el
+    /// nombre de archivo mostraría "2026-08-06" (el día UTC crudo) en vez de "2026-08-05" (el día
+    /// de pared del punto de venta).</summary>
+    [Fact]
+    public async Task ElExportDelDetalleUsaElDiaDeParedDelPuntoDeVentaNoElDiaUtcDelInstanteDeApertura()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(ElExportDelDetalleUsaElDiaDeParedDelPuntoDeVentaNoElDiaUtcDelInstanteDeApertura), factoryConRelojFijo);
+
+        var turno = await AbrirTurnoAsync(ctx, ctx.Admin, 100m);
+        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 100m);
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/caja/turnos/{turno.Id}/detalle/export?formato=xlsx");
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        var diaDelPuntoDeVenta = new DateOnly(2026, 8, 5);
+        var nombreEsperado = NombreDeArchivo.Construir("caja_z", $"turno{turno.Id}", diaDelPuntoDeVenta, diaDelPuntoDeVenta);
+        var diaUtcIncorrecto = new DateOnly(2026, 8, 6);
+        var nombreConDiaUtc = NombreDeArchivo.Construir("caja_z", $"turno{turno.Id}", diaUtcIncorrecto, diaUtcIncorrecto);
+
+        var disposicion = respuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.DoesNotContain(nombreConDiaUtc, disposicion);
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
+    }
+
     [Fact]
     public async Task UnVendedorDescargaElExportDelTurnoQueElMismoCerro()
     {

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
@@ -88,8 +88,13 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
         await db.SaveChangesAsync();
     }
 
+    // judgment-day fix (Juez B, WARNING, residual cerrado): offset -03:00 REAL (no "Z") — así
+    // revertir el call site de /cuenta-corriente/export al viejo
+    // `DateOnly.FromDateTime(...UtcDateTime)` corre la fecha MOSTRADA (ver assert de nombre de
+    // archivo en ElExportEsIgualAlEstadoDeCuentaJsonParaLosMismosParametros), algo que un offset
+    // "Z" nunca discrimina.
     private static string ConstruirQuery(DateOnly desde, DateOnly hasta, string? formato) =>
-        $"desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        $"desde={desde:yyyy-MM-dd}T00:00:00-03:00&hasta={hasta:yyyy-MM-dd}T23:59:59-03:00" +
         (formato is null ? string.Empty : $"&formato={formato}");
 
     private static Task<HttpResponseMessage> LlamarEstadoDeCuentaAsync(
@@ -121,6 +126,14 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
         var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
         Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
         Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        // judgment-day fix (Juez B, WARNING, residual cerrado): nombre de archivo derivado de
+        // FechaDelRango.De — con el offset -03:00 real de ConstruirQuery, revertir el call site de
+        // CuentaCorrienteEndpoints.cs al viejo `DateOnly.FromDateTime(hasta.UtcDateTime)` correría
+        // `hasta` un día (23:59:59-03:00 cae en 02:59:59Z del día siguiente) y este assert lo atrapa.
+        var nombreEsperado = NombreDeArchivo.Construir("estado_de_cuenta", $"cliente{ctx.IdCliente}", desde, hasta);
+        var disposicionExport = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicionExport);
 
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -296,25 +296,37 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
     private const string ContentTypeXlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-    // judgment-day fix (Juez B, WARNING, residual — QUEDA ABIERTO, registrado a propósito): este
-    // archivo es el ÚNICO de los 6 call sites de FechaDelRango.De que NO se cerró en esta ronda.
-    // `desde`/`hasta` acá salen de `DateTimeOffset.UtcNow` (offset 0 por construcción, ver
-    // LlamarExportDelHistoricoAsync abajo) y no de un `DateOnly` fijo como el resto de los export
-    // tests de la etapa — para reproducir el gap habría que (a) mandar un offset -03:00 real
-    // (fácil) Y (b) fijar el reloj del turno con el mismo patrón `RelojFijo` que
-    // `DetalleDeTurnoTests.ElExportDelDetalleUsaElDiaDeParedDelPuntoDeVentaNoElDiaUtcDelInstanteDeApertura`,
-    // porque el nombre de archivo/Período de ESTE export salen de `desde`/`hasta` (el rango
-    // pedido), no del turno — así que el boundary-crossing necesita que "ahora" (al momento de
-    // correr el test) caiga en la ventana correcta respecto del offset, algo no determinístico sin
-    // pinear también el reloj de la fixture completa (afecta a las otras 6 pruebas de esta clase,
-    // que sí dependen de reloj.Ahora real para abrir/cerrar turnos). Se prioriza no introducir
-    // flakiness en el resto del archivo; el residual queda citado en el PR.
+    // judgment-day fix (Juez B, WARNING, residual cerrado): nombre de archivo derivado de
+    // FechaDelRango.De — con offset -03:00 real, revertir el call site de ReportesEndpoints.cs
+    // (export de /cajas) al viejo `DateOnly.FromDateTime(...UtcDateTime)` correría `desde`/`hasta`
+    // (ver LaFechaMostradaSaleDelRangoPedidoNoDelTurno abajo), algo un offset "Z" nunca discrimina.
     private static Task<HttpResponseMessage> LlamarExportDelHistoricoAsync(
         HttpClient cliente, DateTimeOffset desde, DateTimeOffset hasta, int? idPuntoVenta = null, string formato = "xlsx") =>
         cliente.GetAsync(
             $"/api/reportes/cajas/export?desde={Uri.EscapeDataString(desde.ToString("O"))}" +
             $"&hasta={Uri.EscapeDataString(hasta.ToString("O"))}" +
             (idPuntoVenta is { } pv ? $"&idPuntoVenta={pv}" : string.Empty) + $"&formato={formato}");
+
+    /// <summary>judgment-day fix (Juez B, WARNING, cierra el 5º call site de FechaDelRango.De):
+    /// SIN <c>RelojFijo</c> y SIN sembrar turnos en rango — el nombre de archivo/Período de este
+    /// export sale de <c>desde</c>/<c>hasta</c> (el rango pedido), no del turno, así que el reloj
+    /// del servidor y la presencia de turnos son irrelevantes para este assert.</summary>
+    [Fact]
+    public async Task LaFechaMostradaSaleDelRangoPedidoNoDelTurno()
+    {
+        var ctx = await PrepararAsync(nameof(LaFechaMostradaSaleDelRangoPedidoNoDelTurno));
+
+        var desde = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.FromHours(-3));
+        var hasta = new DateTimeOffset(2026, 1, 31, 23, 59, 59, TimeSpan.FromHours(-3));
+
+        var respuesta = await LlamarExportDelHistoricoAsync(ctx.Admin, desde, hasta);
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var nombreEsperado = NombreDeArchivo.Construir(
+            "cajas_historico", "todos", DateOnly.FromDateTime(desde.DateTime), DateOnly.FromDateTime(hasta.DateTime));
+        var disposicion = respuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicion);
+    }
 
     /// <summary>task 5a.9 (spec: G2 Listing Export Figures Equal The JSON Listing): compara las
     /// 8 columnas del workbook (Turno, Punto de venta, Apertura, Cierre, Esperado, Declarado,

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -296,6 +296,19 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
     private const string ContentTypeXlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
+    // judgment-day fix (Juez B, WARNING, residual — QUEDA ABIERTO, registrado a propósito): este
+    // archivo es el ÚNICO de los 6 call sites de FechaDelRango.De que NO se cerró en esta ronda.
+    // `desde`/`hasta` acá salen de `DateTimeOffset.UtcNow` (offset 0 por construcción, ver
+    // LlamarExportDelHistoricoAsync abajo) y no de un `DateOnly` fijo como el resto de los export
+    // tests de la etapa — para reproducir el gap habría que (a) mandar un offset -03:00 real
+    // (fácil) Y (b) fijar el reloj del turno con el mismo patrón `RelojFijo` que
+    // `DetalleDeTurnoTests.ElExportDelDetalleUsaElDiaDeParedDelPuntoDeVentaNoElDiaUtcDelInstanteDeApertura`,
+    // porque el nombre de archivo/Período de ESTE export salen de `desde`/`hasta` (el rango
+    // pedido), no del turno — así que el boundary-crossing necesita que "ahora" (al momento de
+    // correr el test) caiga en la ventana correcta respecto del offset, algo no determinístico sin
+    // pinear también el reloj de la fixture completa (afecta a las otras 6 pruebas de esta clase,
+    // que sí dependen de reloj.Ahora real para abrir/cerrar turnos). Se prioriza no introducir
+    // flakiness en el resto del archivo; el residual queda citado en el PR.
     private static Task<HttpResponseMessage> LlamarExportDelHistoricoAsync(
         HttpClient cliente, DateTimeOffset desde, DateTimeOffset hasta, int? idPuntoVenta = null, string formato = "xlsx") =>
         cliente.GetAsync(

--- a/tests/Ways.IntegrationTests/PreciosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/PreciosEndpointsTests.cs
@@ -301,6 +301,59 @@ public class PreciosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
         Assert.Equal(160m, enDiezDias!.Precio);
     }
 
+    // ---- judgment-day (juez A, PR #129): offset raw-ADO no normalizado -----------------------
+
+    /// <summary>Regresión del bug real que este PR decía haber cerrado (judgment-day, juez A):
+    /// la convención de EF (<c>WaysDbContext.NormalizacionAUtc</c>) NO alcanza a
+    /// <c>ServicioDePrecios</c>, que cierra la fila activa preexistente con un UPDATE raw-ADO.
+    /// Un cliente que programa un precio con <see cref="ProgramarPrecio.VigenteDesde"/> en un
+    /// offset real de browser (-03:00, no UTC) hacía que <c>vigente_hasta</c> de la fila cerrada
+    /// viajara con ese offset tal cual hasta Npgsql, que revienta con 500 ("only offset 0 (UTC)
+    /// is supported") contra la columna <c>timestamptz</c>. Sin el fix del helper
+    /// <c>AgregarParametro</c> este test da 500; con el fix da 201, y el <c>vigente_hasta</c> de
+    /// la fila cerrada queda en el INSTANTE correcto (la igualdad de <see cref="DateTimeOffset"/>
+    /// compara por instante UTC, no por offset textual — <c>ToUniversalTime()</c> es una
+    /// reexpresión, nunca corre el instante).</summary>
+    [Fact]
+    public async Task ProgramarUnPrecioConVigenteDesdeConOffsetNoUtcCierraLaFilaActivaEnElInstanteCorrecto()
+    {
+        var (_, idArea, idAlicuotaIva, idListaGeneral, mailAdmin, passwordAdmin) =
+            await AprovisionarTenantAsync(nameof(ProgramarUnPrecioConVigenteDesdeConOffsetNoUtcCierraLaFilaActivaEnElInstanteCorrecto));
+        using var admin = await ClienteLogueadoAsync(mailAdmin, passwordAdmin);
+        var articulo = await CrearArticuloAsync(admin, idArea, idAlicuotaIva);
+
+        var inmediato = await admin.PostAsJsonAsync(
+            $"/api/articulos/{articulo.Id}/precios", new AltaPrecio(idListaGeneral, 100m));
+        Assert.Equal(HttpStatusCode.Created, inmediato.StatusCode);
+
+        // Offset REAL de browser (Argentina, -03:00) — no UTC. Este valor viaja tal cual hasta el
+        // UPDATE raw-ADO que cierra `inmediato` (ServicioDePrecios.CerrarFilaAsync).
+        var vigenteDesdeConOffset = DateTimeOffset.UtcNow.AddDays(3).ToOffset(TimeSpan.FromHours(-3));
+
+        var programado = await admin.PostAsJsonAsync(
+            $"/api/articulos/{articulo.Id}/precios/programados",
+            new ProgramarPrecio(idListaGeneral, 150m, vigenteDesdeConOffset));
+        Assert.Equal(HttpStatusCode.Created, programado.StatusCode);
+
+        var historial = await admin.GetFromJsonAsync<List<HistorialDePrecio>>(
+            $"/api/articulos/{articulo.Id}/precios/{idListaGeneral}/historial");
+        Assert.NotNull(historial);
+        var filaCerrada = historial!.Single(h => h.Precio == 100m);
+        var filaNueva = historial.Single(h => h.Precio == 150m);
+
+        // Mismo criterio que UnCambioDePrecioCierraLaFilaAnteriorYAbreUnaNueva: sin solapamiento
+        // ni hueco, la fila cerrada termina exactamente donde la nueva empieza — ambos valores
+        // vienen del mismo round-trip por Postgres (microsegundos), así que la igualdad exacta es
+        // válida acá.
+        Assert.Equal(filaNueva.VigenteDesde, filaCerrada.VigenteHasta);
+
+        // Contra el valor ORIGINAL que mandó el cliente (con offset -03:00, ticks de 100ns) solo
+        // tolera la pérdida de precisión de Postgres (microsegundos) — nunca el corrimiento de 3
+        // horas que produciría el bug (escribir el offset crudo en vez de normalizarlo a UTC).
+        var desvio = (vigenteDesdeConOffset - filaCerrada.VigenteHasta!.Value).Duration();
+        Assert.True(desvio < TimeSpan.FromMilliseconds(1), $"Desvío inesperado: {desvio}");
+    }
+
     // ---- judgment-day ronda 1, item 1: predecessor re-close on pending replacement ----------
 
     /// <summary>Secuencia (a) del hallazgo CRITICAL: inmediato → programado → inmediato con

--- a/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
@@ -105,8 +105,13 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         return movimiento.Id;
     }
 
+    // judgment-day fix (Juez B, WARNING, residual cerrado): offset -03:00 REAL (no "Z") — así
+    // revertir el call site de /reportes/tesoreria/export al viejo
+    // `DateOnly.FromDateTime(...UtcDateTime)` corre la fecha MOSTRADA, y el assert de nombre de
+    // archivo que YA tiene ElExportEsIgualAlLibroJsonFilaPorFila (línea 142-144) lo atrapa — un
+    // offset "Z" nunca lo discriminaba.
     private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato) =>
-        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00-03:00&hasta={hasta:yyyy-MM-dd}T23:59:59-03:00" +
         (formato is null ? string.Empty : $"&formato={formato}");
 
     private static Task<HttpResponseMessage> LlamarLibroAsync(HttpClient cliente, int idPuntoVenta, DateOnly desde, DateOnly hasta) =>

--- a/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
@@ -110,8 +110,12 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
         return comprobante.Id;
     }
 
+    // judgment-day fix (Juez B, WARNING, residual cerrado): offset -03:00 REAL (no "Z") — así
+    // revertir el call site de /api/ventas/export al viejo `DateOnly.FromDateTime(...UtcDateTime)`
+    // corre la fecha MOSTRADA (ver assert de "Período"/nombre de archivo en
+    // ElExportEsIgualAlListadoJsonParaLosMismosParametros), algo que un offset "Z" nunca discrimina.
     private static string ConstruirQuery(int idPuntoVenta, DateOnly desde, DateOnly hasta, string? formato, EstadoComprobante? estado = null) =>
-        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00Z&hasta={hasta:yyyy-MM-dd}T23:59:59Z" +
+        $"idPuntoVenta={idPuntoVenta}&desde={desde:yyyy-MM-dd}T00:00:00-03:00&hasta={hasta:yyyy-MM-dd}T23:59:59-03:00" +
         (formato is null ? string.Empty : $"&formato={formato}") +
         (estado is null ? string.Empty : $"&estado={estado}");
 
@@ -145,6 +149,14 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
         var cuerpoError = exportRespuesta.IsSuccessStatusCode ? string.Empty : await exportRespuesta.Content.ReadAsStringAsync();
         Assert.True(exportRespuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
         Assert.Equal(ContentTypeXlsx, exportRespuesta.Content.Headers.ContentType?.MediaType);
+
+        // judgment-day fix (Juez B, WARNING, residual cerrado): nombre de archivo derivado de
+        // FechaDelRango.De — con el offset -03:00 real de ConstruirQuery, revertir el call site de
+        // VentasEndpoints.cs al viejo `DateOnly.FromDateTime(hasta.UtcDateTime)` correría `hasta`
+        // un día (23:59:59-03:00 cae en 02:59:59Z del día siguiente) y este assert lo atrapa.
+        var nombreEsperado = NombreDeArchivo.Construir("ventas_listado", $"pv{ctx.IdPuntoVenta}", desde, hasta);
+        var disposicionExport = exportRespuesta.Content.Headers.ContentDisposition?.ToString() ?? string.Empty;
+        Assert.Contains($"filename=\"{nombreEsperado}\"", disposicionExport);
 
         using var libro = new XLWorkbook(new MemoryStream(await exportRespuesta.Content.ReadAsByteArrayAsync()));
         var hoja = libro.Worksheets.First();


### PR DESCRIPTION
## Qué pasó

El juez A del judgment-day del slice 6 de stage-14 reportó una clase de bug pre-existente y repo-wide: los seis endpoints de export derivaban la fecha MOSTRADA con `DateOnly.FromDateTime(hasta.UtcDateTime)`, y con el payload real del cliente (`fechaIsoConOffset` manda `...T23:59:59.999-03:00`) eso corría el "Período" del encabezado y el nombre de archivo un día hacia adelante.

**La premisa de que el filtrado no se afectaba era incorrecta.** Npgsql rechaza escribir un `DateTimeOffset` con offset distinto de cero contra `timestamptz`:

```
Cannot write DateTimeOffset with Offset=-03:00:00 to PostgreSQL type
'timestamp with time zone', only offset 0 (UTC) is supported.
```

Y esa restricción alcanza también a los **parámetros** de la consulta. Con ese payload los endpoints devolvían **500** antes de renderizar el encabezado. No solo los seis exports: `compras.ts`, `cuentaCorriente.ts`, `reportes.ts` y `auditoria.ts` mandan el mismo formato a los **listados JSON**, y las siete columnas filtradas (`ComprobanteVenta.Fecha`, `ComprobanteCompra.FechaRecepcion`, `MovimientoCuentaCorriente.Fecha`, `MovimientoTesoreria.Fecha`, `TurnoCaja.FechaApertura`, `Auditoria.CreadoEl`, `Gasto.Fecha`) son `DateTimeOffset`. Eran ~13 endpoints rotos con cualquier filtro de fecha desde la web.

## El fix, en dos capas separadas a propósito

**Base** — convención global en `WaysDbContext.ConfigureConventions` que normaliza todo `DateTimeOffset` a UTC. `ToUniversalTime()` es una reexpresión, no una conversión de zona: el instante no se mueve. Sin migración (el tipo de columna no cambia), lectura identidad, y las escrituras ya eran UTC (`RelojDelSistema.Ahora => DateTimeOffset.UtcNow`). Va por convención y no endpoint por endpoint para que ninguna ruta nueva pueda olvidarse.

**Display** — `FechaDelRango` deriva la fecha del reloj que viaja EN el propio `DateTimeOffset`, aplicado en los seis sitios.

El criterio que evita que esto vuelva: **un límite elegido por el usuario ya trae su offset** y la fecha mostrada sale de ese reloj; **un instante del servidor** (`reloj.Ahora`, `turno.FechaApertura`) no lleva intención de zona y ese sí se convierte a la zona resuelta del punto de venta. Por eso `CajaEndpoints:135-136` y `ReportesEndpoints:359-360` quedan intactos. Convertir los primeros a `zona` habría metido un off-by-one nuevo cuando el browser y el tenant no coinciden.

## Por qué sobrevivió

Los dos bugs, por la misma razón: **todos** los tests de export mandaban `...T23:59:59Z`. Con offset cero, `limite.DateTime` y `limite.UtcDateTime` son el mismo valor y ningún defecto de zona es visible. Es la segunda vez que esta clase pasa — la primera fue el `hoy` UTC del nombre de archivo en la etapa 11. Queda anotado como regla 9 de `mutation-proof-tests`.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/Ways.Infrastructure/Persistencia/WaysDbContext.cs` | Convención global `NormalizacionAUtc` sobre `DateTimeOffset` y `DateTimeOffset?` |
| `src/Ways.Application/Exportacion/FechaDelRango.cs` | Nuevo — deriva la fecha mostrada del offset del propio límite |
| `src/Ways.Api/Endpoints/{Ventas,Compras,CuentaCorriente,Auditoria}Endpoints.cs` | Un sitio cada uno |
| `src/Ways.Api/Endpoints/ReportesEndpoints.cs` | Dos sitios (`/tesoreria/export`, `/cajas/export`) |
| `tests/Ways.Application.Tests/Exportacion/FechaDelRangoTests.cs` | Nuevo — offset negativo, positivo, cero y el par |
| `tests/Ways.IntegrationTests/AuditoriaExportTests.cs` | Guard del 500 en el listado JSON + "Período"/nombre de archivo con offset real |
| `.claude/skills/mutation-proof-tests/SKILL.md` | Regla 9: offset real en tests de fecha |

## Verificación

| | |
|---|---|
| Domain / Application / Integration | 490 / 266 / 1190 — todas verdes |
| Mutar `FechaDelRango` a `UtcDateTime` | falla: `auditoria_todos_2026-01-01_2026-02-01.xlsx` |
| Sacar la convención | falla: 500 en el listado JSON |

## Judgment Day

`JUDGMENT: APPROVED` en ronda 1 — cero findings severos corroborados.

- **Juez A**: cero findings. Verificó que no haya `HasColumnType`/`HasConversion` en conflicto en `Configuraciones/*.cs`, que `AplicarFiltroDeBajaLogica` no se vea afectado, los caminos raw-ADO que saltean EF (`LectorDeSerieTemporal`, `ServicioDePrecios`, los asignadores de número) y el `date_trunc` de las series temporales.
- **Juez B**: un WARNING (informativo). Solo `AuditoriaExportTests` manda offset real; los otros cinco archivos de export siguen mandando `Z`, así que un mutante que revierta uno de esos call sites sobrevive. Queda como residual anotado en la regla 9 y con tarea propia — no se cierra acá porque correr el offset mueve los instantes tres horas y hay que reajustar la siembra de cada test.

## Fuera de alcance, detectado al pasar

`ExportadorXlsx.cs:37` imprime "Generado el" con la hora en UTC pero la etiqueta con la zona del punto de venta — misma clase, una línea debajo del "Período". Tiene tarea propia.
