### PR TITLE
refactor(application): unifica los 16 helpers de parametros raw-ADO en ParametrosDeComando

### DIFF
--- a/src/Ways.Application/Abstracciones/ParametrosDeComando.cs
+++ b/src/Ways.Application/Abstracciones/ParametrosDeComando.cs
@@ -1,0 +1,41 @@
+using System.Data;
+using System.Data.Common;
+
+namespace Ways.Application.Abstracciones;
+
+/// <summary>
+/// Fábrica única de parámetros para statements raw-ADO (Npgsql) — reemplaza los 16 métodos
+/// privados <c>AgregarParametro</c>/<c>AgregarParametroNulo</c>/<c>AgregarParametroNullable</c>
+/// duplicados en src/Ways.Application (judgment-day del PR #129). Normaliza a UTC cualquier
+/// <see cref="DateTimeOffset"/> antes de escribirlo: la convención de EF
+/// (<c>WaysDbContext.NormalizacionAUtc</c>) no alcanza este camino porque acá el
+/// <c>DbParameter</c> se arma a mano, y Npgsql rechaza escribir contra <c>timestamptz</c> con
+/// offset distinto de cero. <c>ToUniversalTime()</c> es una reexpresión, nunca mueve el
+/// instante.
+/// </summary>
+internal static class ParametrosDeComando
+{
+    public static void Agregar(DbCommand comando, object valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = Normalizar(valor);
+        comando.Parameters.Add(parametro);
+    }
+
+    public static void AgregarNulo(DbCommand comando, object? valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor is null ? DBNull.Value : Normalizar(valor);
+        comando.Parameters.Add(parametro);
+    }
+
+    public static void AgregarNulo(IDbCommand comando, object? valor)
+    {
+        var parametro = comando.CreateParameter();
+        parametro.Value = valor is null ? DBNull.Value : Normalizar(valor);
+        comando.Parameters.Add(parametro);
+    }
+
+    private static object Normalizar(object valor) =>
+        valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
+}

--- a/src/Ways.Application/Abstracciones/ParametrosDeComando.cs
+++ b/src/Ways.Application/Abstracciones/ParametrosDeComando.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Data.Common;
 
 namespace Ways.Application.Abstracciones;
@@ -23,13 +22,6 @@ internal static class ParametrosDeComando
     }
 
     public static void AgregarNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is null ? DBNull.Value : Normalizar(valor);
-        comando.Parameters.Add(parametro);
-    }
-
-    public static void AgregarNulo(IDbCommand comando, object? valor)
     {
         var parametro = comando.CreateParameter();
         parametro.Value = valor is null ? DBNull.Value : Normalizar(valor);

--- a/src/Ways.Application/Articulos/AsignadorDeCodigoInternoArticulo.cs
+++ b/src/Ways.Application/Articulos/AsignadorDeCodigoInternoArticulo.cs
@@ -38,7 +38,7 @@ public static class AsignadorDeCodigoInternoArticulo
             "INSERT INTO numeraciones_articulos (id_tenant, proximo_numero) VALUES ($1, 1) " +
             "ON CONFLICT (id_tenant) DO NOTHING";
 
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -53,7 +53,7 @@ public static class AsignadorDeCodigoInternoArticulo
             "UPDATE numeraciones_articulos SET proximo_numero = proximo_numero + 1 " +
             "WHERE id_tenant = $1 RETURNING proximo_numero - 1";
 
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException(
@@ -73,12 +73,5 @@ public static class AsignadorDeCodigoInternoArticulo
         }
 
         return conexion;
-    }
-
-    private static void AgregarParametro(DbCommand comando, int valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor;
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Auditoria/ServicioDeAuditoria.cs
+++ b/src/Ways.Application/Auditoria/ServicioDeAuditoria.cs
@@ -69,38 +69,16 @@ public sealed class ServicioDeAuditoria(IWaysDbContext db, IRelojDelSistema relo
             "(id_tenant, id_punto_venta, id_actor, accion, entidad, id_entidad, valor_anterior, valor_nuevo, creado_el) " +
             "VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9)";
 
-        AgregarParametro(comando, registro.IdTenant);
-        AgregarParametroNulo(comando, registro.IdPuntoVenta);
-        AgregarParametro(comando, contexto.UsuarioId);
-        AgregarParametro(comando, registro.Accion.Accion);
-        AgregarParametro(comando, registro.Accion.Entidad);
-        AgregarParametro(comando, registro.IdEntidad);
-        AgregarParametroNulo(comando, valorAnterior);
-        AgregarParametro(comando, valorNuevo);
-        AgregarParametro(comando, reloj.Ahora);
+        ParametrosDeComando.Agregar(comando, registro.IdTenant);
+        ParametrosDeComando.AgregarNulo(comando, registro.IdPuntoVenta);
+        ParametrosDeComando.Agregar(comando, contexto.UsuarioId);
+        ParametrosDeComando.Agregar(comando, registro.Accion.Accion);
+        ParametrosDeComando.Agregar(comando, registro.Accion.Entidad);
+        ParametrosDeComando.Agregar(comando, registro.IdEntidad);
+        ParametrosDeComando.AgregarNulo(comando, valorAnterior);
+        ParametrosDeComando.Agregar(comando, valorNuevo);
+        ParametrosDeComando.Agregar(comando, reloj.Ahora);
 
         await comando.ExecuteNonQueryAsync(ct);
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    private static void AgregarParametroNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Caja/ServicioDeTurnos.cs
+++ b/src/Ways.Application/Caja/ServicioDeTurnos.cs
@@ -158,7 +158,7 @@ public class ServicioDeTurnos(
         await using var comando = conexion.CreateCommand();
         comando.Transaction = transaccionCruda;
         comando.CommandText = "SELECT estado::text FROM turnos_caja WHERE id_turno_caja = $1 FOR SHARE";
-        AgregarParametro(comando, idTurnoCaja);
+        ParametrosDeComando.Agregar(comando, idTurnoCaja);
 
         var estado = (string?)await comando.ExecuteScalarAsync(ct);
         if (estado != "abierto")
@@ -328,13 +328,13 @@ public class ServicioDeTurnos(
             "WHERE id_turno_caja = $4 AND id_tenant = $5 AND estado = $6 " +
             "RETURNING id_punto_venta";
 
-        AgregarParametro(comando, EstadoTurno.Cerrado);
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, idEmpleadoCierre);
-        AgregarParametro(comando, idTurnoCaja);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, EstadoTurno.Abierto);
-        AgregarParametro(comando, (object?)observacionesCierre ?? DBNull.Value);
+        ParametrosDeComando.Agregar(comando, EstadoTurno.Cerrado);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, idEmpleadoCierre);
+        ParametrosDeComando.Agregar(comando, idTurnoCaja);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, EstadoTurno.Abierto);
+        ParametrosDeComando.Agregar(comando, (object?)observacionesCierre ?? DBNull.Value);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is null ? null : Convert.ToInt32(resultado);
@@ -428,16 +428,6 @@ public class ServicioDeTurnos(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 
     // ---- proyecciones -----------------------------------------------------------------------

--- a/src/Ways.Application/Catalogos/ServicioDeCategorias.cs
+++ b/src/Ways.Application/Catalogos/ServicioDeCategorias.cs
@@ -151,8 +151,8 @@ public class ServicioDeCategorias(IWaysDbContext db, IRelojDelSistema reloj, ITe
             var conexion = Db.Database.GetDbConnection();
             await using var comando = conexion.CreateCommand();
             comando.CommandText = SqlExistePadre;
-            AgregarParametro(comando, idCategoria);
-            AgregarParametro(comando, tenantActual.Id);
+            ParametrosDeComando.AgregarNulo(comando, idCategoria);
+            ParametrosDeComando.AgregarNulo(comando, tenantActual.Id);
 
             var resultado = await comando.ExecuteScalarAsync(ct);
             return resultado is bool existe && existe;
@@ -175,8 +175,8 @@ public class ServicioDeCategorias(IWaysDbContext db, IRelojDelSistema reloj, ITe
             var conexion = Db.Database.GetDbConnection();
             await using var comando = conexion.CreateCommand();
             comando.CommandText = SqlDescendientes;
-            AgregarParametro(comando, idCategoria);
-            AgregarParametro(comando, tenantActual.Id);
+            ParametrosDeComando.AgregarNulo(comando, idCategoria);
+            ParametrosDeComando.AgregarNulo(comando, tenantActual.Id);
 
             var descendientes = new List<int>();
             await using var lector = await comando.ExecuteReaderAsync(ct);
@@ -205,8 +205,8 @@ public class ServicioDeCategorias(IWaysDbContext db, IRelojDelSistema reloj, ITe
             var conexion = Db.Database.GetDbConnection();
             await using var comando = conexion.CreateCommand();
             comando.CommandText = sql;
-            AgregarParametro(comando, idCategoria);
-            AgregarParametro(comando, tenantActual.Id);
+            ParametrosDeComando.AgregarNulo(comando, idCategoria);
+            ParametrosDeComando.AgregarNulo(comando, tenantActual.Id);
 
             var resultado = await comando.ExecuteScalarAsync(ct);
             return Convert.ToInt32(resultado);
@@ -234,20 +234,5 @@ public class ServicioDeCategorias(IWaysDbContext db, IRelojDelSistema reloj, ITe
 
         await Db.Database.OpenConnectionAsync(ct);
         return true;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(System.Data.IDbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Clientes/AsignadorDeNumeroCliente.cs
+++ b/src/Ways.Application/Clientes/AsignadorDeNumeroCliente.cs
@@ -45,7 +45,7 @@ public static class AsignadorDeNumeroCliente
             "INSERT INTO numeraciones_clientes (id_tenant, proximo_numero) VALUES ($1, 1) " +
             "ON CONFLICT (id_tenant) DO NOTHING";
 
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -60,7 +60,7 @@ public static class AsignadorDeNumeroCliente
             "UPDATE numeraciones_clientes SET proximo_numero = proximo_numero + 1 " +
             "WHERE id_tenant = $1 RETURNING proximo_numero - 1";
 
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException(
@@ -80,12 +80,5 @@ public static class AsignadorDeNumeroCliente
         }
 
         return conexion;
-    }
-
-    private static void AgregarParametro(DbCommand comando, int valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor;
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -671,9 +671,9 @@ public class ServicioDeCompras(
             "AND numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL " +
             "RETURNING id_punto_venta, id_tipo_comprobante";
 
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, id);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
         if (!await lector.ReadAsync(ct))
@@ -694,9 +694,9 @@ public class ServicioDeCompras(
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'confirmada'::estado_compra " +
             "RETURNING id_punto_venta";
 
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, id);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is null ? null : Convert.ToInt32(resultado);
@@ -712,8 +712,8 @@ public class ServicioDeCompras(
             "WHERE id_comprobante_compra = $1 AND id_tenant = $2 AND estado = 'borrador'::estado_compra " +
             "FOR UPDATE";
 
-        AgregarParametro(comando, id);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is not null;
@@ -731,15 +731,15 @@ public class ServicioDeCompras(
             "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_compra, id_empleado, creado_el, id_lote) " +
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, cantidad);
-        AgregarParametro(comando, motivo);
-        AgregarParametro(comando, idComprobanteCompra);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametro(comando, creadoEl);
-        AgregarParametroNulo(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, cantidad);
+        ParametrosDeComando.Agregar(comando, motivo);
+        ParametrosDeComando.Agregar(comando, idComprobanteCompra);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, creadoEl);
+        ParametrosDeComando.AgregarNulo(comando, idLote);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -757,10 +757,10 @@ public class ServicioDeCompras(
             "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock no devolvió ninguna fila.");
@@ -786,11 +786,11 @@ public class ServicioDeCompras(
             "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idLote);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock_lotes no devolvió ninguna fila.");
@@ -807,10 +807,10 @@ public class ServicioDeCompras(
         comando.CommandText =
             "UPDATE articulos SET costo_nominal = $1, updated_at = $2 WHERE id_articulo = $3 AND id_tenant = $4";
 
-        AgregarParametro(comando, costoNominal);
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, costoNominal);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -825,31 +825,6 @@ public class ServicioDeCompras(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    /// <summary>Mismo criterio que <c>ServicioDeStock.AgregarParametroNulo</c> — <c>id_lote</c> es
-    /// el primer parámetro nullable que esta clase envía por statement crudo (etapa 12, slice 5);
-    /// <see cref="AgregarParametro"/> nunca necesitó <c>DBNull.Value</c> hasta ahora.</summary>
-    private static void AgregarParametroNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 
     // ---- resolución de contexto (fuera de transacción) ---------------------------------------------

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorriente.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using Ways.Application.Abstracciones;
 using Ways.Domain.CuentaCorriente;
 
 namespace Ways.Application.CuentaCorriente;
@@ -34,9 +35,9 @@ public static class EscriturasDeCuentaCorriente
         comando.CommandText =
             "UPDATE clientes SET saldo = saldo + $1 WHERE id_cliente = $2 AND id_tenant = $3 RETURNING saldo";
 
-        AgregarParametro(comando, importe);
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, importe);
+        ParametrosDeComando.Agregar(comando, idCliente);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException($"No se pudo actualizar el saldo del cliente {idCliente}.");
@@ -76,17 +77,17 @@ public static class EscriturasDeCuentaCorriente
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) " +
             "RETURNING id_movimiento";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, fecha);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametro(comando, tipo);
-        AgregarParametroNullable(comando, idComprobanteVenta);
-        AgregarParametroNullable(comando, idPagoComprobante);
-        AgregarParametro(comando, importe);
-        AgregarParametro(comando, saldoResultante);
-        AgregarParametroNullable(comando, detalle);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idCliente);
+        ParametrosDeComando.Agregar(comando, fecha);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, tipo);
+        ParametrosDeComando.AgregarNulo(comando, idComprobanteVenta);
+        ParametrosDeComando.AgregarNulo(comando, idPagoComprobante);
+        ParametrosDeComando.Agregar(comando, importe);
+        ParametrosDeComando.Agregar(comando, saldoResultante);
+        ParametrosDeComando.AgregarNulo(comando, detalle);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("No se pudo insertar el movimiento de cuenta corriente.");
@@ -119,27 +120,5 @@ public static class EscriturasDeCuentaCorriente
                 "Un movimiento de tipo ActualizacionPrecios no lleva id_comprobante_venta ni id_pago_comprobante — " +
                 "invariante de escritura violado.");
         }
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    private static void AgregarParametroNullable(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeReliquidacion.cs
@@ -189,8 +189,8 @@ public class ServicioDeReliquidacion(
         comando.Transaction = transaccionCruda;
         comando.CommandText = "SELECT saldo, id_lista_precio FROM clientes WHERE id_cliente = $1 AND id_tenant = $2 FOR UPDATE";
 
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idCliente);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
         if (!await lector.ReadAsync(ct))
@@ -218,9 +218,9 @@ public class ServicioDeReliquidacion(
             "UPDATE movimientos_cuenta_corriente SET id_movimiento_actualizacion = $1 " +
             "WHERE id_movimiento = ANY($2) AND id_tenant = $3 AND id_movimiento_actualizacion IS NULL";
 
-        AgregarParametro(comando, idMovimientoActualizacion);
-        AgregarParametro(comando, idsMovimiento.ToArray());
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idMovimientoActualizacion);
+        ParametrosDeComando.Agregar(comando, idsMovimiento.ToArray());
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         return await comando.ExecuteNonQueryAsync(ct);
     }
@@ -261,14 +261,4 @@ public class ServicioDeReliquidacion(
         contexto.IdTenant
             ?? throw new InvalidOperationException(
                 "ServicioDeReliquidacion requiere un actor de tenant; SupervisionDeCuentaCorriente no admite plataforma.");
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
 }

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -195,8 +195,8 @@ public class ServicioDeGastos(
         comando.CommandText =
             "SELECT estado::text, id_proveedor FROM comprobantes_compra " +
             "WHERE id_comprobante_compra = $1 AND id_tenant = $2 FOR SHARE";
-        AgregarParametro(comando, idComprobanteCompra);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idComprobanteCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
         if (!await lector.ReadAsync(ct))
@@ -239,16 +239,6 @@ public class ServicioDeGastos(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 
     // ---- resolución interna ---------------------------------------------------------------

--- a/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
+++ b/src/Ways.Application/Ofertas/ServicioDeOfertas.cs
@@ -616,8 +616,8 @@ public class ServicioDeOfertas(
         comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
         comando.CommandText = "SELECT pg_advisory_xact_lock($1, $2)";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idOferta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idOferta);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -632,16 +632,6 @@ public class ServicioDeOfertas(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 
     private async Task<Oferta> BuscarAsync(int id, CancellationToken ct) =>

--- a/src/Ways.Application/Precios/ServicioDePrecios.cs
+++ b/src/Ways.Application/Precios/ServicioDePrecios.cs
@@ -602,8 +602,8 @@ public class ServicioDePrecios(
         comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
         comando.CommandText = "SELECT pg_advisory_xact_lock($1, $2)";
 
-        AgregarParametro(comando, clave1);
-        AgregarParametro(comando, clave2);
+        ParametrosDeComando.Agregar(comando, clave1);
+        ParametrosDeComando.Agregar(comando, clave2);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -633,9 +633,9 @@ public class ServicioDePrecios(
             "WHERE id_articulo = $1 AND id_lista_precio = $2 AND id_tenant = $3 " +
             "AND vigente_hasta IS NULL AND deleted_at IS NULL";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idListaPrecio);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idListaPrecio);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
 
@@ -694,11 +694,11 @@ public class ServicioDePrecios(
             "AND vigente_desde <> vigente_hasta " +
             "ORDER BY vigente_desde ASC LIMIT 1";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idListaPrecio);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, limiteOriginal);
-        AgregarParametro(comando, idFilaPendienteCerrada);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idListaPrecio);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, limiteOriginal);
+        ParametrosDeComando.Agregar(comando, idFilaPendienteCerrada);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
 
@@ -720,9 +720,9 @@ public class ServicioDePrecios(
         comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
         comando.CommandText = "UPDATE precios SET vigente_hasta = $1, updated_at = $2 WHERE id_precio = $3";
 
-        AgregarParametro(comando, vigenteHasta);
-        AgregarParametro(comando, ahora);
-        AgregarParametro(comando, idPrecio);
+        ParametrosDeComando.Agregar(comando, vigenteHasta);
+        ParametrosDeComando.Agregar(comando, ahora);
+        ParametrosDeComando.Agregar(comando, idPrecio);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -737,19 +737,6 @@ public class ServicioDePrecios(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> ANTES de escribirlo como
-    /// parámetro raw-ADO (judgment-day, juez A) — la convención de EF
-    /// (<c>WaysDbContext.NormalizacionAUtc</c>) no alcanza este camino: Npgsql rechaza escribir
-    /// contra <c>timestamptz</c> con offset distinto de cero, y acá se arma el <c>DbParameter</c>
-    /// a mano. <c>ToUniversalTime()</c> es una reexpresión, nunca mueve el instante — mismo
-    /// criterio que el converter de EF.</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 
     /// <summary><c>Monto</c> es el before-image de <c>precio.cambio</c> (task 2.2) — solo

--- a/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
+++ b/src/Ways.Application/Reportes/LectorDeSerieTemporal.cs
@@ -89,11 +89,11 @@ public class LectorDeSerieTemporal(IWaysDbContext db)
             await using var comando = conexion.CreateCommand();
             comando.CommandText = string.Format(sqlTemplate, LiteralDeGranularidad(granularidad));
 
-            AgregarParametro(comando, zona);
-            AgregarParametro(comando, idTenant);
-            AgregarParametro(comando, idsPuntoVenta.ToArray());
-            AgregarParametro(comando, desdeUtc);
-            AgregarParametro(comando, hastaUtcExclusivo);
+            ParametrosDeComando.Agregar(comando, zona);
+            ParametrosDeComando.Agregar(comando, idTenant);
+            ParametrosDeComando.Agregar(comando, idsPuntoVenta.ToArray());
+            ParametrosDeComando.Agregar(comando, desdeUtc);
+            ParametrosDeComando.Agregar(comando, hastaUtcExclusivo);
 
             var filas = new List<T>();
             await using var lector = await comando.ExecuteReaderAsync(ct);
@@ -142,16 +142,6 @@ public class LectorDeSerieTemporal(IWaysDbContext db)
 
         await db.Database.OpenConnectionAsync(ct);
         return true;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 }
 

--- a/src/Ways.Application/Stock/ServicioDeLotes.cs
+++ b/src/Ways.Application/Stock/ServicioDeLotes.cs
@@ -52,12 +52,12 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "SET updated_at = lotes.updated_at " +
             "RETURNING id_lote, fecha_vencimiento";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, codigoResuelto);
-        AgregarParametro(comando, fechaVencimiento);
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, momento);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, codigoResuelto);
+        ParametrosDeComando.Agregar(comando, fechaVencimiento);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, momento);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
         if (!await lector.ReadAsync(ct))
@@ -101,11 +101,11 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "SET updated_at = lotes.updated_at " +
             "RETURNING id_lote";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, ReglaDeLotes.CodigoSinIdentificar);
-        AgregarParametro(comando, momento);
-        AgregarParametro(comando, momento);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, ReglaDeLotes.CodigoSinIdentificar);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, momento);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El get-or-create del lote sin identificar no devolvió ninguna fila.");
@@ -302,8 +302,8 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "  ORDER BY id_lote FOR UPDATE" +
             ") bloqueadas";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("La suma bajo lock de stock_lotes no devolvió ninguna fila.");
@@ -327,14 +327,14 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_empleado, id_lote, creado_el) " +
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, cantidad);
-        AgregarParametro(comando, MotivoStock.Reclasificacion);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametroNulo(comando, idLote);
-        AgregarParametro(comando, creadoEl);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, cantidad);
+        ParametrosDeComando.Agregar(comando, MotivoStock.Reclasificacion);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.AgregarNulo(comando, idLote);
+        ParametrosDeComando.Agregar(comando, creadoEl);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -356,11 +356,11 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
             "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idLote);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock_lotes no devolvió ninguna fila.");
@@ -497,30 +497,6 @@ public class ServicioDeLotes(IWaysDbContext db, IRelojDelSistema reloj, IContext
         return new LoteListado(
             lote.Id, lote.IdArticulo, lote.Codigo, lote.FechaVencimiento, lote.EsSinIdentificar, Cantidad: 0m,
             ReglaDeLotes.Clasificar(lote.FechaVencimiento, hoy, diasAlertaPorDefecto), Sugerido: false);
-    }
-
-    // ---- statements crudos (misma convención que ServicioDeStock/ServicioDeCompras) --------------
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    private static void AgregarParametroNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 
     // ---- validaciones ---------------------------------------------------------------------------

--- a/src/Ways.Application/Stock/ServicioDeStock.cs
+++ b/src/Ways.Application/Stock/ServicioDeStock.cs
@@ -169,11 +169,11 @@ public class ServicioDeStock(
             "SET minimo = EXCLUDED.minimo, reposicion = EXCLUDED.reposicion " +
             "RETURNING cantidad, minimo, reposicion";
 
-        AgregarParametro(comando, solicitud.IdArticulo);
-        AgregarParametro(comando, solicitud.IdPuntoVenta);
-        AgregarParametro(comando, idTenant);
-        AgregarParametroNulo(comando, solicitud.Minimo);
-        AgregarParametroNulo(comando, solicitud.Reposicion);
+        ParametrosDeComando.Agregar(comando, solicitud.IdArticulo);
+        ParametrosDeComando.Agregar(comando, solicitud.IdPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.AgregarNulo(comando, solicitud.Minimo);
+        ParametrosDeComando.AgregarNulo(comando, solicitud.Reposicion);
 
         await using var lector = await comando.ExecuteReaderAsync(ct);
         if (!await lector.ReadAsync(ct))
@@ -896,9 +896,9 @@ public class ServicioDeStock(
             "SET cantidad = stock.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert no-op de stock no devolvió ninguna fila.");
@@ -923,10 +923,10 @@ public class ServicioDeStock(
             "SET cantidad = stock_lotes.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idLote);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert no-op de stock_lotes no devolvió ninguna fila.");
@@ -970,17 +970,17 @@ public class ServicioDeStock(
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) " +
             "RETURNING id_movimiento";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, cantidad);
-        AgregarParametro(comando, motivo);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametroNulo(comando, observaciones);
-        AgregarParametroNulo(comando, idComprobanteCompra);
-        AgregarParametroNulo(comando, idPuntoVentaDestino);
-        AgregarParametro(comando, creadoEl);
-        AgregarParametroNulo(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, cantidad);
+        ParametrosDeComando.Agregar(comando, motivo);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.AgregarNulo(comando, observaciones);
+        ParametrosDeComando.AgregarNulo(comando, idComprobanteCompra);
+        ParametrosDeComando.AgregarNulo(comando, idPuntoVentaDestino);
+        ParametrosDeComando.Agregar(comando, creadoEl);
+        ParametrosDeComando.AgregarNulo(comando, idLote);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El INSERT de movimientos_stock no devolvió ninguna fila.");
@@ -1001,10 +1001,10 @@ public class ServicioDeStock(
             "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock no devolvió ninguna fila.");
@@ -1031,11 +1031,11 @@ public class ServicioDeStock(
             "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idLote);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException("El upsert de stock_lotes no devolvió ninguna fila.");
@@ -1053,28 +1053,6 @@ public class ServicioDeStock(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    private static void AgregarParametroNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 
     // ---- validaciones -------------------------------------------------------------------------

--- a/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
+++ b/src/Ways.Application/Ventas/AsignadorDeNumeroComprobante.cs
@@ -66,9 +66,9 @@ public static class AsignadorDeNumeroComprobante
             "VALUES ($1, $2, $3, 1) " +
             "ON CONFLICT (id_punto_venta, tipo_comprobante) DO NOTHING";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, tipoComprobante);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, tipoComprobante);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -84,8 +84,8 @@ public static class AsignadorDeNumeroComprobante
             "UPDATE numeraciones_comprobante SET proximo_numero = proximo_numero + 1 " +
             "WHERE id_punto_venta = $1 AND tipo_comprobante = $2 RETURNING proximo_numero - 1";
 
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, tipoComprobante);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, tipoComprobante);
 
         var resultado = await comando.ExecuteScalarAsync(ct)
             ?? throw new InvalidOperationException(
@@ -105,15 +105,5 @@ public static class AsignadorDeNumeroComprobante
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
     }
 }

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -685,8 +685,8 @@ public class ServicioDeVentas(
             "WHERE c.id_comprobante_venta = $1 AND c.id_tenant = $2 " +
             "FOR SHARE OF t";
 
-        AgregarParametro(comando, idComprobanteVenta);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idComprobanteVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var estado = (string?)await comando.ExecuteScalarAsync(ct);
         if (estado == "cerrado")
@@ -705,8 +705,8 @@ public class ServicioDeVentas(
         comando.Transaction = transaccion;
         comando.CommandText = "SELECT 1 FROM clientes WHERE id_cliente = $1 AND id_tenant = $2 FOR UPDATE";
 
-        AgregarParametro(comando, idCliente);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idCliente);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         await comando.ExecuteScalarAsync(ct);
     }
@@ -724,8 +724,8 @@ public class ServicioDeVentas(
             "SELECT id_movimiento_actualizacion FROM movimientos_cuenta_corriente " +
             "WHERE id_movimiento = $1 AND id_tenant = $2";
 
-        AgregarParametro(comando, idMovimiento);
-        AgregarParametro(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idMovimiento);
+        ParametrosDeComando.Agregar(comando, idTenant);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is null or DBNull ? null : Convert.ToInt32(resultado);
@@ -748,10 +748,10 @@ public class ServicioDeVentas(
             "WHERE id_comprobante_venta = $2 AND id_tenant = $3 AND estado = $4 " +
             "RETURNING id_punto_venta";
 
-        AgregarParametro(comando, EstadoComprobante.Anulado);
-        AgregarParametro(comando, idComprobanteVenta);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, EstadoComprobante.Emitido);
+        ParametrosDeComando.Agregar(comando, EstadoComprobante.Anulado);
+        ParametrosDeComando.Agregar(comando, idComprobanteVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, EstadoComprobante.Emitido);
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is null ? null : Convert.ToInt32(resultado);
@@ -1089,15 +1089,15 @@ public class ServicioDeVentas(
             "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_comprobante_venta, id_empleado, creado_el, id_lote) " +
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
 
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, cantidad);
-        AgregarParametro(comando, motivo);
-        AgregarParametro(comando, idComprobanteVenta);
-        AgregarParametro(comando, idEmpleado);
-        AgregarParametro(comando, creadoEl);
-        AgregarParametroNulo(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, cantidad);
+        ParametrosDeComando.Agregar(comando, motivo);
+        ParametrosDeComando.Agregar(comando, idComprobanteVenta);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, creadoEl);
+        ParametrosDeComando.AgregarNulo(comando, idLote);
 
         await comando.ExecuteNonQueryAsync(ct);
     }
@@ -1119,10 +1119,10 @@ public class ServicioDeVentas(
             "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         await comando.ExecuteScalarAsync(ct);
     }
@@ -1146,11 +1146,11 @@ public class ServicioDeVentas(
             "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
             "RETURNING cantidad";
 
-        AgregarParametro(comando, idArticulo);
-        AgregarParametro(comando, idPuntoVenta);
-        AgregarParametro(comando, idLote);
-        AgregarParametro(comando, idTenant);
-        AgregarParametro(comando, delta);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
 
         await comando.ExecuteScalarAsync(ct);
     }
@@ -1165,32 +1165,6 @@ public class ServicioDeVentas(
         }
 
         return conexion;
-    }
-
-    /// <summary>Normaliza a UTC cualquier <see cref="DateTimeOffset"/> antes de escribirlo como
-    /// parámetro raw-ADO — la convención de EF no alcanza este camino (ver el doc-comment de
-    /// <c>ServicioDePrecios.AgregarParametro</c>, judgment-day juez A).</summary>
-    private static void AgregarParametro(DbCommand comando, object valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor is DateTimeOffset dto ? dto.ToUniversalTime() : valor;
-        comando.Parameters.Add(parametro);
-    }
-
-    /// <summary>Mismo criterio que <c>ServicioDeCompras.AgregarParametroNulo</c>/
-    /// <c>ServicioDeStock.AgregarParametroNulo</c> — <c>id_lote</c> es el primer parámetro nullable
-    /// que esta clase envía por statement crudo (etapa 12, slice 8); <see cref="AgregarParametro"/>
-    /// nunca necesitó <c>DBNull.Value</c> hasta ahora.</summary>
-    private static void AgregarParametroNulo(DbCommand comando, object? valor)
-    {
-        var parametro = comando.CreateParameter();
-        parametro.Value = valor switch
-        {
-            null => DBNull.Value,
-            DateTimeOffset dto => dto.ToUniversalTime(),
-            _ => valor
-        };
-        comando.Parameters.Add(parametro);
     }
 
     // ---- Utilidades ---------------------------------------------------------------------------

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -149,7 +149,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     /// zona), no hay migración (el tipo de columna es el mismo), y ningún endpoint EF nuevo puede
     /// volver a olvidarse. Los caminos raw-ADO (que arman su <c>DbParameter</c> a mano y no pasan
     /// por esta convención) quedan cubiertos por la MISMA normalización, pero aplicada en el
-    /// helper compartido <c>AgregarParametro</c> de cada servicio que usa ADO crudo
+    /// helper único <c>Ways.Application.Abstracciones.ParametrosDeComando</c>
     /// (judgment-day, juez A: <c>ServicioDePrecios.AbrirNuevoPrecioAsync</c> escribía
     /// <c>vigente_hasta</c> con el offset tal cual del cliente y tiraba 500 — bug real, no
     /// hipotético). La lectura es identidad — Npgsql ya devuelve offset cero.

--- a/tests/Ways.IntegrationTests/PreciosEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/PreciosEndpointsTests.cs
@@ -310,7 +310,7 @@ public class PreciosEndpointsTests(WaysApiFixture fixture) : IClassFixture<WaysA
     /// offset real de browser (-03:00, no UTC) hacía que <c>vigente_hasta</c> de la fila cerrada
     /// viajara con ese offset tal cual hasta Npgsql, que revienta con 500 ("only offset 0 (UTC)
     /// is supported") contra la columna <c>timestamptz</c>. Sin el fix del helper
-    /// <c>AgregarParametro</c> este test da 500; con el fix da 201, y el <c>vigente_hasta</c> de
+    /// <c>ParametrosDeComando.Agregar</c> este test da 500; con el fix da 201, y el <c>vigente_hasta</c> de
     /// la fila cerrada queda en el INSTANTE correcto (la igualdad de <see cref="DateTimeOffset"/>
     /// compara por instante UTC, no por offset textual — <c>ToUniversalTime()</c> es una
     /// reexpresión, nunca corre el instante).</summary>


### PR DESCRIPTION
## Resumen

- Crea `ParametrosDeComando` (Ways.Application/Abstracciones): el helper único de parámetros raw-ADO con la normalización UTC del fix de #129.
- Migra los 16 archivos que tenían copias locales de `AgregarParametro`/`AgregarParametroNulo` (incl. `ServicioDeCategorias`, migrado por semántica: su helper local null-tolerant mapea a `AgregarNulo`).
- Elimina el overload muerto `IDbCommand` y actualiza los doc-comments que nombraban el helper viejo (hallazgos info del judgment-day).

## Judgment-day (ronda limpia)

- Juez B (mutador): 0 hallazgos. Evidencia: build `--no-incremental`, Domain 490/490, Application 270/270, Integration filtrada 982/982; mutación 1 (quitar normalización UTC) → `ProgramarUnPrecioConVigenteDesdeConOffsetNoUtc` falla; mutación 2 (romper DBNull) → 167 tests fallan. Ambas revertidas, árbol limpio.
- Juez A (estático): 0 severos; 2 WARNINGs + 1 SUGGESTION (código muerto/comentarios stale) fixeados en `95bc672`.
- Pasada acotada final de ambos jueces sobre el delta del fix: 0 hallazgos.

VentasCheckoutTests ausente del diff; checkout intocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)