### PR TITLE
test(export): barrido de los 3 gaps compartidos en las 18 rutas /export

### DIFF
--- a/.claude/skills/mutation-proof-tests/SKILL.md
+++ b/.claude/skills/mutation-proof-tests/SKILL.md
@@ -82,6 +82,23 @@ so deleting the clause under test changes nothing the test can see.
    also kills the adjacent hard-coded-label mutant. Pre-existing exports share the
    gap; close it whenever an export equality test is touched.)
 
+9. **The three shared gaps of every `/export` route test, and the settled question
+   about `IsEmpty()`.** An export route needs all three, per route, or a mutant lives:
+   (a) the tope-rejection test seeds `tope + 2` and asserts the REAL count — on a
+   LISTADO route (two `Exigir`, `.Take(tope + 1)`) seeding `tope + 1` makes the count
+   and the truncated read agree, so deleting the first `Exigir` survives; AGREGADO
+   routes have one `Exigir` over a materialized `Filas.Count` and need no change;
+   (b) a `formato=pdf` test PER ROUTE — one test does not cover its siblings;
+   (c) an exactly-tope success test asserting 200 and a complete workbook, or
+   `Exigir(count, tope - 1)` survives. Assert the count as `"tiene N filas"`, never a
+   bare `"N"` — the title also carries the tope, so a lone digit can match the wrong
+   number. `hoja.Row(n).IsEmpty()` IS load-bearing as the end-of-data assertion:
+   `ExportadorXlsx.AplicarFormatoDeColumna` styles whole columns, but a styled-yet-
+   unwritten row still reads empty while a row holding data reads non-empty (proven
+   by forcing a fourth data row into a three-row expectation and watching the assert
+   fail). Both judges raised this independently — it is settled, do not re-litigate.
+   (Stage 14 slice 6 found the three gaps; swept across all 18 routes and 11 files.)
+
 ## Decision Gate
 
 | Situation | Action |

--- a/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasListadoExportTests.cs
@@ -189,6 +189,12 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
 
     // ---- task 3.7: rechazo por tope ---------------------------------------------------------------
 
+    /// <summary>Discriminador real del PRIMER <c>GuardaDeTope.Exigir</c> (sobre el <c>COUNT(*)</c>):
+    /// se siembra tope+2 (5, no tope+1) filas porque con solo 4 filas el <c>COUNT(*)</c> real y la
+    /// lectura truncada por <c>.Take(tope + 1)</c> coinciden en "4" — borrar el primer <c>Exigir</c>
+    /// sobrevive porque el segundo rechaza igual con el mismo número. Con 5 filas el <c>Take(4)</c>
+    /// trunca: el mutante reporta "4" (el truncado) en vez de la cantidad REAL "5", y el assert de
+    /// abajo lo discrimina.</summary>
     [Fact]
     public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
     {
@@ -199,7 +205,7 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
         var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
         var dia = new DateOnly(2026, 8, 1);
 
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < 5; i++)
         {
             await SembrarCompraAsync(ctx, dia, 100m + i, $"0001-0000000{i}");
         }
@@ -211,6 +217,67 @@ public class ComprasListadoExportTests(WaysApiFixture fixture) : IClassFixture<W
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- FormatoDeExportacion.Parsear en esta ruta (barrido de gaps compartidos) ------------------
+
+    /// <summary>Sin este test, borrar la llamada a <see cref="FormatoDeExportacion.Parsear"/> en
+    /// <c>/api/compras/export</c> sobrevive — un <c>formato=pdf</c> devolvería 200 XLSX en vez de
+    /// 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeCompras()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeCompras), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, hoy, hoy, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- exportar exactamente el tope de filas es legítimo (barrido de gaps compartidos) ----------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(items.Count, tope - 1)</c> sobrevive
+    /// — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c> solo cubre el rechazo por
+    /// ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> filas y se espera 200 con el
+    /// workbook completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarCompraAsync(ctx, dia, 100m + i, $"0001-0000000{i}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, dia, dia);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que
+        // ElExportEsIgualAlListadoJsonParaLosMismosParametros): las tope=3 filas ocupan 7-9, la
+        // fila 10 debe quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 }

--- a/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
+++ b/tests/Ways.IntegrationTests/DetalleDeTurnoTests.cs
@@ -2,9 +2,12 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.Exportacion;
 using Ways.Application.Gastos;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
@@ -44,9 +47,11 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         int IdTenant, int IdPuntoVenta, int IdEmpleadoAdmin, int IdCliente, int IdTipoComprobanteTx,
         int IdMedioEfectivo, HttpClient Admin, HttpClient Vendedor);
 
-    private async Task<Contexto> PrepararAsync(string nombre)
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
     {
-        using var root = fixture.CreateClient();
+        var host = factory ?? fixture;
+
+        using var root = host.CreateClient();
         var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
         Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
 
@@ -56,7 +61,7 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
         var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
 
-        var admin = fixture.CreateClient();
+        var admin = host.CreateClient();
         var loginAdmin = await admin.PostAsJsonAsync(
             "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
         Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
@@ -67,7 +72,7 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
             "/api/usuarios", new CrearUsuario($"vendedor-{corto}", mailVendedor, (int)RolConocido.Vendedor, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
 
-        var vendedor = fixture.CreateClient();
+        var vendedor = host.CreateClient();
         var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
 
@@ -362,5 +367,113 @@ public class DetalleDeTurnoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
 
         Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
         Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+    }
+
+    // ---- barrido export: FormatoDeExportacion.Parsear en esta ruta -------------------------------
+
+    /// <summary>Sin la llamada a <see cref="FormatoDeExportacion.Parsear"/> dentro de
+    /// <c>/caja/turnos/{id}/detalle/export</c>, un <c>formato=pdf</c> devolvería 200 XLSX en vez de
+    /// 400. <c>Parsear</c> corre ANTES de resolver el turno (CajaEndpoints.cs:116, previo al
+    /// <c>ObtenerAsync</c> de la línea 120), así que ni siquiera hace falta un turno existente — un
+    /// id arbitrario alcanza para probar este clause sin sembrar ningún dato.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeDetalleDeTurno()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeDetalleDeTurno));
+
+        var respuesta = await ctx.Admin.GetAsync("/api/caja/turnos/999999/detalle/export?formato=pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- barrido export: borde EXACTO del tope y rechazo por ARRIBA del tope ----------------------
+    //
+    // Esta ruta no tenía NINGÚN test de tope: su único GuardaDeTope.Exigir (CajaEndpoints.cs:142)
+    // podía borrarse sin que la suite se rompiera. ExportacionDeCaja.De(DetalleDeTurno, ...) arma
+    // tabla.Filas sumando SEIS bloques (Medios + Egresos por categoría + Egresos por área + Retiros
+    // (SIEMPRE una fila, incondicional) + Tickets + Gastos). Para que la cuenta sea determinística
+    // se sella la actividad del turno a UN SOLO medio de pago (Efectivo, vía fondoInicial != 0 y
+    // ventas solo con ese medio) y CERO gastos:
+    //   - Medios: 1 fila (Efectivo es el único con TuvoFilas/ancla — ResolvedorDeMedioDeCajaFisica
+    //     exige exactamente un medio Efectivo, y ningún otro medio tiene actividad).
+    //   - Egresos por categoría / por área: 0 filas cada uno — LectorDeContenidoDeResumen agrupa
+    //     con GroupBy sobre `db.Gastos.Where(turno)`; sin gastos sembrados, el GroupBy no emite
+    //     ningún grupo (a diferencia de "1 grupo con total 0").
+    //   - Retiros: 1 fila siempre (ExportacionDeCaja.cs:136-142 la agrega incondicionalmente).
+    //   - Tickets: N filas, una por venta sembrada (SembrarVentaAsync, estado Emitido).
+    //   - Gastos: 0 filas (ninguno sembrado).
+    // Total = 1 (Medios) + 0 + 0 + 1 (Retiros) + N (Tickets) + 0 = 2 + N. Con tope = 3, N = 1 pega
+    // EXACTO en el tope; N = 2 pega en tope + 1.
+
+    /// <summary>Discriminador real del ÚNICO <c>GuardaDeTope.Exigir</c> de esta ruta AGREGADA del
+    /// lado del ÉXITO: sin este test, mutar <c>Exigir(tabla.Filas.Count, tope)</c> a
+    /// <c>Exigir(tabla.Filas.Count, tope - 1)</c> sobrevive — nada más en este archivo ejercita el
+    /// export con el tope bajado. Un ticket sembrado (más el "Medios" y el "Retiros" incondicional,
+    /// sin gastos) da EXACTAMENTE 3 filas contra un tope de 3.</summary>
+    [Fact]
+    public async Task UnaExportacionDelDetalleDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDelDetalleDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var turno = await AbrirTurnoAsync(ctx, ctx.Admin, 100m);
+
+        await SembrarVentaAsync(ctx, turno.Id, 50m);
+        // esperado efectivo = 100 (fondo) + 50 (venta) = 150 — sin gastos ni retiros.
+        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 150m);
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/caja/turnos/{turno.Id}/detalle/export?formato=xlsx");
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Header en la fila 6, datos desde la 7 (mismo layout que ElExportDelDetalleEsIgualAlJsonParaElMismoTurno):
+        // Medios (fila 7) + Retiros (fila 8) + el ticket sembrado (fila 9) = las tope=3 filas, y la
+        // fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
+    }
+
+    /// <summary>Sibling de rechazo del test de arriba — esta ruta no tenía NINGÚN test de tope
+    /// (ver el comentario de bloque de arriba): sin este test, borrar el
+    /// <c>GuardaDeTope.Exigir</c> de <c>/detalle/export</c> (CajaEndpoints.cs:142) sobrevive
+    /// completo, sin ningún test de la suite notándolo. Dos tickets sembrados dan 4 filas (tope +
+    /// 1) contra un tope de 3.</summary>
+    [Fact]
+    public async Task UnaExportacionDelDetalleQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDelDetalleQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var turno = await AbrirTurnoAsync(ctx, ctx.Admin, 100m);
+
+        await SembrarVentaAsync(ctx, turno.Id, 50m);
+        await SembrarVentaAsync(ctx, turno.Id, 60m);
+        // esperado efectivo = 100 (fondo) + 50 + 60 (ventas) = 210 — sin gastos ni retiros.
+        await CerrarTurnoAsync(ctx.Admin, turno.Id, ctx.IdMedioEfectivo, 210m);
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/caja/turnos/{turno.Id}/detalle/export?formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 4 filas", problema.GetProperty("title").GetString());
     }
 }

--- a/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
+++ b/tests/Ways.IntegrationTests/EstadoDeCuentaExportTests.cs
@@ -162,6 +162,12 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
 
     // ---- task 3.7: rechazo por tope ---------------------------------------------------------------
 
+    /// <summary>Discriminador real del PRIMER <c>GuardaDeTope.Exigir</c> (sobre el <c>COUNT(*)</c>):
+    /// se siembra tope+2 (5, no tope+1) filas porque con solo 4 filas el <c>COUNT(*)</c> real y la
+    /// lectura truncada por <c>.Take(tope + 1)</c> coinciden en "4" — borrar el primer <c>Exigir</c>
+    /// sobrevive porque el segundo rechaza igual con el mismo número. Con 5 filas el <c>Take(4)</c>
+    /// trunca: el mutante reporta "4" (el truncado) en vez de la cantidad REAL "5", y el assert de
+    /// abajo lo discrimina.</summary>
     [Fact]
     public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
     {
@@ -173,7 +179,7 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
         var dia = new DateOnly(2026, 8, 1);
         var saldo = 0m;
 
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < 5; i++)
         {
             saldo += 100m;
             await SembrarMovimientoAsync(ctx, dia, 100m, saldo);
@@ -186,6 +192,71 @@ public class EstadoDeCuentaExportTests(WaysApiFixture fixture) : IClassFixture<W
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- FormatoDeExportacion.Parsear en esta ruta (barrido de gaps compartidos) ------------------
+
+    /// <summary>Sin este test, borrar la llamada a <see cref="FormatoDeExportacion.Parsear"/> en
+    /// <c>/api/clientes/{id}/cuenta-corriente/export</c> sobrevive — un <c>formato=pdf</c>
+    /// devolvería 200 XLSX en vez de 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeEstadoDeCuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeEstadoDeCuenta), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdCliente, hoy, hoy, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- exportar exactamente el tope de filas es legítimo (barrido de gaps compartidos) ----------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(filas.Count, tope - 1)</c> sobrevive
+    /// — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c> solo cubre el rechazo por
+    /// ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> movimientos y se espera 200 con el
+    /// workbook completo. El servicio no antepone fila de saldo inicial ni agrega totales
+    /// (<c>ObtenerEstadoDeCuentaParaExportacionAsync</c> mapea 1:1 <c>filas → Movimientos</c>), así
+    /// que tope=3 movimientos son exactamente 3 filas de datos.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+        var saldo = 0m;
+
+        for (var i = 0; i < 3; i++)
+        {
+            saldo += 100m;
+            await SembrarMovimientoAsync(ctx, dia, 100m, saldo);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdCliente, dia, dia);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que
+        // ElExportEsIgualAlEstadoDeCuentaJsonParaLosMismosParametros): las tope=3 filas ocupan
+        // 7-9, la fila 10 debe quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 }

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -285,6 +285,67 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 4 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- barrido export: FormatoDeExportacion.Parsear en esta ruta -------------------------------
+
+    /// <summary>Sin la llamada a <see cref="FormatoDeExportacion.Parsear"/> dentro de
+    /// <c>/stock/existencias/export</c>, un <c>formato=pdf</c> devolvería 200 XLSX en vez de 400 —
+    /// mismo patrón que <c>ReportesVentasResumenExportTests</c>. No necesita datos sembrados: el
+    /// parseo del formato corre antes de cualquier lectura.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeExistencias()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeExistencias));
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- barrido export: borde EXACTO del tope (200, no 400) --------------------------------------
+
+    /// <summary>Discriminador real del ÚNICO <c>GuardaDeTope.Exigir</c> de esta ruta AGREGADA del
+    /// lado del ÉXITO: sin este test, mutar <c>Exigir(tabla.Filas.Count, tope)</c> a
+    /// <c>Exigir(tabla.Filas.Count, tope - 1)</c> sobrevive — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c>
+    /// solo cubre el rechazo por ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> filas
+    /// (un artículo con stock = una fila, sin fila de totales) y se espera 200 con el workbook
+    /// completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(ctx, $"articulo-tope-existencias-{i}");
+            await SembrarStockAsync(ctx, idArticulo, 1m);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Header en la fila 6, datos desde la 7 (mismo layout que el test de igualdad de arriba):
+        // las tope=3 filas ocupan 7-9, y la fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 }

--- a/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
+++ b/tests/Ways.IntegrationTests/ExportacionDeReportesTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClosedXML.Excel;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
 using Ways.Application.Exportacion;
@@ -58,9 +60,13 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         int IdCliente, int IdEmpleadoAdmin, int IdTipoComprobanteTx, int IdArea, int IdAlicuotaIva, int IdListaPrecio,
         int IdMedioPagoEfectivo, int IdProveedor);
 
-    private async Task<Contexto> PrepararAsync(string nombre)
+    /// <summary>Parametrizado por <paramref name="factory"/> (mismo idioma que
+    /// <c>ReportesVentasResumenExportTests.PrepararAsync</c>): las pruebas de tope de esta clase
+    /// usan un <c>WithWebHostBuilder</c> propio para bajar <c>OpcionesDeExportacion.TopeDeFilas</c>
+    /// sin afectar al resto de la clase, que sigue pasando la <c>fixture</c> compartida.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program> factory)
     {
-        var root = fixture.CreateClient();
+        var root = factory.CreateClient();
         var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
         Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
 
@@ -70,13 +76,13 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
         var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
 
-        var admin = fixture.CreateClient();
+        var admin = factory.CreateClient();
         var loginAdmin = await admin.PostAsJsonAsync(
             "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
         Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
 
-        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
-        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+        var supervisor = await CrearYLoguearAsync(admin, factory, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, factory, nombre, "vendedor", RolConocido.Vendedor);
 
         await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
         var ahora = DateTimeOffset.UtcNow;
@@ -111,14 +117,15 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
             idMedioEfectivo, proveedor.Id);
     }
 
-    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    private static async Task<HttpClient> CrearYLoguearAsync(
+        HttpClient admin, WebApplicationFactory<Program> factory, string nombre, string sufijo, RolConocido rol)
     {
         var corto = Guid.NewGuid().ToString("N")[..8];
         var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
         var alta = await admin.PostAsJsonAsync("/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
 
-        var cliente = fixture.CreateClient();
+        var cliente = factory.CreateClient();
         var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
         Assert.Equal(HttpStatusCode.OK, login.StatusCode);
         return cliente;
@@ -307,12 +314,19 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         return new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
     }
 
+    /// <summary>Sibling de <see cref="DescargarLibroAsync"/> que NO valida la respuesta — las
+    /// pruebas de rechazo (formato no soportado, tope superado) necesitan el <see
+    /// cref="HttpResponseMessage"/> crudo para inspeccionar el 400 y el ProblemDetails, algo que
+    /// <see cref="DescargarLibroAsync"/> no puede devolver porque exige 200 con el assert.</summary>
+    private static Task<HttpResponseMessage> LlamarExportSinValidarAsync(HttpClient cliente, string ruta) =>
+        cliente.GetAsync(ruta);
+
     // ---- task 2.4: equality tests (uno por export nuevo) ------------------------------------------
 
     [Fact]
     public async Task ElExportDePorPuntoVentaEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDePorPuntoVentaEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDePorPuntoVentaEsIgualAlEndpointJson), fixture);
         await SembrarComprobanteAsync(ctx, 300m);
 
         var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/ventas/por-punto-venta?{Rango(ctx.IdEmpresa)}");
@@ -339,7 +353,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDePorVendedorEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDePorVendedorEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDePorVendedorEsIgualAlEndpointJson), fixture);
         await SembrarComprobanteAsync(ctx, 500m);
 
         var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/ventas/por-vendedor?{Rango(ctx.IdEmpresa)}");
@@ -366,7 +380,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDePorMedioPagoEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDePorMedioPagoEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDePorMedioPagoEsIgualAlEndpointJson), fixture);
         var idComprobante = await SembrarComprobanteAsync(ctx, 400m);
         await SembrarPagoAsync(ctx, idComprobante, 400m);
 
@@ -393,7 +407,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeArticulosTopEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeArticulosTopEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDeArticulosTopEsIgualAlEndpointJson), fixture);
         var idArticulo = await SembrarArticuloAsync(ctx, "Articulo export top");
         await SembrarLineaAsync(ctx, idArticulo, "Articulo export top", 2m, 200m);
 
@@ -421,7 +435,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeComprasPorProveedorEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeComprasPorProveedorEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDeComprasPorProveedorEsIgualAlEndpointJson), fixture);
         await SembrarCompraAsync(ctx, 1000m);
 
         var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/compras/por-proveedor?{Rango(ctx.IdEmpresa)}");
@@ -448,7 +462,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeGastosResumenEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeGastosResumenEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDeGastosResumenEsIgualAlEndpointJson), fixture);
         var idTurno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
         await SembrarGastoAsync(ctx, idTurno, 700m);
 
@@ -475,7 +489,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeRentabilidadEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadEsIgualAlEndpointJson), fixture);
         var idArticulo = await SembrarArticuloAsync(ctx, "Articulo export rentabilidad");
         await SembrarLineaAsync(ctx, idArticulo, "Articulo export rentabilidad", 1m, 300m, costoUnitario: 100m);
 
@@ -505,7 +519,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeComisionesEsIgualAlEndpointJson()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeComisionesEsIgualAlEndpointJson));
+        var ctx = await PrepararAsync(nameof(ElExportDeComisionesEsIgualAlEndpointJson), fixture);
         await ConfigurarComisionAsync(ctx, "10");
         await SembrarComprobanteAsync(ctx, 1000m);
 
@@ -542,7 +556,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [MemberData(nameof(RutasSoloLecturaDeReportes))]
     public async Task UnVendedorEsRechazadoEnLosSeisExportsDeLecturaDeReportes(string ruta)
     {
-        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLosSeisExportsDeLecturaDeReportes) + ruta.Replace("/", "-"));
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoEnLosSeisExportsDeLecturaDeReportes) + ruta.Replace("/", "-"), fixture);
 
         var respuesta = await ctx.Vendedor.GetAsync(
             $"/api/reportes/{ruta}?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
@@ -564,7 +578,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnSupervisorEsRechazadoEnElExportDeRentabilidad()
     {
-        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeRentabilidad));
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeRentabilidad), fixture);
 
         var respuesta = await ctx.Supervisor.GetAsync($"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
 
@@ -574,7 +588,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task UnSupervisorEsRechazadoEnElExportDeComisiones()
     {
-        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeComisiones));
+        var ctx = await PrepararAsync(nameof(UnSupervisorEsRechazadoEnElExportDeComisiones), fixture);
 
         var respuesta = await ctx.Supervisor.GetAsync($"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
 
@@ -592,7 +606,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeRentabilidadCargaElBloqueDeCobertura()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadCargaElBloqueDeCobertura));
+        var ctx = await PrepararAsync(nameof(ElExportDeRentabilidadCargaElBloqueDeCobertura), fixture);
         var idArticulo = await SembrarArticuloAsync(ctx, "Articulo cobertura");
 
         for (var i = 0; i < 7; i++)
@@ -634,7 +648,7 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
     [Fact]
     public async Task ElExportDeComisionesLlevaLaEtiquetaProvisional()
     {
-        var ctx = await PrepararAsync(nameof(ElExportDeComisionesLlevaLaEtiquetaProvisional));
+        var ctx = await PrepararAsync(nameof(ElExportDeComisionesLlevaLaEtiquetaProvisional), fixture);
         await SembrarComprobanteAsync(ctx, 100m);
 
         var jsonRespuesta = await ctx.Admin.GetAsync($"/api/reportes/comisiones?{Rango(ctx.IdEmpresa)}");
@@ -647,5 +661,438 @@ public class ExportacionDeReportesTests(WaysApiFixture fixture) : IClassFixture<
         var hoja = libro.Worksheets.First();
 
         Assert.Contains("PROVISIONAL", hoja.Cell(4, 1).GetString());
+    }
+
+    // ---- sweep GAP 2: FormatoDeExportacion.Parsear por cada una de las ocho rutas -----------------
+
+    public static readonly TheoryData<string> RutasDeLosOchoExports = new()
+    {
+        "ventas/por-punto-venta/export", "ventas/por-vendedor/export", "ventas/por-medio-pago/export",
+        "articulos/top/export", "compras/por-proveedor/export", "gastos/resumen/export",
+        "rentabilidad/export", "comisiones/export"
+    };
+
+    /// <summary>Cierra el gap de <see cref="FormatoDeExportacion.Parsear"/> para los ocho export
+    /// siblings de esta clase — ninguno lo tenía cubierto (esta clase no tenía ni un test de
+    /// formato): borrar el <c>Parsear(formato)</c> de CUALQUIERA de las ocho rutas de
+    /// <c>ReportesEndpoints.MapearReportes</c> deja pasar un <c>formato=pdf</c> con 200 XLSX en vez
+    /// de 400. Un solo <c>[Theory]</c> con un caso por ruta (en vez de ocho <c>[Fact]</c>s) porque
+    /// las ocho comparten los mismos parámetros obligatorios (idEmpresa,
+    /// desde, hasta, formato); <c>granularidad=Dia</c> viaja siempre en la query aunque solo
+    /// <c>gastos/resumen/export</c> la exija — minimal API ignora los query params no declarados
+    /// por una ruta, así que no rompe a las otras siete. Sin datos sembrados: <c>Parsear</c> corta
+    /// ANTES de tocar el servicio de reportes, mismo criterio que el resto del barrido.</summary>
+    [Theory]
+    [MemberData(nameof(RutasDeLosOchoExports))]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnCadaUnoDeLosOchoExports(string ruta)
+    {
+        var ctx = await PrepararAsync(
+            nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnCadaUnoDeLosOchoExports) + ruta.Replace("/", "-"),
+            fixture);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/{ruta}?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- sweep GAP 3: el único GuardaDeTope.Exigir AGREGADO de cada ruta, pineado de ambos lados --
+    //
+    // Las ocho rutas de este archivo son AGREGADAS (un solo Exigir sobre tabla.Filas.Count, sin
+    // .Take ni COUNT(*) propio) — GAP 1 del barrido no aplica. Cada par de abajo reusa EXACTAMENTE
+    // la siembra de su test de igualdad (task 2.4), sin inventar siembra nueva: el tope se baja
+    // hasta calzar justo con la cantidad de filas que esa siembra ya produce.
+    //   - por-punto-venta / por-vendedor / por-medio-pago / articulos-top / comisiones: sin fila de
+    //     totales (ExportacionDeReportes.De no le agrega una) — 1 comprobante/línea sembrada ⇒
+    //     tabla.Filas.Count == 1 ⇒ tope éxito = 1, tope rechazo = 0.
+    //   - compras-por-proveedor / gastos-resumen / rentabilidad: SÍ agregan una fila de totales
+    //     (ExportacionDeReportes.De) — 1 fila de negocio sembrada ⇒ tabla.Filas.Count == 2 (dato +
+    //     totales) ⇒ tope éxito = 2, tope rechazo = 1.
+
+    /// <summary>Discrimina el ÚNICO <c>GuardaDeTope.Exigir</c> de <c>ventas/por-punto-venta/export</c>
+    /// del lado del ÉXITO: <c>ElExportDePorPuntoVentaEsIgualAlEndpointJson</c> siembra un
+    /// comprobante y <c>VentasPorPuntoVenta.Filas</c> trae exactamente 1 fila, sin fila de totales
+    /// (<c>ExportacionDeReportes.De(VentasPorPuntoVenta, …)</c> no le agrega una) ⇒
+    /// <c>tabla.Filas.Count == 1</c>. Con <c>TopeDeFilas = 1</c>, mutar el segundo argumento a
+    /// <c>tope - 1</c> sobrevive sin este test — la prueba de rechazo de abajo solo cubre el lado de
+    /// ARRIBA del tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDePorPuntoVentaExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorPuntoVentaExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        await SembrarComprobanteAsync(ctx, 300m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-punto-venta/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.True(hoja.Row(8).IsEmpty());
+    }
+
+    /// <summary>Discrimina el mismo <c>Exigir</c> del lado del RECHAZO: con <c>TopeDeFilas = 0</c> la
+    /// única fila sembrada (1 &gt; 0) rechaza con la cantidad REAL en el título — sin este test,
+    /// borrar el <c>Exigir</c> completo de la ruta sobrevivía (esta clase no tenía ningún test de
+    /// tope hasta esta pasada del barrido).</summary>
+    [Fact]
+    public async Task UnaExportacionDePorPuntoVentaQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 0)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorPuntoVentaQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        await SembrarComprobanteAsync(ctx, 300m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-punto-venta/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 1 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Mismo par que <c>por-punto-venta</c>, ruta <c>ventas/por-vendedor/export</c>: 1
+    /// comprobante sembrado (mismo criterio de <c>ElExportDePorVendedorEsIgualAlEndpointJson</c>) ⇒
+    /// <c>VentasPorVendedor.Filas.Count == 1</c>, sin totales ⇒ tope éxito 1 / rechazo 0.</summary>
+    [Fact]
+    public async Task UnaExportacionDePorVendedorExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorVendedorExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        await SembrarComprobanteAsync(ctx, 500m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-vendedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.True(hoja.Row(8).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo: <c>TopeDeFilas = 0</c> contra la misma fila única — sin
+    /// ningún test de tope previo en esta ruta, borrar el <c>Exigir</c> de
+    /// <c>ventas/por-vendedor/export</c> sobrevivía.</summary>
+    [Fact]
+    public async Task UnaExportacionDePorVendedorQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 0)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorVendedorQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        await SembrarComprobanteAsync(ctx, 500m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-vendedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 1 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Mismo par, ruta <c>ventas/por-medio-pago/export</c>: 1 comprobante + 1 pago (mismo
+    /// criterio de <c>ElExportDePorMedioPagoEsIgualAlEndpointJson</c>) ⇒
+    /// <c>VentasPorMedioPago.Filas.Count == 1</c>, sin totales ⇒ tope éxito 1 / rechazo 0.</summary>
+    [Fact]
+    public async Task UnaExportacionDePorMedioPagoExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorMedioPagoExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        var idComprobante = await SembrarComprobanteAsync(ctx, 400m);
+        await SembrarPagoAsync(ctx, idComprobante, 400m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-medio-pago/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.True(hoja.Row(8).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>ventas/por-medio-pago/export</c>: <c>TopeDeFilas = 0</c>
+    /// contra la misma fila única — sin este par, la ruta no tenía ningún test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDePorMedioPagoQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 0)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDePorMedioPagoQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var idComprobante = await SembrarComprobanteAsync(ctx, 400m);
+        await SembrarPagoAsync(ctx, idComprobante, 400m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/ventas/por-medio-pago/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 1 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Mismo par, ruta <c>articulos/top/export</c>: 1 artículo + 1 línea (mismo criterio de
+    /// <c>ElExportDeArticulosTopEsIgualAlEndpointJson</c>) ⇒ <c>TopArticulos.Articulos.Count == 1</c>,
+    /// sin totales ⇒ tope éxito 1 / rechazo 0.</summary>
+    [Fact]
+    public async Task UnaExportacionDeArticulosTopExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeArticulosTopExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo tope top");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo tope top", 2m, 200m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/articulos/top/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.True(hoja.Row(8).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>articulos/top/export</c>: <c>TopeDeFilas = 0</c> contra
+    /// la misma fila única — sin este par, la ruta no tenía ningún test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDeArticulosTopQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 0)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeArticulosTopQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo tope top rechazo");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo tope top rechazo", 2m, 200m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/articulos/top/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 1 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Ruta <c>compras/por-proveedor/export</c>: 1 compra (mismo criterio de
+    /// <c>ElExportDeComprasPorProveedorEsIgualAlEndpointJson</c>) ⇒ <c>PorProveedor.Count == 1</c>
+    /// MÁS la fila de totales que <c>ExportacionDeReportes.De(ComprasPorProveedor, …)</c> siempre
+    /// agrega (línea 166-171: <c>filas.Add([… "Total" …])</c>) ⇒ <c>tabla.Filas.Count == 2</c> ⇒
+    /// tope éxito 2 / rechazo 1. Fila 7 = dato, fila 8 = totales, fila 9 tiene que quedar vacía.</summary>
+    [Fact]
+    public async Task UnaExportacionDeComprasPorProveedorExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 2)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeComprasPorProveedorExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        await SembrarCompraAsync(ctx, 1000m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/compras/por-proveedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.False(hoja.Row(8).IsEmpty());
+        Assert.True(hoja.Row(9).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>compras/por-proveedor/export</c>: con
+    /// <c>TopeDeFilas = 1</c> las 2 filas reales (dato + totales) superan el tope — sin este par, la
+    /// ruta no tenía ningún test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDeComprasPorProveedorQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeComprasPorProveedorQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        await SembrarCompraAsync(ctx, 1000m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/compras/por-proveedor/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 2 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Ruta <c>gastos/resumen/export</c>: 1 gasto (mismo criterio de
+    /// <c>ElExportDeGastosResumenEsIgualAlEndpointJson</c>) ⇒ <c>Serie.Count == 1</c> MÁS la fila de
+    /// totales que <c>ExportacionDeReportes.De(ResumenDeGastos, …)</c> siempre agrega (línea 197:
+    /// <c>filas.Add([… ImporteTotal])</c>) ⇒ <c>tabla.Filas.Count == 2</c> ⇒ tope éxito 2 / rechazo
+    /// 1.</summary>
+    [Fact]
+    public async Task UnaExportacionDeGastosResumenExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 2)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeGastosResumenExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        var idTurno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+        await SembrarGastoAsync(ctx, idTurno, 700m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/gastos/resumen/export?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.False(hoja.Row(8).IsEmpty());
+        Assert.True(hoja.Row(9).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>gastos/resumen/export</c>: con <c>TopeDeFilas = 1</c>
+    /// las 2 filas reales (bucket + totales) superan el tope — sin este par, la ruta no tenía ningún
+    /// test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDeGastosResumenQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeGastosResumenQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var idTurno = await AbrirTurnoAsync(ctx.Admin, ctx.IdPuntoVenta);
+        await SembrarGastoAsync(ctx, idTurno, 700m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/gastos/resumen/export?{Rango(ctx.IdEmpresa)}&granularidad=Dia&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 2 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Ruta <c>rentabilidad/export</c>: 1 línea con costo real (mismo criterio de
+    /// <c>ElExportDeRentabilidadEsIgualAlEndpointJson</c>) ⇒ <c>PorArticulo.Count == 1</c> MÁS la
+    /// fila de totales que <c>ExportacionDeReportes.De(Rentabilidad, …)</c> siempre agrega (línea
+    /// 233-241: <c>filas.Add([… "Total" …])</c>) ⇒ <c>tabla.Filas.Count == 2</c> ⇒ tope éxito 2 /
+    /// rechazo 1.</summary>
+    [Fact]
+    public async Task UnaExportacionDeRentabilidadExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 2)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeRentabilidadExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo tope rentabilidad");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo tope rentabilidad", 1m, 300m, costoUnitario: 100m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.False(hoja.Row(8).IsEmpty());
+        Assert.True(hoja.Row(9).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>rentabilidad/export</c>: con <c>TopeDeFilas = 1</c> las
+    /// 2 filas reales (artículo + totales) superan el tope — sin este par, la ruta no tenía ningún
+    /// test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDeRentabilidadQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeRentabilidadQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo tope rentabilidad rechazo");
+        await SembrarLineaAsync(ctx, idArticulo, "Articulo tope rentabilidad rechazo", 1m, 300m, costoUnitario: 100m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/rentabilidad/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 2 filas", problema.GetProperty("title").GetString());
+    }
+
+    /// <summary>Ruta <c>comisiones/export</c>: 1 comprobante con comisión configurada (mismo
+    /// criterio de <c>ElExportDeComisionesEsIgualAlEndpointJson</c>) ⇒ <c>Comisiones.Filas.Count ==
+    /// 1</c>, sin fila de totales (<c>ExportacionDeReportes.De(Comisiones, …)</c> no le agrega una —
+    /// la etiqueta PROVISIONAL viaja en el encabezado, no en una fila) ⇒ tope éxito 1 / rechazo
+    /// 0.</summary>
+    [Fact]
+    public async Task UnaExportacionDeComisionesExactamenteEnElTopeSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 1)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeComisionesExactamenteEnElTopeSeAceptaCompleta), factoryBajo);
+        await ConfigurarComisionAsync(ctx, "10");
+        await SembrarComprobanteAsync(ctx, 1000m);
+
+        using var libro = await DescargarLibroAsync(
+            ctx.Admin, $"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+        var hoja = libro.Worksheets.First();
+
+        Assert.False(hoja.Row(7).IsEmpty());
+        Assert.True(hoja.Row(8).IsEmpty());
+    }
+
+    /// <summary>Contraparte de rechazo de <c>comisiones/export</c>: <c>TopeDeFilas = 0</c> contra la
+    /// misma fila única — sin este par, la ruta no tenía ningún test de tope.</summary>
+    [Fact]
+    public async Task UnaExportacionDeComisionesQueSuperaElTopeSeRechazaConLaCantidadReal()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 0)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeComisionesQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
+        await ConfigurarComisionAsync(ctx, "10");
+        await SembrarComprobanteAsync(ctx, 1000m);
+
+        var respuesta = await LlamarExportSinValidarAsync(
+            ctx.Admin, $"/api/reportes/comisiones/export?{Rango(ctx.IdEmpresa)}&formato=xlsx");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
+        Assert.Contains("tiene 1 filas", problema.GetProperty("title").GetString());
     }
 }

--- a/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
+++ b/tests/Ways.IntegrationTests/HistoricoDeCajasTests.cs
@@ -406,7 +406,12 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
         var ctx = await PrepararAsync(nameof(UnaExportacionDelHistoricoQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
 
-        for (var i = 0; i < 4; i++)
+        // tope+2 = 5 turnos (no tope+1 = 4): con solo 4 turnos, el COUNT(*) real y el count
+        // leído del Take(tope+1) coinciden, y borrar el PRIMER GuardaDeTope.Exigir sobrevive (el
+        // segundo Exigir, sobre turnos.Count, rechaza igual con el mismo "4"). Con 5 turnos el
+        // Take(4) trunca: si el primer Exigir se borra, el mutante reporta "4" (el truncado) en
+        // vez de "5" (la cantidad REAL) y el assert de abajo lo discrimina.
+        for (var i = 0; i < 5; i++)
         {
             var turno = await AbrirTurnoAsync(ctx, ctx.IdPuntoVenta, 100m);
             await CerrarTurnoAsync(ctx, turno.Id, [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)]);
@@ -420,6 +425,69 @@ public class HistoricoDeCajasTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- barrido-export GAP 3: borde EXACTO del tope se acepta completo -----------------------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(turnos.Count, tope - 1)</c>
+    /// sobrevive — <see cref="UnaExportacionDelHistoricoQueSuperaElTopeSeRechazaConLaCantidadReal"/>
+    /// solo cubre el rechazo por ARRIBA del tope. Acá se cierran EXACTAMENTE <c>tope</c> turnos
+    /// (3) y se espera 200 con el workbook completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDelHistoricoDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDelHistoricoDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var turno = await AbrirTurnoAsync(ctx, ctx.IdPuntoVenta, 100m);
+            await CerrarTurnoAsync(ctx, turno.Id, [new ConteoDeclarado(ctx.IdMedioEfectivo, 100m)]);
+        }
+
+        var ahora = DateTimeOffset.UtcNow;
+        var respuesta = await LlamarExportDelHistoricoAsync(ctx.Admin, ahora.AddMinutes(-5), ahora.AddMinutes(5));
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que
+        // ElExportDelHistoricoEsIgualAlListadoJsonTurnoPorTurno): las tope=3 filas ocupan 7-9, la
+        // fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
+    }
+
+    // ---- barrido-export GAP 2: FormatoDeExportacion.Parsear en esta ruta ------------------------
+
+    /// <summary>Sin este test, borrar la llamada a <c>FormatoDeExportacion.Parsear</c> en
+    /// <c>/api/reportes/cajas/export</c> sobrevive — un <c>formato=pdf</c> devolvería 200 XLSX en
+    /// vez de 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDelHistorico()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDelHistorico));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var respuesta = await LlamarExportDelHistoricoAsync(
+            ctx.Admin, ahora.AddMinutes(-5), ahora.AddMinutes(5), formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
     }
 }

--- a/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
+++ b/tests/Ways.IntegrationTests/ReportesVentasResumenExportTests.cs
@@ -292,7 +292,7 @@ public class ReportesVentasResumenExportTests(WaysApiFixture fixture) : IClassFi
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 4 filas", problema.GetProperty("title").GetString());
     }
 
     // ---- task 1b.10: éxito exactamente en el tope -------------------------------------------------

--- a/tests/Ways.IntegrationTests/ReposicionExportTests.cs
+++ b/tests/Ways.IntegrationTests/ReposicionExportTests.cs
@@ -246,7 +246,7 @@ public class ReposicionExportTests(WaysApiFixture fixture) : IClassFixture<WaysA
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 4 filas", problema.GetProperty("title").GetString());
     }
 
     // ---- task 4.11: 403 (mitad export) --------------------------------------------------------------
@@ -259,5 +259,65 @@ public class ReposicionExportTests(WaysApiFixture fixture) : IClassFixture<WaysA
         var respuesta = await LlamarExportAsync(ctx.Vendedor, ctx.IdPuntoVenta);
 
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // ---- barrido export: FormatoDeExportacion.Parsear en esta ruta -------------------------------
+
+    /// <summary>Sin la llamada a <see cref="FormatoDeExportacion.Parsear"/> dentro de
+    /// <c>/stock/reposicion/export</c>, un <c>formato=pdf</c> devolvería 200 XLSX en vez de 400. No
+    /// necesita datos sembrados: el parseo del formato corre antes de cualquier lectura.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeReposicion()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeReposicion));
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- barrido export: borde EXACTO del tope (200, no 400) --------------------------------------
+
+    /// <summary>Discriminador real del ÚNICO <c>GuardaDeTope.Exigir</c> de esta ruta AGREGADA del
+    /// lado del ÉXITO: sin este test, mutar <c>Exigir(tabla.Filas.Count, tope)</c> a
+    /// <c>Exigir(tabla.Filas.Count, tope - 1)</c> sobrevive — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c>
+    /// solo cubre el rechazo por ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> filas
+    /// (mismo criterio de alerta que el test de rechazo: <c>minimo</c> configurado, <c>cantidad
+    /// &lt;= minimo</c>) y se espera 200 con el workbook completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var idArticulo = await SembrarArticuloAsync(ctx, $"articulo-tope-reposicion-exacto-{i}");
+            await SembrarStockAsync(ctx, idArticulo, cantidad: 0m, minimo: 1m, reposicion: null);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Header en la fila 6, datos desde la 7 (mismo layout que el test de igualdad de arriba):
+        // las tope=3 filas ocupan 7-9, y la fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 }

--- a/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
+++ b/tests/Ways.IntegrationTests/TesoreriaExportTests.cs
@@ -184,7 +184,12 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
         var dia = new DateOnly(2026, 8, 1);
 
-        for (var i = 0; i < 4; i++)
+        // tope+2 = 5 filas (no tope+1 = 4): con solo 4 filas, el COUNT(*) real y el count leído
+        // del Take(tope+1) coinciden, y borrar el PRIMER GuardaDeTope.Exigir sobrevive (el
+        // segundo Exigir, sobre items.Count, rechaza igual con el mismo "4"). Con 5 filas el
+        // Take(4) trunca: si el primer Exigir se borra, el mutante reporta "4" (el truncado) en
+        // vez de "5" (la cantidad REAL) y el assert de abajo lo discrimina.
+        for (var i = 0; i < 5; i++)
         {
             await SembrarMovimientoAsync(ctx, dia, 0m, 10m + i, 0m, 10m + i);
         }
@@ -196,9 +201,15 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
     }
 
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// el assert del workbook completo (y no solo el status code), mutar ese segundo
+    /// <c>Exigir</c> a <c>Exigir(items.Count, tope - 1)</c> sobrevive —
+    /// <see cref="UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal"/> solo cubre el
+    /// rechazo por ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> movimientos (3) y se
+    /// espera 200 con el workbook completo.</summary>
     [Fact]
     public async Task UnaExportacionExactamenteEnElTopeSeAcepta()
     {
@@ -215,8 +226,41 @@ public class TesoreriaExportTests(WaysApiFixture fixture) : IClassFixture<WaysAp
         }
 
         var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
 
-        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que el test de igualdad de
+        // arriba): las tope=3 filas ocupan 7-9, la fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
+    }
+
+    // ---- barrido-export GAP 2: FormatoDeExportacion.Parsear en esta ruta ------------------------
+
+    /// <summary>Sin este test, borrar la llamada a <c>FormatoDeExportacion.Parsear</c> en
+    /// <c>/api/reportes/tesoreria/export</c> sobrevive — un <c>formato=pdf</c> devolvería 200
+    /// XLSX en vez de 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeTesoreria()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeTesoreria), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, hoy, hoy, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
     }
 
     // ---- task 7.11: rol un escalón debajo del gate, mitad export -------------------------------

--- a/tests/Ways.IntegrationTests/VencimientosExportTests.cs
+++ b/tests/Ways.IntegrationTests/VencimientosExportTests.cs
@@ -221,7 +221,12 @@ public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<Way
         var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
         var idArticulo = await SembrarArticuloAsync(ctx, "Articulo con muchos lotes");
 
-        for (var i = 0; i < 4; i++)
+        // tope+2 = 5 filas (no tope+1 = 4): con solo 4 filas, el COUNT(*) real y el count leído
+        // del Take(tope+1) coinciden, y borrar el PRIMER GuardaDeTope.Exigir sobrevive (el
+        // segundo Exigir, sobre filas.Count, rechaza igual con el mismo "4"). Con 5 filas el
+        // Take(4) trunca: si el primer Exigir se borra, el mutante reporta "4" (el truncado) en
+        // vez de "5" (la cantidad REAL) y el assert de abajo lo discrimina.
+        for (var i = 0; i < 5; i++)
         {
             await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2027, 1, 1 + i), 1m, codigo: $"L-TOPE-{i}");
         }
@@ -233,7 +238,67 @@ public class VencimientosExportTests(WaysApiFixture fixture) : IClassFixture<Way
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- barrido-export GAP 3: borde EXACTO del tope se acepta completo -----------------------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(filas.Count, tope - 1)</c>
+    /// sobrevive — <see cref="UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal"/> solo
+    /// cubre el rechazo por ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> lotes (3,
+    /// uno por artículo sembrado) y se espera 200 con el workbook completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Articulo con lotes exactos al tope");
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarLoteAsync(ctx, idArticulo, new DateOnly(2027, 1, 1 + i), 1m, codigo: $"L-EXACTO-{i}");
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que el resto del archivo): las
+        // tope=3 filas ocupan 7-9, sin fila de totales (ver comentario del test de igualdad de
+        // arriba), así que la fila 10 tiene que quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
+    }
+
+    // ---- barrido-export GAP 2: FormatoDeExportacion.Parsear en esta ruta ------------------------
+
+    /// <summary>Sin este test, borrar la llamada a <c>FormatoDeExportacion.Parsear</c> en
+    /// <c>/api/reportes/stock/vencimientos/export</c> sobrevive — un <c>formato=pdf</c>
+    /// devolvería 200 XLSX en vez de 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeVencimientos()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeVencimientos));
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
     }
 
     // ---- task 13.10: 403 ---------------------------------------------------------------------------

--- a/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
+++ b/tests/Ways.IntegrationTests/VentasListadoExportTests.cs
@@ -222,6 +222,12 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
 
     // ---- task 3.7: rechazo por tope (COUNT real, no una serie gap-filled) ------------------------
 
+    /// <summary>Discriminador real del PRIMER <c>GuardaDeTope.Exigir</c> (sobre el <c>COUNT(*)</c>):
+    /// se siembra tope+2 (5, no tope+1) filas porque con solo 4 filas el <c>COUNT(*)</c> real y la
+    /// lectura truncada por <c>.Take(tope + 1)</c> coinciden en "4" — borrar el primer <c>Exigir</c>
+    /// sobrevive porque el segundo rechaza igual con el mismo número. Con 5 filas el <c>Take(4)</c>
+    /// trunca: el mutante reporta "4" (el truncado) en vez de la cantidad REAL "5", y el assert de
+    /// abajo lo discrimina.</summary>
     [Fact]
     public async Task UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal()
     {
@@ -232,7 +238,7 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
         var ctx = await PrepararAsync(nameof(UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal), factoryBajo);
         var dia = new DateOnly(2026, 8, 1);
 
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < 5; i++)
         {
             await SembrarComprobanteAsync(ctx, dia, 100m + i);
         }
@@ -244,7 +250,68 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 5 filas", problema.GetProperty("title").GetString());
+    }
+
+    // ---- FormatoDeExportacion.Parsear en esta ruta (barrido de gaps compartidos) ------------------
+
+    /// <summary>Sin este test, borrar la llamada a <see cref="FormatoDeExportacion.Parsear"/> en
+    /// <c>/api/ventas/export</c> sobrevive — un <c>formato=pdf</c> devolvería 200 XLSX en vez de
+    /// 400.</summary>
+    [Fact]
+    public async Task UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeVentas()
+    {
+        var ctx = await PrepararAsync(nameof(UnFormatoNoSoportadoRechazaConProblemDetailsEnElExportDeVentas), fixture);
+        var hoy = new DateOnly(2026, 8, 1);
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, hoy, hoy, formato: "pdf");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        Assert.NotEqual(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("formato_no_soportado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- exportar exactamente el tope de filas es legítimo (barrido de gaps compartidos) ----------
+
+    /// <summary>Discriminador real del SEGUNDO <c>GuardaDeTope.Exigir</c> del lado del ÉXITO: sin
+    /// este test, mutar ese segundo <c>Exigir</c> a <c>Exigir(crudos.Count, tope - 1)</c> sobrevive
+    /// — <c>UnaExportacionQueSuperaElTopeSeRechazaConLaCantidadReal</c> solo cubre el rechazo por
+    /// ARRIBA del tope. Acá se exportan EXACTAMENTE <c>tope</c> filas y se espera 200 con el
+    /// workbook completo.</summary>
+    [Fact]
+    public async Task UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta()
+    {
+        using var factoryBajo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.Configure<OpcionesDeExportacion>(o => o.TopeDeFilas = 3)));
+
+        var ctx = await PrepararAsync(nameof(UnaExportacionDeExactamenteElTopeDeFilasSeAceptaCompleta), factoryBajo);
+        var dia = new DateOnly(2026, 8, 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await SembrarComprobanteAsync(ctx, dia, 100m + i);
+        }
+
+        var respuesta = await LlamarExportAsync(ctx.Admin, ctx.IdPuntoVenta, dia, dia);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+        Assert.Equal(ContentTypeXlsx, respuesta.Content.Headers.ContentType?.MediaType);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var hoja = libro.Worksheets.First();
+
+        // Encabezado en la fila 6, datos desde la 7 (mismo layout que
+        // ElExportEsIgualAlListadoJsonParaLosMismosParametros): las tope=3 filas ocupan 7-9, la
+        // fila 10 debe quedar vacía.
+        const int primeraFilaDeDatos = 7;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.False(hoja.Row(primeraFilaDeDatos + i).IsEmpty());
+        }
+        Assert.True(hoja.Row(primeraFilaDeDatos + 3).IsEmpty());
     }
 
     // ---- task 3.8: backstop de carrera del `+1` (mutation-proof-tests) ---------------------------
@@ -304,7 +371,7 @@ public class VentasListadoExportTests(WaysApiFixture fixture) : IClassFixture<Wa
 
         var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("exportacion_demasiado_grande", problema.GetProperty("codigo").GetString());
-        Assert.Contains("4", problema.GetProperty("title").GetString());
+        Assert.Contains("tiene 4 filas", problema.GetProperty("title").GetString());
     }
 
     /// <summary>Retiene la SEGUNDA consulta que toca <c>comprobantes_venta</c> (la lectura


### PR DESCRIPTION
## Barrido transversal — los 3 gaps que judgment-day encontró en el slice 6 de la etapa 14

El contrato de `VentasListadoExportTests` se copió **verbatim** por las etapas 11-13, así que los tres defectos que el juez B cazó en el slice 6 estaban en todos los hermanos. Este PR los cierra en las **18 rutas `/export`** (11 archivos — dos rutas de caja viven en `HistoricoDeCajasTests` y `DetalleDeTurnoTests`, que no matchean `*Export*`).

- **Gap 1 — el rechazo por tope no discriminaba el count real.** Se sembraba `tope+1`, así que el `COUNT(*)` real y el count del `.Take(tope+1)` daban el mismo número y **borrar el PRIMER `GuardaDeTope.Exigir` sobrevivía**: el segundo rechazaba con el mismo "4". Ahora se siembra `tope+2` y se afirma la cantidad REAL. Aplica **solo a las 6 rutas LISTADO**: las AGREGADAS corren un único `Exigir` sobre `Filas.Count` ya materializado, sin truncado que enmascare nada, así que su sembrado ya era sano y quedó intacto.
- **Gap 2 — `FormatoDeExportacion.Parsear` tenía UN test para 18 rutas.** Ahora una por ruta (`formato=pdf` → 400 `formato_no_soportado`).
- **Gap 3 — exportar exactamente el tope no tenía test de éxito**, así que mutar `Exigir(count, tope)` a `Exigir(count, tope-1)` sobrevivía. Las 18 afirman 200 con workbook completo. El de tesorería existía pero solo miraba el status code: reforzado en su lugar, no duplicado.

**Hallazgo extra:** las 8 rutas de `ExportacionDeReportesTests` y el detalle de turno **no tenían NINGÚN test de tope** — se podía borrar la guarda entera con la suite verde. Es el mismo gap en su forma extrema, así que suman también el test de rechazo.

De paso, 19 asserts pasaron de `Contains("N", title)` a `Contains("tiene N filas", title)`: el título es `"La exportación tiene N filas; el tope es T"` y un dígito suelto también matchea el tope.

## Tests — de 48 a 108, todos verdes

Cero cambios de producción. Suite filtrada contra un solo daemon de Docker, de a una.

## Evidencia de mutación

Muté la **primitiva compartida** en vez de cada call site: 3 ciclos en vez de ~40, sin perder atribución por test (cada test toca una sola ruta).

| Mutación | Fallos | Lectura |
|---|---|---|
| `Parsear` neutralizado | **18** | uno por ruta, ninguno de más |
| `Exigir` con `>=` (≡ `tope-1`) | **19** | los 18 de tope exacto + el de carrera de ventas, que también toca el borde |
| Primer `Exigir` a `int.MaxValue` en los 6 servicios LISTADO | **6** | uno por ruta LISTADO |

**Control negativo (lo que prueba que el gap era real):** con ese último mutante puesto y el sembrado de ventas revertido a las 4 filas viejas, el test **PASÓ**. Con 5 muere.

## Judgment-day — ronda limpia

Los dos jueces convergieron de forma independiente en **el mismo y único hallazgo**, ambos WARNING: si `Row(n).IsEmpty()` es portante como marca de fin de datos, dado que `ExportadorXlsx.AplicarFormatoDeColumna` estiliza la columna entera. Ninguno pudo resolverlo sin ejecutar la suite.

Medido en vez de archivado: forzando una cuarta fila de datos contra una expectativa de tres, el assert **falla**. La aserción es portante. **0 severos, 0 suspects, 0 contradicciones, 0 rondas de corrección.** El target quedó byte-idéntico al juzgado.

`55082ce` lleva el hallazgo al skill `mutation-proof-tests` (regla 9): los tres gaps que debe tener toda ruta `/export` y la duda de `IsEmpty` cerrada, para que el próximo juez no la re-litigue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)