### PR TITLE
feat(ordenes-compra): borrador y envio con numeracion propia (etapa 16, slice 2)

### DIFF
--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -183,6 +183,24 @@
       (`test(stage16-slice2): endurece replace-set y FechaEsperada/Observaciones (judgment-day juez
       B)`).
 
+19. **`judgment-day` round 1 (juez A): 1 WARNING documental registrado + 1 CRITICAL REFUTADO
+    con evidencia.**
+    - **WARNING (drift de nombre, este registro es el cierre)**: design.md:243 nombra el rechazo
+      de pre-lectura del enviar como `orden_compra_ya_enviada`; el código shipped usa
+      `orden_compra_no_enviable` y REUSA el mismo código para el caso 0-filas de la carrera del
+      PUT que muda de PV. El nombre del código es DELIBERADAMENTE más general que el del design:
+      cubre ambas causas reales de no-enviabilidad (estado ≠ borrador y la reclasificación por
+      carrera) con una sola verdad; ningún spec ni test pinea el string del design. El design
+      queda como texto stale en esa línea; este registro es la desviación que faltaba.
+    - **CRITICAL REFUTADO**: el juez A reportó que el diff "borra" la extensión de la regla 12c
+      de mutation-proof-tests. Falso positivo del método de congelado: el orquestador commiteó
+      esa extensión a main (87d612d) DESPUÉS de que esta rama naciera (dcb517f), y el diff de
+      dos puntos `main..HEAD` muestra el avance de main como reversa. Evidencia: `git log
+      main..HEAD --name-only` no contiene ningún archivo de `.claude/` (la rama jamás tocó la
+      skill) y el diff three-dot `main...HEAD` (merge-base) trae solo los 7 archivos reales del
+      slice. El merge three-way preserva la regla en main. Regla de proceso nueva: los diffs de
+      judgment se congelan con `main...HEAD`.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -153,6 +153,35 @@
       end-to-end in one pass, each verified FAIL → revert → green before proceeding to the next.
       Docker Desktop was already healthy at the start of this phase (verified with `docker info`
       before the first test run).
+18. **`judgment-day` round 1 (juez B) confirmed 2 MAJOR on task 2.26's `ServicioDeOrdenesDeCompra`
+    test coverage — tests-only, production code correct in both cases.**
+    - **MAJOR 1 (regla 12c)**: the replace-set `DELETE`
+      (`ServicioDeOrdenesDeCompra.cs:111`, `Where(i => i.IdOrdenCompra == id)`) widened to
+      unscoped `db.ItemsOrdenCompra` survives 11/11 — no test seeded a SIBLING OC of the same
+      tenant. Closed by widening `ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando`: seeds
+      a second OC of the same tenant with its own discriminant items (quantities 77/88 on both
+      articles), then asserts after both `PUT`s on the first OC that the sibling's two items are
+      untouched (exact count + identity + quantity). Mutation evidence: widened the `DELETE` to
+      `db.ItemsOrdenCompra.ToListAsync(ct)` (no `Where`) → `dotnet build --no-incremental` clean →
+      the sibling assertion FAILED (`Assert.Equal` expected 2, actual 0 — the sibling's items were
+      deleted by the unscoped replace-set) → `git checkout -- src/` → `git status` clean.
+    - **MAJOR 2 (dto-contract-honesty)**: `SolicitudDeOrdenDeCompra.FechaEsperada`/`.Observaciones`
+      were never asserted as persisted — forcing both to `null` in `CrearBorradorAsync`/
+      `EjecutarActualizacionAsync` survives 11/11. Closed with a new fact,
+      `FechaEsperadaYObservacionesSePersistenYSeActualizanEnElReplaceSet`: sends both fields with
+      real discriminant values on `CREATE` (`DateOnly(2026,9,15)` — the field is `DateOnly?`, no
+      offset applies — + a discriminant observation string), asserts the response AND a direct DB
+      read match; then changes both on `PUT` to different discriminant values, asserts the new
+      truth; then clears both to `null` on a third `PUT`, asserts the DB reflects `null` for both.
+      Mutation evidence: forced `FechaEsperada = null` / `Observaciones = null` (dropping
+      `solicitud.FechaEsperada`/`NormalizarOpcional(solicitud.Observaciones)`) in both
+      `CrearBorradorAsync` and `EjecutarActualizacionAsync` → build clean → the new test FAILED
+      (`Assert.Equal` expected `15/09/2026`, actual `null`) → `git checkout -- src/` → `git status`
+      clean.
+    - Both cycles rebuilt clean after revert; full `ServicioDeOrdenesDeCompraTests` green (12/12,
+      the extra test being the new fact) with `git status` clean. Committed as `8b15fa2`
+      (`test(stage16-slice2): endurece replace-set y FechaEsperada/Observaciones (judgment-day juez
+      B)`).
 
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -121,6 +121,38 @@
     (`Assert.Equal` expected `["id_proveedor","id_tenant"]`, got `["id_tenant","id_proveedor"]`),
     reverted with `git checkout -- src/`, rebuilt, full `OrdenesCompraSchemaTests` green (19/19)
     after revert, `git status` clean.
+17. **Slice 2 apply-phase decisions and deviations (decision 15 discipline).**
+    - **OD9 (orchestrator, launch prompt for this phase): the FK 2/FK 3 pre-check resolvers of
+      `ServicioDeOrdenesDeCompra` are PRIVATE and PROPER to that class**, copying the FORM of
+      `ServicioDeCompras.ResolverProveedorAsync`/`ResolverPuntoVentaAsync` (both `private` there,
+      so there is nothing to reuse by composition) instead of promoting them to a shared helper —
+      same criterion `ServicioDeGastos` already applies against `ServicioDeCompras` for the same
+      pair of resolutions. Followed verbatim; `ResolverProveedorAsync`/`ResolverPuntoVentaAsync`/
+      `ExigirArticulosExistentesAsync` in `ServicioDeOrdenesDeCompra.cs` are `private`, simplified
+      to existence checks (`AnyAsync` → `ErrorDominio.NoEncontrado`/`referencia_invalida`) since the
+      draft path never needs the resolved entity's other columns the way `ServicioDeCompras` does.
+    - **Response DTO deviation**: this slice introduces `OrdenDeCompraBorrador`
+      (`ContratosDeOrdenDeCompra.cs`) instead of populating design's single `OrdenDeCompraDetalle`
+      early — the latter's `Cobertura`/`TotalEstimado`/`TotalReal`/`DesvioTotal`/
+      `ComprobantesLigados` fields cannot be honestly filled before the reception book exists
+      (slice 3) and the read model that computes them (slice 5, task 5.1 — which still *creates*
+      `OrdenDeCompraDetalle`, unmodified from the original plan). `dto-contract-honesty` rule 1: a
+      field that would always be `null`/empty in this slice is not a contract, it's filler.
+    - **DELETE endpoint / `EliminarAsync` NOT implemented**, despite being named in this phase's
+      launch prompt ("PUNTOS CLAVE"/"ARTEFACTOS"). Neither `tasks.md` (this file, before this
+      phase), `design.md`'s API Surface table (7 routes: `GET /`, `GET /{id}`, `POST /`,
+      `PUT /{id}`, `POST /{id}/enviar`, `POST /{id}/cerrar`, `POST /{id}/anular` — no `DELETE`) nor
+      `design.md`'s `File Changes`/authorization-matrix task (4.11, "the five new non-GET routes")
+      name a delete route. Adding a sixth write route not covered by the slice-4 authorization
+      allowlist test would silently break that binding count. Treated as a launch-prompt/artifact
+      conflict resolved in favor of the authoritative SDD artifacts (`sdd-apply`'s contract: follow
+      design decisions, don't freelance); flagged here for the orchestrator to decide whether a
+      future task should add it.
+    - **Process note**: the apply-phase host process did not die mid-cycle this slice (unlike
+      slice 1's task 1.39-adjacent note) — all 8 mutation-evidence cycles (targets #10-#17) ran
+      end-to-end in one pass, each verified FAIL → revert → green before proceeding to the next.
+      Docker Desktop was already healthy at the start of this phase (verified with `docker info`
+      before the first test run).
 
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
@@ -370,78 +402,161 @@ disappear, schema unused for these paths, nothing to repair. **Done** = tests gr
 **Budget note**: no pre-authorized split named for this slice; if it overflows, split at the
 draft-CRUD / `enviar` boundary and register the new cut here (decision 15).
 
-- [ ] 2.1 Create `src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs` — the write records
+- [x] 2.1 Create `src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs` — the write records
   (`SolicitudDeOrdenDeCompra`, `LineaDeOrdenSolicitada`, `ItemDeOrden`); `orden` is server-assigned
-  1..N, never accepted from the request. *(design.md:166-174, mutation target #14)*
-- [ ] 2.2 Create `src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs` — `CrearBorradorAsync`
+  1..N, never accepted from the request (no `orden` field exists on the request records at all —
+  stronger than "accepted but overwritten"). *(design.md:166-174, mutation target #14)* —
+  **DEVIATION registered (decision 17 below)**: this file also defines `OrdenDeCompraBorrador`, a
+  slice-2-scoped response record (header + items only) instead of design's single
+  `OrdenDeCompraDetalle` (which needs `Cobertura`/`TotalEstimado`/`TotalReal`/`DesvioTotal`/
+  `ComprobantesLigados` — all derived from the reception book that doesn't exist until slice 3/5).
+  `OrdenDeCompraDetalle` is created in slice 5 (task 5.1) exactly as originally planned.
+- [x] 2.2 Create `src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs` — `CrearBorradorAsync`
   (`INSERT`, `estado='borrador'`, `numero NULL`). *(proposal.md:266, design.md:376)*
-- [ ] 2.3 Same file: `ActualizarBorradorAsync` — full replace-set under `SELECT … FOR UPDATE …
+- [x] 2.3 Same file: `ActualizarBorradorAsync` — full replace-set under `SELECT … FOR UPDATE …
   WHERE estado = 'borrador'`, `RemoveRange`/`AddRange` items, the `BloquearBorradorAsync` pattern.
   *(proposal.md:267, mutation targets #10, #15)*
-- [ ] 2.4 Same file: `EnviarAsync` — outside the caller's transaction, wrapped in
+- [x] 2.4 Same file: `EnviarAsync` — outside the caller's transaction, wrapped in
   `db.Database.CreateExecutionStrategy()`, call `AsignadorDeNumeroComprobante.
   AsignarComprometidoAsync(db, idTenant, idPuntoVenta, "OC")`; then `EstrategiaSinReintento ⇒
   UPDATE ordenes_compra SET numero, fecha_envio, estado='enviada' WHERE id AND tenant AND
   estado='borrador' AND id_punto_venta = $pv RETURNING numero`; 0 rows ⇒ reclassify under read
-  (409), number stays burnt. *(design.md:36-40, 244-250, mutation targets #11-#13, #16)*
-- [ ] 2.5 Guard: refuse `enviar` on an OC with zero items — `orden_compra_sin_items`, 400 —
+  (409, `orden_compra_no_enviable`), number stays burnt. *(design.md:36-40, 244-250, mutation
+  targets #11-#13, #16)*
+- [x] 2.5 Guard: refuse `enviar` on an OC with zero items — `orden_compra_sin_items`, 400 —
   mirroring `compra_sin_items`. *(design.md:62, decision 7; mutation target #17; conflict #3
   above)*
-- [ ] 2.6 Every raw-ADO parameter through `ParametrosDeComando.Agregar`/`AgregarNulo` — no hand-
+- [x] 2.6 Every raw-ADO parameter through `ParametrosDeComando.Agregar`/`AgregarNulo` — no hand-
   built parameter without `ToUniversalTime()`. *(design.md, mutation target #16)*
-- [ ] 2.7 Create `src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs` — `POST /`, `PUT /{id}`,
-  `POST /{id}/enviar`, grouped under `OperacionDePos`, stacking `GestionDeCatalogo` on writes.
-  *(design.md:301-307, decision 16)*
-- [ ] 2.8 [P] Integration — `PUT` on a `borrador` OC replaces items exactly (add + remove in one
-  request, no stale row). *(ordenes-de-compra/spec.md:52-55)*
-- [ ] 2.9 [P] Integration — `PUT` on a non-`borrador` OC is rejected `409`.
+- [x] 2.7 Create `src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs` — `POST /`, `PUT /{id}`,
+  `POST /{id}/enviar`, grouped under `OperacionDePos`, stacking `GestionDeCatalogo` on writes —
+  gate copied verbatim from `ComprasEndpoints.cs:20-22, 76-109`. Registered in `Program.cs`
+  (`app.MapearOrdenesDeCompra()`, after `MapearCompras()`) and `Ways.Application/
+  DependencyInjection.cs` (`AddScoped<ServicioDeOrdenesDeCompra>()`). *(design.md:301-307,
+  decision 16)* — **DEVIATION registered (decision 17 below)**: no `DELETE /api/ordenes-compra`
+  endpoint/`EliminarAsync` was implemented — not named in `tasks.md`/`design.md`'s API Surface (7
+  routes total, no DELETE) nor in the slice-4 authorization matrix (task 4.11 pins exactly 5 write
+  routes). Adding one would silently break both binding counts.
+- [x] 2.8 [P] Integration — `PUT` on a `borrador` OC replaces items exactly (add + remove in one
+  request, no stale row). `ServicioDeOrdenesDeCompraTests.
+  ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando`. *(ordenes-de-compra/spec.md:52-55)*
+- [x] 2.9 [P] Integration — `PUT` on a non-`borrador` OC is rejected `409`.
+  `ServicioDeOrdenesDeCompraTests.EditarUnaOrdenNoBorradorEsRechazada409`.
   *(ordenes-de-compra/spec.md:57-60, mutation target #10)*
-- [ ] 2.10 [P] Integration — `enviar` on a fresh PV assigns `numero = 1`, sets `fecha_envio`,
-  `estado = enviada`. *(ordenes-de-compra/spec.md:73-76)*
-- [ ] 2.11 [P] Integration — re-sending an already-`enviada` OC is rejected `409`, `numero` not
-  reassigned. *(ordenes-de-compra/spec.md:83-86)*
-- [ ] 2.12 [P] Integration — `enviar` on an OC with no items is rejected `orden_compra_sin_items`,
-  400. *(conflict #3 above, mutation target #17)*
-- [ ] 2.13 [P] Integration — the `-03:00` offset test on `fecha_envio`: `RelojFijo(2026-08-19T12:
-  00:00Z)` at offset zero AND a real `-03:00` write both persist the exact fixed instant.
-  *(decision 13 above, mutation target #16)*
-- [ ] 2.14 [P] **Binding gate test (b), part 1** — two concurrent `enviar` on **two distinct** OCs
-  at one punto de venta ⇒ two distinct `numero` values, **neither** response `409`.
+- [x] 2.10 [P] Integration — `enviar` on a fresh PV assigns `numero = 1`, sets `fecha_envio`,
+  `estado = enviada`. `ServicioDeOrdenesDeCompraTests.
+  EnviarAsignaElPrimerNumeroParaUnPuntoDeVentaFresco`. *(ordenes-de-compra/spec.md:73-76)*
+- [x] 2.11 [P] Integration — re-sending an already-`enviada` OC is rejected `409`, `numero` not
+  reassigned. `ServicioDeOrdenesDeCompraTests.
+  ReenviarUnaOrdenYaEnviadaEsRechazada409SinReasignarNumero`. *(ordenes-de-compra/spec.md:83-86)*
+- [x] 2.12 [P] Integration — `enviar` on an OC with no items is rejected `orden_compra_sin_items`,
+  400. `ServicioDeOrdenesDeCompraTests.EnviarUnaOrdenSinItemsEsRechazadaConOrdenCompraSinItems400`.
+  *(conflict #3 above, mutation target #17)*
+- [x] 2.13 [P] Integration — the `-03:00` offset test on `fecha_envio`: `RelojFijo` returning the
+  same instant as `2026-08-19T12:00:00Z` but expressed with real offset `-03:00` persists the
+  exact fixed instant (a hand-built, non-normalized parameter would 500 on the offset≠0-vs-
+  timestamptz Npgsql rejection — see the `datetimeoffset-utc-npgsql` memory note). `ServicioDeOrdenesDeCompraTests.
+  EnviarConOffsetMenosTresPersisteElInstanteFijoExacto`. *(decision 13 above, mutation target #16)*
+- [x] 2.14 [P] **Binding gate test (b), part 1 — VINCULANTE** — two concurrent `enviar` on **two
+  distinct** OCs at one punto de venta ⇒ two distinct `numero` values, **neither** response `409`.
+  `ServicioDeOrdenesDeCompraTests.
+  DosEnviarConcurrentesDeOrdenesDistintasEnElMismoPuntoDeVentaDanNumerosDistintosSin409`.
   *(ordenes-de-compra/spec.md:78-81; design.md decision T1; conflict #1 above)*
-- [ ] 2.15 [P] **Binding gate test (b), part 2** — two concurrent `enviar` on the **same** OC ⇒
-  one `200` + one `409`, the loser's number burnt (never reassigned). *(design.md T1, conflict #1
+- [x] 2.15 [P] **Binding gate test (b), part 2 — VINCULANTE** — two concurrent `enviar` on the
+  **same** OC ⇒ one `200` + one `409`, the loser's number burnt (never reassigned) — verified by a
+  follow-up `enviar` on a fresh OC of the same PV jumping straight to `numero = 3` (1 = winner, 2 =
+  burnt by the loser). `ServicioDeOrdenesDeCompraTests.
+  DosEnviarConcurrentesDeLaMismaOrdenDanUn200YUn409ConNumeroQuemado`. *(design.md T1, conflict #1
   above)*
-- [ ] 2.16 [P] Integration — concurrent `PUT`-moves-the-PV race: a `PUT` relinking the OC's punto
+- [x] 2.16 [P] Integration — concurrent `PUT`-moves-the-PV race: a `PUT` relinking the OC's punto
   de venta between the pre-read and the `enviar` lock leaves the number correctly scoped to the
-  **old** series (0 rows under the mismatched `WHERE`, reclassified). *(design.md:61, mutation
-  target #11)*
-- [ ] 2.17 [P] **Mutation target #10** — `WHERE estado = 'borrador'` in the draft lock → delete →
-  `PUT` on an `enviada` OC ⇒ expected 409 (2.9) must fail.
-- [ ] 2.18 [P] **Mutation target #11** — `AND id_punto_venta = $pv` in the `enviar` UPDATE →
-  delete → the concurrent-`PUT`-moves-the-PV test (2.16) must fail.
-- [ ] 2.19 [P] **Mutation target #12** — `AsignarComprometidoAsync` → replace with `MAX(numero) +
-  1` → two concurrent `enviar` on one PV (2.14) ⇒ same number / `23505` must surface.
-- [ ] 2.20 [P] **Mutation target #13** — the assigner call moved **inside** the `enviar`
+  **old** series (0 rows under the mismatched `WHERE`, reclassified `409 orden_compra_no_enviable`)
+  — forced deterministically with a `DbTransactionInterceptor` pausing right after
+  `EjecutarEnvioAsync`'s `BeginTransactionAsync` (same pattern as `ComprasAnulacionYConcurrenciaTests.
+  InterceptorDePausaTrasIniciarLaTransaccion`), never left to real timing. `ServicioDeOrdenesDeCompraTests.
+  UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja`.
+  *(design.md:61, mutation target #11)*
+- [x] 2.17 [P] **Mutation target #10** — `WHERE estado = 'borrador'` in the draft lock → delete →
+  `PUT` on an `enviada` OC ⇒ expected 409 (2.9) must fail. **Evidence**: deleted `AND estado =
+  'borrador'::estado_orden_compra` from `BloquearBorradorAsync`'s SQL → `dotnet build
+  --no-incremental` (clean) → `EditarUnaOrdenNoBorradorEsRechazada409` FAILED (expected `Conflict`,
+  actual `OK`) → `git checkout -- src/` → `git status` clean → rebuilt → green (1/1).
+- [x] 2.18 [P] **Mutation target #11** — `AND id_punto_venta = $pv` in the `enviar` UPDATE →
+  delete → the concurrent-`PUT`-moves-the-PV test (2.16) must fail. **Evidence**: deleted `AND
+  id_punto_venta = $5` from `EnviarHeaderAsync`'s SQL → build clean →
+  `UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja` FAILED
+  (the `enviar` succeeded — `200`, `estado: Enviada`, `idPuntoVenta: 4` — instead of the expected
+  `409`, proving the number landed in the relinked PV's series) → reverted, clean → green (1/1).
+- [x] 2.19 [P] **Mutation target #12** — `AsignarComprometidoAsync` → replace with `MAX(numero) +
+  1` → two concurrent `enviar` on one PV (2.14) ⇒ same number / `23505` must surface. **Evidence**:
+  replaced the call with a non-atomic `db.OrdenesCompra.Where(...).MaxAsync()+1` LINQ read → build
+  clean → `DosEnviarConcurrentesDeOrdenesDistintasEnElMismoPuntoDeVentaDanNumerosDistintosSin409`
+  FAILED (`Assert.NotEqual` — one response was `Conflict`, proving the racy MAX+1 let both draw the
+  same number and collide on `ux_ordenes_compra_numero`) → reverted, clean → green (1/1).
+- [x] 2.20 [P] **Mutation target #13** — the assigner call moved **inside** the `enviar`
   transaction → nested-transaction failure / the burnt-number semantics test (2.15) must fail.
-- [ ] 2.21 [P] **Mutation target #14** — server-assigned `orden` 1..N replaced with the request's
-  own value → `ux_items_orden_compra_orden` ⇒ `orden_de_item_duplicado` test (1.24) must fail.
-- [ ] 2.22 [P] **Mutation target #15** — `RemoveRange(itemsExistentes)` in the replace-set →
-  delete → the per-line count/identity assertion (2.8) must fail.
-- [ ] 2.23 [P] **Mutation target #16** — `ParametrosDeComando.Agregar` on `fecha_envio` → hand-
+  **Evidence**: moved `AsignarComprometidoAsync` (which itself opens `BeginTransactionAsync`) to
+  right after `EjecutarEnvioAsync`'s own `BeginTransactionAsync`, on the same `DbContext` → build
+  clean → `DosEnviarConcurrentesDeLaMismaOrdenDanUn200YUn409ConNumeroQuemado` FAILED (`Assert.Equal`
+  expected 1 winner, actual 0 — the nested transaction attempt broke BOTH concurrent requests, no
+  200 survived) → reverted, clean → green (1/1).
+- [x] 2.21 [P] **Mutation target #14** — server-assigned `orden` 1..N replaced with a non-
+  incrementing value (the request DTO carries no `orden` field to "take" — the closest faithful
+  mutation is defeating the server-side sequential assignment itself) → `ux_items_orden_compra_orden`
+  ⇒ `orden_de_item_duplicado` must surface on a multi-item replace-set. **Evidence**: changed
+  `MaterializarItems`'s `Orden = orden++` to a constant `Orden = 1` → build clean →
+  `ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando` FAILED with `409
+  orden_de_item_duplicado` (the exact translated code from `ManejadorDeErrores`'s slice-1 backstop,
+  confirming both the service-level defense and the schema backstop end-to-end) → reverted, clean →
+  green (1/1).
+- [x] 2.22 [P] **Mutation target #15** — `RemoveRange(itemsExistentes)` in the replace-set →
+  delete → the per-line count/identity assertion (2.8) must fail. **Evidence**: deleted the
+  `db.ItemsOrdenCompra.RemoveRange(itemsExistentes)` line (and its now-unused read) in
+  `EjecutarActualizacionAsync` → build clean →
+  `ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando` FAILED with `409
+  orden_de_item_duplicado` (the stale row from the first PUT collided with the new set's `orden=1`
+  under `ux_items_orden_compra_orden`) → reverted, clean → green (1/1).
+- [x] 2.23 [P] **Mutation target #16** — `ParametrosDeComando.Agregar` on `fecha_envio` → hand-
   built parameter without `ToUniversalTime()` → the `-03:00` offset test (2.13) must fail.
-- [ ] 2.24 [P] **Mutation target #17** — the `orden_compra_sin_items` guard → delete → an empty OC
-  projects straight to `cerrada` (2.12 regresses).
-- [ ] 2.25 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
-  `Migraciones/`.
-- [ ] 2.26 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  **Evidence**: replaced the `ParametrosDeComando.Agregar(comando, momento)` call in
+  `EnviarHeaderAsync` with a hand-built `DbParameter` (`Value = momento` directly, no
+  normalization) → build clean → `EnviarConOffsetMenosTresPersisteElInstanteFijoExacto` FAILED with
+  a `500 error_interno` (Npgsql's offset≠0-vs-`timestamptz` rejection surfacing as an unhandled
+  exception, not a domain 409/400 — exactly the documented failure mode) → reverted, clean → green
+  (1/1).
+- [x] 2.24 [P] **Mutation target #17** — the `orden_compra_sin_items` guard → delete → an empty OC
+  projects straight to `cerrada` (2.12 regresses). **Evidence**: deleted the `tieneItems` check and
+  its `throw` in `EnviarAsync` → build clean →
+  `EnviarUnaOrdenSinItemsEsRechazadaConOrdenCompraSinItems400` FAILED (expected `BadRequest`,
+  actual `OK` — an empty OC now sends successfully) → reverted, clean → green (1/1).
+- [x] 2.25 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
+  `Migraciones/`. Verified two ways: (a) `dotnet ef migrations has-pending-model-changes --project
+  src/Ways.Infrastructure/Ways.Infrastructure.csproj --startup-project
+  src/Ways.Infrastructure/Ways.Infrastructure.csproj` → *"No changes have been made to the model
+  since the last migration."* (running it with `Ways.Api` as the startup project errors — that
+  project doesn't reference `Microsoft.EntityFrameworkCore.Design`, a pre-existing environment
+  quirk unrelated to this slice); (b) the in-process
+  `ServicioDeOrdenesDeCompraTests.NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1`
+  asserting `db.Database.HasPendingModelChanges() == false` — green. `git diff --stat main --
+  src/Ways.Infrastructure/Persistencia/Migraciones/` shows no new file.
+- [ ] 2.26 Run `judgment-day`; fix confirmed issues; re-judge until clean. **NOT RUN by
+  `sdd-apply`** — same executor-contract carve-out as slice 1 task 1.38: this executor cannot
+  launch sub-agents/reviewers. Left for the orchestrator to run before merge.
 - [ ] 2.27 Branch `feat/stage16-slice2-borrador-y-envio` off `main` (parent: slice 1); PR; merge
-  stacked-to-main.
+  stacked-to-main. **PARTIAL**: the worktree was already provisioned on
+  `feat/stage16-slice2-borrador-envio` off `main` (`dcb517f`, slice 1 already merged) before this
+  phase started — branching is done, naming differs by a hyphen from this task's literal
+  `-borrador-y-envio` (cosmetic, not re-branched to avoid losing the provisioned worktree — flagged
+  for the orchestrator). PR creation/merge is explicitly out of scope (`NO pushees` instruction) —
+  left for the orchestrator.
 
 **Test plan**: replace-set (2.8-2.9); enviar happy/blocked paths (2.10-2.12); the `-03:00` offset
-(2.13); the two binding concurrency tests (2.14-2.15); the PV-relink race (2.16); 8 mutation
-targets (2.17-2.24).
+(2.13); the two binding concurrency tests (2.14-2.15) — **VINCULANTES**; the PV-relink race (2.16);
+8 mutation targets (2.17-2.24); the gate guard regression check (2.25 evidence).
 
-**Verify**: `dotnet test --filter FullyQualifiedName~ServicioDeOrdenesDeCompra`
+**Verify**: `dotnet test --filter FullyQualifiedName~ServicioDeOrdenesDeCompra` — 11/11 green
+(`OrdenesCompraSchemaTests`/`ManejadorDeErroresOrdenesDeCompraTests` from slice 1 re-run clean,
+34/34; the full `Compras` regression suite, 137/137).
 
 ---
 

--- a/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
@@ -1,0 +1,52 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Compras;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// Órdenes de compra (design: API Surface, decisión 16) — gate copiado VERBATIM de
+/// <c>ComprasEndpoints.cs:20-22, 76-109</c>: lecturas bajo <c>OperacionDePos</c>, toda escritura
+/// apila <c>GestionDeCatalogo</c> (Admin-only). Ningún <c>Politicas</c> nuevo (proposal decisión
+/// 7).
+///
+/// Slice 2: <c>POST /</c> (borrador), <c>PUT /{id}</c> (replace-set), <c>POST /{id}/enviar</c>
+/// (numeración propia). <c>GET /</c>/<c>GET /{id}</c> llegan en slice 5 (necesitan el detalle con
+/// cobertura); <c>POST /{id}/cerrar</c>/<c>POST /{id}/anular</c> en slice 4.
+/// </summary>
+public static class OrdenesDeCompraEndpoints
+{
+    public static IEndpointRouteBuilder MapearOrdenesDeCompra(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/ordenes-compra")
+            .WithTags("OrdenesDeCompra")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapPost("/", async (
+            ServicioDeOrdenesDeCompra servicio, SolicitudDeOrdenDeCompra solicitud, CancellationToken ct) =>
+        {
+            var creada = await servicio.CrearBorradorAsync(solicitud, ct);
+            return Results.Created($"/api/ordenes-compra/{creada.Id}", creada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Crea un borrador de orden de compra (header + items opcionales).");
+
+        grupo.MapPut("/{id:int}", async (
+            ServicioDeOrdenesDeCompra servicio, int id, SolicitudDeOrdenDeCompra solicitud, CancellationToken ct) =>
+        {
+            var actualizada = await servicio.ActualizarBorradorAsync(id, solicitud, ct);
+            return Results.Ok(actualizada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Reemplaza el header y el set completo de items de un borrador (borrador únicamente).");
+
+        grupo.MapPost("/{id:int}/enviar", async (ServicioDeOrdenesDeCompra servicio, int id, CancellationToken ct) =>
+        {
+            var enviada = await servicio.EnviarAsync(id, ct);
+            return Results.Ok(enviada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Asigna numero/fecha_envio propios (serie 'OC') y pasa la orden a enviada.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -174,6 +174,8 @@ app.MapearCaja();
 app.MapearGastos();
 app.MapearCuentaCorriente();
 app.MapearCompras();
+// stage-16-ordenes-de-compra, Slice 2: borrador CRUD + enviar (numeración propia, serie 'OC').
+app.MapearOrdenesDeCompra();
 // stage-15-cc-proveedores-ledger, Slice 4: estado de cuenta paginado del proveedor.
 app.MapearCuentaCorrienteDeProveedor();
 app.MapearReportes();

--- a/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
+++ b/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
@@ -1,0 +1,55 @@
+using Ways.Domain.Compras;
+
+namespace Ways.Application.Compras;
+
+/// <summary>Una línea del cuerpo de <c>POST/PUT /api/ordenes-compra</c> (design: Interfaces/
+/// Contracts) — <c>orden</c> NO viaja en la solicitud: es server-asignado 1..N dentro del
+/// replace-set (mutation target #14), nunca input de cliente. <see cref="CostoUnitarioEstimado"/>
+/// es intención de precio, jamás un hecho — <c>NULL</c> = no cotizado.</summary>
+public sealed record LineaDeOrdenSolicitada(
+    int IdArticulo,
+    string Descripcion,
+    decimal CantidadPedida,
+    decimal? CostoUnitarioEstimado);
+
+/// <summary>Cuerpo de <c>POST /api/ordenes-compra</c> (crea un borrador) y de <c>PUT
+/// /api/ordenes-compra/{id}</c> (design decisión 2 vía el precedente de compras: replace-set
+/// completo del header + los items — un PUT reemplaza <see cref="Items"/> entero, nunca un CRUD
+/// incremental por item).</summary>
+public sealed record SolicitudDeOrdenDeCompra(
+    int IdProveedor,
+    int IdPuntoVenta,
+    DateOnly? FechaEsperada,
+    string? Observaciones,
+    IReadOnlyList<LineaDeOrdenSolicitada> Items);
+
+/// <summary>Un item ya persistido — <see cref="Orden"/> es el valor server-asignado.</summary>
+public sealed record ItemDeOrden(
+    int Orden,
+    int IdArticulo,
+    string Descripcion,
+    decimal CantidadPedida,
+    decimal? CostoUnitarioEstimado);
+
+/// <summary>Respuesta de <c>POST /api/ordenes-compra</c>, <c>PUT /api/ordenes-compra/{id}</c> y
+/// <c>POST /{id}/enviar</c> — el shape que esta slice puede llenar honestamente (header + items).
+///
+/// DEVIATION registrada (tasks.md decisión 15): el design (Interfaces/Contracts) define un único
+/// <c>OrdenDeCompraDetalle</c> con <c>Cobertura</c>/<c>TotalEstimado</c>/<c>TotalReal</c>/
+/// <c>DesvioTotal</c>/<c>ComprobantesLigados</c> — pero esos campos derivan del libro de
+/// recepción (slice 3) y de la lectura paginada/cobertura (task 5.1, que crea explícitamente ese
+/// tipo). Poblarlos acá con `null`/vacío constante sería deshonesto (dto-contract-honesty regla
+/// 1: un campo que nunca varía no es un contrato, es relleno). Este tipo cubre solo lo que el
+/// camino de escritura de esta slice puede proyectar honestamente; <c>OrdenDeCompraDetalle</c> se
+/// crea en la slice 5 tal como el propio task list lo asigna, para <c>GET /{id}</c>.</summary>
+public sealed record OrdenDeCompraBorrador(
+    int Id,
+    int IdProveedor,
+    int IdPuntoVenta,
+    long? Numero,
+    DateTimeOffset FechaEmision,
+    DateTimeOffset? FechaEnvio,
+    DateOnly? FechaEsperada,
+    string? Observaciones,
+    EstadoOrdenCompra Estado,
+    IReadOnlyList<ItemDeOrden> Items);

--- a/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
+++ b/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
@@ -1,0 +1,361 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ventas;
+using Ways.Domain.Common;
+using Ways.Domain.Compras;
+
+namespace Ways.Application.Compras;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 2 (design: Technical Approach, decisiones 6-7). Borrador CRUD
+/// (replace-set, mismo criterio que <see cref="ServicioDeCompras"/>) + <see cref="EnviarAsync"/>
+/// (numeración propia, serie <c>'OC'</c>, consumida al enviar). <c>cerrar</c>/<c>anular</c> llegan
+/// en slice 4; la lectura paginada + el detalle con cobertura en slice 5; la ligadura con
+/// <c>comprobantes_compra</c> en slice 3 — ninguno de esos caminos existe todavía.
+///
+/// OD9 (orquestador, apply de esta slice): los resolvers 404 de proveedor/punto de venta son
+/// PRIVADOS y PROPIOS de esta clase — copian la FORMA exacta de
+/// <see cref="ServicioDeCompras.ResolverProveedorAsync"/>/<c>ResolverPuntoVentaAsync</c> (ambos
+/// <c>private</c> ahí, así que no hay nada que reusar por composición) en vez de promoverlos a un
+/// helper compartido: mismo criterio que <c>ServicioDeGastos</c> ya aplica frente a
+/// <c>ServicioDeCompras</c> para el mismo par de resoluciones.
+/// </summary>
+public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
+{
+    // ---- borrador: crear + replace-set (mismo criterio que ServicioDeCompras) --------------------
+
+    public async Task<OrdenDeCompraBorrador> CrearBorradorAsync(
+        SolicitudDeOrdenDeCompra solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        await ResolverProveedorAsync(solicitud.IdProveedor, ct);
+        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        await ExigirArticulosExistentesAsync(solicitud.Items, ct);
+
+        var orden = new OrdenCompra
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdProveedor = solicitud.IdProveedor,
+            IdEmpleado = idEmpleado,
+            Numero = null,
+            FechaEmision = momento,
+            FechaEsperada = solicitud.FechaEsperada,
+            Observaciones = NormalizarOpcional(solicitud.Observaciones),
+            Estado = EstadoOrdenCompra.Borrador,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.OrdenesCompra.Add(orden);
+        await db.SaveChangesAsync(ct);
+
+        var items = MaterializarItems(orden.Id, idTenant, solicitud.Items, momento);
+        db.ItemsOrdenCompra.AddRange(items);
+        await db.SaveChangesAsync(ct);
+
+        return Proyectar(orden, items);
+    }
+
+    /// <summary>Mismo criterio que <see cref="ServicioDeCompras.ActualizarBorradorAsync"/>:
+    /// replace-set completo bajo <c>SELECT … FOR UPDATE … WHERE estado='borrador'</c> (mutation
+    /// target #10) — el predicado de estado en el mismo statement hace que editar una orden ya
+    /// enviada sea estructuralmente imposible. Reemplaza también <c>IdPuntoVenta</c> — esto es lo
+    /// que habilita la carrera de mutation target #11 (task 2.16): un PUT concurrente puede mover
+    /// la orden a otro punto de venta entre la pre-lectura y el lock de <see cref="EnviarAsync"/>.</summary>
+    public async Task<OrdenDeCompraBorrador> ActualizarBorradorAsync(
+        int id, SolicitudDeOrdenDeCompra solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        await ResolverProveedorAsync(solicitud.IdProveedor, ct);
+        await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        await ExigirArticulosExistentesAsync(solicitud.Items, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarActualizacionAsync(id, idTenant, solicitud, momento, ct));
+    }
+
+    private async Task<OrdenDeCompraBorrador> EjecutarActualizacionAsync(
+        int id, int idTenant, SolicitudDeOrdenDeCompra solicitud, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var bloqueado = await BloquearBorradorAsync(conexion, transaccionCruda, id, idTenant, ct);
+        if (!bloqueado)
+        {
+            var existe = await db.OrdenesCompra.AsNoTracking().AnyAsync(o => o.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+            }
+
+            throw new ErrorDominio(
+                "orden_compra_no_editable", "Solo una orden de compra en borrador puede editarse.", 409);
+        }
+
+        // El lock de fila crudo de arriba ya serializa cualquier escritor concurrente sobre este
+        // header — misma lógica que EjecutarActualizacionAsync de ServicioDeCompras.
+        var orden = await db.OrdenesCompra.FirstAsync(o => o.Id == id, ct);
+
+        var itemsExistentes = await db.ItemsOrdenCompra.Where(i => i.IdOrdenCompra == id).ToListAsync(ct);
+        db.ItemsOrdenCompra.RemoveRange(itemsExistentes);
+
+        orden.IdProveedor = solicitud.IdProveedor;
+        orden.IdPuntoVenta = solicitud.IdPuntoVenta;
+        orden.FechaEsperada = solicitud.FechaEsperada;
+        orden.Observaciones = NormalizarOpcional(solicitud.Observaciones);
+        orden.UpdatedAt = momento;
+
+        var itemsNuevos = MaterializarItems(id, idTenant, solicitud.Items, momento);
+        db.ItemsOrdenCompra.AddRange(itemsNuevos);
+
+        await db.SaveChangesAsync(ct);
+        await transaccion.CommitAsync(ct);
+
+        return Proyectar(orden, itemsNuevos);
+    }
+
+    // ---- enviar: numeración propia consumida ANTES de la transacción (design decisión 6) --------
+
+    /// <summary>design: Transactions — ENVIAR OC. El número (serie <c>'OC'</c>) se asigna y
+    /// COMITEA en su propia transacción chica ANTES de abrir la que escribe la orden (mismo shape
+    /// que <c>ServicioDeVentas.cs:278-280</c>) — <c>AsignadorDeNumeroComprobante.
+    /// AsignarComprometidoAsync</c> no se toca. El <c>UPDATE</c> final pinea
+    /// <c>id_punto_venta = $pv</c> (el capturado en la pre-lectura, ANTES del draw): 0 filas puede
+    /// deberse a un doble-enviar (mutation target #12/#13, tasks 2.14-2.15) o a un <c>PUT</c>
+    /// concurrente que movió la orden a otro punto de venta (mutation target #11, task 2.16) — en
+    /// ambos casos el número YA se comiteó y queda quemado, residuo aceptado (design decisión
+    /// 6).</summary>
+    public async Task<OrdenDeCompraBorrador> EnviarAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var preLectura = await db.OrdenesCompra.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id, ct);
+        if (preLectura is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+        }
+
+        if (preLectura.Estado != EstadoOrdenCompra.Borrador)
+        {
+            throw new ErrorDominio(
+                "orden_compra_no_enviable", "La orden de compra ya no está en borrador.", 409);
+        }
+
+        // Conflicto #3 (tasks.md, design decisión 7, Open Question T6): una orden sin items
+        // proyectaría `cerrada` en la primera confirmación (la derivación de la slice 3 es
+        // vacuamente `completa`) — se rechaza ACÁ, antes de gastar un número.
+        var tieneItems = await db.ItemsOrdenCompra.AsNoTracking().AnyAsync(i => i.IdOrdenCompra == id, ct);
+        if (!tieneItems)
+        {
+            throw new ErrorDominio(
+                "orden_compra_sin_items", "La orden de compra no tiene items para enviar.", 400);
+        }
+
+        var idPuntoVenta = preLectura.IdPuntoVenta;
+
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, idTenant, idPuntoVenta, "OC", ct));
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarEnvioAsync(id, idTenant, idPuntoVenta, numero, momento, ct));
+    }
+
+    private async Task<OrdenDeCompraBorrador> EjecutarEnvioAsync(
+        int id, int idTenant, int idPuntoVenta, long numero, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var numeroAsignado = await EnviarHeaderAsync(
+            conexion, transaccionCruda, id, idTenant, idPuntoVenta, numero, momento, ct);
+        if (numeroAsignado is null)
+        {
+            var existe = await db.OrdenesCompra.AsNoTracking().AnyAsync(o => o.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+            }
+
+            throw new ErrorDominio(
+                "orden_compra_no_enviable", "La orden de compra ya no está en borrador en ese punto de venta.", 409);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerParaRespuestaAsync(id, ct);
+    }
+
+    // ---- statements crudos (sibling raw SQL, mismo criterio que ServicioDeCompras) ----------------
+
+    private static async Task<bool> BloquearBorradorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT 1 FROM ordenes_compra " +
+            "WHERE id_orden_compra = $1 AND id_tenant = $2 AND estado = 'borrador'::estado_orden_compra " +
+            "FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    /// <summary>design: Transactions — ENVIAR OC, único statement de la transacción de escritura.
+    /// El predicado pinea <c>estado='borrador'</c> Y <c>id_punto_venta=$pv</c> (mutation target
+    /// #11) — sin el segundo conjunto, un número dibujado para la serie vieja de un punto de venta
+    /// podría escribirse igual tras un relink concurrente, aterrizando en la serie equivocada.
+    /// <c>fecha_envio</c> viaja SIEMPRE por <see cref="ParametrosDeComando.Agregar"/> (mutation
+    /// target #16) — nunca un parámetro armado a mano sin <c>ToUniversalTime()</c>.</summary>
+    private static async Task<long?> EnviarHeaderAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, int idPuntoVenta, long numero,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE ordenes_compra SET numero = $1, fecha_envio = $2, estado = 'enviada'::estado_orden_compra, " +
+            "updated_at = $2 " +
+            "WHERE id_orden_compra = $3 AND id_tenant = $4 AND estado = 'borrador'::estado_orden_compra " +
+            "AND id_punto_venta = $5 " +
+            "RETURNING numero";
+
+        ParametrosDeComando.Agregar(comando, numero);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return lector.IsDBNull(0) ? null : lector.GetInt64(0);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    // ---- resolución de contexto (fuera de transacción, resolvers PRIVADOS PROPIOS — OD9) ---------
+
+    private async Task ExigirArticulosExistentesAsync(IReadOnlyList<LineaDeOrdenSolicitada> items, CancellationToken ct)
+    {
+        var idsArticulo = items.Select(i => i.IdArticulo).Distinct().ToList();
+        if (idsArticulo.Count == 0)
+        {
+            return;
+        }
+
+        var existentes = await db.Articulos.Where(a => idsArticulo.Contains(a.Id)).Select(a => a.Id).ToListAsync(ct);
+        var faltantes = idsArticulo.Except(existentes).ToList();
+        if (faltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el artículo {faltantes[0]}.", 400);
+        }
+    }
+
+    private async Task ResolverProveedorAsync(int idProveedor, CancellationToken ct)
+    {
+        var existe = await db.Proveedores.AsNoTracking().AnyAsync(p => p.Id == idProveedor, ct);
+        if (!existe)
+        {
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+            throw ErrorDominio.NoEncontrado($"No existe el proveedor {idProveedor}.");
+        }
+    }
+
+    private async Task ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct)
+    {
+        var existe = await db.PuntosVenta.AsNoTracking().AnyAsync(pv => pv.Id == idPuntoVenta, ct);
+        if (!existe)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+        }
+    }
+
+    private async Task<OrdenDeCompraBorrador> ObtenerParaRespuestaAsync(int id, CancellationToken ct)
+    {
+        var orden = await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == id, ct);
+        var items = await db.ItemsOrdenCompra.AsNoTracking()
+            .Where(i => i.IdOrdenCompra == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        return Proyectar(orden, items);
+    }
+
+    private static List<ItemOrdenCompra> MaterializarItems(
+        int idOrdenCompra, int idTenant, IReadOnlyList<LineaDeOrdenSolicitada> items, DateTimeOffset momento)
+    {
+        var resultado = new List<ItemOrdenCompra>(items.Count);
+        var orden = 1;
+
+        foreach (var linea in items)
+        {
+            resultado.Add(new ItemOrdenCompra
+            {
+                IdTenant = idTenant,
+                IdOrdenCompra = idOrdenCompra,
+                Orden = orden++,
+                IdArticulo = linea.IdArticulo,
+                Descripcion = linea.Descripcion,
+                CantidadPedida = linea.CantidadPedida,
+                CostoUnitarioEstimado = linea.CostoUnitarioEstimado,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            });
+        }
+
+        return resultado;
+    }
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeOrdenesDeCompra requiere un actor de tenant; GestionDeCatalogo no admite plataforma.");
+
+    private static OrdenDeCompraBorrador Proyectar(OrdenCompra orden, IReadOnlyList<ItemOrdenCompra> items) => new(
+        orden.Id, orden.IdProveedor, orden.IdPuntoVenta, orden.Numero, orden.FechaEmision, orden.FechaEnvio,
+        orden.FechaEsperada, orden.Observaciones, orden.Estado,
+        items
+            .OrderBy(i => i.Orden)
+            .Select(i => new ItemDeOrden(i.Orden, i.IdArticulo, i.Descripcion, i.CantidadPedida, i.CostoUnitarioEstimado))
+            .ToList());
+}

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -89,6 +89,10 @@ public static class DependencyInjection
         // (design decisión 11) — dedicado, no extiende ServicioDeProveedores.
         services.AddScoped<ServicioDeSaldoDeProveedor>();
 
+        // stage-16-ordenes-de-compra, Slice 2: borrador CRUD + enviar (numeración propia, serie
+        // 'OC', vía AsignadorDeNumeroComprobante — no se toca). cerrar/anular llegan en slice 4.
+        services.AddScoped<ServicioDeOrdenesDeCompra>();
+
         // stage-15-cc-proveedores-ledger, Slice 4: el lado de lectura del ledger de proveedores —
         // estado de cuenta paginado (task 4.3).
         services.AddScoped<ServicioDeCuentaCorrienteDeProveedor>();

--- a/tests/Ways.IntegrationTests/ServicioDeOrdenesDeCompraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeOrdenesDeCompraTests.cs
@@ -159,6 +159,19 @@ public class ServicioDeOrdenesDeCompraTests(WaysApiFixture fixture) : IClassFixt
         var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
         Assert.Single(creada.Items);
 
+        // Regla 12c: una OC HERMANA del mismo tenant con items propios discriminantes — el
+        // replace-set de "creada" nunca debe tocarla (el DELETE del replace-set debe seguir
+        // scopeado a IdOrdenCompra == creada.Id, jamás ensanchado a toda la tabla).
+        var hermana = await CrearBorradorAsync(
+            ctx.Admin,
+            new SolicitudDeOrdenDeCompra(
+                ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+                [
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Hermana item 1", 77m, 770m),
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo2, "Hermana item 2", 88m, 880m)
+                ]));
+        Assert.Equal(2, hermana.Items.Count);
+
         var conDosItems = new SolicitudDeOrdenDeCompra(
             ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
             [
@@ -184,6 +197,74 @@ public class ServicioDeOrdenesDeCompraTests(WaysApiFixture fixture) : IClassFixt
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(1, await db.ItemsOrdenCompra.CountAsync(i => i.IdOrdenCompra == creada.Id));
+
+        // Regla 12c: los DOS replace-sets de arriba sobre "creada" (agregar+quitar) no tocaron a
+        // la hermana — sus items siguen siendo exactamente los dos originales, con las mismas
+        // cantidades discriminantes.
+        var itemsHermana = await db.ItemsOrdenCompra
+            .Where(i => i.IdOrdenCompra == hermana.Id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync();
+        Assert.Equal(2, itemsHermana.Count);
+        Assert.Equal(ctx.IdArticulo, itemsHermana[0].IdArticulo);
+        Assert.Equal(77m, itemsHermana[0].CantidadPedida);
+        Assert.Equal(ctx.IdArticulo2, itemsHermana[1].IdArticulo);
+        Assert.Equal(88m, itemsHermana[1].CantidadPedida);
+    }
+
+    // ---- task 2.8/2.9: FechaEsperada/Observaciones sobreviven el ciclo completo (dto-contract-honesty) ----
+
+    /// <summary>dto-contract-honesty regla 1: <c>FechaEsperada</c>/<c>Observaciones</c> no son
+    /// relleno — se persisten y se leen de vuelta con el valor exacto enviado, y el replace-set
+    /// del PUT los CAMBIA (incluida la limpieza explícita a <c>null</c>), nunca los ignora ni los
+    /// fuerza a <c>null</c> por default.</summary>
+    [Fact]
+    public async Task FechaEsperadaYObservacionesSePersistenYSeActualizanEnElReplaceSet()
+    {
+        var ctx = await PrepararAsync(nameof(FechaEsperadaYObservacionesSePersistenYSeActualizanEnElReplaceSet));
+        var fechaEsperadaInicial = new DateOnly(2026, 9, 15);
+        var solicitudInicial = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta, fechaEsperadaInicial, "Observación inicial discriminante",
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo, "Item de prueba", 10m, 100m)]);
+
+        var creada = await CrearBorradorAsync(ctx.Admin, solicitudInicial);
+        Assert.Equal(fechaEsperadaInicial, creada.FechaEsperada);
+        Assert.Equal("Observación inicial discriminante", creada.Observaciones);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var persistida = await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == creada.Id);
+            Assert.Equal(fechaEsperadaInicial, persistida.FechaEsperada);
+            Assert.Equal("Observación inicial discriminante", persistida.Observaciones);
+        }
+
+        var fechaEsperadaNueva = new DateOnly(2026, 12, 24);
+        var solicitudActualizada = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta, fechaEsperadaNueva, "Observación actualizada distinta",
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo, "Item de prueba", 10m, 100m)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", solicitudActualizada);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+        var actualizada = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpoPut, OpcionesJson)!;
+        Assert.Equal(fechaEsperadaNueva, actualizada.FechaEsperada);
+        Assert.Equal("Observación actualizada distinta", actualizada.Observaciones);
+
+        var solicitudLimpiando = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo, "Item de prueba", 10m, 100m)]);
+        var respuestaPutLimpiando = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", solicitudLimpiando);
+        var cuerpoPutLimpiando = await respuestaPutLimpiando.Content.ReadAsStringAsync();
+        Assert.True(respuestaPutLimpiando.StatusCode == HttpStatusCode.OK, cuerpoPutLimpiando);
+        var limpia = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpoPutLimpiando, OpcionesJson)!;
+        Assert.Null(limpia.FechaEsperada);
+        Assert.Null(limpia.Observaciones);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var final = await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == creada.Id);
+            Assert.Null(final.FechaEsperada);
+            Assert.Null(final.Observaciones);
+        }
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/ServicioDeOrdenesDeCompraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeOrdenesDeCompraTests.cs
@@ -1,0 +1,544 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 2 (tasks 2.8-2.24; design: Transactions — ENVIAR OC; tasks.md
+/// decisión 4/conflict #1: los DOS shapes de concurrencia de <c>enviar</c>). Borrador CRUD
+/// (replace-set) + <c>enviar</c> con numeración propia (serie <c>'OC'</c>), consumida ANTES de la
+/// transacción de escritura (design decisión 6).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeOrdenesDeCompraTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "vendedor-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdPuntoVenta2, HttpClient Admin, HttpClient Vendedor,
+        int IdProveedor, int IdArticulo, int IdArticulo2, string MailAdmin, string PasswordAdmin);
+
+    /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados — <c>PrepararAsync</c>
+    /// nunca produce tenant/proveedor/PV/artículo numéricamente alineados entre sí (cada entidad
+    /// nace en su propia tabla con su propia identidad autoincremental, nunca forzada a coincidir).</summary>
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var passwordAdmin = default(string);
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+        passwordAdmin = resultado.PasswordTemporal;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        // Un segundo punto de venta de la MISMA empresa — task 2.16 (el relink concurrente mueve
+        // la orden acá).
+        var idEmpresa = await db.PuntosVenta.Where(pv => pv.Id == resultado.IdPuntoVenta).Select(pv => pv.IdEmpresa).FirstAsync();
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = idEmpresa, Nombre = $"{nombre}-PV2", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "OC-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-oc-1-{Guid.NewGuid():N}", Nombre = "OC Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-oc-2-{Guid.NewGuid():N}", Nombre = "OC Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        var hasheador = new HasheadorPbkdf2();
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = resultado.IdTenant, NombreUsuario = "oc-vendedor", Mail = mailVendedor, RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor), PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var vendedor = fixture.CreateClient();
+        var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, puntoVenta2.Id, admin, vendedor,
+            proveedor.Id, articulo1.Id, articulo2.Id, mailAdmin, passwordAdmin!);
+    }
+
+    private static SolicitudDeOrdenDeCompra SolicitudSimple(
+        Contexto ctx, decimal cantidad = 10m, decimal? costo = 100m, int? idPuntoVenta = null, int? idArticulo = null) =>
+        new(
+            ctx.IdProveedor, idPuntoVenta ?? ctx.IdPuntoVenta, null, null,
+            [new LineaDeOrdenSolicitada(idArticulo ?? ctx.IdArticulo, "Item de prueba", cantidad, costo)]);
+
+    private static SolicitudDeOrdenDeCompra SolicitudSinItems(Contexto ctx, int? idPuntoVenta = null) =>
+        new(ctx.IdProveedor, idPuntoVenta ?? ctx.IdPuntoVenta, null, null, []);
+
+    private static async Task<OrdenDeCompraBorrador> CrearBorradorAsync(
+        HttpClient cliente, SolicitudDeOrdenDeCompra solicitud)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/ordenes-compra", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 2.8/2.9: replace-set del borrador ----------------------------------------------------
+
+    [Fact]
+    public async Task ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando()
+    {
+        var ctx = await PrepararAsync(nameof(ItemsSeReemplazanCompletosEnUnRequestAgregandoYQuitando));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        Assert.Single(creada.Items);
+
+        var conDosItems = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+            [
+                new LineaDeOrdenSolicitada(ctx.IdArticulo, "Item 1", 5m, 50m),
+                new LineaDeOrdenSolicitada(ctx.IdArticulo2, "Item 2", 3m, 30m)
+            ]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", conDosItems);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+        var actualizada = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpoPut, OpcionesJson)!;
+        Assert.Equal(2, actualizada.Items.Count);
+        Assert.Equal([1, 2], actualizada.Items.Select(i => i.Orden));
+
+        var conUnItemDistinto = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo2, "Solo item 2", 9m, 90m)]);
+        var respuestaPut2 = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", conUnItemDistinto);
+        Assert.Equal(HttpStatusCode.OK, respuestaPut2.StatusCode);
+        var final = (await respuestaPut2.Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson))!;
+        Assert.Single(final.Items);
+        Assert.Equal(ctx.IdArticulo2, final.Items[0].IdArticulo);
+        Assert.Equal(1, final.Items[0].Orden); // server-reasignado, nunca hereda el 2 del request anterior
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.ItemsOrdenCompra.CountAsync(i => i.IdOrdenCompra == creada.Id));
+    }
+
+    [Fact]
+    public async Task EditarUnaOrdenNoBorradorEsRechazada409()
+    {
+        var ctx = await PrepararAsync(nameof(EditarUnaOrdenNoBorradorEsRechazada409));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var enviar = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.OK, enviar.StatusCode);
+
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", SolicitudSimple(ctx));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("orden_compra_no_editable", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.10/2.11: enviar asigna numero propio, per PV ---------------------------------------
+
+    [Fact]
+    public async Task EnviarAsignaElPrimerNumeroParaUnPuntoDeVentaFresco()
+    {
+        var ctx = await PrepararAsync(nameof(EnviarAsignaElPrimerNumeroParaUnPuntoDeVentaFresco));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        Assert.Null(creada.Numero);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var enviada = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(1, enviada.Numero);
+        Assert.NotNull(enviada.FechaEnvio);
+        Assert.Equal(EstadoOrdenCompra.Enviada, enviada.Estado);
+    }
+
+    [Fact]
+    public async Task ReenviarUnaOrdenYaEnviadaEsRechazada409SinReasignarNumero()
+    {
+        var ctx = await PrepararAsync(nameof(ReenviarUnaOrdenYaEnviadaEsRechazada409SinReasignarNumero));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var primerEnvio = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.OK, primerEnvio.StatusCode);
+        var enviada = (await primerEnvio.Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson))!;
+
+        var segundoEnvio = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+
+        Assert.Equal(HttpStatusCode.Conflict, segundoEnvio.StatusCode);
+        var problema = await segundoEnvio.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("orden_compra_no_enviable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.OrdenesCompra.FirstAsync(o => o.Id == creada.Id);
+        Assert.Equal(enviada.Numero, actual.Numero);
+    }
+
+    // ---- task 2.12: conflict #3 — OC vacía ----------------------------------------------------------
+
+    [Fact]
+    public async Task EnviarUnaOrdenSinItemsEsRechazadaConOrdenCompraSinItems400()
+    {
+        var ctx = await PrepararAsync(nameof(EnviarUnaOrdenSinItemsEsRechazadaConOrdenCompraSinItems400));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("orden_compra_sin_items", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.OrdenesCompra.FirstAsync(o => o.Id == creada.Id);
+        Assert.Equal(EstadoOrdenCompra.Borrador, actual.Estado);
+        Assert.Null(actual.Numero);
+    }
+
+    // ---- task 2.13: mutation target #16 — el offset -03:00 sobrevive la normalización -------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>Decisión 13 (tasks.md): <c>RelojFijo</c> devuelve el mismo instante que
+    /// <c>2026-08-19T12:00:00Z</c> pero expresado con offset real <c>-03:00</c> — si
+    /// <c>EnviarHeaderAsync</c> alguna vez construyera el parámetro de <c>fecha_envio</c> a mano
+    /// (sin pasar por <see cref="ParametrosDeComando"/>, mutation target #16), Npgsql rechaza
+    /// escribir un <c>timestamptz</c> con offset != 0 y la respuesta pasaría de <c>200</c> a un
+    /// <c>500</c> silencioso.</summary>
+    [Fact]
+    public async Task EnviarConOffsetMenosTresPersisteElInstanteFijoExacto()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+        var mismoInstanteConOffset = new DateTimeOffset(2026, 8, 19, 9, 0, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(instanteFijo, mismoInstanteConOffset);
+
+        using var factoryConRelojFijo = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(new RelojFijo(mismoInstanteConOffset))));
+
+        var ctx = await PrepararAsyncConFactory(
+            nameof(EnviarConOffsetMenosTresPersisteElInstanteFijoExacto), factoryConRelojFijo);
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.OrdenesCompra.FirstAsync(o => o.Id == creada.Id);
+        Assert.Equal(instanteFijo, actual.FechaEnvio);
+    }
+
+    // ---- task 2.14/2.15: los DOS binding gate tests de concurrencia (conflict #1) -------------------
+
+    /// <summary>Binding gate test (b), parte 1 (tasks.md decisión 4, spec: "Two concurrent enviar
+    /// calls at the same punto de venta never collide"): dos OCs DISTINTAS del mismo punto de
+    /// venta, enviadas en simultáneo, sacan números distintos — NINGUNA responde 409. Mutation
+    /// target #12: si <c>AsignarComprometidoAsync</c> se reemplazara por <c>MAX(numero)+1</c>,
+    /// ambas leerían el mismo máximo y colisionarían.</summary>
+    [Fact]
+    public async Task DosEnviarConcurrentesDeOrdenesDistintasEnElMismoPuntoDeVentaDanNumerosDistintosSin409()
+    {
+        var ctx = await PrepararAsync(nameof(DosEnviarConcurrentesDeOrdenesDistintasEnElMismoPuntoDeVentaDanNumerosDistintosSin409));
+        var ordenA = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var ordenB = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var tareaA = ctx.Admin.PostAsync($"/api/ordenes-compra/{ordenA.Id}/enviar", null);
+        var tareaB = ctx.Admin.PostAsync($"/api/ordenes-compra/{ordenB.Id}/enviar", null);
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        foreach (var respuesta in respuestas)
+        {
+            Assert.NotEqual(HttpStatusCode.Conflict, respuesta.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        }
+
+        var enviadaA = await respuestas[0].Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson);
+        var enviadaB = await respuestas[1].Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson);
+
+        Assert.NotNull(enviadaA!.Numero);
+        Assert.NotNull(enviadaB!.Numero);
+        Assert.NotEqual(enviadaA.Numero, enviadaB.Numero);
+    }
+
+    /// <summary>Binding gate test (b), parte 2 (tasks.md decisión 4, design.md T1, conflict #1):
+    /// dos <c>enviar</c> concurrentes de la MISMA OC producen un <c>200</c> + un <c>409</c> — nunca
+    /// dos <c>200</c>. El número del perdedor queda quemado (design decisión 6, residuo aceptado):
+    /// ambas tareas ya dibujaron un número ANTES del <c>UPDATE</c> final (el asignador comitea su
+    /// propia transacción incondicionalmente), así que el conteo total de números consumidos para
+    /// este PV es 2 aunque solo una OC haya quedado <c>enviada</c>.</summary>
+    [Fact]
+    public async Task DosEnviarConcurrentesDeLaMismaOrdenDanUn200YUn409ConNumeroQuemado()
+    {
+        var ctx = await PrepararAsync(nameof(DosEnviarConcurrentesDeLaMismaOrdenDanUn200YUn409ConNumeroQuemado));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var tareaA = ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        var tareaB = ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        var ganadores = respuestas.Count(r => r.StatusCode == HttpStatusCode.OK);
+        var perdedores = respuestas.Count(r => r.StatusCode == HttpStatusCode.Conflict);
+        Assert.Equal(1, ganadores);
+        Assert.Equal(1, perdedores);
+
+        var perdedor = respuestas.First(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await perdedor.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("orden_compra_no_enviable", problema.GetProperty("codigo").GetString());
+
+        // Una siguiente OC del MISMO punto de venta prueba el hueco: el perdedor quemó un número
+        // que nadie más va a ver, así que el próximo enviar salta a 3 (1=ganador, 2=quemado por el
+        // perdedor, 3=el siguiente).
+        var siguienteOrden = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var siguienteEnvio = await ctx.Admin.PostAsync($"/api/ordenes-compra/{siguienteOrden.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.OK, siguienteEnvio.StatusCode);
+        var siguienteEnviada = (await siguienteEnvio.Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson))!;
+        Assert.Equal(3, siguienteEnviada.Numero);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoOrdenCompra.Enviada, (await db.OrdenesCompra.FirstAsync(o => o.Id == creada.Id)).Estado);
+    }
+
+    // ---- task 2.16: mutation target #11 — la carrera del relink de PV -------------------------------
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target #11 (task 2.16, design decisión 6): un <c>PUT</c> que mueve la OC
+    /// del punto de venta 1 al punto de venta 2 gana la carrera y COMMITEA DESPUÉS de que el número
+    /// ya fue dibujado (serie del PV 1) pero ANTES de que el <c>UPDATE</c> final de <c>enviar</c>
+    /// corra — pausado justo tras <c>BeginTransactionAsync</c> de <c>EjecutarEnvioAsync</c>, mismo
+    /// patrón que <c>ComprasAnulacionYConcurrenciaTests.InterceptorDePausaTrasIniciarLaTransaccion</c>.
+    /// El <c>WHERE id_punto_venta = $pv</c> (pineado al PV 1, capturado en la pre-lectura) no
+    /// matchea la fila ya movida al PV 2 ⇒ 0 filas ⇒ <c>409</c>, el número dibujado para el PV 1
+    /// queda quemado SIN aparecer en ninguna orden — nunca aterriza en la serie del PV 2.</summary>
+    [Fact]
+    public async Task UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja()
+    {
+        var ctx = await PrepararAsync(nameof(UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idPuntoVenta: ctx.IdPuntoVenta));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteEnviar = factory.CreateClient();
+        var login = await clienteEnviar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaEnviar = clienteEnviar.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+
+        await transaccionIniciada.Task;
+
+        // El PUT gana la carrera: mueve la OC al PV 2 y COMMITEA antes de que el UPDATE final de
+        // enviar corra.
+        var solicitudRelink = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor, ctx.IdPuntoVenta2, null, null,
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo, "Item de prueba", 10m, 100m)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", solicitudRelink);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaEnviar = await tareaEnviar;
+        var cuerpoEnviar = await respuestaEnviar.Content.ReadAsStringAsync();
+        Assert.True(respuestaEnviar.StatusCode == HttpStatusCode.Conflict, cuerpoEnviar);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoEnviar, OpcionesJson);
+        Assert.Equal("orden_compra_no_enviable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.OrdenesCompra.FirstAsync(o => o.Id == creada.Id);
+        Assert.Equal(EstadoOrdenCompra.Borrador, actual.Estado);
+        Assert.Null(actual.Numero);
+        Assert.Equal(ctx.IdPuntoVenta2, actual.IdPuntoVenta);
+
+        // El número quemado (serie del PV 1) nunca aparece en ninguna orden de ese punto de venta:
+        // un envío siguiente del PV 1 salta directo al 2.
+        var siguienteOrdenPv1 = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idPuntoVenta: ctx.IdPuntoVenta));
+        var siguienteEnvioPv1 = await ctx.Admin.PostAsync($"/api/ordenes-compra/{siguienteOrdenPv1.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.OK, siguienteEnvioPv1.StatusCode);
+        var siguienteEnviadaPv1 = (await siguienteEnvioPv1.Content.ReadFromJsonAsync<OrdenDeCompraBorrador>(OpcionesJson))!;
+        Assert.Equal(2, siguienteEnviadaPv1.Numero);
+    }
+
+    // ---- autorización — spot-check (la matriz completa la cierra la slice 4) ------------------------
+
+    [Fact]
+    public async Task VendedorEsBloqueadoEnElCicloDeEscrituraDeOrdenesDeCompra()
+    {
+        var ctx = await PrepararAsync(nameof(VendedorEsBloqueadoEnElCicloDeEscrituraDeOrdenesDeCompra));
+        var creada = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var crear = await ctx.Vendedor.PostAsJsonAsync("/api/ordenes-compra", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, crear.StatusCode);
+
+        var editar = await ctx.Vendedor.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, editar.StatusCode);
+
+        var enviar = await ctx.Vendedor.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, enviar.StatusCode);
+    }
+
+    // ---- gate guard (task 2.25) ----------------------------------------------------------------------
+
+    /// <summary>Gate guard (task 2.25, decisión 2 de tasks.md): esta slice no agrega DDL — el
+    /// modelo EF sigue coincidiendo exactamente con la migración de slice 1.</summary>
+    [Fact]
+    public async Task NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1()
+    {
+        using var _ = fixture.CreateClient();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var hayPendientes = db.Database.HasPendingModelChanges();
+        Assert.False(hayPendientes);
+    }
+
+    /// <summary>Variante de <see cref="PrepararAsync"/> que arranca el host desde un
+    /// <c>WebApplicationFactory</c> ya configurado (p. ej. con <see cref="RelojFijo"/> inyectado) en
+    /// vez del <see cref="fixture"/> por defecto — mismo criterio que
+    /// <c>VencimientosReporteTests.PrepararAsync</c>.</summary>
+    private async Task<Contexto> PrepararAsyncConFactory(
+        string nombre, WebApplicationFactory<Program> factory)
+    {
+        using var root = factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var idEmpresa = await db.PuntosVenta.Where(pv => pv.Id == resultado.IdPuntoVenta).Select(pv => pv.IdEmpresa).FirstAsync();
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = idEmpresa, Nombre = $"{nombre}-PV2", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "OC-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-oc-1-{Guid.NewGuid():N}", Nombre = "OC Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo1);
+        await db.SaveChangesAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, puntoVenta2.Id, admin, admin,
+            proveedor.Id, articulo1.Id, articulo1.Id, mailAdmin, resultado.PasswordTemporal);
+    }
+}


### PR DESCRIPTION
## Resumen

- `ServicioDeOrdenesDeCompra`: borrador CRUD con replace-set bajo `FOR UPDATE WHERE estado='borrador'` (items con orden server-asignado), `EnviarAsync` con la serie propia 'OC' — el número se compromete ANTES de la transacción de escritura (`AsignarComprometidoAsync` commitea la suya, envuelto en `CreateExecutionStrategy`) y el `UPDATE ... RETURNING` pinea estado Y `id_punto_venta` (cierra la carrera del PUT que muda de PV). Resolvers 404 privados propios (OD9).
- Endpoints top-level `POST /`, `PUT /{id}`, `POST /{id}/enviar` con el gate copiado verbatim de `/api/compras`. DTO `OrdenDeCompraBorrador` honesto (decisión 17 — `OrdenDeCompraDetalle` llega con el slice 5). Sin ruta DELETE (el design nunca la tuvo; ratificado).
- Los 2 tests VINCULANTES del gate: dos `enviar` concurrentes de OCs distintas mismo PV ⇒ números distintos sin 409; misma OC ⇒ 200+409 con número QUEMADO (el tercer envío asserta el hueco: obtiene 3).
- 8/8 mutation targets con evidencia + carrera determinista del PV-relink con `DbTransactionInterceptor`.

## Judgment-day

- Juez B (mutador), ronda 1: **2 MAJORs de cobertura** — el DELETE del replace-set sin scope sobrevivía (sin OC hermana — regla 12c, extendida en la skill a escrituras scoped por esta 2da ocurrencia) y `FechaEsperada`/`Observaciones` aceptados-y-descartables. Fix tests-only `8b15fa2` — re-ronda B limpia (2 vs 0 items de la hermana; 15/09/2026 vs null; clear-a-null contra la DB).
- Juez A (estático): 1 WARNING documental (drift del nombre `orden_compra_no_enviable` vs el design — registrado como decisión 19, el nombre shipped es deliberadamente más general) + 1 CRITICAL **refutado con evidencia** (artefacto del diff de dos puntos contra un main que avanzó: la rama jamás tocó `.claude/`; regla de proceso nueva: congelar con `main...HEAD`).

Gate: `has-pending-model-changes` limpio, cero DDL, ManejadorDeErrores/ServicioDeCompras/VentasCheckoutTests intocados. Regresión: 176/176 del filtro Compras/OC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)