### PR TITLE
feat(stage-14): slice 7 web-auditoria — pantalla de consulta Admin-only con panel de cambios

### DIFF
--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1698,7 +1698,7 @@ operator through the export. A documented reduction, never a silent one.
     passed, 693/693 tests passed (689 pre-existentes + 4 nuevos:
     `Auditoria.test.tsx` 8→11, `compararPayloads.test.ts` 6→7). `npm run
     build` (`tsc -b && vite build`) limpio. JUDGMENT: APPROVED.
-- [ ] 7.16 Branch `feat/stage14-slice7-web` off `main` (parent: slices 5+6);
+- [x] 7.16 Branch `feat/stage14-slice7-web` off `main` (parent: slices 5+6); *(CLEAN 2026-08-16: juez B ronda 1 — 3 MAJORs (BUG DE PRODUCCION: limpiar una fecha desincronizaba el listado JSON del export, que armaba desde=T00:00:00+NaN:NaN y el endpoint rechazaba; paridad de filtros asertada solo para accion; borde de ultima pagina sobredeterminado por fixture total:1) + 4 WARNINGs + 2 sugerencias -> fix a249dab con UN builder de alcance compartido (precedente construirQueryDeAlcanceDeCajas) y boton deshabilitado con motivo visible; re-ronda B aprobada con 6 re-mutantes muertos incl. probe de que el test de stale reforzado sigue discriminando. Juez A: 0 severos, 2 WARNINGs (mirror inerte FiltrosDeAuditoria con doc que sobredeclaraba -> removido; rama de fallback de etiquetaDeAccion, el mecanismo de la decision 15, sin test -> exportada y cubierta) + 2 sugerencias cerradas en 3413eee. JUDGMENT: APPROVED.)*
   PR; merge stacked-to-main. **If the slice overflows at apply time, drop
   tasks 7.5/7.7/7.8 (`PanelDeCambio`/`compararPayloads`) per the
   pre-approved degradation above and record the reduction in the PR body —

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1573,6 +1573,84 @@ operator through the export. A documented reduction, never a silent one.
   --short` shows only `src/Ways.Web/**` paths.
 - [ ] 7.15 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator)*
+  - Ronda 1 (juez B): 3 MAJOR + 5 WARNING + 2 sugerencias.
+    **Finding 1 (MAJOR, cerrado):** `construirQueryDeConsultaDeAuditoria` y
+    `construirQueryDeExportacionDeAuditoria` divergían en la guarda de
+    `desde`/`hasta` vacíos — la consulta JSON los omitía, el export los
+    mandaba igual y `fechaIsoConOffset` sobre un string vacío producía
+    `desde=...T00:00:00+NaN:NaN` (`DateTimeOffset` malformado, 400 del
+    servidor). Unificados en `construirQueryDeAlcanceDeAuditoria`
+    (`api/auditoria.ts`), mismo criterio que `construirQueryDeAlcanceDeCajas`
+    (`reportes.ts:177`) — el caso vacío queda guardado en los dos lados por
+    construcción. Decisión de producto: `AuditoriaEndpoints.cs:44` declara
+    `DateTimeOffset desde, DateTimeOffset hasta` sin `?` en `/export` (no
+    nullable), así que `Auditoria.tsx` deshabilita el botón de descarga con
+    el motivo visible (`puedeExportarAuditoria`) en vez de emitir una URL
+    que el servidor rechaza. Evidencia de mutación: reintroducido un
+    builder de export sin guarda → `una respuesta desactualizada...NaN`
+    FALLÓ (`+NaN:NaN` reproducido literal) → revert → 7/7 verdes
+    (`auditoria.test.ts`).
+    **Finding 2 (MAJOR, cerrado):** la paridad JSON↔export solo estaba
+    asertada para `accion` — borrar `idPuntoVenta` (o `idActor`/`entidad`/
+    `idEntidad`) solo del builder de export sobrevivía. Agregado un test
+    de paridad que compara la URL completa (los 7 filtros de alcance) de
+    ambas superficies. Evidencia de mutación: forkeado un builder de
+    export que omite `idPuntoVenta` → el test de paridad Y el test
+    preexistente de "agrega los 5 filtros opcionales" FALLARON → revert →
+    verdes.
+    **Finding 3 (MAJOR, cerrado):** el único test de bordes del pager
+    usaba `total: 1`, que colapsa página 1 y última página en el mismo
+    fixture — `Math.ceil`→`Math.floor` en `totalPaginas` sobrevivía.
+    Agregado un fixture multi-página (total 60, tamaño 25 ⇒ 3 páginas, la
+    última parcial) navegando hasta la última página real, asertando la
+    etiqueta "Página N de M" y el disabled de "Siguiente" ahí. Evidencia
+    de mutación: `Math.ceil`→`Math.floor` → el nuevo test FALLÓ ("Página 1
+    de 2" en vez de "de 3") → revert → verde.
+    **Finding 4 (WARNING, cerrado):** cubierto por el test de paridad del
+    finding 2 — la URL completa asertada incluye `idActor` y el resto de
+    los filtros no-`accion`, verificado.
+    **Finding 5 (WARNING, cerrado):** `PanelDeCambio` tenía 0 tests
+    (renderizar `valorNuevo` de ambos lados sobrevivía) y `formatearValor`
+    no tenía su test colocado (`web-descriptor-tests`). Exportado
+    `formatearValor` y creado `PanelDeCambio.test.tsx`: unit tests del
+    helper + tests por `data-testid` de cada lado (agregada → "—" del
+    lado anterior; modificada → ambos valores reales y distintos; valor
+    `undefined` del lado nuevo → "—" ahí; sin cambios → mismo valor en
+    ambos lados). Evidencia de mutación: cambiado el lado anterior para
+    renderizar `valorNuevo` → 2 tests FALLARON (modificada, valor
+    `undefined`) → revert → 8/8 verdes.
+    **Finding 6 (WARNING, cerrado):** el guard de `cambiarEntidad` (limpiar
+    `entidad` limpia también `idEntidad`, si no el request siguiente 400ea
+    `entidad_requerida`) no tenía test. Agregado: setear entidad+idEntidad,
+    limpiar entidad, assertar que el request siguiente NO manda `idEntidad`
+    y que el input `#Id` queda vacío (no solo disabled). Evidencia de
+    mutación: quitado `idEntidad: null` de la rama de limpieza → el test
+    FALLÓ (`idEntidad=41` seguía viajando) → revert → verde.
+    **Finding 7 (WARNING, pre-existente — registrado, SIN fix):** ningún
+    test importa `Layout`/`App`, así que ambos gates Admin-only son
+    infalsificables (widenearlos a Supervisor pasa toda la suite). El
+    backstop real es el server (403 probado en slices 5/6 por
+    `PoliticasTests`). Limitación suite-wide conocida, mismo registro que
+    dejó slice 6 de la etapa 13 — no se agregó un test de `Layout`/`App`
+    porque ningún sibling de la suite lo hace (no hay patrón que replicar
+    sin abrir una superficie nueva fuera del alcance de esta ronda).
+    **Sugerencia 1 (aplicada):** `etiquetaDeAccion` era reducible a
+    `return accion` sin fallar ningún test — agregado un assert de la
+    etiqueta en español ("Cambio de precio") en la celda de la tabla
+    (`getByRole('cell', ...)`, scoped para no chocar con el `<option>`
+    homónimo del filtro).
+    **Sugerencia 2 (aplicada, honestidad de evidencia):** la nota de esta
+    misma task (7.10) decía "resuelto dentro de `act` y asertado
+    sincrónicamente" pero el test usaba `waitFor` — discriminaba igual,
+    pero la nota describía una construcción más fuerte que la real.
+    Fortalecido el test al patrón real de `Vencimientos.test.tsx` (regla
+    7): el flush del microtask va dentro de `act`, el assert es sincrónico
+    después, sin `waitFor`.
+    **Vitest tras los fixes de ronda 1**: `npx vitest run` → 41 test files
+    passed, 689/689 tests passed (674 pre-existentes + 15 nuevos:
+    `auditoria.test.ts` 3→7, `Auditoria.test.tsx` 5→8, `PanelDeCambio.test.tsx`
+    0→8). `npm run build` (`tsc -b && vite build`) limpio. Re-ronda y
+    JUDGMENT final: ver 7.16 (orchestrator).
 - [ ] 7.16 Branch `feat/stage14-slice7-web` off `main` (parent: slices 5+6);
   PR; merge stacked-to-main. **If the slice overflows at apply time, drop
   tasks 7.5/7.7/7.8 (`PanelDeCambio`/`compararPayloads`) per the

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1488,6 +1488,16 @@ operator through the export. A documented reduction, never a silent one.
   `FiltrosDeAuditoria`, `FilaDeAuditoria`, `PaginaDeAuditoria`, and the
   12-action catalog labels. `dto-contract-honesty`: doc-comment each
   mirrored field's source (the `Contratos.cs` records from slice 5).
+  **DEVIATION (judgment-day ronda 2, juez A, WARNING — registered, not
+  silent):** the `FiltrosDeAuditoria` mirror shipped with zero type
+  consumers (the screen's own `FiltrosDeConsultaDeAuditoria`/
+  `FiltrosDeAlcanceDeAuditoria`, `api/auditoria.ts`, are independently
+  defined — never derived from it) while its doc-comment claimed real
+  consumption. Removed from `tipos.ts`: its shape genuinely differs from
+  the screen filters (`DateTimeOffset?` nullable ISO vs. non-null
+  `YYYY-MM-DD` strings), so a `Pick`/derivation would force an artificial
+  shape rather than ship an inert mirror. `FilaDeAuditoria`/
+  `PaginaDeAuditoria` remain, both with real consumers.
   **Also added** `puedeVerAuditoria(rolId)` next to the other `puede*`
   role helpers (Admin-only, mirrors `Politicas.LecturaDeAuditoria` — not
   in the task's literal text, but required by 7.6's nav gating and the
@@ -1571,9 +1581,12 @@ operator through the export. A documented reduction, never a silent one.
   the last migration."; `git diff --stat main --
   src/Ways.Infrastructure/Persistencia/Migraciones/` → empty; `git status
   --short` shows only `src/Ways.Web/**` paths.
-- [ ] 7.15 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 7.15 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   *(orchestrator)*
-  - Ronda 1 (juez B): 3 MAJOR + 5 WARNING + 2 sugerencias.
+  - Ronda 1 (juez B): 3 MAJOR + 4 WARNING + 2 sugerencias. *(judgment-day
+    ronda 2, juez A, sugerencia cerrada: el conteo original decía "5
+    WARNING" pero solo se enumeran 4 (findings 4-7) — corregido al conteo
+    real.)*
     **Finding 1 (MAJOR, cerrado):** `construirQueryDeConsultaDeAuditoria` y
     `construirQueryDeExportacionDeAuditoria` divergían en la guarda de
     `desde`/`hasta` vacíos — la consulta JSON los omitía, el export los
@@ -1651,6 +1664,40 @@ operator through the export. A documented reduction, never a silent one.
     `auditoria.test.ts` 3→7, `Auditoria.test.tsx` 5→8, `PanelDeCambio.test.tsx`
     0→8). `npm run build` (`tsc -b && vite build`) limpio. Re-ronda y
     JUDGMENT final: ver 7.16 (orchestrator).
+
+    **Ronda 2 (juez A): 0 severos; 2 WARNING + 2 sugerencias.**
+    **Finding (WARNING, `dto-contract-honesty`, cerrado):** `tipos.ts:1638-
+    1652` mirroreaba `FiltrosDeAuditoria` (`Contratos.cs`) sin ningún
+    consumidor de tipo (`auditoria.ts` solo importa `PaginaDeAuditoria`; la
+    pantalla usa `FiltrosDeConsultaDeAuditoria`/`FiltrosDeAlcanceDeAuditoria`
+    definidos localmente) con un doc-comment que afirmaba consumo real —
+    falso para ese tipo. Eliminado el mirror inerte (las formas difieren
+    genuinamente: `DateTimeOffset?` nullable del backend vs. `string`
+    no-nulo `YYYY-MM-DD` de pantalla, así que un `Pick`/derivación no
+    aplica sin forzar el shape); doc-comment de `tipos.ts` y las dos
+    referencias cruzadas en `auditoria.ts` corregidos para describir solo
+    los mirrors que sí atan (`FilaDeAuditoria`/`PaginaDeAuditoria`).
+    Verificado con `npx tsc -b` limpio tras el borrado.
+    **Finding (WARNING, cerrado):** el fallback `?? accion` de
+    `etiquetaDeAccion` (`Auditoria.tsx`, el mecanismo exacto de la decisión
+    15 del design) no tenía test y la función no estaba exportada.
+    Exportada; agregados los tests de sus dos ramas (catálogo → etiqueta en
+    español; no catalogada → código crudo) más un assert de componente con
+    una fila de acción retirada. Evidencia de mutación: `?? accion` → `??
+    '—'` → 2 tests FALLARON (unitario de la rama fallback + el assert de
+    componente) → revert → 11/11 verdes (`Auditoria.test.tsx`).
+    **Sugerencia (aplicada):** `compararPayloads.ts`'s `sonIguales` compara
+    con `JSON.stringify`, sensible al orden de claves. Documentado en el
+    código como limitación conocida (riesgo bajo: ambos payloads salen del
+    mismo serializador) y fijado con un test que asienta el comportamiento
+    actual (objeto anidado con distinto orden de claves ⇒ `'cambiada'`).
+    **Sugerencia (aplicada):** el header de esta misma ronda 1 decía "5
+    WARNING" pero solo se enumeran 4 (findings 4-7) — corregido al conteo
+    real arriba.
+    **Vitest tras los fixes de ronda 2**: `npx vitest run` → 41 test files
+    passed, 693/693 tests passed (689 pre-existentes + 4 nuevos:
+    `Auditoria.test.tsx` 8→11, `compararPayloads.test.ts` 6→7). `npm run
+    build` (`tsc -b && vite build`) limpio. JUDGMENT: APPROVED.
 - [ ] 7.16 Branch `feat/stage14-slice7-web` off `main` (parent: slices 5+6);
   PR; merge stacked-to-main. **If the slice overflows at apply time, drop
   tasks 7.5/7.7/7.8 (`PanelDeCambio`/`compararPayloads`) per the

--- a/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
+++ b/openspec/changes/stage-14-auditoria-trazabilidad/tasks.md
@@ -1484,14 +1484,25 @@ ship the screen with filters, listing and download; **drop
 `PanelDeCambio`/`compararPayloads`**. The payload still reaches the
 operator through the export. A documented reduction, never a silent one.
 
-- [ ] 7.1 Modify `src/Ways.Web/src/api/tipos.ts`: mirror
+- [x] 7.1 Modify `src/Ways.Web/src/api/tipos.ts`: mirror
   `FiltrosDeAuditoria`, `FilaDeAuditoria`, `PaginaDeAuditoria`, and the
   12-action catalog labels. `dto-contract-honesty`: doc-comment each
   mirrored field's source (the `Contratos.cs` records from slice 5).
-- [ ] 7.2 Modify/create `src/Ways.Web/src/api/auditoria.ts`:
+  **Also added** `puedeVerAuditoria(rolId)` next to the other `puede*`
+  role helpers (Admin-only, mirrors `Politicas.LecturaDeAuditoria` — not
+  in the task's literal text, but required by 7.6's nav gating and the
+  same convention every other Admin-only screen already uses
+  `puedeVerRentabilidad`/`puedeGestionarCatalogos`).
+- [x] 7.2 Modify/create `src/Ways.Web/src/api/auditoria.ts`:
   `clienteDeAuditoria.consultar`, wired to `rutasDeExportacion.auditoria`
-  from 6.4.
-- [ ] 7.3 Create `src/Ways.Web/src/paginas/Auditoria.tsx`:
+  from 6.4. **Also added** `FiltrosDeConsultaDeAuditoria` (the screen-shape
+  filter, `desde`/`hasta` as `input[type=date]` strings + `pagina`/
+  `tamanio` — same split as `FiltrosDeHistoricoDeCajas` vs. the raw
+  `FiltrosDeAuditoria` DTO in `tipos.ts`) and `filtrosDeAuditoriaVacios()`
+  (reuses `rangoUltimosSieteDias` imported from `reportes.ts`, same
+  cross-domain reuse `Tesoreria.tsx`/`Tablero.tsx` already do — not
+  duplicated).
+- [x] 7.3 Create `src/Ways.Web/src/paginas/Auditoria.tsx`:
   `HistoricoDeCajas.tsx`-shape filters+pager (`FiltrosDeAuditoria` object,
   `filtrosDeAuditoriaVacios()`, `generacionRef` per `react-async-state`
   rule 2, `cambiarFiltro` resets to page 1, `cambiarPagina(±1)` disabled at
@@ -1499,38 +1510,75 @@ operator through the export. A documented reduction, never a silent one.
   · Entidad · #Id · Actor · PV`; `Actor` null ⇒ `#<idActor>`; PV null ⇒
   `—` with `title="Evento de todo el tenant"`; the "Todos" PV option is an
   **absent** filter, never `0`.
-- [ ] 7.4 Create the pure helper `compararPayloads(anterior, nuevo)`
-  (colocated module): a key only in `nuevo` renders `"—→ valor"`; a changed
-  key is marked as changed; an equal key is not; both-`null` handled.
-- [ ] 7.5 Create `PanelDeCambio`: an expandable row rendering
+- [x] 7.4 Create the pure helper `compararPayloads(anterior, nuevo)`
+  (colocated module, `src/Ways.Web/src/paginas/compararPayloads.ts`): a
+  key only in `nuevo` renders `"—→ valor"`; a changed key is marked as
+  changed; an equal key is not; both-`null` handled.
+- [x] 7.5 Create `PanelDeCambio`: an expandable row rendering
   `valor_anterior`/`valor_nuevo` key by key via `compararPayloads`, with
-  its own `data-testid` per side.
-- [ ] 7.6 Modify `src/Ways.Web/src/App.tsx` and
+  its own `data-testid` per side (`panel-cambio-anterior-<clave>` /
+  `panel-cambio-nuevo-<clave>`). **Not dropped** — the slice fit within
+  budget, the pre-approved cut (Budget note) was not exercised.
+- [x] 7.6 Modify `src/Ways.Web/src/App.tsx` and
   `componentes/Layout.tsx`: add the `/auditoria` route and one nav line,
-  visible only to Admin.
-- [ ] 7.7 [P] **Mutation target**: `compararPayloads`'s "key only in
+  visible only to Admin (`RutaProtegida rolesPermitidos={[ROL.Admin]}` +
+  `puedeVerAuditoria`).
+- [x] 7.7 [P] **Mutation target**: `compararPayloads`'s "key only in
   `nuevo`" branch — treat it as "no change" — the colocated helper test
   (7.8) must fail. *(slice 7 row 1, the sole one; `web-descriptor-tests`)*
-- [ ] 7.8 [P] Descriptor tests for `compararPayloads`: key only in `nuevo`,
+  **Evidence**: mutated (the `'agregada'` branch return changed to
+  `'sin_cambio'`) → `npx vitest run src/paginas/compararPayloads.test.ts`
+  → 2 tests FAILED (`una clave presente solo en nuevo se marca agregada,
+  nunca sin_cambio` and `anterior null (accion hecho puro) marca TODAS las
+  claves de nuevo como agregadas`, both expected `'agregada'`/got
+  `'sin_cambio'`) → reverted → 6/6 green.
+  **DEVIATION (registered)**: the house rule "commitear antes de mutar"
+  was not respected for this one target — the mutation was applied and
+  reverted before the first commit of this slice existed yet (no commit
+  to be "before"). Flagged here rather than silently omitted; every
+  subsequent slice-7 commit lands on the already-reverted, green file.
+- [x] 7.8 [P] Descriptor tests for `compararPayloads`: key only in `nuevo`,
   changed key, unchanged key, both-null. *(`web-descriptor-tests`)*
-- [ ] 7.9 [P] Component test: changing any filter resets the page to 1.
-- [ ] 7.10 [P] Component test: a stale response resolved **inside `act`**
+  `compararPayloads.test.ts` — 6 cases (adds a deep-equal nested-array
+  case beyond the 4 named, since the comparator's `sonIguales` does a
+  `JSON.stringify` structural compare, not `===`, for object/array
+  values — `movimientos_generados`-shaped payloads from stock.conteo need
+  that covered too).
+- [x] 7.9 [P] Component test: changing any filter resets the page to 1.
+  `Auditoria.test.tsx` — `cambiar cualquier filtro resetea la página a 1`.
+- [x] 7.10 [P] Component test: a stale response resolved **inside `act`**
   after a filter change is discarded, asserted synchronously after the
-  flush (`react-async-state` rule 7).
-- [ ] 7.11 [P] Component test: pager `disabled` at both edges (page 1 and
-  the last page).
-- [ ] 7.12 [P] Component test: `actor: null` renders `#<idActor>`;
+  flush (`react-async-state` rule 7). `Auditoria.test.tsx` — `una
+  respuesta desactualizada nunca pisa la más reciente (generación)`.
+- [x] 7.11 [P] Component test: pager `disabled` at both edges (page 1 and
+  the last page). `Auditoria.test.tsx` — single-page fixture (`total: 1`)
+  puts page 1 at BOTH edges simultaneously, asserting `Anterior` AND
+  `Siguiente` disabled together.
+- [x] 7.12 [P] Component test: `actor: null` renders `#<idActor>`;
   `id_punto_venta: null` renders `—` with the tenant-wide title.
-- [ ] 7.13 [P] Component test: the download button calls
+  `Auditoria.test.tsx` — `actor null renderiza #idActor; punto de venta
+  null renderiza — con el título tenant-wide`.
+- [x] 7.13 [P] Component test: the download button calls
   `rutasDeExportacion.auditoria(filtros)` with the current filter state.
-- [ ] 7.14 Gate guard: `has-pending-model-changes` clean; zero new files in
+  `Auditoria.test.tsx` — asserts the descargar call's route starts with
+  `/auditoria/export?`, carries the currently-selected `accion` filter,
+  and ends in `formato=xlsx`.
+- [x] 7.14 Gate guard: `has-pending-model-changes` clean; zero new files in
   `Migraciones/` (web-only slice — confirms no accidental API/EF drift).
+  **Confirmed**: `dotnet ef migrations has-pending-model-changes
+  --project src/Ways.Infrastructure --startup-project
+  src/Ways.Infrastructure` → "No changes have been made to the model since
+  the last migration."; `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` → empty; `git status
+  --short` shows only `src/Ways.Web/**` paths.
 - [ ] 7.15 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  *(orchestrator)*
 - [ ] 7.16 Branch `feat/stage14-slice7-web` off `main` (parent: slices 5+6);
   PR; merge stacked-to-main. **If the slice overflows at apply time, drop
   tasks 7.5/7.7/7.8 (`PanelDeCambio`/`compararPayloads`) per the
   pre-approved degradation above and record the reduction in the PR body —
-  never a silent cut.**
+  never a silent cut.** *(orchestrator — degradation NOT exercised, see
+  7.5)*
 
 **Test plan**: mutation target (7.7), descriptor tests (7.8), stale-inside-
 `act` (7.10), pager edges (7.11), null renders (7.12), download wiring

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './auth/AuthContext'
 import { RutaProtegida } from './auth/RutaProtegida'
 import { Layout } from './componentes/Layout'
 import { Articulos } from './paginas/Articulos'
+import { Auditoria } from './paginas/Auditoria'
 import { Caja } from './paginas/Caja'
 import { CajaZ } from './paginas/CajaZ'
 import { CierreDeCaja } from './paginas/CierreDeCaja'
@@ -162,6 +163,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Supervisor, ROL.Admin]}>
                   <Reposicion />
+                </RutaProtegida>
+              }
+            />
+            {/* stage-14-auditoria-trazabilidad (Slice 7, design decisión 17): Admin-only —
+                Politicas.LecturaDeAuditoria NO se apila sobre LecturaDeReportes, es su propio
+                gate, mismo criterio admin-only que /clientes/-proveedores más abajo. */}
+            <Route
+              path="/auditoria"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Admin]}>
+                  <Auditoria />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/auditoria.test.ts
+++ b/src/Ways.Web/src/api/auditoria.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import type { FiltrosDeExportacionDeAuditoria } from './auditoria'
+import type { FiltrosDeConsultaDeAuditoria, FiltrosDeExportacionDeAuditoria } from './auditoria'
 
-const { rutasDeExportacion } = await import('./auditoria')
+const { rutasDeExportacion, construirQueryDeConsultaDeAuditoria, puedeExportarAuditoria } = await import('./auditoria')
 
 function offsetEsperado(anio: number, mes: number, dia: number): string {
   const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
@@ -57,5 +57,76 @@ describe('rutasDeExportacion.auditoria', () => {
     expect(ruta).toContain('entidad=articulo')
     expect(ruta).toContain('idEntidad=41')
     expect(ruta).toContain('idPuntoVenta=7')
+  })
+
+  // judgment-day ronda 1, finding 1: dos builders divergentes dejaban `desde`/`hasta` vacíos
+  // guardados en la consulta JSON pero NO en el export (fechaIsoConOffset sobre un string vacío
+  // ⇒ `T00:00:00+NaN:NaN`, un DateTimeOffset malformado que el servidor rechaza con 400). Con el
+  // builder unificado (`construirQueryDeAlcanceDeAuditoria`) el caso vacío queda guardado en
+  // AMBOS lados por construcción, no por disciplina.
+  it('con desde/hasta vacíos, la URL de export NO contiene NaN (guardada por construcción, no por disciplina)', () => {
+    const ruta = rutasDeExportacion.auditoria(filtrosFixture({ desde: '', hasta: '' }))
+
+    expect(ruta).not.toContain('NaN')
+    expect(ruta).not.toContain('desde=')
+    expect(ruta).not.toContain('hasta=')
+    expect(ruta).toBe('/auditoria/export?&formato=xlsx')
+  })
+})
+
+describe('puedeExportarAuditoria', () => {
+  it('es false si desde o hasta están vacíos', () => {
+    expect(puedeExportarAuditoria({ desde: '', hasta: '2026-08-11' })).toBe(false)
+    expect(puedeExportarAuditoria({ desde: '2026-08-05', hasta: '' })).toBe(false)
+    expect(puedeExportarAuditoria({ desde: '', hasta: '' })).toBe(false)
+  })
+
+  it('es true cuando ambas fechas están seteadas', () => {
+    expect(puedeExportarAuditoria({ desde: '2026-08-05', hasta: '2026-08-11' })).toBe(true)
+  })
+})
+
+// judgment-day ronda 1, finding 2/4: la paridad JSON↔export solo estaba asertada para `accion` —
+// borrar `idPuntoVenta`, `idActor`, `entidad` o `idEntidad` de un solo builder sobrevivía. Con el
+// builder unificado esto es casi estructural, pero se asertan igual las DOS URLs completas: si
+// alguien vuelve a divergir los builders, este test lo detecta sin depender de cuál filtro se
+// borró.
+describe('paridad JSON↔export — construirQueryDeConsultaDeAuditoria vs. rutasDeExportacion.auditoria', () => {
+  function filtrosConsultaFixture(sobrescribir: Partial<FiltrosDeConsultaDeAuditoria> = {}): FiltrosDeConsultaDeAuditoria {
+    return {
+      desde: '2026-08-05',
+      hasta: '2026-08-11',
+      accion: null,
+      idActor: null,
+      entidad: null,
+      idEntidad: null,
+      idPuntoVenta: null,
+      pagina: 1,
+      tamanio: 25,
+      ...sobrescribir,
+    }
+  }
+
+  it('con los 7 filtros de alcance seteados, la consulta JSON y la URL de export llevan EXACTAMENTE los mismos filtros', () => {
+    const filtrosCompletos = filtrosConsultaFixture({
+      accion: 'precio.cambio',
+      idActor: 3,
+      entidad: 'articulo',
+      idEntidad: 41,
+      idPuntoVenta: 7,
+    })
+
+    const queryJson = construirQueryDeConsultaDeAuditoria(filtrosCompletos)
+    const alcanceDesdeJson = queryJson.replace(/&pagina=\d+&tamanio=\d+$/, '').slice(1)
+
+    const urlExport = rutasDeExportacion.auditoria(filtrosCompletos)
+    const alcanceDesdeExport = urlExport.replace('/auditoria/export?', '').replace(/&formato=xlsx$/, '')
+
+    expect(alcanceDesdeExport).toBe(alcanceDesdeJson)
+    // Sanity check — que la comparación no esté vacía por un regex que no matcheó nada.
+    expect(alcanceDesdeJson).toContain('idPuntoVenta=7')
+    expect(alcanceDesdeJson).toContain('idActor=3')
+    expect(alcanceDesdeJson).toContain('entidad=articulo')
+    expect(alcanceDesdeJson).toContain('idEntidad=41')
   })
 })

--- a/src/Ways.Web/src/api/auditoria.ts
+++ b/src/Ways.Web/src/api/auditoria.ts
@@ -6,9 +6,12 @@
  * (judgment-day ronda 1, finding 1) — `FiltrosDeConsultaDeAuditoria` solo suma `pagina`/`tamanio`,
  * propios de la ruta JSON. Mismo criterio que `reportes.ts` (`FiltrosDeHistoricoDeCajas` vs. el
  * query del export): los tipos de filtro propios de un dominio viven en el archivo del dominio,
- * nunca en `tipos.ts` — ahí solo viven los DTOs espejo del backend (`FiltrosDeAuditoria`/
- * `FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`, design decisión 8/Orchestrator
- * Decision 8).
+ * nunca en `tipos.ts` — ahí solo viven los DTOs espejo del backend que sí comparten forma exacta
+ * con el mirror (`FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`, design decisión 8/
+ * Orchestrator Decision 8). El DTO crudo del backend (`FiltrosDeAuditoria`, `Contratos.cs`) NO
+ * tiene mirror en `tipos.ts` (judgment-day, ronda 2, juez A) — su forma difiere genuinamente de
+ * los filtros de pantalla definidos acá, así que un mirror sin consumidor de tipo se hubiera
+ * quedado inerte.
  *
  * Mismo criterio de offset local que `reportes.ts` (`fechaIsoConOffset`/`desplazamientoUtcLocal`,
  * duplicado a propósito: no hay un módulo compartido de utilidades de fecha en esta web todavía) —
@@ -93,11 +96,12 @@ export const rutasDeExportacion = {
 
 /** Filtro de pantalla de `Auditoria.tsx` — mismo shape que `FiltrosDeHistoricoDeCajas`
  * (`reportes.ts`): `desde`/`hasta` en formato `input[type=date]` (`YYYY-MM-DD`), a diferencia de
- * `FiltrosDeAuditoria` (`tipos.ts`, el DTO crudo del backend, `DateTimeOffset?` ISO completo) —
- * `construirQueryDeConsultaDeAuditoria` hace la conversión recién al armar el query string, mismo
- * criterio que `construirQueryDeAlcanceDeAuditoria` arriba. `desde`/`hasta` vacíos SÍ están
- * permitidos acá (a diferencia del export, que los exige): el listado JSON no necesita un rango
- * acotado para nombrar un archivo — el botón de descarga se deshabilita en ese caso
+ * `FiltrosDeAuditoria` (`Ways.Application.Auditoria.Contratos`, el DTO crudo del backend,
+ * `DateTimeOffset?` ISO completo, SIN mirror en `tipos.ts` — ver nota de `dto-contract-honesty`
+ * arriba) — `construirQueryDeConsultaDeAuditoria` hace la conversión recién al armar el query
+ * string, mismo criterio que `construirQueryDeAlcanceDeAuditoria` arriba. `desde`/`hasta` vacíos
+ * SÍ están permitidos acá (a diferencia del export, que los exige): el listado JSON no necesita
+ * un rango acotado para nombrar un archivo — el botón de descarga se deshabilita en ese caso
  * (`puedeExportarAuditoria`). */
 export type FiltrosDeConsultaDeAuditoria = FiltrosDeAlcanceDeAuditoria & {
   pagina: number

--- a/src/Ways.Web/src/api/auditoria.ts
+++ b/src/Ways.Web/src/api/auditoria.ts
@@ -1,20 +1,24 @@
 /**
- * stage-14-auditoria-trazabilidad (Slice 6): SOLO el constructor de ruta de exportación —
- * `rutasDeExportacion.auditoria(filtros)`. El cliente JSON (`clienteDeAuditoria`) y los espejos
- * de tipos (`FiltrosDeAuditoria`/`FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`,
- * design decisión 8) quedan para la Slice 7 (la pantalla `Auditoria.tsx`) — acá no hay ningún
- * consumidor todavía.
- *
- * `tipos.ts` no se modifica en esta slice: es un módulo de tipos verdaderamente transversales
- * (`ROL`, `EstadoUsuario`, `PaginaDe<T>`, …), y el precedente de `reportes.ts` es que los tipos de
- * filtro propios de un dominio (`FiltrosDeHistoricoDeCajas`, `FiltrosDeTesoreria`, …) viven en el
- * archivo del dominio, nunca en `tipos.ts` — `FiltrosDeExportacionDeAuditoria` sigue ese mismo
- * criterio acá.
+ * Cliente de `GET /api/auditoria` + `/export` (Slice 5/6) y ahora también el cliente JSON
+ * (`clienteDeAuditoria`, Slice 7) consumido por `Auditoria.tsx`. `FiltrosDeExportacionDeAuditoria`
+ * (export, Slice 6) y `FiltrosDeConsultaDeAuditoria` (JSON, Slice 7) son shapes de pantalla
+ * distintos, mismo criterio que `reportes.ts` (`FiltrosDeHistoricoDeCajas` vs. el query del
+ * export): los tipos de filtro propios de un dominio viven en el archivo del dominio, nunca en
+ * `tipos.ts` — ahí solo viven los DTOs espejo del backend (`FiltrosDeAuditoria`/
+ * `FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`, design decisión 8/Orchestrator
+ * Decision 8).
  *
  * Mismo criterio de offset local que `reportes.ts` (`fechaIsoConOffset`/`desplazamientoUtcLocal`,
  * duplicado a propósito: no hay un módulo compartido de utilidades de fecha en esta web todavía) —
- * `auditoria.creado_el` es `timestamptz`, igual que `cajas.fecha_cierre`.
+ * `auditoria.creado_el` es `timestamptz`, igual que `cajas.fecha_cierre`. `rangoUltimosSieteDias`
+ * en cambio SÍ se reutiliza de `reportes.ts` (mismo criterio que `Tesoreria.tsx`/`Tablero.tsx`,
+ * que ya lo importan cross-dominio) — es un helper de fecha genérico, no un concern propio de
+ * reportes.
  */
+import { api } from './cliente'
+import { rangoUltimosSieteDias } from './reportes'
+import type { PaginaDeAuditoria } from './tipos'
+
 function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
   const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
   const signo = minutos > 0 ? '-' : '+'
@@ -56,8 +60,72 @@ function construirQueryDeExportacionDeAuditoria(filtros: FiltrosDeExportacionDeA
 }
 
 /** Misma convención de `reportes.ts` (`rutasDeExportacion.<dominio>(filtros)`), en su propio
- * módulo — `auditoria.ts` no depende de `reportes.ts` ni viceversa. */
+ * módulo. */
 export const rutasDeExportacion = {
   auditoria: (filtros: FiltrosDeExportacionDeAuditoria) =>
     `/auditoria/export${construirQueryDeExportacionDeAuditoria(filtros)}&formato=xlsx`,
+}
+
+// ---- Cliente JSON de `GET /api/auditoria` (Slice 7, `Auditoria.tsx`) --------------------------
+
+/** Filtro de pantalla de `Auditoria.tsx` — mismo shape que `FiltrosDeHistoricoDeCajas`
+ * (`reportes.ts`): `desde`/`hasta` en formato `input[type=date]` (`YYYY-MM-DD`), a diferencia de
+ * `FiltrosDeAuditoria` (`tipos.ts`, el DTO crudo del backend, `DateTimeOffset?` ISO completo) —
+ * `construirQueryDeConsultaDeAuditoria` hace la conversión recién al armar el query string, mismo
+ * criterio que `construirQueryDeExportacionDeAuditoria` arriba. `desde`/`hasta` vacíos SÍ están
+ * permitidos acá (a diferencia del export, que los exige): el listado JSON no necesita un rango
+ * acotado para nombrar un archivo. */
+export type FiltrosDeConsultaDeAuditoria = {
+  desde: string
+  hasta: string
+  accion: string | null
+  idActor: number | null
+  entidad: string | null
+  idEntidad: number | null
+  idPuntoVenta: number | null
+  pagina: number
+  tamanio: number
+}
+
+/** Default de `Auditoria.tsx` al montar — últimos 7 días (mismo criterio "vacíos" de
+ * `filtrosDeHistoricoDeCajasVacios`: el nombre dice "vacíos" pero el rango de fechas viene
+ * prellenado), sin ningún otro filtro y página 1. */
+export function filtrosDeAuditoriaVacios(): FiltrosDeConsultaDeAuditoria {
+  const rango = rangoUltimosSieteDias()
+  return {
+    desde: rango.desde,
+    hasta: rango.hasta,
+    accion: null,
+    idActor: null,
+    entidad: null,
+    idEntidad: null,
+    idPuntoVenta: null,
+    pagina: 1,
+    tamanio: 25,
+  }
+}
+
+/** Query compartido de `GET /api/auditoria` — `dto-contract-honesty`: cada parámetro solo se
+ * agrega si `AuditoriaEndpoints.cs` lo lee (`desde, hasta, accion, idActor, entidad, idEntidad,
+ * idPuntoVenta, pagina, tamanio`, todos opcionales salvo pagina/tamanio con default del propio
+ * endpoint — acá se mandan siempre explícitos, mismo criterio que `construirQueryDeHistoricoDeCajas`). */
+function construirQueryDeConsultaDeAuditoria(filtros: FiltrosDeConsultaDeAuditoria): string {
+  const parametros = new URLSearchParams()
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  if (filtros.accion !== null) parametros.set('accion', filtros.accion)
+  if (filtros.idActor !== null) parametros.set('idActor', String(filtros.idActor))
+  if (filtros.entidad !== null) parametros.set('entidad', filtros.entidad)
+  if (filtros.idEntidad !== null) parametros.set('idEntidad', String(filtros.idEntidad))
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+/** Único consumidor JSON de `/api/auditoria` — el export (Slice 6) ya vive en
+ * `rutasDeExportacion.auditoria` arriba, sin pasar por `api.get` (es una descarga de archivo). */
+export const clienteDeAuditoria = {
+  consultar: (filtros: FiltrosDeConsultaDeAuditoria) =>
+    api.get<PaginaDeAuditoria>(`/auditoria${construirQueryDeConsultaDeAuditoria(filtros)}`),
 }

--- a/src/Ways.Web/src/api/auditoria.ts
+++ b/src/Ways.Web/src/api/auditoria.ts
@@ -1,10 +1,12 @@
 /**
  * Cliente de `GET /api/auditoria` + `/export` (Slice 5/6) y ahora también el cliente JSON
  * (`clienteDeAuditoria`, Slice 7) consumido por `Auditoria.tsx`. `FiltrosDeExportacionDeAuditoria`
- * (export, Slice 6) y `FiltrosDeConsultaDeAuditoria` (JSON, Slice 7) son shapes de pantalla
- * distintos, mismo criterio que `reportes.ts` (`FiltrosDeHistoricoDeCajas` vs. el query del
- * export): los tipos de filtro propios de un dominio viven en el archivo del dominio, nunca en
- * `tipos.ts` — ahí solo viven los DTOs espejo del backend (`FiltrosDeAuditoria`/
+ * (export, Slice 6) y `FiltrosDeConsultaDeAuditoria` (JSON, Slice 7) comparten los mismos 7
+ * filtros de alcance vía `FiltrosDeAlcanceDeAuditoria`/`construirQueryDeAlcanceDeAuditoria`
+ * (judgment-day ronda 1, finding 1) — `FiltrosDeConsultaDeAuditoria` solo suma `pagina`/`tamanio`,
+ * propios de la ruta JSON. Mismo criterio que `reportes.ts` (`FiltrosDeHistoricoDeCajas` vs. el
+ * query del export): los tipos de filtro propios de un dominio viven en el archivo del dominio,
+ * nunca en `tipos.ts` — ahí solo viven los DTOs espejo del backend (`FiltrosDeAuditoria`/
  * `FilaDeAuditoria`/`PaginaDeAuditoria`, `dto-contract-honesty`, design decisión 8/Orchestrator
  * Decision 8).
  *
@@ -33,11 +35,15 @@ function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
   return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
 }
 
-/** Filtros del export de auditoría — `desde`/`hasta` son OBLIGATORIOS acá (a diferencia del
- * futuro `GET /api/auditoria` JSON, Slice 7): regla de la casa del export + nombre de archivo
- * determinístico (mismo criterio que `historicoDeCajas`/`tesoreria` en `reportes.ts`). El resto
- * replica 1:1 los 5 filtros opcionales de `FiltrosDeAuditoria` (backend, Slice 5). */
-export type FiltrosDeExportacionDeAuditoria = {
+/** Filtros compartidos por AMBAS superficies de `/api/auditoria` (JSON y export) — mismo shape,
+ * mismo builder (`construirQueryDeAlcanceDeAuditoria` abajo), mismo criterio de guardas que
+ * `construirQueryDeAlcanceDeCajas` (`reportes.ts:177`): un único lugar donde vive la guarda de
+ * `desde`/`hasta` vacíos, para que el caso vacío quede resuelto igual en los dos lados por
+ * construcción — dos builders divergentes (judgment-day, ronda 1, finding 1) dejaban el caso
+ * vacío guardado en la consulta JSON pero NO en el export, que mandaba
+ * `desde=...T00:00:00+NaN:NaN` (`fechaIsoConOffset` sobre un string vacío) — un `DateTimeOffset`
+ * malformado que el servidor rechaza con 400. */
+export type FiltrosDeAlcanceDeAuditoria = {
   desde: string
   hasta: string
   accion: string | null
@@ -47,10 +53,10 @@ export type FiltrosDeExportacionDeAuditoria = {
   idPuntoVenta: number | null
 }
 
-function construirQueryDeExportacionDeAuditoria(filtros: FiltrosDeExportacionDeAuditoria): string {
+function construirQueryDeAlcanceDeAuditoria(filtros: FiltrosDeAlcanceDeAuditoria): string {
   const parametros = new URLSearchParams()
-  parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
-  parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
   if (filtros.accion !== null) parametros.set('accion', filtros.accion)
   if (filtros.idActor !== null) parametros.set('idActor', String(filtros.idActor))
   if (filtros.entidad !== null) parametros.set('entidad', filtros.entidad)
@@ -59,11 +65,28 @@ function construirQueryDeExportacionDeAuditoria(filtros: FiltrosDeExportacionDeA
   return `?${parametros.toString()}`
 }
 
+/** Filtros del export de auditoría — mismo shape que `FiltrosDeAlcanceDeAuditoria`.
+ * `AuditoriaEndpoints.cs:44` (`/export`) declara `DateTimeOffset desde, DateTimeOffset hasta` SIN
+ * `?` — a diferencia de `/` (Slice 7, ambos opcionales) — así que el servidor rechaza esta ruta
+ * con `desde`/`hasta` vacíos. Decisión de producto (judgment-day, ronda 1, finding 1): con
+ * filtros de fecha vacíos, `Auditoria.tsx` deshabilita el botón de descarga
+ * (`puedeExportarAuditoria` abajo) en vez de emitir una URL que el servidor va a rechazar. El
+ * guard de `construirQueryDeAlcanceDeAuditoria` sigue aplicando igual acá como defensa en
+ * profundidad — con el botón deshabilitado, esta rama no debería ejecutarse en producción. */
+export type FiltrosDeExportacionDeAuditoria = FiltrosDeAlcanceDeAuditoria
+
+/** Habilita el botón de descarga de `Auditoria.tsx` solo cuando el rango está completo —
+ * `/export` exige `desde`/`hasta` no nulos (`AuditoriaEndpoints.cs:44`), a diferencia de la
+ * consulta JSON (`/`, ambos opcionales). */
+export function puedeExportarAuditoria(filtros: { desde: string; hasta: string }): boolean {
+  return filtros.desde !== '' && filtros.hasta !== ''
+}
+
 /** Misma convención de `reportes.ts` (`rutasDeExportacion.<dominio>(filtros)`), en su propio
  * módulo. */
 export const rutasDeExportacion = {
   auditoria: (filtros: FiltrosDeExportacionDeAuditoria) =>
-    `/auditoria/export${construirQueryDeExportacionDeAuditoria(filtros)}&formato=xlsx`,
+    `/auditoria/export${construirQueryDeAlcanceDeAuditoria(filtros)}&formato=xlsx`,
 }
 
 // ---- Cliente JSON de `GET /api/auditoria` (Slice 7, `Auditoria.tsx`) --------------------------
@@ -72,17 +95,11 @@ export const rutasDeExportacion = {
  * (`reportes.ts`): `desde`/`hasta` en formato `input[type=date]` (`YYYY-MM-DD`), a diferencia de
  * `FiltrosDeAuditoria` (`tipos.ts`, el DTO crudo del backend, `DateTimeOffset?` ISO completo) —
  * `construirQueryDeConsultaDeAuditoria` hace la conversión recién al armar el query string, mismo
- * criterio que `construirQueryDeExportacionDeAuditoria` arriba. `desde`/`hasta` vacíos SÍ están
+ * criterio que `construirQueryDeAlcanceDeAuditoria` arriba. `desde`/`hasta` vacíos SÍ están
  * permitidos acá (a diferencia del export, que los exige): el listado JSON no necesita un rango
- * acotado para nombrar un archivo. */
-export type FiltrosDeConsultaDeAuditoria = {
-  desde: string
-  hasta: string
-  accion: string | null
-  idActor: number | null
-  entidad: string | null
-  idEntidad: number | null
-  idPuntoVenta: number | null
+ * acotado para nombrar un archivo — el botón de descarga se deshabilita en ese caso
+ * (`puedeExportarAuditoria`). */
+export type FiltrosDeConsultaDeAuditoria = FiltrosDeAlcanceDeAuditoria & {
   pagina: number
   tamanio: number
 }
@@ -108,16 +125,12 @@ export function filtrosDeAuditoriaVacios(): FiltrosDeConsultaDeAuditoria {
 /** Query compartido de `GET /api/auditoria` — `dto-contract-honesty`: cada parámetro solo se
  * agrega si `AuditoriaEndpoints.cs` lo lee (`desde, hasta, accion, idActor, entidad, idEntidad,
  * idPuntoVenta, pagina, tamanio`, todos opcionales salvo pagina/tamanio con default del propio
- * endpoint — acá se mandan siempre explícitos, mismo criterio que `construirQueryDeHistoricoDeCajas`). */
-function construirQueryDeConsultaDeAuditoria(filtros: FiltrosDeConsultaDeAuditoria): string {
-  const parametros = new URLSearchParams()
-  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
-  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
-  if (filtros.accion !== null) parametros.set('accion', filtros.accion)
-  if (filtros.idActor !== null) parametros.set('idActor', String(filtros.idActor))
-  if (filtros.entidad !== null) parametros.set('entidad', filtros.entidad)
-  if (filtros.idEntidad !== null) parametros.set('idEntidad', String(filtros.idEntidad))
-  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+ * endpoint). Los 7 filtros de alcance vienen de `construirQueryDeAlcanceDeAuditoria` (mismo
+ * builder que usa el export, arriba) — `pagina`/`tamanio` son propios de esta ruta y no viajan al
+ * export, mismo criterio que `construirQueryDeHistoricoDeCajas`/`construirQueryDeAlcanceDeCajas`
+ * (`reportes.ts:177-189`). */
+export function construirQueryDeConsultaDeAuditoria(filtros: FiltrosDeConsultaDeAuditoria): string {
+  const parametros = new URLSearchParams(construirQueryDeAlcanceDeAuditoria(filtros).slice(1))
   parametros.set('pagina', String(filtros.pagina))
   parametros.set('tamanio', String(filtros.tamanio))
   return `?${parametros.toString()}`

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -120,6 +120,16 @@ export function puedeVerComisiones(rolId: number) {
   return rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.LecturaDeAuditoria` (stage-14-auditoria-trazabilidad, Slice 5): SOLO admin
+ * ve el log de auditoría — ni supervisor, ni vendedor, ni root (spec auditoria-de-operaciones:
+ * "GET /api/auditoria Is Filtered, Paginated, And Admin-Only" — la policy NO se apila sobre
+ * `LecturaDeReportes`, es su propio gate, mismo criterio admin-only que `puedeVerRentabilidad`).
+ * Puramente cosmético: el servidor vuelve a exigir la misma policy en `/api/auditoria` y
+ * `/api/auditoria/export`. */
+export function puedeVerAuditoria(rolId: number) {
+  return rolId === ROL.Admin
+}
+
 // --- Catálogos de tenant (ADR-11) ---
 
 export type ComportamientoMedioPago = 'Efectivo' | 'Electronico' | 'CuentaCorriente'
@@ -1619,3 +1629,68 @@ export type Comisiones = {
   filas: ComisionPorEmpleado[]
   provisional: boolean
 }
+
+// --- Auditoría (stage-14-auditoria-trazabilidad, Slice 7) — espejo de
+// `Ways.Application.Auditoria.Contratos` (Slice 5). `dto-contract-honesty`: cada campo mirror se
+// consume en `clienteDeAuditoria.consultar`/`construirQueryDeConsultaDeAuditoria` (`api/
+// auditoria.ts`) o directamente en `Auditoria.tsx` al renderizar cada columna/el panel de detalle.
+
+/** Espejo de `FiltrosDeAuditoria` (`Ways.Application.Auditoria.Contratos`, Slice 5) — los 7
+ * filtros crudos que `GET /api/auditoria` lee. `desde`/`hasta` viajan como ISO completo
+ * (`DateTimeOffset?`, mismo offset explícito que `FiltrosDeExportacionDeAuditoria`), a diferencia
+ * del estado de pantalla de `Auditoria.tsx` (`FiltrosDeConsultaDeAuditoria`, `api/auditoria.ts`),
+ * que guarda `desde`/`hasta` en formato `input[type=date]` (`YYYY-MM-DD`) hasta el momento de
+ * armar el query string. */
+export type FiltrosDeAuditoria = {
+  desde: string | null
+  hasta: string | null
+  accion: string | null
+  idActor: number | null
+  entidad: string | null
+  idEntidad: number | null
+  idPuntoVenta: number | null
+}
+
+/** Espejo de `FilaDeAuditoria` (Slice 5). `actor` `null` significa "el nombre no es visible para
+ * esta sesión" (un actor de plataforma, excluido por el filtro de tenant/RLS de `usuarios` bajo
+ * el LEFT JOIN) — NUNCA "sin actor": `idActor` siempre viaja, `Auditoria.tsx` lo muestra como
+ * `#idActor`. `valorAnterior`/`valorNuevo` viajan con sus claves TAL CUAL fueron serializadas por
+ * `SerializadorDeAuditoria` (snake_case) — la pantalla no las reinterpreta, solo las compara
+ * clave por clave (`compararPayloads`, `PanelDeCambio`). */
+export type FilaDeAuditoria = {
+  idAuditoria: number
+  creadoEl: string
+  accion: string
+  entidad: string
+  idEntidad: number
+  idActor: number
+  actor: string | null
+  idPuntoVenta: number | null
+  valorAnterior: Record<string, unknown> | null
+  valorNuevo: Record<string, unknown>
+}
+
+/** Página de `GET /api/auditoria` — espejo de `PaginaDeAuditoria` (Slice 5). */
+export type PaginaDeAuditoria = { items: FilaDeAuditoria[]; total: number; pagina: number; tamanio: number }
+
+/** Espejo del catálogo de 12 pares `(accion, entidad)` de `AccionAuditada`
+ * (`Ways.Domain.Auditoria`, Slice 1) — alimenta el `<select>` de acción de `Auditoria.tsx`.
+ * Etiquetas en español; el VALOR que viaja al backend es siempre el `accion` crudo
+ * (`precio.cambio`, ...) — la base no valida `accion` contra este catálogo (design decisión 15),
+ * así que una fila con una acción retirada de acá sigue siendo consultable filtrando por su texto
+ * exacto (no aparece en el `<select>`, pero el filtro por texto libre seguiría funcionando si se
+ * expusiera). */
+export const CATALOGO_DE_ACCIONES_AUDITADAS: { valor: string; etiqueta: string }[] = [
+  { valor: 'precio.cambio', etiqueta: 'Cambio de precio' },
+  { valor: 'venta.anulacion', etiqueta: 'Anulación de venta' },
+  { valor: 'compra.anulacion', etiqueta: 'Anulación de compra' },
+  { valor: 'stock.ajuste', etiqueta: 'Ajuste de stock' },
+  { valor: 'stock.decomiso', etiqueta: 'Decomiso de stock' },
+  { valor: 'stock.conteo', etiqueta: 'Conteo de inventario' },
+  { valor: 'cc.reliquidacion', etiqueta: 'Reliquidación de cuenta corriente' },
+  { valor: 'usuario.alta', etiqueta: 'Alta de usuario' },
+  { valor: 'usuario.actualizacion', etiqueta: 'Actualización de usuario' },
+  { valor: 'usuario.baja', etiqueta: 'Baja de usuario' },
+  { valor: 'usuario.desbloqueo', etiqueta: 'Desbloqueo de usuario' },
+  { valor: 'usuario.password', etiqueta: 'Cambio de contraseña' },
+]

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1631,25 +1631,14 @@ export type Comisiones = {
 }
 
 // --- Auditoría (stage-14-auditoria-trazabilidad, Slice 7) — espejo de
-// `Ways.Application.Auditoria.Contratos` (Slice 5). `dto-contract-honesty`: cada campo mirror se
-// consume en `clienteDeAuditoria.consultar`/`construirQueryDeConsultaDeAuditoria` (`api/
-// auditoria.ts`) o directamente en `Auditoria.tsx` al renderizar cada columna/el panel de detalle.
-
-/** Espejo de `FiltrosDeAuditoria` (`Ways.Application.Auditoria.Contratos`, Slice 5) — los 7
- * filtros crudos que `GET /api/auditoria` lee. `desde`/`hasta` viajan como ISO completo
- * (`DateTimeOffset?`, mismo offset explícito que `FiltrosDeExportacionDeAuditoria`), a diferencia
- * del estado de pantalla de `Auditoria.tsx` (`FiltrosDeConsultaDeAuditoria`, `api/auditoria.ts`),
- * que guarda `desde`/`hasta` en formato `input[type=date]` (`YYYY-MM-DD`) hasta el momento de
- * armar el query string. */
-export type FiltrosDeAuditoria = {
-  desde: string | null
-  hasta: string | null
-  accion: string | null
-  idActor: number | null
-  entidad: string | null
-  idEntidad: number | null
-  idPuntoVenta: number | null
-}
+// `Ways.Application.Auditoria.Contratos` (Slice 5). `dto-contract-honesty`: `FilaDeAuditoria`/
+// `PaginaDeAuditoria` abajo son los únicos DTOs mirroreados acá — cada campo se consume
+// directamente en `Auditoria.tsx` al renderizar cada columna/el panel de detalle.
+// `FiltrosDeAuditoria` (`Contratos.cs`) NO tiene mirror en este archivo (judgment-day, ronda 2,
+// juez A): su forma difiere genuinamente de los filtros de pantalla (`desde`/`hasta` viajan como
+// `DateTimeOffset?` nullable en el backend vs. `string` no-nulo `input[type=date]` en
+// `FiltrosDeAlcanceDeAuditoria`/`FiltrosDeConsultaDeAuditoria`, `api/auditoria.ts`) — un mirror sin
+// consumidor de tipo no ata nada, así que se optó por no crearlo en vez de dejarlo inerte.
 
 /** Espejo de `FilaDeAuditoria` (Slice 5). `actor` `null` significa "el nombre no es visible para
  * esta sesión" (un actor de plataforma, excluido por el filtro de tenant/RLS de `usuarios` bajo

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -7,6 +7,7 @@ import {
   puedeGestionarCatalogos,
   puedeGestionarUsuarios,
   puedeOperarPos,
+  puedeVerAuditoria,
   puedeVerReportes,
 } from '../api/tipos'
 
@@ -115,6 +116,17 @@ export function Layout() {
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/reportes/stock/reposicion">
                       Reposición
+                    </NavLink>
+                  </li>
+                )}
+                {/* stage-14-auditoria-trazabilidad (Slice 7, design decisión 17): Admin-only —
+                    nav y ruta comparten Politicas.LecturaDeAuditoria (puedeVerAuditoria), NUNCA
+                    apilada sobre puedeVerReportes (Supervisor queda afuera acá, a diferencia de
+                    Tablero/Histórico de cajas/etc.). */}
+                {usuario && puedeVerAuditoria(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/auditoria">
+                      Auditoría
                     </NavLink>
                   </li>
                 )}

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -174,6 +174,29 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     expect(within(celdaPv).getByText('—')).toBeInTheDocument()
   })
 
+  // judgment-day ronda 1, finding 1: `/auditoria/export` exige desde/hasta no vacíos
+  // (AuditoriaEndpoints.cs: DateTimeOffset sin `?`) — con cualquiera de las dos fechas vacía, el
+  // botón queda deshabilitado con el motivo visible en vez de mandar una descarga que el servidor
+  // rechaza.
+  it('con Desde o Hasta vacíos, el botón de descarga queda deshabilitado con el motivo visible', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderAuditoria()
+
+    await screen.findByText('#41')
+    expect(screen.getByRole('button', { name: 'Descargar' })).toBeEnabled()
+
+    await usuario.clear(screen.getByLabelText('Desde'))
+
+    expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
+    expect(screen.getByText('Completá Desde y Hasta para descargar.')).toBeInTheDocument()
+
+    await usuario.type(screen.getByLabelText('Desde'), '2026-08-05')
+    await usuario.clear(screen.getByLabelText('Hasta'))
+
+    expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
+  })
+
   it('el botón de descarga llama a rutasDeExportacion.auditoria con el filtro actual', async () => {
     mockearRutasBase()
     const usuario = userEvent.setup()

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -158,6 +158,37 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
   })
 
+  // judgment-day ronda 1, finding 3: `total: 1` colapsa página 1 y última página en el mismo
+  // fixture — `Math.ceil`→`Math.floor` en `totalPaginas` sobrevivía al único test previo. Fixture
+  // multi-página (60 eventos, tamaño 25 ⇒ 3 páginas, la última parcial con 10) navegando hasta la
+  // última página discrimina el mutante: con `Math.floor`, `total: 60 / tamanio: 25` da
+  // `totalPaginas = 2`, no 3, y "Siguiente" quedaría deshabilitado en la página 2 (falso borde).
+  it('en la última página parcial (total 60, tamaño 25 ⇒ 3 páginas), la etiqueta y el disabled de Siguiente son correctos', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) {
+        const paginaSolicitada = ruta.includes('pagina=3') ? 3 : ruta.includes('pagina=2') ? 2 : 1
+        return Promise.resolve(paginaFixture([filaFixture()], { total: 60, pagina: paginaSolicitada, tamanio: 25 }))
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderAuditoria()
+
+    await screen.findByText(/Página 1 de 3/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 2 de 3/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 3 de 3/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
   it('actor null renderiza #idActor; punto de venta null renderiza — con el título tenant-wide', async () => {
     mockearRutasBase((ruta) => {
       if (ruta.startsWith('/auditoria?')) {
@@ -172,6 +203,11 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     expect(await screen.findByText('#7')).toBeInTheDocument()
     const celdaPv = screen.getByTitle('Evento de todo el tenant')
     expect(within(celdaPv).getByText('—')).toBeInTheDocument()
+    // Sugerencia 1 (judgment-day ronda 1): `etiquetaDeAccion` es reducible a `return accion` sin
+    // fallar ningún test previo — la celda de acción debe mostrar la etiqueta en español del
+    // catálogo, nunca el código crudo `precio.cambio` (scoped al `<td>`, "Cambio de precio"
+    // también existe como `<option>` del filtro).
+    expect(screen.getByRole('cell', { name: 'Cambio de precio' })).toBeInTheDocument()
   })
 
   // judgment-day ronda 1, finding 1: `/auditoria/export` exige desde/hasta no vacíos

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Auditoria } from './Auditoria'
+import type { FilaDeAuditoria, PaginaDeAuditoria, PuntoVentaListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiDescargarMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: (...args: unknown[]) => apiDescargarMock(...(args as [string])),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+const puntoVentaCentro: PuntoVentaListado = {
+  id: 10,
+  idTenant: 1,
+  idEmpresa: 1,
+  nombre: 'PV Centro',
+  domicilio: null,
+  horario: null,
+  whatsapp: null,
+  instagram: null,
+  facebook: null,
+  web: null,
+}
+
+function filaFixture(sobrescribir: Partial<FilaDeAuditoria> = {}): FilaDeAuditoria {
+  return {
+    idAuditoria: 500,
+    creadoEl: '2026-08-14T12:00:00Z',
+    accion: 'precio.cambio',
+    entidad: 'articulo',
+    idEntidad: 41,
+    idActor: 2,
+    actor: 'admin',
+    idPuntoVenta: 10,
+    valorAnterior: { monto: 100 },
+    valorNuevo: { monto: 150 },
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(items: FilaDeAuditoria[] = [filaFixture()], sobrescribir: Partial<PaginaDeAuditoria> = {}): PaginaDeAuditoria {
+  return { items, total: items.length, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function renderAuditoria() {
+  return render(<Auditoria />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+function mockearRutasBase(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaCentro])
+    const propia = sobrescribir?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/auditoria?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiDescargarMock.mockReset()
+  apiDescargarMock.mockResolvedValue(undefined)
+})
+
+describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
+  it('cambiar cualquier filtro resetea la página a 1', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) {
+        return Promise.resolve(paginaFixture([filaFixture()], { total: 60, pagina: 1, tamanio: 25 }))
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderAuditoria()
+
+    await screen.findByText('#41')
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/auditoria?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('pagina=2'))).toBe(true)
+    })
+
+    apiGetMock.mockClear()
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) return Promise.resolve(paginaFixture([filaFixture()], { total: 60, pagina: 1, tamanio: 25 }))
+      return undefined
+    })
+    await usuario.selectOptions(screen.getByLabelText('Acción'), 'venta.anulacion')
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/auditoria?'))
+      expect(
+        llamadas.some(
+          (call: unknown[]) => (call[0] as string).includes('accion=venta.anulacion') && (call[0] as string).includes('pagina=1'),
+        ),
+      ).toBe(true)
+    })
+  })
+
+  // react-async-state regla 7 / mutation-proof-tests regla 7: la promesa desactualizada se
+  // resuelve DENTRO de act y se asserta sincrónicamente después del flush.
+  it('una respuesta desactualizada nunca pisa la más reciente (generación)', async () => {
+    let resolverPrimera: (valor: PaginaDeAuditoria) => void = () => {}
+    const primera = new Promise<PaginaDeAuditoria>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let cantidadDeLlamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) {
+        cantidadDeLlamadas += 1
+        if (cantidadDeLlamadas === 1) return primera
+        return Promise.resolve(paginaFixture([filaFixture({ idAuditoria: 202 })]))
+      }
+      return undefined
+    })
+
+    const usuario = userEvent.setup()
+    renderAuditoria()
+    await screen.findByLabelText('Acción')
+
+    await usuario.selectOptions(screen.getByLabelText('Acción'), 'venta.anulacion')
+    expect(await screen.findByText('#41')).toBeInTheDocument()
+
+    await resolverPrimera(paginaFixture([filaFixture({ idAuditoria: 909, idEntidad: 999 })]))
+    await waitFor(() => expect(screen.queryByText('#999')).not.toBeInTheDocument())
+    expect(screen.getByText('#41')).toBeInTheDocument()
+  })
+
+  it('el pager está deshabilitado en ambos bordes (página 1 y última página)', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) return Promise.resolve(paginaFixture([filaFixture()], { total: 1, pagina: 1, tamanio: 25 }))
+      return undefined
+    })
+    renderAuditoria()
+
+    await screen.findByText('#41')
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
+  it('actor null renderiza #idActor; punto de venta null renderiza — con el título tenant-wide', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) {
+        return Promise.resolve(
+          paginaFixture([filaFixture({ idAuditoria: 501, actor: null, idActor: 7, idPuntoVenta: null })]),
+        )
+      }
+      return undefined
+    })
+    renderAuditoria()
+
+    expect(await screen.findByText('#7')).toBeInTheDocument()
+    const celdaPv = screen.getByTitle('Evento de todo el tenant')
+    expect(within(celdaPv).getByText('—')).toBeInTheDocument()
+  })
+
+  it('el botón de descarga llama a rutasDeExportacion.auditoria con el filtro actual', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderAuditoria()
+
+    await screen.findByText('#41')
+    await usuario.selectOptions(screen.getByLabelText('Acción'), 'venta.anulacion')
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/auditoria?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('accion=venta.anulacion'))).toBe(true)
+    })
+
+    await usuario.click(screen.getByRole('button', { name: 'Descargar' }))
+
+    expect(apiDescargarMock).toHaveBeenCalledTimes(1)
+    const rutaDescargada = apiDescargarMock.mock.calls[0][0] as string
+    expect(rutaDescargada).toMatch(/^\/auditoria\/export\?/)
+    expect(rutaDescargada).toContain('accion=venta.anulacion')
+    expect(rutaDescargada).toContain('formato=xlsx')
+  })
+})

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -233,6 +233,34 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     expect(screen.getByRole('button', { name: 'Descargar' })).toBeDisabled()
   })
 
+  // judgment-day ronda 1, finding 6: `cambiarEntidad` limpia `idEntidad` cuando se vacía `entidad`
+  // (`idEntidad` sin `entidad` es 400 `entidad_requerida` del servidor) — el guard no tenía test;
+  // borrar `idEntidad: null` de esa rama sobrevivía.
+  it('limpiar Entidad limpia también #Id: el input queda vacío y el request siguiente no manda idEntidad', async () => {
+    mockearRutasBase()
+    const usuario = userEvent.setup()
+    renderAuditoria()
+
+    await screen.findByText('#41')
+    await usuario.type(screen.getByLabelText('Entidad'), 'articulo')
+    await usuario.type(screen.getByLabelText('#Id'), '41')
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/auditoria?'))
+      expect(llamadas.some((call: unknown[]) => (call[0] as string).includes('idEntidad=41'))).toBe(true)
+    })
+
+    apiGetMock.mockClear()
+    mockearRutasBase()
+    await usuario.clear(screen.getByLabelText('Entidad'))
+
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/auditoria?'))
+      expect(llamadas.length).toBeGreaterThan(0)
+      expect(llamadas.every((call: unknown[]) => !(call[0] as string).includes('idEntidad='))).toBe(true)
+    })
+    expect(screen.getByLabelText('#Id')).toHaveValue(null)
+  })
+
   it('el botón de descarga llama a rutasDeExportacion.auditoria con el filtro actual', async () => {
     mockearRutasBase()
     const usuario = userEvent.setup()

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -141,8 +141,15 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     await usuario.selectOptions(screen.getByLabelText('Acción'), 'venta.anulacion')
     expect(await screen.findByText('#41')).toBeInTheDocument()
 
-    await resolverPrimera(paginaFixture([filaFixture({ idAuditoria: 909, idEntidad: 999 })]))
-    await waitFor(() => expect(screen.queryByText('#999')).not.toBeInTheDocument())
+    // El flush del microtask va DENTRO de act (mutation-proof-tests regla 7, mismo patrón que
+    // Vencimientos.test.tsx): un waitFor solo pasaría en su primer tick, antes de que el .then
+    // stale aterrice — envolver en act y assertar sincrónicamente después SÍ discrimina.
+    const { act } = await import('@testing-library/react')
+    await act(async () => {
+      resolverPrimera(paginaFixture([filaFixture({ idAuditoria: 909, idEntidad: 999 })]))
+      await primera
+    })
+    expect(screen.queryByText('#999')).not.toBeInTheDocument()
     expect(screen.getByText('#41')).toBeInTheDocument()
   })
 

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { Auditoria } from './Auditoria'
+import { Auditoria, etiquetaDeAccion } from './Auditoria'
 import type { FilaDeAuditoria, PaginaDeAuditoria, PuntoVentaListado } from '../api/tipos'
 
 const apiGetMock = vi.fn()
@@ -78,6 +78,21 @@ beforeEach(() => {
   apiGetMock.mockReset()
   apiDescargarMock.mockReset()
   apiDescargarMock.mockResolvedValue(undefined)
+})
+
+// ---- etiquetaDeAccion: helper puro, sin DOM (web-descriptor-tests) ----------------------------
+
+describe('etiquetaDeAccion', () => {
+  it('una acción del catálogo devuelve su etiqueta en español', () => {
+    expect(etiquetaDeAccion('precio.cambio')).toBe('Cambio de precio')
+  })
+
+  // judgment-day ronda 2, juez A: el fallback `?? accion` (design decisión 15 — "una acción
+  // retirada deja rastro consultable") no tenía test. Mutation target: `?? accion` → `?? '—'` (o
+  // cualquier valor fijo) debe hacer fallar este test.
+  it('una acción NO catalogada (retirada) devuelve el código crudo, no un placeholder', () => {
+    expect(etiquetaDeAccion('modulo.retirado')).toBe('modulo.retirado')
+  })
 })
 
 describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
@@ -215,6 +230,21 @@ describe('Auditoria (stage-14-auditoria-trazabilidad, Slice 7)', () => {
     // catálogo, nunca el código crudo `precio.cambio` (scoped al `<td>`, "Cambio de precio"
     // también existe como `<option>` del filtro).
     expect(screen.getByRole('cell', { name: 'Cambio de precio' })).toBeInTheDocument()
+  })
+
+  // judgment-day ronda 2, juez A: el fallback de `etiquetaDeAccion` (`?? accion`, design decisión
+  // 15 — "una acción retirada deja rastro consultable") no tenía cobertura de componente. Una fila
+  // con una acción no catalogada debe mostrar el código crudo, no desaparecer ni romper el render.
+  it('una fila con una acción retirada del catálogo muestra el código crudo en la celda de Acción', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/auditoria?')) {
+        return Promise.resolve(paginaFixture([filaFixture({ idAuditoria: 502, accion: 'modulo.retirado' })]))
+      }
+      return undefined
+    })
+    renderAuditoria()
+
+    expect(await screen.findByRole('cell', { name: 'modulo.retirado' })).toBeInTheDocument()
   })
 
   // judgment-day ronda 1, finding 1: `/auditoria/export` exige desde/hasta no vacíos

--- a/src/Ways.Web/src/paginas/Auditoria.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import {
   clienteDeAuditoria,
   filtrosDeAuditoriaVacios,
+  puedeExportarAuditoria,
   rutasDeExportacion,
   type FiltrosDeConsultaDeAuditoria,
 } from '../api/auditoria'
@@ -232,9 +233,16 @@ export function Auditoria() {
                 idPuntoVenta: filtros.idPuntoVenta,
               })}
               etiqueta="Descargar"
+              disabled={!puedeExportarAuditoria(filtros)}
               onError={setErrorDescarga}
               onInicio={() => setErrorDescarga('')}
             />
+            {/* `/auditoria/export` exige desde/hasta no vacíos (AuditoriaEndpoints.cs) — con
+                cualquiera de las dos fechas vacía, el botón queda deshabilitado con el motivo
+                visible en vez de mandar una descarga que el servidor va a rechazar. */}
+            {!puedeExportarAuditoria(filtros) && (
+              <div className="small text-muted mt-1">Completá Desde y Hasta para descargar.</div>
+            )}
           </div>
         </div>
 

--- a/src/Ways.Web/src/paginas/Auditoria.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.tsx
@@ -18,7 +18,10 @@ function formatearFechaHora(iso: string): string {
   return new Date(iso).toLocaleString('es-AR')
 }
 
-function etiquetaDeAccion(accion: string): string {
+/** Exportada para el test colocado (`Auditoria.test.tsx`, `web-descriptor-tests`). Fallback
+ * `?? accion` (design decisión 15): una acción retirada del catálogo deja rastro consultable —
+ * la fila muestra el código crudo (`modulo.retirado`) en vez de desaparecer o romper el render. */
+export function etiquetaDeAccion(accion: string): string {
   return CATALOGO_DE_ACCIONES_AUDITADAS.find((a) => a.valor === accion)?.etiqueta ?? accion
 }
 

--- a/src/Ways.Web/src/paginas/Auditoria.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.tsx
@@ -1,0 +1,334 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  clienteDeAuditoria,
+  filtrosDeAuditoriaVacios,
+  rutasDeExportacion,
+  type FiltrosDeConsultaDeAuditoria,
+} from '../api/auditoria'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { CATALOGO_DE_ACCIONES_AUDITADAS, type FilaDeAuditoria, type PaginaDeAuditoria, type PuntoVentaListado } from '../api/tipos'
+import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+import { PanelDeCambio } from './PanelDeCambio'
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+function etiquetaDeAccion(accion: string): string {
+  return CATALOGO_DE_ACCIONES_AUDITADAS.find((a) => a.valor === accion)?.etiqueta ?? accion
+}
+
+/**
+ * Auditoria (stage-14-auditoria-trazabilidad, Slice 7, design decisión 17: "Web composition —
+ * Auditoria.tsx") — filtros + paginado con el shape verbatim de `HistoricoDeCajas.tsx`
+ * (`FiltrosDeConsultaDeAuditoria`, `filtrosDeAuditoriaVacios()`, `generacionRef` per
+ * `react-async-state` regla 2, `cambiarFiltro` resetea a página 1, `cambiarPagina(±1)` con
+ * `disabled` en los bordes) más el `BotonDeDescarga` de `Vencimientos.tsx` apuntando a
+ * `rutasDeExportacion.auditoria`. Pantalla Admin-only (`Politicas.LecturaDeAuditoria`,
+ * `puedeVerAuditoria` en `tipos.ts`) — nunca supervisor, vendedor ni root.
+ */
+export function Auditoria() {
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDeConsultaDeAuditoria>(filtrosDeAuditoriaVacios())
+  const [pagina, setPagina] = useState<PaginaDeAuditoria | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const [errorDescarga, setErrorDescarga] = useState('')
+  const [filaExpandidaId, setFilaExpandidaId] = useState<number | null>(null)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeAuditoria
+      .consultar(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el log de auditoría.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeConsultaDeAuditoria, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarEntidad(valor: string) {
+    // `idEntidad` sin `entidad` es un 400 del servidor (design decisión 16) — limpiarlo cuando
+    // se vacía `entidad` evita mandar un filtro imposible.
+    cambiarFiltro(valor === '' ? { entidad: null, idEntidad: null } : { entidad: valor })
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  function alternarDetalle(fila: FilaDeAuditoria) {
+    setFilaExpandidaId((actual) => (actual === fila.idAuditoria ? null : fila.idAuditoria))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Auditoría" variante="inverse">
+        {error && (
+          <div className="alert alert-danger rounded-0 d-flex justify-content-between align-items-center gap-2">
+            <span>{error}</span>
+            <button type="button" className="btn btn-sm btn-outline-danger rounded-0" onClick={cargar}>
+              Reintentar
+            </button>
+          </div>
+        )}
+        {errorPuntosVenta && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="auditoria-desde">
+              Desde
+            </label>
+            <input
+              id="auditoria-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="auditoria-hasta">
+              Hasta
+            </label>
+            <input
+              id="auditoria-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="auditoria-accion">
+              Acción
+            </label>
+            <select
+              id="auditoria-accion"
+              className="form-select rounded-0"
+              value={filtros.accion ?? ''}
+              onChange={(e) => cambiarFiltro({ accion: e.target.value === '' ? null : e.target.value })}
+            >
+              <option value="">Todas</option>
+              {CATALOGO_DE_ACCIONES_AUDITADAS.map((a) => (
+                <option key={a.valor} value={a.valor}>
+                  {a.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-1">
+            <label className="form-label" htmlFor="auditoria-actor">
+              Actor
+            </label>
+            <input
+              id="auditoria-actor"
+              type="number"
+              className="form-control rounded-0"
+              placeholder="Id"
+              value={filtros.idActor ?? ''}
+              onChange={(e) => cambiarFiltro({ idActor: e.target.value === '' ? null : Number(e.target.value) })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="auditoria-entidad">
+              Entidad
+            </label>
+            <input
+              id="auditoria-entidad"
+              type="text"
+              className="form-control rounded-0"
+              placeholder="articulo, usuario…"
+              value={filtros.entidad ?? ''}
+              onChange={(e) => cambiarEntidad(e.target.value)}
+            />
+          </div>
+          <div className="col-md-1">
+            <label className="form-label" htmlFor="auditoria-id-entidad">
+              #Id
+            </label>
+            <input
+              id="auditoria-id-entidad"
+              type="number"
+              className="form-control rounded-0"
+              disabled={filtros.entidad === null}
+              value={filtros.idEntidad ?? ''}
+              onChange={(e) => cambiarFiltro({ idEntidad: e.target.value === '' ? null : Number(e.target.value) })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="auditoria-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="auditoria-punto-venta"
+              className="form-select rounded-0"
+              value={filtros.idPuntoVenta ?? ''}
+              onChange={(e) => cambiarFiltro({ idPuntoVenta: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-auto">
+            <BotonDeDescarga
+              ruta={rutasDeExportacion.auditoria({
+                desde: filtros.desde,
+                hasta: filtros.hasta,
+                accion: filtros.accion,
+                idActor: filtros.idActor,
+                entidad: filtros.entidad,
+                idEntidad: filtros.idEntidad,
+                idPuntoVenta: filtros.idPuntoVenta,
+              })}
+              etiqueta="Descargar"
+              onError={setErrorDescarga}
+              onInicio={() => setErrorDescarga('')}
+            />
+          </div>
+        </div>
+
+        {errorDescarga && <div className="alert alert-danger rounded-0 py-1 px-2 small mb-2">{errorDescarga}</div>}
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Acción</th>
+                    <th>Entidad</th>
+                    <th>#Id</th>
+                    <th>Actor</th>
+                    <th>PV</th>
+                    <th>Detalle</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((f) => (
+                    <Fragment key={f.idAuditoria}>
+                      <tr>
+                        <td>{formatearFechaHora(f.creadoEl)}</td>
+                        <td>{etiquetaDeAccion(f.accion)}</td>
+                        <td>{f.entidad}</td>
+                        <td>#{f.idEntidad}</td>
+                        <td>{f.actor ?? `#${f.idActor}`}</td>
+                        <td>
+                          {f.idPuntoVenta === null ? (
+                            <span title="Evento de todo el tenant">—</span>
+                          ) : (
+                            (puntosVenta ?? []).find((pv) => pv.id === f.idPuntoVenta)?.nombre ?? `PV #${f.idPuntoVenta}`
+                          )}
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary rounded-0"
+                            onClick={() => alternarDetalle(f)}
+                          >
+                            {filaExpandidaId === f.idAuditoria ? 'Ocultar' : 'Ver'}
+                          </button>
+                        </td>
+                      </tr>
+                      {filaExpandidaId === f.idAuditoria && (
+                        <tr>
+                          <td colSpan={7} className="p-0">
+                            <PanelDeCambio valorAnterior={f.valorAnterior} valorNuevo={f.valorNuevo} />
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="text-center text-muted py-4">
+                        No hay eventos de auditoría que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} evento(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/PanelDeCambio.test.tsx
+++ b/src/Ways.Web/src/paginas/PanelDeCambio.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { formatearValor, PanelDeCambio } from './PanelDeCambio'
+
+// ---- formatearValor: helper puro, sin DOM (web-descriptor-tests) ------------------------------
+
+describe('formatearValor', () => {
+  it('undefined se muestra como —', () => {
+    expect(formatearValor(undefined)).toBe('—')
+  })
+
+  it('null se muestra como el string "null" (distinto de "clave ausente")', () => {
+    expect(formatearValor(null)).toBe('null')
+  })
+
+  it('un objeto/array se serializa con JSON.stringify', () => {
+    expect(formatearValor({ id: 1 })).toBe('{"id":1}')
+    expect(formatearValor([1, 2, 3])).toBe('[1,2,3]')
+  })
+
+  it('un valor primitivo (number/string/boolean) se convierte con String()', () => {
+    expect(formatearValor(150)).toBe('150')
+    expect(formatearValor('activo')).toBe('activo')
+    expect(formatearValor(true)).toBe('true')
+  })
+})
+
+// ---- PanelDeCambio: componente, judgment-day ronda 1 finding 5 (0 tests previos) --------------
+
+describe('PanelDeCambio', () => {
+  it('una clave agregada (valorAnterior null) muestra — del lado anterior y el valor real del lado nuevo', () => {
+    render(<PanelDeCambio valorAnterior={null} valorNuevo={{ nombre: 'Artículo nuevo' }} />)
+
+    expect(screen.getByTestId('panel-cambio-anterior-nombre')).toHaveTextContent('—')
+    expect(screen.getByTestId('panel-cambio-nuevo-nombre')).toHaveTextContent('Artículo nuevo')
+  })
+
+  it('una clave modificada muestra AMBOS valores reales y distintos, nunca el mismo lado repetido', () => {
+    render(<PanelDeCambio valorAnterior={{ monto: 100 }} valorNuevo={{ monto: 150 }} />)
+
+    const celdaAnterior = screen.getByTestId('panel-cambio-anterior-monto')
+    const celdaNuevo = screen.getByTestId('panel-cambio-nuevo-monto')
+
+    expect(celdaAnterior).toHaveTextContent('100')
+    expect(celdaNuevo).toHaveTextContent('150')
+    expect(celdaAnterior.textContent).not.toBe(celdaNuevo.textContent)
+  })
+
+  it('una clave quitada (valor undefined del lado nuevo) muestra — del lado nuevo, valor real del lado anterior', () => {
+    render(<PanelDeCambio valorAnterior={{ campo: 'valor viejo' }} valorNuevo={{ campo: undefined }} />)
+
+    expect(screen.getByTestId('panel-cambio-anterior-campo')).toHaveTextContent('valor viejo')
+    expect(screen.getByTestId('panel-cambio-nuevo-campo')).toHaveTextContent('—')
+  })
+
+  it('una clave sin cambios muestra el mismo valor en ambos lados', () => {
+    render(<PanelDeCambio valorAnterior={{ estado: 'activo' }} valorNuevo={{ estado: 'activo' }} />)
+
+    expect(screen.getByTestId('panel-cambio-anterior-estado')).toHaveTextContent('activo')
+    expect(screen.getByTestId('panel-cambio-nuevo-estado')).toHaveTextContent('activo')
+  })
+})

--- a/src/Ways.Web/src/paginas/PanelDeCambio.tsx
+++ b/src/Ways.Web/src/paginas/PanelDeCambio.tsx
@@ -5,7 +5,9 @@ type PropsPanelDeCambio = {
   valorNuevo: Record<string, unknown>
 }
 
-function formatearValor(valor: unknown): string {
+/** Exportada para el test colocado (`PanelDeCambio.test.tsx`, `web-descriptor-tests`: todo
+ * formatter/mapper puro nuevo lleva su propio test unitario, sin DOM). */
+export function formatearValor(valor: unknown): string {
   if (valor === undefined) return '—'
   if (valor === null) return 'null'
   if (typeof valor === 'object') return JSON.stringify(valor)

--- a/src/Ways.Web/src/paginas/PanelDeCambio.tsx
+++ b/src/Ways.Web/src/paginas/PanelDeCambio.tsx
@@ -1,0 +1,49 @@
+import { compararPayloads } from './compararPayloads'
+
+type PropsPanelDeCambio = {
+  valorAnterior: Record<string, unknown> | null
+  valorNuevo: Record<string, unknown>
+}
+
+function formatearValor(valor: unknown): string {
+  if (valor === undefined) return '—'
+  if (valor === null) return 'null'
+  if (typeof valor === 'object') return JSON.stringify(valor)
+  return String(valor)
+}
+
+/**
+ * Panel de detalle expandible de `Auditoria.tsx` (stage-14-auditoria-trazabilidad, Slice 7;
+ * design: "Web composition — Auditoria.tsx", Panel de detalle) — pre-aprobado como corte si la
+ * slice desborda (los payloads siguen llegando por el export). Renderiza `valor_anterior`/
+ * `valor_nuevo` clave por clave vía `compararPayloads`, con `data-testid` propio por lado
+ * (`panel-cambio-anterior-<clave>` / `panel-cambio-nuevo-<clave>`) para que los tests apunten a
+ * un lado sin ambigüedad. Una clave agregada muestra "—" del lado anterior (design literal:
+ * "—→ valor") — estética más allá de los testids está exenta (Testing Strategy, fila "Exempt").
+ */
+export function PanelDeCambio({ valorAnterior, valorNuevo }: PropsPanelDeCambio) {
+  const comparaciones = compararPayloads(valorAnterior, valorNuevo)
+
+  return (
+    <table className="table table-sm table-borderless mb-0">
+      <thead>
+        <tr>
+          <th>Clave</th>
+          <th>Valor anterior</th>
+          <th>Valor nuevo</th>
+        </tr>
+      </thead>
+      <tbody>
+        {comparaciones.map((c) => (
+          <tr key={c.clave} className={c.estado === 'sin_cambio' ? undefined : 'table-warning'}>
+            <td className="text-muted">{c.clave}</td>
+            <td data-testid={`panel-cambio-anterior-${c.clave}`}>
+              {c.estado === 'agregada' ? '—' : formatearValor(c.valorAnterior)}
+            </td>
+            <td data-testid={`panel-cambio-nuevo-${c.clave}`}>{formatearValor(c.valorNuevo)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/Ways.Web/src/paginas/compararPayloads.test.ts
+++ b/src/Ways.Web/src/paginas/compararPayloads.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { compararPayloads } from './compararPayloads'
+
+describe('compararPayloads', () => {
+  // mutation target (tasks.md slice 7, fila única): tratar esta rama como 'sin_cambio' debe
+  // hacer fallar este test.
+  it('una clave presente solo en nuevo se marca agregada, nunca sin_cambio', () => {
+    const resultado = compararPayloads({ id_lista_precio: 1 }, { id_lista_precio: 1, vigente_desde: '2026-08-14' })
+
+    const agregada = resultado.find((c) => c.clave === 'vigente_desde')
+    expect(agregada?.estado).toBe('agregada')
+    expect(agregada?.valorAnterior).toBeUndefined()
+    expect(agregada?.valorNuevo).toBe('2026-08-14')
+  })
+
+  it('anterior null (accion hecho puro) marca TODAS las claves de nuevo como agregadas', () => {
+    const resultado = compararPayloads(null, { por_el_propio_usuario: true })
+
+    expect(resultado).toEqual([{ clave: 'por_el_propio_usuario', valorAnterior: undefined, valorNuevo: true, estado: 'agregada' }])
+  })
+
+  it('una clave con valor distinto en anterior y nuevo se marca cambiada', () => {
+    const resultado = compararPayloads({ monto: 100 }, { monto: 150 })
+
+    expect(resultado).toEqual([{ clave: 'monto', valorAnterior: 100, valorNuevo: 150, estado: 'cambiada' }])
+  })
+
+  it('una clave con el mismo valor primitivo en anterior y nuevo se marca sin_cambio', () => {
+    const resultado = compararPayloads({ estado: 'activo' }, { estado: 'activo' })
+
+    expect(resultado).toEqual([{ clave: 'estado', valorAnterior: 'activo', valorNuevo: 'activo', estado: 'sin_cambio' }])
+  })
+
+  it('una clave null en ambos lados se marca sin_cambio, no cambiada', () => {
+    const resultado = compararPayloads({ deleted_at: null }, { deleted_at: null })
+
+    expect(resultado).toEqual([{ clave: 'deleted_at', valorAnterior: null, valorNuevo: null, estado: 'sin_cambio' }])
+  })
+
+  it('un valor objeto anidado igual estructuralmente se marca sin_cambio (comparacion profunda, no por referencia)', () => {
+    const resultado = compararPayloads(
+      { movimientos_generados: [1, 2, 3] },
+      { movimientos_generados: [1, 2, 3] },
+    )
+
+    expect(resultado).toEqual([{ clave: 'movimientos_generados', valorAnterior: [1, 2, 3], valorNuevo: [1, 2, 3], estado: 'sin_cambio' }])
+  })
+})

--- a/src/Ways.Web/src/paginas/compararPayloads.test.ts
+++ b/src/Ways.Web/src/paginas/compararPayloads.test.ts
@@ -45,4 +45,16 @@ describe('compararPayloads', () => {
 
     expect(resultado).toEqual([{ clave: 'movimientos_generados', valorAnterior: [1, 2, 3], valorNuevo: [1, 2, 3], estado: 'sin_cambio' }])
   })
+
+  // judgment-day ronda 2, juez A, sugerencia: `sonIguales` compara con `JSON.stringify`, sensible
+  // al orden de claves — fijado acá como comportamiento CONOCIDO, no como bug: un objeto anidado
+  // semánticamente igual pero con distinto orden de claves se reporta 'cambiada'. El riesgo real
+  // es bajo porque ambos payloads salen del mismo serializador (mismo orden para el mismo shape).
+  it('(limitación conocida) un objeto anidado semánticamente igual pero con distinto orden de claves se marca cambiada', () => {
+    const resultado = compararPayloads({ datos: { a: 1, b: 2 } }, { datos: { b: 2, a: 1 } })
+
+    expect(resultado).toEqual([
+      { clave: 'datos', valorAnterior: { a: 1, b: 2 }, valorNuevo: { b: 2, a: 1 }, estado: 'cambiada' },
+    ])
+  })
 })

--- a/src/Ways.Web/src/paginas/compararPayloads.ts
+++ b/src/Ways.Web/src/paginas/compararPayloads.ts
@@ -7,6 +7,12 @@ export type ComparacionDeClave = {
   estado: EstadoDeClave
 }
 
+// Limitación conocida (judgment-day ronda 2, juez A, sugerencia): `JSON.stringify` es sensible al
+// orden de claves — dos objetos anidados semánticamente iguales con distinto orden de claves se
+// reportarían como `'cambiada'`. No se normaliza recursivamente porque el riesgo real es bajo:
+// `valorAnterior`/`valorNuevo` salen del MISMO serializador (`SerializadorDeAuditoria`, backend),
+// que siempre emite las claves en el mismo orden para el mismo shape. Comportamiento fijado como
+// conocido por `compararPayloads.test.ts`.
 function sonIguales(a: unknown, b: unknown): boolean {
   if (a === b) return true
   if (a === null || b === null) return false

--- a/src/Ways.Web/src/paginas/compararPayloads.ts
+++ b/src/Ways.Web/src/paginas/compararPayloads.ts
@@ -1,0 +1,49 @@
+export type EstadoDeClave = 'agregada' | 'cambiada' | 'sin_cambio'
+
+export type ComparacionDeClave = {
+  clave: string
+  valorAnterior: unknown
+  valorNuevo: unknown
+  estado: EstadoDeClave
+}
+
+function sonIguales(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null) return false
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * Compara `valor_anterior`/`valor_nuevo` clave por clave para `PanelDeCambio`
+ * (stage-14-auditoria-trazabilidad, Slice 7; design: "Web composition — Auditoria.tsx", Panel de
+ * detalle). `anterior` es `null` para las acciones "hecho puro" (`usuario.password`,
+ * `usuario.alta`) — TODAS las claves de `nuevo` se muestran como `'agregada'` en ese caso.
+ *
+ * Invariante del dominio (`RegistroDeAuditoria`, Slice 1): las claves de `anterior` son SIEMPRE
+ * un subconjunto de las de `nuevo` — nunca hay una clave "solo en anterior" que mostrar, así que
+ * este helper solo itera sobre las claves de `nuevo`.
+ *
+ * mutation target (slice 7, tasks.md fila única de esta slice): una clave presente SOLO en
+ * `nuevo` (ausente en `anterior`, o `anterior` entero `null`) DEBE marcarse `'agregada'`, nunca
+ * `'sin_cambio'` — el test colocado (`compararPayloads.test.ts`) es el discriminador.
+ */
+export function compararPayloads(
+  anterior: Record<string, unknown> | null,
+  nuevo: Record<string, unknown>,
+): ComparacionDeClave[] {
+  return Object.keys(nuevo).map((clave) => {
+    const valorNuevo = nuevo[clave]
+
+    if (anterior === null || !(clave in anterior)) {
+      return { clave, valorAnterior: undefined, valorNuevo, estado: 'agregada' }
+    }
+
+    const valorAnterior = anterior[clave]
+    return {
+      clave,
+      valorAnterior,
+      valorNuevo,
+      estado: sonIguales(valorAnterior, valorNuevo) ? 'sin_cambio' : 'cambiada',
+    }
+  })
+}


### PR DESCRIPTION
## Etapa 14 — Auditoría · Slice 7 (Web) — cierre de la etapa

- `Auditoria.tsx`: filtros (rango, acción del catálogo de 12, actor, entidad+id, PV) + pager del patrón `HistoricoDeCajas` + `BotonDeDescarga` + `PanelDeCambio` expandible por fila (helper puro `compararPayloads` con sus 4 estados).
- Ruta y nav **Admin-only** (espejo de `LecturaDeAuditoria`); fetch con generación gateada en las tres ramas.
- **BUG DE PRODUCCIÓN cazado pre-merge por el juez B**: al limpiar una fecha, la consulta JSON omitía el límite (listado sin filtro) mientras la URL de descarga armaba `desde=T00:00:00+NaN:NaN` — un `DateTimeOffset` requerido y malformado que el endpoint rechazaba: **los mismos filtros visibles daban listado OK y descarga 400**. Cerrado estructuralmente con UN builder de alcance compartido por ambas superficies (precedente `construirQueryDeAlcanceDeCajas`), más el botón deshabilitado con motivo visible cuando faltan fechas (el endpoint de export exige fechas no-nulas; el de consulta no).
- Mirror inerte `FiltrosDeAuditoria` removido (tenía doc-comment que afirmaba consumo inexistente); `etiquetaDeAccion` exportada y con sus DOS ramas cubiertas — la de fallback es el mecanismo de la decisión 15 (una acción retirada sigue consultable).

## Tests
vitest **693/693** (41 archivos): paridad de URL completa entre consulta y export en los 7 filtros de alcance, borde real de última página (fixture 60/25 navegando hasta la 3), `PanelDeCambio` con testids por lado para agregada/modificada/quitada, guard de `entidad`→`idEntidad`, stale con `act`+assert síncrono, y el target de `compararPayloads`.

## Judgment-day
Juez B: 3 MAJORs + 4 WARNINGs + 2 sugerencias → fix `a249dab`; re-ronda B con 6 re-mutantes muertos. Juez A: 0 severos, 2 WARNINGs + 2 sugerencias → `3413eee`. Ronda limpia.

Nota de presupuesto: ~870 líneas de autoría (estimación de diseño ~360), desborde por profundidad de tests — mismo criterio de PR único que el resto de la etapa, reconocido como `size:exception` de facto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)