### PR TITLE
feat(ordenes-compra): ligadura OC-comprobante y proyeccion de estado (etapa 16, slice 3)

### DIFF
--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -676,7 +676,20 @@ if this slice overflows — decision 3 above.
   `DbCommandInterceptor`/`ContadorDeComandos` "command count" is structurally blind to this slice's
   raw-ADO statements (same empirically-proven limitation `ServicioDeComprasLockOrderTests`'s own
   doc-comment already recorded for the lock-order proof) — `mutation-proof-tests` rule 3 escape
-  hatch applied, same as the one task 3.24 pre-authorized.
+  hatch applied, same as the one task 3.24 pre-authorized. **Corrected (decision 21 below,
+  judgment-day round 2, WARNING closed)**: the two nets are NOT redundant covers of the same
+  mutant — each catches a DIFFERENT one, and neither alone is complete. The structural lock-order
+  test catches the LITERAL unconditional-call mutant (`?? 0`), but that mutant never actually
+  reaches the byte-identical asserts of the behavioral test — it dies earlier with a `500`
+  (`BloquearYLeerAsync`'s FK-invariant throw on the sentinel id `0`), so those two specific asserts
+  are dead code for that mutant. The byte-identical asserts' real, independently-provable target is
+  a REALISTIC soft mutant — one that resolves the OC "by coincidence" (proveedor + PV of the
+  header) instead of the real FK and finds a legitimately existing row — which the structural test,
+  by construction, cannot see (the call site still has a syntactically valid guard). The behavioral
+  test was strengthened with a same-proveedor/same-PV sibling plus an EF-seeded "landmine" receipt
+  (a confirmed, FK-linked reception the production code never re-derives against because the
+  unlinked confirm's `id_orden_compra` is `NULL`) so that soft mutant becomes observable instead of
+  a silent idempotent no-op — verified by mutation (see decision 21).
 - [x] 3.13 [P] Integration — a borrador draft links to a matching (`enviada`) OC; persisted.
   *(comprobantes-compra/spec.md:14-17)*
 - [x] 3.14 [P] Integration — a mismatched proveedor/PV/tenant cannot link, refused before any
@@ -910,6 +923,37 @@ if this slice overflows — decision 3 above.
       staleness the target names), so the observed `409 orden_compra_cierre_incoherente` confirms
       the test suite rejects this SQL shape, but does not, on its own, isolate the exact stale-read
       mechanism in prose. Recorded honestly per mutation-proof-tests rule 2 rather than reshaped.
+
+21. **Judgment-day round 2, WARNING closed — the 3.12 doc-comment overclaimed the byte-identical
+    asserts were "the" behavioral proxy for zero-extra-statements, when they were dead code for the
+    literal mutant already recorded under 3.36.** The judge (round-2 blind reviewer B) flagged that
+    `UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente`'s doc-comment and this file both
+    called the test "the byte-identical sibling" proof without noting that, under the literal
+    `?? 0` mutant, execution never reaches lines 723-724 at all — `ConfirmarHeaderAsync`'s caller
+    dies first with a `500` from `BloquearYLeerAsync`'s FK-invariant throw, and the test's failure
+    (correctly recorded under 3.36) actually comes from `ConfirmarCompraAsync`'s generic
+    `StatusCode == OK` assert, not from the two byte-identical lines. Verified by mutation
+    (`mutation-proof-tests` rule 2, run before this fix and again after):
+    - **Before the fix**: applied a REALISTIC soft mutant to `EjecutarConfirmarAsync` — resolve
+      `idOc` via `encabezado.IdOrdenCompra ?? <lookup ordenes_compra by id_tenant/id_proveedor/
+      id_punto_venta, most recent>` instead of the literal `?? 0` — against the pre-fix test (sibling
+      already at the same proveedor/PV by the existing test helper defaults, no landmine). Build
+      clean → the pre-fix test **PASSED** (`0` failures) — the mutant is caught by neither net: the
+      structural test can't see it (syntactically valid guard argument) and the byte-identical
+      asserts see a genuine idempotent no-op (`ProyectarEstadoAsync` on the sibling derives the same
+      state it already has, so statement 3 never runs) — confirming the WARNING.
+    - **The fix**: added an EF-seeded "landmine" — a `Confirmada` receipt FK-linked to the sibling
+      OC that covers its full pedido, written directly (bypassing `ServicioDeCompras`/
+      `EscriturasDeOrdenDeCompra` entirely, same pattern as `SembrarOrdenAnuladaAsync`). Under
+      correct production code the sibling is never re-derived (`id_orden_compra` of the unlinked
+      confirm is `NULL`) so it stays stale-but-untouched forever — asserts pass. Re-ran the SAME
+      soft mutant against the strengthened test → build clean → the test **FAILED** at
+      `Assert.Equal(hermanaAntes.Estado, hermanaDespues.Estado)` (`Enviada` vs `Cerrada` — the
+      landmine's `completa = true` closed the sibling once the mutant's coincidental lookup handed
+      it to `ProyectarEstadoAsync`) → `git checkout -- src/` → `git status` clean → rebuild → green.
+    - Doc-comments in `ServicioDeComprasLigaduraTests.cs` (task 3.12 test) and this task's line 3.12
+      above corrected to name BOTH nets and what each one independently catches, instead of implying
+      the byte-identical asserts alone are sufficient.
 
 **Test plan**: zero-extra-statements (3.12); link happy/blocked paths incl. state-gating
 (3.13-3.16); the projection scenarios (3.17-3.20); derivation fidelity (3.21); confirm×confirm race

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -620,119 +620,308 @@ green + `judgment-day` clean round + PR merged.
 call + confirm×confirm race) / `3b` (anulación call + estado regression + anular×confirmar race)
 if this slice overflows — decision 3 above.
 
-- [ ] 3.1 Create `src/Ways.Application/Compras/EscriturasDeOrdenDeCompra.cs` — static class,
+- [x] 3.1 Create `src/Ways.Application/Compras/EscriturasDeOrdenDeCompra.cs` — static class,
   `ProyectarEstadoAsync` (lock → short-circuit → derive → conditional `UPDATE … RETURNING`, 3
   statements) and `BloquearYExigirNoAnuladaAsync` (defense-in-depth guard). *(design.md:78-99,
   decisions 1-2)*
-- [ ] 3.2 Same file, statement 1: `SELECT estado::text, (id_empleado_cierre IS NOT NULL) FOR
+- [x] 3.2 Same file, statement 1: `SELECT estado::text, (id_empleado_cierre IS NOT NULL) FOR
   UPDATE`; `anulada` OR manual close ⇒ return **without** statements 2/3. *(design.md:102-108,
   mutation targets #18, #26, #27)*
-- [ ] 3.3 Same file, statement 2: the derivation CTE — `pedido`/`recibido` grouped by
+- [x] 3.3 Same file, statement 2: the derivation CTE — `pedido`/`recibido` grouped by
   `id_articulo` on **both** sides, `c.estado = 'confirmada'`, `deleted_at IS NULL` on both joined
   tables, `algoRecibido` sourced from the **reception** side. *(design.md:110-129, mutation targets
   #22-#25)*
-- [ ] 3.4 Same file, statement 3: `UPDATE ordenes_compra SET estado, fecha_cierre (CASE, regresión
+- [x] 3.4 Same file, statement 3: `UPDATE ordenes_compra SET estado, fecha_cierre (CASE, regresión
   limpia NULL), updated_at WHERE … AND estado = $anterior RETURNING`, **skipped** when projected ==
   current. *(design.md:131-139, mutation targets #19, #28)*
-- [ ] 3.5 Modify `ServicioDeCompras.cs`'s `ConfirmarHeaderAsync` — widen `RETURNING` to add
+- [x] 3.5 Modify `ServicioDeCompras.cs`'s `ConfirmarHeaderAsync` — widen `RETURNING` to add
   `id_orden_compra`. *(design.md:44-46, mutation target #20)*
-- [ ] 3.6 Modify `ServicioDeCompras.cs`'s `MarcarAnuladaAsync` — same widening.
+- [x] 3.6 Modify `ServicioDeCompras.cs`'s `MarcarAnuladaAsync` — same widening.
   *(design.md:44-46)*
-- [ ] 3.7 Modify `ServicioDeCompras.cs`'s `EjecutarConfirmarAsync` — after step 1 (header lock),
+- [x] 3.7 Modify `ServicioDeCompras.cs`'s `EjecutarConfirmarAsync` — after step 1 (header lock),
   before lotes: `if (encabezado.IdOrdenCompra is { } idOc) { BloquearYExigirNoAnuladaAsync; }` at
-  lock position 2, before `proveedores`. *(design.md:214-221, mutation targets #21, #29)*
-- [ ] 3.8 Modify `ServicioDeCompras.cs`'s `EjecutarAnulacionAsync` — same guarded call at position
+  lock position 2, before `proveedores`. *(design.md:214-221, mutation targets #21, #29)* —
+  **DEVIATION registered (decision 20 below)**: the literal pinned signatures (design's Interfaces/
+  Contracts — `BloquearYExigirNoAnuladaAsync` has NO `momento` parameter) mean this call site issues
+  **both** `BloquearYExigirNoAnuladaAsync` (its own `SELECT … FOR UPDATE`) **and then**
+  `ProyectarEstadoAsync` (which takes the **same** row lock again as its own statement 1) — two
+  redundant-but-safe re-locks of the same row within the transaction, not one shared lock. Postgres
+  re-acquiring `FOR UPDATE` on a row already locked by the same transaction is a documented no-op
+  (re-verifies visibility, does not block, cannot deadlock against itself); this reading matches the
+  two separate public method signatures design pins verbatim and their doc-comment framing ("ANTES
+  DE QUE LA PROYECCIÓN ESCRIBA").
+- [x] 3.8 Modify `ServicioDeCompras.cs`'s `EjecutarAnulacionAsync` — same guarded call at position
   2, after the (unmoved) audit step. *(design.md:229-236)*
-- [ ] 3.9 Modify `ServicioDeCompras.cs`'s draft path (both `CrearBorradorAsync` and
+- [x] 3.9 Modify `ServicioDeCompras.cs`'s draft path (both `CrearBorradorAsync` and
   `ActualizarBorradorAsync`) — accept `idOrdenCompra`, call `ExigirOrdenLigableAsync` (`SELECT …
   FOR SHARE`) validating tenant + proveedor + punto de venta + linkable estado
   (`enviada`/`recibida_parcial`/`cerrada`; refuse `borrador` → `orden_compra_no_enviada` 409,
   `anulada` → `orden_compra_anulada` 409). *(design.md:63, conflict #2 above, mutation target #30)*
-- [ ] 3.10 Modify `src/Ways.Api/Endpoints/ComprasEndpoints.cs` — `SolicitudDeCompra` gains `int?
-  IdOrdenCompra`; **no route/policy change**. *(design.md:206-208)*
-- [ ] 3.11 Modify `ComprasEndpoints.cs`'s response contract — `CompraDetalle` gains `int?
+- [x] 3.10 Modify `src/Ways.Application/Compras/Contratos.cs` — `SolicitudDeCompra` gains `int?
+  IdOrdenCompra`; **no route/policy change**. *(design.md:206-208)* — **DEVIATION (cosmetic)**: the
+  field lives in `Contratos.cs` (the actual repo filename for these DTOs), not
+  `ComprasEndpoints.cs` as the task literally names — `ComprasEndpoints.cs` itself needed zero
+  changes since the endpoint already threads the whole `SolicitudDeCompra`/`CompraDetalle` record
+  through unmodified.
+- [x] 3.11 Modify `Contratos.cs`'s response contract — `CompraDetalle` gains `int?
   IdOrdenCompra`. *(design.md:206-208, conflict #4 above)*
-- [ ] 3.12 [P] Integration — **binding gate test (a): zero-extra-statements**. A confirm with
-  `id_orden_compra IS NULL` issues the exact pre-stage command count; existing
-  `ComprasConfirmarTests`/`ComprasAnularTests` green and **unedited** in the diff.
-  *(comprobantes-compra/spec.md:50-54, 75-79; design.md, Testing Strategy)*
-- [ ] 3.13 [P] Integration — a borrador draft links to a matching (`enviada`) OC; persisted.
+- [x] 3.12 [P] Integration — **binding gate test (a): zero-extra-statements**.
+  `UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente` (behavioral: a sibling OC's `estado`/
+  `updated_at` stay byte-identical) + `EscriturasDeOrdenDeCompraLockOrderTests.
+  LasLlamadasAEscriturasDeOrdenDeCompraEnConfirmarNuncaOcurrenFueraDelGuardNulo` (structural: the
+  calls never appear outside the null-check guard). `ComprasLifecycleTests`/
+  `ComprasAnulacionYConcurrenciaTests` green and **unedited** in the diff (verified: 87/87, `git
+  status` shows neither file touched). *(comprobantes-compra/spec.md:50-54, 75-79; design.md,
+  Testing Strategy)* — **DEVIATION registered (decision 20 below)**: a literal EF
+  `DbCommandInterceptor`/`ContadorDeComandos` "command count" is structurally blind to this slice's
+  raw-ADO statements (same empirically-proven limitation `ServicioDeComprasLockOrderTests`'s own
+  doc-comment already recorded for the lock-order proof) — `mutation-proof-tests` rule 3 escape
+  hatch applied, same as the one task 3.24 pre-authorized.
+- [x] 3.13 [P] Integration — a borrador draft links to a matching (`enviada`) OC; persisted.
   *(comprobantes-compra/spec.md:14-17)*
-- [ ] 3.14 [P] Integration — a mismatched proveedor/PV/tenant cannot link, refused before any
+- [x] 3.14 [P] Integration — a mismatched proveedor/PV/tenant cannot link, refused before any
   write. *(ordenes-de-compra/spec.md:196-204, comprobantes-compra/spec.md:19-22)*
-- [ ] 3.15 [P] Integration — linking to a `borrador` OC ⇒ `409 orden_compra_no_enviada`; linking to
+- [x] 3.15 [P] Integration — linking to a `borrador` OC ⇒ `409 orden_compra_no_enviada`; linking to
   an `anulada` OC ⇒ `409 orden_compra_anulada`; linking to a `cerrada` OC succeeds. *(conflict #2
   above)*
-- [ ] 3.16 [P] Integration — the link is frozen once confirmed; `CompraDetalle.IdOrdenCompra`
+- [x] 3.16 [P] Integration — the link is frozen once confirmed; `CompraDetalle.IdOrdenCompra`
   round-trips exactly what was set at draft time. *(comprobantes-compra/spec.md:24-27, conflict #4
   above)*
-- [ ] 3.17 [P] Integration — confirming a linked reception moves the OC to `recibida_parcial` in
+- [x] 3.17 [P] Integration — confirming a linked reception moves the OC to `recibida_parcial` in
   the same transaction. *(ordenes-de-compra/spec.md:109-112, comprobantes-compra/spec.md:39-43)*
-- [ ] 3.18 [P] Integration — confirming the remainder closes the OC automatically,
+- [x] 3.18 [P] Integration — confirming the remainder closes the OC automatically,
   `id_empleado_cierre IS NULL`. *(ordenes-de-compra/spec.md:114-117)*
-- [ ] 3.19 [P] Integration — confirming against an `anulada` OC is refused `409
+- [x] 3.19 [P] Integration — confirming against an `anulada` OC is refused `409
   orden_compra_anulada`, no write. *(ordenes-de-compra/spec.md:185-188, comprobantes-
   compra/spec.md:45-48)*
-- [ ] 3.20 [P] Integration — annulling the only reception of an automatically-closed OC returns it
+- [x] 3.20 [P] Integration — annulling the only reception of an automatically-closed OC returns it
   to `enviada`. *(ordenes-de-compra/spec.md:119-122, comprobantes-compra/spec.md:65-68)*
-- [ ] 3.21 [P] Integration — **derivation fidelity** (rule 11): two OC lines of one artículo (3+4
-  ⇒ 7 pedidas), a reception splitting it (2 then 5), an artículo received but never ordered, an
-  over-delivery (8 against 7), a soft-deleted reception, a linked `borrador` reception, a reception
-  of another OC of the same proveedor — every `Recibida`/`Pendiente` asserted per artículo, never a
-  fresh 1-line/1-reception seed. *(design.md, Testing Strategy; ordenes-de-compra/spec.md:124-129;
-  decision 13 above — desynchronized ids)*
-- [ ] 3.22 [P] Integration — **the two races**: confirm × confirm of two receptions of one OC (both
-  commit, no deadlock, resulting estado = the sum of both, never only one); anular OC × confirmar
-  reception in both orders (one `200` + one `409`, never a reception lands on an `anulada` OC,
-  never a deadlock). *(ordenes-de-compra/spec.md:131-135, design.md Concurrency guarantees)*
-- [ ] 3.23 [P] Integration — a fault injected after the projection leaves the OC untouched
-  (fault-point test, both confirm and anular paths). *(design.md, Testing Strategy)*
-- [ ] 3.24 [P] Integration — the pinned lock order holds: `comprobantes_compra → ordenes_compra →
-  lotes → stock/stock_lotes → proveedores → ledger`, verified by source-order or interceptor per
-  the stage-15 precedent if a live rendezvous cannot discriminate it (`mutation-proof-tests` rule
-  3 escape hatch, registered if invoked). *(design.md:268-282)*
-- [ ] 3.25 [P] **Mutation target #18** — `SELECT … FOR UPDATE` (statement 1) → delete, keep
-  derive+update → confirm×confirm rendezvous (3.22) ⇒ stale estado.
-- [ ] 3.26 [P] **Mutation target #19** — the derivation folded into one `UPDATE … FROM (SELECT
-  …)` → same rendezvous (3.22) ⇒ `EvalPlanQual` stale snapshot.
-- [ ] 3.27 [P] **Mutation target #20** — `id_orden_compra` read from `preLectura` instead of the
-  widened `RETURNING` → confirm under a concurrent `PUT` that relinks the draft must fail.
-- [ ] 3.28 [P] **Mutation target #21** — OC lock moved after the `proveedores` lock → confirm×
-  confirm rendezvous (3.22) ⇒ deadlock/timeout.
-- [ ] 3.29 [P] **Mutation target #22** — `c.estado = 'confirmada'` widened to any estado → a
-  linked `borrador` reception moves the OC (3.21 fixture) must fail.
-- [ ] 3.30 [P] **Mutation target #23** — either `deleted_at IS NULL` deleted → the soft-deleted-
-  reception fixture (3.21) must fail.
-- [ ] 3.31 [P] **Mutation target #24** — `GROUP BY id_articulo` on the ordered side matched line-
-  to-line → the duplicate-OC-lines fixture (3.21, 3+4⇒7) must fail.
-- [ ] 3.32 [P] **Mutation target #25** — `algoRecibido` sourced from the ordered side's coalesced
+- [x] 3.21 [P] Integration — **derivation fidelity** (rule 11): two OC lines of one artículo (3+4
+  ⇒ 7 pedidas, plus a DISCRIMINANT 5-of-7 partial receive that over-delivery alone could not have
+  proven), an artículo received but never ordered, a soft-deleted reception, a linked `borrador`
+  reception, a reception of another OC of the same proveedor — every fixture asserted via the
+  resulting projected `estado` (the only slice-3-observable artifact; per-artículo `Recibida`/
+  `Pendiente` numbers are a slice-5 read-model concern, not yet built). *(design.md, Testing
+  Strategy; ordenes-de-compra/spec.md:124-129; decision 13 above — desynchronized ids)*
+- [x] 3.22 [P] Integration — **the two races**: confirm × confirm of two receptions of one OC (both
+  commit, no deadlock, resulting estado = the sum of both, never only one) — **DONE**,
+  `DosConfirmacionesConcurrentesDeDosRecepcionesDeUnaOrdenNuncaSeSobreescriben`. **DEVIATION
+  registered (decision 20 below)**: "anular OC × confirmar reception in both orders" is **NOT
+  implementable in this slice** — `POST /{id}/anular` for an OC and
+  `ServicioDeOrdenesDeCompra.AnularAsync` are slice-4 tasks (4.2/4.3); no OC-anulación write path
+  exists anywhere in this slice's scope to race against. Deferred to slice 4, where the endpoint
+  will exist. *(ordenes-de-compra/spec.md:131-135, design.md Concurrency guarantees)*
+- [x] 3.23 [P] Integration — a fault injected after the projection leaves the OC untouched
+  (fault-point test) — **confirm path DONE** (`UnaFallaDespuesDeLaProyeccionEnConfirmarDejaLaOrdenSinCambios`,
+  a zero-item borrador linked to an OC trips `compra_sin_items` in step 2, AFTER step 1.b's
+  projection already ran inside the aborted transaction). **Anular path NOT implemented** — every
+  guard in `EjecutarAnulacionAsync` after its own OC-projection call (1.6) is pre-existing,
+  unmodified stage-8/12 stock-negative logic; constructing a fault there specific to THIS slice's
+  call-ordering claim would duplicate `ComprasAnulacionYConcurrenciaTests`' own stock-negative
+  coverage without adding a new signal, so it was not duplicated here — registered as a gap, not a
+  fabricated pass. *(design.md, Testing Strategy)*
+- [x] 3.24 [P] Integration — the pinned lock order holds — **DONE via the `mutation-proof-tests`
+  rule 3 escape hatch, invoked**: `EscriturasDeOrdenDeCompraLockOrderTests` asserts the lock-order
+  claim by SOURCE TEXT (same reasoning as `ServicioDeComprasLockOrderTests`'s own precedent — a
+  `DbCommandInterceptor` cannot see this slice's raw-ADO statements). The behavioral rendezvous test
+  (3.22) does **not** independently discriminate a same-path reorder (see decision 20 below,
+  mutation target #21 finding) — the source-text test is the actual functioning detector.
+  *(design.md:268-282)*
+- [x] 3.25 [P] **Mutation target #18** — `SELECT … FOR UPDATE` (statement 1) → delete, keep
+  derive+update → confirm×confirm rendezvous (3.22) ⇒ stale estado. **Evidence**: deleted `FOR
+  UPDATE` from `BloquearYLeerAsync`'s SQL → `dotnet build --no-incremental` clean →
+  `DosConfirmacionesConcurrentesDeDosRecepcionesDeUnaOrdenNuncaSeSobreescriben` FAILED (one
+  concurrent confirm surfaced `500 error_interno` — the loser's conditional `UPDATE … WHERE estado =
+  $5` no longer matched under the lockless race) → `git checkout -- src/` → rebuilt → green.
+- [x] 3.26 [P] **Mutation target #19** — the derivation folded into one `UPDATE … FROM (SELECT
+  …)` → same rendezvous (3.22) ⇒ `EvalPlanQual` stale snapshot. **Evidence**: replaced
+  `ProyectarEstadoAsync`'s derive+update tail with a single self-referential `WITH pedido, recibido
+  UPDATE ordenes_compra … FROM …` (statement 1's lock kept intact, isolating this claim from #18) →
+  build clean → the rendezvous test FAILED (`409 orden_compra_cierre_incoherente` — the simplified
+  merged statement also dropped `fecha_cierre` handling, so the observed failure mode is a CHECK
+  violation rather than a pure stale-read assertion; recorded honestly, not reshaped into a cleaner
+  narrative) → `git checkout -- src/` → rebuilt → green.
+- [x] 3.27 [P] **Mutation target #20** — `id_orden_compra` read from `preLectura` instead of the
+  widened `RETURNING` → confirm under a concurrent `PUT` that relinks the draft must fail. **New
+  test added**: `ConfirmarUsaElIdOrdenCompraVistoBajoElLockNoElDePreLectura` (`DbTransactionInterceptor`
+  pausing `EjecutarConfirmarAsync` right after `BeginTransactionAsync`, same pattern as
+  `ServicioDeOrdenesDeCompraTests.InterceptorDePausaTrasIniciarLaTransaccion`) — a borrador linked to
+  OC-A is relinked to OC-B by a concurrent `PUT` while paused; OC-B must close, OC-A must stay
+  untouched. **Evidence**: threaded `preLectura.IdOrdenCompra` into `EjecutarConfirmarAsync` in place
+  of `encabezado.IdOrdenCompra` → build clean → test FAILED (OC-B stayed `Enviada` — the projection
+  wrongly targeted stale OC-A instead) → `git checkout -- src/` → rebuilt → green.
+- [x] 3.28 [P] **Mutation target #21** — OC lock moved after the `proveedores` lock. **FINDING,
+  not a clean pass** (mutation-proof-tests rule 3): moved the guarded block to right after the
+  `proveedores` lock in `EjecutarConfirmarAsync` → the SOURCE-TEXT test
+  (`ElGuardDeLaOrdenDeCompraEstaEnPosicion2…`) FAILED immediately, as expected. The BEHAVIORAL
+  rendezvous test (3.22) **stayed green under this exact mutation** — verified empirically (rule 2):
+  a confirm×confirm reordering of the SAME code path takes both locks in the SAME relative order on
+  both sides (`proveedores → OC` for both concurrent callers), which cannot form a genuine
+  lock-cycle with itself; a real deadlock needs a *different* call path taking the two locks in the
+  opposite order, and no such path exists inside this slice (only slice 4's `AnularAsync` would be a
+  candidate, and it already takes `OC` **before** any stock/proveedores work per its own guarded
+  call). Design's "confirm × confirm rendezvous ⇒ deadlock/timeout" phrasing for this target does
+  not hold for the confirm×confirm sub-case specifically; the source-text test is the real,
+  functioning detector. Reverted (`git checkout -- src/`), rebuilt, both tests green.
+- [x] 3.29 [P] **Mutation target #22** — `c.estado = 'confirmada'` widened to any estado → a
+  linked `borrador` reception moves the OC (3.21 fixture) must fail. **Evidence**: replaced the
+  filter with `AND true` → build clean →
+  `UnaRecepcionEnBorradorLigadaNoCuentaParaLaDerivacion` FAILED (expected `RecibidaParcial`, actual
+  `Cerrada` — the unconfirmed borrador's quantity leaked into the derivation) → reverted, clean →
+  green.
+- [x] 3.30 [P] **Mutation target #23** — `ic.deleted_at IS NULL` deleted → the soft-deleted-
+  reception fixture (3.21) must fail. **Evidence**: dropped `ic.deleted_at IS NULL` from the
+  `recibido` CTE's `WHERE` → build clean →
+  `UnItemDeRecepcionSoftDeleteadoDejaDeContarEnLaDerivacion` FAILED (expected `RecibidaParcial`,
+  actual `Cerrada` — the soft-deleted item's quantity still counted) → reverted, clean → green.
+- [x] 3.31 [P] **Mutation target #24** — `GROUP BY id_articulo` on the ordered side matched line-
+  to-line → the duplicate-OC-lines fixture must fail. **New DISCRIMINANT test added**
+  (`DosLineasDelMismoArticuloComparanContraLaSumaNoContraCadaLineaIndividual`, 3+4=7 pedidos vs. 5
+  recibidos — the pre-existing 8-vs-7 over-delivery test does NOT discriminate this mutation, since
+  8 exceeds every individual line too; 5 exceeds neither individual line (3, 4) but IS less than the
+  correct sum (7), so only the correct grouping reports `RecibidaParcial`). **Evidence**: changed
+  `GROUP BY i.id_articulo` to `GROUP BY i.id_articulo, i.id_item` in the `pedido` CTE → build clean →
+  the new test FAILED (expected `RecibidaParcial`, actual `Cerrada` — each individual line read
+  "covered" against the shared 5-unit receipt) → reverted, clean → green.
+- [x] 3.32 [P] **Mutation target #25** — `algoRecibido` sourced from the ordered side's coalesced
   sum instead of the reception side → the pure-substitution fixture (OC stays `enviada`) must
-  fail.
-- [ ] 3.33 [P] **Mutation target #26** — `id_empleado_cierre IS NOT NULL` short-circuit deleted →
-  annulling a reception of a manually-closed OC reopens it (3.20's sibling test) must fail.
-- [ ] 3.34 [P] **Mutation target #27** — `estado = 'anulada'` terminal short-circuit deleted →
-  the projection resurrects an annulled OC (3.19's sibling test) must fail.
-- [ ] 3.35 [P] **Mutation target #28** — `fecha_cierre = NULL` on regression kept as old value →
-  `ck_ordenes_compra_cierre` ⇒ `23514` (3.20 regresses).
-- [ ] 3.36 [P] **Mutation target #29** — `if (encabezado.IdOrdenCompra is { } idOc)` called
-  unconditionally → the zero-extra-statements command count (3.12) must fail.
-- [ ] 3.37 [P] **Mutation target #30** — `id_proveedor`/`id_punto_venta` equality dropped in
-  `ExigirOrdenLigableAsync` → the cross-proveedor/cross-PV link test (3.14) must fail.
-- [ ] 3.38 [P] `db-error-backstops` — FK 9 (`fk_comprobantes_compra_orden_compra`) client-
-  reachable test: linking to an OC being annulled concurrently (race) + generic `23503` mapping.
-  *(design.md:325)*
-- [ ] 3.39 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
-  `Migraciones/`; `git diff --stat` confirms no file under `src/Ways.Application/Ventas/` or
-  `src/Ways.Application/Stock/` appears.
-- [ ] 3.40 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  fail. **Evidence**: changed `algo_recibido` to `SUM(r2.recibida) FROM pedido p2 JOIN recibido r2
+  ON r2.id_articulo = p2.id_articulo` (inner join against ordered lines only) → build clean →
+  `UnaEntregaPorSustitucionNuncaPedidaMuevaAOrdenARecibidaParcial` FAILED (expected
+  `RecibidaParcial`, actual `Enviada` — the substitution delivery, received but never ordered,
+  became invisible) → reverted, clean → green.
+- [x] 3.33 [P] **Mutation target #26** — `id_empleado_cierre IS NOT NULL` short-circuit deleted →
+  annulling a reception of a manually-closed OC reopens it. **New test added**
+  (`AnularUnaRecepcionDeUnaOrdenCerradaManualmenteNoLaReabre`, OC seeded `Cerrada`+
+  `IdEmpleadoCierre` directly by EF — `POST /{id}/cerrar` is slice 4). **FINDING**: deleting ONLY the
+  C# early-return (`|| lockeado.CierreManual`) is a FALSE PASS by itself —
+  `ProyectorDeEstadoDeOrden.Proyectar`'s OWN domain logic ALSO checks `cierreManual` first
+  (defense-in-depth, already exhaustively truth-tabled in slice 1), so the no-op branch still lands
+  on `Cerrada` even without the early-return. Routed below the confound (rule 3): mutated the
+  early-return AND hardcoded `cierreManual: false` in the `Proyectar` call together → build clean →
+  the new test FAILED (`409` instead of `200`/stayed-`Cerrada`) → reverted BOTH lines
+  (`git checkout -- src/`), clean → green.
+- [x] 3.34 [P] **Mutation target #27** — `estado = 'anulada'` terminal short-circuit deleted.
+  **INVESTIGATED, NOT independently provable via a single-layer mutation** (mutation-proof-tests
+  rule 3, same class as stage-16 slice-1 target #6's precedent): deleted ONLY the C# early-return's
+  `estadoActual == EstadoOrdenCompra.Anulada ||` clause → new test
+  `AnularUnaRecepcionLigadaAUnaOrdenYaAnuladaNoLaResucita` (OC seeded `Anulada` directly by EF)
+  **STAYED GREEN** — `ProyectorDeEstadoDeOrden.Proyectar`'s own first arm
+  (`estadoActual is Anulada ⇒ Anulada`) already redundantly protects the terminal rule, and since
+  the recomputed `nuevoEstado` still equals `estadoActual`, statement 3 is skipped as a no-op either
+  way — same final observable state. The invariant IS proven, exhaustively, by slice 1's domain
+  truth-table unit test (`ProyectorDeEstadoDeOrdenTests`, "`anulada` terminal from every input") —
+  this is a genuine two-layer defense, not a production gap. Not pursued further (a combined
+  mutation like target #26's would require also lying about `estadoActual` to `Proyectar`, at which
+  point the test would stop exercising this specific early-return at all). Reverted, clean → green
+  (unchanged, since nothing was left mutated).
+- [x] 3.35 [P] **Mutation target #28** — `fecha_cierre = NULL` on regression kept as old value →
+  `ck_ordenes_compra_cierre` ⇒ `23514` (3.20 regresses). **Evidence**: changed the `CASE` to `ELSE
+  fecha_cierre` (keep the pre-update value) instead of `ELSE NULL` → build clean →
+  `AnularLaUnicaRecepcionDeUnaOrdenCerradaAutomaticamenteLaDevuelveAEnviada` FAILED (`409`, the
+  `ck_ordenes_compra_cierre` CHECK rejected the regression that left a stale `fecha_cierre` on a
+  non-`cerrada` row) → reverted, clean → green. Strengthened the base test with an explicit
+  `Assert.Null(final.FechaCierre)` in the same pass.
+- [x] 3.36 [P] **Mutation target #29** — `if (encabezado.IdOrdenCompra is { } idOc)` called
+  unconditionally → the zero-extra-statements proof (3.12) must fail. **Evidence**: replaced the
+  guard with an unconditional block (`idOc = encabezado.IdOrdenCompra ?? 0`) → build clean → BOTH
+  detectors failed: the structural test
+  (`LasLlamadasAEscriturasDeOrdenDeCompraEnConfirmarNuncaOcurrenFueraDelGuardNulo`, "no se encontró
+  el guard nulo") and the behavioral test (`UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente`,
+  `500` — the sentinel id `0` broke the FK invariant) → reverted, clean → both green.
+- [x] 3.37 [P] **Mutation target #30** — `id_proveedor`/`id_punto_venta` equality dropped in
+  `ExigirOrdenLigableAsync` → the cross-proveedor/cross-PV link test (3.14) must fail. **Evidence**:
+  ran BOTH conjuncts independently. Dropping the `id_proveedor` check → build clean →
+  `UnProveedorNoCoincidenteNoPuedeLigar` FAILED (expected `BadRequest`, actual `Created`) → reverted.
+  Dropping the `id_punto_venta` check → build clean → `UnPuntoDeVentaNoCoincidenteNoPuedeLigar`
+  FAILED (same shape) → reverted. `git status` clean after both, rebuilt, both green.
+- [x] 3.38 [P] `db-error-backstops` — FK 9 (`fk_comprobantes_compra_orden_compra`) client-
+  reachable test: **DONE** for the primary path (`LigarAUnaOrdenInexistenteEsRechazadaComo404` —
+  `ExigirOrdenLigableAsync`'s own 404 pre-check catches an invalid `idOrdenCompra` before any write;
+  under normal operation this makes the raw `23503`/generic-mapping backstop unreachable, the same
+  "backstop of last resort" posture as other exempted FKs in this repo). **The race sub-clause
+  ("linking to an OC being annulled concurrently") is NOT implemented** — same reason as 3.22's
+  deferred half: no OC-anulación write path exists in this slice to race against; deferred to slice
+  4. Generic `23503` → `referencia_invalida` mapping itself needed zero new code (already covers any
+  `fk_*`-prefixed constraint since slice 1). *(design.md:325)*
+- [x] 3.39 Gate guard: `dotnet ef migrations has-pending-model-changes` clean (verified); zero new
+  files under `Migraciones/` (`git diff --stat main -- .../Migraciones/` empty); `git diff --stat`
+  confirms no file under `src/Ways.Application/Ventas/` or `src/Ways.Application/Stock/` appears
+  (verified empty). Gate holds, no deviation.
+- [ ] 3.40 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+  RUN by `sdd-apply`** — same executor-contract carve-out as slice 1 task 1.38 / slice 2 task
+  2.26: this executor cannot launch sub-agents/reviewers. Left for the orchestrator to run before
+  merge.
 - [ ] 3.41 Branch `feat/stage16-slice3-ligadura-y-proyeccion` off `main` (parent: slice 2); PR;
-  merge stacked-to-main.
+  merge stacked-to-main. **PARTIAL**: the worktree was already provisioned on
+  `feat/stage16-slice3-ligadura` off `main` (`8b720d3`, slice 2 already merged) before this phase
+  started — branching is done, naming differs by dropping `-y-proyeccion` (cosmetic, not re-branched
+  to avoid losing the provisioned worktree — flagged for the orchestrator). PR creation/merge is
+  explicitly out of scope (`NO pushees` instruction) — left for the orchestrator.
+
+20. **Slice 3 apply-phase decisions and deviations (decision 15 discipline).**
+    - **Double lock in `EjecutarConfirmarAsync`'s guarded block**: the literal pinned interface
+      (two separate public methods, `BloquearYExigirNoAnuladaAsync` carrying NO `momento` parameter)
+      means the confirm call site issues `BloquearYExigirNoAnuladaAsync` followed by
+      `ProyectarEstadoAsync`, each taking its OWN `SELECT … FOR UPDATE` on the same OC row —
+      Postgres re-acquiring a lock already held by the same transaction is a documented, harmless
+      no-op (verifies visibility, never blocks, cannot self-deadlock). Followed literally rather
+      than collapsed into a single shared-lock helper, since the design's own interface pins two
+      distinct signatures with distinct throwing semantics.
+    - **`ContadorDeComandos`/`DbCommandInterceptor` cannot prove "zero extra statements" for this
+      slice** — same empirically-recorded limitation `ServicioDeComprasLockOrderTests`'s own
+      doc-comment already established for the lock-order proof (raw `conexion.CreateCommand()`
+      statements never enter EF's command pipeline, with or without the guard executing). Resolved
+      via the `mutation-proof-tests` rule 3 escape hatch: a source-text structural proof (the calls
+      appear ONLY inside the null-check guard) plus a behavioral sibling-untouched proof (an
+      unrelated OC's `estado`/`updated_at` stay byte-identical across an unlinked confirm).
+    - **Mutation target #21's "deadlock/timeout" claim does not hold for the confirm×confirm
+      sub-case** — verified empirically (mutation-proof-tests rule 2, "run it, don't reason it"):
+      reordering the OC guard to after the `proveedores` lock leaves the BEHAVIORAL rendezvous test
+      green, because both concurrent confirmations traverse the SAME code path and therefore take
+      the two locks in the SAME relative order on both sides — no lock-order inversion, no cycle.
+      The SOURCE-TEXT test is the actual functioning detector for this target; registered so it is
+      not read as a gap.
+    - **Mutation target #27 investigated, found non-independently-provable via a single-layer
+      mutation** — same class as stage-16 slice-1 target #6's "investigated finding, not a
+      fabricated pass": `ProyectorDeEstadoDeOrden.Proyectar`'s own domain-level terminal check on
+      `Anulada` redundantly protects the invariant this slice's C# early-return also protects,
+      so deleting only the early-return produces the same final observable state (no-op skip).
+      Mutation target #26 needed the SAME combined treatment (early-return deleted AND
+      `cierreManual` lied about to `Proyectar`) to become independently provable — both cycles run
+      together, evidence recorded under 3.33 above. Neither is a production gap: both invariants are
+      separately, exhaustively proven at the domain-unit level by slice 1's
+      `ProyectorDeEstadoDeOrdenTests` truth table.
+    - **Two race sub-clauses deferred to slice 4** (tasks 3.22, 3.38): "anular OC × confirmar
+      reception" and "linking to an OC being annulled concurrently" both require an OC-anulación
+      write path (`POST /{id}/anular`, `ServicioDeOrdenesDeCompra.AnularAsync`) that does not exist
+      anywhere in this slice's scope — those are slice-4 tasks 4.2/4.3. Registered here rather than
+      silently narrowed; the guard code they would exercise (`BloquearYExigirNoAnuladaAsync`'s 409,
+      the no-lock `EXISTS` read of decision 9) IS already fully implemented and unit/structurally
+      covered — only the CONCURRENT race proof against a not-yet-existing endpoint is deferred.
+    - **Mutation target #23's fault-point (task 3.23) covers only the CONFIRM path** — the ANULAR
+      path's every post-projection guard is pre-existing stage-8/12 stock-negative logic already
+      covered by `ComprasAnulacionYConcurrenciaTests`; duplicating it here would not add a new
+      signal specific to this slice's ordering claim, so it was not duplicated (registered as an
+      intentional gap, not fabricated coverage).
+    - **Mutation target #19's evidence surfaced via a CHECK-constraint violation, not a pure
+      stale-snapshot assertion** — the temporary merged-statement mutation used for evidence dropped
+      `fecha_cierre` handling for simplicity (a genuinely different bug from the EvalPlanQual
+      staleness the target names), so the observed `409 orden_compra_cierre_incoherente` confirms
+      the test suite rejects this SQL shape, but does not, on its own, isolate the exact stale-read
+      mechanism in prose. Recorded honestly per mutation-proof-tests rule 2 rather than reshaped.
 
 **Test plan**: zero-extra-statements (3.12); link happy/blocked paths incl. state-gating
-(3.13-3.16); the projection scenarios (3.17-3.20); derivation fidelity (3.21); both races (3.22);
-fault points (3.23); lock order (3.24); 13 mutation targets (3.25-3.37); FK 9 race (3.38).
+(3.13-3.16); the projection scenarios (3.17-3.20); derivation fidelity (3.21); confirm×confirm race
+(3.22, anular×confirmar deferred to slice 4); fault point, confirm path (3.23); lock order (3.24);
+13 mutation targets (3.25-3.37, two registered as investigated/non-actionable defense-in-depth
+findings rather than fabricated passes — #27 alone, #21's behavioral half); FK 9 primary path (3.38,
+race deferred to slice 4).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~EscriturasDeOrdenDeCompra|FullyQualifiedName~ServicioDeCompras`
+— 25/25 green in `ServicioDeComprasLigaduraTests` + `EscriturasDeOrdenDeCompraLockOrderTests`
+combined with slices 1-2's re-run suites (177/177 across all Compras/OrdenesCompra/
+SuperficieDeAutorizacion/GastosLigadosACompra integration tests; 289/289 in `Ways.Application.Tests`).
 
 ---
 

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -861,7 +861,7 @@ if this slice overflows — decision 3 above.
   files under `Migraciones/` (`git diff --stat main -- .../Migraciones/` empty); `git diff --stat`
   confirms no file under `src/Ways.Application/Ventas/` or `src/Ways.Application/Stock/` appears
   (verified empty). Gate holds, no deviation.
-- [ ] 3.40 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+- [x] 3.40 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
   RUN by `sdd-apply`** — same executor-contract carve-out as slice 1 task 1.38 / slice 2 task
   2.26: this executor cannot launch sub-agents/reviewers. Left for the orchestrator to run before
   merge.

--- a/src/Ways.Application/Compras/Contratos.cs
+++ b/src/Ways.Application/Compras/Contratos.cs
@@ -23,7 +23,15 @@ public sealed record LineaDeCompraSolicitada(
 
 /// <summary>Cuerpo de <c>POST /api/compras</c> (crea un borrador) y de <c>PUT
 /// /api/compras/{id}</c> (design decisión 2: replace-set completo del header + los items — un
-/// PUT reemplaza <see cref="Items"/> entero, nunca un CRUD incremental por item).</summary>
+/// PUT reemplaza <see cref="Items"/> entero, nunca un CRUD incremental por item).
+///
+/// <see cref="IdOrdenCompra"/> — stage-16-ordenes-de-compra, Slice 3 (design: Interfaces/
+/// Contracts; spec comprobantes-compra: "A Comprobante Compra MAY Carry A Linked Orden De
+/// Compra"). Al final del record, con default <c>null</c>, para no romper ningún call site
+/// posicional existente (`dto-contract-honesty` regla 3 — el campo se traza hasta
+/// <c>ServicioDeCompras.ExigirOrdenLigableAsync</c>/<c>ComprobanteCompra.IdOrdenCompra</c>, nunca
+/// solo declarado). Seteable/cambiable solo mientras el comprobante es <c>borrador</c>; congelado
+/// después (spec: "The link is frozen once the compra is confirmed").</summary>
 public sealed record SolicitudDeCompra(
     int IdProveedor,
     int IdTipoComprobante,
@@ -31,7 +39,8 @@ public sealed record SolicitudDeCompra(
     string? NumeroExterno,
     DateOnly? FechaComprobante,
     string? Observaciones,
-    IReadOnlyList<LineaDeCompraSolicitada> Items);
+    IReadOnlyList<LineaDeCompraSolicitada> Items,
+    int? IdOrdenCompra = null);
 
 /// <summary>Un item ya persistido, con su <c>precioSugerido</c> (design: API Surface — "Header +
 /// items + precioSugerido per item"). Sin <c>unidades</c> propio: solo <see cref="Cantidad"/>
@@ -59,7 +68,12 @@ public sealed record ItemDeCompra(
     int? IdLote);
 
 /// <summary>Detalle completo de una compra — respuesta de <c>GET /api/compras/{id}</c>,
-/// <c>POST /api/compras</c>, <c>PUT /api/compras/{id}</c>, <c>POST …/confirmar</c>.</summary>
+/// <c>POST /api/compras</c>, <c>PUT /api/compras/{id}</c>, <c>POST …/confirmar</c>.
+///
+/// <see cref="IdOrdenCompra"/> — stage-16-ordenes-de-compra, Slice 3 (conflicto #4 de tasks.md,
+/// `state.yaml` OD8/T7): corrige el "no response shape changes" original del proposal bajo
+/// `dto-contract-honesty` regla 2 — un campo request-only no puede satisfacer la aserción de
+/// round-trip (task 3.16).</summary>
 public sealed record CompraDetalle(
     int Id,
     int IdProveedor,
@@ -74,7 +88,8 @@ public sealed record CompraDetalle(
     decimal Total,
     string? Observaciones,
     EstadoCompra Estado,
-    IReadOnlyList<ItemDeCompra> Items);
+    IReadOnlyList<ItemDeCompra> Items,
+    int? IdOrdenCompra);
 
 /// <summary>Fila de <c>GET /api/compras</c> — shape reducido, mismo criterio que
 /// <c>ComprobanteListado</c>/<c>GastoListado</c>. <see cref="EstadoPago"/> lo resuelve

--- a/src/Ways.Application/Compras/EscriturasDeOrdenDeCompra.cs
+++ b/src/Ways.Application/Compras/EscriturasDeOrdenDeCompra.cs
@@ -1,0 +1,197 @@
+using System.Data.Common;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.Compras;
+
+namespace Ways.Application.Compras;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 3 (design decisiones 1-2, Interfaces/Contracts — "Application
+/// — the one projection authority"). Copia estructural de
+/// <see cref="Ways.Application.CuentaCorriente.EscriturasDeCuentaCorrienteProveedor"/>: <c>static</c>,
+/// misma postura de conexión/transacción del llamador (nunca abre/flushea/comitea nada), todos los
+/// parámetros por <see cref="ParametrosDeComando"/>. La ÚNICA clase que escribe
+/// <c>ordenes_compra.estado</c> a partir del libro de recepción — llamada desde
+/// <c>ServicioDeCompras.EjecutarConfirmarAsync</c> y <c>EjecutarAnulacionAsync</c>, nunca desde
+/// <c>ServicioDeOrdenesDeCompra</c> directamente (design decisión 1: la contención es el producto —
+/// un DI seam acá solo invitaría a una segunda implementación, y <c>ServicioDeCompras</c> no puede
+/// depender de <c>ServicioDeOrdenesDeCompra</c> sin ciclo).
+///
+/// TRES statements como mínimo, nunca uno (design decisión 2): bajo READ COMMITTED, un
+/// <c>UPDATE ... FROM (SELECT ...)</c> que bloquea en la fila de la OC re-evalúa SOLO la fila
+/// lockeada (EvalPlanQual) cuando el ganador comitea — su subconsulta conserva el snapshot que
+/// tenía al arrancar el statement. Dos confirmaciones concurrentes de la MISMA OC proyectarían
+/// desde un libro viejo y la perdedora sobreescribiría el estado de la ganadora. El fix es el lock
+/// primero (<c>SELECT ... FOR UPDATE</c>), la derivación en un statement SEPARADO (snapshot nuevo,
+/// ve el commit del ganador) y recién después el <c>UPDATE ... RETURNING</c>.
+/// </summary>
+public static class EscriturasDeOrdenDeCompra
+{
+    private readonly record struct EstadoLockeado(string Estado, bool CierreManual);
+
+    /// <summary>Estado + <see cref="ProyectarEstadoAsync"/>/<see cref="BloquearYExigirNoAnuladaAsync"/>
+    /// comparten esta lectura crudo bajo lock — el ÚNICO <c>SELECT ... FOR UPDATE</c> de esta clase
+    /// (mutation target #18). 0 filas es un invariante roto (la FK
+    /// <c>fk_comprobantes_compra_orden_compra</c> ya garantiza que la fila existe para este
+    /// tenant): nunca un <see cref="ErrorDominio"/> — el 404 de "no existe la OC" vive aguas
+    /// arriba, en <c>ExigirOrdenLigableAsync</c>, no acá.</summary>
+    private static async Task<EstadoLockeado> BloquearYLeerAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idOrdenCompra, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT estado::text, (id_empleado_cierre IS NOT NULL) AS cierre_manual " +
+            "FROM ordenes_compra WHERE id_orden_compra = $1 AND id_tenant = $2 FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            throw new InvalidOperationException(
+                $"La orden de compra {idOrdenCompra} no existe para el tenant {idTenant} — invariante de FK roto.");
+        }
+
+        return new EstadoLockeado(lector.GetString(0), lector.GetBoolean(1));
+    }
+
+    /// <summary>Statement 2 — la derivación, en su PROPIO statement (snapshot nuevo: ve el commit
+    /// del ganador de una carrera). Agrupa por <c>id_articulo</c> en AMBOS lados (design decisión
+    /// 3, proposal decisión 2: line-to-line es imposible, un artículo puede repetirse en cualquiera
+    /// de las dos tablas) — <c>completa</c> exige que TODO artículo pedido esté cubierto;
+    /// <c>algoRecibido</c> se toma del lado RECEPCIÓN, nunca del pedido (design decisión 3/T9: una
+    /// entrega por sustitución — recibido no pedido — tiene que contar).</summary>
+    private static async Task<(bool Completa, bool AlgoRecibido)> DerivarAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idOrdenCompra, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "WITH pedido AS (" +
+            "    SELECT i.id_articulo, SUM(i.cantidad_pedida) AS pedida " +
+            "    FROM items_orden_compra i " +
+            "    WHERE i.id_orden_compra = $1 AND i.id_tenant = $2 AND i.deleted_at IS NULL " +
+            "    GROUP BY i.id_articulo), " +
+            "recibido AS (" +
+            "    SELECT ic.id_articulo, SUM(ic.cantidad) AS recibida " +
+            "    FROM items_comprobante_compra ic " +
+            "    JOIN comprobantes_compra c " +
+            "      ON c.id_comprobante_compra = ic.id_comprobante_compra AND c.id_tenant = ic.id_tenant " +
+            "    WHERE c.id_orden_compra = $1 AND c.id_tenant = $2 " +
+            "      AND c.estado = 'confirmada'::estado_compra " +
+            "      AND c.deleted_at IS NULL AND ic.deleted_at IS NULL " +
+            "    GROUP BY ic.id_articulo) " +
+            "SELECT " +
+            "    NOT EXISTS (SELECT 1 FROM pedido p " +
+            "                LEFT JOIN recibido r ON r.id_articulo = p.id_articulo " +
+            "                WHERE p.pedida > COALESCE(r.recibida, 0)) AS completa, " +
+            "    COALESCE((SELECT SUM(recibida) FROM recibido), 0) > 0 AS algo_recibido";
+
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        await lector.ReadAsync(ct);
+        return (lector.GetBoolean(0), lector.GetBoolean(1));
+    }
+
+    /// <summary>Statement 3 — la ÚNICA autoridad de transición de <c>ordenes_compra.estado</c>.
+    /// <c>fecha_cierre</c> se limpia a NULL en cualquier destino que no sea <c>cerrada</c> — la
+    /// regresión (cerrada→recibida_parcial/enviada) queda LIMPIA en el mismo statement (design
+    /// decisión 5, mutation target #28); nunca toca <c>id_empleado_cierre</c> (el cierre manual ya
+    /// cortó antes de llegar acá).</summary>
+    private static async Task<EstadoOrdenCompra> ActualizarAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idOrdenCompra, DateTimeOffset momento,
+        EstadoOrdenCompra estadoAnterior, EstadoOrdenCompra nuevoEstado, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE ordenes_compra " +
+            "SET estado = $3::estado_orden_compra, " +
+            "    fecha_cierre = CASE WHEN $3 = 'cerrada' THEN $4 ELSE NULL END, " +
+            "    updated_at = $4 " +
+            "WHERE id_orden_compra = $1 AND id_tenant = $2 AND estado = $5::estado_orden_compra " +
+            "RETURNING estado::text";
+
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, nuevoEstado);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, estadoAnterior);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException(
+                $"La proyección de la orden de compra {idOrdenCompra} no afectó ninguna fila bajo el lock ya tomado.");
+
+        return ParsearEstado((string)resultado);
+    }
+
+    /// <summary>Lock → cortocircuito → derivación → UPDATE condicional (design decisión 2). Llamada
+    /// desde AMBOS caminos de escritura (confirmar y anular) — es la ÚNICA autoridad que muta
+    /// <c>ordenes_compra.estado</c> desde el libro de recepción. Los cortocircuitos NO son una
+    /// optimización: <c>anulada</c> terminal (mutation target #27) y el cierre MANUAL nunca
+    /// revisitado (mutation target #26) son los dos hechos que el libro jamás puede pisar (design
+    /// decisión 9/5, proposal decisión 3) — expresarlos como early-return BAJO EL LOCK los hace
+    /// imposibles de esquivar, no una rama de <c>CASE</c> que alguien podría ensanchar. Saltear el
+    /// UPDATE no-op hace la idempotencia observable: una re-proyección que no cambia nada no emite
+    /// statement 3 (mutation target #19: si la derivación se pliega en un solo
+    /// <c>UPDATE ... FROM (SELECT ...)</c>, la carrera de confirm×confirm vuelve a ser posible —
+    /// ver el doc-comment de la clase).</summary>
+    public static async Task<EstadoOrdenCompra> ProyectarEstadoAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idOrdenCompra,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        var lockeado = await BloquearYLeerAsync(conexion, transaccion, idTenant, idOrdenCompra, ct);
+        var estadoActual = ParsearEstado(lockeado.Estado);
+
+        // El lock de statement 1 ya está tomado — los cortocircuitos cortan ACÁ, sin statement 2 ni
+        // 3 (mutation targets #26/#27).
+        if (estadoActual == EstadoOrdenCompra.Anulada || lockeado.CierreManual)
+        {
+            return estadoActual;
+        }
+
+        var (completa, algoRecibido) = await DerivarAsync(conexion, transaccion, idTenant, idOrdenCompra, ct);
+        var nuevoEstado = ProyectorDeEstadoDeOrden.Proyectar(estadoActual, lockeado.CierreManual, completa, algoRecibido);
+
+        if (nuevoEstado == estadoActual)
+        {
+            // Idempotencia observable: cero statements extra cuando la proyección no cambia nada.
+            return estadoActual;
+        }
+
+        return await ActualizarAsync(conexion, transaccion, idTenant, idOrdenCompra, momento, estadoActual, nuevoEstado, ct);
+    }
+
+    /// <summary>Guard de defensa en profundidad del camino de confirmación (design decisión 9,
+    /// spec ordenes-de-compra: "Anulación Is Governed By The Book... independently, confirming a
+    /// comprobante whose linked OC is anulada MUST be refused"). Toma el MISMO statement 1
+    /// (<see cref="BloquearYLeerAsync"/>, compartido — mutation target #18 aplica igual acá) y
+    /// rechaza ANTES de que <see cref="ProyectarEstadoAsync"/> corra — expuesta aparte para que
+    /// <c>EjecutarConfirmarAsync</c> no tenga que interpretar el estado devuelto, solo llamarla y
+    /// dejar que tire.</summary>
+    public static async Task<EstadoOrdenCompra> BloquearYExigirNoAnuladaAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idOrdenCompra, CancellationToken ct)
+    {
+        var lockeado = await BloquearYLeerAsync(conexion, transaccion, idTenant, idOrdenCompra, ct);
+        if (lockeado.Estado == "anulada")
+        {
+            throw new ErrorDominio("orden_compra_anulada", "La orden de compra ligada está anulada.", 409);
+        }
+
+        return ParsearEstado(lockeado.Estado);
+    }
+
+    private static EstadoOrdenCompra ParsearEstado(string estado) => estado switch
+    {
+        "borrador" => EstadoOrdenCompra.Borrador,
+        "enviada" => EstadoOrdenCompra.Enviada,
+        "recibida_parcial" => EstadoOrdenCompra.RecibidaParcial,
+        "cerrada" => EstadoOrdenCompra.Cerrada,
+        "anulada" => EstadoOrdenCompra.Anulada,
+        _ => throw new InvalidOperationException($"Estado de orden de compra desconocido: '{estado}'.")
+    };
+}

--- a/src/Ways.Application/Compras/ServicioDeCompras.cs
+++ b/src/Ways.Application/Compras/ServicioDeCompras.cs
@@ -159,6 +159,16 @@ public class ServicioDeCompras(
         var (tipo, _, _, _, porcentajePorAlicuota, margenes) = await ResolverContextoAsync(solicitud, ct);
         var (lineas, calculada) = Calcular(solicitud.Items, tipo.DiscriminaIva, porcentajePorAlicuota, margenes);
 
+        // stage-16-ordenes-de-compra, Slice 3 (design decisión 8, spec ordenes-de-compra:
+        // "Ligadura Invariant"): sin transacción propia acá (CrearBorradorAsync no abre una), así
+        // que el FOR SHARE de ExigirOrdenLigableAsync se toma y libera de inmediato — validación de
+        // coherencia, no lock TOCTOU (design: "honest residue"). La autoridad VINCULANTE contra una
+        // carrera real es el lock de posición 2 de EjecutarConfirmarAsync.
+        if (solicitud.IdOrdenCompra is { } idOrdenCompraSolicitada)
+        {
+            await ExigirOrdenLigableAsync(idOrdenCompraSolicitada, idTenant, solicitud.IdProveedor, solicitud.IdPuntoVenta, ct);
+        }
+
         var comprobante = new ComprobanteCompra
         {
             IdTenant = idTenant,
@@ -175,6 +185,7 @@ public class ServicioDeCompras(
             Total = calculada.Total,
             Observaciones = NormalizarOpcional(solicitud.Observaciones),
             Estado = EstadoCompra.Borrador,
+            IdOrdenCompra = solicitud.IdOrdenCompra,
             CreatedAt = momento,
             UpdatedAt = momento
         };
@@ -235,6 +246,15 @@ public class ServicioDeCompras(
         // tras TomarLockDelParAsync).
         var comprobante = await db.ComprobantesCompra.FirstAsync(c => c.Id == id, ct);
 
+        // stage-16-ordenes-de-compra, Slice 3 (design decisión 8): DENTRO de esta transacción — acá
+        // el FOR SHARE de ExigirOrdenLigableAsync SÍ es un guard TOCTOU real contra una anulación
+        // concurrente de la OC (la anulación toma su propio lock EXCLUSIVO como primer statement,
+        // slice 4). Unlink permitido mientras borrador (solicitud.IdOrdenCompra == null).
+        if (solicitud.IdOrdenCompra is { } idOrdenCompraSolicitada)
+        {
+            await ExigirOrdenLigableAsync(idOrdenCompraSolicitada, idTenant, solicitud.IdProveedor, solicitud.IdPuntoVenta, ct);
+        }
+
         var itemsExistentes = await db.ItemsComprobanteCompra.Where(i => i.IdComprobanteCompra == id).ToListAsync(ct);
         db.ItemsComprobanteCompra.RemoveRange(itemsExistentes);
 
@@ -244,6 +264,7 @@ public class ServicioDeCompras(
         comprobante.FechaComprobante = solicitud.FechaComprobante;
         comprobante.IdPuntoVenta = solicitud.IdPuntoVenta;
         comprobante.Observaciones = NormalizarOpcional(solicitud.Observaciones);
+        comprobante.IdOrdenCompra = solicitud.IdOrdenCompra;
         comprobante.Subtotal = calculada.Subtotal;
         comprobante.DescuentoTotal = calculada.DescuentoTotal;
         comprobante.IvaTotal = calculada.IvaTotal;
@@ -351,6 +372,21 @@ public class ServicioDeCompras(
             }
 
             throw new ErrorDominio("compra_no_es_borrador", "La compra ya no está en borrador.", 409);
+        }
+
+        // 1.b. stage-16-ordenes-de-compra, Slice 3 (design decisiones 6/9; Transactions —
+        // CONFIRMAR COMPRA): si la compra está ligada a una OC, su lock va en POSICIÓN 2 —
+        // inmediatamente después del header y ANTES de lotes/stock/proveedores (decisión 3 del
+        // design: "proveedores es el ÚLTIMO row lock", mutation target #21). Con
+        // encabezado.IdOrdenCompra IS NULL (100% del tráfico anterior a esta etapa) este bloque no
+        // emite NINGÚN statement extra (mutation target #29). BloquearYExigirNoAnuladaAsync tira
+        // 409 orden_compra_anulada ANTES de que ProyectarEstadoAsync escriba nada (decisión 9,
+        // defensa en profundidad); ProyectarEstadoAsync hace su propio lock → cortocircuito →
+        // derivación → UPDATE condicional (design decisión 2, EscriturasDeOrdenDeCompra).
+        if (encabezado.IdOrdenCompra is { } idOc)
+        {
+            await EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync(conexion, transaccionCruda, idTenant, idOc, ct);
+            await EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion, transaccionCruda, idTenant, idOc, momento, ct);
         }
 
         // 2. El read set de items queda congelado bajo el lock del header (design decisión 1).
@@ -556,6 +592,19 @@ public class ServicioDeCompras(
                 valorAnteriorCompraAnulacion, valorNuevoCompraAnulacion),
             ct);
 
+        // 1.6. stage-16-ordenes-de-compra, Slice 3 (design decisión 9; Transactions — ANULAR
+        // COMPRA): si la compra anulada estaba ligada a una OC, re-proyectar su estado — MISMA
+        // posición 2, MISMA transacción que la reversa de stock (design: "Failure semantics: any
+        // throw rolls the comprobante and the OC estado back together"). Puede REGRESAR
+        // cerrada→recibida_parcial→enviada; nunca sale de `anulada` ni de un cierre manual
+        // (cortocircuitos de EscriturasDeOrdenDeCompra.ProyectarEstadoAsync). Con
+        // encabezadoAnulado.Value.IdOrdenCompra IS NULL este bloque no emite ningún statement
+        // extra (mismo criterio que el confirm, mutation target #29).
+        if (encabezadoAnulado.Value.IdOrdenCompra is { } idOc)
+        {
+            await EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion, transaccionCruda, idTenant, idOc, momento, ct);
+        }
+
         // 2. El ledger ORIGINAL, nunca recalculado desde items (design: doc-comment de
         // ServicioDeVentas.AnularAsync, mismo criterio acá). Orden ascendente (id_articulo,
         // id_lote) — etapa 12, slice 6, mismo criterio de lock que el confirmar (decisión 8/9).
@@ -699,8 +748,14 @@ public class ServicioDeCompras(
     /// escritura del ledger de proveedor los necesita y este lock ya los tiene, así que leerlos
     /// del <c>preLectura</c> anterior o con un <c>SELECT</c> aparte sería confiar en un valor que
     /// un <c>PUT</c> concurrente pudo cambiar entre esa lectura y este lock (mutation target
-    /// #15).</summary>
-    private readonly record struct EncabezadoConfirmado(int IdPuntoVenta, int IdTipoComprobante, int IdProveedor, decimal Total);
+    /// #15).
+    ///
+    /// <see cref="IdOrdenCompra"/> ensancha el <c>RETURNING</c> otra vez (stage-16-ordenes-de-
+    /// compra, Slice 3, mismo criterio que decisión 4 de la 15 — mutation target #20): leerlo de
+    /// <c>preLectura</c> (fuera de la transacción) confiaría en un valor que un <c>PUT</c>
+    /// concurrente pudo cambiar entre esa lectura y ESTE lock.</summary>
+    private readonly record struct EncabezadoConfirmado(
+        int IdPuntoVenta, int IdTipoComprobante, int IdProveedor, decimal Total, int? IdOrdenCompra);
 
     /// <summary>El predicado incluye <c>numero_externo</c>/<c>fecha_comprobante IS NOT NULL</c>
     /// además de <c>estado='borrador'</c> — validación bajo el mismo lock, resuelta por el propio
@@ -721,7 +776,7 @@ public class ServicioDeCompras(
             "UPDATE comprobantes_compra SET estado = 'confirmada'::estado_compra, fecha_recepcion = $1, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'borrador'::estado_compra " +
             "AND numero_externo IS NOT NULL AND fecha_comprobante IS NOT NULL " +
-            "RETURNING id_punto_venta, id_tipo_comprobante, id_proveedor, total";
+            "RETURNING id_punto_venta, id_tipo_comprobante, id_proveedor, total, id_orden_compra";
 
         ParametrosDeComando.Agregar(comando, momento);
         ParametrosDeComando.Agregar(comando, id);
@@ -733,7 +788,9 @@ public class ServicioDeCompras(
             return null;
         }
 
-        return new EncabezadoConfirmado(lector.GetInt32(0), lector.GetInt32(1), lector.GetInt32(2), lector.GetDecimal(3));
+        return new EncabezadoConfirmado(
+            lector.GetInt32(0), lector.GetInt32(1), lector.GetInt32(2), lector.GetDecimal(3),
+            lector.IsDBNull(4) ? null : lector.GetInt32(4));
     }
 
     /// <summary>Fila devuelta por el UPDATE...RETURNING de <see cref="MarcarAnuladaAsync"/>.
@@ -746,7 +803,11 @@ public class ServicioDeCompras(
     /// exactamente la razón que decisión 4 da para ensanchar en primer lugar. `total` no cambia
     /// tras confirmar (spec comprobantes-compra: "confirmada... MUST be immutable"), así que este
     /// valor es tan autoritativo como cualquier otro leído bajo este lock.</summary>
-    private readonly record struct EncabezadoAnulado(int IdPuntoVenta, int IdProveedor, decimal Total);
+    /// <c>IdOrdenCompra</c> ensancha el <c>RETURNING</c> otra vez (stage-16-ordenes-de-compra,
+    /// Slice 3, mismo criterio que <c>EncabezadoConfirmado</c>): el paso 1.6 de
+    /// <c>EjecutarAnulacionAsync</c> lo necesita para el guard de proyección, y este lock ya lo
+    /// tiene.
+    private readonly record struct EncabezadoAnulado(int IdPuntoVenta, int IdProveedor, decimal Total, int? IdOrdenCompra);
 
     private static async Task<EncabezadoAnulado?> MarcarAnuladaAsync(
         DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
@@ -756,7 +817,7 @@ public class ServicioDeCompras(
         comando.CommandText =
             "UPDATE comprobantes_compra SET estado = 'anulada'::estado_compra, updated_at = $1 " +
             "WHERE id_comprobante_compra = $2 AND id_tenant = $3 AND estado = 'confirmada'::estado_compra " +
-            "RETURNING id_punto_venta, id_proveedor, total";
+            "RETURNING id_punto_venta, id_proveedor, total, id_orden_compra";
 
         ParametrosDeComando.Agregar(comando, momento);
         ParametrosDeComando.Agregar(comando, id);
@@ -768,7 +829,8 @@ public class ServicioDeCompras(
             return null;
         }
 
-        return new EncabezadoAnulado(lector.GetInt32(0), lector.GetInt32(1), lector.GetDecimal(2));
+        return new EncabezadoAnulado(
+            lector.GetInt32(0), lector.GetInt32(1), lector.GetDecimal(2), lector.IsDBNull(3) ? null : lector.GetInt32(3));
     }
 
     private static async Task<bool> BloquearBorradorAsync(
@@ -786,6 +848,74 @@ public class ServicioDeCompras(
 
         var resultado = await comando.ExecuteScalarAsync(ct);
         return resultado is not null;
+    }
+
+    /// <summary>stage-16-ordenes-de-compra, Slice 3 (design decisión 8, spec ordenes-de-compra:
+    /// "Ligadura Invariant"; spec comprobantes-compra: "A Comprobante Compra MAY Carry A Linked
+    /// Orden De Compra") — <c>SELECT ... FOR SHARE</c> crudo, MISMO shape que
+    /// <c>ServicioDeGastos.ExigirCompraLigableAsync</c> (<c>:224-267</c>): bajo la transacción de
+    /// <see cref="EjecutarActualizacionAsync"/> es un guard TOCTOU real contra una anulación
+    /// concurrente de la MISMA OC (la anulación toma su propio lock EXCLUSIVO como primer
+    /// statement, slice 4); en <see cref="CrearBorradorAsync"/> (sin transacción propia) se toma y
+    /// libera de inmediato — validación de coherencia, no lock (design: "honest residue"). La
+    /// autoridad VINCULANTE contra la carrera real es el lock de posición 2 de
+    /// <see cref="EjecutarConfirmarAsync"/> (<c>EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync</c>).
+    /// Linkable: <c>enviada</c>/<c>recibida_parcial</c>/<c>cerrada</c> (design decisión 8, conflicto
+    /// #2 de tasks.md — `state.yaml` OD8/T2 ratifica que `cerrada` SIGUE ligable: una entrega tardía
+    /// tras un cierre automático es la misma postura informativa de la derivación). Refusadas:
+    /// <c>borrador</c> (mutation target #30 no aplica acá, es el conjunto proveedor/PV) y
+    /// <c>anulada</c>.</summary>
+    private async Task ExigirOrdenLigableAsync(
+        int idOrdenCompra, int idTenant, int idProveedor, int idPuntoVenta, CancellationToken ct)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccionCruda;
+        comando.CommandText =
+            "SELECT estado::text, id_proveedor, id_punto_venta FROM ordenes_compra " +
+            "WHERE id_orden_compra = $1 AND id_tenant = $2 FOR SHARE";
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+            throw ErrorDominio.NoEncontrado($"No existe la orden de compra {idOrdenCompra}.");
+        }
+
+        var estado = lector.GetString(0);
+        var idProveedorDeLaOrden = lector.GetInt32(1);
+        var idPuntoVentaDeLaOrden = lector.GetInt32(2);
+
+        if (estado == "borrador")
+        {
+            throw new ErrorDominio(
+                "orden_compra_no_enviada", "La orden de compra ligada todavía no fue enviada.", 409);
+        }
+
+        if (estado == "anulada")
+        {
+            throw new ErrorDominio("orden_compra_anulada", "La orden de compra ligada está anulada.", 409);
+        }
+
+        // mutation target #30: cada conjunto es su propia línea — borrar cualquiera de los dos
+        // deja pasar una ligadura cruzada de proveedor o de punto de venta.
+        if (idProveedorDeLaOrden != idProveedor)
+        {
+            throw new ErrorDominio(
+                "proveedor_no_coincide_con_la_orden",
+                "El proveedor indicado no coincide con el de la orden de compra.", 400);
+        }
+
+        if (idPuntoVentaDeLaOrden != idPuntoVenta)
+        {
+            throw new ErrorDominio(
+                "punto_de_venta_no_coincide_con_la_orden",
+                "El punto de venta indicado no coincide con el de la orden de compra.", 400);
+        }
     }
 
     private static async Task InsertarMovimientoStockAsync(
@@ -1120,5 +1250,6 @@ public class ServicioDeCompras(
                 i.Orden, i.IdArticulo, i.Descripcion, i.Cantidad, i.Bultos, i.UnidadesPorBulto,
                 i.CostoUnitario, i.Descuento, i.IdAlicuotaIva, i.PorcentajeIva, i.Total, i.ActualizaCosto,
                 i.PrecioSugerido, i.CodigoLote, i.FechaVencimiento, i.IdLote))
-            .ToList());
+            .ToList(),
+        comprobante.IdOrdenCompra);
 }

--- a/tests/Ways.Application.Tests/Compras/EscriturasDeOrdenDeCompraLockOrderTests.cs
+++ b/tests/Ways.Application.Tests/Compras/EscriturasDeOrdenDeCompraLockOrderTests.cs
@@ -1,0 +1,160 @@
+namespace Ways.Application.Tests.Compras;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 3 (design decisiones 6/9; Transactions — CONFIRMAR COMPRA/
+/// ANULAR COMPRA; mutation targets #21, #29). Complementa
+/// <see cref="ServicioDeComprasLockOrderTests"/> con las dos aserciones nuevas del lock de OC:
+/// posición 2 (inmediatamente después del header, ANTES de lotes/stock/proveedores) y que la
+/// llamada está SIEMPRE detrás del null-check <c>if (encabezado.IdOrdenCompra is { } idOc)</c>.
+///
+/// Resuelto con aserción de TEXTO FUENTE, no de comportamiento — mismo criterio documentado en
+/// <c>ServicioDeComprasLockOrderTests</c>: <c>EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync</c>/
+/// <c>ProyectarEstadoAsync</c> corren sobre un <c>DbCommand</c> crudo (<c>conexion.CreateCommand()</c>),
+/// fuera del pipeline de <c>DbCommandInterceptor</c> de EF Core — verificado empíricamente por esa
+/// misma clase (mutation-proof-tests rule 2/3). Por la misma razón, la "binding gate test (a)
+/// zero-extra-statements" del design tampoco puede probarse con un contador de comandos EF
+/// (<c>ContadorDeComandos</c>, usado en otras slices, solo ve statements EMITIDOS POR EF — un
+/// <c>ContadorDeComandos</c> adjunto a un confirm sin OC ligada vería el MISMO conteo con o sin
+/// este bloque, porque sus statements son crudos y por lo tanto invisibles para el interceptor
+/// tanto si corren como si no): la prueba real de "cero statements extra" es esta aserción
+/// estructural (el bloque entero, statements incluidos, nunca corre si <c>IdOrdenCompra</c> es
+/// <c>null</c> — es un <c>if</c>, no una condición dentro del SQL) MÁS la prueba comportamental de
+/// <c>ServicioDeComprasLigaduraTests.UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente</c>
+/// (una OC hermana permanece byte-idéntica). Registrado como el mismo escape hatch que
+/// <c>mutation-proof-tests</c> regla 3 pre-autoriza en tasks.md task 3.24.
+/// </summary>
+public class EscriturasDeOrdenDeCompraLockOrderTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "Compras", "ServicioDeCompras.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
+
+    [Fact]
+    public void ElGuardDeLaOrdenDeCompraEstaEnPosicion2DeEjecutarConfirmarAsyncAntesDeLotesStockYProveedores()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente, "private async Task<CompraDetalle> EjecutarConfirmarAsync(",
+            "// ---- anular (design: Transactions");
+
+        var indiceHeaderLock = metodo.IndexOf("ConfirmarHeaderAsync(conexion, transaccionCruda, id, idTenant, momento, ct)", StringComparison.Ordinal);
+        var indiceGuardNulo = metodo.IndexOf("if (encabezado.IdOrdenCompra is { } idOc)", StringComparison.Ordinal);
+        var indiceBloquearNoAnulada = metodo.IndexOf("EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync(", StringComparison.Ordinal);
+        var indiceProyectar = metodo.IndexOf("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(", StringComparison.Ordinal);
+        var indiceItemsQuery = metodo.IndexOf("db.ItemsComprobanteCompra", StringComparison.Ordinal);
+        var indiceLotes = metodo.IndexOf("ServicioDeLotes.ResolverOCrearAsync(", StringComparison.Ordinal);
+        var indiceStock = metodo.IndexOf("InsertarMovimientoStockAsync(", StringComparison.Ordinal);
+        var indiceProveedores = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(", StringComparison.Ordinal);
+
+        Assert.True(indiceHeaderLock >= 0, "No se encontró el lock del header (ConfirmarHeaderAsync).");
+        Assert.True(indiceGuardNulo >= 0, "No se encontró el null-check guard de IdOrdenCompra.");
+        Assert.True(indiceBloquearNoAnulada >= 0, "No se encontró la llamada a BloquearYExigirNoAnuladaAsync.");
+        Assert.True(indiceProyectar >= 0, "No se encontró la llamada a ProyectarEstadoAsync.");
+        Assert.True(indiceItemsQuery >= 0, "No se encontró el read set de items (paso 2).");
+        Assert.True(indiceLotes >= 0, "No se encontró la resolución de lotes (paso 2.b).");
+        Assert.True(indiceStock >= 0, "No se encontró InsertarMovimientoStockAsync (paso 3).");
+        Assert.True(indiceProveedores >= 0, "No se encontró el lock de proveedores (paso 5).");
+
+        // El guard nulo va DESPUÉS del lock del header, y el lock/guard de la OC vive DENTRO de ese
+        // bloque — posición 2 (mutation target #21).
+        Assert.True(indiceGuardNulo > indiceHeaderLock, "El guard de la OC debe ir DESPUÉS del lock del header.");
+        Assert.True(
+            indiceBloquearNoAnulada > indiceGuardNulo && indiceBloquearNoAnulada < indiceItemsQuery,
+            "BloquearYExigirNoAnuladaAsync debe estar DENTRO del guard nulo y ANTES del read set de items.");
+        Assert.True(
+            indiceProyectar > indiceBloquearNoAnulada && indiceProyectar < indiceItemsQuery,
+            "ProyectarEstadoAsync debe correr DESPUÉS de BloquearYExigirNoAnuladaAsync y ANTES del read set de items.");
+
+        // ANTES de lotes/stock/proveedores — nunca después (mutation target #21: moverlo tras
+        // proveedores debe hacer fallar el rendezvous de confirm×confirm por deadlock).
+        Assert.True(indiceProyectar < indiceLotes, "El lock de la OC debe preceder a la resolución de lotes.");
+        Assert.True(indiceProyectar < indiceStock, "El lock de la OC debe preceder al primer InsertarMovimientoStockAsync.");
+        Assert.True(indiceProyectar < indiceProveedores, "El lock de la OC debe preceder al lock de proveedores (design decisión 3/6).");
+    }
+
+    [Fact]
+    public void LasLlamadasAEscriturasDeOrdenDeCompraEnConfirmarNuncaOcurrenFueraDelGuardNulo()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente, "private async Task<CompraDetalle> EjecutarConfirmarAsync(",
+            "// ---- anular (design: Transactions");
+
+        // mutation target #29: si el guard `if (encabezado.IdOrdenCompra is { } idOc)` se llamara
+        // incondicionalmente, esta aserción de conteo lo detecta — EL ÚNICO lugar donde
+        // "EscriturasDeOrdenDeCompra." puede aparecer en todo el método es dentro del bloque del
+        // guard. OJO: `is { } idOc` ya contiene su propio par `{ }` (el patrón "not-null") ANTES
+        // de la llave del bloque — buscar la primera `{`/`}` desde `indiceGuardNulo` encontraría
+        // ESE par, no el del bloque. Se ancla al final literal del `if (...)` para saltarlo.
+        const string guardIfConfirmar = "if (encabezado.IdOrdenCompra is { } idOc)";
+        var indiceGuardNulo = metodo.IndexOf(guardIfConfirmar, StringComparison.Ordinal);
+        Assert.True(indiceGuardNulo >= 0, "No se encontró el guard nulo.");
+        var indiceAperturaDelGuard = metodo.IndexOf('{', indiceGuardNulo + guardIfConfirmar.Length);
+        var indiceCierreDelGuard = metodo.IndexOf('}', indiceAperturaDelGuard);
+        Assert.True(indiceAperturaDelGuard > 0 && indiceCierreDelGuard > indiceAperturaDelGuard, "No se pudo delimitar el bloque del guard nulo.");
+
+        var antesDelGuard = metodo[..indiceGuardNulo];
+        var dentroDelGuard = metodo[indiceGuardNulo..(indiceCierreDelGuard + 1)];
+        var despuesDelGuard = metodo[(indiceCierreDelGuard + 1)..];
+
+        // Se busca la FORMA de LLAMADA real (con el argumento `conexion` pegado al paréntesis),
+        // no el nombre pelado de la clase — los doc-comments de esta misma clase mencionan
+        // "EscriturasDeOrdenDeCompra" en prosa (referencian el método por nombre), lo que un
+        // `DoesNotContain` sobre el prefijo pelado confundiría con una llamada real.
+        Assert.DoesNotContain("EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync(conexion", antesDelGuard, StringComparison.Ordinal);
+        Assert.DoesNotContain("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion", antesDelGuard, StringComparison.Ordinal);
+        Assert.DoesNotContain("EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync(conexion", despuesDelGuard, StringComparison.Ordinal);
+        Assert.DoesNotContain("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion", despuesDelGuard, StringComparison.Ordinal);
+        Assert.Contains("EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync(conexion", dentroDelGuard, StringComparison.Ordinal);
+        Assert.Contains("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion", dentroDelGuard, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ElGuardDeLaOrdenDeCompraEnEjecutarAnulacionAsyncVaDespuesDeLaAuditoriaYAntesDeLaReversaDeStock()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente, "private async Task<ResultadoAnulacion> EjecutarAnulacionAsync(",
+            "// ---- aplicar precio sugerido");
+
+        var indiceAuditoria = metodo.IndexOf("servicioDeAuditoriaAnulacionCompra.RegistrarAsync(", StringComparison.Ordinal);
+        var indiceGuardNulo = metodo.IndexOf("if (encabezadoAnulado.Value.IdOrdenCompra is { } idOc)", StringComparison.Ordinal);
+        var indiceProyectar = metodo.IndexOf("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(", StringComparison.Ordinal);
+        var indiceReversaDeStock = metodo.IndexOf("db.MovimientosStock", StringComparison.Ordinal);
+        var indiceProveedores = metodo.IndexOf("EscriturasDeCuentaCorrienteProveedor.ActualizarSaldoProveedorAsync(", StringComparison.Ordinal);
+
+        Assert.True(indiceAuditoria >= 0, "No se encontró el registro de auditoría.");
+        Assert.True(indiceGuardNulo >= 0, "No se encontró el null-check guard de IdOrdenCompra en anular.");
+        Assert.True(indiceProyectar >= 0, "No se encontró la llamada a ProyectarEstadoAsync en anular.");
+        Assert.True(indiceReversaDeStock >= 0, "No se encontró la reversa de stock (paso 2).");
+        Assert.True(indiceProveedores >= 0, "No se encontró el lock de proveedores (paso 6).");
+
+        Assert.True(indiceGuardNulo > indiceAuditoria, "El guard de la OC debe ir DESPUÉS de la auditoría (que no lockea nada).");
+        Assert.True(
+            indiceProyectar > indiceGuardNulo && indiceProyectar < indiceReversaDeStock,
+            "ProyectarEstadoAsync debe estar DENTRO del guard nulo y ANTES de la reversa de stock.");
+        Assert.True(indiceProyectar < indiceProveedores, "El lock de la OC debe preceder al lock de proveedores en anular.");
+
+        var antesDelGuard = metodo[..indiceGuardNulo];
+        Assert.DoesNotContain("EscriturasDeOrdenDeCompra.ProyectarEstadoAsync(conexion", antesDelGuard, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
@@ -1,7 +1,10 @@
+using System.Data.Common;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
 using Ways.Application.Compras;
 using Ways.Application.Organizacion;
@@ -13,6 +16,7 @@ using Ways.Domain.Organizacion;
 using Ways.Domain.Proveedores;
 using Ways.Domain.Usuarios;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 using Ways.Infrastructure.Seguridad;
 
 namespace Ways.IntegrationTests;
@@ -47,7 +51,7 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
 
     private sealed record Contexto(
         int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdProveedor2, int IdArticulo,
-        int IdArticulo2, int IdAlicuotaIva21, int IdTipoCFA, int IdEmpleadoAdmin);
+        int IdArticulo2, int IdAlicuotaIva21, int IdTipoCFA, int IdEmpleadoAdmin, string MailAdmin, string PasswordAdmin);
 
     /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados — cada entidad nace en
     /// su propia tabla, ninguna forzada a alinearse con otra.</summary>
@@ -114,7 +118,7 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
 
         return new Contexto(
             resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, proveedor2.Id, articulo1.Id, articulo2.Id,
-            idAlicuotaIva21, idTipoCFA, idEmpleadoAdmin);
+            idAlicuotaIva21, idTipoCFA, idEmpleadoAdmin, mailAdmin, resultado.PasswordTemporal);
     }
 
     // ---- helpers: órdenes de compra (slice 2, vía HTTP) ------------------------------------------
@@ -419,7 +423,66 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
         var anulacion = await AnularCompraHttpAsync(ctx, recepcion.Id);
         Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
 
-        Assert.Equal(EstadoOrdenCompra.Enviada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+        var final = await LeerOrdenAsync(ctx, orden.Id);
+        Assert.Equal(EstadoOrdenCompra.Enviada, final.Estado);
+        // Mutation target #28: la regresión tiene que LIMPIAR fecha_cierre en el mismo statement —
+        // dejarla vieja violaría ck_ordenes_compra_cierre ((fecha_cierre IS NULL) = (estado <>
+        // 'cerrada')).
+        Assert.Null(final.FechaCierre);
+    }
+
+    /// <summary>Mutation target #26: el cortocircuito de cierre MANUAL nunca se revierte. Sembrado
+    /// directo por EF (<c>POST /{id}/cerrar</c> es slice 4) — lo que <c>ProyectarEstadoAsync</c>
+    /// interpreta es <c>id_empleado_cierre IS NOT NULL</c> en la fila, no el camino que lo
+    /// escribió.</summary>
+    [Fact]
+    public async Task AnularUnaRecepcionDeUnaOrdenCerradaManualmenteNoLaReabre()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaRecepcionDeUnaOrdenCerradaManualmenteNoLaReabre));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 30m);
+        var recepcion = await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 10m); // parcial a propósito
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.OrdenesCompra.FirstAsync(o => o.Id == orden.Id);
+            fila.Estado = EstadoOrdenCompra.Cerrada;
+            fila.IdEmpleadoCierre = ctx.IdEmpleadoAdmin;
+            fila.FechaCierre = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync();
+        }
+
+        var anulacion = await AnularCompraHttpAsync(ctx, recepcion.Id);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var final = await LeerOrdenAsync(ctx, orden.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, final.Estado); // NUNCA se revierte
+        Assert.NotNull(final.IdEmpleadoCierre);
+    }
+
+    /// <summary>Mutation target #27: <c>anulada</c> es terminal — el camino de ANULAR (no el de
+    /// confirmar) también tiene que respetarlo. Se llega a una OC ya anulada por EF (el endpoint es
+    /// slice 4); lo importante es que <c>ProyectarEstadoAsync</c>, llamado desde
+    /// <c>EjecutarAnulacionAsync</c>, nunca la resucite.</summary>
+    [Fact]
+    public async Task AnularUnaRecepcionLigadaAUnaOrdenYaAnuladaNoLaResucita()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaRecepcionLigadaAUnaOrdenYaAnuladaNoLaResucita));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 30m);
+        var recepcion = await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 10m);
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.OrdenesCompra.FirstAsync(o => o.Id == orden.Id);
+            fila.Estado = EstadoOrdenCompra.Anulada;
+            await db.SaveChangesAsync();
+        }
+
+        var anulacion = await AnularCompraHttpAsync(ctx, recepcion.Id);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        Assert.Equal(EstadoOrdenCompra.Anulada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
     }
 
     // ================================================================================================
@@ -634,6 +697,78 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
         var hermanaDespues = await LeerOrdenAsync(ctx, hermana.Id);
         Assert.Equal(hermanaAntes.Estado, hermanaDespues.Estado);
         Assert.Equal(hermanaAntes.UpdatedAt, hermanaDespues.UpdatedAt); // ni un statement la tocó
+    }
+
+    // ================================================================================================
+    // task 3.27 / mutation target #20: id_orden_compra tiene que venir del RETURNING del lock, nunca
+    // de preLectura — una carrera de relink concurrente lo hace discriminante.
+    // ================================================================================================
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target #20: si <c>encabezado.IdOrdenCompra</c> se leyera de
+    /// <c>preLectura</c> (capturada ANTES de la transacción) en vez del <c>RETURNING</c> ensanchado
+    /// de <c>ConfirmarHeaderAsync</c>, esta prueba lo detecta. Pausa <c>EjecutarConfirmarAsync</c>
+    /// justo tras <c>BeginTransactionAsync</c> (mismo patrón que
+    /// <c>ServicioDeOrdenesDeCompraTests.InterceptorDePausaTrasIniciarLaTransaccion</c>); mientras
+    /// está pausado, un <c>PUT</c> concurrente relinkea el borrador de OC-A a OC-B y COMMITEA. Con
+    /// el valor correcto (leído bajo el lock), la proyección opera sobre OC-B; con el mutante,
+    /// operaría sobre la OC-A stale de <c>preLectura</c> — discriminado por cuál OC efectivamente
+    /// se mueve.</summary>
+    [Fact]
+    public async Task ConfirmarUsaElIdOrdenCompraVistoBajoElLockNoElDePreLectura()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUsaElIdOrdenCompraVistoBajoElLockNoElDePreLectura));
+        var ordenA = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+        var ordenB = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+
+        var (_, creada, _) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idArticulo: ctx.IdArticulo, idOrdenCompra: ordenA.Id));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteConfirmar = factory.CreateClient();
+        var login = await clienteConfirmar.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaConfirmar = clienteConfirmar.PostAsync($"/api/compras/{creada!.Id}/confirmar", null);
+
+        await transaccionIniciada.Task;
+
+        var solicitudRelink = SolicitudDeCompraSimple(ctx, unidades: 10m, idArticulo: ctx.IdArticulo, idOrdenCompra: ordenB.Id);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/compras/{creada.Id}", solicitudRelink);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+
+        // La OC efectivamente movida es OC-B (los 10 recibidos cubren sus 10 pedidos ⇒ cierre
+        // automático): si el código leyera preLectura en vez del RETURNING bajo lock, la
+        // proyección operaría sobre OC-A en su lugar, y esta aserción fallaría.
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, ordenB.Id));
+        Assert.Equal(EstadoOrdenCompra.Enviada, await LeerEstadoDeOrdenAsync(ctx, ordenA.Id));
     }
 
     // ================================================================================================

--- a/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
@@ -511,6 +511,31 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
         Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
     }
 
+    /// <summary>Mutation target #24, versión DISCRIMINANTE: 3+4=7 pedidos, se reciben 5 — mayor
+    /// que CUALQUIER línea individual (3 y 4) pero MENOR que la suma agrupada (7). Si el <c>GROUP
+    /// BY</c> del lado pedido matcheara línea a línea en vez de por artículo, cada línea
+    /// individual (3 y 4) leería "cubierta" contra 5 recibidos y la orden cerraría de más — el
+    /// agrupado correcto exige comparar contra la SUMA (7 &gt; 5, sigue pendiente).</summary>
+    [Fact]
+    public async Task DosLineasDelMismoArticuloComparanContraLaSumaNoContraCadaLineaIndividual()
+    {
+        var ctx = await PrepararAsync(nameof(DosLineasDelMismoArticuloComparanContraLaSumaNoContraCadaLineaIndividual));
+
+        var creadaOrden = await CrearBorradorDeOrdenAsync(
+            ctx,
+            new SolicitudDeOrdenDeCompra(
+                ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+                [
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea A", 3m, 100m),
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea B", 4m, 100m)
+                ]));
+        var orden = await EnviarOrdenAsync(ctx, creadaOrden.Id);
+
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 5m);
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
     /// <summary>Mutation target #25: <c>algoRecibido</c> tiene que salir del lado RECEPCIÓN. Un
     /// artículo NUNCA pedido, recibido por sustitución, no cubre lo pedido (sigue
     /// <c>recibida_parcial</c>, nunca <c>enviada</c>) — si <c>algoRecibido</c> se derivara (mal) del

--- a/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
@@ -1,0 +1,651 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 3 (tasks 3.12-3.38; design: Transactions — CONFIRMAR
+/// COMPRA/ANULAR COMPRA; decisiones 1, 2, 3, 5, 8, 9). La ligadura OC↔comprobante +
+/// <c>EscriturasDeOrdenDeCompra.ProyectarEstadoAsync</c>/<c>BloquearYExigirNoAnuladaAsync</c>
+/// llamadas desde <c>ServicioDeCompras.EjecutarConfirmarAsync</c>/<c>EjecutarAnulacionAsync</c>.
+///
+/// DEVIATION registrada (decisión 15 de tasks.md): la mitad "anular OC × confirmar reception" del
+/// binding gate test (c) (task 3.22) NO puede implementarse en esta slice — <c>POST
+/// /api/ordenes-compra/{id}/anular</c> y <c>ServicioDeOrdenesDeCompra.AnularAsync</c> son tareas de
+/// la SLICE 4 (tasks.md, Slice 4, task 4.2/4.3); no existe ningún camino de escritura de anulación
+/// de OC en el árbol de esta slice para correr esa carrera. La mitad "confirm × confirm" SÍ se
+/// implementa acá (es la prueba central de decisión 2: dos statements separados bajo
+/// <c>READ COMMITTED</c>). Los escenarios que necesitan una OC ya <c>anulada</c> (tasks 3.15, 3.19)
+/// se siembran directo por EF — el estado de la fila, no el camino que la produjo, es lo que
+/// <c>ExigirOrdenLigableAsync</c>/<c>BloquearYExigirNoAnuladaAsync</c> interpretan.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, int IdProveedor, int IdProveedor2, int IdArticulo,
+        int IdArticulo2, int IdAlicuotaIva21, int IdTipoCFA, int IdEmpleadoAdmin);
+
+    /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados — cada entidad nace en
+    /// su propia tabla, ninguna forzada a alinearse con otra.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Ligadura-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var proveedor2 = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"{nombre}-otro", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.AddRange(proveedor, proveedor2);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-lig-1-{Guid.NewGuid():N}", Nombre = "Ligadura Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-lig-2-{Guid.NewGuid():N}", Nombre = "Ligadura Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+        var idEmpleadoAdmin = await db.Usuarios.Where(u => u.Mail == mailAdmin).Select(u => u.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, proveedor.Id, proveedor2.Id, articulo1.Id, articulo2.Id,
+            idAlicuotaIva21, idTipoCFA, idEmpleadoAdmin);
+    }
+
+    // ---- helpers: órdenes de compra (slice 2, vía HTTP) ------------------------------------------
+
+    private static SolicitudDeOrdenDeCompra SolicitudDeOrdenSimple(
+        Contexto ctx, decimal cantidad = 10m, decimal? costo = 100m, int? idArticulo = null, int? idProveedor = null) =>
+        new(
+            idProveedor ?? ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+            [new LineaDeOrdenSolicitada(idArticulo ?? ctx.IdArticulo, "Item de orden", cantidad, costo)]);
+
+    private static async Task<OrdenDeCompraBorrador> CrearBorradorDeOrdenAsync(Contexto ctx, SolicitudDeOrdenDeCompra solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ordenes-compra", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> EnviarOrdenAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/ordenes-compra/{id}/enviar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> CrearYEnviarOrdenAsync(
+        Contexto ctx, decimal cantidad = 10m, decimal? costo = 100m, int? idArticulo = null, int? idProveedor = null)
+    {
+        var creada = await CrearBorradorDeOrdenAsync(ctx, SolicitudDeOrdenSimple(ctx, cantidad, costo, idArticulo, idProveedor));
+        return await EnviarOrdenAsync(ctx, creada.Id);
+    }
+
+    /// <summary>Siembra directa por EF — el único camino disponible en esta slice para una OC
+    /// <c>anulada</c> (<c>POST /{id}/anular</c> es slice 4, ver el doc-comment de la clase). El
+    /// estado de la fila es lo que el guard interpreta, no el camino que la produjo.</summary>
+    private async Task<int> SembrarOrdenAnuladaAsync(Contexto ctx)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var orden = new OrdenCompra
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdProveedor = ctx.IdProveedor,
+            IdEmpleado = ctx.IdEmpleadoAdmin, Numero = 999, FechaEmision = ahora, FechaEnvio = ahora,
+            Estado = EstadoOrdenCompra.Anulada, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.OrdenesCompra.Add(orden);
+        await db.SaveChangesAsync();
+        return orden.Id;
+    }
+
+    // ---- helpers: comprobantes de compra (slices 1-2, ya existentes; el link es esta slice) ------
+
+    private static SolicitudDeCompra SolicitudDeCompraSimple(
+        Contexto ctx, decimal unidades = 10m, decimal costoUnitario = 100m, int? idArticulo = null,
+        int? idOrdenCompra = null, string? numeroExterno = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, numeroExterno ?? $"0001-{Guid.NewGuid():N}"[..8], DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(idArticulo ?? ctx.IdArticulo, "Item de recepción", unidades, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, false)],
+            idOrdenCompra);
+
+    private static async Task<(HttpStatusCode Estado, CompraDetalle? Compra, JsonElement? Problema)> CrearBorradorDeCompraAsync(
+        Contexto ctx, SolicitudDeCompra solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud);
+        if (respuesta.StatusCode != HttpStatusCode.Created)
+        {
+            return (respuesta.StatusCode, null, await respuesta.Content.ReadFromJsonAsync<JsonElement>());
+        }
+
+        return (respuesta.StatusCode, await respuesta.Content.ReadFromJsonAsync<CompraDetalle>(OpcionesJson), null);
+    }
+
+    private static async Task<HttpResponseMessage> ConfirmarCompraHttpAsync(Contexto ctx, int id) =>
+        await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+
+    private static async Task<CompraDetalle> ConfirmarCompraAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ConfirmarCompraHttpAsync(ctx, id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<HttpResponseMessage> AnularCompraHttpAsync(Contexto ctx, int id) =>
+        await ctx.Admin.PostAsync($"/api/compras/{id}/anular", null);
+
+    /// <summary>Crea + confirma una recepción ligada a <paramref name="idOrdenCompra"/> en un solo
+    /// paso — la forma que casi todos los tests de proyección necesitan.</summary>
+    private static async Task<CompraDetalle> CrearYConfirmarRecepcionAsync(
+        Contexto ctx, int idOrdenCompra, decimal unidades, int? idArticulo = null)
+    {
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades, idArticulo: idArticulo, idOrdenCompra: idOrdenCompra));
+        Assert.True(estado == HttpStatusCode.Created, problema?.ToString() ?? estado.ToString());
+        return await ConfirmarCompraAsync(ctx, creada!.Id);
+    }
+
+    private async Task<EstadoOrdenCompra> LeerEstadoDeOrdenAsync(Contexto ctx, int idOrdenCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return (await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == idOrdenCompra)).Estado;
+    }
+
+    private async Task<OrdenCompra> LeerOrdenAsync(Contexto ctx, int idOrdenCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == idOrdenCompra);
+    }
+
+    // ================================================================================================
+    // task 3.13-3.16: ligadura happy/blocked paths + state-gating + freeze + round-trip
+    // ================================================================================================
+
+    [Fact]
+    public async Task UnBorradorLigaAUnaOrdenEnviadaYPersiste()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorLigaAUnaOrdenEnviadaYPersiste));
+        var orden = await CrearYEnviarOrdenAsync(ctx);
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id));
+        Assert.True(estado == HttpStatusCode.Created, problema?.ToString());
+        Assert.Equal(orden.Id, creada!.IdOrdenCompra);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var persistido = await db.ComprobantesCompra.AsNoTracking().FirstAsync(c => c.Id == creada.Id);
+        Assert.Equal(orden.Id, persistido.IdOrdenCompra);
+    }
+
+    [Fact]
+    public async Task UnProveedorNoCoincidenteNoPuedeLigar()
+    {
+        var ctx = await PrepararAsync(nameof(UnProveedorNoCoincidenteNoPuedeLigar));
+        var orden = await CrearYEnviarOrdenAsync(ctx); // dueña de ctx.IdProveedor
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx,
+            SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id) with { IdProveedor = ctx.IdProveedor2 });
+
+        Assert.Equal(HttpStatusCode.BadRequest, estado);
+        Assert.Null(creada);
+        Assert.Equal("proveedor_no_coincide_con_la_orden", problema!.Value.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesCompra.CountAsync());
+    }
+
+    [Fact]
+    public async Task UnPuntoDeVentaNoCoincidenteNoPuedeLigar()
+    {
+        var ctx = await PrepararAsync(nameof(UnPuntoDeVentaNoCoincidenteNoPuedeLigar));
+        var orden = await CrearYEnviarOrdenAsync(ctx);
+
+        // Segundo PV de la misma empresa — la fila de la OC quedó en ctx.IdPuntoVenta.
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var idEmpresa = await db.PuntosVenta.Where(pv => pv.Id == ctx.IdPuntoVenta).Select(pv => pv.IdEmpresa).FirstAsync();
+        var ahora = DateTimeOffset.UtcNow;
+        var pv2 = new PuntoVenta { IdTenant = ctx.IdTenant, IdEmpresa = idEmpresa, Nombre = "PV2", CreatedAt = ahora, UpdatedAt = ahora };
+        db.PuntosVenta.Add(pv2);
+        await db.SaveChangesAsync();
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx,
+            SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id) with { IdPuntoVenta = pv2.Id });
+
+        Assert.Equal(HttpStatusCode.BadRequest, estado);
+        Assert.Null(creada);
+        Assert.Equal("punto_de_venta_no_coincide_con_la_orden", problema!.Value.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task LigarAUnaOrdenBorradorEsRechazada409()
+    {
+        var ctx = await PrepararAsync(nameof(LigarAUnaOrdenBorradorEsRechazada409));
+        var borrador = await CrearBorradorDeOrdenAsync(ctx, SolicitudDeOrdenSimple(ctx)); // nunca enviada
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: borrador.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, estado);
+        Assert.Null(creada);
+        Assert.Equal("orden_compra_no_enviada", problema!.Value.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task LigarAUnaOrdenAnuladaEsRechazada409()
+    {
+        var ctx = await PrepararAsync(nameof(LigarAUnaOrdenAnuladaEsRechazada409));
+        var idOrdenAnulada = await SembrarOrdenAnuladaAsync(ctx);
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: idOrdenAnulada));
+
+        Assert.Equal(HttpStatusCode.Conflict, estado);
+        Assert.Null(creada);
+        Assert.Equal("orden_compra_anulada", problema!.Value.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task LigarAUnaOrdenCerradaEsPermitido()
+    {
+        var ctx = await PrepararAsync(nameof(LigarAUnaOrdenCerradaEsPermitido));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 5m);
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 5m); // cubre todo -> cierre automático
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+
+        var (estado, creada, problema) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id));
+
+        Assert.True(estado == HttpStatusCode.Created, problema?.ToString());
+        Assert.Equal(orden.Id, creada!.IdOrdenCompra);
+    }
+
+    [Fact]
+    public async Task ElLinkSeCongelaAlConfirmarYCompraDetalleHaceRoundTrip()
+    {
+        var ctx = await PrepararAsync(nameof(ElLinkSeCongelaAlConfirmarYCompraDetalleHaceRoundTrip));
+        var orden = await CrearYEnviarOrdenAsync(ctx);
+
+        var (_, creada, _) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id));
+        Assert.Equal(orden.Id, creada!.IdOrdenCompra);
+
+        var confirmada = await ConfirmarCompraAsync(ctx, creada.Id);
+        Assert.Equal(orden.Id, confirmada.IdOrdenCompra); // round-trip exacto (conflicto #4, dto-contract-honesty)
+
+        // Congelado: ningún endpoint permite editar una compra que ya no es borrador.
+        var intentoDeEdicion = await ctx.Admin.PutAsJsonAsync(
+            $"/api/compras/{creada.Id}", SolicitudDeCompraSimple(ctx, idOrdenCompra: null));
+        Assert.Equal(HttpStatusCode.Conflict, intentoDeEdicion.StatusCode);
+    }
+
+    // ================================================================================================
+    // task 3.17-3.20: los escenarios de proyección del propio spec
+    // ================================================================================================
+
+    [Fact]
+    public async Task ConfirmarUnaRecepcionLigadaMueveLaOrdenARecibidaParcial()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUnaRecepcionLigadaMueveLaOrdenARecibidaParcial));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 100m);
+
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 40m);
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    [Fact]
+    public async Task ConfirmarElRemanenteCierraLaOrdenAutomaticamente()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarElRemanenteCierraLaOrdenAutomaticamente));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 100m);
+
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 40m);
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 60m);
+
+        var final = await LeerOrdenAsync(ctx, orden.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, final.Estado);
+        Assert.Null(final.IdEmpleadoCierre);
+        Assert.NotNull(final.FechaCierre);
+    }
+
+    [Fact]
+    public async Task ConfirmarContraUnaOrdenAnuladaEsRechazada409SinEscribirNada()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarContraUnaOrdenAnuladaEsRechazada409SinEscribirNada));
+        var idOrdenAnulada = await SembrarOrdenAnuladaAsync(ctx);
+
+        // El link en sí se rechaza al crear el borrador (LigarAUnaOrdenAnuladaEsRechazada409) —
+        // para llegar al guard de CONFIRMAR hace falta que la orden se anule DESPUÉS de que el
+        // borrador ya está ligado: se liga a una orden viva, se anula por EF, y recién ahí se
+        // confirma.
+        var orden = await CrearYEnviarOrdenAsync(ctx);
+        var (_, creada, _) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: orden.Id));
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.OrdenesCompra.FirstAsync(o => o.Id == orden.Id);
+            fila.Estado = EstadoOrdenCompra.Anulada;
+            await db.SaveChangesAsync();
+        }
+
+        var respuesta = await ConfirmarCompraHttpAsync(ctx, creada!.Id);
+        var cuerpo = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        Assert.Equal("orden_compra_anulada", cuerpo.GetProperty("codigo").GetString());
+
+        await using var dbVerif = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var compraTrasElIntento = await dbVerif.ComprobantesCompra.AsNoTracking().FirstAsync(c => c.Id == creada.Id);
+        Assert.Equal(EstadoCompra.Borrador, compraTrasElIntento.Estado); // no write: sigue borrador
+        Assert.Equal(0, await dbVerif.MovimientosStock.CountAsync(m => m.IdComprobanteCompra == creada.Id));
+    }
+
+    [Fact]
+    public async Task AnularLaUnicaRecepcionDeUnaOrdenCerradaAutomaticamenteLaDevuelveAEnviada()
+    {
+        var ctx = await PrepararAsync(nameof(AnularLaUnicaRecepcionDeUnaOrdenCerradaAutomaticamenteLaDevuelveAEnviada));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 30m);
+        var recepcion = await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 30m);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+
+        var anulacion = await AnularCompraHttpAsync(ctx, recepcion.Id);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        Assert.Equal(EstadoOrdenCompra.Enviada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    // ================================================================================================
+    // task 3.21: fidelidad de la derivación (rule 11 — cantidades/fixtures discriminantes)
+    // ================================================================================================
+
+    [Fact]
+    public async Task DosLineasDelMismoArticuloSeAgrupanYUnaSobreEntregaNoBloqueaNiErrorea()
+    {
+        var ctx = await PrepararAsync(nameof(DosLineasDelMismoArticuloSeAgrupanYUnaSobreEntregaNoBloqueaNiErrorea));
+
+        // Server-asigna `orden` 1/2 dentro del mismo replace-set: dos líneas de UN artículo, 3+4=7.
+        var creadaOrden = await CrearBorradorDeOrdenAsync(
+            ctx,
+            new SolicitudDeOrdenDeCompra(
+                ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+                [
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea A", 3m, 100m),
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea B", 4m, 100m)
+                ]));
+        var orden = await EnviarOrdenAsync(ctx, creadaOrden.Id);
+
+        // Una recepción de 8 unidades — sobre-entrega contra las 7 pedidas (grupo por artículo).
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 8m);
+
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    /// <summary>Mutation target #25: <c>algoRecibido</c> tiene que salir del lado RECEPCIÓN. Un
+    /// artículo NUNCA pedido, recibido por sustitución, no cubre lo pedido (sigue
+    /// <c>recibida_parcial</c>, nunca <c>enviada</c>) — si <c>algoRecibido</c> se derivara (mal) del
+    /// lado pedido, este fixture leería 0 recibido y la orden quedaría stale en <c>enviada</c>.</summary>
+    [Fact]
+    public async Task UnaEntregaPorSustitucionNuncaPedidaMuevaAOrdenARecibidaParcial()
+    {
+        var ctx = await PrepararAsync(nameof(UnaEntregaPorSustitucionNuncaPedidaMuevaAOrdenARecibidaParcial));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+
+        // La recepción trae el OTRO artículo — nada del pedido original llega.
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 5m, idArticulo: ctx.IdArticulo2);
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    /// <summary>Mutation target #22: solo comprobantes <c>confirmada</c> cuentan. Un borrador
+    /// ligado con cantidad suficiente para cubrir todo el pedido NO debe cerrarlo — la orden se
+    /// mantiene <c>recibida_parcial</c> tras una recepción chica de OTRO artículo (que solo sirve
+    /// para disparar una re-proyección observable).</summary>
+    [Fact]
+    public async Task UnaRecepcionEnBorradorLigadaNoCuentaParaLaDerivacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnaRecepcionEnBorradorLigadaNoCuentaParaLaDerivacion));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+
+        // Ligada, pero JAMÁS confirmada.
+        await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idOrdenCompra: orden.Id));
+
+        // Dispara una re-proyección real con una recepción chica de otro artículo.
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 1m, idArticulo: ctx.IdArticulo2);
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    /// <summary>Mutation target #23: filas con <c>deleted_at</c> (en cualquiera de las dos tablas
+    /// del join) se excluyen de la derivación. Cierra automático con la primera recepción; tras
+    /// soft-deletar su item, una segunda recepción (de otro artículo, para re-disparar la
+    /// proyección) debe REGRESAR la orden a <c>recibida_parcial</c> — probando que la cantidad
+    /// soft-deleteada dejó de contar.</summary>
+    [Fact]
+    public async Task UnItemDeRecepcionSoftDeleteadoDejaDeContarEnLaDerivacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnItemDeRecepcionSoftDeleteadoDejaDeContarEnLaDerivacion));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+
+        var recepcion = await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 10m, idArticulo: ctx.IdArticulo);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var item = await db.ItemsComprobanteCompra.FirstAsync(i => i.IdComprobanteCompra == recepcion.Id);
+            item.DeletedAt = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync();
+        }
+
+        // Re-dispara la proyección con una recepción chica de otro artículo.
+        await CrearYConfirmarRecepcionAsync(ctx, orden.Id, unidades: 1m, idArticulo: ctx.IdArticulo2);
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    /// <summary>Regla 12c aplicada a la derivación: una recepción de OTRA orden del MISMO proveedor
+    /// no debe filtrarse hacia esta — cada OC solo ve su propio libro.</summary>
+    [Fact]
+    public async Task UnaRecepcionDeOtraOrdenDelMismoProveedorNoCuenta()
+    {
+        var ctx = await PrepararAsync(nameof(UnaRecepcionDeOtraOrdenDelMismoProveedorNoCuenta));
+        var ordenA = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+        var ordenB = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m, idArticulo: ctx.IdArticulo);
+
+        await CrearYConfirmarRecepcionAsync(ctx, ordenB.Id, unidades: 10m, idArticulo: ctx.IdArticulo);
+
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, ordenB.Id));
+        Assert.Equal(EstadoOrdenCompra.Enviada, await LeerEstadoDeOrdenAsync(ctx, ordenA.Id)); // intacta
+    }
+
+    // ================================================================================================
+    // task 3.22: la carrera confirm × confirm de dos recepciones de UNA orden (binding gate test c)
+    // ================================================================================================
+
+    [Fact]
+    public async Task DosConfirmacionesConcurrentesDeDosRecepcionesDeUnaOrdenNuncaSeSobreescriben()
+    {
+        var ctx = await PrepararAsync(nameof(DosConfirmacionesConcurrentesDeDosRecepcionesDeUnaOrdenNuncaSeSobreescriben));
+        var orden = await CrearBorradorDeOrdenAsync(
+            ctx,
+            new SolicitudDeOrdenDeCompra(
+                ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+                [
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea A", 10m, 100m),
+                    new LineaDeOrdenSolicitada(ctx.IdArticulo2, "Linea B", 10m, 100m)
+                ]));
+        var enviada = await EnviarOrdenAsync(ctx, orden.Id);
+
+        var (_, compraA, _) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idArticulo: ctx.IdArticulo, idOrdenCompra: enviada.Id));
+        var (_, compraB, _) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idArticulo: ctx.IdArticulo2, idOrdenCompra: enviada.Id));
+
+        var tareaA = ConfirmarCompraHttpAsync(ctx, compraA!.Id);
+        var tareaB = ConfirmarCompraHttpAsync(ctx, compraB!.Id);
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        foreach (var respuesta in respuestas)
+        {
+            var cuerpo = await respuesta.Content.ReadAsStringAsync();
+            Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        }
+
+        // Ambas confirmaciones cubren TODO lo pedido (10+10 de dos artículos distintos) — el
+        // resultado tiene que ser la SUMA de las dos, nunca solo una (design: Concurrency
+        // guarantees, "never only one of them"). Si el lock/derivación de statement 1/2 fallaran,
+        // una de las dos pisaría a la otra y la orden quedaría en recibida_parcial en vez de cerrada.
+        Assert.Equal(EstadoOrdenCompra.Cerrada, await LeerEstadoDeOrdenAsync(ctx, enviada.Id));
+    }
+
+    // ================================================================================================
+    // task 3.23: fault-point — una falla DESPUÉS de la proyección deja la orden intacta
+    // ================================================================================================
+
+    [Fact]
+    public async Task UnaFallaDespuesDeLaProyeccionEnConfirmarDejaLaOrdenSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(UnaFallaDespuesDeLaProyeccionEnConfirmarDejaLaOrdenSinCambios));
+        var orden = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+
+        // Artículo con control de lote efectivo (controla_lote AND lotes_habilitado) — una línea
+        // SIN codigo_lote/fecha_vencimiento pasa la validación de borrador (ValidarVencimientosDe
+        // Recepcion solo rechaza un codigo sin fecha, o una fecha pasada; ninguno de los dos aplica
+        // acá) pero dispara `lote_requerido` (400) en el paso 2.b de EjecutarConfirmarAsync —
+        // DESPUÉS de que el paso 1.b (proyección de la OC, cantidad real, transición real
+        // enviada→recibida_parcial) ya corrió sus tres statements DENTRO de la misma transacción.
+        // El rollback tiene que deshacer también esa proyección ya ejecutada.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var articulo = await db.Articulos.FirstAsync(a => a.Id == ctx.IdArticulo);
+            articulo.ControlaLote = true;
+            var idEmpresa = await db.PuntosVenta.Where(pv => pv.Id == ctx.IdPuntoVenta).Select(pv => pv.IdEmpresa).FirstAsync();
+            db.Parametros.Add(new Parametro
+            {
+                IdTenant = ctx.IdTenant, IdEmpresa = idEmpresa, IdPuntoVenta = null,
+                Clave = "lotes_habilitado", Valor = "true", CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var solicitud = new SolicitudDeCompra(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, "0001-99999999", DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(ctx.IdArticulo, "Item sin lote", 10m, null, null, 100m, 0m, ctx.IdAlicuotaIva21, false)],
+            orden.Id);
+
+        var (estadoCreacion, creada, _) = await CrearBorradorDeCompraAsync(ctx, solicitud);
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var respuesta = await ConfirmarCompraHttpAsync(ctx, creada!.Id);
+        var cuerpoFalla = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.BadRequest, cuerpoFalla.ToString());
+        Assert.Equal("lote_requerido", cuerpoFalla.GetProperty("codigo").GetString());
+
+        // La orden nunca se movió de `enviada` — el rollback deshizo la proyección junto con todo
+        // lo demás, aunque el UPDATE de 1.b ya había corrido dentro de la transacción abortada.
+        Assert.Equal(EstadoOrdenCompra.Enviada, await LeerEstadoDeOrdenAsync(ctx, orden.Id));
+    }
+
+    // ================================================================================================
+    // task 3.12: binding gate test (a) — zero-extra-statements (proxy comportamental, ver
+    // EscriturasDeOrdenDeCompraLockOrderTests para la prueba de texto fuente complementaria)
+    // ================================================================================================
+
+    [Fact]
+    public async Task UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente()
+    {
+        var ctx = await PrepararAsync(nameof(UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente));
+
+        // Regla 12c: una OC hermana, completamente ajena a la compra que se va a confirmar.
+        var hermana = await CrearYEnviarOrdenAsync(ctx);
+        var hermanaAntes = await LeerOrdenAsync(ctx, hermana.Id);
+
+        var (_, creada, _) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: null));
+        Assert.Null(creada!.IdOrdenCompra);
+        await ConfirmarCompraAsync(ctx, creada.Id);
+
+        var hermanaDespues = await LeerOrdenAsync(ctx, hermana.Id);
+        Assert.Equal(hermanaAntes.Estado, hermanaDespues.Estado);
+        Assert.Equal(hermanaAntes.UpdatedAt, hermanaDespues.UpdatedAt); // ni un statement la tocó
+    }
+
+    // ================================================================================================
+    // task 3.38: FK 9 (fk_comprobantes_compra_orden_compra) client-reachable — backstop genérico
+    // ================================================================================================
+
+    [Fact]
+    public async Task LigarAUnaOrdenInexistenteEsRechazadaComo404()
+    {
+        var ctx = await PrepararAsync(nameof(LigarAUnaOrdenInexistenteEsRechazadaComo404));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", SolicitudDeCompraSimple(ctx, idOrdenCompra: 999_999_999));
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeComprasLigaduraTests.cs
@@ -703,7 +703,21 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
 
     // ================================================================================================
     // task 3.12: binding gate test (a) — zero-extra-statements (proxy comportamental, ver
-    // EscriturasDeOrdenDeCompraLockOrderTests para la prueba de texto fuente complementaria)
+    // EscriturasDeOrdenDeCompraLockOrderTests para la prueba de texto fuente complementaria).
+    //
+    // Judgment-day (ronda 2, hallazgo WARNING del juez B, decisión 21 de tasks.md): el criterio
+    // cero-statements-extra tiene DOS redes, ninguna sola alcanza. (1) El guard estructural de
+    // EscriturasDeOrdenDeCompraLockOrderTests caza el mutante LITERAL (llamada incondicional con
+    // `?? 0`) — pero ese mutante NUNCA llega a los asserts byte-idénticos de acá abajo: revienta
+    // antes con un 500 (invariante de FK roto en BloquearYLeerAsync, "orden 0 no existe"), y
+    // ConfirmarCompraAsync ya falla por el StatusCode != OK. (2) Los asserts byte-idénticos de
+    // esta prueba cazan el mutante REALISTA — uno que resuelve la OC "por coincidencia"
+    // (proveedor + PV del encabezado) en vez del FK real y encuentra una fila legítima — algo que
+    // el guard estructural, por definición, no puede ver (no hay texto fuente que lo delate: la
+    // llamada SÍ tiene un argumento válido). Verificado por mutación real: con la hermana en el
+    // MISMO proveedor/PV que "creada" pero SIN el landmine de abajo, ese mutante pasa la prueba
+    // en silencio (ProyectarEstadoAsync sobre la hermana es un no-op idempotente — nada que
+    // comparar). El landmine lo convierte en observable.
     // ================================================================================================
 
     [Fact]
@@ -711,8 +725,46 @@ public class ServicioDeComprasLigaduraTests(WaysApiFixture fixture) : IClassFixt
     {
         var ctx = await PrepararAsync(nameof(UnConfirmSinOrdenLigadaNoTocaNingunaOrdenDeCompraExistente));
 
-        // Regla 12c: una OC hermana, completamente ajena a la compra que se va a confirmar.
+        // Regla 12c: una OC hermana, completamente ajena a la compra que se va a confirmar — del
+        // MISMO proveedor y MISMO PV que "creada" (default de CrearYEnviarOrdenAsync/
+        // SolicitudDeCompraSimple, ambos ctx.IdProveedor/ctx.IdPuntoVenta). A propósito: es lo que
+        // hace que el mutante "por coincidencia" (proveedor/PV) encuentre justo esta fila en vez
+        // de ninguna.
         var hermana = await CrearYEnviarOrdenAsync(ctx);
+
+        // Landmine: una recepción YA confirmada, ligada a la hermana por FK REAL, sembrada directo
+        // por EF — bypass total de ServicioDeCompras/EscriturasDeOrdenDeCompra (el único camino
+        // para dejar ordenes_compra.estado deliberadamente stale respecto de lo que una
+        // re-derivación en vivo calcularía; mismo criterio que SembrarOrdenAnuladaAsync: el estado
+        // de la fila es lo que importa, no el camino que lo produjo). Cubre exactamente la
+        // cantidad pedida (10) → una re-derivación en vivo vería completa=true y CERRARÍA la
+        // hermana. Bajo la producción correcta (id_orden_compra de "creada" es NULL → el bloque
+        // 1.b entero saltea, mutation target #29) esa re-derivación JAMÁS corre — la hermana se
+        // queda 'enviada' tal cual, stale, para siempre en este test.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var ahora = DateTimeOffset.UtcNow;
+            var comprobante = new ComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdProveedor = ctx.IdProveedor, IdTipoComprobante = ctx.IdTipoCFA,
+                NumeroExterno = $"0001-{Guid.NewGuid():N}"[..8], FechaComprobante = DateOnly.FromDateTime(DateTime.UtcNow),
+                FechaRecepcion = ahora, IdPuntoVenta = ctx.IdPuntoVenta, IdEmpleado = ctx.IdEmpleadoAdmin,
+                Subtotal = 1000m, DescuentoTotal = 0m, Total = 1000m, IvaTotal = 210m,
+                Estado = EstadoCompra.Confirmada, IdOrdenCompra = hermana.Id, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.ComprobantesCompra.Add(comprobante);
+            await db.SaveChangesAsync();
+
+            db.ItemsComprobanteCompra.Add(new ItemComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdComprobanteCompra = comprobante.Id, Orden = 1, IdArticulo = ctx.IdArticulo,
+                Descripcion = "Item de recepción (landmine, ver doc-comment de la clase)", Cantidad = 10m,
+                CostoUnitario = 100m, Descuento = 0m, IdAlicuotaIva = ctx.IdAlicuotaIva21, PorcentajeIva = 21m,
+                Total = 1000m
+            });
+            await db.SaveChangesAsync();
+        }
+
         var hermanaAntes = await LeerOrdenAsync(ctx, hermana.Id);
 
         var (_, creada, _) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, idOrdenCompra: null));


### PR DESCRIPTION
## Resumen

- `EscriturasDeOrdenDeCompra`: la proyección del estado en TRES statements (SELECT FOR UPDATE → derivación en statement separado → UPDATE RETURNING condicional — un UPDATE...FROM(SELECT) no revalida bajo READ COMMITTED), agrupando por artículo en ambos lados, con `algoRecibido` del lado recepción y regresión de estado que limpia `fecha_cierre` SOLO si el cierre era automático (el manual es inmutable).
- `ServicioDeCompras`: RETURNINGs ensanchados (+`id_orden_compra`), guard NULL-check en posición de lock 2 (proveedores sigue ÚLTIMO), `ExigirOrdenLigableAsync` con FOR SHARE (ligar a cerrada permitido; anulada 409; borrador-de-OC 409), `SolicitudDeCompra`/`CompraDetalle` ganan `IdOrdenCompra` con round-trip probado (OD8/T7). El motor queda byte-idéntico para el confirm sin OC — criterio vinculante con DOS redes documentadas: el guard estructural (caza la llamada incondicional) y la hermana co-ubicada con mina (caza la proyección por coincidencia).
- 13 targets: 11 muertos con evidencia + 2 hallazgos honestos (defensa-redundante verificada por doble capa; el reorder same-path no deadlockea). Carreras: rendezvous confirmar×confirmar, relink del PV con interceptor (el punto ciego de la 15 acá tiene test dedicado).

## Judgment-day

- Juez B ronda 1: **1 WARNING** — el test comportamental de cero-statements moría por la razón equivocada (500 del invariante, asserts byte-idénticos muertos para ese mutante). Fix `5136927`: mina FK-ligada a la hermana co-ubicada — el mutante blando (proyección por coincidencia proveedor/PV) que ANTES pasaba en silencio ahora muere en el assert de Estado (Enviada vs Cerrada). Re-ronda B limpia, incluida la reproducción del pass silencioso pre-fix vía git show.
- Juez A: 0 severos; 1 WARNING (doble FOR UPDATE no-op vs la forma pineada — ya auto-divulgado como desviación 20.1, mismo lock semántico).

Gate: cero DDL, `has-pending-model-changes` limpio, motor probado con las suites preexistentes SIN EDITAR (70/70), VentasCheckoutTests intacto. Regresión 177/177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)