### PR TITLE
feat(ordenes-compra): cierre manual y anulacion gobernada por el libro (etapa 16, slice 4)

### DIFF
--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -1130,9 +1130,14 @@ the authorization matrix are proven; the anulación guard reads `comprobantes_co
 mutation targets incl. 34a (4.14-4.17).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~OrdenesCompraCierreYAnulacion|FullyQualifiedName~SuperficieDeAutorizacion`
-— 20/20 green in `OrdenesCompraCierreYAnulacionTests`, combined with slices 1-3's re-run suites
-(222/222 across all `Compras`/`OrdenesCompra`/`SuperficieDeAutorizacion`/`ManejadorDeErrores`
-integration tests; 11/11 in `Ways.Application.Tests`; 58/58 in `Ways.Domain.Tests`).
+— 21/21 green in `OrdenesCompraCierreYAnulacionTests` (includes
+`ConfirmarUnaRecepcionLigadaAUnaOrdenRealmenteAnuladaPorElEndpointEsRechazada409`, verifying the
+existing slice-3 guard `EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync` against an OC
+anulada by THIS slice's real `POST /anular` endpoint, not EF-seeded — the first end-to-end path
+that can produce this combination without bypassing `ExigirOrdenLigableAsync`), combined with
+slices 1-3's re-run suites (223/223 across all `Compras`/`OrdenesCompra`/
+`SuperficieDeAutorizacion`/`ManejadorDeErrores` integration tests; 11/11 in
+`Ways.Application.Tests`; 58/58 in `Ways.Domain.Tests`).
 
 22. **Slice 4 apply-phase decisions and deviations (decision 15 discipline).**
     - **Domain code convention for `AnularAsync`/`CerrarAsync`**: the spec's own literal contract

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -1114,7 +1114,7 @@ the authorization matrix are proven; the anulación guard reads `comprobantes_co
   src/Ways.Infrastructure/Persistencia/Migraciones/ src/Ways.Api/Seguridad/Politicas.cs` empty;
   `OrdenesCompraCierreYAnulacionTests.NoHayCambiosPendientesDeModeloEnLaSlice4` green (in-process
   `HasPendingModelChanges() == false`). Gate holds, no deviation.
-- [ ] 4.19 Run `judgment-day`; fix confirmed issues; re-judge until clean. **NOT RUN by
+- [x] 4.19 Run `judgment-day`; fix confirmed issues; re-judge until clean. **NOT RUN by
   `sdd-apply`** — same executor-contract carve-out as slices 1-3: this executor cannot launch
   sub-agents/reviewers. Left for the orchestrator to run before merge.
 - [ ] 4.20 Branch `feat/stage16-slice4-cierre-y-anulacion` off `main` (parent: slice 3); PR; merge

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -1193,10 +1193,17 @@ slices 1-3's re-run suites (223/223 across all `Compras`/`OrdenesCompra`/
       comprobante via an uncommitted `UPDATE`, wants OC `FOR UPDATE`) reproduced Postgres's deadlock
       detector firing (one side threw) within the 15s window; the identical scenario against the
       SHIPPED statement 3 (no `FOR SHARE`) completed both sides cleanly. Not kept as a permanent
-      test — the two shipped interceptor tests above already give the permanent "both orders
-      resolve cleanly" regression coverage against real production code; a raw-SQL-literal test
-      that never calls `ServicioDeOrdenesDeCompra` would only assert Postgres's own locking
-      semantics, not this codebase's behavior.
+      test — a raw-SQL-literal test that never calls `ServicioDeOrdenesDeCompra` would only assert
+      Postgres's own locking semantics, not this codebase's behavior. **Correction (judgment-day
+      round, juez B, MAJOR — see decision 23)**: this bullet originally claimed the two shipped
+      interceptor tests above (`AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada`/
+      `AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada`) "already give the permanent
+      regression coverage" for this invariant. That is FALSE: both interceptor tests pause the
+      `DbTransactionInterceptor` immediately after `BeginTransactionAsync`, BEFORE either
+      transaction's first statement runs — they never recreate the row-contention window a deadlock
+      needs, so they regress the RESULT of the race (which side's estado guard wins), not the
+      absence of locking on statements 2/3. The permanent structural regression for THIS invariant
+      is `ServicioDeOrdenesDeCompraLockFreeGuardsTests` (decision 23), not these two tests.
     - **Confound found and fixed (mutation-proof-tests rule 3, task 4.8/4.16 guard "a")**: the
       realistic end-to-end fixture for "an OC with an effective reception cannot be annulled"
       (`UnaOrdenConRecepcionEfectivaNoPuedeAnularse409`) does not, by itself, discriminate
@@ -1213,6 +1220,32 @@ slices 1-3's re-run suites (223/223 across all `Compras`/`OrdenesCompra`/
       process did not die mid-cycle — all 4 mutation-evidence cycles (targets #31/#32/#33/#34a) ran
       end-to-end in one session, each verified FAIL → revert → green before proceeding to the next,
       `git status` clean after every revert.
+
+23. **`judgment-day` round confirmed 1 MAJOR (juez B) on decision 22's interceptor-tests claim —
+    closed with a permanent structural test.** Decision 22's `FOR SHARE`-on-statement-3 bullet
+    claimed the two shipped `DbTransactionInterceptor` tests
+    (`AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada`/
+    `AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada`) "already give the permanent
+    regression coverage" for the lock-free invariant on statements 2/3 of `AnularAsync`
+    (`TieneRecepcionConfirmadaAsync`/`TieneComprobanteLigadoEnBorradorAsync`,
+    `ServicioDeOrdenesDeCompra.cs:447-491`). **FALSE, confirmed by inspection**: both interceptor
+    tests pause the interceptor right after `BeginTransactionAsync`, before either transaction's
+    first statement — they never create the row-contention window a deadlock needs, so they
+    regress the RESULT of the race (which side's estado guard wins), never the presence/absence of
+    row locking on these two statements. Left as documented, a deliberate "safety" reintroduction
+    of `FOR SHARE`/`FOR UPDATE` on either guard would ship real deadlock risk with zero red test.
+    **Fix**: added `ServicioDeOrdenesDeCompraLockFreeGuardsTests` (source-text assertion, same
+    technique as `EscriturasDeOrdenDeCompraLockOrderTests`/`ServicioDeComprasLockOrderTests` —
+    mutation-proof-tests rule 3: the absence of a deadlock is a non-event, inherently untestable
+    behaviorally, so the structural confound is the documented escape hatch) — extracts each
+    method's real body via `IndexOf`/substring (not a duplicated SQL literal) and asserts neither
+    contains `FOR SHARE` nor `FOR UPDATE`. Mutation evidence (both guards, both lock clauses):
+    reintroducing `FOR SHARE` in statement 3's `EXISTS` or `FOR UPDATE` in statement 2's `EXISTS`
+    made the corresponding new test fail on a clean `--no-incremental` build; `git checkout -- src/`
+    plus a rebuild returned to green, `git status` clean between cycles. Decision 22's bullet is
+    corrected in place (struck through in effect, replaced with this cross-reference) rather than
+    rewritten silently, per decision 15's honesty discipline; the one-shot raw-ADO deadlock capture
+    described there remains historical evidence, not a claim about the interceptor tests.
 
 ---
 

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -976,60 +976,238 @@ the authorization matrix are proven; the anulación guard reads `comprobantes_co
 **Rollback**: revert branch — both endpoints disappear, the projection (slice 3) is unaffected.
 **Done** = tests green + `judgment-day` clean round + PR merged.
 
-- [ ] 4.1 Same `ServicioDeOrdenesDeCompra.cs`: `CerrarAsync` — `UPDATE … SET estado='cerrada',
+- [x] 4.1 Same `ServicioDeOrdenesDeCompra.cs`: `CerrarAsync` — `UPDATE … SET estado='cerrada',
   fecha_cierre=$m, id_empleado_cierre=$actor WHERE … AND estado IN ('enviada','recibida_parcial')
-  RETURNING`. *(design.md:262-263, ordenes-de-compra/spec.md:139-141)*
-- [ ] 4.2 Same file: `AnularAsync` — statement 1 `SELECT estado FOR UPDATE` (first and only lock);
+  RETURNING`. *(design.md:262-263, ordenes-de-compra/spec.md:139-141)* — **DEVIATION registered
+  (decision 22 below)**: `OrdenDeCompraBorrador` gains `FechaCierre`/`IdEmpleadoCierre` (previously
+  absent from that slice-2 response DTO) — `CerrarAsync` is the write path that makes these two
+  fields honest for the first time (`dto-contract-honesty` rule 1).
+- [x] 4.2 Same file: `AnularAsync` — statement 1 `SELECT estado FOR UPDATE` (first and only lock);
   statement 2 the derived-received-zero guard (any artículo `> 0` ⇒ `409
   orden_compra_con_recepciones`); statement 3 the linked-`borrador` `EXISTS` guard, **WITHOUT any
   row lock** (decision 9); statement 4 `UPDATE … estado='anulada' WHERE … estado IN
-  ('borrador','enviada') RETURNING`. *(design.md:252-259, decision 9, mutation target #33)*
-- [ ] 4.3 Modify `OrdenesDeCompraEndpoints.cs` — add `POST /{id}/cerrar`, `POST /{id}/anular`,
+  ('borrador','enviada') RETURNING`. *(design.md:252-259, decision 9, mutation target #33)* — the
+  three failing guards (statement 1's estado check, statement 2, statement 3) all throw the SAME
+  domain code, `orden_compra_con_recepciones` — the spec's own literal contract
+  (ordenes-de-compra/spec.md:162-164, "otherwise 409 orden_compra_con_recepciones") pins one code
+  for every refusal shape, same deliberate-generality criterion as decision 19's
+  `orden_compra_no_enviable`. `CerrarAsync`'s own 0-row case uses `orden_compra_no_cerrable` (not
+  literally named by spec/design; chosen following the same naming convention as
+  `orden_compra_no_enviable`/`orden_compra_no_editable`).
+- [x] 4.3 Modify `OrdenesDeCompraEndpoints.cs` — add `POST /{id}/cerrar`, `POST /{id}/anular`,
   same policy stack. *(design.md:306-307)*
-- [ ] 4.4 [P] Integration — a supplier order closed manually stamps `fecha_cierre` +
+- [x] 4.4 [P] Integration — a supplier order closed manually stamps `fecha_cierre` +
   `id_empleado_cierre`. *(ordenes-de-compra/spec.md:145-148)*
-- [ ] 4.5 [P] Integration — a manually-closed OC does not reopen when its reception is annulled.
+  `OrdenesCompraCierreYAnulacionTests.CerrarManualmenteEstampaFechaCierreYEmpleado`.
+- [x] 4.5 [P] Integration — a manually-closed OC does not reopen when its reception is annulled.
   *(ordenes-de-compra/spec.md:150-153, comprobantes-compra/spec.md:70-73)*
-- [ ] 4.6 [P] Integration — closing an already-`cerrada` OC is rejected `409`.
-  *(ordenes-de-compra/spec.md:155-158)*
-- [ ] 4.7 [P] Integration — an OC whose only reception was later annulled CAN itself be annulled
+  `UnaOrdenCerradaManualmenteNoSeReabreAlAnularSuRecepcion`.
+- [x] 4.6 [P] Integration — closing an already-`cerrada` OC is rejected `409`.
+  *(ordenes-de-compra/spec.md:155-158)* — implemented as a `[Theory]` covering all three
+  non-cerrable states (`borrador`, `cerrada`, `anulada`),
+  `CerrarUnaOrdenFueraDeEnviadaORecibidaParcialEsRechazada409`, seeded directly by EF (same
+  criterion as `ServicioDeComprasLigaduraTests.SembrarOrdenAnuladaAsync` — the row's state is what
+  the guard interprets, not the path that produced it).
+- [x] 4.7 [P] Integration — an OC whose only reception was later annulled CAN itself be annulled
   (derived quantity zero). *(ordenes-de-compra/spec.md:169-173)*
-- [ ] 4.8 [P] Integration — an OC with an effective (not-annulled) reception CANNOT be annulled ⇒
+  `UnaOrdenCuyaUnicaRecepcionFueAnuladaPuedeAnularseElla`.
+- [x] 4.8 [P] Integration — an OC with an effective (not-annulled) reception CANNOT be annulled ⇒
   `409 orden_compra_con_recepciones`. *(ordenes-de-compra/spec.md:175-178)*
-- [ ] 4.9 [P] Integration — an OC with a still-confirmable linked `borrador` draft CANNOT be
+  `UnaOrdenConRecepcionEfectivaNoPuedeAnularse409` — **FINDING (mutation-proof-tests rule 3,
+  registered here)**: this realistic end-to-end fixture does NOT discriminate statement 2's guard
+  in isolation — any real confirmed reception already moves the estado out of
+  `('borrador','enviada')` via `EscriturasDeOrdenDeCompra`, so statement 1 alone already rejects
+  (confound, verified by mutation). Routed below the confound with a second test,
+  `UnaOrdenEnviadaConUnaRecepcionConfirmadaLigadaDirectaNoPuedeAnularse409` (EF-seeded OC `enviada`
+  + a directly-seeded confirmed comprobante, an estado combination the real projection never
+  produces but that statement 2 must still catch) — this second test is the actual mutation
+  target #33 (guard "a") discriminator.
+- [x] 4.9 [P] Integration — an OC with a still-confirmable linked `borrador` draft CANNOT be
   annulled ⇒ `409 orden_compra_con_recepciones`. *(ordenes-de-compra/spec.md:180-183)*
-- [ ] 4.10 [P] Integration — **the no-lock `EXISTS` proof**: adding `FOR SHARE` to the linked-draft
+  `UnaOrdenConBorradorLigadoConfirmableNoPuedeAnularse409` — no confound here (statements 1/2 both
+  pass cleanly, only statement 3 can reject).
+- [x] 4.10 [P] Integration — **the no-lock `EXISTS` proof**: adding `FOR SHARE` to the linked-draft
   guard's read reproduces the anular×confirmar deadlock; without it, both orders resolve to one
-  `200` + one `409`, never a deadlock. *(design.md:64, decision 9, mutation target #33)*
-- [ ] 4.11 [P] Integration — **authorization matrix**: Vendedor 200 on both GETs, `403` on all
+  `200` + one `409`, never a deadlock. *(design.md:64, decision 9, mutation target #33)* — **this
+  is deferred race #1 from slice 3 (decision 20's "anular OC × confirmar reception", tasks 3.22/
+  3.38), paid off here (decision 22 below).** Two shipped tests force BOTH lock-acquisition orders
+  via `DbTransactionInterceptor` (`AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada`,
+  `AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada`) against the REAL HTTP endpoints —
+  **FINDING**: given a genuinely pre-existing linked `borrador` draft, the race is NOT
+  bidirectional in outcome — `anular` loses in BOTH orders (via statement 1 if `confirmar` wins the
+  OC lock first, via statement 3 if `anular` wins it first but still finds the draft `borrador`,
+  invisible-uncommitted confirm notwithstanding under READ COMMITTED). Both orderings verified
+  empirically, both green. The "adding `FOR SHARE` reproduces a deadlock" half was verified with a
+  TEMPORARY raw-two-connection test (removed after evidence capture, not shipped — it duplicates
+  Postgres locking semantics rather than exercising production code): mutating statement 3's read
+  to add `FOR SHARE` and forcing the exact lock cycle (A holds OC `FOR UPDATE`, wants comprobante
+  `FOR SHARE`; B holds comprobante via an uncommitted `UPDATE`, wants OC `FOR UPDATE`) → Postgres's
+  deadlock detector fired and one side threw within the 15s window; the SAME scenario without
+  `FOR SHARE` (statement 3 as shipped) completed both sides cleanly, no exception, confirming
+  decision 9's "lock-free" claim empirically (`mutation-proof-tests` rule 2).
+- [x] 4.11 [P] Integration — **authorization matrix**: Vendedor 200 on both GETs, `403` on all
   five writes (`POST`, `PUT`, `enviar`, `cerrar`, `anular`); Supervisor same; Admin 200 on all;
   tenant B never sees tenant A's OCs. `SuperficieDeAutorizacionTests` allowlist gains the five
-  new non-GET routes. *(ordenes-de-compra/spec.md:232-240, design.md:309-310)*
-- [ ] 4.12 [P] Integration — non-regression: `ComprasConfirmarTests`/`ComprasAnularTests` green
-  and unedited in the diff (repeated per binding verify criterion 3). *(design.md:513-514)*
-- [ ] 4.13 [P] Confirm `cuenta-corriente-de-proveedores`/`saldo-de-proveedor` untouched by
-  `git diff --stat` (spec OD7/T5). *(not-a-new-conflict note above)*
-- [ ] 4.14 [P] **Mutation target #31** — `WHERE estado IN ('enviada','recibida_parcial')` in
-  `cerrar` widened → closing a `borrador`/`anulada` OC succeeds (must fail the test).
-- [ ] 4.15 [P] **Mutation target #32** — `id_empleado_cierre = $actor` on manual close written
-  NULL → the "a manually closed OC is not reopened" test (4.5) must fail.
-- [ ] 4.16 [P] **Mutation target #33** — either the derived-received-zero guard or the linked-
+  new non-GET routes. *(ordenes-de-compra/spec.md:232-240, design.md:309-310)* —
+  `VendedorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra`,
+  `SupervisorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra`,
+  `AdminEjerceElCicloCompletoDeEscrituraDeOrdenesDeCompra`,
+  `CerrarYAnularUnaOrdenDeOtroTenantEsRechazadaComo404` (tenant isolation, ADR-8 404). **No
+  `SuperficieDeAutorizacionTests` allowlist edit was needed**: `OrdenesDeCompraEndpoints.cs` already
+  stacks `GestionDeCatalogo` on every write route (slices 2 and 4), so the generic
+  `TodoEndpointNoGetFueraDelAllowlistApilaGestionDeCatalogo` walk covers the two new routes for
+  free — confirmed by mutation (target #34a, task 4.17) that this generic guard actually fires.
+  GETs are not yet implemented (slice 5), so the "200 on both GETs" half of this task is deferred
+  there by construction — no route to test yet.
+- [x] 4.12 [P] Integration — non-regression: `ComprasConfirmarTests`/`ComprasAnularTests` green
+  and unedited in the diff (repeated per binding verify criterion 3). *(design.md:513-514)* —
+  these names refer to `ComprasLifecycleTests`/`ComprasAnulacionYConcurrenciaTests` (same mapping
+  task 3.12's doc-comment already used). `git diff --stat` against both files: empty. Full
+  `Ways.IntegrationTests` regression run: 222/222 green (`Compras`/`OrdenesCompra`/
+  `SuperficieDeAutorizacion`/`ManejadorDeErrores` filter).
+- [x] 4.13 [P] Confirm `cuenta-corriente-de-proveedores`/`saldo-de-proveedor` untouched by
+  `git diff --stat` (spec OD7/T5). *(not-a-new-conflict note above)* — `git diff --stat` against
+  `src/Ways.Application/CuentaCorriente/`: empty.
+- [x] 4.14 [P] **Mutation target #31** — `WHERE estado IN ('enviada','recibida_parcial')` in
+  `cerrar` widened → closing a `borrador`/`anulada` OC succeeds (must fail the test). **Evidence**:
+  deleted the `AND estado IN (...)` clause from `CerrarHeaderAsync`'s SQL → `dotnet build
+  --no-incremental` (clean) → all three `CerrarUnaOrdenFueraDeEnviadaORecibidaParcialEsRechazada409`
+  theory cases FAILED (`borrador`: wrong domain code, the request fell through to an unrelated
+  service-level 409; `cerrada`/`anulada`: `200` instead of `409`, the row's real estado came back
+  `Cerrada` in the response body) → `git checkout -- src/` → `git status` clean → rebuilt → green
+  (3/3).
+- [x] 4.15 [P] **Mutation target #32** — `id_empleado_cierre = $actor` on manual close written
+  NULL → the "a manually closed OC is not reopened" test (4.5) must fail. **Evidence**: replaced
+  `ParametrosDeComando.Agregar(comando, idEmpleado)` with
+  `ParametrosDeComando.AgregarNulo(comando, null)` in `CerrarHeaderAsync` → build clean → BOTH
+  `UnaOrdenCerradaManualmenteNoSeReabreAlAnularSuRecepcion` (expected `Cerrada`, actual `Enviada` —
+  the projection's `cierre_manual` short-circuit reads `id_empleado_cierre IS NOT NULL`, now false,
+  so annulling the reception walked the OC back) AND `CerrarManualmenteEstampaFechaCierreYEmpleado`
+  (expected employee id `3`, actual `null`) FAILED → `git checkout -- src/` → clean → rebuilt →
+  green (2/2).
+- [x] 4.16 [P] **Mutation target #33** — either the derived-received-zero guard or the linked-
   `borrador` `EXISTS` guard deleted → `409 orden_compra_con_recepciones` test (4.8/4.9) must fail,
   one test per guard; adding `FOR SHARE` to the `EXISTS` read → the anular × confirmar rendezvous
-  (4.10) deadlocks.
-- [ ] 4.17 [P] **Mutation target #34a** — `.RequireAuthorization(Politicas.GestionDeCatalogo)`
-  dropped from any of the five write routes → its own 403-matrix test (4.11) must fail.
-- [ ] 4.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
-  `Migraciones/`; `Politicas.cs` unchanged (`git diff --stat`).
-- [ ] 4.19 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  (4.10) deadlocks. **Evidence, guard "a" (statement 2)**: neutered the call
+  (`if (false && await TieneRecepcionConfirmadaAsync(...))`) → build clean →
+  `UnaOrdenConRecepcionEfectivaNoPuedeAnularse409` **stayed green** (confound, see task 4.8's
+  finding above) → the isolated discriminator,
+  `UnaOrdenEnviadaConUnaRecepcionConfirmadaLigadaDirectaNoPuedeAnularse409`, FAILED (`200
+  Anulada` instead of `409`) → reverted, clean → both green. **Evidence, guard "b" (statement 3)**:
+  same neutering pattern on `TieneComprobanteLigadoEnBorradorAsync`'s call → build clean →
+  `UnaOrdenConBorradorLigadoConfirmableNoPuedeAnularse409` FAILED (`200 Anulada` instead of `409`,
+  no confound this time) → reverted, clean → green. **Evidence, `FOR SHARE` deadlock**: see task
+  4.10's write-up above (temporary raw-connection test, both directions verified, removed after
+  capture).
+- [x] 4.17 [P] **Mutation target #34a** — `.RequireAuthorization(Politicas.GestionDeCatalogo)`
+  dropped from any of the five write routes → its own 403-matrix test (4.11) must fail. **Evidence**:
+  removed the `.RequireAuthorization(Politicas.GestionDeCatalogo)` call from the `/cerrar` route in
+  `OrdenesDeCompraEndpoints.cs` → build clean → THREE tests failed simultaneously:
+  `VendedorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra` and
+  `SupervisorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra` (expected `Forbidden`, actual
+  `OK` on the `/cerrar` assertion) AND the pre-existing generic
+  `SuperficieDeAutorizacionTests.TodoEndpointNoGetFueraDelAllowlistApilaGestionDeCatalogo`
+  (`"Endpoint(s) de escritura sin GestionDeCatalogo y fuera del allowlist: POST
+  /api/ordenes-compra/{id:int}/cerrar"`) → reverted, clean → all three green again.
+- [x] 4.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
+  `Migraciones/`; `Politicas.cs` unchanged (`git diff --stat`). Verified: `git diff --stat --
+  src/Ways.Infrastructure/Persistencia/Migraciones/ src/Ways.Api/Seguridad/Politicas.cs` empty;
+  `OrdenesCompraCierreYAnulacionTests.NoHayCambiosPendientesDeModeloEnLaSlice4` green (in-process
+  `HasPendingModelChanges() == false`). Gate holds, no deviation.
+- [ ] 4.19 Run `judgment-day`; fix confirmed issues; re-judge until clean. **NOT RUN by
+  `sdd-apply`** — same executor-contract carve-out as slices 1-3: this executor cannot launch
+  sub-agents/reviewers. Left for the orchestrator to run before merge.
 - [ ] 4.20 Branch `feat/stage16-slice4-cierre-y-anulacion` off `main` (parent: slice 3); PR; merge
-  stacked-to-main.
+  stacked-to-main. **PARTIAL**: the worktree was already provisioned on
+  `feat/stage16-slice4-cierre-anulacion` off `main` (`a89e7c0`, slice 3 already merged) before this
+  phase started — branching is done, naming differs by dropping `-y-` (same cosmetic deviation
+  pattern as slices 2/3, not re-branched to avoid losing the provisioned worktree — flagged for the
+  orchestrator). PR creation/merge is explicitly out of scope (`NO pushees` instruction) — left for
+  the orchestrator.
 
 **Test plan**: cierre happy/blocked (4.4, 4.6); non-reopening (4.5); anulación book-governed rule
 (4.7-4.9); the no-lock proof (4.10); authorization matrix (4.11); non-regression (4.12-4.13); 4
 mutation targets incl. 34a (4.14-4.17).
 
 **Verify**: `dotnet test --filter FullyQualifiedName~OrdenesCompraCierreYAnulacion|FullyQualifiedName~SuperficieDeAutorizacion`
+— 20/20 green in `OrdenesCompraCierreYAnulacionTests`, combined with slices 1-3's re-run suites
+(222/222 across all `Compras`/`OrdenesCompra`/`SuperficieDeAutorizacion`/`ManejadorDeErrores`
+integration tests; 11/11 in `Ways.Application.Tests`; 58/58 in `Ways.Domain.Tests`).
+
+22. **Slice 4 apply-phase decisions and deviations (decision 15 discipline).**
+    - **Domain code convention for `AnularAsync`/`CerrarAsync`**: the spec's own literal contract
+      (ordenes-de-compra/spec.md:162-164) pins a SINGLE code, `orden_compra_con_recepciones`, for
+      every anulación refusal — the estado check (statement 1), the derived-received guard
+      (statement 2) and the linked-borrador guard (statement 3) all throw it. This is the SAME
+      deliberate-generality criterion decision 19 already established for
+      `orden_compra_no_enviable` (one code covering multiple real causes, none of them individually
+      named by spec/design), not a fresh judgment call. `CerrarAsync`'s 0-row rejection uses
+      `orden_compra_no_cerrable` — not literally named anywhere, chosen by the same naming
+      convention as its two slice-2 siblings (`orden_compra_no_enviable`/`orden_compra_no_editable`).
+    - **`OrdenDeCompraBorrador` DTO extension**: gains `FechaCierre`/`IdEmpleadoCierre` (both
+      `DateTimeOffset?`/`int?`, additive trailing positional fields, the one call site
+      (`Proyectar`) updated in the same commit). Not named by design's Interfaces/Contracts (which
+      predates the slice-2 `OrdenDeCompraBorrador` deviation entirely and only knows about the
+      single `OrdenDeCompraDetalle`), but `dto-contract-honesty` rule 1 applies the other direction
+      here: `CerrarAsync` is the write path that makes these two fields real for the first time, so
+      leaving them off the response the cierre call itself returns would hide the fact this exact
+      request just wrote. `OrdenDeCompraDetalle` (slice 5) already plans to carry them; this is not
+      a duplicate decision, just an earlier honest population of the same two columns on the
+      narrower slice-2 DTO.
+    - **The two deferred races from slice 3 (decision 20's tasks 3.22/3.38), paid off here.** Both
+      required an OC-anulación write path that did not exist before this slice.
+      - **"anular OC × confirmar reception" (task 4.10)**: implemented as two `DbTransactionInterceptor`-
+        forced orderings against the REAL HTTP endpoints (`AnularPierdeCuandoConfirmarComitePrimero
+        MientrasAnularEstaPausada`, `AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada`).
+        **FINDING, registered honestly rather than reshaped (mutation-proof-tests rule 2)**: given a
+        genuinely pre-existing linked `borrador` draft, this race is NOT bidirectional in outcome —
+        `anular` loses in BOTH lock-acquisition orders (via statement 1 if `confirmar` wins the OC
+        lock first and commits its projection before `anular` reads; via statement 3 if `anular`
+        wins the OC lock first, because statement 3's lock-free read still sees the comprobante as
+        `borrador` — `confirmar`'s own uncommitted `UPDATE` is invisible under READ COMMITTED to a
+        plain `SELECT`). Task 4.9's own guard dominates this fixture regardless of timing; both
+        orderings were verified empirically (both green), not reasoned. The design's Concurrency
+        Guarantees prose ("the annulment loses" as one of two named outcomes) describes the general
+        defense-in-depth mechanism, which this fixture only ever exercises through one of its two
+        branches — same class of honest finding as slice 3's target #21.
+      - **"linking to an OC being annulled concurrently" (FK 9's race sub-clause, task 3.38)**: this
+        is a DIFFERENT, genuinely bidirectional race — `ExigirOrdenLigableAsync`'s `FOR SHARE`
+        (under `ActualizarBorradorAsync`'s own transaction, a real TOCTOU guard per design T3)
+        against `AnularAsync`'s statement-1 `FOR UPDATE` on the SAME OC row. Two tests force both
+        orders (`AnularGanaLaCarreraCuandoElPutQueLigaEstaPausado`,
+        `ElPutQueLigaGanaLaCarreraCuandoAnularEstaPausada`): whichever transaction takes the row
+        lock first wins outright (the other sees the loser's already-committed fact and rejects
+        accordingly — `orden_compra_anulada` if anular won, `orden_compra_con_recepciones` via
+        statement 3 if the link won) — never a deadlock (`FOR SHARE`/`FOR UPDATE` contend on ONE
+        resource, no cycle is reachable). Both orderings verified empirically, both green.
+    - **`FOR SHARE`-on-statement-3 deadlock evidence (mutation target #33, third clause)** was
+      captured with a TEMPORARY test using two raw ADO connections (not the production call sites —
+      it duplicates Postgres locking primitives directly to force the exact lock cycle
+      deterministically) and REMOVED after capturing the evidence: mutating statement 3 to add
+      `FOR SHARE` and forcing (A holds OC `FOR UPDATE`, wants comprobante `FOR SHARE`; B holds
+      comprobante via an uncommitted `UPDATE`, wants OC `FOR UPDATE`) reproduced Postgres's deadlock
+      detector firing (one side threw) within the 15s window; the identical scenario against the
+      SHIPPED statement 3 (no `FOR SHARE`) completed both sides cleanly. Not kept as a permanent
+      test — the two shipped interceptor tests above already give the permanent "both orders
+      resolve cleanly" regression coverage against real production code; a raw-SQL-literal test
+      that never calls `ServicioDeOrdenesDeCompra` would only assert Postgres's own locking
+      semantics, not this codebase's behavior.
+    - **Confound found and fixed (mutation-proof-tests rule 3, task 4.8/4.16 guard "a")**: the
+      realistic end-to-end fixture for "an OC with an effective reception cannot be annulled"
+      (`UnaOrdenConRecepcionEfectivaNoPuedeAnularse409`) does not, by itself, discriminate
+      statement 2's guard — any real confirmed reception already walks the estado out of
+      `('borrador','enviada')` via `EscriturasDeOrdenDeCompra`'s projection, so statement 1's own
+      check already rejects before statement 2 ever runs, verified by mutation (neutering statement
+      2 left this test green). Routed below the confound with a second, EF-seeded test
+      (`UnaOrdenEnviadaConUnaRecepcionConfirmadaLigadaDirectaNoPuedeAnularse409`) that produces an
+      estado/book combination the real projection never creates but that statement 2 must still
+      catch honestly. The realistic test is kept (it documents true end-to-end behavior); the
+      EF-seeded test is the actual mutation-evidence discriminator for that guard.
+    - **Process note**: Docker Desktop was already healthy at the start of this phase (`docker info`
+      verified before the first test run, same discipline as prior slices); the apply-phase host
+      process did not die mid-cycle — all 4 mutation-evidence cycles (targets #31/#32/#33/#34a) ran
+      end-to-end in one session, each verified FAIL → revert → green before proceeding to the next,
+      `git status` clean after every revert.
 
 ---
 

--- a/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
@@ -10,8 +10,10 @@ namespace Ways.Api.Endpoints;
 /// 7).
 ///
 /// Slice 2: <c>POST /</c> (borrador), <c>PUT /{id}</c> (replace-set), <c>POST /{id}/enviar</c>
-/// (numeración propia). <c>GET /</c>/<c>GET /{id}</c> llegan en slice 5 (necesitan el detalle con
-/// cobertura); <c>POST /{id}/cerrar</c>/<c>POST /{id}/anular</c> en slice 4.
+/// (numeración propia). Slice 4: <c>POST /{id}/cerrar</c> (cierre manual), <c>POST /{id}/anular</c>
+/// (gobernada por el libro, design decisión 9) — mismo gate que las tres rutas de arriba (task
+/// 4.11, matriz de autorización: las CINCO rutas de escritura apilan <c>GestionDeCatalogo</c>).
+/// <c>GET /</c>/<c>GET /{id}</c> llegan en slice 5 (necesitan el detalle con cobertura).
 /// </summary>
 public static class OrdenesDeCompraEndpoints
 {
@@ -46,6 +48,22 @@ public static class OrdenesDeCompraEndpoints
         })
         .RequireAuthorization(Politicas.GestionDeCatalogo)
         .WithSummary("Asigna numero/fecha_envio propios (serie 'OC') y pasa la orden a enviada.");
+
+        grupo.MapPost("/{id:int}/cerrar", async (ServicioDeOrdenesDeCompra servicio, int id, CancellationToken ct) =>
+        {
+            var cerrada = await servicio.CerrarAsync(id, ct);
+            return Results.Ok(cerrada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Cierra manualmente una orden de compra (enviada/recibida_parcial → cerrada).");
+
+        grupo.MapPost("/{id:int}/anular", async (ServicioDeOrdenesDeCompra servicio, int id, CancellationToken ct) =>
+        {
+            var anulada = await servicio.AnularAsync(id, ct);
+            return Results.Ok(anulada);
+        })
+        .RequireAuthorization(Politicas.GestionDeCatalogo)
+        .WithSummary("Anula una orden de compra gobernada por el libro de recepción (design decisión 9).");
 
         return app;
     }

--- a/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
+++ b/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
@@ -42,6 +42,11 @@ public sealed record ItemDeOrden(
 /// 1: un campo que nunca varía no es un contrato, es relleno). Este tipo cubre solo lo que el
 /// camino de escritura de esta slice puede proyectar honestamente; <c>OrdenDeCompraDetalle</c> se
 /// crea en la slice 5 tal como el propio task list lo asigna, para <c>GET /{id}</c>.</summary>
+/// <summary><see cref="FechaCierre"/>/<see cref="IdEmpleadoCierre"/> agregados en Slice 4
+/// (design: Transactions — CERRAR OC): <c>CerrarAsync</c> es el camino de escritura que hace estos
+/// dos campos honestos por primera vez — <c>NULL</c> hasta el cierre, poblados en el mismo
+/// <c>UPDATE … RETURNING</c> que los escribe (dto-contract-honesty regla 1: no es relleno, varían
+/// con el cierre real).</summary>
 public sealed record OrdenDeCompraBorrador(
     int Id,
     int IdProveedor,
@@ -50,6 +55,8 @@ public sealed record OrdenDeCompraBorrador(
     DateTimeOffset FechaEmision,
     DateTimeOffset? FechaEnvio,
     DateOnly? FechaEsperada,
+    DateTimeOffset? FechaCierre,
+    int? IdEmpleadoCierre,
     string? Observaciones,
     EstadoOrdenCompra Estado,
     IReadOnlyList<ItemDeOrden> Items);

--- a/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
+++ b/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
@@ -12,9 +12,15 @@ namespace Ways.Application.Compras;
 /// <summary>
 /// stage-16-ordenes-de-compra, Slice 2 (design: Technical Approach, decisiones 6-7). Borrador CRUD
 /// (replace-set, mismo criterio que <see cref="ServicioDeCompras"/>) + <see cref="EnviarAsync"/>
-/// (numeración propia, serie <c>'OC'</c>, consumida al enviar). <c>cerrar</c>/<c>anular</c> llegan
-/// en slice 4; la lectura paginada + el detalle con cobertura en slice 5; la ligadura con
-/// <c>comprobantes_compra</c> en slice 3 — ninguno de esos caminos existe todavía.
+/// (numeración propia, serie <c>'OC'</c>, consumida al enviar). La lectura paginada + el detalle
+/// con cobertura llegan en slice 5; la ligadura con <c>comprobantes_compra</c> en slice 3 (ver
+/// <see cref="EscriturasDeOrdenDeCompra"/>, llamada SOLO desde <see cref="ServicioDeCompras"/>).
+///
+/// Slice 4 (design: Transactions — CERRAR OC/ANULAR OC, decisiones 5/9): <see cref="CerrarAsync"/>
+/// (cierre manual, actor-stamped, jamás revertido por la proyección) y <see cref="AnularAsync"/>
+/// (gobernada por el libro, guard lock-free — decisión 9, mutation target #33). Ninguno de los dos
+/// pasa por <see cref="EscriturasDeOrdenDeCompra"/>: son caminos de escritura propios de esta
+/// clase, no proyecciones del libro de recepción.
 ///
 /// OD9 (orquestador, apply de esta slice): los resolvers 404 de proveedor/punto de venta son
 /// PRIVADOS y PROPIOS de esta clase — copian la FORMA exacta de
@@ -202,6 +208,135 @@ public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj
         return await ObtenerParaRespuestaAsync(id, ct);
     }
 
+    // ---- cerrar: manual, actor-stamped, jamás revertido (design decisión 5, Transactions — CERRAR OC) ----
+
+    /// <summary>design: Transactions — CERRAR OC (manual). Una única <c>UPDATE … RETURNING</c>
+    /// escribe la tríada <c>estado</c>/<c>fecha_cierre</c>/<c>id_empleado_cierre</c> — el CHECK 2
+    /// (<c>ck_ordenes_compra_cierre</c>, proposal §B) exige que las tres cambien juntas. Válido
+    /// solo desde <c>enviada</c>/<c>recibida_parcial</c> (ordenes-de-compra/spec.md: "Manual Close
+    /// Is A Human Decision"); <c>borrador</c> NO es cerrable (nunca se envió), ni <c>cerrada</c>
+    /// (mutation target #31) ni <c>anulada</c>. Una vez escrito, <c>id_empleado_cierre IS NOT
+    /// NULL</c> hace que <see cref="EscriturasDeOrdenDeCompra.ProyectarEstadoAsync"/> jamás vuelva
+    /// a tocar esta orden (design decisión 2, cortocircuito bajo el mismo lock, mutation target
+    /// #26).</summary>
+    public async Task<OrdenDeCompraBorrador> CerrarAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarCierreAsync(id, idTenant, idEmpleado, momento, ct));
+    }
+
+    private async Task<OrdenDeCompraBorrador> EjecutarCierreAsync(
+        int id, int idTenant, int idEmpleado, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var cerrada = await CerrarHeaderAsync(conexion, transaccionCruda, id, idTenant, idEmpleado, momento, ct);
+        if (!cerrada)
+        {
+            var existe = await db.OrdenesCompra.AsNoTracking().AnyAsync(o => o.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+            }
+
+            // Código único deliberadamente general (mismo criterio que orden_compra_no_enviable,
+            // decisión 19 de tasks.md): borrador (nunca se envió), ya cerrada (mutation target
+            // #31) y anulada colapsan en la misma causa observable — "no está en un estado
+            // cerrable ahora mismo".
+            throw new ErrorDominio(
+                "orden_compra_no_cerrable", "La orden de compra no está en un estado cerrable.", 409);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerParaRespuestaAsync(id, ct);
+    }
+
+    // ---- anular: gobernada por el libro, guard lock-free (design decisión 9, Transactions — ANULAR OC) ----
+
+    /// <summary>design decisión 9 (proposal decisión 9, ratificada): anulación GOBERNADA POR EL
+    /// LIBRO, nunca por el estado solo. Statement 1 (<c>SELECT … FOR UPDATE</c>) es el ÚNICO lock
+    /// de fila de todo el método — ni el statement 2 (recepción confirmada) ni el 3 (borrador
+    /// ligado) toman lock alguno (decisión 9: "adding FOR SHARE there closes a lock cycle against
+    /// the confirm path" — un <c>FOR SHARE</c> acá armaría el ciclo confirm-quiere-OC /
+    /// anular-quiere-comprobante, mutation target #33, tasks 4.10/OD-decisión-20.2 de este
+    /// slice). Los TRES guards fallidos colapsan al MISMO código de dominio,
+    /// <c>orden_compra_con_recepciones</c> — el propio contrato del spec ("otherwise 409
+    /// orden_compra_con_recepciones") lo pinea como código único, mismo criterio de generalidad
+    /// deliberada que decisión 19 (<c>orden_compra_no_enviable</c>).</summary>
+    public async Task<OrdenDeCompraBorrador> AnularAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarAnulacionDeOrdenAsync(id, idTenant, momento, ct));
+    }
+
+    private async Task<OrdenDeCompraBorrador> EjecutarAnulacionDeOrdenAsync(
+        int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // Statement 1 — PRIMER y ÚNICO lock (FOR UPDATE). 0 filas ⇒ la orden no existe para este
+        // tenant (ADR-8: mismo 404 para "no existe" y "es de otro tenant").
+        var estado = await BloquearYLeerEstadoOrdenAsync(conexion, transaccionCruda, id, idTenant, ct);
+        if (estado is null)
+        {
+            throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+        }
+
+        if (estado != "borrador" && estado != "enviada")
+        {
+            throw new ErrorDominio(
+                "orden_compra_con_recepciones", "La orden de compra no puede anularse.", 409);
+        }
+
+        // Statement 2 — recepción confirmada (recibida > 0 en cualquier artículo). Lock-free
+        // (decisión 9): un SELECT simple nunca bloquea bajo READ COMMITTED, ve solo el último
+        // commit — el UPDATE en curso de un confirm concurrente (todavía sin comitear) es
+        // invisible acá, no hace falta ningún lock para no verlo.
+        if (await TieneRecepcionConfirmadaAsync(conexion, transaccionCruda, id, idTenant, ct))
+        {
+            throw new ErrorDominio(
+                "orden_compra_con_recepciones", "La orden de compra tiene una recepción confirmada.", 409);
+        }
+
+        // Statement 3 — comprobante ligado todavía en borrador (mutation target #33, task 4.10):
+        // SIN lock de fila — agregar FOR SHARE acá arma el ciclo de deadlock contra
+        // EjecutarConfirmarAsync (que toma comprobantes_compra primero y quiere ordenes_compra
+        // después, mientras esta transacción ya tiene ordenes_compra y querría comprobantes_compra).
+        if (await TieneComprobanteLigadoEnBorradorAsync(conexion, transaccionCruda, id, idTenant, ct))
+        {
+            throw new ErrorDominio(
+                "orden_compra_con_recepciones",
+                "La orden de compra tiene un comprobante ligado todavía en borrador.", 409);
+        }
+
+        // Statement 4 — la ÚNICA autoridad de transición a `anulada`. El lock de statement 1 ya
+        // serializa cualquier escritor concurrente sobre esta fila — 0 filas acá sería un
+        // invariante roto (nadie más pudo mover el estado entretanto), nunca un ErrorDominio.
+        var anulada = await MarcarOrdenAnuladaAsync(conexion, transaccionCruda, id, idTenant, momento, ct)
+            ?? throw new InvalidOperationException(
+                $"La anulación de la orden de compra {id} no afectó ninguna fila bajo el lock ya tomado.");
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerParaRespuestaAsync(id, ct);
+    }
+
     // ---- statements crudos (sibling raw SQL, mismo criterio que ServicioDeCompras) ----------------
 
     private static async Task<bool> BloquearBorradorAsync(
@@ -253,6 +388,130 @@ public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj
         }
 
         return lector.IsDBNull(0) ? null : lector.GetInt64(0);
+    }
+
+    /// <summary>design: Transactions — CERRAR OC, único statement. Escribe la tríada
+    /// <c>estado</c>/<c>fecha_cierre</c>/<c>id_empleado_cierre</c> en UN <c>UPDATE … RETURNING</c>
+    /// (design decisión 5) — el CHECK 2 exige que las tres cambien juntas, así que partirlo en dos
+    /// statements dejaría una ventana con la fila en un estado que el propio CHECK rechazaría.
+    /// <c>momento</c>/<c>idEmpleado</c> viajan SIEMPRE por <see cref="ParametrosDeComando.Agregar"/>
+    /// (mutation target #32 para el segundo).</summary>
+    private static async Task<bool> CerrarHeaderAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, int idEmpleado,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE ordenes_compra SET estado = 'cerrada'::estado_orden_compra, " +
+            "fecha_cierre = $1, id_empleado_cierre = $2, updated_at = $1 " +
+            "WHERE id_orden_compra = $3 AND id_tenant = $4 " +
+            "AND estado IN ('enviada'::estado_orden_compra, 'recibida_parcial'::estado_orden_compra) " +
+            "RETURNING estado";
+
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    /// <summary>design: Transactions — ANULAR OC, statement 1. El ÚNICO <c>FOR UPDATE</c> de todo
+    /// el método <see cref="EjecutarAnulacionDeOrdenAsync"/> — statements 2/3 son lecturas
+    /// lock-free a propósito (decisión 9). <c>null</c> ⇒ la fila no existe para este tenant
+    /// (invariante de FK garantiza que, si existe, esta lectura la ve).</summary>
+    private static async Task<string?> BloquearYLeerEstadoOrdenAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT estado::text FROM ordenes_compra WHERE id_orden_compra = $1 AND id_tenant = $2 FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado as string;
+    }
+
+    /// <summary>design: Transactions — ANULAR OC, statement 2 ("recibida &gt; 0 en cualquier
+    /// artículo"). <c>cantidad</c> de un item de comprobante confirmado es SIEMPRE positiva
+    /// (<c>ck_items_comprobante_compra_cantidad_positiva</c>) — por eso alcanza con un EXISTS de
+    /// cualquier item confirmado y ligado, sin necesidad de sumar por artículo como hace
+    /// <see cref="EscriturasDeOrdenDeCompra"/>: cualquier fila que pase el filtro ya prueba
+    /// "recibida &gt; 0" para SU artículo. SIN lock de fila — lectura simple, nunca bloquea bajo
+    /// READ COMMITTED (decisión 9).</summary>
+    private static async Task<bool> TieneRecepcionConfirmadaAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idOrdenCompra, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT EXISTS (" +
+            "    SELECT 1 " +
+            "    FROM items_comprobante_compra ic " +
+            "    JOIN comprobantes_compra c " +
+            "      ON c.id_comprobante_compra = ic.id_comprobante_compra AND c.id_tenant = ic.id_tenant " +
+            "    WHERE c.id_orden_compra = $1 AND c.id_tenant = $2 " +
+            "      AND c.estado = 'confirmada'::estado_compra " +
+            "      AND c.deleted_at IS NULL AND ic.deleted_at IS NULL" +
+            ")";
+
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        return (bool)(await comando.ExecuteScalarAsync(ct))!;
+    }
+
+    /// <summary>design: Transactions — ANULAR OC, statement 3 (mutation target #33, task 4.10):
+    /// EXISTS de un comprobante ligado todavía en <c>borrador</c> — SIN lock de fila, a propósito
+    /// (decisión 9: agregar <c>FOR SHARE</c> acá cierra el ciclo de deadlock contra
+    /// <c>EjecutarConfirmarAsync</c>, que toma <c>comprobantes_compra</c> primero y
+    /// <c>ordenes_compra</c> después — el orden inverso exacto de esta transacción, que ya tiene
+    /// <c>ordenes_compra</c> desde el statement 1 y pediría <c>comprobantes_compra</c> acá).</summary>
+    private static async Task<bool> TieneComprobanteLigadoEnBorradorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idOrdenCompra, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT EXISTS (" +
+            "    SELECT 1 FROM comprobantes_compra " +
+            "    WHERE id_orden_compra = $1 AND id_tenant = $2 " +
+            "      AND estado = 'borrador'::estado_compra AND deleted_at IS NULL" +
+            ")";
+
+        ParametrosDeComando.Agregar(comando, idOrdenCompra);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        return (bool)(await comando.ExecuteScalarAsync(ct))!;
+    }
+
+    /// <summary>design: Transactions — ANULAR OC, statement 4 — la ÚNICA autoridad de transición a
+    /// <c>anulada</c>. <c>fecha_cierre</c> no se toca: <c>borrador</c>/<c>enviada</c> nunca la
+    /// tuvieron seteada (CHECK 2 ya lo garantiza), así que no hace falta ningún <c>CASE</c> de
+    /// limpieza como el de <see cref="EscriturasDeOrdenDeCompra"/>.</summary>
+    private static async Task<string?> MarcarOrdenAnuladaAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE ordenes_compra SET estado = 'anulada'::estado_orden_compra, updated_at = $1 " +
+            "WHERE id_orden_compra = $2 AND id_tenant = $3 " +
+            "AND estado IN ('borrador'::estado_orden_compra, 'enviada'::estado_orden_compra) " +
+            "RETURNING estado::text";
+
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado as string;
     }
 
     private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
@@ -353,7 +612,7 @@ public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj
 
     private static OrdenDeCompraBorrador Proyectar(OrdenCompra orden, IReadOnlyList<ItemOrdenCompra> items) => new(
         orden.Id, orden.IdProveedor, orden.IdPuntoVenta, orden.Numero, orden.FechaEmision, orden.FechaEnvio,
-        orden.FechaEsperada, orden.Observaciones, orden.Estado,
+        orden.FechaEsperada, orden.FechaCierre, orden.IdEmpleadoCierre, orden.Observaciones, orden.Estado,
         items
             .OrderBy(i => i.Orden)
             .Select(i => new ItemDeOrden(i.Orden, i.IdArticulo, i.Descripcion, i.CantidadPedida, i.CostoUnitarioEstimado))

--- a/tests/Ways.Application.Tests/Compras/ServicioDeOrdenesDeCompraLockFreeGuardsTests.cs
+++ b/tests/Ways.Application.Tests/Compras/ServicioDeOrdenesDeCompraLockFreeGuardsTests.cs
@@ -1,0 +1,88 @@
+namespace Ways.Application.Tests.Compras;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 4 (design decisión 9; ANULAR OC statements 2/3; mutation
+/// target #33). Regresión ESTRUCTURAL PERMANENTE del invariante "estos dos guards son lock-free"
+/// de <see cref="ServicioDeOrdenesDeCompra"/>: <c>TieneRecepcionConfirmadaAsync</c> (statement 2) y
+/// <c>TieneComprobanteLigadoEnBorradorAsync</c> (statement 3) deben seguir siendo un
+/// <c>SELECT EXISTS</c> simple, SIN <c>FOR SHARE</c>/<c>FOR UPDATE</c> — agregar cualquiera de los
+/// dos cierra el ciclo de deadlock contra <c>EjecutarConfirmarAsync</c> (que toma
+/// <c>comprobantes_compra</c> primero y <c>ordenes_compra</c> después, el orden inverso exacto de
+/// esta transacción).
+///
+/// **Por qué texto fuente y no comportamiento (mutation-proof-tests regla 3)**: la AUSENCIA de un
+/// deadlock es, por construcción, un no-evento — no hay ningún resultado observable que distinga
+/// "nunca hubo contención" de "hubo contención pero se resolvió por casualidad de timing". Los dos
+/// tests de interceptor ya existentes (<c>AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada</c>/
+/// <c>AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada</c>,
+/// <c>OrdenesCompraCierreYAnulacionTests</c>) pausan el interceptor INMEDIATAMENTE después de
+/// <c>BeginTransactionAsync</c> — ANTES de que corra el primer statement de cualquiera de las dos
+/// transacciones — así que jamás recrean la ventana de contención de fila que un deadlock necesita;
+/// regresionan el RESULTADO de la carrera (quién gana el guard de estado), no la ausencia de
+/// locking en estos dos statements. La captura empírica real del deadlock (dos conexiones ADO
+/// crudas forzando el ciclo exacto de locks) fue un experimento ONE-SHOT, removido tras confirmar
+/// el hallazgo — ver tasks.md decisión 22/23 — y no reproducible como test estable (depende del
+/// detector de deadlock de Postgres disparando dentro de una ventana de tiempo). Esta clase cierra
+/// esa brecha con la misma técnica que <c>EscriturasDeOrdenDeCompraLockOrderTests</c>/
+/// <c>ServicioDeComprasLockOrderTests</c>: extracción del método real + búsqueda de substring
+/// inequívoca, sin duplicar el SQL en un string aparte.
+/// </summary>
+public class ServicioDeOrdenesDeCompraLockFreeGuardsTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "Compras", "ServicioDeOrdenesDeCompra.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
+
+    [Fact]
+    public void TieneRecepcionConfirmadaAsyncSigueSiendoUnExistsLockFreeSinForShareNiForUpdate()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente,
+            "private static async Task<bool> TieneRecepcionConfirmadaAsync(",
+            // Se corta ANTES del doc-comment XML del método siguiente, no en su firma: ese
+            // doc-comment describe en prosa por qué NO se agrega `FOR SHARE` al statement 3 (mismo
+            // riesgo de confusión de substring que EscriturasDeOrdenDeCompraLockOrderTests ya
+            // documenta para el nombre pelado de una clase en prosa) y un corte en la firma lo
+            // incluiría dentro del método extraído, haciendo que este test falle por una mención en
+            // prosa en vez de por SQL real.
+            "/// <summary>design: Transactions — ANULAR OC, statement 3");
+
+        Assert.Contains("SELECT EXISTS (", metodo, StringComparison.Ordinal);
+        Assert.DoesNotContain("FOR SHARE", metodo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FOR UPDATE", metodo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TieneComprobanteLigadoEnBorradorAsyncSigueSiendoUnExistsLockFreeSinForShareNiForUpdate()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente,
+            "private static async Task<bool> TieneComprobanteLigadoEnBorradorAsync(",
+            "private static async Task<string?> MarcarOrdenAnuladaAsync(");
+
+        Assert.Contains("SELECT EXISTS (", metodo, StringComparison.Ordinal);
+        Assert.DoesNotContain("FOR SHARE", metodo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FOR UPDATE", metodo, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
@@ -386,6 +386,66 @@ public class OrdenesCompraCierreYAnulacionTests(WaysApiFixture fixture) : IClass
         Assert.Equal(EstadoOrdenCompra.RecibidaParcial, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
     }
 
+    /// <summary>mutation-proof-tests regla 3 ("kill the confounds, not the layers") — el test de
+    /// arriba NO discrimina el guard de statement 2 en aislamiento: cualquier recepción confirmada
+    /// real ya mueve el estado vía <see cref="EscriturasDeOrdenDeCompra"/> fuera de
+    /// <c>('borrador','enviada')</c>, así que statement 1 SOLO ya rechaza — borrar statement 2
+    /// entero no cambia el resultado observable de ese fixture (confound verificado por mutación,
+    /// ver PR body / mutation target #33). Este test rutea POR DEBAJO del confound (regla 3):
+    /// siembra directo por EF una OC en <c>enviada</c> (bypass total de la proyección) CON un
+    /// comprobante confirmado ya ligado — un estado que la proyección normal jamás produce, pero
+    /// que <c>TieneRecepcionConfirmadaAsync</c> tiene que ver igual (statement 2 es una lectura
+    /// honesta del libro, no una confianza en que el estado ya lo refleja). Statements 1 y 3 pasan
+    /// limpio acá; SOLO statement 2 puede rechazar.</summary>
+    [Fact]
+    public async Task UnaOrdenEnviadaConUnaRecepcionConfirmadaLigadaDirectaNoPuedeAnularse409()
+    {
+        var ctx = await PrepararAsync(nameof(UnaOrdenEnviadaConUnaRecepcionConfirmadaLigadaDirectaNoPuedeAnularse409));
+        var ahora = DateTimeOffset.UtcNow;
+
+        int idOrden;
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var orden = new OrdenCompra
+            {
+                IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdProveedor = ctx.IdProveedor,
+                IdEmpleado = ctx.IdEmpleadoAdmin, Numero = 950, FechaEmision = ahora, FechaEnvio = ahora,
+                Estado = EstadoOrdenCompra.Enviada, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.OrdenesCompra.Add(orden);
+            await db.SaveChangesAsync();
+            idOrden = orden.Id;
+
+            var comprobante = new ComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdProveedor = ctx.IdProveedor, IdTipoComprobante = ctx.IdTipoCFA,
+                NumeroExterno = $"0001-{Guid.NewGuid():N}"[..8], FechaComprobante = DateOnly.FromDateTime(DateTime.UtcNow),
+                FechaRecepcion = ahora, IdPuntoVenta = ctx.IdPuntoVenta, IdEmpleado = ctx.IdEmpleadoAdmin,
+                Subtotal = 1000m, DescuentoTotal = 0m, Total = 1000m, IvaTotal = 210m,
+                Estado = EstadoCompra.Confirmada, IdOrdenCompra = idOrden, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.ComprobantesCompra.Add(comprobante);
+            await db.SaveChangesAsync();
+
+            db.ItemsComprobanteCompra.Add(new ItemComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdComprobanteCompra = comprobante.Id, Orden = 1, IdArticulo = ctx.IdArticulo,
+                Descripcion = "Item confirmado ligado directo (statement 2 aislado)", Cantidad = 4m,
+                CostoUnitario = 100m, Descuento = 0m, IdAlicuotaIva = ctx.IdAlicuotaIva21, PorcentajeIva = 21m,
+                Total = 484m
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var respuesta = await AnularHttpAsync(ctx, idOrden);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.Enviada, (await LeerOrdenAsync(ctx, idOrden)).Estado);
+    }
+
     [Fact]
     public async Task UnaOrdenConBorradorLigadoConfirmableNoPuedeAnularse409()
     {

--- a/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
@@ -502,6 +502,57 @@ public class OrdenesCompraCierreYAnulacionTests(WaysApiFixture fixture) : IClass
         Assert.Null(persistida.Numero);
     }
 
+    /// <summary>Verifica el guard existente de slice 3
+    /// (<c>EscriturasDeOrdenDeCompra.BloquearYExigirNoAnuladaAsync</c>,
+    /// <c>ServicioDeComprasLigaduraTests.ConfirmarContraUnaOrdenAnuladaEsRechazada409SinEscribirNada</c>)
+    /// contra una OC REALMENTE anulada por el endpoint nuevo de esta slice (<c>POST /anular</c>),
+    /// no sembrada por EF como hace el test de slice 3 — el primer camino end-to-end que puede
+    /// producir esta combinación sin bypass. Igual que en slice 3, el comprobante ligado-borrador
+    /// tiene que sembrarse por EF porque no hay forma honesta de ligar un borrador a una OC ya
+    /// anulada (<c>ExigirOrdenLigableAsync</c> lo rechaza en el link).</summary>
+    [Fact]
+    public async Task ConfirmarUnaRecepcionLigadaAUnaOrdenRealmenteAnuladaPorElEndpointEsRechazada409()
+    {
+        var ctx = await PrepararAsync(nameof(ConfirmarUnaRecepcionLigadaAUnaOrdenRealmenteAnuladaPorElEndpointEsRechazada409));
+        var creada = await CrearBorradorDeOrdenAsync(ctx);
+
+        var anular = await AnularHttpAsync(ctx, creada.Id);
+        Assert.Equal(HttpStatusCode.OK, anular.StatusCode);
+        Assert.Equal(EstadoOrdenCompra.Anulada, (await LeerOrdenAsync(ctx, creada.Id)).Estado);
+
+        int idComprobante;
+        var ahora = DateTimeOffset.UtcNow;
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var comprobante = new ComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdProveedor = ctx.IdProveedor, IdTipoComprobante = ctx.IdTipoCFA,
+                NumeroExterno = $"0001-{Guid.NewGuid():N}"[..8], FechaComprobante = DateOnly.FromDateTime(DateTime.UtcNow),
+                IdPuntoVenta = ctx.IdPuntoVenta, IdEmpleado = ctx.IdEmpleadoAdmin,
+                Subtotal = 1000m, DescuentoTotal = 0m, Total = 1000m, IvaTotal = 210m,
+                Estado = EstadoCompra.Borrador, IdOrdenCompra = creada.Id, CreatedAt = ahora, UpdatedAt = ahora
+            };
+            db.ComprobantesCompra.Add(comprobante);
+            await db.SaveChangesAsync();
+            idComprobante = comprobante.Id;
+
+            db.ItemsComprobanteCompra.Add(new ItemComprobanteCompra
+            {
+                IdTenant = ctx.IdTenant, IdComprobanteCompra = idComprobante, Orden = 1, IdArticulo = ctx.IdArticulo,
+                Descripcion = "Item de recepción (OC anulada de verdad)", Cantidad = 5m,
+                CostoUnitario = 100m, Descuento = 0m, IdAlicuotaIva = ctx.IdAlicuotaIva21, PorcentajeIva = 21m,
+                Total = 605m
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var respuesta = await ConfirmarCompraHttpAsync(ctx, idComprobante);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_anulada", problema.GetProperty("codigo").GetString());
+    }
+
     // ================================================================================================
     // task 4.10 / mutation target #33 (segunda cláusula) / decisión 20.2: RACE 1 — anular OC ×
     // confirmar el comprobante ligado, en AMBOS órdenes (interceptor). Ver doc-comment de la clase.

--- a/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraCierreYAnulacionTests.cs
@@ -1,0 +1,758 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 4 (tasks 4.4-4.17; design: Transactions — CERRAR OC/ANULAR
+/// OC, decisiones 5/9). Cierre manual (<c>POST /{id}/cerrar</c>) + anulación gobernada por el
+/// libro (<c>POST /{id}/anular</c>, guard lock-free) + la matriz 409/autorización.
+///
+/// OD (orquestador, decisión 20.2 de tasks.md, launch prompt de este slice): las DOS carreras
+/// diferidas de slices anteriores SE PAGAN ACÁ.
+/// - Race 1 (deferred de task 3.22 / design Testing Strategy "the two races" / mutation target
+///   #33's "anular × confirmar rendezvous", task 4.10): <c>anular</c> vs <c>confirmar</c> de un
+///   comprobante YA ligado (todavía borrador). Probada en AMBOS órdenes con
+///   <see cref="InterceptorDePausaTrasIniciarLaTransaccion"/>. **FINDING** (mutation-proof-tests
+///   regla 2/3, mismo criterio que el hallazgo de target #21 en slice 3): con el guard lock-free
+///   real (statement 3 de <c>AnularAsync</c>, SIN <c>FOR SHARE</c>), el resultado es DETERMINISTA
+///   en AMBOS órdenes — <c>anular</c> SIEMPRE pierde mientras el comprobante exista ligado en
+///   borrador (si <c>anular</c> toma el lock de la OC primero, su propio statement 3 encuentra el
+///   comprobante todavía 'borrador' — el UPDATE de confirmar está sin comitear, invisible bajo
+///   READ COMMITTED — y lo rechaza; si <c>confirmar</c> toma el lock primero, comitea, y el
+///   statement 1 de <c>anular</c> ve el estado ya proyectado, fuera de
+///   <c>('borrador','enviada')</c>). El texto de design ("el guard del confirm... rechaza si
+///   anulada") describe el mecanismo GENERAL de defensa en profundidad, no necesariamente
+///   alcanzable con ESTE fixture específico — la propia task 4.9 (un borrador ligado bloquea SIEMPRE
+///   la anulación) domina. Ambos órdenes se prueban igual: verifican que NUNCA hay deadlock y que
+///   el resultado es <c>SIEMPRE</c> un 200 (confirmar) + un 409 (anular), nunca los dos 200, nunca
+///   los dos 409.
+/// - Race 2 (deferred de task 3.38, FK 9 / design Backstop Map "linking to an OC being annulled
+///   concurrently"): <c>ExigirOrdenLigableAsync</c> (<c>FOR SHARE</c>, bajo la transacción de
+///   <c>ActualizarBorradorAsync</c>) vs el <c>FOR UPDATE</c> de statement 1 de <c>AnularAsync</c> —
+///   ESTA sí es genuinamente bidireccional: quien tome el lock de la fila de la OC primero decide
+///   el resultado (el otro pierde), nunca deadlock (SHARE vs UPDATE sobre la MISMA fila, sin
+///   ciclo — un solo recurso en juego).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OrdenesCompraCierreYAnulacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordUsuario = "una-contraseña-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, HttpClient Admin, string MailAdmin, string PasswordAdmin,
+        int IdProveedor, int IdArticulo, int IdArticulo2, int IdAlicuotaIva21, int IdTipoCFA, int IdEmpleadoAdmin);
+
+    /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Cierre-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.Add(proveedor);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-cie-1-{Guid.NewGuid():N}", Nombre = "Cierre Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-cie-2-{Guid.NewGuid():N}", Nombre = "Cierre Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        var idTipoCFA = await db.TiposComprobante.Where(t => t.Codigo == "C-FA").Select(t => t.Id).SingleAsync();
+        var idEmpleadoAdmin = await db.Usuarios.Where(u => u.Mail == mailAdmin).Select(u => u.Id).FirstAsync();
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, admin, mailAdmin, resultado.PasswordTemporal,
+            proveedor.Id, articulo1.Id, articulo2.Id, idAlicuotaIva21, idTipoCFA, idEmpleadoAdmin);
+    }
+
+    private async Task<HttpClient> CrearUsuarioConRolAsync(Contexto ctx, string nombre, RolConocido rol)
+    {
+        var mail = $"{nombre.ToLowerInvariant()}@ways.test";
+        var alta = await ctx.Admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario(nombre, mail, (int)rol, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordUsuario));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    // ---- helpers: órdenes de compra ----------------------------------------------------------------
+
+    private static SolicitudDeOrdenDeCompra SolicitudDeOrdenSimple(
+        Contexto ctx, decimal cantidad = 10m, decimal? costo = 100m, int? idArticulo = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdPuntoVenta, null, null,
+            [new LineaDeOrdenSolicitada(idArticulo ?? ctx.IdArticulo, "Item de orden", cantidad, costo)]);
+
+    private static async Task<OrdenDeCompraBorrador> CrearBorradorDeOrdenAsync(
+        Contexto ctx, SolicitudDeOrdenDeCompra? solicitud = null, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsJsonAsync("/api/ordenes-compra", solicitud ?? SolicitudDeOrdenSimple(ctx));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> EnviarOrdenAsync(Contexto ctx, int id, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsync($"/api/ordenes-compra/{id}/enviar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> CrearYEnviarOrdenAsync(
+        Contexto ctx, decimal cantidad = 10m, decimal? costo = 100m, int? idArticulo = null)
+    {
+        var creada = await CrearBorradorDeOrdenAsync(ctx, SolicitudDeOrdenSimple(ctx, cantidad, costo, idArticulo));
+        return await EnviarOrdenAsync(ctx, creada.Id);
+    }
+
+    private static async Task<HttpResponseMessage> CerrarHttpAsync(Contexto ctx, int id, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsync($"/api/ordenes-compra/{id}/cerrar", null);
+
+    private static async Task<HttpResponseMessage> AnularHttpAsync(Contexto ctx, int id, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsync($"/api/ordenes-compra/{id}/anular", null);
+
+    // ---- helpers: comprobantes de compra (ligadura, slices 1-3) --------------------------------------
+
+    private static SolicitudDeCompra SolicitudDeCompraSimple(
+        Contexto ctx, decimal unidades, int? idOrdenCompra, int? idArticulo = null) =>
+        new(
+            ctx.IdProveedor, ctx.IdTipoCFA, ctx.IdPuntoVenta, $"0001-{Guid.NewGuid():N}"[..8], DateOnly.FromDateTime(DateTime.UtcNow), null,
+            [new LineaDeCompraSolicitada(idArticulo ?? ctx.IdArticulo, "Item de recepción", unidades, null, null, 100m, 0m, ctx.IdAlicuotaIva21, false)],
+            idOrdenCompra);
+
+    private static async Task<(HttpStatusCode Estado, CompraDetalle? Compra)> CrearBorradorDeCompraAsync(
+        Contexto ctx, SolicitudDeCompra solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud);
+        if (respuesta.StatusCode != HttpStatusCode.Created)
+        {
+            return (respuesta.StatusCode, null);
+        }
+
+        return (respuesta.StatusCode, await respuesta.Content.ReadFromJsonAsync<CompraDetalle>(OpcionesJson));
+    }
+
+    private static async Task<HttpResponseMessage> ConfirmarCompraHttpAsync(Contexto ctx, int id, HttpClient? cliente = null) =>
+        await (cliente ?? ctx.Admin).PostAsync($"/api/compras/{id}/confirmar", null);
+
+    private static async Task<CompraDetalle> ConfirmarCompraAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ConfirmarCompraHttpAsync(ctx, id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<HttpResponseMessage> AnularCompraHttpAsync(Contexto ctx, int id) =>
+        await ctx.Admin.PostAsync($"/api/compras/{id}/anular", null);
+
+    private async Task<OrdenCompra> LeerOrdenAsync(Contexto ctx, int idOrdenCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == idOrdenCompra);
+    }
+
+    // ================================================================================================
+    // task 4.4/4.15: cerrar manualmente estampa fecha_cierre + id_empleado_cierre en UN UPDATE
+    // ================================================================================================
+
+    [Fact]
+    public async Task CerrarManualmenteEstampaFechaCierreYEmpleado()
+    {
+        var ctx = await PrepararAsync(nameof(CerrarManualmenteEstampaFechaCierreYEmpleado));
+        var enviada = await CrearYEnviarOrdenAsync(ctx);
+
+        // Regla 12c: una OC hermana del mismo tenant — el cierre de la primera no debe tocarla.
+        var hermana = await CrearYEnviarOrdenAsync(ctx, idArticulo: ctx.IdArticulo2);
+
+        var respuesta = await CerrarHttpAsync(ctx, enviada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var cerrada = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(EstadoOrdenCompra.Cerrada, cerrada.Estado);
+        Assert.NotNull(cerrada.FechaCierre);
+        Assert.Equal(ctx.IdEmpleadoAdmin, cerrada.IdEmpleadoCierre);
+
+        var persistida = await LeerOrdenAsync(ctx, enviada.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, persistida.Estado);
+        Assert.NotNull(persistida.FechaCierre);
+        Assert.Equal(ctx.IdEmpleadoAdmin, persistida.IdEmpleadoCierre);
+
+        // Hermana intacta (regla 12c).
+        var hermanaDespues = await LeerOrdenAsync(ctx, hermana.Id);
+        Assert.Equal(EstadoOrdenCompra.Enviada, hermanaDespues.Estado);
+        Assert.Null(hermanaDespues.FechaCierre);
+        Assert.Null(hermanaDespues.IdEmpleadoCierre);
+    }
+
+    // ================================================================================================
+    // task 4.5/4.15 (mutation target #26 ya cubierto en slice 3; acá el camino HTTP real de cierre):
+    // una OC cerrada manualmente no se reabre al anular su recepción
+    // ================================================================================================
+
+    [Fact]
+    public async Task UnaOrdenCerradaManualmenteNoSeReabreAlAnularSuRecepcion()
+    {
+        var ctx = await PrepararAsync(nameof(UnaOrdenCerradaManualmenteNoSeReabreAlAnularSuRecepcion));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 4m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+        var confirmada = await ConfirmarCompraAsync(ctx, creada!.Id);
+
+        var antesDelCierre = await LeerOrdenAsync(ctx, enviada.Id);
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, antesDelCierre.Estado);
+
+        var cierre = await CerrarHttpAsync(ctx, enviada.Id);
+        Assert.Equal(HttpStatusCode.OK, cierre.StatusCode);
+
+        var anulacion = await AnularCompraHttpAsync(ctx, confirmada.Id);
+        Assert.Equal(HttpStatusCode.OK, anulacion.StatusCode);
+
+        var despues = await LeerOrdenAsync(ctx, enviada.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, despues.Estado);
+        Assert.NotNull(despues.FechaCierre);
+        Assert.Equal(ctx.IdEmpleadoAdmin, despues.IdEmpleadoCierre);
+    }
+
+    // ================================================================================================
+    // task 4.6/4.14: mutation target #31 — cerrar una orden que no está en enviada/recibida_parcial
+    // ================================================================================================
+
+    [Theory]
+    [InlineData("borrador")]
+    [InlineData("cerrada")]
+    [InlineData("anulada")]
+    public async Task CerrarUnaOrdenFueraDeEnviadaORecibidaParcialEsRechazada409(string estadoInicial)
+    {
+        var ctx = await PrepararAsync(nameof(CerrarUnaOrdenFueraDeEnviadaORecibidaParcialEsRechazada409) + estadoInicial);
+        var id = await SembrarOrdenEnEstadoAsync(ctx, estadoInicial);
+
+        var respuesta = await CerrarHttpAsync(ctx, id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_no_cerrable", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>Siembra directa por EF en el estado pedido — mismo criterio que
+    /// <c>ServicioDeComprasLigaduraTests.SembrarOrdenAnuladaAsync</c>: el estado de la fila es lo
+    /// que el guard interpreta, no el camino que la produjo.</summary>
+    private async Task<int> SembrarOrdenEnEstadoAsync(Contexto ctx, string estado)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var (estadoEnum, numero, fechaEnvio, fechaCierre, idEmpleadoCierre) = estado switch
+        {
+            "borrador" => (EstadoOrdenCompra.Borrador, (long?)null, (DateTimeOffset?)null, (DateTimeOffset?)null, (int?)null),
+            "cerrada" => (EstadoOrdenCompra.Cerrada, 900L, ahora, ahora, ctx.IdEmpleadoAdmin),
+            "anulada" => (EstadoOrdenCompra.Anulada, 901L, ahora, (DateTimeOffset?)null, (int?)null),
+            _ => throw new ArgumentOutOfRangeException(nameof(estado))
+        };
+
+        var orden = new OrdenCompra
+        {
+            IdTenant = ctx.IdTenant, IdPuntoVenta = ctx.IdPuntoVenta, IdProveedor = ctx.IdProveedor,
+            IdEmpleado = ctx.IdEmpleadoAdmin, Numero = numero, FechaEmision = ahora, FechaEnvio = fechaEnvio,
+            FechaCierre = fechaCierre, IdEmpleadoCierre = idEmpleadoCierre,
+            Estado = estadoEnum, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.OrdenesCompra.Add(orden);
+        await db.SaveChangesAsync();
+        return orden.Id;
+    }
+
+    // ================================================================================================
+    // task 4.7/4.9/4.16: anulación gobernada por el libro
+    // ================================================================================================
+
+    [Fact]
+    public async Task UnaOrdenCuyaUnicaRecepcionFueAnuladaPuedeAnularseElla()
+    {
+        var ctx = await PrepararAsync(nameof(UnaOrdenCuyaUnicaRecepcionFueAnuladaPuedeAnularseElla));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+        var confirmada = await ConfirmarCompraAsync(ctx, creada!.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+
+        var anulacionCompra = await AnularCompraHttpAsync(ctx, confirmada.Id);
+        Assert.Equal(HttpStatusCode.OK, anulacionCompra.StatusCode);
+        // El cierre fue AUTOMÁTICO (no manual) — la proyección la devuelve a `enviada`.
+        Assert.Equal(EstadoOrdenCompra.Enviada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+
+        var respuesta = await AnularHttpAsync(ctx, enviada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var anulada = JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoOrdenCompra.Anulada, anulada.Estado);
+
+        Assert.Equal(EstadoOrdenCompra.Anulada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    [Fact]
+    public async Task UnaOrdenConRecepcionEfectivaNoPuedeAnularse409()
+    {
+        var ctx = await PrepararAsync(nameof(UnaOrdenConRecepcionEfectivaNoPuedeAnularse409));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 4m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+        await ConfirmarCompraAsync(ctx, creada!.Id);
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+
+        var respuesta = await AnularHttpAsync(ctx, enviada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    [Fact]
+    public async Task UnaOrdenConBorradorLigadoConfirmableNoPuedeAnularse409()
+    {
+        var ctx = await PrepararAsync(nameof(UnaOrdenConBorradorLigadoConfirmableNoPuedeAnularse409));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 4m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var respuesta = await AnularHttpAsync(ctx, enviada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.Enviada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+
+        // El borrador sigue confirmable — anular no lo tocó.
+        var confirmar = await ConfirmarCompraHttpAsync(ctx, creada!.Id);
+        Assert.Equal(HttpStatusCode.OK, confirmar.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnularUnaOrdenYaAnuladaEsRechazada409()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnaOrdenYaAnuladaEsRechazada409));
+        var id = await SembrarOrdenEnEstadoAsync(ctx, "anulada");
+
+        var respuesta = await AnularHttpAsync(ctx, id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Conflict, cuerpo);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+    }
+
+    // ================================================================================================
+    // task 4.4/4.404 desvío-friendly: anular un borrador SIN número (CHECK 1 lo admite)
+    // ================================================================================================
+
+    [Fact]
+    public async Task AnularUnBorradorSinNumeroEsPermitido()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnBorradorSinNumeroEsPermitido));
+        var creada = await CrearBorradorDeOrdenAsync(ctx);
+        Assert.Null(creada.Numero);
+
+        var respuesta = await AnularHttpAsync(ctx, creada.Id);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        var persistida = await LeerOrdenAsync(ctx, creada.Id);
+        Assert.Equal(EstadoOrdenCompra.Anulada, persistida.Estado);
+        Assert.Null(persistida.Numero);
+    }
+
+    // ================================================================================================
+    // task 4.10 / mutation target #33 (segunda cláusula) / decisión 20.2: RACE 1 — anular OC ×
+    // confirmar el comprobante ligado, en AMBOS órdenes (interceptor). Ver doc-comment de la clase.
+    // ================================================================================================
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Orden 1: <c>anular</c> pausada justo tras abrir su transacción — <c>confirmar</c>
+    /// corre y comitea PRIMERO (mueve la OC vía <see cref="EscriturasDeOrdenDeCompra"/>). Al
+    /// reanudar, el statement 1 de <c>anular</c> ve el estado YA proyectado (fuera de
+    /// <c>('borrador','enviada')</c>) y rechaza.</summary>
+    [Fact]
+    public async Task AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada()
+    {
+        var ctx = await PrepararAsync(nameof(AnularPierdeCuandoConfirmarComitePrimeroMientrasAnularEstaPausada));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaAnular = clienteAnular.PostAsync($"/api/ordenes-compra/{enviada.Id}/anular", null);
+        await transaccionIniciada.Task;
+
+        var respuestaConfirmar = await ConfirmarCompraHttpAsync(ctx, creada!.Id);
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaAnular = await tareaAnular;
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.Conflict, cuerpoAnular);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoAnular, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.Cerrada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    /// <summary>Orden 2: <c>confirmar</c> pausada justo tras abrir su transacción —
+    /// <c>anular</c> corre PRIMERO, completa sus 4 statements. Su statement 3 (EXISTS lock-free)
+    /// encuentra el comprobante TODAVÍA 'borrador' (el UPDATE de confirmar sigue sin comitear,
+    /// invisible bajo READ COMMITTED) y rechaza — <c>anular</c> hace rollback, libera el lock. Al
+    /// reanudar, <c>confirmar</c> ve el estado SIN CAMBIOS (todavía enviada, nunca anulada) y
+    /// completa con éxito.</summary>
+    [Fact]
+    public async Task AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada()
+    {
+        var ctx = await PrepararAsync(nameof(AnularPierdeCuandoIntentaPrimeroMientrasConfirmarEstaPausada));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+        var (estadoCreacion, creada) = await CrearBorradorDeCompraAsync(
+            ctx, SolicitudDeCompraSimple(ctx, unidades: 10m, idOrdenCompra: enviada.Id));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteConfirmar = factory.CreateClient();
+        var login = await clienteConfirmar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaConfirmar = clienteConfirmar.PostAsync($"/api/compras/{creada!.Id}/confirmar", null);
+        await transaccionIniciada.Task;
+
+        var respuestaAnular = await AnularHttpAsync(ctx, enviada.Id);
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.Conflict, cuerpoAnular);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoAnular, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaConfirmar = await tareaConfirmar;
+        var cuerpoConfirmar = await respuestaConfirmar.Content.ReadAsStringAsync();
+        Assert.True(respuestaConfirmar.StatusCode == HttpStatusCode.OK, cuerpoConfirmar);
+
+        Assert.Equal(EstadoOrdenCompra.Cerrada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    // ================================================================================================
+    // decisión 20.2: RACE 2 — ligar un borrador (PUT, ExigirOrdenLigableAsync FOR SHARE) × anular
+    // la OC (FOR UPDATE, statement 1). Genuinamente bidireccional: quien tome el lock de la fila
+    // primero decide, nunca deadlock (SHARE/UPDATE sobre la MISMA fila — un solo recurso, sin ciclo).
+    // ================================================================================================
+
+    /// <summary>Orden A: el PUT que liga (bajo <c>ActualizarBorradorAsync</c>'s transacción, real
+    /// TOCTOU guard — design T3) pausado justo tras abrir su transacción. <c>anular</c> corre
+    /// PRIMERO y comitea sin contención (nada ligado todavía) — luego el PUT reanuda, su
+    /// <c>ExigirOrdenLigableAsync</c> ve <c>estado='anulada'</c> fresco y rechaza.</summary>
+    [Fact]
+    public async Task AnularGanaLaCarreraCuandoElPutQueLigaEstaPausado()
+    {
+        var ctx = await PrepararAsync(nameof(AnularGanaLaCarreraCuandoElPutQueLigaEstaPausado));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+        var (estadoCreacion, borrador) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, unidades: 5m, idOrdenCompra: null));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clientePut = factory.CreateClient();
+        var login = await clientePut.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var solicitudRelink = SolicitudDeCompraSimple(ctx, unidades: 5m, idOrdenCompra: enviada.Id);
+        var tareaPut = clientePut.PutAsJsonAsync($"/api/compras/{borrador!.Id}", solicitudRelink);
+        await transaccionIniciada.Task;
+
+        var respuestaAnular = await AnularHttpAsync(ctx, enviada.Id);
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.OK, cuerpoAnular);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaPut = await tareaPut;
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.Conflict, cuerpoPut);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoPut, OpcionesJson);
+        Assert.Equal("orden_compra_anulada", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.Anulada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    /// <summary>Orden B: <c>anular</c> pausada justo tras abrir su transacción. El PUT que liga
+    /// corre PRIMERO — su <c>FOR SHARE</c> ve <c>estado='enviada'</c> (todavía), liga, comitea,
+    /// libera el <c>FOR SHARE</c>. Al reanudar, <c>anular</c> toma el <c>FOR UPDATE</c> (ahora
+    /// libre) y su statement 3 encuentra el comprobante recién ligado, todavía 'borrador' →
+    /// rechaza.</summary>
+    [Fact]
+    public async Task ElPutQueLigaGanaLaCarreraCuandoAnularEstaPausada()
+    {
+        var ctx = await PrepararAsync(nameof(ElPutQueLigaGanaLaCarreraCuandoAnularEstaPausada));
+        var enviada = await CrearYEnviarOrdenAsync(ctx, cantidad: 10m);
+        var (estadoCreacion, borrador) = await CrearBorradorDeCompraAsync(ctx, SolicitudDeCompraSimple(ctx, unidades: 5m, idOrdenCompra: null));
+        Assert.Equal(HttpStatusCode.Created, estadoCreacion);
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaAnular = clienteAnular.PostAsync($"/api/ordenes-compra/{enviada.Id}/anular", null);
+        await transaccionIniciada.Task;
+
+        var solicitudRelink = SolicitudDeCompraSimple(ctx, unidades: 5m, idOrdenCompra: enviada.Id);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/compras/{borrador!.Id}", solicitudRelink);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaAnular = await tareaAnular;
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.Conflict, cuerpoAnular);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoAnular, OpcionesJson);
+        Assert.Equal("orden_compra_con_recepciones", problema.GetProperty("codigo").GetString());
+
+        Assert.Equal(EstadoOrdenCompra.Enviada, (await LeerOrdenAsync(ctx, enviada.Id)).Estado);
+    }
+
+    // ================================================================================================
+    // task 4.11 / mutation target #34a: matriz de autorización — las CINCO rutas de escritura
+    // ================================================================================================
+
+    [Fact]
+    public async Task VendedorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra()
+    {
+        var ctx = await PrepararAsync(nameof(VendedorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra));
+        using var vendedor = await CrearUsuarioConRolAsync(ctx, "vendedor-matriz-oc", RolConocido.Vendedor);
+        var creada = await CrearBorradorDeOrdenAsync(ctx);
+        var enviada = await CrearYEnviarOrdenAsync(ctx, idArticulo: ctx.IdArticulo2);
+
+        var crear = await vendedor.PostAsJsonAsync("/api/ordenes-compra", SolicitudDeOrdenSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, crear.StatusCode);
+
+        var editar = await vendedor.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", SolicitudDeOrdenSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, editar.StatusCode);
+
+        var enviar = await vendedor.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, enviar.StatusCode);
+
+        var cerrar = await vendedor.PostAsync($"/api/ordenes-compra/{enviada.Id}/cerrar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, cerrar.StatusCode);
+
+        var anular = await vendedor.PostAsync($"/api/ordenes-compra/{enviada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Forbidden, anular.StatusCode);
+    }
+
+    [Fact]
+    public async Task SupervisorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra()
+    {
+        var ctx = await PrepararAsync(nameof(SupervisorEsRechazadoEnLasCincoRutasDeEscrituraDeOrdenesDeCompra));
+        using var supervisor = await CrearUsuarioConRolAsync(ctx, "supervisor-matriz-oc", RolConocido.Supervisor);
+        var creada = await CrearBorradorDeOrdenAsync(ctx);
+        var enviada = await CrearYEnviarOrdenAsync(ctx, idArticulo: ctx.IdArticulo2);
+
+        var crear = await supervisor.PostAsJsonAsync("/api/ordenes-compra", SolicitudDeOrdenSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, crear.StatusCode);
+
+        var editar = await supervisor.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", SolicitudDeOrdenSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, editar.StatusCode);
+
+        var enviar = await supervisor.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, enviar.StatusCode);
+
+        var cerrar = await supervisor.PostAsync($"/api/ordenes-compra/{enviada.Id}/cerrar", null);
+        Assert.Equal(HttpStatusCode.Forbidden, cerrar.StatusCode);
+
+        var anular = await supervisor.PostAsync($"/api/ordenes-compra/{enviada.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Forbidden, anular.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminEjerceElCicloCompletoDeEscrituraDeOrdenesDeCompra()
+    {
+        var ctx = await PrepararAsync(nameof(AdminEjerceElCicloCompletoDeEscrituraDeOrdenesDeCompra));
+
+        var creada = await CrearBorradorDeOrdenAsync(ctx);
+
+        var editar = await ctx.Admin.PutAsJsonAsync($"/api/ordenes-compra/{creada.Id}", SolicitudDeOrdenSimple(ctx));
+        Assert.Equal(HttpStatusCode.OK, editar.StatusCode);
+
+        var enviar = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/enviar", null);
+        Assert.Equal(HttpStatusCode.OK, enviar.StatusCode);
+
+        var cerrar = await ctx.Admin.PostAsync($"/api/ordenes-compra/{creada.Id}/cerrar", null);
+        Assert.Equal(HttpStatusCode.OK, cerrar.StatusCode);
+
+        // Segunda OC, sin enviar — ejerce anular desde borrador (número nunca quemado).
+        var segunda = await CrearBorradorDeOrdenAsync(ctx, idArticulo: null);
+        var anular = await ctx.Admin.PostAsync($"/api/ordenes-compra/{segunda.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anular.StatusCode);
+    }
+
+    private static async Task<OrdenDeCompraBorrador> CrearBorradorDeOrdenAsync(Contexto ctx, int? idArticulo) =>
+        await CrearBorradorDeOrdenAsync(ctx, SolicitudDeOrdenSimple(ctx, idArticulo: idArticulo));
+
+    // ================================================================================================
+    // task 4.11: aislamiento entre tenants — cerrar/anular una OC de OTRO tenant es 404 (ADR-8)
+    // ================================================================================================
+
+    [Fact]
+    public async Task CerrarYAnularUnaOrdenDeOtroTenantEsRechazadaComo404()
+    {
+        var tenantA = await PrepararAsync(nameof(CerrarYAnularUnaOrdenDeOtroTenantEsRechazadaComo404) + "-A");
+        var tenantB = await PrepararAsync(nameof(CerrarYAnularUnaOrdenDeOtroTenantEsRechazadaComo404) + "-B");
+        var ordenDeA = await CrearYEnviarOrdenAsync(tenantA);
+
+        var cerrar = await tenantB.Admin.PostAsync($"/api/ordenes-compra/{ordenDeA.Id}/cerrar", null);
+        Assert.Equal(HttpStatusCode.NotFound, cerrar.StatusCode);
+
+        var anular = await tenantB.Admin.PostAsync($"/api/ordenes-compra/{ordenDeA.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.NotFound, anular.StatusCode);
+    }
+
+    // ================================================================================================
+    // task 4.12: no-regresión — ComprasLifecycleTests/ComprasAnulacionYConcurrenciaTests intactos.
+    // Verificado por git diff --stat, no por un assert acá (ver PR body).
+    // ================================================================================================
+
+    // task 4.13: cuenta-corriente-de-proveedores untouched — verificado por git diff --stat.
+
+    // ================================================================================================
+    // task 4.18: gate guard — ninguna DDL nueva
+    // ================================================================================================
+
+    [Fact]
+    public async Task NoHayCambiosPendientesDeModeloEnLaSlice4()
+    {
+        using var _ = fixture.CreateClient();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        Assert.False(db.Database.HasPendingModelChanges());
+    }
+}


### PR DESCRIPTION
## Resumen

- `CerrarAsync`: la tríada estado+fecha_cierre+id_empleado_cierre en UN `UPDATE...RETURNING` (CHECK 2 respalda), válido desde enviada/recibida_parcial; el cierre manual JAMÁS se revierte.
- `AnularAsync` gobernada por el libro: 4 statements — lock `FOR UPDATE` único → guard derivado de recepción SIN lock → `EXISTS` de borradores ligados SIN lock (OD8/T10: lockearlo arma ciclo de deadlock contra el confirm) → `UPDATE...RETURNING`. Borrador sin número y enviada con número quemado ambos admitidos por el CHECK 1.
- **Las 2 carreras diferidas pagadas**: anular×confirmar en AMBOS órdenes (hallazgo honesto: anular pierde SIEMPRE — no bidireccional como sugería el design) y ligar×anular (genuinamente bidireccional). Prueba one-shot del deadlock real con el detector de Postgres (FOR SHARE mutado → deadlock en 15s; sin mutar → limpio).
- Size:exception concedida: producción ~296 líneas; las 869 de tests son profundidad mandada (precedente W3 de la 13).

## Judgment-day

- Juez B ronda 1: **1 MAJOR de regla 12** — la decisión 22 afirmaba que los tests de interceptor cubrían el invariante lock-free (falso: pausan antes de cualquier statement; FOR SHARE reintroducido pasaba 21/21). Fix `f6237cd`: red estructural permanente (texto fuente de ambos guards, OrdinalIgnoreCase, límites de extracción esquivando los doc-comments que mencionan FOR SHARE en prosa) + decisión 22 corregida. Re-ronda B limpia.
- Juez A: 0 hallazgos — traza completa de constraints, carreras con lados de interceptor verificados distintos, allowlist de autorización genuinamente ejercida.

Gate: cero DDL, `has-pending-model-changes` limpio, regresión 223/223. Protegidos intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)