### PR TITLE
feat(cc-proveedores): el ledger registra la deuda — confirmar y anular escriben movimientos (etapa 15, slice 2)

### DIFF
--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -594,6 +594,32 @@ above):**
     — `ServicioDeGastos`'s real write path does not exist until slice 3. A
     `gastos` row is seeded only to satisfy `id_gasto`'s FK; the ledger
     write itself never goes through `InsertarGastoAsync`.
+24. **Judgment-day judge B found task 2.22 / mutation target #16's original
+    evidence insufficient — a VALUE-class mutant survived the recorded
+    proof.** The only `SaldoResultante` assertion in
+    `CuentaCorrienteProveedorEscriturasTests.cs`
+    (`ConfirmarUnaCompraEscribeExactamenteUnMovimientoCompraYSubeElSaldo`)
+    ran against a FRESH proveedor (saldo previo 0), where
+    `saldo_resultante == encabezado.Total` by pure coincidence: replacing
+    `nuevoSaldoProveedor` with `encabezado.Total` in
+    `EjecutarConfirmarAsync` (`ServicioDeCompras.cs:~482`) passed all 9
+    tests. The anulación path (`EjecutarAnulacionAsync:~635-643`) had NO
+    assertion on the ajuste movement's `SaldoResultante` at all. Closed
+    tests-only (production code is correct — the gap was coverage, not a
+    defect): added
+    `ConfirmarConDeudaPreviaEscribeElSaldoResultanteDelReturningNoElTotalDeEstaCompra`
+    (real prior debt from a previously confirmed compra, ≠ 0 and ≠ this
+    compra's total) and widened `AnulandoUnaCompraImpagaReviertaSoloLaDeuda`
+    /`AnulandoUnaCompraPreCutoverEscribeElAjusteConElFallback` with a second,
+    untouched confirmed compra so the ajuste's resulting saldo is neither 0
+    nor equal to the reverted importe. Mutation evidence (two cycles, this
+    round): (1) `nuevoSaldoProveedor` → `encabezado.Total` in
+    `EjecutarConfirmarAsync` — the new confirm test failed (`2300` expected
+    vs `1500` actual), reverted; (2) the ajuste's `saldoResultante` →
+    `-importeOriginal` (a local value) in `EjecutarAnulacionAsync` — both
+    widened anulación tests failed (`300`/`400` expected vs `-1000`/`-2000`
+    actual), reverted. Full `CuentaCorrienteProveedorEscriturasTests` green
+    (10/10) after revert.
 
 - [x] 2.1 Create
   `src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorrienteProveedor.cs`

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -509,35 +509,121 @@ paths (append-only, nothing to repair). **Done** = tests green +
 **Budget note**: pre-authorized split `2a`/`2b` if this slice overflows —
 see decision 3 above.
 
-- [ ] 2.1 Create
+**Deviations registered during `sdd-apply` (stage-12 discipline, decision 14
+above):**
+
+19. **`MarcarAnuladaAsync`'s `RETURNING` is corrected to include `total`,
+    not only `id_punto_venta, id_proveedor`.** Design decision 4's literal
+    column list (`design.md:56`) omits `total`, but the Transactions
+    section's own step 5 for anulación (`design.md:201`) reads
+    `importeOriginal := total del RETURNING` for the pre-cutover fallback
+    — there is no other RETURNING in that transaction to read it from. The
+    same widening rationale decision 4 gives for `ConfirmarHeaderAsync`
+    ("zero extra round trips") applies identically here: `total` does not
+    change once a compra is confirmed (spec `comprobantes-compra`:
+    "confirmada... MUST be immutable"), so reading it under this same lock
+    is exactly as authoritative as `id_punto_venta`/`id_proveedor`. Shipped
+    as `RETURNING id_punto_venta, id_proveedor, total`.
+20. **Three pre-existing integration test files were missing
+    `MapEnum<TipoMovimientoCcProveedor>` in their manually-curated
+    `DbContextOptionsBuilder<WaysDbContext>`** — a gap opened by slice 1
+    (which added the enum) but not exercised until this slice's own code
+    path (`ConfirmarAsync`/`AnularAsync`) started writing to the ledger:
+    `ComprasAnulacionYConcurrenciaTests.CrearContextoConContador` (task
+    2.15's own budget-of-commands harness — surfaced immediately as an
+    `InvalidCastException` writing the enum parameter), and, discovered
+    only by running the FULL integration suite once (per the "una sola
+    corrida" rule) rather than a filtered subset:
+    `ComprasTipoSeedTests.LosTiposDeCompraAterrizanEnUnaBaseYaMigradaDesdeStage7...`
+    and
+    `CuentaCorrienteEtapa7BackstopTests.RcResuelveEnUnaBaseYaMigradaDesdeStage6SinDuplicar`
+    (both migrate a fresh database to HEAD and hit
+    `PendingModelChangesWarning` because their hand-built model diverges
+    from the real migration snapshot without the mapping). Fixed in this
+    slice's diff — leaving them red would violate the "tests green" gate
+    criterion, and none of the three files needed anything beyond the one
+    missing `MapEnum` line.
+21. **Mutation target #17's literal runtime scenario is structurally
+    unreachable through the real call sites — resolved with a source-text
+    assertion, `mutation-proof-tests` rule 3 exhausted first**, same
+    criterion as slice 1's targets #4/#11.
+    `ServicioDeCompras.ConfirmarAsync`/`AnularAsync` both wrap their
+    transactional core in `FabricaDeEstrategiaSinReintento.
+    CrearEstrategiaSinReintento` (`maxRetryCount: 0`, `ShouldRetryOn`
+    always `false`) — its own doc-comment states this exists PRECISELY so
+    a `CreateExecutionStrategy` replay never reaches these statements.
+    Design's mutation description ("double-count under a forced
+    execution-strategy retry") therefore cannot be forced through either
+    real call site without defeating the very isolation this class
+    provides. Resolution:
+    `EscriturasDeCuentaCorrienteProveedorTests.
+    ElTextoFuenteDeActualizarSaldoProveedorAsyncUsaElUpdateAditivoCrudoTarget17`
+    reads `EscriturasDeCuentaCorrienteProveedor.cs` from disk and asserts
+    both the literal additive SQL text and the absence of any tracked
+    `Proveedores`/`SaveChangesAsync` access in that method.
+22. **Mutation target #19 could not be proven with a live rendezvous —
+    resolved with a deterministic source-text ordering assertion instead**,
+    after two runtime attempts were exhausted (`mutation-proof-tests` rule
+    2/3). First, a `DbCommandInterceptor` capturing the SQL statement
+    sequence was tried and discarded EMPIRICALLY: the raw-ADO statements of
+    `EjecutarConfirmarAsync`/`EjecutarAnulacionAsync` are created via
+    `conexion.CreateCommand()` directly on `db.Database.GetDbConnection()`,
+    bypassing EF Core's command pipeline entirely — `interceptor.Orden`
+    stayed empty in the real run. Second, a genuine timing-forced
+    "deadlock" is structurally impossible to construct here: design's own
+    Concurrency guarantees (`design.md:239-244`) state confirm × pago share
+    only ONE lockable resource (the proveedor row) and "neither holds
+    anything the other needs after taking it" — with a single shared
+    resource there is no second resource to invert for an actual PostgreSQL
+    deadlock, under either the correct or the mutated ordering. Resolution:
+    `ServicioDeComprasLockOrderTests` (new file,
+    `tests/Ways.Application.Tests/Compras/`) reads `ServicioDeCompras.cs`
+    from disk and asserts, by text-index order inside each method, that
+    the proveedor lock (`ActualizarSaldoProveedorAsync`) appears strictly
+    after every stock/costo statement and strictly before the commit, with
+    the ledger `INSERT` immediately following it — proving task 2.9's
+    pinned order directly and discriminating target #19 (moving the lock
+    to "step 1.5" moves its text index before the stock statements,
+    confirmed by mutation). Task 2.17's real concurrency test
+    (`ConfirmarYUnPagoDirectoAlMismoProveedorSeSerializanSinDeadlock`)
+    still ships as the SPEC-level proof that confirm × pago serialize
+    without error — it is a behavioral coverage test, not target #19's
+    mutation discriminator.
+23. **Tasks 2.13 and 2.17's "payment" is simulated by calling
+    `EscriturasDeCuentaCorrienteProveedor` directly**, per decision 7 above
+    — `ServicioDeGastos`'s real write path does not exist until slice 3. A
+    `gastos` row is seeded only to satisfy `id_gasto`'s FK; the ledger
+    write itself never goes through `InsertarGastoAsync`.
+
+- [x] 2.1 Create
   `src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorrienteProveedor.cs`
   — static class, `ActualizarSaldoProveedorAsync`: raw `UPDATE proveedores
   SET saldo = saldo + $1 WHERE id_proveedor = $2 AND id_tenant = $3
   RETURNING saldo` — never a tracked `proveedor.Saldo +=`. *(design.md:
   74-95, decisions 1-2)*
-- [ ] 2.2 Same file: `InsertarMovimientoCcProveedorAsync` — the ONE
+- [x] 2.2 Same file: `InsertarMovimientoCcProveedorAsync` — the ONE
   ledger `INSERT ... RETURNING id_movimiento`. *(design.md:90-107)*
-- [ ] 2.3 Same file: `ValidarFormaPorTipo` — the 4×3 shape matrix
+- [x] 2.3 Same file: `ValidarFormaPorTipo` — the 4×3 shape matrix
   (`apertura`/`compra`/`pago`/`ajuste`), `InvalidOperationException`
   (never `ErrorDominio` — a call-site defect, not a client error).
   *(design.md:109-118)*
-- [ ] 2.4 Every raw-ADO parameter through `ParametrosDeComando.Agregar` /
+- [x] 2.4 Every raw-ADO parameter through `ParametrosDeComando.Agregar` /
   `AgregarNulo` (normalizes any `DateTimeOffset` to UTC) — no private
   `AgregarParametro` clone; `EscriturasDeCuentaCorriente.cs`'s own private
   copy is explicitly NOT refactored in this stage. *(design decision 3,
   `design.md:55, 511-515`)*
-- [ ] 2.5 Modify `ServicioDeCompras.cs`'s `ConfirmarHeaderAsync` (`:663-685`)
+- [x] 2.5 Modify `ServicioDeCompras.cs`'s `ConfirmarHeaderAsync` (`:663-685`)
   — widen `RETURNING` to `id_punto_venta, id_tipo_comprobante,
   id_proveedor, total`. *(design decision 4, `design.md:56, 184`)*
-- [ ] 2.6 Modify `ServicioDeCompras.cs`'s `MarcarAnuladaAsync` (`:687-700`)
+- [x] 2.6 Modify `ServicioDeCompras.cs`'s `MarcarAnuladaAsync` (`:687-700`)
   — widen `RETURNING` to `id_punto_venta, id_proveedor`. *(design.md:196)*
-- [ ] 2.7 Modify `ServicioDeCompras.cs`'s `EjecutarConfirmarAsync`
+- [x] 2.7 Modify `ServicioDeCompras.cs`'s `EjecutarConfirmarAsync`
   (`:312-470`), after the costo loop (`:462-465`), immediately before
   commit (`:467`) — step 5: `ActualizarSaldoProveedorAsync(+total)`, the
   LAST lock for update; step 6: `INSERT` the `compra` movement
   (`id_comprobante_compra` = the id, `id_gasto` NULL, `importe = +total`).
   *(design decision 5, `design.md:57, 189-192`)*
-- [ ] 2.8 Modify `ServicioDeCompras.cs`'s `EjecutarAnulacionAsync`
+- [x] 2.8 Modify `ServicioDeCompras.cs`'s `EjecutarAnulacionAsync`
   (`:504-600`), after the informational `gastosLigados` count (`:594`,
   unchanged) — step 5: `importeOriginal := SUM(importe)` of this compra's
   `compra` movement(s); **0 filas ⇒ pre-cutover fallback**
@@ -546,75 +632,75 @@ see decision 3 above.
   `ActualizarSaldoProveedorAsync(−importeOriginal)`, the LAST lock; step
   7: `INSERT` the reversing `ajuste` (`id_comprobante_compra` = the id).
   *(design decision 6, OD8 ratified fallback, `design.md:58, 200-204`)*
-- [ ] 2.9 Confirm the pinned lock order holds unchanged for both paths —
+- [x] 2.9 Confirm the pinned lock order holds unchanged for both paths —
   no existing statement in `EjecutarConfirmarAsync`/`EjecutarAnulacionAsync`
   moves; the proveedor lock lands strictly after the header/lotes/stock
   locks and immediately before the commit. *(design.md:229-230)*
-- [ ] 2.10 [P] Domain unit — `ValidarFormaPorTipo`: the 4×3 shape matrix,
+- [x] 2.10 [P] Domain unit — `ValidarFormaPorTipo`: the 4×3 shape matrix,
   one fact per illegal combination. *(design.md:372)*
-- [ ] 2.11 [P] Integration — confirming a compra writes exactly one
+- [x] 2.11 [P] Integration — confirming a compra writes exactly one
   `compra` movement, `importe = total`, `proveedores.saldo` increases.
   *(spec `cuenta-corriente-de-proveedores`: "Confirming a compra increases
   the proveedor's saldo")*
-- [ ] 2.12 [P] Integration — anulando an unpaid compra reverses only the
+- [x] 2.12 [P] Integration — anulando an unpaid compra reverses only the
   debt. *(spec scenario: "Anulando an unpaid compra reverses only the
   debt")*
-- [ ] 2.13 [P] Integration — anulando a fully-paid compra leaves a saldo a
+- [x] 2.13 [P] Integration — anulando a fully-paid compra leaves a saldo a
   favor; the linked gasto and its `pago` movement remain untouched
   (requires slice-3's write path — co-locate or defer to slice 3's
   coverage if the pago path isn't testable yet; if deferred, register the
   deferral here per decision 14). *(spec scenario: "Anulando a fully-paid
   compra leaves a saldo a favor")*
-- [ ] 2.14 [P] Integration — anulando a **pre-cutover** compra (its only
+- [x] 2.14 [P] Integration — anulando a **pre-cutover** compra (its only
   `compra`-equivalent debt lives in the `apertura` backfill row, no own
   `compra` movement) writes an `ajuste` of `−total` with the fallback
   detalle. *(OD8, design decision 6 fallback — decision 6 above)*
-- [ ] 2.15 [P] Integration — the `-03:00` offset test: everything under
+- [x] 2.15 [P] Integration — the `-03:00` offset test: everything under
   `RelojFijo(2026-08-17T12:00:00Z)`, the `compra`/`ajuste` movement's
   `fecha` equals the fixed instant exactly at offset zero AND at a real
   `-03:00` write (mutation-proof-tests rule 10 — a `Z` fixture cannot see
   a raw-ADO UTC-normalization regression, stage-14 verify W2/PR #129).
-- [ ] 2.16 [P] Integration — fault point: a failure forced at the ledger
+- [x] 2.16 [P] Integration — fault point: a failure forced at the ledger
   write of `EjecutarConfirmarAsync` leaves `proveedores.saldo`, the
   ledger, **and** the compra's `estado` (still `borrador`) untouched.
-- [ ] 2.17 [P] Integration — **confirm × pago rendezvous** on the same
+- [x] 2.17 [P] Integration — **confirm × pago rendezvous** on the same
   proveedor: race `EjecutarConfirmarAsync` against a direct call to
   `EscriturasDeCuentaCorrienteProveedor` shaped like a payment (decision 7
   above — the real `ServicioDeGastos` wiring lands in slice 3); both
   commit, serialized on the proveedor row, no deadlock.
-- [ ] 2.18 [P] **Mutation target #12** — `ValidarFormaPorTipo`, `compra`
+- [x] 2.18 [P] **Mutation target #12** — `ValidarFormaPorTipo`, `compra`
   requires a comprobante → delete the arm → the Domain fact (2.10) must
   fail.
-- [ ] 2.19 [P] **Mutation target #13** — `ValidarFormaPorTipo`, `apertura`
+- [x] 2.19 [P] **Mutation target #13** — `ValidarFormaPorTipo`, `apertura`
   forbids actor/PV → delete the arm → the Domain fact (2.10) must fail.
-- [ ] 2.20 [P] **Mutation target #14** — `ParametrosDeComando.Agregar` on
+- [x] 2.20 [P] **Mutation target #14** — `ParametrosDeComando.Agregar` on
   `fecha` → replace with a hand-built parameter without
   `ToUniversalTime()` → the `-03:00` offset test (2.15) must fail.
-- [ ] 2.21 [P] **Mutation target #15** — `id_proveedor, total` added to
+- [x] 2.21 [P] **Mutation target #15** — `id_proveedor, total` added to
   `ConfirmarHeaderAsync`'s `RETURNING` → read them from `preLectura`
   instead → a confirm-under-concurrent-`PUT` test (the movement's
   importe diverges) must fail.
-- [ ] 2.22 [P] **Mutation target #16** — the saldo `UPDATE` placed
+- [x] 2.22 [P] **Mutation target #16** — the saldo `UPDATE` placed
   **before** the ledger `INSERT` → swap them → `saldo_resultante` no
   longer equals the post-update saldo (2.11 regresses).
-- [ ] 2.23 [P] **Mutation target #17** — `saldo = saldo + $1` raw →
+- [x] 2.23 [P] **Mutation target #17** — `saldo = saldo + $1` raw →
   replace with a tracked `proveedor.Saldo +=` → double-count under a
   forced `CreateExecutionStrategy` retry.
-- [ ] 2.24 [P] **Mutation target #18** — `AND id_tenant = $3` in the
+- [x] 2.24 [P] **Mutation target #18** — `AND id_tenant = $3` in the
   saldo `UPDATE` → delete it → a cross-tenant update test routed BELOW
   RLS (mutation-proof-tests rule 3) must fail.
-- [ ] 2.25 [P] **Mutation target #19** — the proveedor lock placed
+- [x] 2.25 [P] **Mutation target #19** — the proveedor lock placed
   **after** the stock loop → move it to step 1.5 → the confirm × pago
   rendezvous (2.17) deadlocks/times out.
-- [ ] 2.26 [P] **Mutation target #20** — the pre-cutover fallback of the
+- [x] 2.26 [P] **Mutation target #20** — the pre-cutover fallback of the
   contramovimiento → remove the fallback (always the ledger sum) →
   annulling a pre-cutover compra (2.14) leaves the debt on the books.
-- [ ] 2.27 **Non-regression (binding verify criterion, design.md:45-47,
+- [x] 2.27 **Non-regression (binding verify criterion, design.md:45-47,
   468-470)**: `tests/Ways.IntegrationTests/VentasCheckoutTests.cs` is
   ABSENT from the stage's diff entirely; no file under
   `src/Ways.Application/Ventas/` appears in this slice's diff. Confirmed
   by `git diff --stat`.
-- [ ] 2.28 Gate guard: `dotnet ef migrations has-pending-model-changes`
+- [x] 2.28 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`.
 - [ ] 2.29 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 2.30 Branch `feat/stage15-slice2-escrituras-y-deuda` off `main`

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -529,8 +529,9 @@ above):**
     `DbContextOptionsBuilder<WaysDbContext>`** — a gap opened by slice 1
     (which added the enum) but not exercised until this slice's own code
     path (`ConfirmarAsync`/`AnularAsync`) started writing to the ledger:
-    `ComprasAnulacionYConcurrenciaTests.CrearContextoConContador` (task
-    2.15's own budget-of-commands harness — surfaced immediately as an
+    `ComprasAnulacionYConcurrenciaTests.CrearContextoConContador` (that
+    suite's own command-budget harness, inherited from an earlier stage —
+    surfaced immediately as an
     `InvalidCastException` writing the enum parameter), and, discovered
     only by running the FULL integration suite once (per the "una sola
     corrida" rule) rather than a filtered subset:
@@ -728,7 +729,7 @@ above):**
   by `git diff --stat`.
 - [x] 2.28 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`.
-- [ ] 2.29 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 2.29 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 2.30 Branch `feat/stage15-slice2-escrituras-y-deuda` off `main`
   (parent: slice 1); PR; merge stacked-to-main.
 

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Auditoria;
+using Ways.Application.CuentaCorriente;
 using Ways.Application.Exportacion;
 using Ways.Application.Precios;
 using Ways.Application.Stock;
@@ -13,6 +14,7 @@ using Ways.Domain.Auditoria;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Common;
 using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Proveedores;
 using Ways.Domain.Stock;
@@ -464,6 +466,21 @@ public class ServicioDeCompras(
             await ActualizarCostoNominalAsync(conexion, transaccionCruda, idTenant, idArticulo, costo, momento, ct);
         }
 
+        // 5. proveedores — ÚLTIMO lock de fila for update de esta transacción (stage-15-cc-
+        // proveedores-ledger, design decisión 5): recién acá, después de items/lotes/stock/costo,
+        // nunca antes — moverlo invertiría el orden total pineado (mutation target #19) y podría
+        // reintroducir el deadlock que ese orden existe para evitar.
+        var nuevoSaldoProveedor = await EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+            conexion, transaccionCruda, idTenant, encabezado.IdProveedor, encabezado.Total, ct);
+
+        // 6. El ÚNICO movimiento `compra` de esta confirmación — importe = total, positivo,
+        // origen = esta compra (design decisión 5). saldo_resultante viene del RETURNING del
+        // UPDATE de arriba, nunca recalculado (mutation target #16: si el orden de estos dos pasos
+        // se invirtiera, saldo_resultante dejaría de coincidir con el saldo post-UPDATE).
+        await EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            conexion, transaccionCruda, idTenant, encabezado.IdProveedor, momento, encabezado.IdPuntoVenta, idEmpleado,
+            TipoMovimientoCcProveedor.Compra, id, idGasto: null, encabezado.Total, nuevoSaldoProveedor, detalle: null, ct);
+
         await transaccion.CommitAsync(ct);
 
         return await ObtenerAsync(id, ct);
@@ -510,8 +527,8 @@ public class ServicioDeCompras(
         var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
 
         // 1. UPDATE ... RETURNING — misma autoridad única que confirmar.
-        var idPuntoVenta = await MarcarAnuladaAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
-        if (idPuntoVenta is null)
+        var encabezadoAnulado = await MarcarAnuladaAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
+        if (encabezadoAnulado is null)
         {
             var existe = await db.ComprobantesCompra.AsNoTracking().AnyAsync(c => c.Id == id, ct);
             if (!existe)
@@ -521,6 +538,8 @@ public class ServicioDeCompras(
 
             throw new ErrorDominio("compra_no_confirmada", "La compra no está confirmada.", 409);
         }
+
+        var idPuntoVenta = encabezadoAnulado.Value.IdPuntoVenta;
 
         // 1.5. Auditoría (stage-14-auditoria-trazabilidad, Slice 3; spec auditoria-de-operaciones;
         // design call site 8) — MISMA transacción cruda; id_punto_venta sale del RETURNING que
@@ -593,6 +612,36 @@ public class ServicioDeCompras(
         // 4. Informativo — la regla invertida (design decisión 6): NUNCA bloquea.
         var gastosLigados = await db.Gastos.CountAsync(g => g.IdComprobanteCompra == id, ct);
 
+        // 5. El ledger ES la autoridad del importe a revertir (stage-15-cc-proveedores-ledger,
+        // design decisión 6) — nunca recalculado desde items/total salvo el fallback explícito de
+        // abajo. 0 filas ⇒ compra confirmada ANTES del cutover (su deuda vive en el `apertura` del
+        // backfill, sin `compra` movement propio, decisión 1 del proposal): el fallback usa
+        // `total` del mismo RETURNING que ya lockeó el header (mutation target #20 — sin este
+        // fallback una anulación pre-cutover dejaría la deuda en los libros).
+        var movimientosCompraOriginales = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdComprobanteCompra == id && m.Tipo == TipoMovimientoCcProveedor.Compra)
+            .Select(m => m.Importe)
+            .ToListAsync(ct);
+
+        var esPreCutover = movimientosCompraOriginales.Count == 0;
+        var importeOriginal = esPreCutover ? encabezadoAnulado.Value.Total : movimientosCompraOriginales.Sum();
+        var detalleAjuste = esPreCutover
+            ? "Contramovimiento de anulación (etapa 15): compra confirmada antes del ledger de " +
+              "proveedores; importe tomado del total del comprobante (no existe movimiento compra propio)."
+            : null;
+
+        // 6. proveedores — ÚLTIMO lock de fila for update de esta transacción, igual que en
+        // confirmar (design decisión 5/9, mutation target #19 — el mismo orden total aplica acá).
+        var nuevoSaldoProveedor = await EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+            conexion, transaccionCruda, idTenant, encabezadoAnulado.Value.IdProveedor, -importeOriginal, ct);
+
+        // 7. El ÚNICO movimiento `ajuste` reversor de esta anulación — solo la deuda se revierte,
+        // los pagos (`gastos`/movimientos `pago`) NUNCA se tocan ("sin motor de reversión de
+        // gastos" sobrevive verbatim, design decisión 5).
+        await EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            conexion, transaccionCruda, idTenant, encabezadoAnulado.Value.IdProveedor, momento, idPuntoVenta, idEmpleado,
+            TipoMovimientoCcProveedor.Ajuste, id, idGasto: null, -importeOriginal, nuevoSaldoProveedor, detalleAjuste, ct);
+
         await transaccion.CommitAsync(ct);
 
         var detalle = await ObtenerAsync(id, ct);
@@ -645,10 +694,13 @@ public class ServicioDeCompras(
 
     /// <summary>Fila devuelta por el UPDATE...RETURNING de <see cref="ConfirmarHeaderAsync"/> —
     /// design: Transactions — CONFIRMAR COMPRA, paso 1. Los valores son los que ESTE lock vio,
-    /// nunca los leídos antes de entrar a la transacción. Solo se devuelven las columnas que la
-    /// transacción consume: la completitud de numero_externo/fecha_comprobante ya la valida el
-    /// propio predicado del UPDATE, así que devolverlas sería código muerto.</summary>
-    private readonly record struct EncabezadoConfirmado(int IdPuntoVenta, int IdTipoComprobante);
+    /// nunca los leídos antes de entrar a la transacción. <c>IdProveedor</c>/<c>Total</c>
+    /// ensanchan el <c>RETURNING</c> (stage-15-cc-proveedores-ledger, design decisión 4): la
+    /// escritura del ledger de proveedor los necesita y este lock ya los tiene, así que leerlos
+    /// del <c>preLectura</c> anterior o con un <c>SELECT</c> aparte sería confiar en un valor que
+    /// un <c>PUT</c> concurrente pudo cambiar entre esa lectura y este lock (mutation target
+    /// #15).</summary>
+    private readonly record struct EncabezadoConfirmado(int IdPuntoVenta, int IdTipoComprobante, int IdProveedor, decimal Total);
 
     /// <summary>El predicado incluye <c>numero_externo</c>/<c>fecha_comprobante IS NOT NULL</c>
     /// además de <c>estado='borrador'</c> — validación bajo el mismo lock, resuelta por el propio
@@ -669,7 +721,7 @@ public class ServicioDeCompras(
             "UPDATE comprobantes_compra SET estado = 'confirmada'::estado_compra, fecha_recepcion = $1, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'borrador'::estado_compra " +
             "AND numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL " +
-            "RETURNING id_punto_venta, id_tipo_comprobante";
+            "RETURNING id_punto_venta, id_tipo_comprobante, id_proveedor, total";
 
         ParametrosDeComando.Agregar(comando, momento);
         ParametrosDeComando.Agregar(comando, id);
@@ -681,10 +733,22 @@ public class ServicioDeCompras(
             return null;
         }
 
-        return new EncabezadoConfirmado(lector.GetInt32(0), lector.GetInt32(1));
+        return new EncabezadoConfirmado(lector.GetInt32(0), lector.GetInt32(1), lector.GetInt32(2), lector.GetDecimal(3));
     }
 
-    private static async Task<int?> MarcarAnuladaAsync(
+    /// <summary>Fila devuelta por el UPDATE...RETURNING de <see cref="MarcarAnuladaAsync"/>.
+    /// <c>IdProveedor</c>/<c>Total</c> ensanchan el <c>RETURNING</c> (stage-15-cc-proveedores-
+    /// ledger, design decisión 4/6). <c>Total</c> es una CORRECCIÓN registrada (tasks.md decisión
+    /// 14, mismo criterio que la deviación 15 de slice 1): la lista literal de columnas de
+    /// decisión 4 (`id_punto_venta, id_proveedor`) omite `total`, pero el paso 5 de la sección
+    /// Transactions del propio design ("0 filas ⇒ compra pre-cutover ⇒ importeOriginal := total
+    /// del RETURNING") exige leerlo de ESTE `RETURNING` — el mismo lock, cero round trips extra,
+    /// exactamente la razón que decisión 4 da para ensanchar en primer lugar. `total` no cambia
+    /// tras confirmar (spec comprobantes-compra: "confirmada... MUST be immutable"), así que este
+    /// valor es tan autoritativo como cualquier otro leído bajo este lock.</summary>
+    private readonly record struct EncabezadoAnulado(int IdPuntoVenta, int IdProveedor, decimal Total);
+
+    private static async Task<EncabezadoAnulado?> MarcarAnuladaAsync(
         DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
@@ -692,14 +756,19 @@ public class ServicioDeCompras(
         comando.CommandText =
             "UPDATE comprobantes_compra SET estado = 'anulada'::estado_compra, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'confirmada'::estado_compra " +
-            "RETURNING id_punto_venta";
+            "RETURNING id_punto_venta, id_proveedor, total";
 
         ParametrosDeComando.Agregar(comando, momento);
         ParametrosDeComando.Agregar(comando, id);
         ParametrosDeComando.Agregar(comando, idTenant);
 
-        var resultado = await comando.ExecuteScalarAsync(ct);
-        return resultado is null ? null : Convert.ToInt32(resultado);
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return new EncabezadoAnulado(lector.GetInt32(0), lector.GetInt32(1), lector.GetDecimal(2));
     }
 
     private static async Task<bool> BloquearBorradorAsync(

--- a/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorrienteProveedor.cs
+++ b/src/Ways.Application/CuentaCorriente/EscriturasDeCuentaCorrienteProveedor.cs
@@ -1,0 +1,144 @@
+using System.Data.Common;
+using Ways.Application.Abstracciones;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// Los dos statements crudos que son la ÚNICA autoridad de escritura sobre
+/// <c>proveedores.saldo</c>/<c>movimientos_cuenta_corriente_proveedor</c> (design decisión 1:
+/// "una sola <c>EscriturasDeCuentaCorrienteProveedor</c>", stage-15-cc-proveedores-ledger) —
+/// copia estructural VERBATIM de <see cref="EscriturasDeCuentaCorriente"/>: misma forma
+/// <c>static</c>, misma postura de conexión/transacción del llamador (nunca abre, flushea ni
+/// comitea nada), mismos parámetros por <see cref="ParametrosDeComando"/>. El único cambio real
+/// es el <c>ValidarFormaPorTipo</c> propio, porque la matriz 4×3 de esta tabla (design.md:113-118)
+/// no es la de <c>TipoMovimientoCc</c>. <c>ServicioDeCompras</c> (confirm/anulación) y, en slice 3,
+/// <c>ServicioDeGastos</c> (pago) y el ajuste manual (slice 5) llaman a esta clase en vez de
+/// duplicar el SQL: así queda exactamente UN <c>UPDATE proveedores ... saldo ... RETURNING</c> y
+/// UN <c>INSERT movimientos_cuenta_corriente_proveedor</c> en todo el codebase — "la extracción es
+/// lo que compra seguridad" (design: Technical Approach, decisión 1).
+/// </summary>
+public static class EscriturasDeCuentaCorrienteProveedor
+{
+    /// <summary><c>UPDATE ... RETURNING</c> crudo: nunca vía una entidad <c>Proveedor</c>
+    /// trackeada (un <c>proveedor.Saldo += x</c> por <c>SaveChangesAsync</c> duplicaría el
+    /// incremento en un reintento de <c>CreateExecutionStrategy</c> — design decisión 2).
+    /// <c>id_tenant</c> en el <c>WHERE</c> además de <c>id</c>: RLS ya aísla por tenant, esto es
+    /// una segunda capa barata (mismo criterio que <c>EscriturasDeCuentaCorriente</c>). Es el
+    /// ÚLTIMO lock de fila (<c>for update</c>) de cualquier transacción que lo llame (design:
+    /// Transactions, "Total order").</summary>
+    public static async Task<decimal> ActualizarSaldoProveedorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idProveedor, decimal importe,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE proveedores SET saldo = saldo + $1 WHERE id_proveedor = $2 AND id_tenant = $3 RETURNING saldo";
+
+        ParametrosDeComando.Agregar(comando, importe);
+        ParametrosDeComando.Agregar(comando, idProveedor);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException($"No se pudo actualizar el saldo del proveedor {idProveedor}.");
+
+        return Convert.ToDecimal(resultado);
+    }
+
+    /// <summary>El ÚNICO <c>INSERT</c> del ledger de proveedores. <paramref name="idPuntoVenta"/>/
+    /// <paramref name="idEmpleado"/> son <c>int?</c> SOLO para que
+    /// <see cref="TipoMovimientoCcProveedor.Apertura"/> sea representable en el tipo; ningún
+    /// llamador de producción de esta etapa pasa null en esas dos posiciones (la única escritora
+    /// de <c>apertura</c> es la migración) y <c>ValidarFormaPorTipo</c> lo refuerza (design
+    /// decisión 15: "apertura is refused at three layers").</summary>
+    public static async Task<int> InsertarMovimientoCcProveedorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idProveedor, DateTimeOffset fecha,
+        int? idPuntoVenta, int? idEmpleado, TipoMovimientoCcProveedor tipo, int? idComprobanteCompra,
+        int? idGasto, decimal importe, decimal saldoResultante, string? detalle, CancellationToken ct)
+    {
+        ValidarFormaPorTipo(tipo, idComprobanteCompra, idGasto, idPuntoVenta, idEmpleado);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_cuenta_corriente_proveedor " +
+            "(id_tenant, id_proveedor, fecha, id_punto_venta, id_empleado, tipo, id_comprobante_compra, " +
+            " id_gasto, importe, saldo_resultante, detalle) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) " +
+            "RETURNING id_movimiento";
+
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idProveedor);
+        ParametrosDeComando.Agregar(comando, fecha);
+        ParametrosDeComando.AgregarNulo(comando, idPuntoVenta);
+        ParametrosDeComando.AgregarNulo(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, tipo);
+        ParametrosDeComando.AgregarNulo(comando, idComprobanteCompra);
+        ParametrosDeComando.AgregarNulo(comando, idGasto);
+        ParametrosDeComando.Agregar(comando, importe);
+        ParametrosDeComando.Agregar(comando, saldoResultante);
+        ParametrosDeComando.AgregarNulo(comando, detalle);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException("No se pudo insertar el movimiento de cuenta corriente de proveedor.");
+        return Convert.ToInt32(resultado);
+    }
+
+    /// <summary>Defensa en profundidad, infraestructura pura (nunca un <c>ErrorDominio</c> 4xx: una
+    /// violación es un defecto de un call site, no un error de cliente) — pinea acá, en el único
+    /// escritor, la forma por tipo de la matriz 4×3 (design.md:113-118, gate §B CHECK). Un arm por
+    /// clausula, mismo criterio que <c>EscriturasDeCuentaCorriente.ValidarFormaPorTipo</c>, para que
+    /// cada mutation target (#12, #13) tenga una línea propia para borrar.</summary>
+    private static void ValidarFormaPorTipo(
+        TipoMovimientoCcProveedor tipo, int? idComprobanteCompra, int? idGasto, int? idPuntoVenta, int? idEmpleado)
+    {
+        if (tipo == TipoMovimientoCcProveedor.Apertura && (idPuntoVenta is not null || idEmpleado is not null))
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Apertura no lleva id_punto_venta ni id_empleado — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Apertura && idComprobanteCompra is not null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Apertura no lleva id_comprobante_compra — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Apertura && idGasto is not null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Apertura no lleva id_gasto — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Compra && idComprobanteCompra is null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Compra requiere id_comprobante_compra — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Compra && idGasto is not null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Compra nunca lleva id_gasto — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Pago && idGasto is null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Pago requiere id_gasto — invariante de escritura violado.");
+        }
+
+        if (tipo == TipoMovimientoCcProveedor.Ajuste && idGasto is not null)
+        {
+            throw new InvalidOperationException(
+                "Un movimiento de tipo Ajuste nunca lleva id_gasto — invariante de escritura violado.");
+        }
+
+        if (tipo != TipoMovimientoCcProveedor.Apertura && (idPuntoVenta is null || idEmpleado is null))
+        {
+            throw new InvalidOperationException(
+                $"Un movimiento de tipo {tipo} requiere id_punto_venta e id_empleado — invariante de escritura violado.");
+        }
+    }
+}

--- a/tests/Ways.Application.Tests/Compras/ServicioDeComprasLockOrderTests.cs
+++ b/tests/Ways.Application.Tests/Compras/ServicioDeComprasLockOrderTests.cs
@@ -1,0 +1,111 @@
+namespace Ways.Application.Tests.Compras;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 2 (task 2.9; design.md: Transactions — Total order,
+/// "`proveedores` is the last row lock any transaction takes for update, and the ledger `INSERT`
+/// follows it immediately"). Mutation target #19: si el lock de <c>proveedores</c>
+/// (<c>EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync</c>) se moviera al paso
+/// 1.5 (antes del loop de stock) dentro de <c>EjecutarConfirmarAsync</c>/
+/// <c>EjecutarAnulacionAsync</c>, esta prueba debe fallar.
+///
+/// Resuelto con una aserción de TEXTO FUENTE, no de comportamiento — mismo criterio que los
+/// mutation targets #4/#11 de slice 1 (<c>CuentaCorrienteProveedorBackfillTests</c>): un
+/// <c>DbCommandInterceptor</c> de EF Core NUNCA ve los statements de
+/// <c>EjecutarConfirmarAsync</c>/<c>EjecutarAnulacionAsync</c> — se crean vía
+/// <c>conexion.CreateCommand()</c> sobre <c>db.Database.GetDbConnection()</c> directamente, fuera
+/// del pipeline de comandos de EF Core (confirmado empíricamente: la primera versión de esta
+/// prueba usaba un interceptor y <c>interceptor.Orden</c> quedó vacío en la corrida real contra
+/// <c>WaysApiFixture</c> — mutation-proof-tests rule 2, "no lo razones, corré la prueba"). No hay
+/// seam de runtime para rutear la prueba por debajo del confound (rule 3 exhausted first); el
+/// orden de las llamadas es, literalmente, el único artefacto observable.
+/// </summary>
+public class ServicioDeComprasLockOrderTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        // tests/Ways.Application.Tests/Compras/ → ../../src/Ways.Application/Compras/ (mismo
+        // criterio que CuentaCorrienteProveedorBackfillTests.RutaDeEsteArchivo, slice 1).
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "Compras", "ServicioDeCompras.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
+
+    [Fact]
+    public void ElLockDeSaldoDeProveedorEsElUltimoDeEjecutarConfirmarAsyncYElLedgerLoSigue()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente, "private async Task<CompraDetalle> EjecutarConfirmarAsync(",
+            "public async Task<ResultadoAnulacion> AnularAsync(");
+
+        var indiceStockInsert = metodo.LastIndexOf("InsertarMovimientoStockAsync(", StringComparison.Ordinal);
+        var indiceCostoUpdate = metodo.LastIndexOf("ActualizarCostoNominalAsync(", StringComparison.Ordinal);
+        var indiceLockProveedor = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(", StringComparison.Ordinal);
+        var indiceLedgerInsert = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(", StringComparison.Ordinal);
+        var indiceCommit = metodo.IndexOf("transaccion.CommitAsync(ct);", StringComparison.Ordinal);
+
+        Assert.True(indiceStockInsert >= 0, "No se encontró la última llamada a InsertarMovimientoStockAsync.");
+        Assert.True(indiceCostoUpdate >= 0, "No se encontró la llamada a ActualizarCostoNominalAsync.");
+        Assert.True(indiceLockProveedor >= 0, "No se encontró la llamada a ActualizarSaldoProveedorAsync.");
+        Assert.True(indiceLedgerInsert >= 0, "No se encontró la llamada a InsertarMovimientoCcProveedorAsync.");
+        Assert.True(indiceCommit >= 0, "No se encontró el commit de EjecutarConfirmarAsync.");
+
+        Assert.True(
+            indiceLockProveedor > indiceStockInsert,
+            "El lock de proveedores debe aparecer DESPUÉS del último InsertarMovimientoStockAsync (mutation target #19).");
+        Assert.True(
+            indiceLockProveedor > indiceCostoUpdate,
+            "El lock de proveedores debe aparecer DESPUÉS de ActualizarCostoNominalAsync (mutation target #19).");
+        Assert.True(
+            indiceLedgerInsert > indiceLockProveedor,
+            "El INSERT del ledger de proveedor debe seguir inmediatamente al lock de saldo.");
+        Assert.True(
+            indiceCommit > indiceLedgerInsert,
+            "El commit de confirmar debe ser posterior al INSERT del ledger de proveedor.");
+    }
+
+    [Fact]
+    public void ElLockDeSaldoDeProveedorEsElUltimoDeEjecutarAnulacionAsyncYElLedgerLoSigue()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente, "private async Task<ResultadoAnulacion> EjecutarAnulacionAsync(",
+            "// ---- aplicar precio sugerido");
+
+        var indiceGastosLigados = metodo.IndexOf("db.Gastos.CountAsync(g => g.IdComprobanteCompra == id, ct);", StringComparison.Ordinal);
+        var indiceLockProveedor = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(", StringComparison.Ordinal);
+        var indiceLedgerInsert = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(", StringComparison.Ordinal);
+        var indiceCommit = metodo.IndexOf("transaccion.CommitAsync(ct);", StringComparison.Ordinal);
+
+        Assert.True(indiceGastosLigados >= 0, "No se encontró el conteo informativo de gastosLigados.");
+        Assert.True(indiceLockProveedor >= 0, "No se encontró la llamada a ActualizarSaldoProveedorAsync.");
+        Assert.True(indiceLedgerInsert >= 0, "No se encontró la llamada a InsertarMovimientoCcProveedorAsync.");
+        Assert.True(indiceCommit >= 0, "No se encontró el commit de EjecutarAnulacionAsync.");
+
+        Assert.True(
+            indiceLockProveedor > indiceGastosLigados,
+            "El lock de proveedores debe aparecer DESPUÉS del conteo informativo de gastosLigados (mutation target #19).");
+        Assert.True(
+            indiceLedgerInsert > indiceLockProveedor,
+            "El INSERT del ledger de proveedor debe seguir inmediatamente al lock de saldo.");
+        Assert.True(
+            indiceCommit > indiceLedgerInsert,
+            "El commit de anular debe ser posterior al INSERT del ledger de proveedor.");
+    }
+}

--- a/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteProveedorTests.cs
+++ b/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteProveedorTests.cs
@@ -143,4 +143,60 @@ public class EscriturasDeCuentaCorrienteProveedorTests
         Assert.Contains("Apertura", excepcion.Message);
         Assert.Contains("id_punto_venta", excepcion.Message);
     }
+
+    // ---- mutation target #17: UPDATE aditivo crudo, nunca un Proveedor.Saldo trackeado -------------
+
+    /// <summary>Mutation target #17 (task 2.23) es un mutante PROVABLY EQUIVALENT AT RUNTIME contra
+    /// los call sites reales de este slice — resuelto con una aserción de texto fuente, mismo
+    /// criterio que los targets #4/#11 de slice 1
+    /// (<c>CuentaCorrienteProveedorBackfillTests</c>) y el #19 de este mismo slice
+    /// (<c>ServicioDeComprasLockOrderTests</c>), <c>mutation-proof-tests</c> rule 3 agotada
+    /// primero.
+    ///
+    /// El escenario literal del target ("double-count under a forced execution-strategy retry")
+    /// es estructuralmente INALCANZABLE por <c>ServicioDeCompras.ConfirmarAsync</c>/
+    /// <c>AnularAsync</c>: ambos envuelven su núcleo transaccional en
+    /// <c>FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento</c>
+    /// (<c>maxRetryCount: 0</c>, <c>ShouldRetryOn</c> siempre <c>false</c>) — cuyo propio
+    /// doc-comment declara que existe PRECISAMENTE para que un reintento nunca vuelva a ejecutar
+    /// este statement. Construir una prueba de comportamiento que fuerce ese reintento exigiría
+    /// bypassear la propia clase que este código usa para prevenirlo — lo que la prueba
+    /// necesitaría demostrar que NO puede pasar.
+    /// </summary>
+    [Fact]
+    public void ElTextoFuenteDeActualizarSaldoProveedorAsyncUsaElUpdateAditivoCrudoTarget17()
+    {
+        var fuente = LeerFuenteDeEscriturasDeCuentaCorrienteProveedor();
+        var metodo = ExtraerMetodo(fuente, "public static async Task<decimal> ActualizarSaldoProveedorAsync(", "public static async Task<int> InsertarMovimientoCcProveedorAsync(");
+
+        Assert.Contains("UPDATE proveedores SET saldo = saldo + $1", metodo);
+
+        // Nunca una entidad Proveedor trackeada — ningún acceso a IWaysDbContext.Proveedores ni a
+        // SaveChangesAsync dentro de este método (design decisión 2).
+        Assert.DoesNotContain(".Proveedores", metodo);
+        Assert.DoesNotContain("SaveChangesAsync", metodo);
+    }
+
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuenteDeEscriturasDeCuentaCorrienteProveedor()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "CuentaCorriente", "EscriturasDeCuentaCorrienteProveedor.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
 }

--- a/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteProveedorTests.cs
+++ b/tests/Ways.Application.Tests/CuentaCorriente/EscriturasDeCuentaCorrienteProveedorTests.cs
@@ -1,0 +1,146 @@
+using Ways.Application.CuentaCorriente;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 2 (task 2.10; design.md:113-118, 372): la matriz 4×3 de
+/// forma por tipo de <c>EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync</c>
+/// — un fact por combinación ilegal. El guard corre ANTES de tocar la conexión (mismo criterio que
+/// <see cref="EscriturasDeCuentaCorrienteTests"/>), así que <c>null!</c> alcanza para pinearlo sin
+/// una base de datos real.
+///
+/// Mutation targets #12 y #13 (task 2.18, 2.19): borrar el arm de <c>Compra</c> exige comprobante,
+/// o el arm de <c>Apertura</c> prohíbe actor/PV, y estos mismos facts deben fallar.
+/// </summary>
+public class EscriturasDeCuentaCorrienteProveedorTests
+{
+    private static Task<int> InsertarAsync(
+        TipoMovimientoCcProveedor tipo, int? idComprobanteCompra = null, int? idGasto = null,
+        int? idPuntoVenta = null, int? idEmpleado = null) =>
+        EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            null!, null, idTenant: 1, idProveedor: 1, fecha: DateTimeOffset.UtcNow, idPuntoVenta, idEmpleado,
+            tipo, idComprobanteCompra, idGasto, importe: 100m, saldoResultante: 100m, detalle: null,
+            CancellationToken.None);
+
+    // ---- apertura ---------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaAperturaConIdPuntoVentaViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Apertura, idPuntoVenta: 5));
+
+        Assert.Contains("Apertura", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaAperturaConIdEmpleadoViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Apertura, idEmpleado: 5));
+
+        Assert.Contains("Apertura", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaAperturaConIdComprobanteCompraViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Apertura, idComprobanteCompra: 5));
+
+        Assert.Contains("Apertura", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaAperturaConIdGastoViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Apertura, idGasto: 5));
+
+        Assert.Contains("Apertura", excepcion.Message);
+    }
+
+    // ---- compra (mutation target #12) --------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaCompraSinIdComprobanteCompraViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Compra, idPuntoVenta: 1, idEmpleado: 1));
+
+        Assert.Contains("Compra", excepcion.Message);
+        Assert.Contains("id_comprobante_compra", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaCompraConIdGastoViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Compra, idComprobanteCompra: 5, idGasto: 9, idPuntoVenta: 1, idEmpleado: 1));
+
+        Assert.Contains("Compra", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnaCompraSinPuntoDeVentaViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Compra, idComprobanteCompra: 5, idEmpleado: 1));
+
+        Assert.Contains("Compra", excepcion.Message);
+    }
+
+    // ---- pago ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnPagoSinIdGastoViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Pago, idPuntoVenta: 1, idEmpleado: 1));
+
+        Assert.Contains("Pago", excepcion.Message);
+        Assert.Contains("id_gasto", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnPagoSinActorViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Pago, idGasto: 9));
+
+        Assert.Contains("Pago", excepcion.Message);
+    }
+
+    // ---- ajuste --------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnAjusteConIdGastoViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Ajuste, idGasto: 9, idPuntoVenta: 1, idEmpleado: 1));
+
+        Assert.Contains("Ajuste", excepcion.Message);
+    }
+
+    [Fact]
+    public async Task UnAjusteSinActorViolaLaFormaYLanza()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Ajuste, idComprobanteCompra: 5));
+
+        Assert.Contains("Ajuste", excepcion.Message);
+    }
+
+    // ---- mutation target #13: Apertura forbids actor/PV (arm aislado de compra/pago/ajuste) ---------
+
+    [Fact]
+    public async Task UnaAperturaConPuntoDeVentaYEmpleadoJuntosViolaLaFormaYLanzaMencionandoApertura()
+    {
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InsertarAsync(TipoMovimientoCcProveedor.Apertura, idPuntoVenta: 1, idEmpleado: 1));
+
+        Assert.Contains("Apertura", excepcion.Message);
+        Assert.Contains("id_punto_venta", excepcion.Message);
+    }
+}

--- a/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasAnulacionYConcurrenciaTests.cs
@@ -796,6 +796,10 @@ public class ComprasAnulacionYConcurrenciaTests(WaysApiFixture fixture) : IClass
                 npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                 npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                 npgsql.MapEnum<EstadoCompra>("estado_compra");
+                // stage-15-cc-proveedores-ledger, Slice 2: ConfirmarAsync/AnularAsync ahora
+                // escriben el ledger de proveedor — sin este mapeo, ExecuteScalarAsync/
+                // ExecuteReaderAsync fallan al (de)serializar TipoMovimientoCcProveedor.
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
             })
             .AddInterceptors(new Ways.Infrastructure.Multitenancy.InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
@@ -108,6 +108,11 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                     npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                     npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                     npgsql.MapEnum<EstadoCompra>("estado_compra");
+                    // stage-15-cc-proveedores-ledger, Slice 2 (hallazgo registrado en tasks.md):
+                    // sin este mapeo, migrar hasta HEAD dispara PendingModelChangesWarning — el
+                    // modelo vivo de este contexto manualmente curado diverge del snapshot real
+                    // (que sí conoce tipo_movimiento_cc_proveedor desde slice 1).
+                    npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -193,6 +193,10 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
                     npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                     npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                     npgsql.MapEnum<EstadoCompra>("estado_compra");
+                    // stage-15-cc-proveedores-ledger, Slice 2 (hallazgo registrado en tasks.md,
+                    // mismo gap que ComprasTipoSeedTests/ComprasAnulacionYConcurrenciaTests):
+                    // migrar hasta HEAD sin este mapeo dispara PendingModelChangesWarning.
+                    npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
@@ -1,7 +1,9 @@
+using System.Data.Common;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Ways.Application.Abstracciones;
@@ -19,6 +21,7 @@ using Ways.Domain.Organizacion;
 using Ways.Domain.Proveedores;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 
 namespace Ways.IntegrationTests;
 
@@ -148,6 +151,76 @@ public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : I
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
         Assert.Equal(5000m, proveedor.Saldo);
         Assert.Equal(proveedor.Saldo, movimiento.SaldoResultante);
+    }
+
+    // ---- mutation target #15: id_proveedor/total salen del RETURNING del lock, no de preLectura ---
+
+    /// <summary>Pausa <c>EjecutarConfirmarAsync</c> justo DESPUÉS de <c>BeginTransactionAsync</c> —
+    /// antes de que el <c>UPDATE ... RETURNING</c> del header corra — mismo patrón que
+    /// <c>ComprasAnulacionYConcurrenciaTests.InterceptorDePausaTrasIniciarLaTransaccion</c> (cada
+    /// archivo de este repo mantiene su propia copia, no comparte una base).</summary>
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target #15 (task 2.21): si <c>encabezado.Total</c> viniera de
+    /// <c>preLectura</c> (leída ANTES de la transacción) en vez del <c>RETURNING</c> del lock, el
+    /// movimiento `compra` cargaría el total VIEJO — un PUT concurrente que sube el costoUnitario
+    /// (y por lo tanto el total) DESPUÉS de <c>preLectura</c> pero ANTES del lock debe reflejarse
+    /// en el importe del movimiento.</summary>
+    [Fact]
+    public async Task ConfirmarConCambioDeTotalConcurrentePorUnPutUsaElTotalQueElLockRealmenteVio()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarConCambioDeTotalConcurrentePorUnPutUsaElTotalQueElLockRealmenteVio));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 100m, numeroExterno: "total-race"));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteConfirmar = factory.CreateClient();
+        var login = await clienteConfirmar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaConfirmar = clienteConfirmar.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+
+        await transaccionIniciada.Task;
+
+        // El PUT gana la carrera: sube costoUnitario (100 → 250, total 1000 → 2500) y COMMITEA
+        // antes de que el lock del header de confirmar corra.
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync(
+            $"/api/compras/{creada.Id}", SolicitudSimple(ctx, unidades: 10m, costoUnitario: 250m, numeroExterno: "total-race"));
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosCuentaCorrienteProveedor.SingleAsync(m => m.IdComprobanteCompra == creada.Id);
+
+        // El total que el LOCK vio (2500, post-PUT) — nunca el 1000 que preLectura capturó antes
+        // de que el confirmar entrara a la transacción.
+        Assert.Equal(2500m, movimiento.Importe);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(2500m, proveedor.Saldo);
     }
 
     // ---- task 2.12: anulando una compra impaga reversa solo la deuda ------------------------------

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
@@ -1,0 +1,469 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 2: el movimiento `compra` en confirmar (tasks 2.11,
+/// 2.15, 2.16), el contramovimiento `ajuste` en anular — impago, pagado y pre-cutover (tasks
+/// 2.12-2.14) —, el orden de locks pineado (task 2.9) y la carrera confirm × pago (task 2.17).
+/// Mutation targets #14-#20 (tasks 2.20-2.26) — evidencia de mutación registrada en el PR body,
+/// no en este archivo.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
+        int IdTipoCFB, string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "CC-proveedor-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        // C-FB no discrimina IVA (a diferencia de C-FA) — total == unidades * costoUnitario
+        // exactamente, sin sumar el 21%, así los importes esperados de este archivo son directos.
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21,
+            idTipoCFB, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(
+        Contexto ctx, decimal unidades = 10m, decimal costoUnitario = 100m, string? numeroExterno = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, numeroExterno ?? $"0001-{Guid.NewGuid():N}"[..14],
+            DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearBorradorAsync(Contexto ctx, SolicitudDeCompra? solicitud = null)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud ?? SolicitudSimple(ctx));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<CompraDetalle> ConfirmarViaApiAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 2.11: confirmar escribe exactamente un movimiento compra ----------------------------
+
+    [Fact]
+    public async Task ConfirmarUnaCompraEscribeExactamenteUnMovimientoCompraYSubeElSaldo()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUnaCompraEscribeExactamenteUnMovimientoCompraYSubeElSaldo));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 500m));
+
+        await ConfirmarViaApiAsync(ctx, creada.Id);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdComprobanteCompra == creada.Id)
+            .ToListAsync();
+
+        var movimiento = Assert.Single(movimientos);
+        Assert.Equal(TipoMovimientoCcProveedor.Compra, movimiento.Tipo);
+        Assert.Equal(5000m, movimiento.Importe);
+        Assert.Null(movimiento.IdGasto);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(5000m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, movimiento.SaldoResultante);
+    }
+
+    // ---- task 2.12: anulando una compra impaga reversa solo la deuda ------------------------------
+
+    [Fact]
+    public async Task AnulandoUnaCompraImpagaReviertaSoloLaDeuda()
+    {
+        var ctx = await PrepararAsync(nameof(AnulandoUnaCompraImpagaReviertaSoloLaDeuda));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 100m));
+        await ConfirmarViaApiAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ajustes = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdComprobanteCompra == creada.Id && m.Tipo == TipoMovimientoCcProveedor.Ajuste)
+            .ToListAsync();
+
+        var ajuste = Assert.Single(ajustes);
+        Assert.Equal(-1000m, ajuste.Importe);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+    }
+
+    // ---- task 2.13: anulando una compra totalmente pagada deja saldo a favor ----------------------
+
+    /// <summary>Simula el pago llamando DIRECTO a la clase escritora del slice 2 (decisión 7 de
+    /// tasks.md: el call site real de <c>ServicioDeGastos</c> recién existe en slice 3) — necesita
+    /// un <c>gastos</c> row solo para satisfacer la FK de <c>id_gasto</c>, sin pasar por
+    /// <c>InsertarGastoAsync</c>.</summary>
+    private async Task<int> SembrarGastoParaFkAsync(Contexto ctx, int idComprobanteCompra, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+        var idMedioPago = await db.MediosPago.Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var turno = new TurnoCaja
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdEmpleadoApertura = idEmpleado,
+            FechaApertura = ahora, FondoInicial = 0m, Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.TurnosCaja.Add(turno);
+        await db.SaveChangesAsync();
+
+        var gasto = new Gasto
+        {
+            IdTenant = ctx.IdTenant, Fecha = ahora, IdPuntoVenta = ctx.IdPuntoVenta, IdTurnoCaja = turno.Id,
+            IdEmpleado = idEmpleado, Categoria = CategoriaGasto.Proveedor, IdProveedor = ctx.IdProveedor,
+            Concepto = "Pago simulado (slice 2)", IdMedioPago = idMedioPago, Importe = importe,
+            IdComprobanteCompra = idComprobanteCompra, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Gastos.Add(gasto);
+        await db.SaveChangesAsync();
+
+        return gasto.Id;
+    }
+
+    private async Task<int> SimularPagoDirectoAsync(Contexto ctx, int idComprobanteCompra, int idGasto, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idEmpleado = await db.Usuarios.Select(u => u.Id).FirstAsync();
+        var conexion = db.Database.GetDbConnection();
+        await db.Database.OpenConnectionAsync();
+
+        var nuevoSaldo = await EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+            conexion, null, ctx.IdTenant, ctx.IdProveedor, -importe, CancellationToken.None);
+
+        await EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            conexion, null, ctx.IdTenant, ctx.IdProveedor, DateTimeOffset.UtcNow, ctx.IdPuntoVenta, idEmpleado,
+            TipoMovimientoCcProveedor.Pago, idComprobanteCompra, idGasto, -importe, nuevoSaldo, detalle: null,
+            CancellationToken.None);
+
+        return idGasto;
+    }
+
+    [Fact]
+    public async Task AnulandoUnaCompraTotalmentePagadaDejaSaldoAFavor()
+    {
+        var ctx = await PrepararAsync(nameof(AnulandoUnaCompraTotalmentePagadaDejaSaldoAFavor));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 100m));
+        await ConfirmarViaApiAsync(ctx, creada.Id);
+
+        var idGasto = await SembrarGastoParaFkAsync(ctx, creada.Id, 1000m);
+        await SimularPagoDirectoAsync(ctx, creada.Id, idGasto, 1000m);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var ajuste = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == creada.Id && m.Tipo == TipoMovimientoCcProveedor.Ajuste);
+        Assert.Equal(-1000m, ajuste.Importe);
+
+        // El pago y su gasto ligado NUNCA se tocan — "sin motor de reversión de gastos" (design
+        // decisión 5).
+        var pago = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == creada.Id && m.Tipo == TipoMovimientoCcProveedor.Pago);
+        Assert.Equal(-1000m, pago.Importe);
+        Assert.True(await db.Gastos.AnyAsync(g => g.Id == idGasto));
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(-1000m, proveedor.Saldo);
+    }
+
+    // ---- task 2.14 / mutation target #20: anulación pre-cutover usa el fallback -total ------------
+
+    /// <summary>Simula una compra "pre-cutover": confirmada (con su movimiento `compra` normal),
+    /// luego se borra ESE movimiento a mano — la forma exacta de "su deuda vive solo en el
+    /// `apertura` del backfill, sin movimiento `compra` propio" que decisión 1 del proposal
+    /// describe, sin tener que correr una migración completa dentro de un test de slice 2.</summary>
+    private async Task BorrarMovimientoCompraAsync(Contexto ctx, int idComprobanteCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == idComprobanteCompra && m.Tipo == TipoMovimientoCcProveedor.Compra);
+        db.MovimientosCuentaCorrienteProveedor.Remove(movimiento);
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task AnulandoUnaCompraPreCutoverEscribeElAjusteConElFallback()
+    {
+        var ctx = await PrepararAsync(nameof(AnulandoUnaCompraPreCutoverEscribeElAjusteConElFallback));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 200m));
+        await ConfirmarViaApiAsync(ctx, creada.Id);
+        await BorrarMovimientoCompraAsync(ctx, creada.Id);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ajuste = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == creada.Id && m.Tipo == TipoMovimientoCcProveedor.Ajuste);
+
+        Assert.Equal(-2000m, ajuste.Importe);
+        Assert.NotNull(ajuste.Detalle);
+        Assert.Contains("compra confirmada antes del ledger", ajuste.Detalle);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+    }
+
+    // ---- task 2.15 / mutation target #14: fecha bajo offset real -03:00 ---------------------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    [Fact]
+    public async Task ElMovimientoDeCompraUsaLaFechaExactaBajoUnRelojConOffsetRealMenosTres()
+    {
+        var ctx = await PrepararAsync(nameof(ElMovimientoDeCompraUsaLaFechaExactaBajoUnRelojConOffsetRealMenosTres));
+        var creada = await CrearBorradorAsync(ctx);
+
+        // mutation-proof-tests rule 10: offset real -03:00, nunca Z — es la única forma de ver una
+        // regresión de normalización UTC cruda (mutation target #14: ParametrosDeComando.Agregar
+        // sin ToUniversalTime habría hecho que Npgsql rechace este parámetro contra timestamptz).
+        var instanteFijo = new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(new DateTimeOffset(2026, 8, 17, 12, 0, 0, TimeSpan.Zero), instanteFijo);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var respuesta = await cliente.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosCuentaCorrienteProveedor.SingleAsync(m => m.IdComprobanteCompra == creada.Id);
+
+        Assert.Equal(instanteFijo.UtcDateTime, movimiento.Fecha.UtcDateTime);
+        Assert.Equal(TimeSpan.Zero, movimiento.Fecha.Offset);
+    }
+
+    // ---- task 2.16: falla en el punto del ledger deja saldo/ledger/estado sin cambios --------------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYEstadoSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYEstadoSinCambios));
+        var creada = await CrearBorradorAsync(ctx);
+
+        await RevocarAsync("movimientos_cuenta_corriente_proveedor", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        }
+        finally
+        {
+            await RestaurarAsync("movimientos_cuenta_corriente_proveedor", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoCompra.Borrador, (await db.ComprobantesCompra.FirstAsync(c => c.Id == creada.Id)).Estado);
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+
+        // El stock SÍ se escribió antes de llegar al paso del ledger (paso 5/6, el ÚLTIMO) — el
+        // rollback de la transacción entera lo revierte igual, mismo criterio que
+        // ComprasAnulacionYConcurrenciaTests.UnaFallaAlEscribirElMovimientoDeStockDejaLaCompraEnBorrador.
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    // ---- task 2.17: confirm × pago (directo) rendezvous, sin deadlock -----------------------------
+
+    [Fact]
+    public async Task ConfirmarYUnPagoDirectoAlMismoProveedorSeSerializanSinDeadlock()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarYUnPagoDirectoAlMismoProveedorSeSerializanSinDeadlock));
+        var otraCompra = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 5m, costoUnitario: 300m));
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 100m));
+        await ConfirmarViaApiAsync(ctx, otraCompra.Id);
+        var idGasto = await SembrarGastoParaFkAsync(ctx, otraCompra.Id, 400m);
+
+        var tareaConfirmar = ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var tareaPago = SimularPagoDirectoAsync(ctx, otraCompra.Id, idGasto, 400m);
+
+        await Task.WhenAll(tareaConfirmar, tareaPago);
+
+        var respuestaConfirmar = await tareaConfirmar;
+        Assert.Equal(HttpStatusCode.OK, respuestaConfirmar.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+
+        // Compra "otraCompra" (1500) + esta compra (1000) − el pago directo (400) = 2100, sin
+        // lost update — serializados sobre la misma fila de proveedores (design: Concurrency
+        // guarantees).
+        Assert.Equal(2100m, proveedor.Saldo);
+
+        var suma = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdProveedor == ctx.IdProveedor)
+            .SumAsync(m => m.Importe);
+        Assert.Equal(proveedor.Saldo, suma);
+    }
+
+    // ---- task 2.9 / mutation target #19: proveedores es el ÚLTIMO lock, el ledger INSERT sigue ----
+    //
+    // Intentado primero como prueba de comportamiento (un DbCommandInterceptor de EF Core
+    // capturando el orden real de statements) y descartado empíricamente: los statements crudos de
+    // EjecutarConfirmarAsync/EjecutarAnulacionAsync se crean vía `conexion.CreateCommand()` sobre
+    // `db.Database.GetDbConnection()` directamente — nunca pasan por el pipeline de comandos de EF
+    // Core, así que NINGÚN DbCommandInterceptor (ReaderExecuting/ScalarExecuting/NonQueryExecuting)
+    // los ve; `interceptor.Orden` quedó vacío en la corrida real (mutation-proof-tests rule 2: "no
+    // lo razones, corré la prueba"). Resuelto con una aserción de texto fuente —mismo criterio que
+    // los targets #4/#11 de slice 1— en
+    // Ways.Application.Tests/Compras/ServicioDeComprasLockOrderTests.cs, que lee
+    // ServicioDeCompras.cs desde disco y verifica el orden de aparición de las llamadas dentro de
+    // EjecutarConfirmarAsync/EjecutarAnulacionAsync.
+
+    // ---- mutation target #18: AND id_tenant = $3, probado por debajo de RLS -----------------------
+
+    [Fact]
+    public async Task LaActualizacionCrudaDeSaldoExigeElTenantAunConUnaConexionQueBypaseaRls()
+    {
+        var ctxA = await PrepararAsync(nameof(LaActualizacionCrudaDeSaldoExigeElTenantAunConUnaConexionQueBypaseaRls) + "A");
+        var ctxB = await PrepararAsync(nameof(LaActualizacionCrudaDeSaldoExigeElTenantAunConUnaConexionQueBypaseaRls) + "B");
+
+        // ways_owner bypasea RLS por completo (rol superuser del contenedor) — a propósito
+        // (mutation-proof-tests rule 3: "route the test BELOW the confound"), para que la ÚNICA
+        // capa que pueda discriminar acá sea el WHERE del propio statement, nunca la política RLS.
+        await using var dbOwner = fixture.CrearContextoDeOwner(new TenantActualFijo(ModoDeAcceso.Tenant, ctxB.IdTenant));
+        var conexion = dbOwner.Database.GetDbConnection();
+        await dbOwner.Database.OpenConnectionAsync();
+
+        // id_proveedor de tenant A, id_tenant de tenant B — combinación que no matchea ninguna
+        // fila. Con "AND id_tenant = $3" intacto, 0 filas ⇒ InvalidOperationException.
+        var excepcion = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+                conexion, null, ctxB.IdTenant, ctxA.IdProveedor, 100m, CancellationToken.None));
+
+        Assert.Contains(ctxA.IdProveedor.ToString(), excepcion.Message);
+
+        await using var dbVerificacion = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctxA.IdTenant));
+        var proveedorA = await dbVerificacion.Proveedores.FirstAsync(p => p.Id == ctxA.IdProveedor);
+        Assert.Equal(0m, proveedorA.Saldo);
+    }
+
+    // ---- task 2.27: non-regression — el diff de esta slice no toca Ventas -------------------------
+    // Verificado con `git diff --stat` en el reporte de evidencia de mutación (mutation-proof-tests
+    // + design.md Binding verify criteria #2), no como assertion de C# — VentasCheckoutTests.cs
+    // queda intocado por construcción (ningún archivo de esta slice está bajo
+    // src/Ways.Application/Ventas/).
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEscriturasTests.cs
@@ -223,14 +223,52 @@ public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : I
         Assert.Equal(2500m, proveedor.Saldo);
     }
 
+    // ---- mutation target #16: saldo_resultante viene del RETURNING del UPDATE, jamás recalculado --
+
+    /// <summary>Discrimina target #16 contra un mutante de VALOR (no de orden): con saldo previo 0,
+    /// <c>saldo_resultante == total</c> por COINCIDENCIA, así que reemplazar <c>nuevoSaldoProveedor</c>
+    /// por <c>encabezado.Total</c> en <c>EjecutarConfirmarAsync</c> pasaría desapercibido — con
+    /// deuda previa REAL (≠ 0, ≠ total de esta compra) el RETURNING (saldoPrevio + total) y el
+    /// total puro dejan de coincidir (hallazgo del juez B, judgment-day de este slice).</summary>
+    [Fact]
+    public async Task ConfirmarConDeudaPreviaEscribeElSaldoResultanteDelReturningNoElTotalDeEstaCompra()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarConDeudaPreviaEscribeElSaldoResultanteDelReturningNoElTotalDeEstaCompra));
+
+        var compraPrevia = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 8m, costoUnitario: 100m, numeroExterno: "previa"));
+        await ConfirmarViaApiAsync(ctx, compraPrevia.Id); // saldo previo = 800
+
+        var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 15m, costoUnitario: 100m, numeroExterno: "sujeto"));
+        await ConfirmarViaApiAsync(ctx, creada.Id); // total de esta compra = 1500
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosCuentaCorrienteProveedor.SingleAsync(m => m.IdComprobanteCompra == creada.Id);
+
+        // 800 (deuda previa) + 1500 (total de esta compra) = 2300 — si el RETURNING fuera
+        // reemplazado por encabezado.Total a secas, el movimiento cargaría 1500, no 2300.
+        Assert.Equal(2300m, movimiento.SaldoResultante);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(2300m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, movimiento.SaldoResultante);
+    }
+
     // ---- task 2.12: anulando una compra impaga reversa solo la deuda ------------------------------
 
     [Fact]
     public async Task AnulandoUnaCompraImpagaReviertaSoloLaDeuda()
     {
         var ctx = await PrepararAsync(nameof(AnulandoUnaCompraImpagaReviertaSoloLaDeuda));
+
+        // Otra compra confirmada que NO se anula acá — deuda previa que discrimina el mismo
+        // mutante de VALOR que target #16 (si saldo_resultante del ajuste viniera de un valor
+        // local como "el importe" en vez del RETURNING, este resto de 300 desenmascara la
+        // diferencia; con saldo previo 0 el resultado hubiera sido 0 en ambos casos).
+        var otraCompra = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 3m, costoUnitario: 100m, numeroExterno: "resto"));
+        await ConfirmarViaApiAsync(ctx, otraCompra.Id); // 300
+
         var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 100m));
-        await ConfirmarViaApiAsync(ctx, creada.Id);
+        await ConfirmarViaApiAsync(ctx, creada.Id); // 1000 — saldo previo al anular = 300 + 1000 = 1300
 
         var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
@@ -244,8 +282,12 @@ public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : I
         var ajuste = Assert.Single(ajustes);
         Assert.Equal(-1000m, ajuste.Importe);
 
+        // 1300 (saldo previo, con la otra compra viva) − 1000 (revertido) = 300.
+        Assert.Equal(300m, ajuste.SaldoResultante);
+
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        Assert.Equal(0m, proveedor.Saldo);
+        Assert.Equal(300m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, ajuste.SaldoResultante);
     }
 
     // ---- task 2.13: anulando una compra totalmente pagada deja saldo a favor ----------------------
@@ -350,8 +392,14 @@ public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : I
     public async Task AnulandoUnaCompraPreCutoverEscribeElAjusteConElFallback()
     {
         var ctx = await PrepararAsync(nameof(AnulandoUnaCompraPreCutoverEscribeElAjusteConElFallback));
+
+        // Otra compra confirmada que se queda con su movimiento `compra` intacto — deuda previa
+        // que discrimina el mismo mutante de VALOR que en el caso impago (mutation target #16).
+        var otraCompra = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 4m, costoUnitario: 100m, numeroExterno: "resto-precutover"));
+        await ConfirmarViaApiAsync(ctx, otraCompra.Id); // 400
+
         var creada = await CrearBorradorAsync(ctx, SolicitudSimple(ctx, unidades: 10m, costoUnitario: 200m));
-        await ConfirmarViaApiAsync(ctx, creada.Id);
+        await ConfirmarViaApiAsync(ctx, creada.Id); // 2000 — saldo previo al anular = 400 + 2000 = 2400
         await BorrarMovimientoCompraAsync(ctx, creada.Id);
 
         var respuesta = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/anular", null);
@@ -366,8 +414,12 @@ public class CuentaCorrienteProveedorEscriturasTests(WaysApiFixture fixture) : I
         Assert.NotNull(ajuste.Detalle);
         Assert.Contains("compra confirmada antes del ledger", ajuste.Detalle);
 
+        // 2400 (con la otra compra viva) − 2000 (fallback del total) = 400.
+        Assert.Equal(400m, ajuste.SaldoResultante);
+
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        Assert.Equal(0m, proveedor.Saldo);
+        Assert.Equal(400m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, ajuste.SaldoResultante);
     }
 
     // ---- task 2.15 / mutation target #14: fecha bajo offset real -03:00 ---------------------------


### PR DESCRIPTION
## Resumen

- `EscriturasDeCuentaCorrienteProveedor`: writer estático (copia estructural del de clientes) — UN `UPDATE ... RETURNING` aditivo del saldo + UN `INSERT ... RETURNING` del movimiento, `ValidarFormaPorTipo` con la matriz 4×3 espejo del CHECK, todo por `ParametrosDeComando`.
- `ServicioDeCompras`: los `UPDATE ... RETURNING` autoritativos se ensanchan (+`id_proveedor`/`total`) — cero pre-lecturas; confirmar escribe el movimiento `compra` como último paso (proveedores = último lock de fila FOR UPDATE); anular escribe el contramovimiento `ajuste` con fallback pre-cutover −total (OD8).
- 9/9 mutation targets (#12-#20) con evidencia; #17/#19 estructuralmente inalcanzables (EstrategiaSinReintento; un solo recurso lockeable compartido) cerrados con pruebas de texto fuente, razonamientos verificados por el juez B.
- Fix in-slice de un gap del slice 1: 3 fixtures preexistentes sin `MapEnum<TipoMovimientoCcProveedor>` (solo visible corriendo la suite completa).

## Judgment-day

- Juez B (mutador), ronda 1: **1 CRITICAL real** — el invariante "saldo_resultante viene del RETURNING" no moría para proveedor con deuda previa (el único assert usaba seed fresco: saldo == total por coincidencia) y la anulación no assertaba `SaldoResultante`. Fix tests-only `331aca1` (deuda previa discriminante 800+1500⇒2300; anulación 300/400) con doble ciclo de evidencia.
- Re-ronda del juez B sobre el delta: limpio — su mutante original y el análogo de anulación ahora mueren; sin fix-caused.
- Juez A (estático): 0 severos; 1 SUGGESTION documental (referencia ambigua en la desviación 20) corregida.

Gate guard: `has-pending-model-changes` limpio, cero DDL. Full Integration 1259/1259 en corrida aislada. VentasCheckoutTests y `Ways.Application/Ventas/` ausentes del diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)