### PR TITLE
fix(exportacion): el encabezado "Generado el" usa la zona del punto de venta, no UTC

### DIFF
--- a/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
+++ b/src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs
@@ -50,6 +50,6 @@ public static class ContextoDeExportacionHttp
             Hasta: hasta,
             ZonaHoraria: zonaHoraria,
             Usuario: usuario.NombreUsuario,
-            GeneradoEl: reloj.Ahora,
+            GeneradoEl: InstanteDeGeneracion.En(reloj.Ahora, zonaHoraria),
             Cobertura: cobertura);
 }

--- a/src/Ways.Application/Exportacion/ContextoDeExportacion.cs
+++ b/src/Ways.Application/Exportacion/ContextoDeExportacion.cs
@@ -2,6 +2,9 @@ namespace Ways.Application.Exportacion;
 
 /// <summary>Encabezado del archivo (proposal decisión 7): empresa, punto de venta o
 /// <c>"Todos"</c>, rango de fechas, y quién/cuándo lo generó junto con su zona horaria.
+/// <see cref="GeneradoEl"/> viene ya expresado en <see cref="ZonaHoraria"/> (vía
+/// <see cref="InstanteDeGeneracion.En"/>), nunca en UTC crudo — la Infrastructure que escribe el
+/// XLSX no resuelve zonas horarias, solo imprime la hora de pared que recibe.
 /// <see cref="Cobertura"/> lleva el texto de la línea de cobertura de costo estimado
 /// (stage-10) cuando el reporte exportado la trae; queda <c>null</c> para el resto.</summary>
 public sealed record ContextoDeExportacion(

--- a/src/Ways.Application/Exportacion/InstanteDeGeneracion.cs
+++ b/src/Ways.Application/Exportacion/InstanteDeGeneracion.cs
@@ -1,0 +1,22 @@
+namespace Ways.Application.Exportacion;
+
+/// <summary>
+/// El encabezado del XLSX imprime la hora de pared junto a la etiqueta de zona
+/// (<c>ContextoDeExportacion.ZonaHoraria</c>), así que el instante tiene que llegar ya expresado
+/// en esa zona antes de guardarse en <c>GeneradoEl</c> — mismo criterio que
+/// <see cref="Celda.FechaHora"/>: la Infrastructure no resuelve zonas horarias, solo escribe el
+/// valor que ya le llega convertido.
+/// </summary>
+public static class InstanteDeGeneracion
+{
+    /// <summary>
+    /// El fallback (instante intacto) existe porque <c>GET /api/reportes/compras/por-proveedor/export</c>
+    /// pasa el centinela <c>"N/A"</c> como zona — ese reporte bucketea por <c>fecha_recepcion</c>
+    /// sin exponer una zona propia. En ese caso el instante queda en UTC porque la etiqueta de al
+    /// lado no afirma ninguna zona.
+    /// </summary>
+    public static DateTimeOffset En(DateTimeOffset instante, string zonaHoraria) =>
+        TimeZoneInfo.TryFindSystemTimeZoneById(zonaHoraria, out var zona)
+            ? TimeZoneInfo.ConvertTime(instante, zona)
+            : instante;
+}

--- a/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs
@@ -95,6 +95,30 @@ public class ExportadorXlsxTests
         Assert.True(celdaDeNeto.Value.IsBlank);
     }
 
+    /// <summary>stage-14: <c>GeneradoEl</c> llega al exportador ya convertido a la zona del punto
+    /// de venta (invariante de <see cref="InstanteDeGeneracion"/>, aplicado en
+    /// <c>ContextoDeExportacionHttp.Construir</c>) — el exportador solo tiene que imprimir la hora
+    /// de pared que recibe, nunca volver a convertirla. Offset -03:00 con hora de pared 22:30 del
+    /// 5/8: si el exportador reconvirtiera (p. ej. leyendo <c>UtcDateTime</c>), imprimiría
+    /// 2026-08-06 01:30 en su lugar.</summary>
+    [Fact]
+    public void ElEncabezadoImprimeLaHoraDeParedDelOffsetRecibidoSinReconvertir()
+    {
+        var contexto = ContextoDePrueba with
+        {
+            GeneradoEl = new DateTimeOffset(2026, 8, 5, 22, 30, 0, TimeSpan.FromHours(-3))
+        };
+        IReadOnlyList<IReadOnlyList<Celda>> filas =
+            [[Celda.Texto("2026-08"), Celda.Moneda(700m), Celda.Fecha(new DateOnly(2026, 8, 12))]];
+        var tabla = new TablaExportable("Hoja", contexto, Columnas, filas);
+
+        using var libro = GenerarYReabrir(tabla);
+        var textoEncabezado = libro.Worksheets.First().Cell(4, 1).GetString();
+
+        Assert.Contains("Generado el 2026-08-05 22:30", textoEncabezado);
+        Assert.DoesNotContain("2026-08-06", textoEncabezado);
+    }
+
     [Fact]
     public void ElEncabezadoOcupaLasFilas1A4YLaTablaArrancaEnLaFila6()
     {

--- a/tests/Ways.Application.Tests/Exportacion/InstanteDeGeneracionTests.cs
+++ b/tests/Ways.Application.Tests/Exportacion/InstanteDeGeneracionTests.cs
@@ -1,0 +1,52 @@
+using Ways.Application.Exportacion;
+
+namespace Ways.Application.Tests.Exportacion;
+
+/// <summary>
+/// <see cref="InstanteDeGeneracion.En"/> es el chokepoint que convierte <c>reloj.Ahora</c> (UTC)
+/// a la zona horaria resuelta del punto de venta antes de guardarlo en
+/// <c>ContextoDeExportacion.GeneradoEl</c> — el mismo instante que el encabezado del XLSX imprime
+/// junto a la etiqueta de esa zona. Cada test nombra la cláusula puntual que prueba.
+/// </summary>
+public class InstanteDeGeneracionTests
+{
+    /// <summary>01:30 UTC del 6/8/2026 en <c>America/Argentina/Buenos_Aires</c> (UTC-3) es
+    /// 2026-08-05 22:30 — día Y hora discriminan: si <see cref="InstanteDeGeneracion.En"/> no
+    /// convirtiera, este assert compararía contra 2026-08-06 01:30 y fallaría.</summary>
+    [Fact]
+    public void ConvierteElInstanteALaHoraDeParedDeLaZonaResuelta()
+    {
+        var instanteUtc = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+
+        var resultado = InstanteDeGeneracion.En(instanteUtc, "America/Argentina/Buenos_Aires");
+
+        Assert.Equal(new DateTime(2026, 8, 5, 22, 30, 0), resultado.DateTime);
+    }
+
+    [Fact]
+    public void ElOffsetResultanteEsElDeLaZonaResuelta()
+    {
+        var instanteUtc = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+
+        var resultado = InstanteDeGeneracion.En(instanteUtc, "America/Argentina/Buenos_Aires");
+
+        Assert.Equal(TimeSpan.FromHours(-3), resultado.Offset);
+    }
+
+    /// <summary>Regresión de <c>GET /api/reportes/compras/por-proveedor/export</c>: ese reporte no
+    /// expone una zona de bucketeo propia y pasa el centinela <c>"N/A"</c>. El fallback tiene que
+    /// devolver el instante intacto sin lanzar, porque la etiqueta de al lado del encabezado no
+    /// afirma ninguna zona.</summary>
+    [Fact]
+    public void UnaZonaNoResolubleDevuelveElInstanteIntactoSinLanzar()
+    {
+        var instante = new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero);
+
+        var resultado = InstanteDeGeneracion.En(instante, "N/A");
+
+        // DateTimeOffset.Equals compara solo el instante: el offset se asserta aparte para que un
+        // corrimiento de zona no pase desapercibido.
+        Assert.Equal(instante, resultado);
+        Assert.Equal(TimeSpan.Zero, resultado.Offset);
+    }
+}

--- a/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
+++ b/tests/Ways.IntegrationTests/ExistenciasExportTests.cs
@@ -248,6 +248,36 @@ public class ExistenciasExportTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Contains($"filename*=UTF-8''{nombreEsperado}", disposicion);
     }
 
+    /// <summary>stage-14: prueba la conversión de <c>reloj.Ahora</c> a la zona resuelta del PV en
+    /// <c>ContextoDeExportacionHttp.Construir</c> — el mismo reloj fijado que
+    /// <see cref="UnSupervisorExportaLasExistenciasConUnNombreDeArchivoDeterministico"/> usa para
+    /// el nombre de archivo (22:30 ART del 5/8, 01:30 UTC del 6/8), acá aplicado al encabezado del
+    /// XLSX. Día Y hora discriminan: si <c>GeneradoEl</c> quedara en UTC crudo, la fila 4
+    /// imprimiría "2026-08-06 01:30" en lugar de "2026-08-05 22:30".</summary>
+    [Fact]
+    public async Task ElEncabezadoImprimeLaHoraDeParedDeLaZonaDelPuntoDeVenta()
+    {
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(
+                    new RelojFijo(new DateTimeOffset(2026, 8, 6, 1, 30, 0, TimeSpan.Zero)))));
+
+        var ctx = await PrepararAsync(
+            nameof(ElEncabezadoImprimeLaHoraDeParedDeLaZonaDelPuntoDeVenta), factoryConRelojFijo);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Yerba mate 1kg");
+        await SembrarStockAsync(ctx, idArticulo, 5m);
+
+        var respuesta = await LlamarExportAsync(ctx.Supervisor, ctx.IdPuntoVenta);
+        var cuerpoError = respuesta.IsSuccessStatusCode ? string.Empty : await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpoError);
+
+        using var libro = new XLWorkbook(new MemoryStream(await respuesta.Content.ReadAsByteArrayAsync()));
+        var texto = libro.Worksheets.First().Cell(4, 1).GetString();
+
+        Assert.Contains("Generado el 2026-08-05 22:30", texto);
+        Assert.DoesNotContain("2026-08-06", texto);
+    }
+
     // ---- task 9.10: rol un escalón debajo del gate, mitad export ---------------------------------
 
     [Fact]


### PR DESCRIPTION
## Tercera ocurrencia de la misma clase de bug

`ExportadorXlsx.EscribirEncabezado` imprimía la fila 4 así:

```csharp
$"Generado el {contexto.GeneradoEl:yyyy-MM-dd HH:mm} ({contexto.ZonaHoraria}) por {contexto.Usuario}"
```

`GeneradoEl` llegaba desde `ContextoDeExportacionHttp.Construir` con `reloj.Ahora`, y `RelojDelSistema.Ahora => DateTimeOffset.UtcNow`. Así que la **hora de pared era UTC** mientras la etiqueta de al lado nombraba la **zona resuelta del punto de venta**. El encabezado mentía 3 horas, y un día entero cerca de medianoche. Una línea debajo del "Período", que ya se había corregido.

Es la misma clase que:
- el "hoy" UTC del nombre de archivo de existencias (etapa 11, arreglado en `ReportesEndpoints.cs:359-360`),
- el "Período" del slice 6 de la etapa 14.

Las tres salieron de asumir que un `DateTimeOffset` del servidor ya venía en la zona del negocio.

## El arreglo — dónde vive la conversión

**Infrastructure no resuelve zonas.** El instante llega a `ContextoDeExportacion` ya expresado en la suya, y el exportador solo imprime lo que recibe. Es el mismo criterio que ya tenía `Celda.FechaHora` un archivo al lado: Application convierte, el adaptador escribe.

`InstanteDeGeneracion.En` es el chokepoint, aplicado en `ContextoDeExportacionHttp.Construir` — la sobrecarga `int` delega en la `string`, así que las ~20 rutas `/export` pasan por un único punto. **`ExportadorXlsx` queda sin cambios: correcto por construcción.**

`GeneradoEl` sigue siendo `DateTimeOffset`, no `DateTime`. Convertido a la zona conserva el offset, y los fixtures de test ya venían escritos con `TimeSpan.FromHours(-3)`, o sea con la forma correcta.

## El 500 que el arreglo obvio habría introducido

`GET /api/reportes/compras/por-proveedor/export` pasa el centinela `"N/A"` como zona: ese reporte bucketea por `fecha_recepcion` sin exponer una zona propia, y el encabezado no puede repetir un valor que la respuesta nunca trae.

Un `TimeZoneInfo.FindSystemTimeZoneById("N/A")` pelado —la corrección de una línea que pedía el bug— convertía esa ruta en un 500. Por eso va `TryFindSystemTimeZoneById` con fallback al instante intacto: la etiqueta `"N/A"` no afirma ninguna zona, así que el fallback no miente. Cubierto con test de regresión.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/Ways.Application/Exportacion/InstanteDeGeneracion.cs` | **nuevo** — el chokepoint de conversión, con el fallback del centinela documentado |
| `src/Ways.Api/Exportacion/ContextoDeExportacionHttp.cs` | `GeneradoEl` pasa por `InstanteDeGeneracion.En` |
| `src/Ways.Application/Exportacion/ContextoDeExportacion.cs` | el XML doc fija la invariante de `GeneradoEl` |
| `tests/Ways.Application.Tests/Exportacion/InstanteDeGeneracionTests.cs` | **nuevo** — conversión, offset y fallback |
| `tests/Ways.Application.Tests/Exportacion/ExportadorXlsxTests.cs` | el exportador no reconvierte lo que recibe |
| `tests/Ways.IntegrationTests/ExistenciasExportTests.cs` | encabezado end-to-end con reloj pineado |

## Evidencia de mutación

Reloj pineado a **01:30 UTC del 6/8 = 22:30 ART del 5/8**: día **y** hora discriminan, así que el test no puede pasar por casualidad según a qué hora corra la suite.

| Mutación | Test que muere | Mensaje |
|---|---|---|
| `GeneradoEl: reloj.Ahora` en `Construir` | `ElEncabezadoImprimeLaHoraDeParedDeLaZonaDelPuntoDeVenta` (integración) | `String: "Generado el 2026-08-06 01:30 (America/Arg"… Not found: "Generado el 2026-08-05 22:30"` |
| `InstanteDeGeneracion.En` sin convertir | `ConvierteElInstanteALaHoraDeParedDeLaZonaResuelta` + `ElOffsetResultanteEsElDeLaZonaResuelta` | `Expected: 2026-08-05T22:30 / Actual: 2026-08-06T01:30` y `Expected: -03:00 / Actual: 00:00` |
| `ExportadorXlsx:38` → `.UtcDateTime` | `ElEncabezadoImprimeLaHoraDeParedDelOffsetRecibidoSinReconvertir` | mismo sub-string ausente |

Las tres revertidas y en verde. Nota sobre el test del fallback: `DateTimeOffset.Equals` compara **solo el instante**, así que el offset se afirma aparte — si no, un corrimiento de zona pasaría desapercibido.

**Suite:** `build --no-incremental` + 42/42 unit de Exportación + 7/7 `ExistenciasExportTests`, de a una suite contra el daemon de Docker. Sin regresiones en `ExportacionDeReportesTests` ni `ReportesVentasResumenExportTests`. Los fixtures existentes construyen `ContextoDeExportacion` directo, sin pasar por `Construir`, así que ninguno se rompió.

## Judgment-day — ronda limpia

**0 severos, 0 suspects, 0 contradicciones, 0 rondas de corrección.**

Los dos jueces convergieron de forma independiente en lo que más me preocupaba del diseño: que el fallback silencioso de `TryFindSystemTimeZoneById` tapara un defecto real. Llegaron por caminos distintos —el juez A recorriendo los ~20 call sites y verificando que todo id no-`"N/A"` ya pasa por un `FindSystemTimeZoneById` que tira antes de llegar a `Construir`; el juez B por `ServicioDeParametros.ValidarTipo`, que valida el IANA id en la escritura del parámetro— a la misma conclusión: **la rama de fallback es alcanzable solo por el centinela documentado.**

El diff se rebasó sobre `origin/main` (PR #130) después del juicio. El rebase fue limpio y el contenido quedó byte-idéntico al juzgado; lo que trajo `main` son tests hermanos y el skill, nada de lo que los jueces inspeccionaron en `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
