### PR TITLE
feat(cc-proveedores): pantalla de estado de cuenta y ajuste manual en la web (etapa 15, slice 6)

### DIFF
--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1328,10 +1328,24 @@ above):**
     ajuste button disables with the same aviso as its `motivo` — while
     the ledger itself (`GET …/cuenta-corriente`, `OperacionDePos`) keeps
     loading and rendering normally, because it is an independent fetch.
-    Both real entry points (`ResumenSaldoDeProveedor`'s link) always pass
+    **Correction (judgment-day stage-15 Slice 6, hallazgo CRITICAL — see
+    #44): the claim below, as originally shipped, was FALSE.** ~~Both real
+    entry points (`ResumenSaldoDeProveedor`'s link) always pass
     `location.state.proveedor`, so this path is a direct-URL/bookmark/
     refresh corner case only, same population `CuentaCorriente.tsx`
-    already documents. `Compras.tsx`'s own pre-existing `GET /proveedores`
+    already documents.~~ In fact the single `<Link>` in
+    `ResumenSaldoDeProveedor.tsx` (the real entry point behind both
+    `Proveedores.tsx` and `Compras.tsx`) did not pass `state` at all, so
+    EVERY real navigation landed with `state` null — not only the
+    direct-URL/bookmark/refresh corner case — and `puedeAjustar` (gated on
+    `errorProveedor === ''`) disabled the ajuste button for a Supervisor
+    hitting the Admin-only 403 through the real link, not just by bookmark.
+    Fixed by #44: `ResumenSaldoDeProveedor` now accepts an optional
+    `proveedor` prop and passes `state={{ proveedor }}` when the caller has
+    the full `ProveedorListado` (both surfaces do); `puedeAjustar` no
+    longer depends on `errorProveedor`/`proveedorInfo` at all — the gate is
+    role + puntos de venta only, so a failed name fetch never blocks the
+    ajuste, by any path. `Compras.tsx`'s own pre-existing `GET /proveedores`
     listing fetch (`api.get('/proveedores?tamanio=200')`, unconditional
     for every role since before this stage) carries the identical
     Admin-only gate — a pre-existing gap this stage does not introduce and
@@ -1411,6 +1425,37 @@ above):**
     window, `disabled` covers the rest — without ranking one as "the real"
     one. Test renamed to "doble click en el mismo tick en 'Registrar ajuste'
     dispara exactamente un POST".
+44. **`judgment-day` (round 2, juez A) confirmed one CRITICAL finding, fixed
+    here: `ResumenSaldoDeProveedor.tsx`'s `<Link>` — the only real entry
+    point to `/proveedores/{id}/cuenta-corriente` — never passed `state`,
+    so every real navigation landed with `location.state.proveedor` null,
+    and `puedeAjustar` (gated on `errorProveedor === ''`) disabled the
+    ajuste button for a Supervisor whenever the Admin-only fallback fetch
+    (`clienteDeProveedores.obtener`) 403'd — which is exactly what happened
+    on every real link, not just the direct-URL/bookmark corner case #37
+    (falsely) claimed was the only affected path.** Two layers, both
+    applied: (1) `puedeAjustar` in `CuentaCorrienteDeProveedor.tsx` no
+    longer references `errorProveedor`/`proveedorInfo`/`cargandoProveedor`
+    at all — the gate is role (`esSupervisorOAdmin`) + puntos de venta
+    only, since the ajuste endpoint only needs `idProveedor` (from the URL)
+    and `idPuntoVenta`, neither of which depends on the name fetch; a
+    failed name resolution now only affects the cosmetic title (falls back
+    to "Proveedor #id") and shows an informational aviso, never the ability
+    to operate. (2) `ResumenSaldoDeProveedor` gained an optional `proveedor`
+    prop; both call sites now pass it when they have the full
+    `ProveedorListado` on hand — `Proveedores.tsx`'s `PanelSaldoDeProveedor`
+    (which already held it, `proveedorSaldo`) and `Compras.tsx` (via its
+    existing `proveedorPorId` index, built from the page's own `GET
+    /proveedores?tamanio=200` fetch) — so the `<Link>` passes
+    `state={{ proveedor }}`, same pattern as `Clientes.tsx`
+    (`state={{ cliente: c }}`). When the caller doesn't have it, the `Link`
+    goes without `state` and layer (1) still covers the Supervisor
+    gracefully. Mutation-verified both layers: re-coupling `puedeAjustar` to
+    `errorProveedor` failed the new "Supervisor sin `location.state`, GET
+    403, ajusta igual" test in `CuentaCorrienteDeProveedor.test.tsx`;
+    removing the `state` from `ResumenSaldoDeProveedor`'s `<Link>` failed the
+    new "el click real en el link propaga `location.state.proveedor`" test
+    in `ResumenSaldoDeProveedor.test.tsx` (both reverted after verifying).
 
 - [x] 6.1 Create `src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts` —
   client + pure mappers (movement mapper, filter builder, `etiquetarAjuste`).

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1502,11 +1502,11 @@ above):**
   `Proveedores.test.tsx`, `Compras.test.tsx`) → reverted (`git diff`
   byte-identical to the committed tip) → 18/18 green across the three
   files.
-- [x] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
+- [ ] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
   clean. **NOT executed by `sdd-apply`** — orchestrator-level review
   action, out of this phase's scope per the project's solo-dev PR
   validation gate (deviation 41 above).
-- [x] 6.15 Branch `feat/stage15-slice6-web` off `main` (parent: slice 5);
+- [ ] 6.15 Branch `feat/stage15-slice6-web` off `main` (parent: slice 5);
   PR; merge stacked-to-main. **NOT executed by `sdd-apply`** — the branch
   already exists (worktree pre-created by the orchestrator) and carries
   this phase's 3 commits; PR creation/merge is an orchestrator action, out

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1292,9 +1292,112 @@ running balance and the filters, and DROP the ajuste modal (the endpoint
 still serves the operation) — a documented reduction, never silent
 (decision 3 above).
 
-- [ ] 6.1 Create `src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts` —
+**Deviations registered during `sdd-apply` (stage-12 discipline, decision 14
+above):**
+
+36. **Task 6.6's "two entry points (per-row action in `Proveedores.tsx`,
+    filtered header in `Compras.tsx`)" is realized as ONE shared entry
+    point — `ResumenSaldoDeProveedor`'s own new link — reachable from both
+    existing surfaces, not two separate, redundant buttons.** design.md's
+    Web Composition section states `ResumenSaldoDeProveedor.tsx` itself
+    "gains the link to the new screen" (`design.md:304-307`) and stays
+    presentational, shared between `Proveedores.tsx`'s panel and
+    `Compras.tsx`'s filtered header — the same component instance IS the
+    entry point in both places once it renders a `<Link>`. Adding a
+    second, separate per-row "Ver estado de cuenta" button in
+    `Proveedores.tsx` would duplicate the same navigation the shared
+    component already offers, for no added coverage. `ResumenSaldoDeProveedor`
+    widened its props to `{ saldo, idProveedor }` (from `{ saldo }`) so
+    the link can be built; both call sites updated (`Proveedores.tsx`
+    passes the panel's own `idProveedor`, `Compras.tsx` passes
+    `saldoProveedor.idProveedor` from the response itself, never a second
+    source of truth for the same id).
+37. **`clienteDeProveedores.obtener` (task 6.2's identity fallback,
+    mirroring `clienteDeClientes.obtener` in `CuentaCorriente.tsx`) is
+    gated `Politicas.GestionDeCatalogo` (Admin-only) server-side
+    (`ProveedoresEndpoints.cs:11-27`) — NOT `OperacionDePos` like
+    `/clientes/{id}` is.** This is pre-existing API surface, unmodified by
+    this stage ("cero cambios de API"), and unlike the client-side
+    precedent, a Vendedor/Supervisor arriving at
+    `/proveedores/:id/cuenta-corriente` by direct URL (no
+    `location.state.proveedor` — e.g. no entry click, a bookmark, a
+    refresh) gets `403` resolving the proveedor's name. Registered, not
+    silently patched: the screen fails CLOSED exactly like
+    `CuentaCorriente.tsx`'s Fix 2 (regla 7) — `errorProveedor` shows a
+    visible aviso, the header falls back to `Proveedor #N`, and the
+    ajuste button disables with the same aviso as its `motivo` — while
+    the ledger itself (`GET …/cuenta-corriente`, `OperacionDePos`) keeps
+    loading and rendering normally, because it is an independent fetch.
+    Both real entry points (`ResumenSaldoDeProveedor`'s link) always pass
+    `location.state.proveedor`, so this path is a direct-URL/bookmark/
+    refresh corner case only, same population `CuentaCorriente.tsx`
+    already documents. `Compras.tsx`'s own pre-existing `GET /proveedores`
+    listing fetch (`api.get('/proveedores?tamanio=200')`, unconditional
+    for every role since before this stage) carries the identical
+    Admin-only gate — a pre-existing gap this stage does not introduce and
+    is out of scope to fix.
+38. **The ajuste modal has NO confirmation checkbox**, unlike
+    `ModalAjusteDeCuenta` (`CuentaCorriente.tsx`, cliente, stage 7's own
+    "Fix 2"). Neither design.md's Web Composition section nor any task
+    below names a confirmation gate for this modal — only detalle/importe
+    validation, full-window disable and the refetch contract (design.md:
+    290-299). Not degraded per decision 3 (that pre-authorization covers
+    dropping the WHOLE modal, not trimming a sub-feature the design never
+    specified); this is read as literal scope, not a silent reduction.
+39. **Task 6.7 (react-async-state rule 10 sweep) found NO new
+    error-recovery or data-honesty pattern to replicate.** This slice
+    introduces no self-heal-on-409 path (the ajuste has no turno, so no
+    `turno_no_abierto` exists to recover — same conclusion
+    `ModalAjusteDeCuenta`/`ModalReliquidacion` already reached for their
+    own turno-less writes) and no new filtered-request counter/flag shape
+    beyond the existing pager/generation patterns already swept in prior
+    stages. No sibling file required a change under this rule.
+40. **Task 6.1's "movement mapper" is realized as two small named
+    helpers** — `etiquetaDeTipoDeMovimiento` (the "Tipo" column, delegating
+    to `etiquetarAjuste` for the `Ajuste` case) and `referenciaDeMovimiento`
+    (the "Comprobante/Gasto" column) — rather than one combined row-shape
+    mapper, matching the granularity `mutation-proof-tests`/
+    `web-descriptor-tests` reward (one assertable unit per column,
+    `cuentaCorrienteDeProveedor.test.ts`). `validarAjusteLocal`/
+    `saldoResultanteDeAjuste`/`LONGITUD_MINIMA_DETALLE_AJUSTE` are
+    REUSED from `cuentaCorriente.ts` rather than duplicated: design
+    decision 13 states the server reuses the exact same
+    `ReglaDeAjusteDeCuenta.Validar` unchanged for both ledgers, so the
+    already-tested client mirror is the same rule, not a sibling one
+    (`fechaIsoConOffset`/`desplazamientoUtcLocal`, which have no shared
+    module across this web, ARE duplicated per the existing convention).
+41. **Task 6.14 (`judgment-day`) and 6.15 (branch/PR/merge) are NOT
+    executed by `sdd-apply`** — orchestrator-level review/delivery
+    actions, out of this phase's scope per the project's solo-dev PR
+    validation gate (same posture as tasks 4.20-4.21/5.14-5.15). The
+    branch `feat/stage15-slice6-web` already exists (worktree pre-created
+    by the orchestrator) and carries this phase's 3 commits.
+42. **Actual diff is ~1 449 changed lines (1 425 additions/24 deletions),
+    above the ~380 forecast in the Suggested Work Units table** —
+    registered per `sdd-phase-common.md` Section E, non-blocking:
+    `state.yaml`/tasks.md already resolved `auto-chain` +
+    `stacked-to-main` with `Decision needed before apply: No` for this
+    slice, and this IS the bounded, autonomous, LAST-in-chain single-PR
+    work unit the chain strategy names — nothing downstream depends on a
+    split. Production code is ~715 lines across two new files
+    (`cuentaCorrienteDeProveedor.ts` ~140, `CuentaCorrienteDeProveedor.tsx`
+    ~460 incl. the ajuste modal) plus the `ResumenSaldoDeProveedor.tsx`
+    re-pointing (~15 net); the rest is test depth — 412 lines of component
+    coverage (`CuentaCorrienteDeProveedor.test.tsx`: header/ledger,
+    role-gating, the stale-generation test, both pager-edge tests, and the
+    ajuste modal's 4 tests including the double-click guard) plus the two
+    colocated pure-helper suites (`cuentaCorrienteDeProveedor.test.ts`,
+    `ResumenSaldoDeProveedor.test.tsx`) — the same shape
+    `mutation-proof-tests`/`web-descriptor-tests` require per column/
+    helper, mirroring the density `CuentaCorriente.test.tsx` (cliente,
+    stage 7, 1052 lines) already carries for the symmetric screen. The
+    pre-authorized degradation (drop the ajuste modal) was NOT exercised —
+    the full scope fit inside one PR with green tests, so there was no
+    coverage to trim.
+
+- [x] 6.1 Create `src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts` —
   client + pure mappers (movement mapper, filter builder, `etiquetarAjuste`).
-- [ ] 6.2 Create `src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx`
+- [x] 6.2 Create `src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx`
   — route `/proveedores/:id/cuenta-corriente`, built from
   `CuentaCorriente.tsx`'s ledger half + `HistoricoDeCajas.tsx`'s pager.
   `key={idProveedor}` on the subtree (react-async-state rule 8);
@@ -1302,38 +1405,50 @@ still serves the operation) — a documented reduction, never silent
   3); post-write refetch has its own `try/catch` and its own copy (rule
   6); first-line re-entrancy guard + full-window disable on the ajuste
   (rule 9). *(design.md:286-299)*
-- [ ] 6.3 Filters `desde`/`hasta`/"ver histórico" built with
+- [x] 6.3 Filters `desde`/`hasta`/"ver histórico" built with
   `fechaIsoConOffset` (the browser's own offset, never `Z`) — the same
   helper `cuentaCorriente.ts` already duplicates.
-- [ ] 6.4 Columns: `Fecha · Tipo · Comprobante/Gasto · Detalle · Importe ·
+- [x] 6.4 Columns: `Fecha · Tipo · Comprobante/Gasto · Detalle · Importe ·
   Saldo resultante`. A negative saldo renders "saldo a favor", NEVER
   clamped to zero.
-- [ ] 6.5 Modify `ResumenSaldoDeProveedor.tsx` — retire the "compras
+- [x] 6.5 Modify `ResumenSaldoDeProveedor.tsx` — retire the "compras
   confirmadas menos gastos ligados" caption and the "aproximación, no
   invariante" callout (both retired by this stage); add the saldo-a-favor
   state + the link to the new screen; stays presentational (`saldo:
   number` prop). *(design.md:304-307)*
-- [ ] 6.6 Modify `App.tsx`, `Proveedores.tsx`, `Compras.tsx` — one route +
+- [x] 6.6 Modify `App.tsx`, `Proveedores.tsx`, `Compras.tsx` — one route +
   two entry points (per-row action in `Proveedores.tsx`, filtered header
-  in `Compras.tsx`).
-- [ ] 6.7 React-async-state rule 10: grep any error-recovery/data-honesty
+  in `Compras.tsx`). *(deviation 36 above — one shared entry point, not
+  two duplicated buttons)*
+- [x] 6.7 React-async-state rule 10: grep any error-recovery/data-honesty
   pattern introduced here across `src/paginas` and replicate in every
-  sibling surface, in this same PR.
-- [ ] 6.8 [P] Colocated unit tests: `etiquetarAjuste` (both directions),
+  sibling surface, in this same PR. *(deviation 39 above — none found)*
+- [x] 6.8 [P] Colocated unit tests: `etiquetarAjuste` (both directions),
   the movement mapper, the filter builder — no DOM.
-- [ ] 6.9 [P] Component test: a stale response is discarded — resolved
+- [x] 6.9 [P] Component test: a stale response is discarded — resolved
   INSIDE `act`, asserted synchronously after the flush (rule 7).
-- [ ] 6.10 [P] Component test: the pager is disabled at the edges.
-- [ ] 6.11 [P] Component test: a negative saldo renders "saldo a favor".
-- [ ] 6.12 [P] Component test: a double click on "Registrar ajuste"
+- [x] 6.10 [P] Component test: the pager is disabled at the edges.
+- [x] 6.11 [P] Component test: a negative saldo renders "saldo a favor".
+- [x] 6.12 [P] Component test: a double click on "Registrar ajuste"
   issues exactly ONE POST (rule 9).
-- [ ] 6.13 [P] **Mutation target #28** — the saldo-a-favor branch in
+- [x] 6.13 [P] **Mutation target #28** — the saldo-a-favor branch in
   `ResumenSaldoDeProveedor.tsx` → delete it → the colocated descriptor
-  test on a negative saldo (6.11) must fail.
-- [ ] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
-  clean.
-- [ ] 6.15 Branch `feat/stage15-slice6-web` off `main` (parent: slice 5);
-  PR; merge stacked-to-main.
+  test on a negative saldo (6.11) must fail. Applied (`{false && ...}`) →
+  built (`vitest run` — in web, the run itself is the "build" per this
+  slice's own instruction) → 3 discriminating tests failed
+  (`ResumenSaldoDeProveedor.test.tsx`'s own negative-saldo test,
+  `Proveedores.test.tsx`, `Compras.test.tsx`) → reverted (`git diff`
+  byte-identical to the committed tip) → 18/18 green across the three
+  files.
+- [x] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
+  clean. **NOT executed by `sdd-apply`** — orchestrator-level review
+  action, out of this phase's scope per the project's solo-dev PR
+  validation gate (deviation 41 above).
+- [x] 6.15 Branch `feat/stage15-slice6-web` off `main` (parent: slice 5);
+  PR; merge stacked-to-main. **NOT executed by `sdd-apply`** — the branch
+  already exists (worktree pre-created by the orchestrator) and carries
+  this phase's 3 commits; PR creation/merge is an orchestrator action, out
+  of this phase's scope (deviation 41 above).
 
 **Test plan**: mutation target (6.13), descriptor tests (6.8), stale
 inside `act` (6.9), pager edges (6.10), saldo a favor (6.11), single POST

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1394,6 +1394,23 @@ above):**
     pre-authorized degradation (drop the ajuste modal) was NOT exercised —
     the full scope fit inside one PR with green tests, so there was no
     coverage to trim.
+43. **`judgment-day` (juez B) confirmed one CRITICAL finding, fixed here:
+    task 6.12's double-click test (`CuentaCorrienteDeProveedor.test.tsx`,
+    "doble click en 'Registrar ajuste' dispara exactamente un POST") was
+    overdetermined** — its two `await userEvent.click` calls let React
+    re-render with `disabled` between clicks, so jsdom no-opeaba the second
+    click on its own; neutralizing the ref guard (`if (registrandoRef.current)
+    return`) still passed 13/13, because `disabled` alone already blocked the
+    second click. The guard's inline comment also asserted (unverified) that
+    the ref was "the real defense", never `disabled` alone. Fixed by
+    dispatching both clicks inside one `act()` (no `await` between them, same
+    pattern as `BotonDeDescarga.test.tsx`'s same-tick double-click test), so
+    the ref guard is the only defense observable in that window; mutating it
+    to a no-op now fails the test with 2 POSTs (verified). The comment now
+    states both defenses are complementary — the ref covers the same-tick
+    window, `disabled` covers the rest — without ranking one as "the real"
+    one. Test renamed to "doble click en el mismo tick en 'Registrar ajuste'
+    dispara exactamente un POST".
 
 - [x] 6.1 Create `src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts` —
   client + pure mappers (movement mapper, filter builder, `etiquetarAjuste`).

--- a/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
+++ b/openspec/changes/stage-15-cc-proveedores-ledger/tasks.md
@@ -1502,7 +1502,7 @@ above):**
   `Proveedores.test.tsx`, `Compras.test.tsx`) → reverted (`git diff`
   byte-identical to the committed tip) → 18/18 green across the three
   files.
-- [ ] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
+- [x] 6.14 Run `judgment-day`; fix confirmed issues; re-judge until
   clean. **NOT executed by `sdd-apply`** — orchestrator-level review
   action, out of this phase's scope per the project's solo-dev PR
   validation gate (deviation 41 above).

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -14,6 +14,7 @@ import { Compras } from './paginas/Compras'
 import { CompraEditor } from './paginas/CompraEditor'
 import { ConteoDeInventario } from './paginas/ConteoDeInventario'
 import { CuentaCorriente } from './paginas/CuentaCorriente'
+import { CuentaCorrienteDeProveedor } from './paginas/CuentaCorrienteDeProveedor'
 import { Empresas } from './paginas/Empresas'
 import { Existencias } from './paginas/Existencias'
 import { HistoricoDeCajas } from './paginas/HistoricoDeCajas'
@@ -216,6 +217,19 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Admin]}>
                   <Proveedores />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-15-cc-proveedores-ledger (Slice 6, design: Web Composition): estado de
+                cuenta del proveedor — Politicas.OperacionDePos (todo rol opera), a diferencia de
+                /proveedores que es admin-only. Entrada desde ResumenSaldoDeProveedor (panel de
+                Proveedores.tsx y header filtrado de Compras.tsx). */}
+            <Route
+              path="/proveedores/:id/cuenta-corriente"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <CuentaCorrienteDeProveedor />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/cuentaCorrienteDeProveedor.test.ts
+++ b/src/Ways.Web/src/api/cuentaCorrienteDeProveedor.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aSolicitudDeAjusteDeProveedor,
+  construirQueryEstadoDeCuentaDeProveedor,
+  esSaldoAFavor,
+  etiquetaDeTipoDeMovimiento,
+  etiquetarAjuste,
+  filtrosDeEstadoDeCuentaDeProveedorVacios,
+  referenciaDeMovimiento,
+} from './cuentaCorrienteDeProveedor'
+import type { MovimientoDeCuentaDeProveedor } from './tipos'
+
+function movimientoFixture(sobrescribir: Partial<MovimientoDeCuentaDeProveedor> = {}): MovimientoDeCuentaDeProveedor {
+  return {
+    idMovimiento: 1,
+    fecha: '2026-08-17T12:00:00Z',
+    tipo: 'Compra',
+    importe: 1000,
+    saldoResultante: 1000,
+    detalle: null,
+    idComprobanteCompra: 5,
+    idGasto: null,
+    etiqueta: null,
+    ...sobrescribir,
+  }
+}
+
+// ---- etiquetarAjuste: helper puro, sin DOM (web-descriptor-tests) -----------------------------
+
+describe('etiquetarAjuste', () => {
+  it('etiqueta === AnulacionContramovimiento devuelve "Contramov. de anulación"', () => {
+    expect(etiquetarAjuste('AnulacionContramovimiento')).toBe('Contramov. de anulación')
+  })
+
+  it('etiqueta === Manual devuelve "Ajuste manual"', () => {
+    expect(etiquetarAjuste('Manual')).toBe('Ajuste manual')
+  })
+
+  it('etiqueta null (nunca debería llegar así en un tipo Ajuste real) cae al mismo default que Manual', () => {
+    expect(etiquetarAjuste(null)).toBe('Ajuste manual')
+  })
+})
+
+// ---- etiquetaDeTipoDeMovimiento / referenciaDeMovimiento: el mapper de fila -------------------
+
+describe('etiquetaDeTipoDeMovimiento', () => {
+  it('Apertura, Compra y Pago se muestran tal cual', () => {
+    expect(etiquetaDeTipoDeMovimiento(movimientoFixture({ tipo: 'Apertura', etiqueta: null }))).toBe('Apertura')
+    expect(etiquetaDeTipoDeMovimiento(movimientoFixture({ tipo: 'Compra', etiqueta: null }))).toBe('Compra')
+    expect(etiquetaDeTipoDeMovimiento(movimientoFixture({ tipo: 'Pago', etiqueta: null }))).toBe('Pago')
+  })
+
+  it('Ajuste delega en etiquetarAjuste, en ambas direcciones', () => {
+    expect(etiquetaDeTipoDeMovimiento(movimientoFixture({ tipo: 'Ajuste', etiqueta: 'Manual' }))).toBe('Ajuste manual')
+    expect(etiquetaDeTipoDeMovimiento(movimientoFixture({ tipo: 'Ajuste', etiqueta: 'AnulacionContramovimiento' }))).toBe(
+      'Contramov. de anulación',
+    )
+  })
+})
+
+describe('referenciaDeMovimiento', () => {
+  it('con idComprobanteCompra devuelve "Compra #N", incluso si además tuviera idGasto', () => {
+    expect(referenciaDeMovimiento({ idComprobanteCompra: 5, idGasto: null })).toBe('Compra #5')
+    expect(referenciaDeMovimiento({ idComprobanteCompra: 5, idGasto: 9 })).toBe('Compra #5')
+  })
+
+  it('sin idComprobanteCompra pero con idGasto devuelve "Gasto #N"', () => {
+    expect(referenciaDeMovimiento({ idComprobanteCompra: null, idGasto: 9 })).toBe('Gasto #9')
+  })
+
+  it('sin ninguno de los dos (apertura, ajuste manual) devuelve "—"', () => {
+    expect(referenciaDeMovimiento({ idComprobanteCompra: null, idGasto: null })).toBe('—')
+  })
+})
+
+// ---- esSaldoAFavor -----------------------------------------------------------------------------
+
+describe('esSaldoAFavor', () => {
+  it('un saldo negativo es "a favor"', () => {
+    expect(esSaldoAFavor(-500)).toBe(true)
+  })
+
+  it('cero y un saldo positivo NO son "a favor"', () => {
+    expect(esSaldoAFavor(0)).toBe(false)
+    expect(esSaldoAFavor(500)).toBe(false)
+  })
+})
+
+// ---- construirQueryEstadoDeCuentaDeProveedor: el filter builder -------------------------------
+
+describe('construirQueryEstadoDeCuentaDeProveedor', () => {
+  it('historico=true omite desde/hasta pero conserva pagina/tamanio', () => {
+    const query = construirQueryEstadoDeCuentaDeProveedor({
+      desde: '2026-07-01',
+      hasta: '2026-08-01',
+      historico: true,
+      pagina: 2,
+      tamanio: 25,
+    })
+    expect(query).toContain('historico=true')
+    expect(query).not.toContain('desde=')
+    expect(query).not.toContain('hasta=')
+    expect(query).toContain('pagina=2')
+    expect(query).toContain('tamanio=25')
+  })
+
+  it('sin historico, desde/hasta viajan con el offset local, nunca Z (mutation-proof-tests regla 10)', () => {
+    const query = construirQueryEstadoDeCuentaDeProveedor({
+      desde: '2026-08-01',
+      hasta: '2026-08-17',
+      historico: false,
+      pagina: 1,
+      tamanio: 25,
+    })
+    expect(query).not.toContain('historico')
+    expect(query).toMatch(/desde=2026-08-01T00%3A00%3A00[+-]\d{2}%3A\d{2}/)
+    expect(query).toMatch(/hasta=2026-08-17T23%3A59%3A59\.999[+-]\d{2}%3A\d{2}/)
+  })
+
+  it('desde/hasta vacíos se omiten (el servidor aplica su propio default de último mes)', () => {
+    const query = construirQueryEstadoDeCuentaDeProveedor({ desde: '', hasta: '', historico: false, pagina: 1, tamanio: 25 })
+    expect(query).not.toContain('desde=')
+    expect(query).not.toContain('hasta=')
+    expect(query).toContain('pagina=1')
+  })
+})
+
+describe('filtrosDeEstadoDeCuentaDeProveedorVacios', () => {
+  it('precarga página 1, tamaño 25, histórico apagado y una ventana desde/hasta no vacía', () => {
+    const filtros = filtrosDeEstadoDeCuentaDeProveedorVacios()
+    expect(filtros.pagina).toBe(1)
+    expect(filtros.tamanio).toBe(25)
+    expect(filtros.historico).toBe(false)
+    expect(filtros.desde).not.toBe('')
+    expect(filtros.hasta).not.toBe('')
+  })
+})
+
+// ---- aSolicitudDeAjusteDeProveedor -------------------------------------------------------------
+
+describe('aSolicitudDeAjusteDeProveedor', () => {
+  it('recorta el detalle antes de armar el cuerpo del POST', () => {
+    expect(aSolicitudDeAjusteDeProveedor(7, -200, '  saldo inicial mal cargado  ')).toEqual({
+      idPuntoVenta: 7,
+      importe: -200,
+      detalle: 'saldo inicial mal cargado',
+    })
+  })
+})

--- a/src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts
+++ b/src/Ways.Web/src/api/cuentaCorrienteDeProveedor.ts
@@ -1,0 +1,130 @@
+/**
+ * Cliente HTTP + mappers puros del ledger de proveedores (stage-15-cc-proveedores-ledger, Slice 6):
+ * estado de cuenta PAGINADO (`GET /api/proveedores/{id}/cuenta-corriente`, design decisión 10) y
+ * el ajuste manual (`POST …/ajustes`, `Politicas.SupervisionDeCuentaDeProveedor`). El ajuste manual
+ * reusa server-side la MISMA `ReglaDeAjusteDeCuenta.Validar` que la cuenta corriente de clientes
+ * (design decisión 13) — este módulo reusa por lo tanto el mirror local ya probado
+ * (`validarAjusteLocal`, `saldoResultanteDeAjuste`, `LONGITUD_MINIMA_DETALLE_AJUSTE`) de
+ * `./cuentaCorriente` en vez de duplicarlo: es la misma regla, no una prima de forma parecida.
+ */
+import { api } from './cliente'
+import { rangoUltimoMes } from './cuentaCorriente'
+import type {
+  EtiquetaDeAjuste,
+  MovimientoDeCuentaDeProveedor,
+  PaginaDeEstadoDeCuentaDeProveedor,
+  SolicitudDeAjusteDeProveedor,
+} from './tipos'
+
+export { rangoUltimoMes }
+
+// ---- Offset local para desde/hasta (mismo criterio que cuentaCorriente.ts/compras.ts: el
+// servidor corre en UTC, `fecha` es `timestamptz`, un `<input type="date">` sin offset se
+// interpretaría como UTC — mutation-proof-tests regla 10). Duplicado a propósito: no hay un módulo
+// compartido de utilidades de fecha en esta web todavía. -----------------------------------------
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+export type FiltrosDeEstadoDeCuentaDeProveedor = {
+  desde: string
+  hasta: string
+  historico: boolean
+  pagina: number
+  tamanio: number
+}
+
+/** Ventana por defecto de la pantalla — mismo default de último mes que
+ * `ServicioDeCuentaCorrienteDeProveedor.ObtenerEstadoDeCuentaAsync` aplica del lado del servidor
+ * cuando no llega ningún filtro, precargado acá para que los inputs nunca queden vacíos. */
+export function filtrosDeEstadoDeCuentaDeProveedorVacios(): FiltrosDeEstadoDeCuentaDeProveedor {
+  const rango = rangoUltimoMes()
+  return { desde: rango.desde, hasta: rango.hasta, historico: false, pagina: 1, tamanio: 25 }
+}
+
+/** Arma el query string de `GET …/cuenta-corriente` — `historico` gana sobre `desde`/`hasta`
+ * (mismo criterio que `ObtenerEstadoDeCuentaAsync`); `pagina`/`tamanio` viajan siempre (design
+ * decisión 10, la superficie PAGINADA). */
+export function construirQueryEstadoDeCuentaDeProveedor(filtros: FiltrosDeEstadoDeCuentaDeProveedor): string {
+  const parametros = new URLSearchParams()
+  if (filtros.historico) {
+    parametros.set('historico', 'true')
+  } else {
+    if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+    if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  }
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+export const clienteDeCuentaCorrienteDeProveedor = {
+  /** `GET /api/proveedores/{id}/cuenta-corriente` — `Politicas.OperacionDePos` (grupo, sin policy
+   * apilada): 200 siempre, header + página en un único payload (design decisión 9). */
+  obtenerEstado: (idProveedor: number, filtros: FiltrosDeEstadoDeCuentaDeProveedor) =>
+    api.get<PaginaDeEstadoDeCuentaDeProveedor>(
+      `/proveedores/${idProveedor}/cuenta-corriente${construirQueryEstadoDeCuentaDeProveedor(filtros)}`,
+    ),
+  /** `POST /api/proveedores/{id}/cuenta-corriente/ajustes` — TOP-LEVEL, `Politicas.
+   * SupervisionDeCuentaDeProveedor` SOLA (design decisión 12): 201 con el movimiento `Ajuste`. Sin
+   * turno (design decisión 14 — "provenance, not authority"), a diferencia de un pago. */
+  registrarAjuste: (idProveedor: number, solicitud: SolicitudDeAjusteDeProveedor) =>
+    api.post<MovimientoDeCuentaDeProveedor>(`/proveedores/${idProveedor}/cuenta-corriente/ajustes`, solicitud),
+}
+
+/** Etiqueta de pantalla de un movimiento `Ajuste` por su origen — espejo de
+ * `CalculadorDeEstadoDeCuentaDeProveedor.EtiquetarAjuste`, ya resuelto server-side en
+ * `m.etiqueta` (el backend reusa el mismo enum `EtiquetaDeAjuste` que la cuenta corriente de
+ * clientes, `Contratos.cs`/`ContratosDeProveedor.cs`). Mismas dos etiquetas de pantalla que
+ * `etiquetaDeMovimiento` (`cuentaCorriente.ts`). */
+export function etiquetarAjuste(etiqueta: EtiquetaDeAjuste | null): string {
+  return etiqueta === 'AnulacionContramovimiento' ? 'Contramov. de anulación' : 'Ajuste manual'
+}
+
+/** Etiqueta de pantalla de la columna "Tipo" — espejo de `TipoMovimientoCcProveedor`, delegando en
+ * `etiquetarAjuste` para distinguir un ajuste manual de un contramovimiento de anulación. */
+export function etiquetaDeTipoDeMovimiento(m: Pick<MovimientoDeCuentaDeProveedor, 'tipo' | 'etiqueta'>): string {
+  switch (m.tipo) {
+    case 'Apertura':
+      return 'Apertura'
+    case 'Compra':
+      return 'Compra'
+    case 'Pago':
+      return 'Pago'
+    case 'Ajuste':
+      return etiquetarAjuste(m.etiqueta)
+  }
+}
+
+/** Columna "Comprobante/Gasto": el origen del movimiento, cuando lo tiene — un `pago` referencia
+ * su `gasto`, un `compra`/contramovimiento de anulación referencia la compra, un `apertura` o un
+ * ajuste manual no referencian nada. */
+export function referenciaDeMovimiento(m: Pick<MovimientoDeCuentaDeProveedor, 'idComprobanteCompra' | 'idGasto'>): string {
+  if (m.idComprobanteCompra !== null) return `Compra #${m.idComprobanteCompra}`
+  if (m.idGasto !== null) return `Gasto #${m.idGasto}`
+  return '—'
+}
+
+/** Un saldo negativo es "saldo a favor" (spec: Anulación decisión — "MAY be negative... MUST NOT
+ * be clamped to zero") — nunca un valor recortado a cero. Compartido por la tabla de movimientos y
+ * el header de esta pantalla. */
+export function esSaldoAFavor(valor: number): boolean {
+  return valor < 0
+}
+
+/** Importe/detalle → `SolicitudDeAjusteDeProveedor` — recorta el detalle (mismo criterio que
+ * `aSolicitudDeAjuste`, `cuentaCorriente.ts`; el servidor también lo recorta, esto es solo para
+ * que el `POST` viaje ya prolijo). */
+export function aSolicitudDeAjusteDeProveedor(idPuntoVenta: number, importe: number, detalle: string): SolicitudDeAjusteDeProveedor {
+  return { idPuntoVenta, importe, detalle: detalle.trim() }
+}

--- a/src/Ways.Web/src/api/proveedores.ts
+++ b/src/Ways.Web/src/api/proveedores.ts
@@ -13,6 +13,11 @@ export const clienteDeProveedores = {
     const cadena = parametros.toString()
     return api.get<PaginaDe<ProveedorListado>>(`/proveedores${cadena ? `?${cadena}` : ''}`)
   },
+  /** `GET /api/proveedores/{id}` — resuelve la identidad de un proveedor sin pasar por el
+   * listado (stage-15-cc-proveedores-ledger, Slice 6): único camino de `CuentaCorrienteDeProveedor`
+   * cuando se llega por URL directa, sin `location.state` (mismo criterio que
+   * `clienteDeClientes.obtener`). */
+  obtener: (id: number) => api.get<ProveedorListado>(`/proveedores/${id}`),
   crear: (datos: AltaProveedor) => api.post<ProveedorListado>('/proveedores', datos),
   actualizar: (id: number, datos: EdicionProveedor) => api.put<ProveedorListado>(`/proveedores/${id}`, datos),
   eliminar: (id: number) => api.delete(`/proveedores/${id}`),

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -93,6 +93,15 @@ export function puedeSupervisarCuentaCorriente(rolId: number) {
   return rolId === ROL.Supervisor || rolId === ROL.Admin
 }
 
+/** Espejo de `Politicas.SupervisionDeCuentaDeProveedor` (stage-15-cc-proveedores-ledger, Slice 5):
+ * supervisor o admin pueden registrar un ajuste manual del ledger de proveedores — vendedor queda
+ * afuera, mismo criterio que `puedeSupervisarCuentaCorriente` pero una policy DISTINTA y propia
+ * (design decisión 8/12: nunca compuesta con `OperacionDePos`). Puramente cosmético: el servidor
+ * vuelve a exigir la misma policy en cada `POST /ajustes`. */
+export function puedeSupervisarCuentaDeProveedor(rolId: number) {
+  return rolId === ROL.Supervisor || rolId === ROL.Admin
+}
+
 /** Espejo de `Politicas.LecturaDeReportes` (stage-10-agregacion-dashboard, Slice 1): supervisor o
  * admin ven `Tablero` — vendedor y root quedan afuera, mismo criterio que
  * `puedeSupervisarCuentaCorriente`. Puramente cosmético: el servidor vuelve a exigir la misma
@@ -1213,6 +1222,52 @@ export type CompraConEstadoPago = {
 }
 
 export type SaldoDeProveedor = { idProveedor: number; saldo: number; compras: CompraConEstadoPago[] }
+
+// --- Cuenta corriente de proveedores (stage-15-cc-proveedores-ledger, Slice 4 backend / Slice 6
+// web) — espejo de `Ways.Application.CuentaCorriente.ContratosDeProveedor`. `GET
+// /api/proveedores/{id}/cuenta-corriente` es la lectura PAGINADA del ledger completo (distinta de
+// `SaldoDeProveedor`/`/saldo`, el resumen por-compra — design decisión 9, dos read models a
+// propósito, ninguno amplía al otro). `POST …/ajustes` es la única escritura de esta superficie.
+
+export type TipoMovimientoCcProveedor = 'Apertura' | 'Compra' | 'Pago' | 'Ajuste'
+
+/** Una fila del ledger de proveedores — `saldoResultante` es la ÚNICA fuente del saldo corrido,
+ * nunca re-derivada en pantalla (design decisión 11). `etiqueta` reutiliza el mismo enum
+ * `EtiquetaDeAjuste` que la cuenta corriente de clientes (el backend reusa la clase, Contratos.cs)
+ * — solo viene poblado cuando `tipo === 'Ajuste'`. */
+export type MovimientoDeCuentaDeProveedor = {
+  idMovimiento: number
+  fecha: string
+  tipo: TipoMovimientoCcProveedor
+  importe: number
+  saldoResultante: number
+  detalle: string | null
+  idComprobanteCompra: number | null
+  idGasto: number | null
+  etiqueta: EtiquetaDeAjuste | null
+}
+
+/** `saldo` viene de `proveedores.saldo` — NUNCA re-derivado de los movimientos de esta misma
+ * página (design decisión 11). */
+export type EstadoDeCuentaDeProveedorHeader = { idProveedor: number; saldo: number }
+
+/** Forma PAGINADA (design decisión 10 / `state.yaml` OD9): `pagina`/`tamanio`/`total` habilitan
+ * "Página N de M" en el web — a diferencia de `EstadoDeCuenta` (clientes, stage 7), que no pagina. */
+export type PaginaDeEstadoDeCuentaDeProveedor = {
+  header: EstadoDeCuentaDeProveedorHeader
+  items: MovimientoDeCuentaDeProveedor[]
+  total: number
+  pagina: number
+  tamanio: number
+  historico: boolean
+  desde: string | null
+  hasta: string | null
+}
+
+/** Cuerpo de `POST /api/proveedores/{id}/cuenta-corriente/ajustes` — deliberadamente SIN `tipo`
+ * ni `saldoResultante` (design decisión 15, `dto-contract-honesty`): ningún endpoint de esta etapa
+ * acepta un saldo o un delta ya calculado por el cliente. */
+export type SolicitudDeAjusteDeProveedor = { idPuntoVenta: number; importe: number; detalle: string }
 
 // --- Stock: transferencias y conteo de inventario (stage-8, Slice 6) -----------------------
 // Espejo de `Ways.Application.Stock.Contratos` — ningún request lleva un delta como input

--- a/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.test.tsx
+++ b/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { esSaldoAFavor, ResumenSaldoDeProveedor } from './ResumenSaldoDeProveedor'
+
+function renderResumen(saldo: number, idProveedor = 1) {
+  return render(<ResumenSaldoDeProveedor saldo={saldo} idProveedor={idProveedor} />, {
+    wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+  })
+}
+
+// ---- esSaldoAFavor: helper puro, sin DOM (web-descriptor-tests) -------------------------------
+
+describe('esSaldoAFavor', () => {
+  it('un saldo negativo es "a favor"', () => {
+    expect(esSaldoAFavor(-1)).toBe(true)
+  })
+
+  it('cero y un saldo positivo NO son "a favor"', () => {
+    expect(esSaldoAFavor(0)).toBe(false)
+    expect(esSaldoAFavor(1)).toBe(false)
+  })
+})
+
+// ---- ResumenSaldoDeProveedor -------------------------------------------------------------------
+
+describe('ResumenSaldoDeProveedor', () => {
+  it('un saldo positivo muestra el importe, sin el callout de saldo a favor', () => {
+    renderResumen(500)
+    expect(screen.getByText('$500,00')).toBeInTheDocument()
+    expect(screen.queryByText('Saldo a favor.')).not.toBeInTheDocument()
+  })
+
+  // mutation target #28 (design.md, tasks.md 6.13): la rama de saldo a favor en
+  // `ResumenSaldoDeProveedor.tsx` → borrarla → este test tiene que fallar.
+  it('un saldo negativo muestra el importe con signo y el callout "Saldo a favor."', () => {
+    renderResumen(-500)
+    expect(screen.getByText('-$500,00')).toBeInTheDocument()
+    expect(screen.getByText('Saldo a favor.')).toBeInTheDocument()
+  })
+
+  it('siempre linkea al estado de cuenta completo del proveedor', () => {
+    renderResumen(0, 42)
+    expect(screen.getByRole('link', { name: 'Ver estado de cuenta completo' })).toHaveAttribute(
+      'href',
+      '/proveedores/42/cuenta-corriente',
+    )
+  })
+})

--- a/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.test.tsx
+++ b/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.test.tsx
@@ -1,12 +1,59 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import { esSaldoAFavor, ResumenSaldoDeProveedor } from './ResumenSaldoDeProveedor'
+import type { ProveedorListado } from '../api/tipos'
 
 function renderResumen(saldo: number, idProveedor = 1) {
   return render(<ResumenSaldoDeProveedor saldo={saldo} idProveedor={idProveedor} />, {
     wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
   })
+}
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 42,
+    razonSocial: 'Proveedor Cuarenta y Dos SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+// Stub de la pantalla destino real (`/proveedores/:id/cuenta-corriente`) — solo lee
+// `location.state.proveedor` y lo vuelca a texto, para discriminar si el LINK REAL (el único
+// punto de entrada de producción) efectivamente propagó `state` o no.
+function EstadoDeCuentaStub() {
+  const location = useLocation()
+  const proveedor = (location.state as { proveedor?: ProveedorListado } | null)?.proveedor
+  return <div>{proveedor ? `state:${proveedor.razonSocial}` : 'sin-state'}</div>
+}
+
+function renderResumenConNavegacionReal(proveedor?: ProveedorListado) {
+  return render(
+    <MemoryRouter initialEntries={['/origen']}>
+      <Routes>
+        <Route
+          path="/origen"
+          element={<ResumenSaldoDeProveedor saldo={0} idProveedor={proveedor?.id ?? 1} proveedor={proveedor} />}
+        />
+        <Route path="/proveedores/:id/cuenta-corriente" element={<EstadoDeCuentaStub />} />
+      </Routes>
+    </MemoryRouter>,
+  )
 }
 
 // ---- esSaldoAFavor: helper puro, sin DOM (web-descriptor-tests) -------------------------------
@@ -45,5 +92,25 @@ describe('ResumenSaldoDeProveedor', () => {
       'href',
       '/proveedores/42/cuenta-corriente',
     )
+  })
+
+  // judgment-day stage-15 Slice 6, hallazgo CRITICAL: este Link es el ÚNICO punto de entrada real
+  // a `/proveedores/:id/cuenta-corriente` — probarlo con un click real (no con `state` inyectado a
+  // mano en el destino) es lo único que discrimina si la navegación real propaga `state` o no.
+  it('con el proveedor completo disponible, el click real en el link propaga location.state.proveedor', async () => {
+    const proveedor = proveedorFixture()
+    renderResumenConNavegacionReal(proveedor)
+
+    await userEvent.click(screen.getByRole('link', { name: 'Ver estado de cuenta completo' }))
+
+    expect(await screen.findByText(`state:${proveedor.razonSocial}`)).toBeInTheDocument()
+  })
+
+  it('sin el proveedor completo, el click real en el link navega sin location.state (degrada con gracia)', async () => {
+    renderResumenConNavegacionReal(undefined)
+
+    await userEvent.click(screen.getByRole('link', { name: 'Ver estado de cuenta completo' }))
+
+    expect(await screen.findByText('sin-state')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.tsx
+++ b/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.tsx
@@ -1,26 +1,40 @@
+import { Link } from 'react-router'
+
 function formatearMoneda(valor: number): string {
   const signo = valor < 0 ? '-' : ''
   return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
 
+/** Un saldo negativo es "saldo a favor" (stage-15-cc-proveedores-ledger, design: Web Composition,
+ * proposal decisión 5) — nunca clampeado a cero. Exportada para el test colocado
+ * (`ResumenSaldoDeProveedor.test.tsx`, mutation target #28). */
+export function esSaldoAFavor(saldo: number): boolean {
+  return saldo < 0
+}
+
 /**
- * Figura de saldo de proveedor + el callout de saldo negativo (gasto colgante) — pieza
- * presentacional compartida entre `Proveedores.tsx` (panel completo, Admin-only) y `Compras.tsx`
- * (header agregado cuando el listado está filtrado por proveedor, decisión: la lectura del saldo
- * sigue `Politicas.OperacionDePos` igual que el resto de `/compras` — Vendedor/Supervisor/Admin
- * tienen que poder verlo, no solo Admin vía `/proveedores`, judgment-day stage-8 Slice 6).
+ * Figura de saldo de proveedor + el link al estado de cuenta completo — pieza presentacional
+ * compartida entre `Proveedores.tsx` (panel completo, Admin-only) y `Compras.tsx` (header
+ * agregado cuando el listado está filtrado por proveedor, decisión: la lectura del saldo sigue
+ * `Politicas.OperacionDePos` igual que el resto de `/compras` — Vendedor/Supervisor/Admin tienen
+ * que poder verlo, no solo Admin vía `/proveedores`, judgment-day stage-8 Slice 6).
+ *
+ * stage-15-cc-proveedores-ledger (Slice 6, design: Web Composition): re-apuntada al ledger — el
+ * saldo ahora es la caché mantenida de `movimientos_cuenta_corriente_proveedor`
+ * (`EscriturasDeCuentaCorrienteProveedor`, single-write-authority), no una aproximación derivada;
+ * la caption ("compras confirmadas menos gastos ligados") y el callout ("aproximación, no
+ * invariante") describían la fórmula RETIRADA por esta etapa — ambos se retiran acá. Sigue
+ * puramente presentacional: sin fetch propio, `saldo`/`idProveedor` son los únicos inputs.
  */
-export function ResumenSaldoDeProveedor({ saldo }: { saldo: number }) {
+export function ResumenSaldoDeProveedor({ saldo, idProveedor }: { saldo: number; idProveedor: number }) {
   return (
     <div>
-      <div className="small text-muted">Saldo (compras confirmadas menos gastos ligados)</div>
+      <div className="small text-muted">Saldo</div>
       <div className="fs-5">{formatearMoneda(saldo)}</div>
-      {saldo < 0 && (
-        <div className="small text-warning-emphasis">
-          Saldo negativo: hay gastos de proveedor sin ligar a ninguna compra puntual — reducen el total, pero
-          no marcan ninguna compra específica como pagada (aproximación, no invariante).
-        </div>
-      )}
+      {esSaldoAFavor(saldo) && <div className="small text-warning-emphasis">Saldo a favor.</div>}
+      <Link className="small" to={`/proveedores/${idProveedor}/cuenta-corriente`}>
+        Ver estado de cuenta completo
+      </Link>
     </div>
   )
 }

--- a/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.tsx
+++ b/src/Ways.Web/src/componentes/ResumenSaldoDeProveedor.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router'
+import type { ProveedorListado } from '../api/tipos'
 
 function formatearMoneda(valor: number): string {
   const signo = valor < 0 ? '-' : ''
@@ -24,15 +25,37 @@ export function esSaldoAFavor(saldo: number): boolean {
  * (`EscriturasDeCuentaCorrienteProveedor`, single-write-authority), no una aproximación derivada;
  * la caption ("compras confirmadas menos gastos ligados") y el callout ("aproximación, no
  * invariante") describían la fórmula RETIRADA por esta etapa — ambos se retiran acá. Sigue
- * puramente presentacional: sin fetch propio, `saldo`/`idProveedor` son los únicos inputs.
+ * puramente presentacional: sin fetch propio, `saldo`/`idProveedor`/`proveedor` son los únicos
+ * inputs.
+ *
+ * `proveedor` (opcional): cuando el llamador ya tiene el `ProveedorListado` completo a mano
+ * (`Proveedores.tsx`, `Compras.tsx` vía su índice por id), este es el ÚNICO punto de entrada real
+ * a `/proveedores/:id/cuenta-corriente` — hay que pasarlo como `location.state.proveedor`, mismo
+ * patrón que `Clientes.tsx` (`state={{ cliente: c }}`), para que la pantalla destino no dependa de
+ * un GET Admin-only para mostrar el nombre (judgment-day stage-15 Slice 6, hallazgo CRITICAL: sin
+ * esto, TODA navegación real llegaba con `state` null). Cuando el llamador no lo tiene, el Link va
+ * sin `state` y la pantalla destino degrada con gracia (fallback "Proveedor #id"); nunca es un
+ * bloqueo para operar.
  */
-export function ResumenSaldoDeProveedor({ saldo, idProveedor }: { saldo: number; idProveedor: number }) {
+export function ResumenSaldoDeProveedor({
+  saldo,
+  idProveedor,
+  proveedor,
+}: {
+  saldo: number
+  idProveedor: number
+  proveedor?: ProveedorListado
+}) {
   return (
     <div>
       <div className="small text-muted">Saldo</div>
       <div className="fs-5">{formatearMoneda(saldo)}</div>
       {esSaldoAFavor(saldo) && <div className="small text-warning-emphasis">Saldo a favor.</div>}
-      <Link className="small" to={`/proveedores/${idProveedor}/cuenta-corriente`}>
+      <Link
+        className="small"
+        to={`/proveedores/${idProveedor}/cuenta-corriente`}
+        state={proveedor ? { proveedor } : undefined}
+      >
         Ver estado de cuenta completo
       </Link>
     </div>

--- a/src/Ways.Web/src/paginas/Compras.test.tsx
+++ b/src/Ways.Web/src/paginas/Compras.test.tsx
@@ -231,7 +231,7 @@ describe('Compras — listado', () => {
     expect(screen.queryByText(/Saldo negativo/)).not.toBeInTheDocument()
   })
 
-  it('un saldo negativo filtrando por proveedor muestra el callout de gasto colgante', async () => {
+  it('un saldo negativo filtrando por proveedor muestra el callout de saldo a favor', async () => {
     const saldo: SaldoDeProveedor = {
       idProveedor: 1,
       saldo: -500,
@@ -249,7 +249,7 @@ describe('Compras — listado', () => {
     await usuario.selectOptions(screen.getByLabelText('Proveedor'), '1')
 
     expect(await screen.findByText('-$500,00')).toBeInTheDocument()
-    expect(screen.getByText(/Saldo negativo: hay gastos de proveedor sin ligar/)).toBeInTheDocument()
+    expect(screen.getByText('Saldo a favor.')).toBeInTheDocument()
   })
 
   it('una respuesta de listado desactualizada nunca pisa la más reciente (generación)', async () => {

--- a/src/Ways.Web/src/paginas/Compras.tsx
+++ b/src/Ways.Web/src/paginas/Compras.tsx
@@ -269,7 +269,7 @@ export function Compras() {
 
         {saldoProveedor && (
           <div className="border p-3 mb-3 bg-white">
-            <ResumenSaldoDeProveedor saldo={saldoProveedor.saldo} />
+            <ResumenSaldoDeProveedor saldo={saldoProveedor.saldo} idProveedor={saldoProveedor.idProveedor} />
           </div>
         )}
 

--- a/src/Ways.Web/src/paginas/Compras.tsx
+++ b/src/Ways.Web/src/paginas/Compras.tsx
@@ -269,7 +269,16 @@ export function Compras() {
 
         {saldoProveedor && (
           <div className="border p-3 mb-3 bg-white">
-            <ResumenSaldoDeProveedor saldo={saldoProveedor.saldo} idProveedor={saldoProveedor.idProveedor} />
+            {/* stage-15-cc-proveedores-ledger (Slice 6, judgment-day hallazgo CRITICAL): `proveedorPorId`
+                ya trae el listado completo (fetch de montaje) — se lo pasamos a `ResumenSaldoDeProveedor`
+                para que el link real cargue con `location.state.proveedor`. Si el id todavía no está en
+                el índice (listado aún cargando), el Link va sin `state` y la pantalla destino degrada
+                con gracia. */}
+            <ResumenSaldoDeProveedor
+              saldo={saldoProveedor.saldo}
+              idProveedor={saldoProveedor.idProveedor}
+              proveedor={proveedorPorId[saldoProveedor.idProveedor]}
+            />
           </div>
         )}
 

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
@@ -228,6 +228,64 @@ describe('CuentaCorrienteDeProveedor — gating de rol (Supervisor+Admin) para e
   })
 })
 
+// judgment-day stage-15 Slice 6, hallazgo CRITICAL: el ÚNICO punto de entrada real
+// (`ResumenSaldoDeProveedor`) podía no traer `location.state.proveedor`, y el fetch de respaldo del
+// nombre (`clienteDeProveedores.obtener`) es Admin-only del lado del servidor — un Supervisor
+// llegando así recibía 403 en ese GET. El gate del botón "Ajuste manual" tiene que ser EXCLUSIVAMENTE
+// el rol (+ puntos de venta), nunca el resultado de ese fetch cosmético.
+describe('CuentaCorrienteDeProveedor — el ajuste NUNCA depende del fetch del nombre del proveedor', () => {
+  it('un Supervisor sin location.state, con el GET del nombre devolviendo 403, puede ajustar igual', async () => {
+    mockearRutasBase((ruta) => {
+      if (/^\/proveedores\/\d+$/.test(ruta)) {
+        return Promise.reject(new ErrorApi(403, 'prohibido', 'No tiene permiso para ver este proveedor.'))
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) =>
+      ruta === '/proveedores/1/cuenta-corriente/ajustes'
+        ? Promise.resolve<MovimientoDeCuentaDeProveedor>(
+            movimientoFixture({ idMovimiento: 60, tipo: 'Ajuste', importe: -50, saldoResultante: 450 }),
+          )
+        : Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`)),
+    )
+
+    renderPantalla(1) // sin state: el link real no lo trajo
+
+    await screen.findByText('$500,00')
+    await screen.findByText(/No tiene permiso para ver este proveedor\./)
+    const boton = screen.getByRole('button', { name: 'Ajuste manual' })
+    expect(boton).toBeEnabled()
+
+    await userEvent.click(boton)
+    await screen.findByText('Ajuste manual de cuenta corriente')
+    await userEvent.type(screen.getByLabelText('Importe'), '-50')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'motivo válido')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith('/proveedores/1/cuenta-corriente/ajustes', {
+        idPuntoVenta: 7,
+        importe: -50,
+        detalle: 'motivo válido',
+      }),
+    )
+    expect(await screen.findByText('Ajuste registrado: -$50,00.')).toBeInTheDocument()
+  })
+
+  it('un Supervisor sin location.state igual ve el fallback "Proveedor #id" en el título', async () => {
+    mockearRutasBase((ruta) => {
+      if (/^\/proveedores\/\d+$/.test(ruta)) {
+        return Promise.reject(new ErrorApi(403, 'prohibido', 'No tiene permiso para ver este proveedor.'))
+      }
+      return undefined
+    })
+
+    renderPantalla(1)
+
+    expect(await screen.findByText('Estado de cuenta — Proveedor #1')).toBeInTheDocument()
+  })
+})
+
 describe('CuentaCorrienteDeProveedor — filtros (react-async-state regla 2, mutation-proof-tests regla 7)', () => {
   // El flush del microtask va DENTRO de act: un `waitFor` solo pasaría en su primer tick, antes de
   // que el `.then` obsoleto aterrice — envolver en act y assertar sincrónicamente después SÍ

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
@@ -1,0 +1,412 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CuentaCorrienteDeProveedor } from './CuentaCorrienteDeProveedor'
+import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type {
+  MovimientoDeCuentaDeProveedor,
+  PaginaDeEstadoDeCuentaDeProveedor,
+  ProveedorListado,
+  PuntoVentaListado,
+  UsuarioAutenticado,
+} from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'supervisor',
+    mail: 'supervisor@ways.test',
+    rolId: ROL.Supervisor,
+    rol: 'Supervisor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 1,
+    razonSocial: 'Proveedor Uno SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+// `importe`/`saldoResultante` deliberadamente distintos del `saldo` del header (500) y entre sí
+// (mutation-proof-tests regla 11), para que ningún assert de "$500,00" choque con una fila.
+function movimientoFixture(sobrescribir: Partial<MovimientoDeCuentaDeProveedor> = {}): MovimientoDeCuentaDeProveedor {
+  return {
+    idMovimiento: 1,
+    fecha: '2026-08-01T12:00:00Z',
+    tipo: 'Compra',
+    importe: 300,
+    saldoResultante: 200,
+    detalle: null,
+    idComprobanteCompra: 10,
+    idGasto: null,
+    etiqueta: null,
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(sobrescribir: Partial<PaginaDeEstadoDeCuentaDeProveedor> = {}): PaginaDeEstadoDeCuentaDeProveedor {
+  return {
+    header: { idProveedor: 1, saldo: 500 },
+    items: [movimientoFixture()],
+    total: 1,
+    pagina: 1,
+    tamanio: 25,
+    historico: false,
+    desde: '2026-07-01T00:00:00Z',
+    hasta: null,
+    ...sobrescribir,
+  }
+}
+
+function renderPantalla(idProveedor: number | string = 1, state?: { proveedor: ProveedorListado }) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: `/proveedores/${idProveedor}/cuenta-corriente`, state }]}>
+      <Routes>
+        <Route path="/proveedores/:id/cuenta-corriente" element={<CuentaCorrienteDeProveedor />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (/^\/proveedores\/\d+$/.test(ruta)) return Promise.resolve<ProveedorListado>(proveedorFixture())
+    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaFixture()])
+    if (ruta.includes('/cuenta-corriente')) return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+async function abrirModalDeAjuste() {
+  mockearRutasBase()
+  renderPantalla(1, { proveedor: proveedorFixture() })
+
+  await screen.findByText('$500,00')
+  await userEvent.click(screen.getByRole('button', { name: 'Ajuste manual' }))
+  await screen.findByText('Ajuste manual de cuenta corriente')
+}
+
+describe('CuentaCorrienteDeProveedor — header y ledger', () => {
+  it('muestra el saldo, la fila del movimiento y "Página N de M"', async () => {
+    mockearRutasBase()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    expect(await screen.findByText('$500,00')).toBeInTheDocument()
+    expect(screen.getByText('Compra')).toBeInTheDocument()
+    expect(screen.getByText('Compra #10')).toBeInTheDocument()
+    expect(screen.getByText(/Página 1 de 1/)).toBeInTheDocument()
+  })
+
+  it('un saldo negativo en el header y en una fila muestra "(saldo a favor)", nunca clampeado a cero', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente')) {
+        return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(
+          paginaFixture({
+            header: { idProveedor: 1, saldo: -500 },
+            items: [movimientoFixture({ saldoResultante: -200 })],
+          }),
+        )
+      }
+      return undefined
+    })
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    expect(await screen.findByText('-$500,00 (saldo a favor)')).toBeInTheDocument()
+    expect(screen.getByText('-$200,00 (saldo a favor)')).toBeInTheDocument()
+  })
+
+  it('un período sin movimientos muestra el estado vacío', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente')) {
+        return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(paginaFixture({ items: [], total: 0 }))
+      }
+      return undefined
+    })
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    expect(await screen.findByText('No hay movimientos en el período seleccionado.')).toBeInTheDocument()
+  })
+})
+
+describe('CuentaCorrienteDeProveedor — gating de rol (Supervisor+Admin) para el ajuste', () => {
+  it('un Vendedor no ve "Ajuste manual"', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    await screen.findByText('$500,00')
+    expect(screen.queryByRole('button', { name: 'Ajuste manual' })).not.toBeInTheDocument()
+  })
+
+  it('un Supervisor ve la acción, habilitada una vez cargados los datos', async () => {
+    mockearRutasBase()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    await screen.findByText('$500,00')
+    expect(screen.getByRole('button', { name: 'Ajuste manual' })).toBeEnabled()
+  })
+
+  it('un Admin también ve la acción', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Admin, rol: 'Admin' })
+    mockearRutasBase()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    await screen.findByText('$500,00')
+    expect(screen.getByRole('button', { name: 'Ajuste manual' })).toBeEnabled()
+  })
+})
+
+describe('CuentaCorrienteDeProveedor — filtros (react-async-state regla 2, mutation-proof-tests regla 7)', () => {
+  // El flush del microtask va DENTRO de act: un `waitFor` solo pasaría en su primer tick, antes de
+  // que el `.then` obsoleto aterrice — envolver en act y assertar sincrónicamente después SÍ
+  // discrimina (mutation-proof-tests regla 7).
+  it('una respuesta desactualizada nunca pisa la más reciente', async () => {
+    let resolverPrimera: (v: PaginaDeEstadoDeCuentaDeProveedor) => void = () => {}
+    const primeraPendiente = new Promise<PaginaDeEstadoDeCuentaDeProveedor>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (!ruta.includes('/cuenta-corriente')) return undefined
+      llamadas += 1
+      if (llamadas === 1) return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(paginaFixture())
+      if (llamadas === 2) return primeraPendiente
+      if (llamadas === 3) {
+        return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(
+          paginaFixture({ items: [movimientoFixture({ idMovimiento: 3, importe: 999, saldoResultante: 111 })] }),
+        )
+      }
+      return Promise.reject(new Error('llamada inesperada'))
+    })
+
+    renderPantalla(1, { proveedor: proveedorFixture() })
+    await screen.findByLabelText('Ver histórico completo')
+
+    // 1ra: activa histórico (queda pendiente, lenta).
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+    expect(screen.getByLabelText('Desde')).toBeDisabled()
+
+    // 2da: lo desactiva de nuevo — dispara una generación MÁS NUEVA, que resuelve rápido.
+    await userEvent.click(screen.getByLabelText('Ver histórico completo'))
+
+    await waitFor(() => expect(screen.getByText('$999,00')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverPrimera(paginaFixture({ items: [movimientoFixture({ idMovimiento: 2, importe: 777, saldoResultante: 888 })] }))
+      await primeraPendiente
+    })
+    expect(screen.getByText('$999,00')).toBeInTheDocument()
+    expect(screen.queryByText('$777,00')).not.toBeInTheDocument()
+    expect(screen.queryByText('$888,00')).not.toBeInTheDocument()
+  })
+})
+
+describe('CuentaCorrienteDeProveedor — pager', () => {
+  it('está deshabilitado en ambos bordes cuando hay una sola página', async () => {
+    mockearRutasBase()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    await screen.findByText('$500,00')
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
+  it('navega entre páginas, con "Anterior"/"Siguiente" habilitados solo del lado correcto', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente')) {
+        const paginaSolicitada = ruta.includes('pagina=2') ? 2 : 1
+        return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(
+          paginaFixture({ total: 50, pagina: paginaSolicitada, tamanio: 25 }),
+        )
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderPantalla(1, { proveedor: proveedorFixture() })
+
+    await screen.findByText(/Página 1 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 2 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+})
+
+describe('CuentaCorrienteDeProveedor — modal de ajuste manual', () => {
+  it('arma el cuerpo del POST con la forma exacta del contrato, detalle recortado, y refresca el ledger', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) =>
+      ruta === '/proveedores/1/cuenta-corriente/ajustes'
+        ? Promise.resolve<MovimientoDeCuentaDeProveedor>(
+            movimientoFixture({ idMovimiento: 55, tipo: 'Ajuste', importe: -200, saldoResultante: 300, detalle: 'nota' }),
+          )
+        : Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`)),
+    )
+
+    await abrirModalDeAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '-200')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), '  nota de ajuste  ')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith('/proveedores/1/cuenta-corriente/ajustes', {
+        idPuntoVenta: 7,
+        importe: -200,
+        detalle: 'nota de ajuste',
+      }),
+    )
+    expect(await screen.findByText('Ajuste registrado: -$200,00.')).toBeInTheDocument()
+    // el refetch corre tras el 201 — dos GET del ledger (montaje + refresco).
+    await waitFor(() => {
+      const llamadas = apiGetMock.mock.calls.filter((c: unknown[]) => (c[0] as string).includes('/cuenta-corriente?'))
+      expect(llamadas.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('importe cero se rechaza localmente, sin llamar al servidor', async () => {
+    await abrirModalDeAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '0')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'motivo válido')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    expect(await screen.findByText('El importe del ajuste no puede ser cero.')).toBeInTheDocument()
+    expect(apiPostMock).not.toHaveBeenCalled()
+  })
+
+  // jsdom no-opea clicks en disabled: el guard real vive en el primer renglón del handler (regla
+  // 9), no en el atributo `disabled` — dos `userEvent.click` + un `fireEvent.click` forzado
+  // reproducen el mismo patrón que `CuentaCorriente.test.tsx` (cliente, stage 7).
+  it('doble click en "Registrar ajuste" dispara exactamente un POST', async () => {
+    await abrirModalDeAjuste()
+    await userEvent.type(screen.getByLabelText('Importe'), '-200')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'motivo válido')
+
+    let resolverAjuste: (m: MovimientoDeCuentaDeProveedor) => void = () => {}
+    const ajustePendiente = new Promise<MovimientoDeCuentaDeProveedor>((resolve) => {
+      resolverAjuste = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) =>
+      ruta === '/proveedores/1/cuenta-corriente/ajustes' ? ajustePendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`)),
+    )
+
+    const boton = screen.getByRole('button', { name: 'Registrar ajuste' })
+    await userEvent.click(boton)
+    await userEvent.click(boton)
+    fireEvent.click(boton)
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/proveedores/1/cuenta-corriente/ajustes')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Registrando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverAjuste(movimientoFixture({ idMovimiento: 55, tipo: 'Ajuste', importe: -200, saldoResultante: 300 }))
+      await Promise.resolve()
+    })
+  })
+
+  it('un ajuste 2xx nunca se reporta como fallo, aunque el refetch del ledger posterior falle', async () => {
+    let llamadasLedger = 0
+    mockearRutasBase((ruta) => {
+      if (ruta.includes('/cuenta-corriente?')) {
+        llamadasLedger += 1
+        if (llamadasLedger === 1) return Promise.resolve<PaginaDeEstadoDeCuentaDeProveedor>(paginaFixture())
+        return Promise.reject(new ErrorApi(500, 'error', 'falló el refresco'))
+      }
+      return undefined
+    })
+    apiPostMock.mockImplementation((ruta: string) =>
+      ruta === '/proveedores/1/cuenta-corriente/ajustes'
+        ? Promise.resolve<MovimientoDeCuentaDeProveedor>(movimientoFixture({ idMovimiento: 55, tipo: 'Ajuste', importe: -200 }))
+        : Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`)),
+    )
+
+    renderPantalla(1, { proveedor: proveedorFixture() })
+    await screen.findByText('$500,00')
+    await userEvent.click(screen.getByRole('button', { name: 'Ajuste manual' }))
+    await screen.findByText('Ajuste manual de cuenta corriente')
+
+    await userEvent.type(screen.getByLabelText('Importe'), '-200')
+    await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'motivo válido')
+    await userEvent.click(screen.getByRole('button', { name: 'Registrar ajuste' }))
+
+    // El ajuste 2xx se reporta como éxito (aviso visible) SIEMPRE — el refetch fallido es un
+    // problema DISTINTO, visible aparte, nunca disfrazado de fallo del ajuste (regla 6).
+    expect(await screen.findByText('Ajuste registrado: -$200,00.')).toBeInTheDocument()
+    expect(await screen.findByText('falló el refresco')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -349,10 +349,14 @@ describe('CuentaCorrienteDeProveedor — modal de ajuste manual', () => {
     expect(apiPostMock).not.toHaveBeenCalled()
   })
 
-  // jsdom no-opea clicks en disabled: el guard real vive en el primer renglón del handler (regla
-  // 9), no en el atributo `disabled` — dos `userEvent.click` + un `fireEvent.click` forzado
-  // reproducen el mismo patrón que `CuentaCorriente.test.tsx` (cliente, stage 7).
-  it('doble click en "Registrar ajuste" dispara exactamente un POST', async () => {
+  // Prueba la guarda de re-entrancia (`if (registrandoRef.current) return`, regla 9): el ref cubre
+  // la ventana same-tick antes del re-render de React, `disabled` cubre el resto — son DOS
+  // defensas complementarias. Para que el guard del ref sea la ÚNICA defensa observable, los dos
+  // clicks viajan DENTRO de un mismo `act()` (no dos `await userEvent.click` separados), así
+  // ningún re-render de React corre entre ellos — si no, el segundo click ya vería el `disabled`
+  // puesto por el primero y el test probaría el atributo, no la guarda del `ref` (mismo patrón que
+  // `BotonDeDescarga.test.tsx`).
+  it('doble click en el mismo tick en "Registrar ajuste" dispara exactamente un POST', async () => {
     await abrirModalDeAjuste()
     await userEvent.type(screen.getByLabelText('Importe'), '-200')
     await userEvent.type(screen.getByLabelText('Detalle (obligatorio)'), 'motivo válido')
@@ -366,9 +370,10 @@ describe('CuentaCorrienteDeProveedor — modal de ajuste manual', () => {
     )
 
     const boton = screen.getByRole('button', { name: 'Registrar ajuste' })
-    await userEvent.click(boton)
-    await userEvent.click(boton)
-    fireEvent.click(boton)
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
 
     expect(apiPostMock.mock.calls.filter((c) => c[0] === '/proveedores/1/cuenta-corriente/ajustes')).toHaveLength(1)
     expect(screen.getByRole('button', { name: 'Registrando…' })).toBeDisabled()

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
@@ -260,24 +260,24 @@ function PantallaCuentaCorrienteDeProveedor({
 
   const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
 
-  // El ajuste manual no necesita medios de pago (no mueve plata física), pero sí el proveedor
-  // confirmado y al menos un punto de venta — mismo criterio fail-closed que
-  // `puedeIngresarPago`/`puedeSupervisarCC` de `CuentaCorriente.tsx` (regla 7: un proveedor NUNCA
-  // verificado no puede habilitar el ajuste).
-  const puedeAjustar =
-    esSupervisorOAdmin &&
-    !cargandoProveedor &&
-    proveedorInfo !== null &&
-    errorProveedor === '' &&
-    puntosVenta !== null &&
-    errorPuntosVenta === '' &&
-    puntosVenta.length > 0
+  // El ajuste manual no necesita medios de pago (no mueve plata física), pero sí al menos un punto
+  // de venta — mismo criterio fail-closed que `puedeIngresarPago`/`puedeSupervisarCC` de
+  // `CuentaCorriente.tsx`. El gate es EXCLUSIVAMENTE rol + puntos de venta: el nombre del
+  // proveedor (`proveedorInfo`/`errorProveedor`) es puramente cosmético (fallback "Proveedor
+  // #id" ya cubierto en el título) y NUNCA gobierna la capacidad de operar — el endpoint del
+  // ajuste solo necesita `idProveedor` (de la URL) y `idPuntoVenta`, ninguno de los dos depende
+  // del fetch del nombre. Acoplar `puedeAjustar` a `errorProveedor` dejaba al Supervisor sin poder
+  // ajustar cuando el fetch Admin-only del nombre (`clienteDeProveedores.obtener`) devolvía 403 —
+  // que es exactamente lo que pasaba en TODA navegación real, porque el único punto de entrada real
+  // (`ResumenSaldoDeProveedor`) no pasaba `location.state.proveedor` (judgment-day stage-15 Slice 6,
+  // hallazgo CRITICAL; ver tasks.md desviación #44).
+  const puedeAjustar = esSupervisorOAdmin && puntosVenta !== null && errorPuntosVenta === '' && puntosVenta.length > 0
 
   let motivoBloqueoAjuste: string | undefined
-  if (cargandoProveedor) {
-    motivoBloqueoAjuste = 'Cargando los datos del proveedor…'
-  } else if (errorProveedor) {
-    motivoBloqueoAjuste = 'No se pudo confirmar el proveedor — no se puede continuar hasta que esto se resuelva.'
+  if (puntosVenta === null) {
+    motivoBloqueoAjuste = 'Cargando los puntos de venta…'
+  } else if (errorPuntosVenta) {
+    motivoBloqueoAjuste = 'No se pudieron cargar los puntos de venta — no se puede continuar hasta que esto se resuelva.'
   } else if (!puedeAjustar) {
     motivoBloqueoAjuste = 'No se pudieron cargar los datos necesarios para registrar un ajuste.'
   }
@@ -285,7 +285,11 @@ function PantallaCuentaCorrienteDeProveedor({
   return (
     <div className="container-fluid py-4">
       <Box
-        titulo={`Estado de cuenta — ${proveedorInfo?.razonSocial ?? `Proveedor #${idProveedor}`}`}
+        titulo={
+          cargandoProveedor
+            ? 'Estado de cuenta — cargando proveedor…'
+            : `Estado de cuenta — ${proveedorInfo?.razonSocial ?? `Proveedor #${idProveedor}`}`
+        }
         herramientas={
           <Link className="btn btn-sm btn-outline-light rounded-0" to="/proveedores">
             Volver a proveedores
@@ -294,9 +298,15 @@ function PantallaCuentaCorrienteDeProveedor({
       >
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
-        {(errorProveedor || errorPuntosVenta) && (
+        {errorProveedor && (
           <div className="alert alert-warning rounded-0 py-1 px-2 small">
-            {errorProveedor || errorPuntosVenta} No se puede registrar un ajuste hasta que esto se resuelva.
+            {errorProveedor} El nombre del proveedor no se pudo confirmar — el estado de cuenta y el ajuste manual
+            funcionan igual.
+          </div>
+        )}
+        {errorPuntosVenta && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorPuntosVenta} No se puede registrar un ajuste hasta que esto se resuelva.
           </div>
         )}
 
@@ -472,10 +482,14 @@ export function CuentaCorrienteDeProveedor() {
   const location = useLocation()
   const proveedorDeState = (location.state as { proveedor?: ProveedorListado } | null)?.proveedor ?? null
 
-  // Sin `location.state` (URL directa) se resuelve por `GET /api/proveedores/{id}` — Admin-only
+  // Sin `location.state` (URL directa, o el link real cuando el llamador no tenía el
+  // `ProveedorListado` completo a mano) se resuelve por `GET /api/proveedores/{id}` — Admin-only
   // del lado del servidor (`Politicas.GestionDeCatalogo`, fuera del alcance de esta slice: "cero
-  // cambios de API"). Un Vendedor/Supervisor llegando así falla CERRADO (regla 7): el nombre no se
-  // resuelve, el aviso queda visible y el ajuste se deshabilita — pero el estado de cuenta en sí
+  // cambios de API"). Un Vendedor/Supervisor llegando así falla CERRADO SOLO en el nombre (regla
+  // 7): el fallback "Proveedor #id" + el aviso quedan visibles, pero el ajuste NUNCA depende de
+  // este fetch (judgment-day stage-15 Slice 6, hallazgo CRITICAL — acoplar `puedeAjustar` a este
+  // error dejaba al Supervisor sin poder ajustar por el link real, que no pasaba `state`; ver
+  // `puedeAjustar` más abajo y tasks.md desviación #44). El estado de cuenta en sí
   // (`OperacionDePos`) sigue cargando y mostrándose igual, porque es un fetch independiente.
   const [proveedorInfo, setProveedorInfo] = useState<ProveedorListado | null>(proveedorDeState)
   const [cargandoProveedor, setCargandoProveedor] = useState(proveedorDeState === null)

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
@@ -77,9 +77,9 @@ function ModalAjusteDeProveedor({ idProveedor, puntosVenta, saldoActual, onCerra
   const saldoResultante = Number.isFinite(importeNumerico) ? saldoResultanteDeAjuste(saldoActual, importeNumerico) : null
 
   async function registrarAjuste() {
-    // regla 9: guard de reentrancia de primera línea — un doble click en el mismo tick no puede
-    // emitir un segundo POST (jsdom no-opea clicks en disabled: la defensa real vive acá, nunca en
-    // el atributo `disabled` solo).
+    // regla 9: guard de reentrancia de primera línea — dos defensas complementarias contra el
+    // doble click: este ref cubre la ventana same-tick, antes de que React re-renderice con
+    // `disabled`; el atributo `disabled` cubre el resto de la ventana mientras `registrando` es true.
     if (registrandoRef.current) return
 
     const rechazo = validarAjusteLocal({ importe: importeNumerico, detalle })

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.tsx
@@ -1,0 +1,565 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useParams } from 'react-router'
+import { ErrorApi } from '../api/cliente'
+import { saldoResultanteDeAjuste, validarAjusteLocal } from '../api/cuentaCorriente'
+import {
+  aSolicitudDeAjusteDeProveedor,
+  clienteDeCuentaCorrienteDeProveedor,
+  esSaldoAFavor,
+  etiquetaDeTipoDeMovimiento,
+  filtrosDeEstadoDeCuentaDeProveedorVacios,
+  referenciaDeMovimiento,
+  type FiltrosDeEstadoDeCuentaDeProveedor,
+} from '../api/cuentaCorrienteDeProveedor'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { clienteDeProveedores } from '../api/proveedores'
+import type {
+  MovimientoDeCuentaDeProveedor,
+  PaginaDeEstadoDeCuentaDeProveedor,
+  ProveedorListado,
+  PuntoVentaListado,
+} from '../api/tipos'
+import { puedeSupervisarCuentaDeProveedor } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatearFechaHora(iso: string): string {
+  return new Date(iso).toLocaleString('es-AR')
+}
+
+/** Saldo con la etiqueta "saldo a favor" cuando es negativo (design: Web Composition — columnas,
+ * proposal decisión 5), nunca clampeado a cero — mismo criterio que `ResumenSaldoDeProveedor`.
+ * Aplica tanto al saldo del header como a `saldoResultante` de cada fila. */
+function formatearSaldoConEtiqueta(valor: number): string {
+  return esSaldoAFavor(valor) ? `${formatearMoneda(valor)} (saldo a favor)` : formatearMoneda(valor)
+}
+
+type PropsModalAjuste = {
+  idProveedor: number
+  puntosVenta: PuntoVentaListado[]
+  saldoActual: number
+  onCerrar: () => void
+  onAntesDeEscribir: () => void
+  onRegistrado: (movimiento: MovimientoDeCuentaDeProveedor) => void
+}
+
+/**
+ * Modal de ajuste manual del ledger de proveedores (Slice 6, design: Web Composition — droppable
+ * pre-autorizado si la slice desborda, tasks.md decisión 3: la pantalla de lectura NUNCA se
+ * degrada, este modal es lo primero que cae). Mismo shape que `ModalAjusteDeCuenta`
+ * (`CuentaCorriente.tsx`, cliente, stage 7) — reusa `ReglaDeAjusteDeCuenta.Validar` server-side
+ * (design decisión 13), así que reusa también su mirror local ya probado (`validarAjusteLocal`,
+ * `saldoResultanteDeAjuste`, `cuentaCorriente.ts`) en vez de duplicarlo.
+ *
+ * `react-async-state`: regla 9 (guard de reentrancia de primera línea + deshabilitado de ventana
+ * completa mientras `registrando`), regla 3 (el llamador bumpea la generación del ledger ANTES de
+ * este POST, vía `onAntesDeEscribir`), regla 6 (el refetch posterior vive en el padre, aislado de
+ * este try/catch). Sin turno (design decisión 14 — "provenance, not authority", mismo criterio que
+ * el ajuste de clientes): este endpoint nunca llama a `ServicioDeTurnos`, así que no hay ningún
+ * `turno_no_abierto` que recuperar acá (rule 10 sweep).
+ */
+function ModalAjusteDeProveedor({ idProveedor, puntosVenta, saldoActual, onCerrar, onAntesDeEscribir, onRegistrado }: PropsModalAjuste) {
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number>(puntosVenta[0].id)
+  const [importe, setImporte] = useState('')
+  const [detalle, setDetalle] = useState('')
+
+  const [registrando, setRegistrando] = useState(false)
+  const registrandoRef = useRef(false)
+  const [error, setError] = useState('')
+
+  const importeNumerico = importe.trim() === '' ? Number.NaN : Number(importe)
+  const saldoResultante = Number.isFinite(importeNumerico) ? saldoResultanteDeAjuste(saldoActual, importeNumerico) : null
+
+  async function registrarAjuste() {
+    // regla 9: guard de reentrancia de primera línea — un doble click en el mismo tick no puede
+    // emitir un segundo POST (jsdom no-opea clicks en disabled: la defensa real vive acá, nunca en
+    // el atributo `disabled` solo).
+    if (registrandoRef.current) return
+
+    const rechazo = validarAjusteLocal({ importe: importeNumerico, detalle })
+    if (rechazo) {
+      setError(rechazo.mensaje)
+      return
+    }
+
+    registrandoRef.current = true
+    setRegistrando(true)
+    setError('')
+
+    // regla 3: bumpear la generación del ledger ANTES de la escritura.
+    onAntesDeEscribir()
+
+    try {
+      const solicitud = aSolicitudDeAjusteDeProveedor(idPuntoVenta, importeNumerico, detalle)
+      const movimiento = await clienteDeCuentaCorrienteDeProveedor.registrarAjuste(idProveedor, solicitud)
+      registrandoRef.current = false
+      setRegistrando(false)
+      // regla 6: el refetch del ledger vive en el padre, aislado de este try/catch.
+      onRegistrado(movimiento)
+    } catch (e) {
+      registrandoRef.current = false
+      setRegistrando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo registrar el ajuste.')
+    }
+  }
+
+  return (
+    <>
+      <div className="modal d-block" tabIndex={-1} role="dialog">
+        <div className="modal-dialog" role="document">
+          <div className="modal-content rounded-0">
+            <div className="modal-header">
+              <h5 className="modal-title">Ajuste manual de cuenta corriente</h5>
+            </div>
+            <div className="modal-body">
+              {error && <div className="alert alert-danger rounded-0 py-1 px-2 small">{error}</div>}
+
+              <div className="mb-3" style={{ maxWidth: 320 }}>
+                <label className="form-label" htmlFor="ccp-ajuste-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="ccp-ajuste-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  disabled={registrando}
+                  onChange={(e) => setIdPuntoVenta(Number(e.target.value))}
+                >
+                  {puntosVenta.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="ccp-ajuste-importe">
+                  Importe
+                </label>
+                <input
+                  id="ccp-ajuste-importe"
+                  type="number"
+                  step="0.01"
+                  className="form-control rounded-0"
+                  value={importe}
+                  disabled={registrando}
+                  onChange={(e) => setImporte(e.target.value)}
+                />
+                <div className="form-text">
+                  Positivo aumenta la deuda del proveedor, negativo la reduce. Nunca puede ser cero.
+                </div>
+              </div>
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="ccp-ajuste-detalle">
+                  Detalle (obligatorio)
+                </label>
+                <input
+                  id="ccp-ajuste-detalle"
+                  type="text"
+                  className="form-control rounded-0"
+                  value={detalle}
+                  disabled={registrando}
+                  onChange={(e) => setDetalle(e.target.value)}
+                />
+              </div>
+
+              <div className="small text-muted">Saldo actual: {formatearSaldoConEtiqueta(saldoActual)}</div>
+              {saldoResultante !== null && <div className="fs-6">Saldo resultante: {formatearSaldoConEtiqueta(saldoResultante)}</div>}
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-outline-secondary rounded-0" disabled={registrando} onClick={onCerrar}>
+                Cancelar
+              </button>
+              <button type="button" className="btn btn-primary rounded-0" disabled={registrando} onClick={registrarAjuste}>
+                {registrando ? 'Registrando…' : 'Registrar ajuste'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop show" />
+    </>
+  )
+}
+
+type PropsPantalla = {
+  idProveedor: number
+  proveedorInfo: ProveedorListado | null
+  cargandoProveedor: boolean
+  errorProveedor: string
+  puntosVenta: PuntoVentaListado[] | null
+  errorPuntosVenta: string
+}
+
+/** Remontada por `key={idProveedor}` (regla 8) — ningún estado de acá (filtros, página, modal de
+ * ajuste) sobrevive a un cambio de proveedor. */
+function PantallaCuentaCorrienteDeProveedor({
+  idProveedor,
+  proveedorInfo,
+  cargandoProveedor,
+  errorProveedor,
+  puntosVenta,
+  errorPuntosVenta,
+}: PropsPantalla) {
+  const [filtros, setFiltros] = useState<FiltrosDeEstadoDeCuentaDeProveedor>(filtrosDeEstadoDeCuentaDeProveedorVacios())
+
+  const [pagina, setPagina] = useState<PaginaDeEstadoDeCuentaDeProveedor | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  const [modalAjusteAbierto, setModalAjusteAbierto] = useState(false)
+  const [aviso, setAviso] = useState('')
+
+  const { usuario } = useAuth()
+  const esSupervisorOAdmin = usuario !== null && puedeSupervisarCuentaDeProveedor(usuario.rolId)
+
+  // regla 2: cada cambio de filtro/página dispara una nueva consulta — una respuesta
+  // desactualizada nunca puede pisar la más reciente.
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeCuentaCorrienteDeProveedor
+      .obtenerEstado(idProveedor, filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo cargar el estado de cuenta.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [idProveedor, filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeEstadoDeCuentaDeProveedor, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  // El ajuste manual no necesita medios de pago (no mueve plata física), pero sí el proveedor
+  // confirmado y al menos un punto de venta — mismo criterio fail-closed que
+  // `puedeIngresarPago`/`puedeSupervisarCC` de `CuentaCorriente.tsx` (regla 7: un proveedor NUNCA
+  // verificado no puede habilitar el ajuste).
+  const puedeAjustar =
+    esSupervisorOAdmin &&
+    !cargandoProveedor &&
+    proveedorInfo !== null &&
+    errorProveedor === '' &&
+    puntosVenta !== null &&
+    errorPuntosVenta === '' &&
+    puntosVenta.length > 0
+
+  let motivoBloqueoAjuste: string | undefined
+  if (cargandoProveedor) {
+    motivoBloqueoAjuste = 'Cargando los datos del proveedor…'
+  } else if (errorProveedor) {
+    motivoBloqueoAjuste = 'No se pudo confirmar el proveedor — no se puede continuar hasta que esto se resuelva.'
+  } else if (!puedeAjustar) {
+    motivoBloqueoAjuste = 'No se pudieron cargar los datos necesarios para registrar un ajuste.'
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={`Estado de cuenta — ${proveedorInfo?.razonSocial ?? `Proveedor #${idProveedor}`}`}
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/proveedores">
+            Volver a proveedores
+          </Link>
+        }
+      >
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {(errorProveedor || errorPuntosVenta) && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorProveedor || errorPuntosVenta} No se puede registrar un ajuste hasta que esto se resuelva.
+          </div>
+        )}
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="row g-3 mb-3 align-items-end">
+              <div className="col-md-4">
+                <div className="small text-muted">Saldo</div>
+                <div className="fs-5">{formatearSaldoConEtiqueta(pagina.header.saldo)}</div>
+              </div>
+              {esSupervisorOAdmin && (
+                <div className="col-md-8 text-md-end">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary rounded-0"
+                    disabled={!puedeAjustar}
+                    title={motivoBloqueoAjuste}
+                    onClick={() => {
+                      setAviso('')
+                      setModalAjusteAbierto(true)
+                    }}
+                  >
+                    Ajuste manual
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="ccp-filtro-desde">
+                  Desde
+                </label>
+                <input
+                  id="ccp-filtro-desde"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={filtros.desde}
+                  disabled={filtros.historico}
+                  onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+                />
+              </div>
+              <div className="col-md-3">
+                <label className="form-label" htmlFor="ccp-filtro-hasta">
+                  Hasta
+                </label>
+                <input
+                  id="ccp-filtro-hasta"
+                  type="date"
+                  className="form-control rounded-0"
+                  value={filtros.hasta}
+                  disabled={filtros.historico}
+                  onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+                />
+              </div>
+              <div className="col-md-3">
+                <div className="form-check">
+                  <input
+                    id="ccp-filtro-historico"
+                    type="checkbox"
+                    className="form-check-input rounded-0"
+                    checked={filtros.historico}
+                    onChange={(e) => cambiarFiltro({ historico: e.target.checked })}
+                  />
+                  <label className="form-check-label" htmlFor="ccp-filtro-historico">
+                    Ver histórico completo
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            {cargando && <p className="text-muted">Actualizando…</p>}
+
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Tipo</th>
+                    <th>Comprobante/Gasto</th>
+                    <th>Detalle</th>
+                    <th className="text-end">Importe</th>
+                    <th className="text-end">Saldo resultante</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((m) => (
+                    <tr key={m.idMovimiento}>
+                      <td>{formatearFechaHora(m.fecha)}</td>
+                      <td>{etiquetaDeTipoDeMovimiento(m)}</td>
+                      <td>{referenciaDeMovimiento(m)}</td>
+                      <td>{m.detalle ?? '—'}</td>
+                      <td className="text-end">{formatearMoneda(m.importe)}</td>
+                      <td className="text-end">{formatearSaldoConEtiqueta(m.saldoResultante)}</td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="text-center text-muted py-4">
+                        No hay movimientos en el período seleccionado.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} movimiento(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+
+      {modalAjusteAbierto && pagina && puntosVenta && (
+        <ModalAjusteDeProveedor
+          idProveedor={idProveedor}
+          puntosVenta={puntosVenta}
+          saldoActual={pagina.header.saldo}
+          onCerrar={() => setModalAjusteAbierto(false)}
+          onAntesDeEscribir={() => {
+            generacionRef.current += 1
+          }}
+          onRegistrado={(movimiento) => {
+            setModalAjusteAbierto(false)
+            setAviso(`Ajuste registrado: ${formatearMoneda(movimiento.importe)}.`)
+            // regla 6: el refetch queda aislado del try/catch de la escritura del modal — si
+            // falla, no pisa el aviso de éxito de arriba.
+            cargar()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Pantalla de estado de cuenta del proveedor (stage-15-cc-proveedores-ledger, Slice 6, design: Web
+ * Composition): header (saldo) + ledger paginado con filtros desde/hasta/histórico y el modal de
+ * ajuste manual (droppable pre-autorizado, tasks.md decisión 3 — el endpoint sigue sirviendo la
+ * operación aunque el modal no se entregue). Entrada desde `ResumenSaldoDeProveedor` (panel de
+ * `Proveedores.tsx` y header filtrado de `Compras.tsx`) — `Politicas.OperacionDePos` del lado del
+ * servidor (todo rol opera), a diferencia de `/proveedores` que es admin-only: un Vendedor llega
+ * acá desde `Compras.tsx`, nunca desde `Proveedores.tsx`.
+ */
+export function CuentaCorrienteDeProveedor() {
+  const { id } = useParams<{ id: string }>()
+  const idProveedor = Number(id)
+  const idProveedorValido = id !== undefined && Number.isFinite(idProveedor)
+
+  const location = useLocation()
+  const proveedorDeState = (location.state as { proveedor?: ProveedorListado } | null)?.proveedor ?? null
+
+  // Sin `location.state` (URL directa) se resuelve por `GET /api/proveedores/{id}` — Admin-only
+  // del lado del servidor (`Politicas.GestionDeCatalogo`, fuera del alcance de esta slice: "cero
+  // cambios de API"). Un Vendedor/Supervisor llegando así falla CERRADO (regla 7): el nombre no se
+  // resuelve, el aviso queda visible y el ajuste se deshabilita — pero el estado de cuenta en sí
+  // (`OperacionDePos`) sigue cargando y mostrándose igual, porque es un fetch independiente.
+  const [proveedorInfo, setProveedorInfo] = useState<ProveedorListado | null>(proveedorDeState)
+  const [cargandoProveedor, setCargandoProveedor] = useState(proveedorDeState === null)
+  const [errorProveedor, setErrorProveedor] = useState('')
+  const generacionProveedorRef = useRef(0)
+
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+
+  useEffect(() => {
+    if (proveedorDeState !== null || !idProveedorValido) {
+      setProveedorInfo(proveedorDeState)
+      setCargandoProveedor(false)
+      setErrorProveedor('')
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionProveedorRef.current += 1)
+    setCargandoProveedor(true)
+    setErrorProveedor('')
+
+    clienteDeProveedores
+      .obtener(idProveedor)
+      .then((proveedor) => {
+        if (!vigente || generacionProveedorRef.current !== miGeneracion) return
+        setProveedorInfo(proveedor)
+      })
+      .catch((e) => {
+        if (!vigente || generacionProveedorRef.current !== miGeneracion) return
+        setProveedorInfo(null)
+        setErrorProveedor(e instanceof ErrorApi ? e.message : 'No se pudo confirmar el proveedor.')
+      })
+      .finally(() => {
+        if (!vigente || generacionProveedorRef.current !== miGeneracion) return
+        setCargandoProveedor(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idProveedor, idProveedorValido, proveedorDeState])
+
+  useEffect(() => {
+    let vigente = true
+    clienteDeOrganizacion
+      .listarPuntosVenta()
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorPuntosVenta(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  if (!idProveedorValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Estado de cuenta" variante="warning">
+          <p className="text-muted">No se especificó el proveedor.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/proveedores">
+            Volver a proveedores
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return (
+    <PantallaCuentaCorrienteDeProveedor
+      key={idProveedor}
+      idProveedor={idProveedor}
+      proveedorInfo={proveedorInfo}
+      cargandoProveedor={cargandoProveedor}
+      errorProveedor={errorProveedor}
+      puntosVenta={puntosVenta}
+      errorPuntosVenta={errorPuntosVenta}
+    />
+  )
+}

--- a/src/Ways.Web/src/paginas/Proveedores.test.tsx
+++ b/src/Ways.Web/src/paginas/Proveedores.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { Proveedores } from './Proveedores'
 import type { PaginaDe, ProveedorListado, SaldoDeProveedor } from '../api/tipos'
+
+function renderProveedores() {
+  return render(<Proveedores />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
 
 const apiGetMock = vi.fn()
 
@@ -67,7 +72,7 @@ beforeEach(() => {
 describe('Proveedores — listado', () => {
   it('renderiza las filas con el botón "Ver saldo"', async () => {
     mockearRutasBase()
-    render(<Proveedores />)
+    renderProveedores()
 
     expect(await screen.findByText('Proveedor Uno SA')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Ver saldo' })).toBeInTheDocument()
@@ -84,7 +89,7 @@ describe('Proveedores — panel de saldo', () => {
     mockearRutasBase((ruta) => (ruta === '/proveedores/1/saldo' ? Promise.resolve(saldo) : undefined))
     const usuario = userEvent.setup()
 
-    render(<Proveedores />)
+    renderProveedores()
     await screen.findByText('Proveedor Uno SA')
     await usuario.click(screen.getByRole('button', { name: 'Ver saldo' }))
 
@@ -94,7 +99,10 @@ describe('Proveedores — panel de saldo', () => {
     expect(screen.getByText('Parcial')).toBeInTheDocument()
   })
 
-  it('un saldo negativo se muestra tal cual, con la nota de aproximación (dangling-gasto, decisión 6)', async () => {
+  // stage-15-cc-proveedores-ledger (Slice 6): `ResumenSaldoDeProveedor` fue re-apuntada al ledger —
+  // el callout "aproximación, no invariante" describía la fórmula RETIRADA por esta etapa, ahora
+  // dice simplemente "Saldo a favor." (mutation target #28, `ResumenSaldoDeProveedor.test.tsx`).
+  it('un saldo negativo se muestra tal cual, con el callout de saldo a favor', async () => {
     const saldo: SaldoDeProveedor = {
       idProveedor: 1,
       saldo: -500,
@@ -103,12 +111,12 @@ describe('Proveedores — panel de saldo', () => {
     mockearRutasBase((ruta) => (ruta === '/proveedores/1/saldo' ? Promise.resolve(saldo) : undefined))
     const usuario = userEvent.setup()
 
-    render(<Proveedores />)
+    renderProveedores()
     await screen.findByText('Proveedor Uno SA')
     await usuario.click(screen.getByRole('button', { name: 'Ver saldo' }))
 
     expect(await screen.findByText('-$500,00')).toBeInTheDocument()
-    expect(screen.getByText(/Saldo negativo: hay gastos de proveedor sin ligar/)).toBeInTheDocument()
+    expect(screen.getByText('Saldo a favor.')).toBeInTheDocument()
     // la compra sigue impaga individualmente aunque el saldo total ya sea negativo — honesto, no invariante.
     expect(screen.getByText('Impaga')).toBeInTheDocument()
   })
@@ -118,7 +126,7 @@ describe('Proveedores — panel de saldo', () => {
     mockearRutasBase((ruta) => (ruta === '/proveedores/1/saldo' ? Promise.resolve(saldo) : undefined))
     const usuario = userEvent.setup()
 
-    render(<Proveedores />)
+    renderProveedores()
     await screen.findByText('Proveedor Uno SA')
     await usuario.click(screen.getByRole('button', { name: 'Ver saldo' }))
 
@@ -130,7 +138,7 @@ describe('Proveedores — panel de saldo', () => {
     mockearRutasBase((ruta) => (ruta === '/proveedores/1/saldo' ? Promise.resolve(saldo) : undefined))
     const usuario = userEvent.setup()
 
-    render(<Proveedores />)
+    renderProveedores()
     await screen.findByText('Proveedor Uno SA')
     await usuario.click(screen.getByRole('button', { name: 'Ver saldo' }))
     await screen.findByText('Saldo de Proveedor Uno SA')

--- a/src/Ways.Web/src/paginas/Proveedores.tsx
+++ b/src/Ways.Web/src/paginas/Proveedores.tsx
@@ -18,9 +18,9 @@ function formatearMoneda(valor: number): string {
 // Montado con `key={idProveedor}` desde el padre (react-async-state regla 8): cambiar de
 // proveedor remonta el panel entero, sin arrastrar el saldo del anterior mientras carga el nuevo.
 
-type PropsPanelSaldo = { idProveedor: number; razonSocial: string; onCerrar: () => void }
+type PropsPanelSaldo = { proveedor: ProveedorListado; onCerrar: () => void }
 
-function PanelSaldoDeProveedor({ idProveedor, razonSocial, onCerrar }: PropsPanelSaldo) {
+function PanelSaldoDeProveedor({ proveedor, onCerrar }: PropsPanelSaldo) {
   const [saldo, setSaldo] = useState<SaldoDeProveedor | null>(null)
   const [cargando, setCargando] = useState(true)
   const [error, setError] = useState('')
@@ -31,7 +31,7 @@ function PanelSaldoDeProveedor({ idProveedor, razonSocial, onCerrar }: PropsPane
     setError('')
 
     clienteDeCompras
-      .obtenerSaldoDeProveedor(idProveedor)
+      .obtenerSaldoDeProveedor(proveedor.id)
       .then((datos) => {
         if (vigente) setSaldo(datos)
       })
@@ -46,12 +46,12 @@ function PanelSaldoDeProveedor({ idProveedor, razonSocial, onCerrar }: PropsPane
     return () => {
       vigente = false
     }
-  }, [idProveedor])
+  }, [proveedor.id])
 
   return (
     <div className="border p-3 mb-4 bg-white">
       <div className="d-flex justify-content-between align-items-start mb-2">
-        <strong>Saldo de {razonSocial}</strong>
+        <strong>Saldo de {proveedor.razonSocial}</strong>
         <button type="button" className="btn btn-sm btn-outline-secondary rounded-0" onClick={onCerrar}>
           Cerrar
         </button>
@@ -63,7 +63,11 @@ function PanelSaldoDeProveedor({ idProveedor, razonSocial, onCerrar }: PropsPane
       {saldo && (
         <>
           <div className="mb-3">
-            <ResumenSaldoDeProveedor saldo={saldo.saldo} idProveedor={idProveedor} />
+            {/* stage-15-cc-proveedores-ledger (Slice 6, judgment-day hallazgo CRITICAL): este panel
+                ya tiene el `ProveedorListado` completo — se lo pasamos a `ResumenSaldoDeProveedor`
+                para que el link real cargue con `location.state.proveedor` (mismo patrón que
+                `Clientes.tsx`). */}
+            <ResumenSaldoDeProveedor saldo={saldo.saldo} idProveedor={proveedor.id} proveedor={proveedor} />
           </div>
 
           <div className="table-responsive">
@@ -311,12 +315,7 @@ export function Proveedores() {
         )}
 
         {proveedorSaldo && (
-          <PanelSaldoDeProveedor
-            key={proveedorSaldo.id}
-            idProveedor={proveedorSaldo.id}
-            razonSocial={proveedorSaldo.razonSocial}
-            onCerrar={() => setProveedorSaldo(null)}
-          />
+          <PanelSaldoDeProveedor key={proveedorSaldo.id} proveedor={proveedorSaldo} onCerrar={() => setProveedorSaldo(null)} />
         )}
 
         {cargando ? (

--- a/src/Ways.Web/src/paginas/Proveedores.tsx
+++ b/src/Ways.Web/src/paginas/Proveedores.tsx
@@ -63,7 +63,7 @@ function PanelSaldoDeProveedor({ idProveedor, razonSocial, onCerrar }: PropsPane
       {saldo && (
         <>
           <div className="mb-3">
-            <ResumenSaldoDeProveedor saldo={saldo.saldo} />
+            <ResumenSaldoDeProveedor saldo={saldo.saldo} idProveedor={idProveedor} />
           </div>
 
           <div className="table-responsive">


### PR DESCRIPTION
## Resumen

- `CuentaCorrienteDeProveedor.tsx`: estado de cuenta paginado (página N de M, patrón etapa 14) con filtros de fecha `fechaIsoConOffset` (regla 10) y modo histórico; modal de ajuste manual con doble defensa de reentrada (ref same-tick + disabled), gate por rol `puedeSupervisarCuentaDeProveedor` (espejo de la policy del server) y refresco post-201 con la verdad del server.
- `ResumenSaldoDeProveedor` re-apuntado al ledger con link único de entrada que propaga `state={{ proveedor }}` (precedente `Clientes.tsx`); `Proveedores.tsx` y `Compras.tsx` threadean la identidad sin fetches nuevos.
- API cliente `cuentaCorrienteDeProveedor.ts` con DTOs espejo del contrato del server; `validarAjusteLocal`/`saldoResultanteDeAjuste` reusados (misma `ReglaDeAjusteDeCuenta` en ambos ledgers).

## Judgment-day (2 CRITICALs cazados y cerrados)

- Juez B ronda 1: **1 CRITICAL** — el test de doble submit sobredeterminado (guard de ref y `disabled` se enmascaraban; el comentario razonaba sobre jsdom sin verificar). Fix `9a51747`: dos `dispatchEvent` nativos en el mismo tick (precedente `BotonDeDescarga.test.tsx`) — cada defensa probada load-bearing por su propio mutante. Re-ronda B limpia. Sus otras 6 clases de mutación (stale gating, verdad del server, offset, paginación, rol) murieron todas a la primera.
- Juez A ronda 1: **1 CRITICAL de producción** — el Link real jamás pasaba `state` ⇒ todo camino real caía al fetch de nombre Admin-only ⇒ 403 del Supervisor ⇒ `puedeAjustar` acoplado a `errorProveedor` deshabilitaba el ajuste (y la desviación #37 documentaba lo contrario). Fix `ed7cac2`: gate desacoplado (solo rol + PVs) + state threading; tests del camino real por click y del Supervisor-sin-state-con-403. Pasada acotada de B y re-ronda de A: limpias.

vitest full 730/730 · `npm run build` limpio · cero cambios de API/DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)