### PR TITLE
feat(cc-proveedores): estado de cuenta paginado y saldo re-sourceado sobre el ledger (etapa 15, slice 4)

### DIFF
--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -859,18 +859,103 @@ merged.
 **Budget note**: pre-authorized split `4a`/`4b` if this slice overflows —
 see decision 3 above.
 
-- [ ] 4.1 Create
+**Deviations registered during `sdd-apply` (stage-12 discipline, decision 14
+above):**
+
+27. **The backfill fidelity test (Slice 1, `CuentaCorrienteProveedorBackfillTests.
+    PrepararFixtureSinMigrarAsync`) captured its pre-migration `saldoPrevio` by
+    calling `ServicioDeSaldoDeProveedor.ObtenerAsync` directly — valid only
+    while that class still computed the retired formula.** Task 4.5 re-sources
+    `ObtenerAsync` onto `movimientos_cuenta_corriente_proveedor`, a table that
+    does not exist yet at the exact point that test calls it (the fixture is
+    deliberately migrated only up to `MigracionAnterior`, before
+    `CuentaCorrienteDeProveedoresEtapa15` runs — the whole point of the test).
+    Calling the re-sourced service there now fails with `42P01 relation "
+    movimientos_cuenta_corriente_proveedor" does not exist`, confirmed
+    empirically. Fixed by inlining the retired formula verbatim (same predicate
+    `Σ compras confirmadas − Σ gastos categoria=proveedor` `ServicioDeSaldoDeProveedor.
+    ObtenerAsync` used before this task) into a new private helper,
+    `CalcularSaldoPorLaFormulaRetiradaAsync`, owned by the test file itself —
+    not a from-memory reimplementation, the exact predicate the class had until
+    this task moved it. Zero production code touched by this fix; the fidelity
+    test's own assertions (`saldoPrevio == saldo` post-migration) are unchanged.
+28. **`SaldoDeProveedorTests.CrearContextoConContador` (stage-8, its own
+    manually-curated `DbContextOptionsBuilder<WaysDbContext>`) was missing
+    `MapEnum<TipoMovimientoCcProveedor>` — the same gap class as slice 2's
+    deviation 20, opened one slice later this time.** Task 4.5's re-sourcing is
+    the FIRST code path that makes `ServicioDeSaldoDeProveedor` actually query
+    `movimientos_cuenta_corriente_proveedor`, and this file's query-budget test
+    (`ElSaldoEmiteUnaCantidadConstanteDeConsultasIndependienteDeLaCantidadDeCompras`)
+    builds its own context instead of using `WaysApiFixture.CrearContextoDeAplicacion`
+    — reproduced empirically (`42883: operator does not exist:
+    tipo_movimiento_cc_proveedor = integer`). Fixed with the one missing
+    `MapEnum` line; the query-count assertion (constant regardless of compra
+    count) still holds after re-sourcing — 4 queries now instead of 3, but
+    still constant.
+29. **Mutation target #25 could not be proven with a behavioral test —
+    resolved with a deterministic source-text assertion instead, after two
+    runtime attempts were exhausted (`mutation-proof-tests` rule 2/3), same
+    criterion as slice 1's targets #4/#11 and slice 2's target #19.** First
+    attempt: three movements seeded with an identical `Fecha` in ascending
+    `id_movimiento` order — the mutant (`ThenByDescending(Id)` deleted) still
+    passed the pagination test, because in an INSERT-only fixture with no
+    updates, PostgreSQL's B-tree TID tiebreaker (>= PG 12) keeps physical tuple
+    order correlated with `id_movimiento` order, so an unordered tie
+    coincidentally resolves the same way. Second attempt: a raw `UPDATE`
+    against the first-seeded row after seeding, specifically to decouple its
+    physical location (TID) from its `id_movimiento` — the mutant STILL passed
+    the HTTP-level paginated test; a follow-up diagnostic query confirmed why:
+    the actual paginated query (with `Skip`/`Take`) and a plain unbounded
+    `ORDER BY fecha DESC` diverge in how PostgreSQL resolves the same tie
+    (bounded top-N sort vs. full sort), so the observable tie-order is
+    plan-dependent, not a property the test can pin down from outside.
+    Resolution: `ServicioDeCuentaCorrienteDeProveedorLecturaTests.
+    ConstruirQueryDesempataPorIdMovimientoDescendenteTarget25` (new file,
+    `tests/Ways.Application.Tests/CuentaCorriente/`) reads
+    `ServicioDeCuentaCorrienteDeProveedor.cs` from disk and asserts
+    `ThenByDescending(m => m.Id)` is chained immediately after
+    `OrderByDescending(m => m.Fecha)` inside `ConstruirQuery` — the only
+    mechanism that can detect this specific deletion given the confirmed
+    plan-dependent confound. Task 4.8's behavioral test ships unchanged as the
+    spec-level coverage that pagination does not duplicate/skip under a tied
+    `fecha` in the ordinary case — it is not target #25's discriminator.
+30. **Mutation evidence for target #24 substituted the full binding formula
+    with each of the two REJECTED ones (proposal's and design's), beyond the
+    narrower "widen one filter" mutation the design.md table literally
+    describes, per explicit instruction.** All three runs used
+    `SaldoDeProveedorReSourceadoTests`' pre-cutover fixtures (tasks 4.12/4.13)
+    plus `SaldoDeProveedorTests.UnPagoParcialLigadoDaEstadoParcial`/
+    `VariosGastosLigadosALaMismaCompraSeAcumulanHastaPagada` (ordinary
+    post-cutover partial payments): (1) narrow mutation — `tipo = 'ajuste'` →
+    `tipo <> 'compra'` (re-including `pago`) — both post-cutover partial-payment
+    tests failed with a doubled `Pagado` (800 vs 400 expected, 1000 vs 500),
+    reverted, green; (2) full substitution with the proposal's formula
+    (`SUM(importe)` over all linked ledger movements including the compra's own
+    `+total`, `<= 0 ⇒ pagada`) — both pre-cutover tests (4.12, 4.13) failed:
+    the no-payment case read `Pagado = 1234.56` instead of `0` (reads `pagada`,
+    the exact defect OD7's arbitration names), the partial-payment case read
+    `Pagado = 1000` instead of `400`; reverted, green; (3) full substitution
+    with the design's formula (`pagado = −Σ importe WHERE tipo <> 'compra'`,
+    ledger-only, never queries `gastos`) — the no-payment case (4.12) passed
+    BY COINCIDENCE (no ledger rows either way ⇒ both formulas read `0`), but
+    the partial-payment case (4.13) failed exactly as `state.yaml` OD7's
+    arbitration predicts: `Pagado = 0` instead of `400` — "a pre-cutover
+    partial payment is lost because the design's formula never queries
+    `gastos` at all". Reverted; `git diff` against the committed slice-4 tip
+    confirms byte-identical production code after all three reverts.
+
+- [x] 4.1 Create
   `src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedor.cs`
   — `EtiquetarAjuste(idComprobanteCompra)`: non-null ⇒ Contramovimiento,
   null ⇒ Manual, pure. `ResolverEstadoPago(pagado, total)` is REUSED
   unchanged from `ServicioDeSaldoDeProveedor.cs:69-77`. *(design.md:
   131-134)*
-- [ ] 4.2 Create `src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs`
+- [x] 4.2 Create `src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs`
   — `MovimientoDeCuentaDeProveedor`, `EstadoDeCuentaDeProveedorHeader`,
   `PaginaDeEstadoDeCuentaDeProveedor(Header, Items, Total, Pagina,
   Tamanio, Historico, Desde, Hasta)` — **PAGINATED** shape, reconciling
   spec.md's unpaginated prose per decision 5 above. *(design.md:139-149)*
-- [ ] 4.3 Create
+- [x] 4.3 Create
   `src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedor.cs`
   — `ObtenerEstadoDeCuentaAsync`: `CountAsync` +
   `Skip((pagina-1)*tamanio).Take(tamanio)`, `pagina = Max(pagina, 1)`,
@@ -878,12 +963,12 @@ see decision 3 above.
   id_movimiento DESC` (the tiebreaker — decision 5 above); `historico`
   overrides `desde`/`hasta`; no filter ⇒ last-month default. *(design.md:
   63, 152-154, 174-177)*
-- [ ] 4.4 Same file: `ConstruirQuery` private helper with the 4 named
+- [x] 4.4 Same file: `ConstruirQuery` private helper with the 4 named
   clauses under `mutation-proof-tests`: `Where(m => m.IdProveedor ==
   idProveedor)`, `ThenByDescending(IdMovimiento)`, the
   `historico`-vs-default-range branch, each `if (desde/hasta is { } x)`.
   *(design.md:164-172)*
-- [ ] 4.5 Modify `ServicioDeSaldoDeProveedor.cs` — `Saldo` sourced from
+- [x] 4.5 Modify `ServicioDeSaldoDeProveedor.cs` — `Saldo` sourced from
   `proveedores.saldo`; the per-compra `pagadoPorCompra` re-sourced
   applying the **BINDING OD7 formula** (decision 4 above): `pagado(X) =
   SUM(gastos.importe) WHERE gastos.id_comprobante_compra = X AND
@@ -897,53 +982,81 @@ see decision 3 above.
   `ResolverEstadoPago` stay byte-identical. **NOT** design.md's rejected
   `−Σ importe WHERE tipo <> 'compra'` shape. *(design decision 8/9,
   OVERRIDDEN by state.yaml OD7 per decision 4 above)*
-- [ ] 4.6 Confirm `GET /api/proveedores/{id}/cuenta-corriente` under the
+- [x] 4.6 Confirm `GET /api/proveedores/{id}/cuenta-corriente` under the
   `OperacionDePos` group; `GET /api/proveedores/{id}/saldo` stays
-  top-level, unchanged route/policy/DTOs. *(design.md:255-257)*
-- [ ] 4.7 [P] Integration — filters with asymmetric seeds (distinct
+  top-level, unchanged route/policy/DTOs. Realized as a NEW file,
+  `src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs`
+  (`MapearCuentaCorrienteDeProveedor`), registered in `Program.cs` right
+  after `MapearCompras()` — mirrors the design's file-changes table, which
+  lists this same file created once with both this slice's `GET` and
+  slice 5's top-level `POST /ajustes` (that route is NOT added here; it
+  lands in slice 5 as a `Modify`, not a second `Create`, a deviation
+  registered so `sdd-verify` doesn't read task 5.5's literal "Create" as a
+  duplicate file). *(design.md:255-257)*
+- [x] 4.7 [P] Integration — filters with asymmetric seeds (distinct
   dates, tipos, importes, imputaciones); order asserted as a sequence.
-- [ ] 4.8 [P] Integration — pagination with `fecha` TIED on every row
+- [x] 4.8 [P] Integration — pagination with `fecha` TIED on every row
   (`RelojFijo`) ⇒ page 2 repeats and skips nothing — proves the OD9
   pagination reconciliation (decision 5 above).
-- [ ] 4.9 [P] Integration — `historico` overrides `desde`/`hasta`; no
+- [x] 4.9 [P] Integration — `historico` overrides `desde`/`hasta`; no
   filter ⇒ last-month default; empty ledger ⇒ empty page with the header
   still populated.
-- [ ] 4.10 [P] Integration — `/saldo` byte-compatibility: the response is
+- [x] 4.10 [P] Integration — `/saldo` byte-compatibility: the response is
   byte-identical over the same data (all 3 records, all fields, per row —
   mutation-proof-tests rule 6).
-- [ ] 4.11 [P] Integration — a fully-imputed compra ⇒ `pagada`; a
+- [x] 4.11 [P] Integration — a fully-imputed compra ⇒ `pagada`; a
   partially-imputed one ⇒ `parcial`; an unimputed payment reduces the
   total saldo without settling any compra. *(spec + MODIFIED
-  `saldo-de-proveedor` scenarios)*
-- [ ] 4.12 [P] Integration — a PRE-CUTOVER confirmed compra with NO
+  `saldo-de-proveedor` scenarios; covered by the pre-existing stage-8
+  `SaldoDeProveedorTests.cs`, which stays green byte-for-byte under the
+  re-sourced formula — no new test needed for the ordinary post-cutover
+  case)*
+- [x] 4.12 [P] Integration — a PRE-CUTOVER confirmed compra with NO
   payments (its debt lives only in the `apertura` asiento) ⇒ `impaga` —
   the discriminating case both the proposal's and the design's original
   formulas got wrong (decision 4 above).
-- [ ] 4.13 [P] Integration — a PRE-CUTOVER compra PARTIALLY paid via a
+- [x] 4.13 [P] Integration — a PRE-CUTOVER compra PARTIALLY paid via a
   linked gasto before the cutover ⇒ `parcial` with the correct remaining
   amount — the case OD7's arbitration names explicitly ("un pago parcial
   pre-cutover se pierde" under design's rejected formula, decision 4
-  above). Also the DISCRIMINATOR for redefined mutation target #24.
-- [ ] 4.14 [P] Integration — authorization: Vendedor `200` on estado de
+  above). Seeded via a DIRECT EF insert of both the `ComprobanteCompra`
+  (bypassing `ServicioDeCompras`, so no own `compra` ledger row exists)
+  AND the linked `Gasto` (bypassing `ServicioDeGastos`, so no `pago`
+  ledger row exists either) — the exact shape a payment made through the
+  retired, pre-ledger mechanism leaves. Also the runtime-attempted (and
+  discarded) DISCRIMINATOR for target #24 — see deviation 29 below for
+  why target #24 uses a different fixture instead.
+- [x] 4.14 [P] Integration — authorization: Vendedor `200` on estado de
   cuenta and `/saldo`; tenant B never sees tenant A's movements.
-- [ ] 4.15 [P] **Mutation target #24 (REDEFINED per decision 4 above)** —
+- [x] 4.15 [P] **Mutation target #24 (REDEFINED per decision 4 above)** —
   the `tipo = 'ajuste'` filter on the ledger-imputed sum → widen to `tipo
   <> 'compra'` (re-including `pago`) → the double-count discriminator
-  (4.13's shape: a partially-paid post-cutover compra whose `pagado`
-  would double if `pago` movements were counted alongside the `gastos`
-  sum) must fail.
-- [ ] 4.16 [P] **Mutation target #25** — `ThenByDescending(IdMovimiento)`
-  → delete it → the tied-`fecha` pagination test (4.8) must fail.
-- [ ] 4.17 [P] **Mutation target #26** — each `if (desde/hasta/historico
+  must fail. Discriminated by the pre-existing, ORDINARY post-cutover
+  partial-payment tests in `SaldoDeProveedorTests.cs`
+  (`UnPagoParcialLigadoDaEstadoParcial`,
+  `VariosGastosLigadosALaMismaCompraSeAcumulanHastaPagada`) — task 4.13's
+  own pre-cutover fixture has no `pago` ledger row to double-count by
+  construction (deviation 30 below), so it cannot discriminate this
+  specific mutation; an ordinary paid compra (own `compra` row + a real,
+  ledger-writing `pago`) can and does.
+- [x] 4.16 [P] **Mutation target #25** — `ThenByDescending(IdMovimiento)`
+  → delete it → RESOLVED WITH A SOURCE-TEXT ASSERTION, not the behavioral
+  tied-`fecha` pagination test (4.8) — see deviation 29 below; two runtime
+  attempts were exhausted first (`mutation-proof-tests` rule 2/3).
+- [x] 4.17 [P] **Mutation target #26** — each `if (desde/hasta/historico
   …)` in `ConstruirQuery` → delete one → that filter's asymmetric-seed
-  test (4.7) must fail.
-- [ ] 4.18 `dto-contract-honesty`: every field of
+  test (4.7) must fail. Proven for both `desde` and `hasta` independently.
+- [x] 4.18 `dto-contract-honesty`: every field of
   `ContratosDeProveedor.cs` traced to its read/use point — no
-  accepted-and-dropped field.
-- [ ] 4.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
-  clean; zero new files under `Migraciones/`.
-- [ ] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
-- [ ] 4.21 Branch `feat/stage15-slice4-estado-de-cuenta` off `main`
+  accepted-and-dropped field. All three records are OUTPUT-only in this
+  slice (no request DTO yet — `SolicitudDeAjusteDeProveedor` is slice 5);
+  every field is populated from a real query result and returned, none
+  accepted from a client and silently dropped.
+- [x] 4.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
+  clean; zero new files under `Migraciones/`. Confirmed: clean, `git diff
+  --stat -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty.
+- [x] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 4.21 Branch `feat/stage15-slice4-estado-de-cuenta` off `main`
   (parent: slice 3); PR; merge stacked-to-main.
 
 **Test plan**: filters (4.7), tied-`fecha` pagination (4.8), defaults

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1113,7 +1113,7 @@ above):**
 - [x] 4.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`. Confirmed: clean, `git diff
   --stat -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty.
-- [ ] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+- [x] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
   **NOT executed by `sdd-apply`** — orchestrator-level review action, out
   of this phase's scope per the project's solo-dev PR validation gate.
 - [ ] 4.21 Branch `feat/stage15-slice4-estado-de-cuenta` off `main`

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -983,6 +983,24 @@ above):**
       `condiciones_fiscales` under the tenant-scoped context and hit an RLS
       violation — fixed by switching to `TenantActualFijo.Plataforma`,
       matching this file's own `PrepararAsync`.)
+32. **`judgment-day` round 1 (juez A) confirmed 1 CRITICAL: the regla-10
+    offset test was self-defeating — production code was correct, the gap
+    was the test.** `CuentaCorrienteProveedorEstadoDeCuentaTests.
+    UnFiltroHastaConOffsetRealMenosTresIncluyeUnMovimientoQueUnFiltroEnUtcExcluiria`
+    sent `historico=true` alongside `desde`/`hasta`; `ServicioDeCuentaCorrienteDeProveedor.
+    ObtenerEstadoDeCuentaAsync:30-40` only assigns `desdeEfectivo`/`hastaEfectivo`
+    `if (!historico)`, so the date filter was never applied and the test passed
+    unconditionally on a single seeded movement (`Assert.Single` trivially
+    true). Fixed tests-only: dropped `historico=true` so the real filter runs,
+    and redesigned the dataset so inclusion depends on the OFFSET, not the bare
+    date — `hasta = 2026-07-31T23:59:59-03:00` (== `2026-08-01T02:59:59Z`), one
+    movement 1m59s before that instant (must be included) and one 5m01s after
+    (must be excluded). Mutation evidence (commit-first / mutate `hastaEfectivo`
+    to `hasta.Value.UtcDateTime.Date` / `dotnet build --no-incremental` /
+    `git checkout -- src/`): the mutated build made the new test fail as
+    expected (0 items instead of 1, the boundary-adjacent movement wrongly
+    excluded), confirmed; reverted, byte-identical `git status` clean. Full
+    file green after the revert (10/10).
 
 - [x] 4.1 Create
   `src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedor.cs`

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -943,6 +943,46 @@ above):**
     partial payment is lost because the design's formula never queries
     `gastos` at all". Reverted; `git diff` against the committed slice-4 tip
     confirms byte-identical production code after all three reverts.
+31. **`judgment-day` round 1 (juez B) confirmed 3 CRITICAL coverage gaps on
+    the slice-4 diff — production code was correct in all three, the gap was
+    always a missing discriminating test.** Fixed tests-only, evidenced with
+    the standard commit-first / mutate / revert cycle (`git checkout -- src/`
+    after each), full target-file run + `SaldoDeProveedorTests` (16/16) green
+    at the end:
+    - **CRITICAL 1** (`ServicioDeSaldoDeProveedor.cs:90-103`): no test
+      discriminated the cache (`proveedores.saldo`) from the retired
+      re-derived-aggregate path, because every existing flow keeps both in
+      sync by construction. New test
+      `SaldoDeProveedorReSourceadoTests.ElSaldoLeeLaCacheAunDesincronizadaDelAgregadoDelLedger`
+      desyncs them on purpose via a raw `UPDATE proveedores SET saldo =
+      777.77` over the fixture's owner connection and asserts `/saldo`
+      returns the sentinel, not the (zero) aggregate. Mutating
+      `ResolverSaldoDeProveedorAsync` to re-derive from
+      `MovimientosCuentaCorrienteProveedor` made it fail (`777.77` expected,
+      `0.00` actual), confirmed.
+    - **CRITICAL 2** (`ServicioDeCuentaCorrienteDeProveedor.cs:44-51`): no
+      test asserted `MovimientoDeCuentaDeProveedor.SaldoResultante` on
+      returned items. New test
+      `CuentaCorrienteProveedorEstadoDeCuentaTests.LosItemsDevuelvenElSaldoResultanteAcumuladoPorFila`
+      seeds a nonzero previous debt plus 3 more movements whose accumulated
+      `SaldoResultante` (1190/1070/1680) are all pairwise-distinct and none
+      equal to their own `Importe` (mutation-proof-tests rule 6). Mutating
+      the projection to hardcode `SaldoResultante = 0m` made it fail (`1190`
+      expected, `0` actual), confirmed.
+    - **CRITICAL 3** (`ServicioDeCuentaCorrienteDeProveedor.cs:83`): deleting
+      `Where(m => m.IdProveedor == idProveedor)` survives because every test
+      in the file seeds exactly one proveedor per tenant. New test
+      `CuentaCorrienteProveedorEstadoDeCuentaTests.UnSegundoProveedorDelMismoTenantNoContaminaElEstadoDeCuenta`
+      (plus a new `CrearSegundoProveedorEnElMismoTenantAsync` helper and a
+      `SembrarMovimientoAsync` overload taking an explicit `idProveedor`)
+      seeds a second proveedor of the SAME tenant with its own movements and
+      asserts proveedor A's estado de cuenta returns exactly A's 2 rows by
+      id, with B's distinct total (333) undetected. Mutating the filter to
+      `Where(m => true)` made it fail (`Total` 2 expected, 4 actual — B's
+      rows leaked in), confirmed. (The helper's first draft wrote
+      `condiciones_fiscales` under the tenant-scoped context and hit an RLS
+      violation — fixed by switching to `TenantActualFijo.Plataforma`,
+      matching this file's own `PrepararAsync`.)
 
 - [x] 4.1 Create
   `src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedor.cs`

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1055,9 +1055,14 @@ above):**
 - [x] 4.19 Gate guard: `dotnet ef migrations has-pending-model-changes`
   clean; zero new files under `Migraciones/`. Confirmed: clean, `git diff
   --stat -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty.
-- [x] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
-- [x] 4.21 Branch `feat/stage15-slice4-estado-de-cuenta` off `main`
-  (parent: slice 3); PR; merge stacked-to-main.
+- [ ] 4.20 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  **NOT executed by `sdd-apply`** — orchestrator-level review action, out
+  of this phase's scope per the project's solo-dev PR validation gate.
+- [ ] 4.21 Branch `feat/stage15-slice4-estado-de-cuenta` off `main`
+  (parent: slice 3); PR; merge stacked-to-main. **NOT executed by
+  `sdd-apply`** — the branch already exists (worktree pre-created by the
+  orchestrator) and carries this phase's commits; PR creation/merge is an
+  orchestrator action, out of this phase's scope.
 
 **Test plan**: filters (4.7), tied-`fecha` pagination (4.8), defaults
 (4.9), `/saldo` byte-compatibility (4.10), payment-status coverage

--- a/src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs
@@ -1,0 +1,31 @@
+using Ways.Api.Seguridad;
+using Ways.Application.CuentaCorriente;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 4 (design: API Surface, task 4.6): el estado de cuenta
+/// paginado del proveedor. Grupo bajo <c>OperacionDePos</c> — sin policy apilada, mismo criterio
+/// que <c>CuentaCorrienteEndpoints</c> (cliente): un Vendedor tiene que poder consultar la cuenta
+/// corriente de un proveedor. <c>POST /ajustes</c> (Slice 5, design decisión 12) se mapea
+/// TOP-LEVEL sobre <c>app</c>, nunca dentro de este grupo — la razón por la que ese endpoint NO
+/// vive acá.
+/// </summary>
+public static class CuentaCorrienteDeProveedorEndpoints
+{
+    public static IEndpointRouteBuilder MapearCuentaCorrienteDeProveedor(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/proveedores/{idProveedor:int}/cuenta-corriente")
+            .WithTags("CuentaCorrienteDeProveedor")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapGet("/", async (
+            ServicioDeCuentaCorrienteDeProveedor servicio, int idProveedor, DateTimeOffset? desde,
+            DateTimeOffset? hasta, bool? historico, int? pagina, int? tamanio, CancellationToken ct) =>
+            Results.Ok(await servicio.ObtenerEstadoDeCuentaAsync(
+                idProveedor, desde, hasta, historico ?? false, pagina ?? 1, tamanio ?? 25, ct)))
+        .WithSummary("Estado de cuenta del proveedor: header + movimientos paginados con saldo corrido.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -174,6 +174,8 @@ app.MapearCaja();
 app.MapearGastos();
 app.MapearCuentaCorriente();
 app.MapearCompras();
+// stage-15-cc-proveedores-ledger, Slice 4: estado de cuenta paginado del proveedor.
+app.MapearCuentaCorrienteDeProveedor();
 app.MapearReportes();
 app.MapearAuditoria();
 

--- a/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
+++ b/src/Ways.Application/Compras/ServicioDeSaldoDeProveedor.cs
@@ -2,64 +2,72 @@ using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Common;
 using Ways.Domain.Compras;
-using Ways.Domain.Gastos;
+using Ways.Domain.CuentaCorriente;
 
 namespace Ways.Application.Compras;
 
 /// <summary>
-/// El saldo derivado del proveedor (design decisión 11, spec: saldo-de-proveedor) — dedicado,
-/// nunca extiende <c>ServicioDeProveedores</c> (un ABM plano que no tiene por qué depender de
-/// dos agregados operativos para servir una lectura). Sin tabla, sin caché, sin estado propio:
-/// <c>Σ compras confirmadas − Σ gastos (categoria = proveedor)</c>, con el estado de pago
-/// por-compra derivado de los gastos LIGADOS únicamente (spec: Per-Compra Payment Status From
-/// Linked Gastos Only).
+/// El saldo del proveedor (design decisión 9, spec: saldo-de-proveedor MODIFIED) — dedicado,
+/// nunca extiende <c>ServicioDeProveedores</c>. Re-sourceado sobre el ledger de
+/// stage-15-cc-proveedores-ledger: <see cref="Saldo"/> viene de <c>proveedores.saldo</c> (la
+/// caché de <c>EscriturasDeCuentaCorrienteProveedor</c>), NUNCA re-derivado de agregados — firma y
+/// los tres records de respuesta se mantienen byte-idénticos a la forma pre-etapa 15 (task 4.10).
 ///
-/// Dos consultas agregadas más el guard de existencia del proveedor (Data Flow del design) — O(1),
-/// nunca N+1: la segunda consulta agregada agrupa TODOS los gastos
-/// de categoría proveedor del proveedor por <c>id_comprobante_compra</c> (incluida la fila NULL,
-/// que agrupa los gastos sin ligar) — de ahí sale tanto el total a restar del saldo como el
-/// desglose por-compra, en un solo <c>GROUP BY</c> (task 4.2: "a single grouped query... no
-/// N+1").
+/// El estado de pago por-compra usa la fórmula VINCULANTE de <c>state.yaml</c> OD7 (tasks.md
+/// decisión 4) — NO la del proposal (<c>SUM(importe) ... &lt;= 0 ⇒ pagada</c>, lee `pagada` una
+/// compra pre-cutover sin movimiento propio) ni la del design (<c>−Σ importe WHERE tipo &lt;&gt;
+/// 'compra'</c>, pierde un pago parcial pre-cutover porque nunca consulta <c>gastos</c>):
+/// <c>pagado(X) = SUM(gastos.importe) WHERE gastos.id_comprobante_compra = X</c> (el mecanismo
+/// retirado, predicado verbatim — sigue siendo verdad para TODO el tiempo porque el pago SIGUE
+/// siendo un gasto) <c>+ SUM(-importe) WHERE movimientos_cuenta_corriente_proveedor.
+/// id_comprobante_compra = X AND tipo = 'ajuste'</c> (contramovimientos y ajustes manuales
+/// imputados). Los movimientos <c>'pago'</c> NO se cuentan acá — ya están contados como gasto;
+/// sumarlos de nuevo sería double-count (mutation target #24 REDEFINIDO). <c>ResolverEstadoPago</c>
+/// no cambia una línea.
 /// </summary>
 public class ServicioDeSaldoDeProveedor(IWaysDbContext db)
 {
     public async Task<SaldoDeProveedor> ObtenerAsync(int idProveedor, CancellationToken ct = default)
     {
-        await ResolverProveedorAsync(idProveedor, ct);
+        var saldo = await ResolverSaldoDeProveedorAsync(idProveedor, ct);
 
         var compras = await db.ComprobantesCompra
             .Where(c => c.IdProveedor == idProveedor && c.Estado == EstadoCompra.Confirmada)
             .Select(c => new { c.Id, c.NumeroExterno, c.Total })
             .ToListAsync(ct);
 
-        // Agrupado por id_comprobante_compra — la fila con clave null agrupa los gastos SIN
-        // ligar (spec: An Unlinked Gasto Still Reduces The Total Saldo). Una sola consulta sirve
-        // tanto al total (spec: Saldo Is A Derived Read) como al desglose por-compra (spec:
-        // Per-Compra Payment Status From Linked Gastos Only).
-        var gastosPorCompra = await db.Gastos
-            .Where(g => g.IdProveedor == idProveedor && g.Categoria == CategoriaGasto.Proveedor)
-            .GroupBy(g => g.IdComprobanteCompra)
+        var idsCompras = compras.Select(c => c.Id).ToList();
+
+        // Primer término de OD7 — el mecanismo retirado, verbatim: SUM(gastos.importe) por
+        // id_comprobante_compra, SIN filtro de categoria acá (distinto del predicado que escribe
+        // el movimiento 'pago' en ServicioDeGastos — ese sí filtra categoria = proveedor). Acotado
+        // a las compras de ESTE proveedor por índice (ix_gastos_comprobante_compra).
+        var pagadoPorGastos = await db.Gastos
+            .Where(g => g.IdComprobanteCompra != null && idsCompras.Contains(g.IdComprobanteCompra.Value))
+            .GroupBy(g => g.IdComprobanteCompra!.Value)
             .Select(grupo => new { IdComprobanteCompra = grupo.Key, Total = grupo.Sum(g => g.Importe) })
-            .ToListAsync(ct);
+            .ToDictionaryAsync(g => g.IdComprobanteCompra, g => g.Total, ct);
 
-        var totalCompras = compras.Sum(c => c.Total);
-        var totalGastos = gastosPorCompra.Sum(g => g.Total);
-
-        var pagadoPorCompra = gastosPorCompra
-            .Where(g => g.IdComprobanteCompra is not null)
-            .ToDictionary(g => g.IdComprobanteCompra!.Value, g => g.Total);
+        // Segundo término de OD7 — SOLO 'ajuste' (contramovimiento de anulación o ajuste manual
+        // imputado); 'pago' queda EXCLUIDO a propósito (ya contado arriba vía gastos — target #24).
+        var reversadoPorAjustes = await db.MovimientosCuentaCorrienteProveedor
+            .Where(m => m.Tipo == TipoMovimientoCcProveedor.Ajuste && m.IdComprobanteCompra != null
+                && idsCompras.Contains(m.IdComprobanteCompra.Value))
+            .GroupBy(m => m.IdComprobanteCompra!.Value)
+            .Select(grupo => new { IdComprobanteCompra = grupo.Key, Total = grupo.Sum(m => -m.Importe) })
+            .ToDictionaryAsync(g => g.IdComprobanteCompra, g => g.Total, ct);
 
         var comprasConEstado = compras
             .Select(c =>
             {
-                var pagado = pagadoPorCompra.GetValueOrDefault(c.Id, 0m);
+                var pagado = pagadoPorGastos.GetValueOrDefault(c.Id, 0m) + reversadoPorAjustes.GetValueOrDefault(c.Id, 0m);
                 var estado = ResolverEstadoPago(pagado, c.Total);
                 return new CompraConEstadoPago(c.Id, c.NumeroExterno, c.Total, pagado, estado);
             })
             .OrderBy(c => c.IdComprobanteCompra)
             .ToList();
 
-        return new SaldoDeProveedor(idProveedor, totalCompras - totalGastos, comprasConEstado);
+        return new SaldoDeProveedor(idProveedor, saldo, comprasConEstado);
     }
 
     /// <summary>spec: A Fully Paid Compra / An Unlinked Gasto Does Not Mark A Compra As Paid — sin
@@ -76,15 +84,22 @@ public class ServicioDeSaldoDeProveedor(IWaysDbContext db)
         return pagado >= total ? EstadoPago.Pagada : EstadoPago.Parcial;
     }
 
-    private async Task ResolverProveedorAsync(int idProveedor, CancellationToken ct)
+    /// <summary>ADR-8: mismo 404 para "no existe" y "es de otro tenant" (spec: Cross-Tenant
+    /// Proveedor Saldo Is Invisible) — trae <c>Saldo</c> en la misma consulta de existencia
+    /// (design decisión 9: <c>proveedores.saldo</c> es la fuente, ya no un agregado).</summary>
+    private async Task<decimal> ResolverSaldoDeProveedorAsync(int idProveedor, CancellationToken ct)
     {
-        var existe = await db.Proveedores.AnyAsync(p => p.Id == idProveedor, ct);
-        if (!existe)
+        var proveedor = await db.Proveedores
+            .Where(p => p.Id == idProveedor)
+            .Select(p => new { p.Saldo })
+            .FirstOrDefaultAsync(ct);
+
+        if (proveedor is null)
         {
-            // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (spec: Cross-Tenant
-            // Proveedor Saldo Is Invisible).
             throw ErrorDominio.NoEncontrado($"No existe el proveedor {idProveedor}.");
         }
+
+        return proveedor.Saldo;
     }
 }
 
@@ -104,8 +119,9 @@ public enum EstadoPago
 public sealed record CompraConEstadoPago(
     int IdComprobanteCompra, string? NumeroExterno, decimal Total, decimal Pagado, EstadoPago EstadoPago);
 
-/// <summary>Respuesta de <c>GET /api/proveedores/{id}/saldo</c> (design: API Surface) —
-/// <see cref="Saldo"/> es la aproximación declarada por el spec (saldo-de-proveedor / Saldo Is
-/// An Approximation, Not An Invariant): un gasto sin ligar la reduce igual, aunque no salde
-/// ninguna compra puntual.</summary>
+/// <summary>Respuesta de <c>GET /api/proveedores/{id}/saldo</c> (design: API Surface), byte-idéntica
+/// a la forma pre-etapa 15 (task 4.10) — <see cref="Saldo"/> ahora es el INVARIANTE de
+/// <c>proveedores.saldo</c> (spec: saldo-de-proveedor / Saldo Is The Single-Write-Authority Cache
+/// Of The Ledger, REMOVED "Saldo Is An Approximation, Not An Invariant"): un gasto sin ligar la
+/// reduce igual, aunque no salde ninguna compra puntual.</summary>
 public sealed record SaldoDeProveedor(int IdProveedor, decimal Saldo, IReadOnlyList<CompraConEstadoPago> Compras);

--- a/src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs
+++ b/src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs
@@ -1,0 +1,27 @@
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// DTOs del estado de cuenta de proveedores (design.md:139-149, task 4.2) —
+/// <c>dto-contract-honesty</c>: cada campo se lee en algún lado, ninguno se acepta y descarta
+/// (task 4.18). Distinta de <c>Ways.Application.Compras.SaldoDeProveedor</c> (Slice 4, /saldo):
+/// esta es la lectura PAGINADA del ledger completo, aquella el resumen por-compra
+/// (design decisión 9 — dos read models a propósito, ninguno amplía al otro).
+/// </summary>
+public sealed record MovimientoDeCuentaDeProveedor(
+    int IdMovimiento, DateTimeOffset Fecha, TipoMovimientoCcProveedor Tipo, decimal Importe,
+    decimal SaldoResultante, string? Detalle, int? IdComprobanteCompra, int? IdGasto,
+    EtiquetaDeAjuste? Etiqueta);
+
+/// <summary><see cref="Saldo"/> viene de <c>proveedores.saldo</c> (la caché de
+/// <c>EscriturasDeCuentaCorrienteProveedor</c>) — NUNCA re-derivado de los movimientos de esta
+/// misma página (design decisión 11).</summary>
+public sealed record EstadoDeCuentaDeProveedorHeader(int IdProveedor, decimal Saldo);
+
+/// <summary>Forma PAGINADA (design decisión 10 / <c>state.yaml</c> OD9 — reconciliación de tasks.md
+/// decisión 5): <c>OFFSET</c>, desempate <c>id_movimiento DESC</c>, <c>Total</c> es el
+/// <c>COUNT(*)</c> sin paginar que habilita "Página N de M" en el web (Slice 6).</summary>
+public sealed record PaginaDeEstadoDeCuentaDeProveedor(
+    EstadoDeCuentaDeProveedorHeader Header, IReadOnlyList<MovimientoDeCuentaDeProveedor> Items,
+    int Total, int Pagina, int Tamanio, bool Historico, DateTimeOffset? Desde, DateTimeOffset? Hasta);

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedor.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedor.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Application.CuentaCorriente;
+
+/// <summary>
+/// El lado de lectura del ledger de proveedores (design.md: Interfaces / Contracts — Application —
+/// read model, tasks 4.3-4.4). Header + página de movimientos en un único <c>GET</c>, sin lock
+/// (lectura pura) — <c>saldo_resultante</c> es la ÚNICA fuente de la corrida, JAMÁS re-derivada
+/// (design decisión 11). <c>historico</c> gana sobre <c>desde</c>/<c>hasta</c>; si ninguno de los
+/// tres viene, aplica el default de último mes — mismo criterio pinneado por
+/// <c>ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaAsync</c> (cliente, stage 7).
+/// PAGINADA (design decisión 10, <c>state.yaml</c> OD9): <c>CountAsync</c> + <c>Skip/Take</c>,
+/// mismo patrón que <c>ServicioDeConsultaDeAuditoria.ConsultarAsync</c> (etapa 14).
+/// El ajuste manual (<c>RegistrarAjusteAsync</c>) llega en Slice 5 — no declarado acá todavía.
+/// </summary>
+public sealed class ServicioDeCuentaCorrienteDeProveedor(IWaysDbContext db, IRelojDelSistema reloj)
+{
+    public async Task<PaginaDeEstadoDeCuentaDeProveedor> ObtenerEstadoDeCuentaAsync(
+        int idProveedor, DateTimeOffset? desde, DateTimeOffset? hasta, bool historico,
+        int pagina, int tamanio, CancellationToken ct = default)
+    {
+        var saldo = await ResolverSaldoDeProveedorAsync(idProveedor, ct);
+
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        DateTimeOffset? desdeEfectivo = null;
+        DateTimeOffset? hastaEfectivo = null;
+        if (!historico)
+        {
+            // Un hasta explícito sin desde también recorta la ventana a un mes — mismo criterio
+            // que ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaAsync (cliente).
+            desdeEfectivo = desde ?? (hasta is { } hastaSinDesde ? hastaSinDesde.AddMonths(-1) : reloj.Ahora.AddMonths(-1));
+            hastaEfectivo = hasta;
+        }
+
+        var query = ConstruirQuery(idProveedor, desdeEfectivo, hastaEfectivo);
+
+        var total = await query.CountAsync(ct);
+
+        var filas = await query
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(m => new
+            {
+                m.Id, m.Fecha, m.Tipo, m.Importe, m.SaldoResultante, m.Detalle, m.IdComprobanteCompra, m.IdGasto
+            })
+            .ToListAsync(ct);
+
+        var items = filas
+            .Select(f => new MovimientoDeCuentaDeProveedor(
+                f.Id, f.Fecha, f.Tipo, f.Importe, f.SaldoResultante, f.Detalle, f.IdComprobanteCompra, f.IdGasto,
+                f.Tipo == TipoMovimientoCcProveedor.Ajuste
+                    ? CalculadorDeEstadoDeCuentaDeProveedor.EtiquetarAjuste(f.IdComprobanteCompra)
+                    : null))
+            .ToList();
+
+        var header = new EstadoDeCuentaDeProveedorHeader(idProveedor, saldo);
+        return new PaginaDeEstadoDeCuentaDeProveedor(
+            header, items, total, pagina, tamanio, historico, desdeEfectivo, hastaEfectivo);
+    }
+
+    /// <summary>
+    /// Cláusulas bajo prueba (<c>mutation-proof-tests</c>, design.md:164-172), en orden de daño si
+    /// se pierden:
+    ///   <c>Where(m => m.IdProveedor == idProveedor)</c> → sin él, el ledger de un proveedor
+    ///                                                      filtra otros (cross-tenant/cross-proveedor)
+    ///   <c>ThenByDescending(Id)</c>                     → con <c>fecha</c> empatada (<c>RelojFijo</c>,
+    ///                                                      o confirmar + contramovimiento) la
+    ///                                                      paginación duplica y saltea (mutation
+    ///                                                      target #25, task 4.16)
+    ///   cada <c>if (desde/hasta is { } x)</c>            → un filtro ignorado devuelve de más, en
+    ///                                                      silencio (mutation target #26, task 4.17)
+    /// El branch <c>historico</c> vs. default de último mes vive en el llamador (no toma
+    /// <paramref name="desde"/>/<paramref name="hasta"/> crudos, ya resueltos ahí).
+    /// </summary>
+    private IQueryable<MovimientoCuentaCorrienteProveedor> ConstruirQuery(
+        int idProveedor, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var consulta = db.MovimientosCuentaCorrienteProveedor.Where(m => m.IdProveedor == idProveedor);
+
+        if (desde is { } desdeAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha >= desdeAplicado);
+        }
+
+        if (hasta is { } hastaAplicado)
+        {
+            consulta = consulta.Where(m => m.Fecha <= hastaAplicado);
+        }
+
+        return consulta.OrderByDescending(m => m.Fecha).ThenByDescending(m => m.Id);
+    }
+
+    /// <summary>ADR-8: mismo 404 para "no existe" y "es de otro tenant" — mismo criterio que
+    /// <c>ServicioDeSaldoDeProveedor.ResolverProveedorAsync</c>, pero trae <c>Saldo</c> en la misma
+    /// consulta (esta lectura lo necesita para el header; aquella solo necesita existencia).</summary>
+    private async Task<decimal> ResolverSaldoDeProveedorAsync(int idProveedor, CancellationToken ct)
+    {
+        var proveedor = await db.Proveedores
+            .Where(p => p.Id == idProveedor)
+            .Select(p => new { p.Saldo })
+            .FirstOrDefaultAsync(ct);
+
+        if (proveedor is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe el proveedor {idProveedor}.");
+        }
+
+        return proveedor.Saldo;
+    }
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -89,6 +89,10 @@ public static class DependencyInjection
         // (design decisión 11) — dedicado, no extiende ServicioDeProveedores.
         services.AddScoped<ServicioDeSaldoDeProveedor>();
 
+        // stage-15-cc-proveedores-ledger, Slice 4: el lado de lectura del ledger de proveedores —
+        // estado de cuenta paginado (task 4.3).
+        services.AddScoped<ServicioDeCuentaCorrienteDeProveedor>();
+
         // stage-10-agregacion-dashboard, Slice 2: LectorDeSerieTemporal es la única superficie de
         // SQL crudo de toda la etapa (design decisión 2) — ServicioDeReportesDeVentas es su
         // primer consumidor.

--- a/src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedor.cs
+++ b/src/Ways.Domain/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedor.cs
@@ -1,0 +1,19 @@
+namespace Ways.Domain.CuentaCorriente;
+
+/// <summary>
+/// Puro, sin DB (design.md:131-134, task 4.1) — la única derivación del estado de cuenta de
+/// proveedores que no vive ya en <see cref="Ways.Application.Compras.ServicioDeSaldoDeProveedor"/>:
+/// etiquetar un <see cref="TipoMovimientoCcProveedor.Ajuste"/> por su origen. Espeja
+/// <see cref="CalculadorDeEstadoDeCuenta.EtiquetarAjuste"/> (cliente, stage 7) — misma derivación
+/// estructural, sin columna nueva: el contramovimiento de anulación (stage-15 Slice 2) siempre
+/// lleva <c>id_comprobante_compra</c>; el ajuste manual (Slice 5) nunca lo lleva.
+/// <see cref="Ways.Application.Compras.ServicioDeSaldoDeProveedor"/>'s <c>ResolverEstadoPago</c>
+/// (por-compra, fórmula OD7) se REUSA sin tocar — no se duplica acá.
+/// </summary>
+public static class CalculadorDeEstadoDeCuentaDeProveedor
+{
+    /// <summary>Aplica solo a filas <see cref="TipoMovimientoCcProveedor.Ajuste"/> — el llamador es
+    /// responsable de no invocarla sobre otro <see cref="TipoMovimientoCcProveedor"/>.</summary>
+    public static EtiquetaDeAjuste EtiquetarAjuste(int? idComprobanteCompra) =>
+        idComprobanteCompra is null ? EtiquetaDeAjuste.Manual : EtiquetaDeAjuste.AnulacionContramovimiento;
+}

--- a/tests/Ways.Application.Tests/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedorLecturaTests.cs
+++ b/tests/Ways.Application.Tests/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedorLecturaTests.cs
@@ -1,0 +1,70 @@
+namespace Ways.Application.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 4 (task 4.16; design.md:164-172 / tasks.md decisión 4 —
+/// mutation target #25). Mutation target #25: si <c>ThenByDescending(m => m.Id)</c> se borrara de
+/// <c>ConstruirQuery</c>, la paginación con <c>fecha</c> empatada podría duplicar o saltear filas.
+///
+/// Resuelto con una aserción de TEXTO FUENTE, no de comportamiento — mismo criterio que los
+/// mutation targets #4/#11 (Slice 1, <c>CuentaCorrienteProveedorBackfillTests</c>) y #19 (Slice 2,
+/// <c>ServicioDeComprasLockOrderTests</c>): dos intentos de rutear el target por comportamiento
+/// fueron descartados EMPÍRICAMENTE (mutation-proof-tests rule 2, "no lo razones, corré la
+/// prueba"; rule 3 exhausted primero). Intento 1 — sembrar tres filas con `fecha` idéntica en
+/// orden ascendente de `id`: el mutante (sin `ThenByDescending`) pasó la prueba de todos modos, en
+/// este entorno de test, porque el orden físico (TID) de un `INSERT`-only sequencial coincide con
+/// el orden de `id`. Intento 2 — forzar un `UPDATE` sobre la primera fila para desacoplar TID de
+/// `id`: el mutante SIGUIÓ pasando la prueba de comportamiento vía el endpoint HTTP paginado
+/// (`Skip`/`Take`), aunque una consulta EF sin `Take` explícito sí reveló una divergencia — la
+/// resolución de un empate de `ORDER BY` sin desempate explícito depende del plan/estrategia de
+/// sort que Postgres elija (quicksort acotado por `LIMIT` vs. sort completo), no de una garantía
+/// observable desde el test. El orden de la cláusula en el código fuente es, por eso, el único
+/// artefacto verificable de forma determinista.
+/// </summary>
+public class ServicioDeCuentaCorrienteDeProveedorLecturaTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        // tests/Ways.Application.Tests/CuentaCorriente/ → ../../src/Ways.Application/CuentaCorriente/
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "CuentaCorriente", "ServicioDeCuentaCorrienteDeProveedor.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodoConstruirQuery(string fuente)
+    {
+        const string firma = "private IQueryable<MovimientoCuentaCorrienteProveedor> ConstruirQuery(";
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        // Único método privado después de ConstruirQuery en este archivo — hasta el cierre de la
+        // clase basta (no hay otro método declarado luego).
+        var finClase = fuente.LastIndexOf('}');
+        Assert.True(finClase > inicio, "No se encontró el cierre de la clase.");
+
+        return fuente[inicio..finClase];
+    }
+
+    [Fact]
+    public void ConstruirQueryDesempataPorIdMovimientoDescendenteTarget25()
+    {
+        var metodo = ExtraerMetodoConstruirQuery(LeerFuente());
+
+        Assert.Contains("OrderByDescending(m => m.Fecha)", metodo, StringComparison.Ordinal);
+        Assert.Contains(
+            "ThenByDescending(m => m.Id)", metodo,
+            StringComparison.Ordinal);
+
+        // El desempate tiene que venir DESPUÉS del OrderByDescending(Fecha) principal, en la misma
+        // expresión encadenada — nunca un ThenBy suelto en otro lugar del archivo.
+        var indiceOrderBy = metodo.IndexOf("OrderByDescending(m => m.Fecha)", StringComparison.Ordinal);
+        var indiceThenBy = metodo.IndexOf("ThenByDescending(m => m.Id)", StringComparison.Ordinal);
+        Assert.True(
+            indiceThenBy > indiceOrderBy && indiceThenBy - indiceOrderBy < 40,
+            "ThenByDescending(Id) tiene que encadenarse inmediatamente después de OrderByDescending(Fecha) (mutation target #25).");
+    }
+}

--- a/tests/Ways.Domain.Tests/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedorTests.cs
+++ b/tests/Ways.Domain.Tests/CuentaCorriente/CalculadorDeEstadoDeCuentaDeProveedorTests.cs
@@ -1,0 +1,25 @@
+using Ways.Domain.CuentaCorriente;
+
+namespace Ways.Domain.Tests.CuentaCorriente;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 4 (task 4.1, design.md:131-134) — pura, sin base de
+/// datos. Espeja <c>CalculadorDeEstadoDeCuentaTests</c> (cliente, stage 7).
+/// </summary>
+public class CalculadorDeEstadoDeCuentaDeProveedorTests
+{
+    [Fact]
+    public void UnAjusteSinComprobanteDeCompraSeEtiquetaComoManual()
+    {
+        Assert.Equal(
+            EtiquetaDeAjuste.Manual, CalculadorDeEstadoDeCuentaDeProveedor.EtiquetarAjuste(idComprobanteCompra: null));
+    }
+
+    [Fact]
+    public void UnAjusteConComprobanteDeCompraSeEtiquetaComoContramovimientoDeAnulacion()
+    {
+        Assert.Equal(
+            EtiquetaDeAjuste.AnulacionContramovimiento,
+            CalculadorDeEstadoDeCuentaDeProveedor.EtiquetarAjuste(idComprobanteCompra: 77));
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
-using Ways.Application.Compras;
 using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
@@ -32,10 +31,11 @@ namespace Ways.IntegrationTests;
 /// recién ahí aplica <c>CuentaCorrienteDeProveedoresEtapa15</c> — así el backfill sí tiene algo
 /// que leer, exactamente como pasaría en una base real ya operando.
 ///
-/// <c>ServicioDeSaldoDeProveedor.ObtenerAsync</c> (Application, SIN CAMBIOS en esta slice — la
-/// re-derivación desde el ledger es tarea 4.5, Slice 4) es la fórmula retirada corriendo de
-/// verdad contra la fixture ANTES de migrar: la captura "antes" contra el mismo código que
-/// calculaba el saldo en producción, no una reimplementación de la fórmula en el test.
+/// <see cref="CalcularSaldoPorLaFormulaRetiradaAsync"/> inlinea la fórmula retirada (verbatim,
+/// mismo predicado que <c>ServicioDeSaldoDeProveedor.ObtenerAsync</c> tenía ANTES de la tarea 4.5)
+/// contra la fixture, ANTES de migrar — deviación registrada: la Slice 4 re-sourcea esa clase
+/// sobre <c>movimientos_cuenta_corriente_proveedor</c> (OD7), tabla que todavía no existe en este
+/// punto del test por diseño, así que llamarla directamente ya no es posible acá.
 /// </summary>
 [Collection("Ways.IntegrationTests secuencial")]
 public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
@@ -218,6 +218,26 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
         await db.SaveChangesAsync();
     }
 
+    /// <summary>La fórmula RETIRADA, verbatim (mismo predicado que
+    /// <c>ServicioDeSaldoDeProveedor.ObtenerAsync</c> tenía antes de la tarea 4.5 — spec:
+    /// saldo-de-proveedor, REMOVED "Saldo Is A Derived Read, Never Persisted"): <c>Σ compras
+    /// confirmadas − Σ gastos (categoria = proveedor)</c>. Inlineada acá porque esta prueba
+    /// necesita evaluarla contra una base migrada SOLO hasta <see cref="MigracionAnterior"/>,
+    /// donde <c>movimientos_cuenta_corriente_proveedor</c> todavía no existe — el punto exacto
+    /// que hace que el backfill tenga algo que leer.</summary>
+    private static async Task<decimal> CalcularSaldoPorLaFormulaRetiradaAsync(WaysDbContext db, int idProveedor)
+    {
+        var totalCompras = await db.ComprobantesCompra
+            .Where(c => c.IdProveedor == idProveedor && c.Estado == EstadoCompra.Confirmada)
+            .SumAsync(c => c.Total);
+
+        var totalGastos = await db.Gastos
+            .Where(g => g.IdProveedor == idProveedor && g.Categoria == CategoriaGasto.Proveedor)
+            .SumAsync(g => g.Importe);
+
+        return totalCompras - totalGastos;
+    }
+
     private sealed record Fixture(
         string NombreBase, string CadenaAdmin, string CadenaNueva,
         int IdConDeuda, int IdCompraConDeuda, decimal SaldoPrevioConDeuda,
@@ -230,8 +250,17 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
 
     /// <summary>Crea la base dedicada, migra hasta <see cref="MigracionAnterior"/>, siembra los 7
     /// proveedores discriminantes (task 1.20) y captura el saldo PREVIO con
-    /// <see cref="ServicioDeSaldoDeProveedor"/> (sin cambios en esta slice) — nunca migra la
-    /// migración bajo prueba: eso lo hace el llamador, para poder decidir cuándo.</summary>
+    /// <see cref="CalcularSaldoPorLaFormulaRetiradaAsync"/> — nunca migra la migración bajo
+    /// prueba: eso lo hace el llamador, para poder decidir cuándo.
+    /// <para>Deviación registrada (Slice 4, tasks.md decisión 4 / task 4.5): esta captura llamaba
+    /// antes a <c>ServicioDeSaldoDeProveedor.ObtenerAsync</c> directamente contra <c>db2</c> —
+    /// válido mientras esa clase todavía calculaba la fórmula retirada. Desde que la tarea 4.5
+    /// la re-sourcea sobre <c>movimientos_cuenta_corriente_proveedor</c> (OD7), esa llamada
+    /// fallaría acá con "relation does not exist": <c>db2</c> está deliberadamente migrado SOLO
+    /// hasta <see cref="MigracionAnterior"/>, ANTES de que esa tabla exista — el estado exacto
+    /// que este archivo necesita para que el backfill tenga algo que leer. La fórmula retirada
+    /// se inlinea acá, verbatim (mismo predicado que <c>ServicioDeSaldoDeProveedor.ObtenerAsync</c>
+    /// tenía antes de la tarea 4.5), en vez de reimplementar de memoria.</para></summary>
     private async Task<Fixture> PrepararFixtureSinMigrarAsync(string sufijo)
     {
         var nombreBase = $"ways_stage15_{sufijo}_{Guid.NewGuid():N}";
@@ -303,7 +332,7 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
         // Target #6: WHERE d.saldo <> 0 — sin ninguna actividad, derivado = 0, sin fila.
         var idSinHistoria = await SembrarProveedorPreMigracionAsync(conexionCruda, ctx.IdTenant, ctx.IdCondicionFiscal, "SinHistoria", eliminado: false);
 
-        var saldoPrevioConDeuda = (await new ServicioDeSaldoDeProveedor(db2).ObtenerAsync(idConDeuda)).Saldo;
+        var saldoPrevioConDeuda = await CalcularSaldoPorLaFormulaRetiradaAsync(db2, idConDeuda);
 
         return new Fixture(
             nombreBase, cadenaAdmin, cadenaNueva,
@@ -396,7 +425,7 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
             }
 
             // ConDeuda (spec scenario): la fila de apertura Y el cache coinciden con el saldo
-            // previo, calculado por el MISMO ServicioDeSaldoDeProveedor que corría antes de migrar.
+            // previo, calculado por CalcularSaldoPorLaFormulaRetiradaAsync ANTES de migrar.
             var aperturaConDeuda = await LeerAperturaAsync(f.IdConDeuda);
             Assert.NotNull(aperturaConDeuda);
             Assert.Equal(1100m, aperturaConDeuda!.Value.Importe);

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
@@ -87,18 +87,26 @@ public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture)
     /// LECTURA (filtros, orden, paginación), no la escritura (ya cubierta por Slices 2/3). Mantiene
     /// el invariante <c>proveedores.saldo == saldo_resultante</c> de la última fila escrita, para
     /// que el header también sea consistente.</summary>
-    private async Task<int> SembrarMovimientoAsync(
+    private Task<int> SembrarMovimientoAsync(
         Contexto ctx, TipoMovimientoCcProveedor tipo, DateTimeOffset fecha, decimal importe, string? detalle = null,
-        int? idComprobanteCompra = null, int? idGasto = null)
+        int? idComprobanteCompra = null, int? idGasto = null) =>
+        SembrarMovimientoAsync(ctx, ctx.IdProveedor, tipo, fecha, importe, detalle, idComprobanteCompra, idGasto);
+
+    /// <summary>Sobrecarga con <paramref name="idProveedor"/> explícito — permite sembrar movimientos
+    /// para UN SEGUNDO proveedor del MISMO tenant (judgment-day round 1, CRITICAL 3), algo que la
+    /// sobrecarga atada a <c>ctx.IdProveedor</c> no puede expresar.</summary>
+    private async Task<int> SembrarMovimientoAsync(
+        Contexto ctx, int idProveedor, TipoMovimientoCcProveedor tipo, DateTimeOffset fecha, decimal importe,
+        string? detalle = null, int? idComprobanteCompra = null, int? idGasto = null)
     {
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
-        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == idProveedor);
         var nuevoSaldo = proveedor.Saldo + importe;
 
         var movimiento = new MovimientoCuentaCorrienteProveedor
         {
             IdTenant = ctx.IdTenant,
-            IdProveedor = ctx.IdProveedor,
+            IdProveedor = idProveedor,
             Fecha = fecha,
             IdPuntoVenta = ctx.IdPuntoVenta,
             IdEmpleado = ctx.IdEmpleadoAdmin,
@@ -113,6 +121,32 @@ public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture)
         proveedor.Saldo = nuevoSaldo;
         await db.SaveChangesAsync();
         return movimiento.Id;
+    }
+
+    /// <summary>Crea un SEGUNDO proveedor en el MISMO tenant que <paramref name="ctx"/> — necesario
+    /// para discriminar <c>Where(m => m.IdProveedor == idProveedor)</c> (judgment-day round 1,
+    /// CRITICAL 3): todo el resto de este archivo siembra UN proveedor por tenant, por lo que borrar
+    /// ese filtro sobrevive sin este test.</summary>
+    private async Task<int> CrearSegundoProveedorEnElMismoTenantAsync(Contexto ctx, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var condicionFiscal = new CondicionFiscal
+        {
+            Codigo = $"{nombre}-CF-B", Nombre = $"{nombre}-B", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedorB = new Proveedor
+        {
+            IdTenant = ctx.IdTenant, RazonSocial = $"{nombre}-B", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedorB);
+        await db.SaveChangesAsync();
+        return proveedorB.Id;
     }
 
     private static async Task<PaginaDeEstadoDeCuentaDeProveedor> ObtenerEstadoDeCuentaAsync(
@@ -270,5 +304,71 @@ public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture)
         var respuesta = await ctxA.Admin.GetAsync($"/api/proveedores/{ctxB.IdProveedor}/cuenta-corriente");
 
         Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- judgment-day round 1, CRITICAL 2: SaldoResultante por fila, corrida discriminante --------
+
+    /// <summary>
+    /// Ningún otro test assertea <c>MovimientoDeCuentaDeProveedor.SaldoResultante</c> — corrida con
+    /// deuda previa ≠ 0 y VARIOS movimientos cuyos <c>saldo_resultante</c> son distintos entre sí y
+    /// de sus propios importes (mutation-proof-tests rule 6, lección del slice 2): una fila con
+    /// <c>SaldoResultante = 0m</c> hardcodeado, o la corrida acumulada, quedaría sin detectar.
+    /// </summary>
+    [Fact]
+    public async Task LosItemsDevuelvenElSaldoResultanteAcumuladoPorFila()
+    {
+        var ctx = await PrepararAsync(nameof(LosItemsDevuelvenElSaldoResultanteAcumuladoPorFila));
+
+        // Deuda previa != 0, fuera de la corrida assertada.
+        await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-10), 850m, "deuda previa");
+
+        // Corrida bajo prueba: saldo_resultante acumulado 850 -> 1190 -> 1070 -> 1680, todos
+        // distintos entre sí y distintos de sus propios importes (340, -120, 610).
+        var idMov1 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-3), 340m, "incrementa");
+        var idMov2 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-2), -120m, "reduce");
+        var idMov3 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-1), 610m, "incrementa de nuevo");
+
+        var pagina = await ObtenerEstadoDeCuentaAsync(ctx, "?historico=true&pagina=1&tamanio=10");
+
+        Assert.Equal(1190m, pagina.Items.Single(m => m.IdMovimiento == idMov1).SaldoResultante);
+        Assert.Equal(1070m, pagina.Items.Single(m => m.IdMovimiento == idMov2).SaldoResultante);
+        Assert.Equal(1680m, pagina.Items.Single(m => m.IdMovimiento == idMov3).SaldoResultante);
+        Assert.Equal(1680m, pagina.Header.Saldo);
+    }
+
+    // ---- judgment-day round 1, CRITICAL 3: un SEGUNDO proveedor del MISMO tenant no se filtra ----
+
+    /// <summary>
+    /// Borrar <c>Where(m => m.IdProveedor == idProveedor)</c> sobrevive a todo el resto de este
+    /// archivo porque cada test siembra UN proveedor por tenant. Este test siembra un SEGUNDO
+    /// proveedor del MISMO tenant con sus propios movimientos y assertea que el estado de cuenta
+    /// del proveedor A trae EXACTAMENTE los de A — conteo exacto, identificación de filas, y el
+    /// total de B es distinto y detectable si se filtrara de más (o de menos).
+    /// </summary>
+    [Fact]
+    public async Task UnSegundoProveedorDelMismoTenantNoContaminaElEstadoDeCuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnSegundoProveedorDelMismoTenantNoContaminaElEstadoDeCuenta));
+        var idProveedorB = await CrearSegundoProveedorEnElMismoTenantAsync(
+            ctx, nameof(UnSegundoProveedorDelMismoTenantNoContaminaElEstadoDeCuenta));
+
+        var idA1 = await SembrarMovimientoAsync(ctx, ctx.IdProveedor, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-3), 111m, "A-uno");
+        var idA2 = await SembrarMovimientoAsync(ctx, ctx.IdProveedor, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-2), 222m, "A-dos");
+
+        // Proveedor B: DOS movimientos también, con un total (555) distinto del de A (333) — si el
+        // filtro se pierde, Total pasaría de 2 a 4 y el saldo del header dejaría de coincidir.
+        await SembrarMovimientoAsync(ctx, idProveedorB, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-3), 333m, "B-uno");
+        await SembrarMovimientoAsync(ctx, idProveedorB, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-2), 222m, "B-dos");
+
+        var pagina = await ObtenerEstadoDeCuentaAsync(ctx, "?historico=true&pagina=1&tamanio=10");
+
+        Assert.Equal(2, pagina.Total);
+        Assert.Equal(2, pagina.Items.Count);
+        Assert.Collection(
+            pagina.Items,
+            m => Assert.Equal(idA2, m.IdMovimiento),
+            m => Assert.Equal(idA1, m.IdMovimiento));
+        Assert.Equal(333m, pagina.Header.Saldo);
+        Assert.DoesNotContain(pagina.Items, m => m.Detalle != null && m.Detalle.StartsWith("B-"));
     }
 }

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
@@ -157,9 +157,12 @@ public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture)
     {
         var ctx = await PrepararAsync(nameof(ConFechaEmpatadaLaPaginacionDesempataPorIdMovimientoDescendenteSinDuplicarNiSaltear));
 
-        // Las tres filas comparten EXACTAMENTE la misma fecha (RelojFijo) — sin
-        // ThenByDescending(Id) el orden entre ellas es indefinido y la paginación puede repetir o
-        // saltear filas.
+        // Las tres filas comparten EXACTAMENTE la misma fecha (RelojFijo) — cobertura de spec
+        // (task 4.8): la paginación no puede duplicar ni saltear filas bajo un empate. La prueba
+        // de mutación real del target #25 es de texto fuente (ver deviación registrada en
+        // tasks.md / apply-progress) — el orden de un empate SQL sin desempate explícito no es
+        // determinista de forma observable en este entorno de test (Postgres puede resolverlo
+        // por plan/estrategia de sort, no por garantía del estándar).
         var id1 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "primero");
         var id2 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "segundo");
         var id3 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "tercero");

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Catalogos;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 4: `GET /api/proveedores/{id}/cuenta-corriente`
+/// PAGINADO (tasks 4.6-4.9, design decisión 10 / `state.yaml` OD9 — reconciliación de tasks.md
+/// decisión 5) y su autorización (task 4.14). Mutation targets #25/#26 (tasks 4.16-4.17) —
+/// evidencia de mutación registrada en el PR body, no en este archivo; los tests 4.8/4.7 son sus
+/// discriminadores.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "vendedor-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Vendedor, int IdProveedor, int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        var altaVendedor = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("vendedor-cc-proveedor", mailVendedor, (int)RolConocido.Vendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.Created, altaVendedor.StatusCode);
+
+        var vendedor = fixture.CreateClient();
+        var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, vendedor, proveedor.Id, resultado.IdUsuarioAdmin);
+    }
+
+    /// <summary>Seedea directo por EF un movimiento del ledger — bypassea
+    /// <c>EscriturasDeCuentaCorrienteProveedor</c> a propósito: estos tests ejercitan el LADO DE
+    /// LECTURA (filtros, orden, paginación), no la escritura (ya cubierta por Slices 2/3). Mantiene
+    /// el invariante <c>proveedores.saldo == saldo_resultante</c> de la última fila escrita, para
+    /// que el header también sea consistente.</summary>
+    private async Task<int> SembrarMovimientoAsync(
+        Contexto ctx, TipoMovimientoCcProveedor tipo, DateTimeOffset fecha, decimal importe, string? detalle = null,
+        int? idComprobanteCompra = null, int? idGasto = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var proveedor = await db.Proveedores.FirstAsync(p => p.Id == ctx.IdProveedor);
+        var nuevoSaldo = proveedor.Saldo + importe;
+
+        var movimiento = new MovimientoCuentaCorrienteProveedor
+        {
+            IdTenant = ctx.IdTenant,
+            IdProveedor = ctx.IdProveedor,
+            Fecha = fecha,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            Tipo = tipo,
+            IdComprobanteCompra = idComprobanteCompra,
+            IdGasto = idGasto,
+            Importe = importe,
+            SaldoResultante = nuevoSaldo,
+            Detalle = detalle
+        };
+        db.MovimientosCuentaCorrienteProveedor.Add(movimiento);
+        proveedor.Saldo = nuevoSaldo;
+        await db.SaveChangesAsync();
+        return movimiento.Id;
+    }
+
+    private static async Task<PaginaDeEstadoDeCuentaDeProveedor> ObtenerEstadoDeCuentaAsync(
+        Contexto ctx, string query = "", HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).GetAsync(
+            $"/api/proveedores/{ctx.IdProveedor}/cuenta-corriente{query}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<PaginaDeEstadoDeCuentaDeProveedor>(cuerpo, OpcionesJson)!;
+    }
+
+    private static readonly DateTimeOffset Mediodia = new(2026, 8, 17, 12, 0, 0, TimeSpan.Zero);
+
+    // ---- task 4.7: filtros con seeds asimétricos — orden como SECUENCIA -----------------------
+
+    [Fact]
+    public async Task LosFiltrosDeFechaDevuelvenElSubconjuntoEnOrdenDeFechaDescendente()
+    {
+        var ctx = await PrepararAsync(nameof(LosFiltrosDeFechaDevuelvenElSubconjuntoEnOrdenDeFechaDescendente));
+
+        var idViejo = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-40), 100m, "fuera de rango (viejo)");
+        var idDentroTemprano = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-5), 200m, "dentro, temprano");
+        var idDentroTarde = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(-1), 300m, "dentro, tarde");
+        var idFuturo = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddDays(5), 400m, "fuera de rango (futuro)");
+
+        var pagina = await ObtenerEstadoDeCuentaAsync(
+            ctx, $"?desde={Uri.EscapeDataString(Mediodia.AddDays(-10).ToString("O"))}&hasta={Uri.EscapeDataString(Mediodia.ToString("O"))}");
+
+        Assert.Equal(2, pagina.Total);
+        Assert.Collection(
+            pagina.Items,
+            m => Assert.Equal(idDentroTarde, m.IdMovimiento),
+            m => Assert.Equal(idDentroTemprano, m.IdMovimiento));
+        Assert.DoesNotContain(pagina.Items, m => m.IdMovimiento == idViejo || m.IdMovimiento == idFuturo);
+    }
+
+    // ---- task 4.8 / mutation target #25: fecha EMPATADA — el desempate id_movimiento DESC -------
+
+    [Fact]
+    public async Task ConFechaEmpatadaLaPaginacionDesempataPorIdMovimientoDescendenteSinDuplicarNiSaltear()
+    {
+        var ctx = await PrepararAsync(nameof(ConFechaEmpatadaLaPaginacionDesempataPorIdMovimientoDescendenteSinDuplicarNiSaltear));
+
+        // Las tres filas comparten EXACTAMENTE la misma fecha (RelojFijo) — sin
+        // ThenByDescending(Id) el orden entre ellas es indefinido y la paginación puede repetir o
+        // saltear filas.
+        var id1 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "primero");
+        var id2 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "segundo");
+        var id3 = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia, 100m, "tercero");
+
+        var pagina1 = await ObtenerEstadoDeCuentaAsync(ctx, "?historico=true&pagina=1&tamanio=2");
+        Assert.Equal(3, pagina1.Total);
+        Assert.Collection(
+            pagina1.Items,
+            m => Assert.Equal(id3, m.IdMovimiento),
+            m => Assert.Equal(id2, m.IdMovimiento));
+
+        var pagina2 = await ObtenerEstadoDeCuentaAsync(ctx, "?historico=true&pagina=2&tamanio=2");
+        Assert.Equal(3, pagina2.Total);
+        var unica = Assert.Single(pagina2.Items);
+        Assert.Equal(id1, unica.IdMovimiento);
+    }
+
+    // ---- task 4.9: histórico gana sobre desde/hasta; sin filtro ⇒ último mes; ledger vacío -------
+
+    [Fact]
+    public async Task HistoricoIgnoraDesdeYHastaYDevuelveTodo()
+    {
+        var ctx = await PrepararAsync(nameof(HistoricoIgnoraDesdeYHastaYDevuelveTodo));
+        await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, Mediodia.AddYears(-2), 500m, "muy viejo");
+
+        // desde/hasta acotan a un rango que EXCLUYE el movimiento — historico=true los ignora.
+        var pagina = await ObtenerEstadoDeCuentaAsync(
+            ctx, $"?historico=true&desde={Uri.EscapeDataString(Mediodia.ToString("O"))}&hasta={Uri.EscapeDataString(Mediodia.ToString("O"))}");
+
+        Assert.Equal(1, pagina.Total);
+        Assert.True(pagina.Historico);
+        Assert.Null(pagina.Desde);
+        Assert.Null(pagina.Hasta);
+    }
+
+    [Fact]
+    public async Task SinFiltroAplicaElDefaultDeUltimoMes()
+    {
+        var ctx = await PrepararAsync(nameof(SinFiltroAplicaElDefaultDeUltimoMes));
+        var idReciente = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, DateTimeOffset.UtcNow.AddDays(-2), 100m, "reciente");
+        await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, DateTimeOffset.UtcNow.AddMonths(-3), 200m, "viejo");
+
+        var pagina = await ObtenerEstadoDeCuentaAsync(ctx);
+
+        Assert.False(pagina.Historico);
+        Assert.NotNull(pagina.Desde);
+        Assert.Null(pagina.Hasta);
+        var unica = Assert.Single(pagina.Items);
+        Assert.Equal(idReciente, unica.IdMovimiento);
+    }
+
+    [Fact]
+    public async Task UnProveedorSinMovimientosDevuelveUnaPaginaVaciaConElHeaderPoblado()
+    {
+        var ctx = await PrepararAsync(nameof(UnProveedorSinMovimientosDevuelveUnaPaginaVaciaConElHeaderPoblado));
+
+        var pagina = await ObtenerEstadoDeCuentaAsync(ctx);
+
+        Assert.Equal(0, pagina.Total);
+        Assert.Empty(pagina.Items);
+        Assert.Equal(ctx.IdProveedor, pagina.Header.IdProveedor);
+        Assert.Equal(0m, pagina.Header.Saldo);
+    }
+
+    // ---- regla 10 de mutation-proof-tests: offset real -03:00 en el filtro de fecha, nunca Z -----
+
+    [Fact]
+    public async Task UnFiltroHastaConOffsetRealMenosTresIncluyeUnMovimientoQueUnFiltroEnUtcExcluiria()
+    {
+        var ctx = await PrepararAsync(nameof(UnFiltroHastaConOffsetRealMenosTresIncluyeUnMovimientoQueUnFiltroEnUtcExcluiria));
+
+        // 2026-08-17T23:30:00-03:00 == 2026-08-18T02:30:00Z (spec: A date-boundary filter uses
+        // the client's real offset, not UTC).
+        var fechaDelMovimiento = new DateTimeOffset(2026, 8, 17, 23, 30, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(new DateTimeOffset(2026, 8, 18, 2, 30, 0, TimeSpan.Zero), fechaDelMovimiento);
+        var idMovimiento = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, fechaDelMovimiento, 100m, "borde -03:00");
+
+        // hasta = el mismo día calendario en -03:00, offset REAL del cliente, nunca `Z`.
+        var hastaConOffsetReal = "2026-08-17T23:59:59-03:00";
+        var pagina = await ObtenerEstadoDeCuentaAsync(
+            ctx, $"?historico=true&desde=2026-08-01T00:00:00-03:00&hasta={Uri.EscapeDataString(hastaConOffsetReal)}");
+
+        var unica = Assert.Single(pagina.Items);
+        Assert.Equal(idMovimiento, unica.IdMovimiento);
+    }
+
+    // ---- task 4.14: autorización — Vendedor lee, tenant B nunca ve al proveedor de A -------------
+
+    [Fact]
+    public async Task UnVendedorLeeElEstadoDeCuentaDeUnProveedor()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorLeeElEstadoDeCuentaDeUnProveedor));
+
+        var respuesta = await ctx.Vendedor.GetAsync($"/api/proveedores/{ctx.IdProveedor}/cuenta-corriente");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnProveedorDeOtroTenantDevuelve404EnElEstadoDeCuenta()
+    {
+        var ctxA = await PrepararAsync(nameof(UnProveedorDeOtroTenantDevuelve404EnElEstadoDeCuenta) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnProveedorDeOtroTenantDevuelve404EnElEstadoDeCuenta) + "-B");
+
+        var respuesta = await ctxA.Admin.GetAsync($"/api/proveedores/{ctxB.IdProveedor}/cuenta-corriente");
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorEstadoDeCuentaTests.cs
@@ -263,24 +263,41 @@ public class CuentaCorrienteProveedorEstadoDeCuentaTests(WaysApiFixture fixture)
 
     // ---- regla 10 de mutation-proof-tests: offset real -03:00 en el filtro de fecha, nunca Z -----
 
+    /// <summary>
+    /// SIN <c>historico</c> — a propósito: con <c>historico=true</c> el llamador nunca asigna
+    /// <c>desdeEfectivo</c>/<c>hastaEfectivo</c> (<c>ServicioDeCuentaCorrienteDeProveedor</c>:30-40
+    /// solo lo hace <c>if (!historico)</c>), así que el filtro de fecha JAMÁS se aplica y este test
+    /// pasaba de forma incondicional (judgment-day ronda A, CRITICAL — tasks.md desviación #32).
+    /// El dataset hace que la inclusión dependa DEL OFFSET real, no de la fecha pelada: el límite
+    /// <c>hasta</c> es <c>2026-07-31T23:59:59-03:00</c> == <c>2026-08-01T02:59:59Z</c>. El movimiento
+    /// A cae 1m59s ANTES de ese instante y el B cae 5m01s DESPUÉS — un mutante que trunque el límite
+    /// a fecha (<c>.Date</c>) o que descarte el offset (lo lea como si fuera <c>Z</c>, corriendo el
+    /// límite ~3hs antes) excluye a A, que debe entrar.
+    /// </summary>
     [Fact]
     public async Task UnFiltroHastaConOffsetRealMenosTresIncluyeUnMovimientoQueUnFiltroEnUtcExcluiria()
     {
         var ctx = await PrepararAsync(nameof(UnFiltroHastaConOffsetRealMenosTresIncluyeUnMovimientoQueUnFiltroEnUtcExcluiria));
 
-        // 2026-08-17T23:30:00-03:00 == 2026-08-18T02:30:00Z (spec: A date-boundary filter uses
-        // the client's real offset, not UTC).
-        var fechaDelMovimiento = new DateTimeOffset(2026, 8, 17, 23, 30, 0, TimeSpan.FromHours(-3));
-        Assert.Equal(new DateTimeOffset(2026, 8, 18, 2, 30, 0, TimeSpan.Zero), fechaDelMovimiento);
-        var idMovimiento = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, fechaDelMovimiento, 100m, "borde -03:00");
+        // A: 2026-07-31T23:58:00-03:00 == 2026-08-01T02:58:00Z — 1m59s antes del límite `hasta`.
+        var fechaDentroDelRango = new DateTimeOffset(2026, 7, 31, 23, 58, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 2, 58, 0, TimeSpan.Zero), fechaDentroDelRango);
+        var idDentro = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, fechaDentroDelRango, 100m, "1m59s antes del limite");
 
-        // hasta = el mismo día calendario en -03:00, offset REAL del cliente, nunca `Z`.
-        var hastaConOffsetReal = "2026-08-17T23:59:59-03:00";
+        // B: 2026-08-01T00:05:00-03:00 == 2026-08-01T03:05:00Z — 5m01s después del límite `hasta`.
+        var fechaFueraDelRango = new DateTimeOffset(2026, 8, 1, 0, 5, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 3, 5, 0, TimeSpan.Zero), fechaFueraDelRango);
+        var idFuera = await SembrarMovimientoAsync(ctx, TipoMovimientoCcProveedor.Ajuste, fechaFueraDelRango, 200m, "5m01s despues del limite");
+
+        // hasta = offset REAL del cliente, nunca `Z`.
+        var hastaConOffsetReal = "2026-07-31T23:59:59-03:00";
         var pagina = await ObtenerEstadoDeCuentaAsync(
-            ctx, $"?historico=true&desde=2026-08-01T00:00:00-03:00&hasta={Uri.EscapeDataString(hastaConOffsetReal)}");
+            ctx, $"?desde=2026-07-01T00:00:00-03:00&hasta={Uri.EscapeDataString(hastaConOffsetReal)}");
 
+        Assert.Equal(1, pagina.Total);
         var unica = Assert.Single(pagina.Items);
-        Assert.Equal(idMovimiento, unica.IdMovimiento);
+        Assert.Equal(idDentro, unica.IdMovimiento);
+        Assert.DoesNotContain(pagina.Items, m => m.IdMovimiento == idFuera);
     }
 
     // ---- task 4.14: autorización — Vendedor lee, tenant B nunca ve al proveedor de A -------------

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorReSourceadoTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorReSourceadoTests.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.Compras;
+using Ways.Application.Gastos;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 4 (task 4.5, tasks.md decisión 4 / `state.yaml` OD7): la
+/// fórmula VINCULANTE del estado de pago por-compra, re-sourceada sobre <c>gastos</c> +
+/// <c>movimientos_cuenta_corriente_proveedor.tipo = 'ajuste'</c> — NI la del proposal
+/// (<c>SUM(importe) ... &lt;= 0 ⇒ pagada</c>) NI la del design (<c>−Σ importe WHERE tipo &lt;&gt;
+/// 'compra'</c>), ambas RECHAZADAS. Los casos 4.12/4.13 seedean directo por EF una compra
+/// confirmada SIN su propio movimiento `compra` en el ledger — la forma exacta que la población
+/// pre-cutover del backfill (Slice 1) deja: la deuda no vive en ningún movimiento propio de la
+/// compra. `SaldoDeProveedorTests.cs` (stage-8, sin tocar) sigue siendo la prueba de regresión de
+/// byte-compatibilidad para el camino post-cutover ordinario — este archivo cubre lo que ese no
+/// puede: los dos casos pre-cutover y el byte-compat con dataset discriminante (task 4.10).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class SaldoDeProveedorReSourceadoTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdArticulo, int IdAlicuotaIva21,
+        int IdTipoCFB, int IdMedioEfectivo, string MailAdmin, string PasswordAdmin, int IdEmpleadoAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "CC-proveedor-saldo-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        await using var dbTenant = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var idMedioEfectivo = await dbTenant.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo).Select(m => m.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = "Articulo",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, articulo.Id, idAlicuotaIva21,
+            idTipoCFB, idMedioEfectivo, mailAdmin, resultado.PasswordTemporal, resultado.IdUsuarioAdmin);
+    }
+
+    private static SolicitudDeCompra SolicitudSimple(Contexto ctx, decimal costoUnitario, string numeroExterno) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, numeroExterno, DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item de prueba", 1m, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, true)]);
+
+    private static async Task<CompraDetalle> CrearYConfirmarCompraDeTotalAsync(Contexto ctx, decimal total, string numeroExterno)
+    {
+        var respuestaCrear = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudSimple(ctx, total, numeroExterno));
+        var cuerpoCrear = await respuestaCrear.Content.ReadAsStringAsync();
+        Assert.True(respuestaCrear.StatusCode == HttpStatusCode.Created, cuerpoCrear);
+        var creada = JsonSerializer.Deserialize<CompraDetalle>(cuerpoCrear, OpcionesJson)!;
+
+        var respuestaConfirmar = await ctx.Admin.PostAsync($"/api/compras/{creada.Id}/confirmar", null);
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpoConfirmar, OpcionesJson)!;
+    }
+
+    private static async Task<int> AbrirTurnoAsync(Contexto ctx)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/caja/turnos", new SolicitudDeApertura(ctx.IdPuntoVenta, 0m, "Apertura de soporte"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<TurnoResumen>(cuerpo, OpcionesJson)!.Id;
+    }
+
+    /// <summary>Seedea directo por EF una compra `confirmada`, SALTEANDO `ServicioDeCompras`
+    /// enteramente — nunca se escribe un movimiento `compra` propio en el ledger. Es la forma
+    /// exacta que la población pre-cutover del backfill (Slice 1) deja: la deuda de esta compra
+    /// no vive en ningún movimiento del ledger, solo en su <c>Total</c> (tasks.md decisión 4 /
+    /// `state.yaml` OD7 — "la deuda pre-cutover no tiene movimiento propio").</summary>
+    private async Task<int> SembrarCompraPreCutoverConfirmadaAsync(
+        Contexto ctx, decimal total, string numeroExterno)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var compra = new ComprobanteCompra
+        {
+            IdTenant = ctx.IdTenant,
+            IdProveedor = ctx.IdProveedor,
+            IdTipoComprobante = ctx.IdTipoCFB,
+            NumeroExterno = numeroExterno,
+            FechaComprobante = DateOnly.FromDateTime(ahora.UtcDateTime),
+            FechaRecepcion = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            Subtotal = total,
+            DescuentoTotal = 0m,
+            Total = total,
+            Estado = EstadoCompra.Confirmada,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.ComprobantesCompra.Add(compra);
+        await db.SaveChangesAsync();
+        return compra.Id;
+    }
+
+    /// <summary>Seedea directo por EF un gasto de categoría proveedor, ligado, SIN pasar por
+    /// <c>ServicioDeGastos.InsertarGastoAsync</c> — nunca se escribe su movimiento `pago` en el
+    /// ledger. Simula un pago registrado por el mecanismo RETIRADO, de antes de que este ledger
+    /// tuviera capacidad de escribir pagos (design.md: "the design's formula loses a pre-cutover
+    /// partial payment because it never queries gastos at all").</summary>
+    private async Task SembrarGastoLigadoSinMovimientoDeLedgerAsync(
+        Contexto ctx, int idTurno, int idComprobanteCompra, decimal importe)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        db.Gastos.Add(new Gasto
+        {
+            IdTenant = ctx.IdTenant,
+            Fecha = ahora,
+            IdPuntoVenta = ctx.IdPuntoVenta,
+            IdTurnoCaja = idTurno,
+            IdEmpleado = ctx.IdEmpleadoAdmin,
+            Categoria = CategoriaGasto.Proveedor,
+            IdProveedor = ctx.IdProveedor,
+            Concepto = "Pago pre-cutover (mecanismo retirado)",
+            IdMedioPago = ctx.IdMedioEfectivo,
+            Importe = importe,
+            IdComprobanteCompra = idComprobanteCompra,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<SaldoDeProveedor> ObtenerSaldoAsync(Contexto ctx) =>
+        JsonSerializer.Deserialize<SaldoDeProveedor>(
+            await (await ctx.Admin.GetAsync($"/api/proveedores/{ctx.IdProveedor}/saldo")).Content.ReadAsStringAsync(),
+            OpcionesJson)!;
+
+    // ---- task 4.12: compra pre-cutover sin pagos ⇒ impaga (discriminador de proposal Y design) ----
+
+    [Fact]
+    public async Task UnaCompraPreCutoverSinPagosLeeImpaga()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCompraPreCutoverSinPagosLeeImpaga));
+        var idCompra = await SembrarCompraPreCutoverConfirmadaAsync(ctx, total: 1234.56m, "pre-cutover-sin-pago");
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/proveedores/{ctx.IdProveedor}/saldo");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var saldo = JsonSerializer.Deserialize<SaldoDeProveedor>(cuerpo, OpcionesJson)!;
+
+        var linea = Assert.Single(saldo.Compras, c => c.IdComprobanteCompra == idCompra);
+        // Bajo la fórmula del proposal (SUM(importe) sobre movimientos del ledger, incluido el
+        // propio `compra`) esta compra NO TIENE movimiento propio ⇒ suma 0 ⇒ "<= 0 ⇒ pagada"
+        // (RECHAZADO — evidencia de mutación abajo). OD7 nunca lee el ledger para este término:
+        // pagado = 0 (sin gastos ligados) ⇒ Impaga, correcto.
+        Assert.Equal(0m, linea.Pagado);
+        Assert.Equal(EstadoPago.Impaga, linea.EstadoPago);
+    }
+
+    // ---- task 4.13: compra pre-cutover PARCIALMENTE pagada por un gasto sin movimiento de ledger --
+
+    [Fact]
+    public async Task UnaCompraPreCutoverPagadaParcialmentePorUnGastoSinMovimientoDeLedgerLeeParcial()
+    {
+        var ctx = await PrepararAsync(nameof(UnaCompraPreCutoverPagadaParcialmentePorUnGastoSinMovimientoDeLedgerLeeParcial));
+        var idTurno = await AbrirTurnoAsync(ctx);
+        var idCompra = await SembrarCompraPreCutoverConfirmadaAsync(ctx, total: 1000m, "pre-cutover-parcial");
+        await SembrarGastoLigadoSinMovimientoDeLedgerAsync(ctx, idTurno, idCompra, importe: 400m);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        var linea = Assert.Single(saldo.Compras, c => c.IdComprobanteCompra == idCompra);
+        // Bajo la fórmula del design (−Σ importe WHERE tipo <> 'compra', solo el ledger): NO hay
+        // NINGÚN movimiento en el ledger para esta compra (ni compra, ni pago) ⇒ suma 0 ⇒ pagado
+        // = 0 ⇒ Impaga (RECHAZADO — el pago pre-cutover queda perdido, exactamente lo que
+        // tasks.md decisión 4 / state.yaml OD7 documentan). OD7 SÍ consulta `gastos`
+        // directamente: pagado = 400 (el gasto ligado) + 0 (sin ajustes) = 400 ⇒ Parcial.
+        Assert.Equal(400m, linea.Pagado);
+        Assert.Equal(EstadoPago.Parcial, linea.EstadoPago);
+        Assert.Equal(1000m, linea.Total);
+    }
+
+    // ---- task 4.10: /saldo byte-compatible, dataset discriminante por fila (mutation rule 6) -----
+
+    [Fact]
+    public async Task ElSaldoEsByteCompatibleConValoresDiscriminantesPorFila()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoEsByteCompatibleConValoresDiscriminantesPorFila));
+
+        // Tres compras con Total/Pagado/EstadoPago TODOS distintos entre sí — ningún valor
+        // coincide con otro campo de otra fila (mutation-proof-tests rule 6).
+        var pagada = await CrearYConfirmarCompraDeTotalAsync(ctx, 1111m, "byte-compat-pagada");
+        var parcial = await CrearYConfirmarCompraDeTotalAsync(ctx, 2222m, "byte-compat-parcial");
+        var impaga = await CrearYConfirmarCompraDeTotalAsync(ctx, 3333m, "byte-compat-impaga");
+        var idTurno = await AbrirTurnoAsync(ctx);
+
+        var pagoPagada = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, ctx.IdProveedor, null, "Pago total", null,
+                ctx.IdMedioEfectivo, null, 1111m, pagada.Id));
+        Assert.Equal(HttpStatusCode.Created, pagoPagada.StatusCode);
+
+        var pagoParcial = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, ctx.IdProveedor, null, "Pago parcial", null,
+                ctx.IdMedioEfectivo, null, 777m, parcial.Id));
+        Assert.Equal(HttpStatusCode.Created, pagoParcial.StatusCode);
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(ctx.IdProveedor, saldo.IdProveedor);
+        // 1111 + 2222 + 3333 − 1111 (pago total) − 777 (pago parcial) = 4778.
+        Assert.Equal(4778m, saldo.Saldo);
+        Assert.Equal(3, saldo.Compras.Count);
+
+        var lineaPagada = saldo.Compras.Single(c => c.IdComprobanteCompra == pagada.Id);
+        Assert.Equal("byte-compat-pagada", lineaPagada.NumeroExterno);
+        Assert.Equal(1111m, lineaPagada.Total);
+        Assert.Equal(1111m, lineaPagada.Pagado);
+        Assert.Equal(EstadoPago.Pagada, lineaPagada.EstadoPago);
+
+        var lineaParcial = saldo.Compras.Single(c => c.IdComprobanteCompra == parcial.Id);
+        Assert.Equal("byte-compat-parcial", lineaParcial.NumeroExterno);
+        Assert.Equal(2222m, lineaParcial.Total);
+        Assert.Equal(777m, lineaParcial.Pagado);
+        Assert.Equal(EstadoPago.Parcial, lineaParcial.EstadoPago);
+
+        var lineaImpaga = saldo.Compras.Single(c => c.IdComprobanteCompra == impaga.Id);
+        Assert.Equal("byte-compat-impaga", lineaImpaga.NumeroExterno);
+        Assert.Equal(3333m, lineaImpaga.Total);
+        Assert.Equal(0m, lineaImpaga.Pagado);
+        Assert.Equal(EstadoPago.Impaga, lineaImpaga.EstadoPago);
+    }
+}

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorReSourceadoTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorReSourceadoTests.cs
@@ -297,4 +297,49 @@ public class SaldoDeProveedorReSourceadoTests(WaysApiFixture fixture) : IClassFi
         Assert.Equal(0m, lineaImpaga.Pagado);
         Assert.Equal(EstadoPago.Impaga, lineaImpaga.EstadoPago);
     }
+
+    // ---- judgment-day round 1, CRITICAL 1: discrimina la CACHE del agregado re-derivado ----------
+
+    /// <summary>
+    /// Todos los demás tests mantienen <c>proveedores.saldo</c> (la caché) y el agregado del
+    /// ledger sincronizados por construcción — ninguno distingue si <c>ResolverSaldoDeProveedorAsync</c>
+    /// lee la caché o re-deriva del agregado retirado. Este test DESINCRONIZA a propósito con SQL
+    /// crudo, vía la conexión owner del fixture: siembra compras/gastos normales y después pisa
+    /// <c>proveedores.saldo</c> con un centinela (777.77) que no coincide con ningún importe ni con
+    /// el agregado. Si <c>/saldo</c> devuelve el centinela, la caché es la fuente (correcto); si
+    /// devuelve el agregado re-derivado, el fix quedó revertido en silencio.
+    /// </summary>
+    [Fact]
+    public async Task ElSaldoLeeLaCacheAunDesincronizadaDelAgregadoDelLedger()
+    {
+        var ctx = await PrepararAsync(nameof(ElSaldoLeeLaCacheAunDesincronizadaDelAgregadoDelLedger));
+
+        var pagada = await CrearYConfirmarCompraDeTotalAsync(ctx, 1111m, "cache-vs-agregado-pagada");
+        var idTurno = await AbrirTurnoAsync(ctx);
+        var pagoPagada = await ctx.Admin.PostAsJsonAsync(
+            "/api/gastos",
+            new SolicitudDeGasto(
+                ctx.IdPuntoVenta, CategoriaGasto.Proveedor, ctx.IdProveedor, null, "Pago total", null,
+                ctx.IdMedioEfectivo, null, 1111m, pagada.Id));
+        Assert.Equal(HttpStatusCode.Created, pagoPagada.StatusCode);
+
+        // El agregado en este punto es 1111 − 1111 = 0. El centinela (777.77) no coincide con
+        // ningún importe sembrado ni con el agregado — desincronización deliberada.
+        const decimal centinela = 777.77m;
+        await using (var cruda = new Npgsql.NpgsqlConnection(fixture.OwnerConnectionString))
+        {
+            await cruda.OpenAsync();
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "UPDATE proveedores SET saldo = @saldo WHERE id_proveedor = @id";
+            comando.Parameters.AddWithValue("saldo", centinela);
+            comando.Parameters.AddWithValue("id", ctx.IdProveedor);
+            var filas = await comando.ExecuteNonQueryAsync();
+            Assert.Equal(1, filas);
+        }
+
+        var saldo = await ObtenerSaldoAsync(ctx);
+
+        Assert.Equal(centinela, saldo.Saldo);
+        Assert.NotEqual(0m, saldo.Saldo);
+    }
 }

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
@@ -447,6 +447,11 @@ public class SaldoDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysA
                 npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                 npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                 npgsql.MapEnum<EstadoCompra>("estado_compra");
+                // stage-15-cc-proveedores-ledger, Slice 4 (deviación registrada, mismo patrón
+                // que slice 2 deviación 20): ServicioDeSaldoDeProveedor ahora consulta
+                // MovimientosCuentaCorrienteProveedor (re-sourcing OD7) — este contexto
+                // manually-curated necesita el mapeo o Npgsql no sabe traducir el enum.
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;


### PR DESCRIPTION
## Resumen

- `GET /api/proveedores/{id}/cuenta-corriente`: estado de cuenta paginado (OFFSET, fecha DESC + desempate id DESC — OD9), running balance = `saldo_resultante` ALMACENADO por fila, filtros desde/hasta con offset real y modo `historico`. Ruta top-level bajo `OperacionDePos`. Sin `/export` (OD6).
- `ServicioDeSaldoDeProveedor` re-sourceado: `Saldo` lee el cache `proveedores.saldo`; estado de pago por compra con la FÓRMULA OD7 (gastos ligados + ajustes imputados; los `pago` jamás se cuentan). DTOs byte-idénticos — los 16 tests preexistentes de stage-8 intactos.
- Evidencia de las tres fórmulas: la vinculante pasa 4.12/4.13; la del proposal falla ambos; la del design pasa 4.12 POR COINCIDENCIA y muere en 4.13 (el defecto documentado). Target #25 (desempate) con prueba de texto fuente — confound de TID de Postgres verificado real por el juez B (el mutante pasó 3 corridas del test comportamental).

## Judgment-day (2 rondas por juez)

- Juez B ronda 1: **3 CRITICALs de cobertura** — Saldo re-derivado del agregado sobrevivía 19 tests (nadie desincronizaba cache y derivación), `SaldoResultante = 0m` sobrevivía 8 tests (proyección sin assert), `Where(IdProveedor)` borrable (un solo proveedor por tenant en todos los seeds). Fix tests-only `cb4ba39` (sentinela 777.77; saldos por fila pairwise-distintos; segundo proveedor del mismo tenant) — re-ronda B limpia.
- Juez A ronda 1: **1 CRITICAL** — el test de la regla 10 se auto-derrotaba (`historico=true` anula el filtro de fecha). Fix `1101b5b` (dos movimientos a caballo del límite -03:00; el mutante de truncado falla) — re-ronda A limpia. Su SUGGESTION (spec deltas con las fórmulas rechazadas) cerrada por enmienda del orquestador en main (`b4a00b0`).
- Los 4 hallazgos alimentaron la skill `mutation-proof-tests` → reglas 11-12 (estado previo discriminante en ledgers; las 3 clases de la capa de lectura).

Gate: `has-pending-model-changes` limpio, cero DDL. Suites del apply: Domain 492 · Application 286 · Integration 1283, todo verde. VentasCheckoutTests/Ventas/ManejadorDeErrores/ServicioDeCompras/ServicioDeGastos ausentes del diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)