### PR TITLE
feat(cc-proveedores): el pago por gasto escribe el movimiento del ledger (etapa 15, slice 3)

### DIFF
--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -775,7 +775,10 @@ above):**
     so a value-substitution mutant (e.g. `saldoResultante` sourced from a
     local value instead of the `RETURNING`) cannot coincidentally pass
     against a "fresh" proveedor. Applied to tasks 3.1's write-site tests
-    (3.3, 3.9-positive, 3.10, 3.13) and the 3.9-negative backstop race.
+    (3.3, 3.4, 3.8, 3.9-positive, 3.10, 3.13) and the 3.9-negative
+    backstop race (enumeration completed per judge A's round-1 WARNING —
+    the original list under-reported 3.4 and 3.8, which apply the same
+    pattern with prior debts 800 and 1500).
 
 - [x] 3.1 Modify `ServicioDeGastos.cs`'s `InsertarGastoAsync` (`:134-174`),
   after `SaveChangesAsync` (`:169`), before the commit (`:171`): if
@@ -830,7 +833,7 @@ above):**
   (`:187-230`), the TOCTOU guard.
 - [x] 3.15 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`.
-- [ ] 3.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 3.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 3.17 Branch `feat/stage15-slice3-pago-por-gasto` off `main` (parent:
   slice 2); PR; merge stacked-to-main.
 

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -753,58 +753,82 @@ FullyQualifiedName~EscriturasDeCuentaCorrienteProveedor|FullyQualifiedName~Servi
 change, nothing to repair. **Done** = tests green + `judgment-day` clean
 round + PR merged.
 
-- [ ] 3.1 Modify `ServicioDeGastos.cs`'s `InsertarGastoAsync` (`:134-174`),
+**Deviations registered during `sdd-apply` (stage-12 discipline, decision 14
+above):**
+
+25. **Test-authoring bug found and fixed by the mandatory full-suite run,
+    never a production defect** — the new integration test file initially
+    used `C-FA` (which discriminates 21% IVA) as its `tipo_comprobante` for
+    every seeded compra, instead of `C-FB` (flat, no IVA) — the exact
+    convention `CuentaCorrienteProveedorEscriturasTests.cs` (slice 2)
+    already documents inline ("C-FB no discrimina IVA... los importes
+    esperados de este archivo son directos"). This broke 6 of 12 new tests'
+    hardcoded expected totals (e.g. `1000` expected vs `1210,00` actual —
+    exactly `1000 × 1.21`). Fixed by switching to `C-FB`, matching slice
+    2's own precedent; zero production code changed for this fix.
+26. **CRITICAL lesson from slice 2 (judge B) applied proactively to every
+    new saldo/saldo_resultante assertion in this slice, per the
+    orchestrator's explicit instruction** — every test that compares a
+    computed `proveedores.saldo` or `saldo_resultante` value now seeds a
+    real, discriminating prior debt (≠ 0, ≠ the operation's own importe,
+    ≠ the trivial sum) from an unrelated confirmed compra that stays alive,
+    so a value-substitution mutant (e.g. `saldoResultante` sourced from a
+    local value instead of the `RETURNING`) cannot coincidentally pass
+    against a "fresh" proveedor. Applied to tasks 3.1's write-site tests
+    (3.3, 3.9-positive, 3.10, 3.13) and the 3.9-negative backstop race.
+
+- [x] 3.1 Modify `ServicioDeGastos.cs`'s `InsertarGastoAsync` (`:134-174`),
   after `SaveChangesAsync` (`:169`), before the commit (`:171`): if
   `categoria = proveedor` AND `id_proveedor IS NOT NULL` →
   `ActualizarSaldoProveedorAsync(−importe)` (the LAST lock) →
   `InsertarMovimientoCcProveedorAsync(pago, id_gasto = the row just
   flushed, id_comprobante_compra = the gasto's link or NULL, importe =
   −importe)`. *(design decision 7, `design.md:59, 207-215`)*
-- [ ] 3.2 Confirm the turno guard (`:140`) and the arqueo egress term stay
+- [x] 3.2 Confirm the turno guard (`:140`) and the arqueo egress term stay
   untouched — no new derivation, no new term. *(design "What does NOT
   change")*
-- [ ] 3.3 [P] Integration — a linked proveedor gasto writes one imputed
+- [x] 3.3 [P] Integration — a linked proveedor gasto writes one imputed
   `pago`. *(spec `gastos`: "A proveedor-categoria gasto with id_proveedor
   writes one pago movement")*
-- [ ] 3.4 [P] Integration — an unlinked proveedor gasto reduces the saldo
+- [x] 3.4 [P] Integration — an unlinked proveedor gasto reduces the saldo
   without imputación. *(spec `cuenta-corriente-de-proveedores`: "An
   unlinked proveedor gasto reduces the saldo without imputación")*
-- [ ] 3.5 [P] Integration — a non-proveedor categoria, or a proveedor
+- [x] 3.5 [P] Integration — a non-proveedor categoria, or a proveedor
   categoria with `id_proveedor IS NULL`, writes ZERO movements (both
   directions). *(spec `gastos`: "A proveedor-categoria gasto with no
   id_proveedor writes no movement")*
-- [ ] 3.6 [P] Integration — a gasto still requires an open turno
+- [x] 3.6 [P] Integration — a gasto still requires an open turno
   regardless of the ledger write; `409 turno_no_abierto` writes no
   movement. *(spec `gastos`: "A gasto still requires an open turno
   regardless of the ledger write")*
-- [ ] 3.7 [P] Integration — arqueo no-regression: a proveedor payment
+- [x] 3.7 [P] Integration — arqueo no-regression: a proveedor payment
   still appears in the turno's arqueo with NO new term.
-- [ ] 3.8 [P] Integration — `pago × pago` rendezvous on the same
+- [x] 3.8 [P] Integration — `pago × pago` rendezvous on the same
   proveedor: both commit, serialized, `proveedores.saldo` correct, no
   lost update. *(spec scenario: "Two concurrent payments to the same
   proveedor serialize")*
-- [ ] 3.9 [P] Integration — `anulación × pago` rendezvous on the same
+- [x] 3.9 [P] Integration — `anulación × pago` rendezvous on the same
   compra: the payment holds `FOR SHARE` on the header so the anulación's
   `FOR UPDATE` waits and computes its reversal over a ledger that already
   contains the payment. *(spec scenario: "Anulación and a payment to the
   same proveedor race without deadlock")*
-- [ ] 3.10 [P] Integration — fault point: a failure forced at the ledger
+- [x] 3.10 [P] Integration — fault point: a failure forced at the ledger
   write of `InsertarGastoAsync` leaves saldo, ledger, and the `gastos` row
   all untouched.
-- [ ] 3.11 [P] **Mutation target #21** — `categoria = proveedor &&
+- [x] 3.11 [P] **Mutation target #21** — `categoria = proveedor &&
   id_proveedor is not null` → drop either conjunct → the zero-movement
   tests (3.5) must fail.
-- [ ] 3.12 [P] **Mutation target #22** — the ledger write placed AFTER
+- [x] 3.12 [P] **Mutation target #22** — the ledger write placed AFTER
   `SaveChangesAsync` → move it before → `id_gasto` is `0` or an FK
   violation.
-- [ ] 3.13 [P] **Mutation target #23** — `importe = −gasto.Importe` (the
+- [x] 3.13 [P] **Mutation target #23** — `importe = −gasto.Importe` (the
   sign) → drop the negation → the invariant test (`saldo == Σ importe`)
   must fail.
-- [ ] 3.14 [P] `db-error-backstops` — `fk_..._comprobante_compra` race:
+- [x] 3.14 [P] `db-error-backstops` — `fk_..._comprobante_compra` race:
   imputar a payment to a compra being annulled concurrently — already
   pre-checked under `FOR SHARE` by `ExigirCompraLigableAsync`
   (`:187-230`), the TOCTOU guard.
-- [ ] 3.15 Gate guard: `dotnet ef migrations has-pending-model-changes`
+- [x] 3.15 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`.
 - [ ] 3.16 Run `judgment-day`; fix confirmed issues; re-judge until clean.
 - [ ] 3.17 Branch `feat/stage15-slice3-pago-por-gasto` off `main` (parent:

--- a/src/Ways.Application/Gastos/ServicioDeGastos.cs
+++ b/src/Ways.Application/Gastos/ServicioDeGastos.cs
@@ -4,7 +4,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
 using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 
@@ -168,9 +170,44 @@ public class ServicioDeGastos(
         db.Gastos.Add(gasto);
         await db.SaveChangesAsync(ct);
 
+        // stage-15-cc-proveedores-ledger, Slice 3 (design decisión 7, tasks.md task 3.1): el
+        // movimiento `pago` va DESPUÉS de SaveChangesAsync — id_gasto es identity, recién existe
+        // acá — y es el ÚLTIMO lock de fila (for update) antes del commit. El predicado es
+        // ServicioDeSaldoDeProveedor.cs:39-43 VERBATIM (la fórmula retirada que este ledger
+        // reemplaza): categoría proveedor Y id_proveedor no nulo. `idProveedor` ya es el valor
+        // RESUELTO (derivado por ExigirCompraLigableAsync cuando la solicitud no lo trae) — el
+        // movimiento usa el mismo valor que la fila guarda, nunca el crudo de la solicitud.
+        if (solicitud.Categoria == CategoriaGasto.Proveedor && idProveedor is { } idProveedorDelPago)
+        {
+            await EscribirPagoAProveedorAsync(idTenant, idProveedorDelPago, solicitud, gasto, idEmpleado, momento, ct);
+        }
+
         await transaccion.CommitAsync(ct);
 
         return gasto;
+    }
+
+    /// <summary>stage-15-cc-proveedores-ledger, Slice 3: el ÚNICO call site de
+    /// <see cref="EscriturasDeCuentaCorrienteProveedor"/> para pagos — <c>importe = −gasto.Importe</c>
+    /// (el pago REDUCE el saldo), <c>id_gasto</c> = la fila recién flusheada,
+    /// <c>id_comprobante_compra</c> = el vínculo del gasto (puede ser null: la imputación es
+    /// opcional, spec: An Unlinked Proveedor Gasto Reduces The Saldo Without Imputación). Misma
+    /// conexión/transacción cruda que <see cref="ExigirCompraLigableAsync"/> reutiliza — nunca una
+    /// segunda transacción.</summary>
+    private async Task EscribirPagoAProveedorAsync(
+        int idTenant, int idProveedor, SolicitudDeGasto solicitud, Gasto gasto, int idEmpleado,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var nuevoSaldo = await EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+            conexion, transaccionCruda, idTenant, idProveedor, -solicitud.Importe, ct);
+
+        await EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            conexion, transaccionCruda, idTenant, idProveedor, momento, solicitud.IdPuntoVenta, idEmpleado,
+            TipoMovimientoCcProveedor.Pago, gasto.IdComprobanteCompra, gasto.Id, -solicitud.Importe, nuevoSaldo,
+            detalle: null, ct);
     }
 
     /// <summary>design decisión 7: <c>SELECT ... FOR SHARE</c> crudo sobre el header de la compra

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorPagoPorGastoTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorPagoPorGastoTests.cs
@@ -1,0 +1,581 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Compras;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 3: el movimiento `pago` dentro de
+/// <c>ServicioDeGastos.InsertarGastoAsync</c> (task 3.1) — la predicado (tasks 3.3-3.5), el guard
+/// de turno intacto (task 3.6), el no-regresión de arqueo (task 3.7), las dos carreras REALES
+/// (tasks 3.8-3.9, decisión 7 de tasks.md: slice 2 solo pudo simular el pago llamando directo al
+/// writer), el punto de falla (task 3.10) y el backstop de <c>fk_..._comprobante_compra</c> (task
+/// 3.14). Mutation targets #21-#23 (tasks 3.11-3.13) — evidencia de mutación registrada en el PR
+/// body, no en este archivo.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string RolApp = "ways_app";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
+        int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "CC-proveedor-pago-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        // MedioPago es tenant-scoped — bajo TenantActualFijo.Plataforma el filtro de EF no acota
+        // por tenant y .FirstAsync() puede devolver la fila de OTRO tenant creado en paralelo por
+        // otra prueba de esta colección (mismo criterio que GastosLigadosACompraTests.PrepararAsync).
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idMedioEfectivo = await dbTenant.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21,
+            idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(Contexto ctx, decimal costoUnitario = 100m, string? numeroExterno = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno ?? $"0001-{Guid.NewGuid():N}"[..14],
+            DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 10m, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearYConfirmarCompraAsync(Contexto ctx, decimal costoUnitario = 100m, string? numeroExterno = null)
+    {
+        var respuestaCrear = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, costoUnitario, numeroExterno));
+        var cuerpoCrear = await respuestaCrear.Content.ReadAsStringAsync();
+        Assert.True(respuestaCrear.StatusCode == HttpStatusCode.Created, cuerpoCrear);
+        var creada = JsonSerializer.Deserialize<CompraDetalle>(cuerpoCrear, OpcionesJson)!;
+
+        var respuestaConfirmar = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpoConfirmar, OpcionesJson)!;
+    }
+
+    private static async Task<int> AbrirTurnoAsync(Contexto ctx)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 0m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!.Id;
+    }
+
+    private static SolicitudDeGasto SolicitudDePago(
+        Contexto ctx, decimal importe, int? idComprobanteCompra = null, int? idProveedor = null,
+        CategoriaGasto categoria = CategoriaGasto.Proveedor) =>
+        new(
+            ctx.IdPuntoVenta, categoria, idProveedor ?? (categoria == CategoriaGasto.Proveedor ? ctx.IdProveedor : null),
+            null, "Pago a proveedor", null, ctx.IdMedioEfectivo, null, importe, idComprobanteCompra);
+
+    // ---- task 3.3: gasto proveedor ligado escribe exactamente un pago imputado ---------------------
+
+    [Fact]
+    public async Task UnGastoDeCategoriaProveedorLigadoEscribeExactamenteUnPagoImputado()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeCategoriaProveedorLigadoEscribeExactamenteUnPagoImputado));
+        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // total 1000
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDePago(ctx, importe: 1000m, idComprobanteCompra: compra.Id));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var pagos = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.Tipo == TipoMovimientoCcProveedor.Pago && m.IdGasto == gasto.Id)
+            .ToListAsync();
+
+        // mutation target #22 (el write movido ANTES de SaveChangesAsync): si id_gasto viniera de
+        // una fila todavía no flusheada, sería 0 — nunca el id real recién generado.
+        var pago = Assert.Single(pagos);
+        Assert.Equal(gasto.Id, pago.IdGasto);
+        Assert.True(pago.IdGasto > 0);
+        Assert.Equal(-1000m, pago.Importe);
+        Assert.Equal(compra.Id, pago.IdComprobanteCompra);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        // compra (+1000) − pago (1000) = 0.
+        Assert.Equal(0m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, pago.SaldoResultante);
+    }
+
+    // ---- task 3.4: gasto sin comprobante reduce el saldo sin imputación ----------------------------
+
+    [Fact]
+    public async Task UnGastoDeCategoriaProveedorSinComprobanteEscribeUnPagoSinImputacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeCategoriaProveedorSinComprobanteEscribeUnPagoSinImputacion));
+        // deuda previa REAL para discriminar el saldo_resultante del mutante de valor (mismo
+        // criterio, hallazgo del juez B slice 2: ningún assert de saldo_resultante contra un
+        // proveedor "fresco").
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 80m); // saldo previo = 800
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 300m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var pago = await db.MovimientosCuentaCorrienteProveedor.SingleAsync(m => m.IdGasto == gasto.Id);
+
+        Assert.Null(pago.IdComprobanteCompra);
+        Assert.Equal(-300m, pago.Importe);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(500m, proveedor.Saldo); // 800 − 300
+        Assert.Equal(proveedor.Saldo, pago.SaldoResultante);
+    }
+
+    // ---- task 3.5 / mutation target #21: los DOS conjuntos del predicado, cada uno por separado ----
+
+    [Fact]
+    public async Task UnGastoDeOtraCategoriaConIdProveedorNoEscribeMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeOtraCategoriaConIdProveedorNoEscribeMovimiento));
+        await AbrirTurnoAsync(ctx);
+
+        // categoria != proveedor, con id_proveedor de todos modos presente en la solicitud (el
+        // servicio lo ignora: SolicitudDeGasto.IdProveedor solo se usa cuando la categoría ES
+        // proveedor) — discrimina el conjunto "categoria = proveedor" del predicado.
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Servicios, ctx.IdProveedor, null, "Gasto de servicios", null,
+                ctx.IdMedioEfectivo, null, 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdGasto == gasto.Id));
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+    }
+
+    [Fact]
+    public async Task UnGastoDeCategoriaProveedorSinIdProveedorNoEscribeMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeCategoriaProveedorSinIdProveedorNoEscribeMovimiento));
+        await AbrirTurnoAsync(ctx);
+
+        // categoria = proveedor, id_proveedor NULL — discrimina el conjunto "id_proveedor no
+        // nulo" del predicado (el mismo caso que la fórmula retirada de ServicioDeSaldoDeProveedor
+        // ya excluía). Construido directo (no vía SolicitudDePago, que RELLENA id_proveedor con
+        // ctx.IdProveedor por defecto cuando la categoría es proveedor).
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, null, null, "Gasto sin proveedor", null,
+                ctx.IdMedioEfectivo, null, 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdGasto == gasto.Id));
+    }
+
+    // ---- task 3.6: el guard de turno sigue intacto — 409 no escribe movimiento ----------------------
+
+    [Fact]
+    public async Task UnGastoDeProveedorSinTurnoAbiertoEsRechazadoYNoEscribeMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnGastoDeProveedorSinTurnoAbiertoEsRechazadoYNoEscribeMovimiento));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 200m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdProveedor == ctx.IdProveedor));
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+    }
+
+    // ---- task 3.7: el pago sigue apareciendo en el arqueo del turno, sin término nuevo -------------
+
+    [Fact]
+    public async Task ElPagoAProveedorSigueApareciendoEnElEgresoPorCategoriaDelResumenSinTerminoNuevo()
+    {
+        var ctx = await PrepararAsync(nameof(ElPagoAProveedorSigueApareciendoEnElEgresoPorCategoriaDelResumenSinTerminoNuevo));
+        var turno = await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 120m));
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, await respuesta.Content.ReadAsStringAsync());
+
+        var resumen = await ctx.Admin.GetFromJsonAsync<ResumenDeTurno>($"/api/caja/turnos/{turno}/resumen", OpcionesJson);
+        Assert.NotNull(resumen);
+
+        // El gasto pesa en Egresos.PorCategoria exactamente como antes de esta etapa (design "What
+        // does NOT change": ningún término nuevo, ninguna derivación nueva) — el ledger de
+        // proveedores no agrega ni resta nada acá.
+        var proveedor = Assert.Single(resumen!.Egresos.PorCategoria, e => e.Categoria == CategoriaGasto.Proveedor);
+        Assert.Equal(120m, proveedor.Total);
+    }
+
+    // ---- task 3.8: pago × pago sobre el mismo proveedor, sin lost update ---------------------------
+
+    [Fact]
+    public async Task DosPagosConcurrentesAlMismoProveedorSeSerializanSinPerderActualizaciones()
+    {
+        var ctx = await PrepararAsync(nameof(DosPagosConcurrentesAlMismoProveedorSeSerializanSinPerderActualizaciones));
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 150m); // saldo previo = 1500
+        await AbrirTurnoAsync(ctx);
+
+        var tareaUno = ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 300m));
+        var tareaDos = ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 200m));
+
+        await Task.WhenAll(tareaUno, tareaDos);
+
+        var respuestaUno = await tareaUno;
+        var respuestaDos = await tareaDos;
+        Assert.True(respuestaUno.StatusCode == HttpStatusCode.Created, await respuestaUno.Content.ReadAsStringAsync());
+        Assert.True(respuestaDos.StatusCode == HttpStatusCode.Created, await respuestaDos.Content.ReadAsStringAsync());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+
+        // 1500 − 300 − 200 = 1000, sin lost update — serializados sobre la misma fila de
+        // proveedores (design: Concurrency guarantees, "pago × pago... serializado, ambos aditivos").
+        Assert.Equal(1000m, proveedor.Saldo);
+
+        var suma = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdProveedor == ctx.IdProveedor)
+            .SumAsync(m => m.Importe);
+        Assert.Equal(proveedor.Saldo, suma);
+    }
+
+    // ---- task 3.9: anulación × pago sobre la misma compra, por el call site REAL de ambos lados ----
+
+    /// <summary>Pausa la transacción manual (<c>ServicioDeCompras.EjecutarAnulacionAsync</c>) justo
+    /// DESPUÉS de <c>BeginTransactionAsync</c> — mismo patrón que
+    /// <c>GastosLigadosACompraTests.InterceptorDePausaTrasIniciarLaTransaccion</c> /
+    /// <c>ComprasAnulacionYConcurrenciaTests</c>.</summary>
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>design decisión 7 / Concurrency guarantees: el pago toma <c>FOR SHARE</c> sobre el
+    /// header (vía <c>ExigirCompraLigableAsync</c>, reusado sin cambios) ANTES que la anulación
+    /// tome su <c>FOR UPDATE</c> exclusivo — si el pago corre y comitea completo mientras la
+    /// anulación sigue pausada sin ningún lock propio todavía, la anulación retoma viendo un ledger
+    /// que YA contiene el pago: su reversa (que solo suma los movimientos `compra`, design decisión
+    /// 6) queda intacta y el pago nunca se toca — "sin motor de reversión de gastos".</summary>
+    [Fact]
+    public async Task ElPagoQueGanaLaCarreraDejaSuMovimientoVisibleEnElLedgerQueLaAnulacionQueLlegaDespuesComputa()
+    {
+        var ctx = await PrepararAsync(nameof(ElPagoQueGanaLaCarreraDejaSuMovimientoVisibleEnElLedgerQueLaAnulacionQueLlegaDespuesComputa));
+        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // total 1000
+        await AbrirTurnoAsync(ctx);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaAnulacion = clienteAnular.PostAsync($"/api/compras/{compra.Id}/anular", null);
+
+        await transaccionIniciada.Task;
+
+        // El pago corre COMPLETO por el call site real mientras la anulación sigue pausada, todavía
+        // sin ningún lock propio.
+        var respuestaPago = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDePago(ctx, importe: 400m, idComprobanteCompra: compra.Id));
+        var cuerpoPago = await respuestaPago.Content.ReadAsStringAsync();
+        Assert.True(respuestaPago.StatusCode == HttpStatusCode.Created, cuerpoPago);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaAnulacion = await tareaAnulacion;
+        var cuerpoAnulacion = await respuestaAnulacion.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+        var resultadoAnulacion = JsonSerializer.Deserialize<ResultadoAnulacion>(cuerpoAnulacion, OpcionesJson)!;
+        Assert.Equal(1, resultadoAnulacion.GastosLigados);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        var ajuste = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == compra.Id && m.Tipo == TipoMovimientoCcProveedor.Ajuste);
+        Assert.Equal(-1000m, ajuste.Importe); // reversa SOLO el `compra` original — nunca el pago.
+
+        var pago = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == compra.Id && m.Tipo == TipoMovimientoCcProveedor.Pago);
+        Assert.Equal(-400m, pago.Importe);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        // 1000 (compra) − 400 (pago) − 1000 (reversa) = −400, sin lost update.
+        Assert.Equal(-400m, proveedor.Saldo);
+        Assert.Equal(proveedor.Saldo, ajuste.SaldoResultante);
+    }
+
+    /// <summary>task 3.14 (`db-error-backstops`, `fk_..._comprobante_compra` race): la anulación
+    /// gana la carrera — commitea completa mientras el pago sigue pausado sin haber tomado su
+    /// propio <c>FOR SHARE</c> todavía. El pago retoma, <c>ExigirCompraLigableAsync</c> ve
+    /// <c>anulada</c> ya comiteada y rechaza con <c>409 compra_anulada</c> — ningún movimiento de
+    /// ledger, ninguna fila de <c>gastos</c>, ningún riesgo de violar
+    /// <c>fk_..._comprobante_compra</c> con una imputación a una compra que ya no admite pagos.
+    /// Mismo patrón que <c>GastosLigadosACompraTests.LaAnulacionGanandoLaCarreraDejaAlGastoRechazadoSinVinculoCorrupto</c>,
+    /// con el assert propio de esta etapa sobre el ledger.</summary>
+    [Fact]
+    public async Task UnPagoQueIntentaImputarseAUnaCompraSiendoAnuladaConcurrentementeEsRechazadoSinEscribirMovimiento()
+    {
+        var ctx = await PrepararAsync(nameof(UnPagoQueIntentaImputarseAUnaCompraSiendoAnuladaConcurrentementeEsRechazadoSinEscribirMovimiento));
+        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m);
+        await AbrirTurnoAsync(ctx);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clientePago = factory.CreateClient();
+        var login = await clientePago.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaPago = clientePago.PostAsJsonAsync(
+            "/api/gastos", SolicitudDePago(ctx, importe: 1000m, idComprobanteCompra: compra.Id));
+
+        await transaccionIniciada.Task;
+
+        // La anulación corre y commitea COMPLETA mientras el pago sigue pausado sin lock propio.
+        var anulacion = await ctx.Admin.PostAsync($"/api/compras/{compra.Id}/anular", null);
+        var cuerpoAnulacion = await anulacion.Content.ReadAsStringAsync();
+        Assert.True(anulacion.StatusCode == HttpStatusCode.OK, cuerpoAnulacion);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaPago = await tareaPago;
+        var cuerpoPago = await respuestaPago.Content.ReadAsStringAsync();
+        Assert.True(respuestaPago.StatusCode == HttpStatusCode.Conflict, cuerpoPago);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoPago, OpcionesJson);
+        Assert.Equal("compra_anulada", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.Gastos.CountAsync(g => g.IdComprobanteCompra == compra.Id));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.Tipo == TipoMovimientoCcProveedor.Pago));
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        // −1000 (reversa de la compra) — el pago rechazado no aportó nada.
+        Assert.Equal(-1000m, proveedor.Saldo);
+    }
+
+    // ---- task 3.10: falla en el punto del ledger deja saldo/ledger/el gasto sin cambios ------------
+
+    private async Task RevocarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"REVOKE {privilegios} ON {tabla} FROM {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private async Task RestaurarAsync(string tabla, string privilegios)
+    {
+        await using var owner = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await owner.OpenAsync();
+        await using var comando = owner.CreateCommand();
+        comando.CommandText = $"GRANT {privilegios} ON {tabla} TO {RolApp}";
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYElGastoSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYElGastoSinCambios));
+        await AbrirTurnoAsync(ctx);
+
+        await RevocarAsync("movimientos_cuenta_corriente_proveedor", "INSERT");
+        HttpResponseMessage respuesta;
+        try
+        {
+            respuesta = await ctx.Admin.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 200m));
+        }
+        finally
+        {
+            await RestaurarAsync("movimientos_cuenta_corriente_proveedor", "INSERT");
+        }
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        // La transacción entera (INSERT gastos + UPDATE saldo + INSERT ledger) revierte junta — el
+        // gasto NUNCA queda huérfano de su movimiento.
+        Assert.Equal(0, await db.Gastos.CountAsync(g => g.IdProveedor == ctx.IdProveedor));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdProveedor == ctx.IdProveedor));
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        Assert.Equal(0m, proveedor.Saldo);
+    }
+
+    // ---- mutation target #23: importe = −gasto.Importe — el invariante saldo == Σ importe ----------
+
+    [Fact]
+    public async Task ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasApertreCompraYPago()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasApertreCompraYPago));
+        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // +1000
+        await AbrirTurnoAsync(ctx);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos", SolicitudDePago(ctx, importe: 600m, idComprobanteCompra: compra.Id));
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, await respuesta.Content.ReadAsStringAsync());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var pago = await db.MovimientosCuentaCorrienteProveedor
+            .SingleAsync(m => m.IdComprobanteCompra == compra.Id && m.Tipo == TipoMovimientoCcProveedor.Pago);
+
+        // Si la negación se perdiera (`importe = gasto.Importe`), el pago SUMARÍA en vez de restar
+        // y el invariante saldo == Σ importe seguiría cumpliéndose trivialmente por construcción —
+        // por eso se compara además contra el valor NEGATIVO explícito, no solo la suma.
+        Assert.Equal(-600m, pago.Importe);
+
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        var suma = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.IdProveedor == ctx.IdProveedor)
+            .SumAsync(m => m.Importe);
+        Assert.Equal(400m, proveedor.Saldo); // 1000 − 600
+        Assert.Equal(proveedor.Saldo, suma);
+    }
+
+    // ---- decisión 13 de tasks.md: el movimiento `pago` bajo un reloj con offset real -03:00 --------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    [Fact]
+    public async Task ElMovimientoDePagoUsaLaFechaExactaBajoUnRelojConOffsetRealMenosTres()
+    {
+        var ctx = await PrepararAsync(nameof(ElMovimientoDePagoUsaLaFechaExactaBajoUnRelojConOffsetRealMenosTres));
+        await AbrirTurnoAsync(ctx);
+
+        // mutation-proof-tests rule 10: offset real -03:00, nunca Z (mediodía UTC — task de la
+        // etapa: RelojFijo(2026-08-17T12:00:00Z)).
+        var instanteFijo = new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(new DateTimeOffset(2026, 8, 17, 12, 0, 0, TimeSpan.Zero), instanteFijo);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var respuesta = await cliente.PostAsJsonAsync("/api/gastos", SolicitudDePago(ctx, importe: 150m));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var gasto = JsonSerializer.Deserialize<GastoRegistrado>(cuerpo, OpcionesJson)!;
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var pago = await db.MovimientosCuentaCorrienteProveedor.SingleAsync(m => m.IdGasto == gasto.Id);
+
+        Assert.Equal(instanteFijo.UtcDateTime, pago.Fecha.UtcDateTime);
+        Assert.Equal(TimeSpan.Zero, pago.Fecha.Offset);
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorPagoPorGastoTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorPagoPorGastoTests.cs
@@ -49,7 +49,7 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
 
     private sealed record Contexto(
         int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
-        int IdTipoCFA, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
+        int IdTipoCFB, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin);
 
     private async Task<Contexto> PrepararAsync(string nombre)
     {
@@ -105,16 +105,20 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         db.Articulos.Add(articulo);
         await db.SaveChangesAsync();
 
-        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+        // C-FB no discrimina IVA (a diferencia de C-FA) — total == unidades * costoUnitario
+        // exactamente, sin sumar el 21%, mismo criterio que
+        // CuentaCorrienteProveedorEscriturasTests.cs (slice 2): así los importes esperados de este
+        // archivo son directos.
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
 
         return new Contexto(
             resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21,
-            idTipoCFA, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
+            idTipoCFB, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal);
     }
 
     private static SolicitudDeCompra SolicitudSimple(Contexto ctx, decimal costoUnitario = 100m, string? numeroExterno = null) =>
         new(
-            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno ?? $"0001-{Guid.NewGuid():N}"[..14],
+            ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, numeroExterno ?? $"0001-{Guid.NewGuid():N}"[..14],
             DateOnly.FromDateTime(DateTime.UtcNow), null,
             [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 10m, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
 
@@ -153,6 +157,10 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
     public async Task UnGastoDeCategoriaProveedorLigadoEscribeExactamenteUnPagoImputado()
     {
         var ctx = await PrepararAsync(nameof(UnGastoDeCategoriaProveedorLigadoEscribeExactamenteUnPagoImputado));
+        // deuda previa REAL (≠ 0) de otra compra que se queda VIVA — discrimina el
+        // saldo_resultante del RETURNING de un mutante de valor (hallazgo del juez B, slice 2:
+        // ningún assert de saldo/saldo_resultante contra un proveedor "fresco").
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 30m, numeroExterno: "resto-imputado"); // 300
         var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // total 1000
         await AbrirTurnoAsync(ctx);
 
@@ -176,8 +184,8 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         Assert.Equal(compra.Id, pago.IdComprobanteCompra);
 
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        // compra (+1000) − pago (1000) = 0.
-        Assert.Equal(0m, proveedor.Saldo);
+        // 300 (otra compra viva) + 1000 (esta compra) − 1000 (este pago) = 300.
+        Assert.Equal(300m, proveedor.Saldo);
         Assert.Equal(proveedor.Saldo, pago.SaldoResultante);
     }
 
@@ -359,6 +367,9 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
     public async Task ElPagoQueGanaLaCarreraDejaSuMovimientoVisibleEnElLedgerQueLaAnulacionQueLlegaDespuesComputa()
     {
         var ctx = await PrepararAsync(nameof(ElPagoQueGanaLaCarreraDejaSuMovimientoVisibleEnElLedgerQueLaAnulacionQueLlegaDespuesComputa));
+        // deuda previa REAL de otra compra viva — discrimina el saldo_resultante del RETURNING de
+        // un mutante de valor (hallazgo del juez B, slice 2).
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 50m, numeroExterno: "resto-carrera"); // 500
         var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // total 1000
         await AbrirTurnoAsync(ctx);
 
@@ -404,8 +415,9 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         Assert.Equal(-400m, pago.Importe);
 
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        // 1000 (compra) − 400 (pago) − 1000 (reversa) = −400, sin lost update.
-        Assert.Equal(-400m, proveedor.Saldo);
+        // 500 (otra compra viva) + 1000 (esta compra) − 400 (pago) − 1000 (reversa) = 100, sin
+        // lost update.
+        Assert.Equal(100m, proveedor.Saldo);
         Assert.Equal(proveedor.Saldo, ajuste.SaldoResultante);
     }
 
@@ -421,7 +433,12 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
     public async Task UnPagoQueIntentaImputarseAUnaCompraSiendoAnuladaConcurrentementeEsRechazadoSinEscribirMovimiento()
     {
         var ctx = await PrepararAsync(nameof(UnPagoQueIntentaImputarseAUnaCompraSiendoAnuladaConcurrentementeEsRechazadoSinEscribirMovimiento));
-        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m);
+
+        // Otra compra confirmada que se queda VIVA — deuda previa REAL (≠ 0) que discrimina el
+        // saldo_resultante del RETURNING de un mutante de valor (mismo criterio, hallazgo del juez
+        // B en slice 2: ningún assert de saldo contra un proveedor "fresco").
+        var otraCompra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 30m, numeroExterno: "resto-race"); // 300
+        var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // 1000 — saldo previo a anular = 1300
         await AbrirTurnoAsync(ctx);
 
         var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -459,8 +476,9 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.Tipo == TipoMovimientoCcProveedor.Pago));
 
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        // −1000 (reversa de la compra) — el pago rechazado no aportó nada.
-        Assert.Equal(-1000m, proveedor.Saldo);
+        // 1300 (otraCompra viva + esta compra) − 1000 (reversa de esta compra) = 300 — el pago
+        // rechazado no aportó nada.
+        Assert.Equal(300m, proveedor.Saldo);
     }
 
     // ---- task 3.10: falla en el punto del ledger deja saldo/ledger/el gasto sin cambios ------------
@@ -487,6 +505,10 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
     public async Task UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYElGastoSinCambios()
     {
         var ctx = await PrepararAsync(nameof(UnaFallaAlEscribirElLedgerDeProveedorDejaSaldoLedgerYElGastoSinCambios));
+        // deuda previa REAL (≠ 0) — para que "sin cambios" sea una prueba real de que el saldo NO
+        // se movió, no una coincidencia con el 0 inicial de un proveedor fresco (hallazgo del juez
+        // B, slice 2).
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 70m, numeroExterno: "resto-falla"); // 700
         await AbrirTurnoAsync(ctx);
 
         await RevocarAsync("movimientos_cuenta_corriente_proveedor", "INSERT");
@@ -506,18 +528,23 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         // La transacción entera (INSERT gastos + UPDATE saldo + INSERT ledger) revierte junta — el
         // gasto NUNCA queda huérfano de su movimiento.
         Assert.Equal(0, await db.Gastos.CountAsync(g => g.IdProveedor == ctx.IdProveedor));
-        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdProveedor == ctx.IdProveedor));
+        Assert.Equal(0, await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.Tipo == TipoMovimientoCcProveedor.Pago));
 
         var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
-        Assert.Equal(0m, proveedor.Saldo);
+        // Sigue en 700 (la deuda previa) — nunca 500 (700 − 200, si el fallo hubiera dejado pasar
+        // parte de la escritura) ni 0.
+        Assert.Equal(700m, proveedor.Saldo);
     }
 
     // ---- mutation target #23: importe = −gasto.Importe — el invariante saldo == Σ importe ----------
 
     [Fact]
-    public async Task ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasApertreCompraYPago()
+    public async Task ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasCompraYPago()
     {
-        var ctx = await PrepararAsync(nameof(ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasApertreCompraYPago));
+        var ctx = await PrepararAsync(nameof(ElSaldoDelProveedorIgualaLaSumaDeMovimientosTrasCompraYPago));
+        // deuda previa REAL de otra compra viva — discrimina el saldo final de un mutante de valor
+        // (hallazgo del juez B, slice 2).
+        await CrearYConfirmarCompraAsync(ctx, costoUnitario: 20m, numeroExterno: "resto-invariante"); // 200
         var compra = await CrearYConfirmarCompraAsync(ctx, costoUnitario: 100m); // +1000
         await AbrirTurnoAsync(ctx);
 
@@ -538,7 +565,7 @@ public class CuentaCorrienteProveedorPagoPorGastoTests(WaysApiFixture fixture) :
         var suma = await db.MovimientosCuentaCorrienteProveedor
             .Where(m => m.IdProveedor == ctx.IdProveedor)
             .SumAsync(m => m.Importe);
-        Assert.Equal(400m, proveedor.Saldo); // 1000 − 600
+        Assert.Equal(600m, proveedor.Saldo); // 200 (otra compra viva) + 1000 − 600
         Assert.Equal(proveedor.Saldo, suma);
     }
 


### PR DESCRIPTION
## Resumen

- `InsertarGastoAsync` escribe el movimiento `pago` (importe negativo, imputado a la compra ligada vía `id_comprobante_compra`, o sin imputación si el gasto no está ligado) DESPUÉS del `SaveChangesAsync` — `id_gasto` es identity — y antes del commit, reusando la transacción del caller y el writer del slice 2. Predicado de elegibilidad verbatim de `ServicioDeSaldoDeProveedor` (categoría proveedor + `id_proveedor` no nulo). 37 líneas de producción.
- 12 tests de integración: predicado por conjunto, carreras pago×pago y anulación×pago por los endpoints REALES, fault point con rollback conjunto (gasto+saldo+ledger), arqueo intocado, y TODA aserción de saldo con deuda previa discriminante (lección del CRITICAL del slice 2 aplicada proactivamente).

## Judgment-day (ronda limpia)

- Juez B (mutador): 0 hallazgos en 6 ciclos — los 4 targets del apply (#21a/#21b/#22/#23) más DOS clases nuevas no listadas (saldo_resultante sustituido por valor local — la clase del CRITICAL del slice 2 sobre el camino de pago — y la imputación anulada): todas mueren.
- Juez A (estático): 0 severos; 1 WARNING documental (la desviación #26 sub-reportaba su alcance) corregido.

Gate: `has-pending-model-changes` limpio, cero DDL. Full Integration 1272/1272. VentasCheckoutTests/Ventas/ManejadorDeErrores ausentes del diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)