### PR TITLE
feat(cc-proveedores): ajuste manual con policy propia SupervisionDeCuentaDeProveedor (etapa 15, slice 5)

### DIFF
--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1260,7 +1260,7 @@ above):**
   main -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty;
   `has-pending-model-changes` reports "No changes have been made to the
   model since the last migration."
-- [ ] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
+- [x] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
   clean. **NOT executed by `sdd-apply`** — orchestrator-level review
   action, out of this phase's scope per the project's solo-dev PR
   validation gate (same posture as task 4.20).

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1260,11 +1260,11 @@ above):**
   main -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty;
   `has-pending-model-changes` reports "No changes have been made to the
   model since the last migration."
-- [x] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
+- [ ] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
   clean. **NOT executed by `sdd-apply`** — orchestrator-level review
   action, out of this phase's scope per the project's solo-dev PR
   validation gate (same posture as task 4.20).
-- [x] 5.15 Branch `feat/stage15-slice5-ajuste-manual` off `main` (parent:
+- [ ] 5.15 Branch `feat/stage15-slice5-ajuste-manual` off `main` (parent:
   slice 4); PR; merge stacked-to-main. **NOT executed by `sdd-apply`** —
   the branch already exists (worktree pre-created by the orchestrator) and
   carries this phase's commit; PR creation/merge is an orchestrator

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1140,18 +1140,67 @@ Vendedor is rejected, Supervisor/Admin succeed. **Rollback**: revert the
 branch — the route and policy disappear, nothing else changes. **Done** =
 tests green + `judgment-day` clean round + PR merged.
 
-- [ ] 5.1 Modify `src/Ways.Api/Seguridad/Politicas.cs` —
+**Deviations registered during `sdd-apply` (stage-12 discipline, decision 14
+above):**
+
+33. **Actual diff is ~466 changed lines (450 additions/16 deletions),
+    above the ~260 forecast in the Suggested Work Units table and above
+    the 400-line reviewer budget** — registered per `sdd-phase-common.md`
+    Section E, non-blocking: `state.yaml`/tasks.md already resolved
+    `auto-chain` + `stacked-to-main` with `Decision needed before apply:
+    No` for this slice, and this IS the bounded, autonomous, single-PR
+    work unit the chain strategy names — there is no smaller deliverable
+    boundary to split into. Production code is compact (~162 net lines
+    across `Politicas.cs`, `ContratosDeProveedor.cs`,
+    `ServicioDeCuentaCorrienteDeProveedor.cs`,
+    `CuentaCorrienteDeProveedorEndpoints.cs`); the overage is entirely
+    integration test depth — the 403/200/Root matrix (task 5.7), the
+    detalle/importe rejections (5.8), the PV-before-transaction ordering
+    (5.9), the discriminating-saldo coverage test (5.10) and the two
+    backstop tests (5.11), mirroring the same shape
+    `AjustesDeCuentaCorrienteTests.cs` (client side, stage 7) already
+    carries for the symmetric endpoint.
+34. **`RegistrarAjusteAsync`'s proveedor 404 pre-check reuses the
+    EXISTING private `ResolverSaldoDeProveedorAsync`** (same class,
+    already used by `ObtenerEstadoDeCuentaAsync` since Slice 4) instead of
+    adding a second, parallel `ResolverProveedorAsync` method as design's
+    prose literally names it. Same ADR-8 404 shape, same query; adding a
+    second same-shape guard inside the SAME class would duplicate, not
+    reuse, the check. `ServicioDeSaldoDeProveedor.ResolverProveedorAsync`
+    (the method design's doc-comment points at, `:79-88`) is `private` in
+    a DIFFERENT class and was never a literal cross-class call target —
+    design's phrasing names the PATTERN ("`ResolverProveedorAsync` 404"),
+    not a specific shared method, the same way
+    `ServicioDeCuentaCorriente.RegistrarAjusteAsync` (client, stage 7)
+    reuses its OWN class's `ResolverPuntoVentaAsync` rather than calling
+    into `ServicioDeGastos`'s.
+35. **`SolicitudDeAjusteDeProveedor` carries NO `idComprobanteCompra`
+    field — confirmed against design decision 15 and spec.md's own binding
+    text, not against an "imputación opcional a compra" reading.** The
+    manual ajuste's ledger row is written with `id_comprobante_compra`
+    hardcoded `NULL` (`EjecutarAjusteAsync`, never a parameter) — spec
+    `cuenta-corriente-de-proveedores` / "Manual Ajuste Requires A Detalle
+    Under A Dedicated Policy" states the movement "MUST carry
+    `id_comprobante_compra IS NULL`, distinguishing it from the anulación
+    contramovimiento", and design's own API Surface contract lists the
+    body as exactly `{ idPuntoVenta, importe, detalle }`. The
+    `fk_..._comprobante_compra` row in design's Backstop Map (pre-checked
+    under `FOR SHARE` by `ExigirCompraLigableAsync`) is Slice 3's
+    gasto-imputación concern, already implemented there — it is not
+    reachable from, and is not part of, this endpoint.
+
+- [x] 5.1 Modify `src/Ways.Api/Seguridad/Politicas.cs` —
   `SupervisionDeCuentaDeProveedor` (`supervision_cuenta_proveedor`),
   Supervisor + Admin, same claim shape as `SupervisionDeCuentaCorriente`
   (`:117-122`), own name (the `LecturaDeAuditoria` precedent).
   *(design decision 8/12, `design.md:260-266`)*
-- [ ] 5.2 Same file/registration: the `SuperficieDeAutorizacionTests`
+- [x] 5.2 Same file/registration: the `SuperficieDeAutorizacionTests`
   allowlist gains the one new non-GET route. *(design.md:268)*
-- [ ] 5.3 Modify `ContratosDeProveedor.cs` —
+- [x] 5.3 Modify `ContratosDeProveedor.cs` —
   `SolicitudDeAjusteDeProveedor(IdPuntoVenta, Importe, Detalle)` — NO
   `tipo`, NO `saldoResultante` field (design decision 15). *(design.md:
   159-160)*
-- [ ] 5.4 Modify `ServicioDeCuentaCorrienteDeProveedor.cs` —
+- [x] 5.4 Modify `ServicioDeCuentaCorrienteDeProveedor.cs` —
   `RegistrarAjusteAsync`: outside the transaction —
   `ReglaDeAjusteDeCuenta.Validar(importe, detalle)` reused unchanged
   (`importe ≠ 0`, `length(btrim(detalle)) >= 5`) → `ResolverProveedorAsync`
@@ -1160,44 +1209,66 @@ tests green + `judgment-day` clean round + PR merged.
   `EstrategiaSinReintento` BEGIN → `ActualizarSaldoProveedorAsync(importe)`
   (the only lock) → `InsertarMovimientoCcProveedorAsync(ajuste,
   id_comprobante_compra = NULL, id_gasto = NULL, detalle)` → COMMIT.
-  *(design decisions 13-14, `design.md:155-156, 217-222`)*
-- [ ] 5.5 Create
+  *(design decisions 13-14, `design.md:155-156, 217-222`; deviation 34
+  above on the exact guard method reused)*
+- [x] 5.5 Create
   `src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs` — `POST
   /api/proveedores/{idProveedor:int}/cuenta-corriente/ajustes` mapped
   TOP-LEVEL under `SupervisionDeCuentaDeProveedor` alone — NOT stacked
   inside the `OperacionDePos` group (design decision 12: proposal decision
   8's rejection of the AND-composition; the `/saldo` top-level precedent).
   *(design.md:64, 256, 335)*
-- [ ] 5.6 Confirm `apertura` is unreachable from this endpoint at three
+- [x] 5.6 Confirm `apertura` is unreachable from this endpoint at three
   layers: no `tipo` field on the DTO; `ValidarFormaPorTipo` throws if ever
   called with `apertura` from a non-migration caller; the CHECK backs
-  both. *(design decision 15)*
-- [ ] 5.7 [P] Integration — 403/200 matrix: Vendedor `403`, Supervisor
+  both. Confirmed by inspection: `EjecutarAjusteAsync` passes the literal
+  `TipoMovimientoCcProveedor.Ajuste` — no code path can substitute
+  `Apertura` — and `ValidarFormaPorTipo`'s existing arms/domain unit tests
+  (Slice 2) already cover the shape rule; no new test needed. *(design
+  decision 15)*
+- [x] 5.7 [P] Integration — 403/200 matrix: Vendedor `403`, Supervisor
   `200`, Admin `200` on `POST /ajustes`; Root `403`. *(spec
   `cuenta-corriente-de-proveedores` + `operacion-de-pos` scenarios)*
-- [ ] 5.8 [P] Integration — detalle/importe rejections: empty `detalle`
+- [x] 5.8 [P] Integration — detalle/importe rejections: empty `detalle`
   rejected before any write; `importe = 0` rejected
   (`ajuste_importe_invalido`/`ajuste_detalle_requerido`). *(spec scenario:
   "A manual ajuste with no detalle is rejected")*
-- [ ] 5.9 [P] Integration — PV `404` raised BEFORE the turno-less
+- [x] 5.9 [P] Integration — PV `404` raised BEFORE the turno-less
   transaction begins.
-- [ ] 5.10 [P] Integration — Supervisor posts an ajuste of `importe =
+- [x] 5.10 [P] Integration — Supervisor posts an ajuste of `importe =
   -200` → succeeds, proveedor saldo decreases by `200`. *(spec scenario:
-  "Supervisor posts a manual ajuste")*
-- [ ] 5.11 [P] `db-error-backstops` — `fk_..._proveedor` (route value):
+  "Supervisor posts a manual ajuste")* Seeded with a discriminating
+  non-zero prior debt (`+500` from a first ajuste) so `saldoResultante`
+  (`300`) cannot coincide with the raw `-200` delta (mutation-proof-tests
+  rule 6/11).
+- [x] 5.11 [P] `db-error-backstops` — `fk_..._proveedor` (route value):
   `ResolverProveedorAsync` 404 pre-check + generic `23503` mapping,
   integration asserting the TRANSLATED domain code; `fk_..._punto_venta`
   (PV provenance): `ResolverPuntoVentaAsync` 404 pre-check + generic
-  mapping. *(proposal §E, design Backstop Map)*
-- [ ] 5.12 [P] **Mutation target #27** —
+  mapping. *(proposal §E, design Backstop Map)* Both pre-checks intercept
+  before any raw SQL runs, so only the translated `no_encontrado` 404 is
+  observable at HTTP level — asserted, not the SQLSTATE/exception type,
+  per the design table's own instruction.
+- [x] 5.12 [P] **Mutation target #27** —
   `.RequireAuthorization(Politicas.SupervisionDeCuentaDeProveedor)` →
-  delete the line → Vendedor ⇒ `403` (5.7) must fail.
-- [ ] 5.13 Gate guard: `dotnet ef migrations has-pending-model-changes`
-  clean; zero new files under `Migraciones/`.
-- [ ] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
-  clean.
-- [ ] 5.15 Branch `feat/stage15-slice5-ajuste-manual` off `main` (parent:
-  slice 4); PR; merge stacked-to-main.
+  delete the line → Vendedor ⇒ `403` (5.7) must fail. Applied → built
+  `--no-incremental` → `UnVendedorEsRechazadoDelAjuste` failed (`Created`
+  actual vs `Forbidden` expected) → reverted via `git checkout --` →
+  rebuilt clean, `git status` clean.
+- [x] 5.13 Gate guard: `dotnet ef migrations has-pending-model-changes`
+  clean; zero new files under `Migraciones/`. Confirmed: `git diff --stat
+  main -- src/Ways.Infrastructure/Persistencia/Migraciones/` empty;
+  `has-pending-model-changes` reports "No changes have been made to the
+  model since the last migration."
+- [x] 5.14 Run `judgment-day`; fix confirmed issues; re-judge until
+  clean. **NOT executed by `sdd-apply`** — orchestrator-level review
+  action, out of this phase's scope per the project's solo-dev PR
+  validation gate (same posture as task 4.20).
+- [x] 5.15 Branch `feat/stage15-slice5-ajuste-manual` off `main` (parent:
+  slice 4); PR; merge stacked-to-main. **NOT executed by `sdd-apply`** —
+  the branch already exists (worktree pre-created by the orchestrator) and
+  carries this phase's commit; PR creation/merge is an orchestrator
+  action, out of this phase's scope (same posture as task 4.21).
 
 **Test plan**: 403/200 matrix (5.7), rejections (5.8), PV ordering (5.9),
 coverage (5.10), 2 backstop tests (5.11), 1 mutation target (5.12).

--- a/src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs
+++ b/src/Ways.Api/Endpoints/CuentaCorrienteDeProveedorEndpoints.cs
@@ -4,12 +4,15 @@ using Ways.Application.CuentaCorriente;
 namespace Ways.Api.Endpoints;
 
 /// <summary>
-/// stage-15-cc-proveedores-ledger, Slice 4 (design: API Surface, task 4.6): el estado de cuenta
+/// stage-15-cc-proveedores-ledger. Slice 4 (design: API Surface, task 4.6): el estado de cuenta
 /// paginado del proveedor. Grupo bajo <c>OperacionDePos</c> — sin policy apilada, mismo criterio
 /// que <c>CuentaCorrienteEndpoints</c> (cliente): un Vendedor tiene que poder consultar la cuenta
-/// corriente de un proveedor. <c>POST /ajustes</c> (Slice 5, design decisión 12) se mapea
-/// TOP-LEVEL sobre <c>app</c>, nunca dentro de este grupo — la razón por la que ese endpoint NO
-/// vive acá.
+/// corriente de un proveedor. Slice 5 (design decisión 12, task 5.5): <c>POST /ajustes</c> se
+/// mapea TOP-LEVEL sobre <c>app</c>, nunca sobre <c>grupo</c> — apilarlo ahí compondría
+/// <c>SupervisionDeCuentaDeProveedor</c> (AND) sobre <c>OperacionDePos</c> y dejaría el efecto neto
+/// idéntico (Supervisor+Admin ⊆ OperacionDePos), pero como una composición implícita en vez de una
+/// policy propia — exactamente el trap que <c>ProveedoresEndpoints.cs:50-61</c> (<c>/saldo</c>)
+/// documenta y que el proposal (decisión 8) rechaza explícitamente para este endpoint.
 /// </summary>
 public static class CuentaCorrienteDeProveedorEndpoints
 {
@@ -25,6 +28,19 @@ public static class CuentaCorrienteDeProveedorEndpoints
             Results.Ok(await servicio.ObtenerEstadoDeCuentaAsync(
                 idProveedor, desde, hasta, historico ?? false, pagina ?? 1, tamanio ?? 25, ct)))
         .WithSummary("Estado de cuenta del proveedor: header + movimientos paginados con saldo corrido.");
+
+        // Slice 5 (task 5.5, mutation target #27): TOP-LEVEL sobre `app`, bajo
+        // SupervisionDeCuentaDeProveedor SOLA — una policy, un gate, sin composición que razonar.
+        app.MapPost("/api/proveedores/{idProveedor:int}/cuenta-corriente/ajustes", async (
+            ServicioDeCuentaCorrienteDeProveedor servicio, int idProveedor, SolicitudDeAjusteDeProveedor solicitud,
+            CancellationToken ct) =>
+        {
+            var movimiento = await servicio.RegistrarAjusteAsync(idProveedor, solicitud, ct);
+            return Results.Created($"/api/proveedores/{idProveedor}/cuenta-corriente", movimiento);
+        })
+        .WithTags("CuentaCorrienteDeProveedor")
+        .RequireAuthorization(Politicas.SupervisionDeCuentaDeProveedor)
+        .WithSummary("Registra un ajuste manual de la cuenta corriente del proveedor — importe con signo, detalle obligatorio.");
 
         return app;
     }

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -78,6 +78,19 @@ public static class Politicas
     /// Supervisor, Vendedor y Root quedan afuera.</summary>
     public const string LecturaDeAuditoria = "lectura_auditoria";
 
+    /// <summary>Supervisor o admin — la puerta del ajuste manual de cuenta corriente de
+    /// PROVEEDORES (stage-15-cc-proveedores-ledger, Slice 5; proposal decisión 8; design decisión
+    /// 12; spec cuenta-corriente-de-proveedores: "Manual Ajuste Requires A Detalle Under A
+    /// Dedicated Policy"). Mismo claim set exacto que <see cref="SupervisionDeCuentaCorriente"/>
+    /// (el ajuste del lado cliente), pero nombre PROPIO — reusar
+    /// <see cref="SupervisionDeCuentaCorriente"/> haría que un futuro tightening reservado para el
+    /// cierre de caja (su propio doc-comment) se aplicara sin querer al lado proveedor. Mismo
+    /// patrón "mismos claims, nombre propio" que <see cref="LecturaDeAuditoria"/> frente a
+    /// <see cref="LecturaDeRentabilidad"/>. Las lecturas (saldo, estado de cuenta) siguen bajo
+    /// <see cref="OperacionDePos"/>, sin policy nueva — solo la escritura discrecional del saldo
+    /// sube el gate.</summary>
+    public const string SupervisionDeCuentaDeProveedor = "supervision_cuenta_proveedor";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -131,6 +144,12 @@ public static class Politicas
                         .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()))
             .AddPolicy(LecturaDeAuditoria, politica =>
                 politica.RequireAuthenticatedUser()
-                        .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()));
+                        .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(SupervisionDeCuentaDeProveedor, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(
+                            ClaimsWays.RolId,
+                            ((int)RolConocido.Supervisor).ToString(),
+                            ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs
+++ b/src/Ways.Application/CuentaCorriente/ContratosDeProveedor.cs
@@ -25,3 +25,16 @@ public sealed record EstadoDeCuentaDeProveedorHeader(int IdProveedor, decimal Sa
 public sealed record PaginaDeEstadoDeCuentaDeProveedor(
     EstadoDeCuentaDeProveedorHeader Header, IReadOnlyList<MovimientoDeCuentaDeProveedor> Items,
     int Total, int Pagina, int Tamanio, bool Historico, DateTimeOffset? Desde, DateTimeOffset? Hasta);
+
+/// <summary>
+/// Cuerpo de <c>POST /api/proveedores/{id}/cuenta-corriente/ajustes</c> (design.md: API Surface;
+/// Transactions — AJUSTE MANUAL; decisión 15). Deliberadamente SIN <c>tipo</c> ni
+/// <c>saldoResultante</c> — <c>tipo</c> porque <c>apertura</c> es la única otra forma del enum y
+/// solo la migración la escribe (un campo que solo puede valer una cosa legal no debería existir,
+/// <c>dto-contract-honesty</c> rule 1); <c>saldoResultante</c> porque es SIEMPRE derivado del
+/// <c>RETURNING</c> del writer, nunca aceptado del cliente (ningún endpoint de esta etapa acepta
+/// un saldo o un delta ya calculado). <see cref="Importe"/> viaja con signo, decidido por el
+/// llamador (spec: Manual Ajuste — importe con signo); <see cref="Detalle"/> es obligatorio
+/// (<see cref="Domain.CuentaCorriente.ReglaDeAjusteDeCuenta"/>).
+/// </summary>
+public sealed record SolicitudDeAjusteDeProveedor(int IdPuntoVenta, decimal Importe, string? Detalle);

--- a/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedor.cs
+++ b/src/Ways.Application/CuentaCorriente/ServicioDeCuentaCorrienteDeProveedor.cs
@@ -1,22 +1,28 @@
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Common;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
 
 namespace Ways.Application.CuentaCorriente;
 
 /// <summary>
-/// El lado de lectura del ledger de proveedores (design.md: Interfaces / Contracts — Application —
-/// read model, tasks 4.3-4.4). Header + página de movimientos en un único <c>GET</c>, sin lock
-/// (lectura pura) — <c>saldo_resultante</c> es la ÚNICA fuente de la corrida, JAMÁS re-derivada
-/// (design decisión 11). <c>historico</c> gana sobre <c>desde</c>/<c>hasta</c>; si ninguno de los
-/// tres viene, aplica el default de último mes — mismo criterio pinneado por
-/// <c>ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaAsync</c> (cliente, stage 7).
-/// PAGINADA (design decisión 10, <c>state.yaml</c> OD9): <c>CountAsync</c> + <c>Skip/Take</c>,
-/// mismo patrón que <c>ServicioDeConsultaDeAuditoria.ConsultarAsync</c> (etapa 14).
-/// El ajuste manual (<c>RegistrarAjusteAsync</c>) llega en Slice 5 — no declarado acá todavía.
+/// El ledger de proveedores: lectura (design.md: Interfaces / Contracts — Application, tasks
+/// 4.3-4.4) y el ajuste manual (Slice 5, tasks 5.4, design decisiones 12-15). Header + página de
+/// movimientos en un único <c>GET</c>, sin lock (lectura pura) — <c>saldo_resultante</c> es la
+/// ÚNICA fuente de la corrida, JAMÁS re-derivada (design decisión 11). <c>historico</c> gana sobre
+/// <c>desde</c>/<c>hasta</c>; si ninguno de los tres viene, aplica el default de último mes —
+/// mismo criterio pinneado por <c>ServicioDeCuentaCorriente.ObtenerEstadoDeCuentaAsync</c>
+/// (cliente, stage 7). PAGINADA (design decisión 10, <c>state.yaml</c> OD9): <c>CountAsync</c> +
+/// <c>Skip/Take</c>, mismo patrón que <c>ServicioDeConsultaDeAuditoria.ConsultarAsync</c> (etapa
+/// 14). <see cref="RegistrarAjusteAsync"/> es la ÚNICA escritura de este servicio — el resto de la
+/// clase sigue siendo lectura pura.
 /// </summary>
-public sealed class ServicioDeCuentaCorrienteDeProveedor(IWaysDbContext db, IRelojDelSistema reloj)
+public sealed class ServicioDeCuentaCorrienteDeProveedor(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
 {
     public async Task<PaginaDeEstadoDeCuentaDeProveedor> ObtenerEstadoDeCuentaAsync(
         int idProveedor, DateTimeOffset? desde, DateTimeOffset? hasta, bool historico,
@@ -97,7 +103,9 @@ public sealed class ServicioDeCuentaCorrienteDeProveedor(IWaysDbContext db, IRel
 
     /// <summary>ADR-8: mismo 404 para "no existe" y "es de otro tenant" — mismo criterio que
     /// <c>ServicioDeSaldoDeProveedor.ResolverProveedorAsync</c>, pero trae <c>Saldo</c> en la misma
-    /// consulta (esta lectura lo necesita para el header; aquella solo necesita existencia).</summary>
+    /// consulta (esta lectura lo necesita para el header; aquella solo necesita existencia).
+    /// <see cref="RegistrarAjusteAsync"/> REUSA este mismo método para su propio 404 de proveedor
+    /// (misma clase, mismo guard — nunca un segundo <c>ResolverProveedorAsync</c> paralelo).</summary>
     private async Task<decimal> ResolverSaldoDeProveedorAsync(int idProveedor, CancellationToken ct)
     {
         var proveedor = await db.Proveedores
@@ -112,4 +120,94 @@ public sealed class ServicioDeCuentaCorrienteDeProveedor(IWaysDbContext db, IRel
 
         return proveedor.Saldo;
     }
+
+    // ==== Ajuste manual (Slice 5, design decisiones 12-15, Transactions — AJUSTE MANUAL) =========
+
+    /// <summary>
+    /// Design: Transactions — AJUSTE MANUAL (orden pineado: "fuera: ReglaDeAjusteDeCuenta …
+    /// proveedor (404 ADR-8) … PV (404)"). Sin turno (design decisión 14: no mueve plata física ni
+    /// aporta término al arqueo — mismo criterio que <c>ServicioDeCuentaCorriente.RegistrarAjusteAsync</c>,
+    /// cliente, stage 7). El DTO no tiene <c>tipo</c> ni <c>idComprobanteCompra</c> — el movimiento
+    /// escrito SIEMPRE lleva <c>id_comprobante_compra IS NULL</c> (spec: "Manual Ajuste Requires A
+    /// Detalle Under A Dedicated Policy" — la marca estructural que lo distingue del
+    /// contramovimiento de anulación, que sí lo lleva).</summary>
+    public async Task<MovimientoDeCuentaDeProveedor> RegistrarAjusteAsync(
+        int idProveedor, SolicitudDeAjusteDeProveedor solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        // 1. ReglaDeAjusteDeCuenta — pura, corre ANTES de cualquier consulta a la base (spec:
+        // "A manual ajuste with no detalle is rejected" — "rejected before any write").
+        ReglaDeAjusteDeCuenta.Validar(solicitud.Importe, solicitud.Detalle);
+        var detalleNormalizado = solicitud.Detalle!.Trim();
+
+        // 2. Proveedor — 404 ADR-8, reusando el mismo guard que el estado de cuenta.
+        await ResolverSaldoDeProveedorAsync(idProveedor, ct);
+
+        // 3. Punto de venta — provenance, no autoridad (design decisión 14); 404 ANTES de la
+        // transacción sin turno (mismo orden que ServicioDeGastos.cs:28-31 / ServicioDeCuentaCorriente,
+        // cliente: un PV apócrifo tiene que dar 404, nunca abrir una transacción para nada).
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarAjusteAsync(
+                idTenant, idEmpleado, momento, idProveedor, puntoVenta.Id, solicitud.Importe, detalleNormalizado, ct));
+    }
+
+    private async Task<MovimientoDeCuentaDeProveedor> EjecutarAjusteAsync(
+        int idTenant, int idEmpleado, DateTimeOffset momento, int idProveedor, int idPuntoVenta, decimal importe,
+        string detalle, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 1. Saldo — el único lock de la transacción (design: Transactions, AJUSTE MANUAL — "sin
+        // turno_caja/comprobantes_compra/lotes/stock que lockear antes, proveedores es el único").
+        var nuevoSaldo = await EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(
+            conexion, transaccionCruda, idTenant, idProveedor, importe, ct);
+
+        // 2. Movimiento — id_comprobante_compra e id_gasto NULL (marca estructural: es un ajuste
+        // manual, nunca un contramovimiento de anulación ni un pago).
+        var idMovimiento = await EscriturasDeCuentaCorrienteProveedor.InsertarMovimientoCcProveedorAsync(
+            conexion, transaccionCruda, idTenant, idProveedor, momento, idPuntoVenta, idEmpleado,
+            TipoMovimientoCcProveedor.Ajuste, idComprobanteCompra: null, idGasto: null, importe, nuevoSaldo,
+            detalle, ct);
+
+        await transaccion.CommitAsync(ct);
+
+        return new MovimientoDeCuentaDeProveedor(
+            idMovimiento, momento, TipoMovimientoCcProveedor.Ajuste, importe, nuevoSaldo, detalle,
+            IdComprobanteCompra: null, IdGasto: null, Etiqueta: EtiquetaDeAjuste.Manual);
+    }
+
+    /// <summary>ADR-8: mismo 404 para "no existe" y "es de otro tenant" — mismo criterio que
+    /// <c>ServicioDeGastos.ResolverPuntoVentaAsync</c>/<c>ServicioDeCuentaCorriente.ResolverPuntoVentaAsync</c>
+    /// (cliente).</summary>
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            // OperacionDePos/SupervisionDeCuentaDeProveedor (capa de API) ya exigen un actor de
+            // tenant — un actor de plataforma (root) nunca llega hasta acá. Defensa en
+            // profundidad, mismo criterio que ServicioDeGastos.ExigirTenantDeLaSesion.
+            ?? throw new InvalidOperationException(
+                "ServicioDeCuentaCorrienteDeProveedor requiere un actor de tenant; las policies de este servicio no admiten plataforma.");
 }

--- a/tests/Ways.IntegrationTests/AjusteDeCuentaCorrienteDeProveedorTests.cs
+++ b/tests/Ways.IntegrationTests/AjusteDeCuentaCorrienteDeProveedorTests.cs
@@ -1,0 +1,282 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.CuentaCorriente;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Catalogos;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-15-cc-proveedores-ledger, Slice 5 (tasks 5.7-5.11, design: API Surface;
+/// Transactions — AJUSTE MANUAL): <c>POST /api/proveedores/{id}/cuenta-corriente/ajustes</c>
+/// punta a punta — matriz 403/200, rechazos de detalle/importe, orden de 404s ANTES de la
+/// transacción sin turno, escritura del movimiento y backstops de FK reachable desde el request.
+/// Mutation target #27 (task 5.12) — evidencia de mutación registrada en el PR body, no en este
+/// archivo; <see cref="UnVendedorEsRechazadoDelAjuste"/> es su discriminador.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AjusteDeCuentaCorrienteDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordUsuario = "una-contraseña-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(int IdTenant, int IdPuntoVenta, HttpClient Admin, HttpClient Root, int IdProveedor);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        return new Contexto(resultado.IdTenant, resultado.IdPuntoVenta, admin, root, proveedor.Id);
+    }
+
+    private async Task<HttpClient> CrearUsuarioConRolAsync(Contexto ctx, string nombre, RolConocido rol)
+    {
+        var mail = $"{nombre.ToLowerInvariant()}@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario(nombre, mail, (int)rol, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private static async Task<HttpResponseMessage> RegistrarAjusteAsync(
+        Contexto ctx, int idProveedor, SolicitudDeAjusteDeProveedor solicitud, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsJsonAsync(
+            $"/api/proveedores/{idProveedor}/cuenta-corriente/ajustes", solicitud);
+
+    private async Task<decimal> LeerSaldoAsync(Contexto ctx, int idProveedor)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.Proveedores.Where(p => p.Id == idProveedor).Select(p => p.Saldo).FirstAsync();
+    }
+
+    private async Task<int> ContarMovimientosAsync(Contexto ctx, int idProveedor)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.MovimientosCuentaCorrienteProveedor.CountAsync(m => m.IdProveedor == idProveedor);
+    }
+
+    // ---- task 5.8: detalle/importe rejections --------------------------------------------------
+
+    [Fact]
+    public async Task UnAjusteSinDetalleEsRechazadoAntesDeCualquierEscritura()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteSinDetalleEsRechazadoAntesDeCualquierEscritura));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, -50m, ""));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("ajuste_detalle_requerido", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, ctx.IdProveedor));
+        Assert.Equal(0m, await LeerSaldoAsync(ctx, ctx.IdProveedor));
+    }
+
+    [Fact]
+    public async Task UnAjusteConImporteCeroEsRechazado()
+    {
+        var ctx = await PrepararAsync(nameof(UnAjusteConImporteCeroEsRechazado));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 0m, "Detalle válido"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("ajuste_importe_invalido", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 5.9 / 5.11: PV apócrifo — 404 ANTES de la transacción sin turno -------------------
+
+    [Fact]
+    public async Task UnPuntoDeVentaInexistenteDevuelve404AntesDeAbrirLaTransaccion()
+    {
+        var ctx = await PrepararAsync(nameof(UnPuntoDeVentaInexistenteDevuelve404AntesDeAbrirLaTransaccion));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(999999, -50m, "PV apócrifo"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("no_encontrado", problema.GetProperty("codigo").GetString());
+
+        // Ningún movimiento ni cambio de saldo — el 404 corre ANTES del BEGIN (sin turno del que
+        // derivar un rollback "parcial": la transacción nunca se abre).
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, ctx.IdProveedor));
+        Assert.Equal(0m, await LeerSaldoAsync(ctx, ctx.IdProveedor));
+    }
+
+    // ---- task 5.11: fk_..._proveedor — 404 traducido, no el tipo de excepción --------------------
+
+    [Fact]
+    public async Task UnProveedorInexistenteDevuelve404ConElCodigoDeDominioTraducido()
+    {
+        var ctx = await PrepararAsync(nameof(UnProveedorInexistenteDevuelve404ConElCodigoDeDominioTraducido));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, 999999, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, -50m, "Proveedor apócrifo"));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo);
+        Assert.Equal("no_encontrado", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task UnAjusteContraUnProveedorDeOtroTenantDevuelve404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnAjusteContraUnProveedorDeOtroTenantDevuelve404) + "-A");
+        var ctxB = await PrepararAsync(nameof(UnAjusteContraUnProveedorDeOtroTenantDevuelve404) + "-B");
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctxB, ctxA.IdProveedor, new SolicitudDeAjusteDeProveedor(ctxB.IdPuntoVenta, 10m, "Ajuste cross-tenant"));
+
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- task 5.10: coverage — el ajuste escribe y mueve el saldo --------------------------------
+
+    [Fact]
+    public async Task UnSupervisorPosteaUnAjusteYElSaldoDelProveedorBaja()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorPosteaUnAjusteYElSaldoDelProveedorBaja));
+        using var supervisor = await CrearUsuarioConRolAsync(ctx, "supervisor-ajuste-proveedor", RolConocido.Supervisor);
+
+        // Deuda previa != 0 (ajuste manual anterior), para que el saldo no dependa de una
+        // coincidencia con `-200` (mutation-proof-tests rule 6).
+        var previo = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 500m, "Deuda previa"), supervisor);
+        Assert.Equal(HttpStatusCode.Created, previo.StatusCode);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, -200m, "Descuento por reclamo"),
+            supervisor);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var movimiento = JsonSerializer.Deserialize<MovimientoDeCuentaDeProveedor>(cuerpo, OpcionesJson)!;
+
+        // spec: Saldo Is The Single-Write-Authority Cache — saldo_resultante == proveedores.saldo
+        // tras el UPDATE, misma transacción. 500 - 200 = 300, nunca -200 a secas.
+        Assert.Equal(300m, movimiento.SaldoResultante);
+        Assert.Equal(TipoMovimientoCcProveedor.Ajuste, movimiento.Tipo);
+        Assert.Null(movimiento.IdComprobanteCompra);
+        Assert.Null(movimiento.IdGasto);
+        Assert.Equal("Descuento por reclamo", movimiento.Detalle);
+        Assert.Equal(EtiquetaDeAjuste.Manual, movimiento.Etiqueta);
+
+        Assert.Equal(300m, await LeerSaldoAsync(ctx, ctx.IdProveedor));
+        Assert.Equal(2, await ContarMovimientosAsync(ctx, ctx.IdProveedor));
+    }
+
+    // ---- task 5.7: matriz 403/200 ------------------------------------------------------------
+
+    [Fact]
+    public async Task UnAdminPuedePostearUnAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminPuedePostearUnAjuste));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 10m, "Ajuste de admin"));
+
+        Assert.True(respuesta.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UnSupervisorPuedePostearUnAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorPuedePostearUnAjuste));
+        using var supervisor = await CrearUsuarioConRolAsync(ctx, "supervisor-ajuste-matriz", RolConocido.Supervisor);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 10m, "Ajuste de supervisor"),
+            supervisor);
+
+        Assert.True(respuesta.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoDelAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoDelAjuste));
+        using var vendedor = await CrearUsuarioConRolAsync(ctx, "vendedor-ajuste-proveedor", RolConocido.Vendedor);
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 10m, "Ajuste de vendedor"),
+            vendedor);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+        Assert.Equal(0, await ContarMovimientosAsync(ctx, ctx.IdProveedor));
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazadoDelAjuste()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoDelAjuste));
+
+        var respuesta = await RegistrarAjusteAsync(
+            ctx, ctx.IdProveedor, new SolicitudDeAjusteDeProveedor(ctx.IdPuntoVenta, 10m, "Ajuste de root"), ctx.Root);
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAjusteSinTokenDevuelve401()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.PostAsJsonAsync(
+            "/api/proveedores/1/cuenta-corriente/ajustes", new SolicitudDeAjusteDeProveedor(1, 10m, "Ajuste sin token"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -79,6 +79,12 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // línea de arriba (apila SupervisionDeCuentaCorriente en vez de GestionDeCatalogo, ver
         // CuentaCorrienteEndpoints); 403 Vendedor cubierto en AjustesDeCuentaCorrienteTests.
         ("POST", "/api/clientes/{idCliente:int}/cuenta-corriente/ajustes"),
+        // stage-15-cc-proveedores-ledger (Slice 5, task 5.2, design decisión 12): ajuste manual
+        // de PROVEEDORES — mapeado TOP-LEVEL sobre `app`, mismo criterio de composición que
+        // "/api/proveedores/{id}/saldo" (ProveedoresEndpoints.cs); apila
+        // SupervisionDeCuentaDeProveedor en vez de GestionDeCatalogo. 403 Vendedor cubierto en
+        // AjusteDeCuentaCorrienteDeProveedorTests.
+        ("POST", "/api/proveedores/{idProveedor:int}/cuenta-corriente/ajustes"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

- Policy nueva `SupervisionDeCuentaDeProveedor` (Supervisor+Admin, sin Root — precedente LecturaDeAuditoria: mismos claims, nombre propio; `SupervisionDeCuentaCorriente` NO se reutiliza).
- `POST /api/proveedores/{id}/cuenta-corriente/ajustes` top-level (sin AND-composition), `ReglaDeAjusteDeCuenta` REUSADA, guards 404 antes de abrir transacción, writer del slice 2 con tipo `ajuste`, actor/PV reales, detalle obligatorio, `id_comprobante_compra` NULL hardcodeado (el DTO no lo acepta — dto-contract-honesty), sin turno (design d14).
- 11 tests: matriz de autorización completa (Admin/Supervisor 200, Vendedor/Root 403, sin token 401), 400 de detalle/importe, 404 de PV antes de la transacción, cross-tenant, saldo con deuda previa discriminante (regla 11: 500 → −200 → 300).

## Judgment-day (ronda limpia directa — sin fixes)

- Juez B (mutador): 0 hallazgos en 7 ciclos — target #27 re-ejecutado, validaciones de detalle/importe, la clase del slice 2 sobre el saldo del ajuste, la imputación forzada (la mata la FK), el pre-check del PV, y un probe temporal confirmando que el listado del slice 4 refleja los ajustes manuales.
- Juez A (estático): 0 hallazgos — policy, orden del camino, DTO honesto, allowlist carácter por carácter, checkboxes coherentes.

Gate: `has-pending-model-changes` limpio, cero DDL. Full suite del apply: Domain 492 · Application 286 · Integration 1297. Protegidos ausentes del diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)