### PR TITLE
feat(ordenes-compra): read model con cobertura por articulo y desvio informativo (etapa 16, slice 5)

### DIFF
--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -283,10 +283,15 @@
       `DetalleDevuelveCadaCampoPosicionalConSuVerdad` que assertea ambos ids contra
       `IdProveedor2`/`IdPuntoVenta2` (desincronizados, con una precondición `Assert.NotEqual` que
       falla ruidosamente si algún día colisionaran) y, por ser la misma causa raíz (ningún campo
-      posicional leído de vuelta), extiende la lectura a TODOS los campos hasta ahora sin cobertura
-      del detalle y de la fila del listado: `Numero`, `FechaEnvio`, `FechaEsperada`, `FechaCierre`,
-      `CierreManual`, `Observaciones`, `Estado` (detalle) y `Estado` (fila de `PaginaDeOrdenesDeCompra`) —
-      todos con valores distintos entre sí.
+      posicional leído de vuelta), extiende la lectura a los campos del detalle hasta ahora sin
+      cobertura: `Numero`, `FechaEnvio`, `FechaEsperada`, `FechaCierre`, `CierreManual`,
+      `Observaciones`, `Estado` — y a `Estado` de la fila de `PaginaDeOrdenesDeCompra`, todos con
+      valores distintos entre sí.
+      **Corrección (decisión 26, judgment-day ronda 2, juez A — CRITICAL 2)**: la frase original de
+      este punto ("extiende la lectura a TODOS los campos ... del detalle y de la fila del listado")
+      era falsa para la fila del listado — solo `Estado` quedó cubierto ahí; `IdProveedor`/
+      `IdPuntoVenta` de `OrdenDeCompraListada` (el mismo swap posicional, pero en el `Select` de
+      `ListarAsync`) seguían sin ningún assert y ese swap pasaba 13/13. Ver decisión 26 para el fix.
     - **Evidencia de mutación** (tres ciclos, `dotnet build --no-incremental` + test filtrado +
       `git checkout -- src/` + rebuild entre cada uno, `git status` limpio en cada punto): (a)
       `pendiente = 0m` fijo → `CoberturaPendienteEsPositivaCuandoLaRecepcionNoCompletaLoPedido`
@@ -297,6 +302,49 @@
       `DetalleDevuelveCadaCampoPosicionalConSuVerdad` FALLA (`Expected: 2, Actual: 4`) → revert
       verificado. Corrida final completa del archivo: **13/13 verde**, `git status` con solo el
       archivo de test modificado.
+
+26. **`judgment-day` ronda 2 (juez A) confirmó 1 CRITICAL de producción + 1 CRITICAL de
+    tests/docs, 1 WARNING, 1 SUGGESTION — cerrados con fixes acotados.**
+    - **CRITICAL 1 (producción)**: `TotalEstimado` (`ObtenerDetalleAsync`) fabricaba costo —
+      agregaba desde `Cobertura` (`CostoEstimado` por-artículo × `Pedida` TOTAL del artículo), pero
+      `CostoEstimado` ya es un promedio ponderado que promedia SOLO las líneas cotizadas de ese
+      artículo, mientras que `Pedida` suma TODAS sus líneas, cotizadas o no — extrapolación
+      silenciosa alcanzable con un POST de dos líneas del mismo artículo, una cotizada y otra sin
+      costo (p.ej. 3 unidades a 100 + 4 sin costo ⇒ el bug daba 100×7=700 en vez de los 300
+      reales). **Fix**: `TotalEstimado` se recalcula a NIVEL LÍNEA — `sum(CostoUnitarioEstimado *
+      CantidadPedida)` sobre `items` (ya materializado en `ObtenerDetalleAsync`) SOLO para las
+      líneas con costo seteado; `null` cuando ninguna lo tiene. `CoberturaDeArticulo.CostoEstimado`
+      (el promedio por-artículo, display) NO se toca — sigue siendo el criterio correcto para esa
+      columna. **Verificado y descartado el mismo patrón en `TotalReal`/`DesvioTotal`**: `CostoReal`
+      y `Recibida` por artículo (`ObtenerCoberturaAsync`, `recibidoPorArticulo`) derivan siempre de
+      la MISMA población de `itemsRecibido` para ese artículo (mismo `GroupBy`, mismo `Cantidad`
+      agregado) — no existe una línea "recibida sin costo" que desacople ambos lados como pasaba en
+      el lado estimado, así que `TotalReal` se deja agregando desde `Cobertura` sin cambios.
+    - **CRITICAL 2 (tests + docs)**: `OrdenDeCompraListada.IdProveedor`/`IdPuntoVenta` jamás se
+      asserteaban (el swap de ambos en el `Select` de `ListarAsync` pasa 13/13) y la decisión 25
+      afirmaba falsamente cobertura de "la fila del listado" cuando solo `Estado` estaba cubierto.
+      **Fix**: `DetalleDevuelveCadaCampoPosicionalConSuVerdad` ahora assertea ambos ids de la fila
+      del listado contra `IdProveedor2`/`IdPuntoVenta2` (desincronizados, discriminantes); la
+      afirmación de la decisión 25 corregida in situ (ver arriba).
+    - **WARNING**: `ComprobantesLigados` (fixture rico de la cobertura) solo se asserteaba con
+      `Count >= 4`, dejando pasar un comprobante extra o de menos en silencio. **Fix**: assert de
+      conjunto exacto contra los 5 ids esperados (los cuatro confirmados + el borrador).
+    - **SUGGESTION**: variable muerta `pasadoManana` eliminada de
+      `CadaFiltroIgnoradoDevolveriaDeMasConSemillasAsimetricas`.
+    - **Tests nuevos obligatorios del CRITICAL 1**: `TotalEstimadoSumaSoloLasLineasCotizadasSin
+      ExtrapolarAlPromedioDelArticulo` (caso mixto: 3 unidades cotizadas a 100 + 4 sin costo del
+      mismo artículo ⇒ `TotalEstimado = 300`, jamás 700 por promedio); el caso todo-sin-costo ⇒
+      `null` ya existía (`UnaLineaNuncaCotizadaReportaNoComparableNuncaCero`) y sigue verde.
+    - **Evidencia de mutación** (dos ciclos, commit primero, `dotnet build --no-incremental` + test
+      filtrado + `git checkout -- src/...` + rebuild entre cada uno, `git status` limpio en cada
+      punto — la producción NUEVA es el estado ya committeado, el mutante es la fórmula/Select
+      viejos): (a) revertida la fórmula de `TotalEstimado` a `promedio × pedida total` →
+      `TotalEstimadoSumaSoloLasLineasCotizadasSinExtrapolarAlPromedioDelArticulo` FALLA (`Expected:
+      300, Actual: 700`) → revert verificado; (b) swap de `IdProveedor`/`IdPuntoVenta` en el
+      `Select` de `ListarAsync` → `DetalleDevuelveCadaCampoPosicionalConSuVerdad` FALLA (`Expected:
+      2, Actual: 4`, el nuevo assert de la fila del listado) → revert verificado. Corrida final
+      completa del archivo: **14/14 verde**; regresión filtrada `Compras`/`OC`: **254/254 verde**;
+      `git status` limpio.
 
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -201,6 +201,64 @@
       slice. El merge three-way preserva la regla en main. Regla de proceso nueva: los diffs de
       judgment se congelan con `main...HEAD`.
 
+20. **Slice 5 apply-phase decisions and deviations (decision 15 discipline).**
+    - **Pre-load (tasks 5.4/5.12) is NOT a backend method — deviation from this file's own prior
+      wording, resolved in favor of `design.md`.** `design.md:347-351` (the Web section) and its
+      Testing Strategy row for "Web (vitest)" place the reposición→OC mapping — `{IdArticulo,
+      Sugerido} → {IdArticulo, CantidadPedida}`, filtering `sugerido = null`, blocking the `"Sin
+      proveedor"` bucket — entirely inside `Reposicion.tsx` (slice 6), posting an ordinary
+      `SolicitudDeOrdenDeCompra` to the ALREADY-EXISTING `POST /` (slice 2). `design.md`'s own File
+      Changes table for `ServicioDeOrdenesDeCompra.cs` (`:376`) lists only "Draft CRUD, `enviar`,
+      `cerrar`, `anular`, list + detail read model" — no pre-load method — and mutation target #34's
+      row places "the `sugerido !== null` filter" under slices "4-6" (the web branch), never 5.
+      This file's own tasks 5.4/5.12 (drafted at `sdd-tasks` time) implied a backend method; treated
+      as a tasks-drafting/design mismatch resolved in favor of the authoritative `design.md` (same
+      "`sdd-apply`'s contract: follow design decisions, don't freelance" criterion slice 2 already
+      applied to the DELETE-endpoint mismatch, decision 17 above). No backend code added for the
+      pre-load; `POST /` needs zero modification.
+    - **The cobertura derivation is a SEPARATE LINQ query, never a shared SQL fragment with
+      `EscriturasDeOrdenDeCompra`'s raw-ADO derivation — resolves the launch prompt's own open
+      question ("¿reusable? — si duplicás la derivación, el design lo prohíbe... extraé o
+      reusá").** `design.md`'s Testing Strategy explicitly names TWO derivations and a fidelity
+      test as the seam between them: "Integration — projection fidelity | For every fixture: the
+      stored `estado` equals `ProyectorDeEstadoDeOrden.Proyectar(...)` recomputed from the **read
+      model's own** cobertura numbers | The one assertion that keeps the raw-ADO derivation and
+      the LINQ derivation from drifting" (`design.md:421`) — this sentence only makes sense if the
+      two derivations are independent implementations, not shared SQL. Decision 12 above
+      ("verdad única") governs the **stored `estado` column** (never re-derived by the read
+      model), not the underlying quantity computation, which legitimately has two
+      implementations cross-checked by task 5.9's fidelity test rather than unified by code
+      sharing. Sharing the raw-ADO CTE text would also be structurally awkward: the write side
+      only needs two aggregated booleans (`completa`/`algoRecibido`); the read side needs full
+      per-artículo rows including recibido-no-pedido (`Pedida = 0`, decision 13) and the price
+      comparison, a materially different shape. Both derivations independently add `deleted_at IS
+      NULL` (no entity in this repo has a global EF query filter for soft-delete — verified by
+      grepping `HasQueryFilter` across `Configuraciones/`, zero hits — so the LINQ side needed its
+      own explicit filter, mirroring the raw-ADO defense-in-depth rather than inheriting it).
+    - **`Pendiente`/`TotalEstimado`/`TotalReal`/`DesvioTotal` formulas — design gaps filled by
+      implementation, registered here since neither `design.md` nor the spec pins the exact
+      arithmetic.** `Pendiente = Math.Max(Pedida - Recibida, 0)` — never negative on an
+      over-delivery, matching `design.md:346`'s own use of `Pendiente > 0` to gate `CompraEditor.tsx`'s
+      pre-fill (a negative value would be a nonsensical gate condition). `CostoEstimado`/`CostoReal`
+      per artículo are cantidad-weighted averages over only the comparable lines (a line with
+      `CostoUnitarioEstimado IS NULL` contributes no zero to the estimated average; an artículo with
+      zero linked confirmed lines has no real average) — `Desvio` is `null` unless BOTH sides exist
+      (never a partial or fabricated value). `TotalEstimado`/`TotalReal` sum only the artículos whose
+      own `CostoEstimado`/`CostoReal` is non-null (`dto-contract-honesty`: mixing real terms with
+      fabricated zeros would misstate the total), `null` when zero terms qualify; `DesvioTotal`
+      follows the same "both totals present, denominator non-zero" gate as the per-artículo `Desvio`.
+    - **Test tipo de comprobante choice**: `C-FB` (`DiscriminaIva = false`) used for every receiving
+      comprobante in this slice's tests, not `C-FA` (used by slices 1/4's fixtures) — deliberate,
+      to keep `CalculadorDeCompra.CalcularCostoEfectivoDesdeItem`'s arithmetic IVA-free
+      (`total/cantidad`) so the price-deviation assertions (`+12%`, weighted averages) land on exact
+      decimal values instead of IVA-rounded ones. Not a production code path change — `DiscriminaIva`
+      is read per-line from each linked comprobante's own tipo either way (decision 14).
+    - **`judgment-day` NOT run** (task 5.19) — same executor-boundary reason as every prior slice.
+      Full solution test suite run once end-to-end post-implementation (`dotnet test`, no filter):
+      **2216/2216 green** (526 Domain + 291 Application + 1399 Integration), confirming the
+      non-regression criterion (mutation target #34's trailing row) holds across the whole tree, not
+      only the `ComprasConfirmar`/`ComprasAnular` suites named there.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-
@@ -1260,57 +1318,102 @@ clean round + PR merged.
 **Budget note**: pre-authorized split `5a` (paginated list) / `5b` (detail + cobertura +
 deviation) if this slice overflows — decision 3 above.
 
-- [ ] 5.1 Same `ContratosDeOrdenDeCompra.cs`: `CoberturaDeArticulo`, `OrdenDeCompraDetalle`,
+- [x] 5.1 Same `ContratosDeOrdenDeCompra.cs`: `CoberturaDeArticulo`, `OrdenDeCompraDetalle`,
   `OrdenDeCompraListada`, `PaginaDeOrdenesDeCompra` — per-artículo cobertura list, never a
   fabricated per-line split. *(design.md:176-192, decision 13, `dto-contract-honesty`)*
-- [ ] 5.2 Same `ServicioDeOrdenesDeCompra.cs`: `ListarAsync` — `ConstruirQuery` with
+- [x] 5.2 Same `ServicioDeOrdenesDeCompra.cs`: `ListarAsync` — `ConstruirQuery` with
   `idProveedor`/`idPuntoVenta`/`estado`/`desde`/`hasta` filters, `ORDER BY fecha_emision DESC,
   id_orden_compra DESC`, `Skip/Take`, `pagina = Math.Max(pagina,1)`, `tamanio =
   Math.Clamp(tamanio,1,200)`. *(design.md:70, 201-204, mutation target #34b)*
-- [ ] 5.3 Same file: `ObtenerDetalleAsync` — items + the per-artículo cobertura (statement-2's
+- [x] 5.3 Same file: `ObtenerDetalleAsync` — items + the per-artículo cobertura (own LINQ
   derivation, read-only) + price deviation via `CalculadorDeCompra.
   CalcularCostoEfectivoDesdeItem`, `null` never `0` when `costo_unitario_estimado IS NULL`.
-  *(design.md:67-69, decision 14, ordenes-de-compra/spec.md:242-249)*
-- [ ] 5.4 Same file: `PreCargarDesdeReposicionAsync` (or the equivalent mapping in `POST /`) —
-  accept the reposición list's shape, `FilaDeReposicion.{IdArticulo, Sugerido} →
-  {IdArticulo, CantidadPedida}`, filtered by proveedor, excluding `sugerido = null` rows.
-  *(design.md:proposal decision 10, ordenes-de-compra/spec.md:264-267)*
-- [ ] 5.5 Modify `OrdenesDeCompraEndpoints.cs` — `GET /` (paginated) and `GET /{id}` under
+  *(design.md:67-69, decision 14, ordenes-de-compra/spec.md:242-249)* — the cobertura derivation is
+  **deliberately separate** from `EscriturasDeOrdenDeCompra.DerivarAsync`'s raw-ADO CTE (decision 20
+  below), never a shared SQL fragment.
+- [x] 5.4 **DEVIATION (decision 20 below): NOT a backend method.** `design.md`'s own Web section
+  (`design.md:347-351`) and its Testing Strategy row ("Web (vitest)": "a `sugerido === null` row is
+  excluded from the pre-load") place the reposición→OC mapping entirely in `Reposicion.tsx`
+  (client-side filter + field mapping, posting a plain `SolicitudDeOrdenDeCompra` to the existing
+  `POST /`). `design.md`'s own File Changes table for `ServicioDeOrdenesDeCompra.cs` (`:376`) lists
+  only "Draft CRUD, `enviar`, `cerrar`, `anular`, list + detail read model" — no pre-load method.
+  Mutation target #34's own row places "the `sugerido !== null` filter" under slices "4-6" (the web
+  branch), never slice 5. No `PreCargarDesdeReposicionAsync` was added; `POST /` needs no
+  modification — it already accepts an ordinary `SolicitudDeOrdenDeCompra` (slice 2).
+- [x] 5.5 Modify `OrdenesDeCompraEndpoints.cs` — `GET /` (paginated) and `GET /{id}` under
   `OperacionDePos` only (no write policy). *(design.md:301-302)*
-- [ ] 5.6 [P] Integration — pagination with `fecha_emision` tied on every row (RelojFijo) ⇒ page 2
+- [x] 5.6 [P] Integration — pagination with `fecha_emision` tied on every row (RelojFijo) ⇒ page 2
   repeats and skips nothing (the `ThenByDescending(o => o.Id)` tiebreaker). *(design.md:70,
-  mutation target #34b)*
-- [ ] 5.7 [P] Integration — each filter (`idProveedor`/`idPuntoVenta`/`estado`/`desde`/`hasta`)
+  mutation target #34b)* — `OrdenesCompraLecturaTests.
+  PaginacionConFechaEmisionEmpatadaNoDuplicaNiSalteaFilas`.
+- [x] 5.7 [P] Integration — each filter (`idProveedor`/`idPuntoVenta`/`estado`/`desde`/`hasta`)
   with asymmetric seeds — an ignored filter must not silently return extra rows. *(design.md:199,
-  mutation target #34b)*
-- [ ] 5.8 [P] Integration — sibling OC of the same tenant seeded on every listing/detail test with
-  its own items (rule 12c) — a raw `UPDATE` desyncing `estado` to a sentinel must surface the
-  sentinel (rule 12a). *(design.md, Testing Strategy; design decision 12)*
-- [ ] 5.9 [P] Integration — **projection fidelity**: for every derivation fixture, the stored
+  mutation target #34b)* — `OrdenesCompraLecturaTests.
+  CadaFiltroIgnoradoDevolveriaDeMasConSemillasAsimetricas`.
+- [x] 5.8 [P] Integration — sibling OC of the same tenant seeded on every listing/detail test with
+  its own items (rule 12c) — a raw EF write desyncing `estado` to a sentinel must surface the
+  sentinel (rule 12a). *(design.md, Testing Strategy; design decision 12)* — `OrdenesCompraLecturaTests.
+  DetalleLeeElEstadoDeLaColumnaSinRederivarloConUnaDesincronizacionCruda` (sentinel: `enviada` OC
+  with zero recepciones force-written to `RecibidaParcial` — a value the real derivation could never
+  produce for that fixture — GET returns the sentinel; sibling OC unaffected).
+- [x] 5.9 [P] Integration — **projection fidelity**: for every derivation fixture, the stored
   `estado` equals `ProyectorDeEstadoDeOrden.Proyectar(...)` recomputed from the read model's own
-  cobertura numbers. *(design.md, Testing Strategy — the raw-ADO/LINQ drift proof)*
-- [ ] 5.10 [P] Integration — a price increase between order and invoice is surfaced (`+12%`), not
-  blocked. *(ordenes-de-compra/spec.md:251-255)*
-- [ ] 5.11 [P] Integration — a never-quoted line reports *no comparable*, never `0`.
-  *(ordenes-de-compra/spec.md:257-260, mutation target #34b)*
-- [ ] 5.12 [P] Integration — pre-load excludes `sugerido = null` rows, never defaults to `0`; the
-  `"Sin proveedor"` bucket cannot pre-load. *(ordenes-de-compra/spec.md:270-278)*
-- [ ] 5.13 [P] Integration — `GET /api/reportes/stock/reposicion`'s response shape and figures
+  cobertura numbers. *(design.md, Testing Strategy — the raw-ADO/LINQ drift proof)* —
+  `OrdenesCompraLecturaTests.
+  CoberturaPorArticuloDiscriminaCorrectamenteYLaProyeccionCoincideConLaColumna`: rule-11 discriminant
+  fixture (two OC lines of one artículo 3+4⇒7 pedidas; a split reception 2 then 5; an artículo
+  received-never-ordered; a soft-deleted reception line excluded; a comprobante ligado still
+  `borrador` excluded; a reception of another OC of the same proveedor excluded) plus the
+  recomputation assertion.
+- [x] 5.10 [P] Integration — a price increase between order and invoice is surfaced (`+12%`), not
+  blocked. *(ordenes-de-compra/spec.md:251-255)* — `OrdenesCompraLecturaTests.
+  UnAumentoDePrecioEntreOrdenYFacturaSeSurfaceaNoSeBloquea`.
+- [x] 5.11 [P] Integration — a never-quoted line reports *no comparable*, never `0`.
+  *(ordenes-de-compra/spec.md:257-260, mutation target #34b)* — `OrdenesCompraLecturaTests.
+  UnaLineaNuncaCotizadaReportaNoComparableNuncaCero`.
+- [x] 5.12 **DEVIATION (decision 20 below), same as 5.4**: the pre-load exclusion of `sugerido =
+  null` rows and the `"Sin proveedor"` bucket's missing action are client-side behaviors
+  (`Reposicion.tsx`, slice 6) — `design.md`'s Testing Strategy places both assertions under "Web
+  (vitest)", not backend integration. No backend test added here; the slice-6 web descriptor tests
+  own this assertion (mutation target #34's "pre-load exclusion test").
+- [x] 5.13 [P] Integration — `GET /api/reportes/stock/reposicion`'s response shape and figures
   unchanged before/after this stage. *(ordenes-de-compra/spec.md:280-283, reposicion-de-
-  stock/spec.md's "byte-identical" scenario)*
-- [ ] 5.14 [P] Integration — the offset boundary: a listing sent at the real client `-03:00` (never
-  `Z`) asserts both the returned rows and the displayed período. *(decision 13 above)*
-- [ ] 5.15 [P] **Mutation target #34b (part 1)** — `.ThenByDescending(o => o.Id)` deleted → the
-  tied-fecha pagination test (5.6) must fail.
-- [ ] 5.16 [P] **Mutation target #34b (part 2)** — any single `if (filtro is { } x)` conjunct
-  deleted → its asymmetric-seed test (5.7) must fail.
-- [ ] 5.17 [P] **Mutation target #34b (part 3)** — the `Desvio` null branch replaced with `0` →
-  the no-comparable test (5.11) must fail.
-- [ ] 5.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean; zero new files under
-  `Migraciones/`.
-- [ ] 5.19 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  stock/spec.md's "byte-identical" scenario)* — `OrdenesCompraLecturaTests.
+  ReposicionMantieneSuShapeYSusFigurasSinCambios`.
+- [x] 5.14 [P] Integration — the offset boundary: a listing sent at the real client `-03:00` (never
+  `Z`) asserts both the returned rows and the displayed período. *(decision 13 above)* —
+  `OrdenesCompraLecturaTests.ListadoConOffsetMenosTresAsertaFilasYPeriodoMostrado`.
+- [x] 5.15 [P] **Mutation target #34b (part 1)** — `.ThenByDescending(o => o.Id)` deleted → the
+  tied-fecha pagination test (5.6) must fail. **Evidence**: deleted the `.ThenByDescending(o =>
+  o.Id)` line in `ListarAsync` → `dotnet build --no-incremental` (clean) →
+  `PaginacionConFechaEmisionEmpatadaNoDuplicaNiSalteaFilas` FAILED (`Assert.Equal` expected
+  `[3, 2]`, actual `[1, 2]` — page 1 repeated the lowest id instead of the two highest) → `git
+  status` clean revert (no diff — exact restore) → rebuilt → green.
+- [x] 5.16 [P] **Mutation target #34b (part 2)** — any single `if (filtro is { } x)` conjunct
+  deleted → its asymmetric-seed test (5.7) must fail. **Evidence**: deleted the `estado` filter's
+  `if` block in `ConstruirQuery` → build clean →
+  `CadaFiltroIgnoradoDevolveriaDeMasConSemillasAsimetricas` FAILED (`Assert.DoesNotContain` — the
+  `borrador` OC leaked into the `estado=Enviada` result set) → `git status` clean revert → rebuilt →
+  green.
+- [x] 5.17 [P] **Mutation target #34b (part 3)** — the `Desvio` null branch replaced with `0` →
+  the no-comparable test (5.11) must fail. **Evidence**: replaced the `: null` fallback with `:
+  0m` in `ObtenerCoberturaAsync` → build clean →
+  `UnaLineaNuncaCotizadaReportaNoComparableNuncaCero` FAILED (`Assert.Null` expected `null`, actual
+  `0`) → `git status` clean revert → rebuilt → green.
+- [x] 5.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean (verified via
+  `db.Database.HasPendingModelChanges()`, same pattern as slices 2/4 —
+  `OrdenesCompraLecturaTests.NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1`); zero
+  new files under `Migraciones/` (`git diff --stat main -- src/Ways.Infrastructure/Persistencia/
+  Migraciones/` empty). Gate holds, no deviation.
+- [ ] 5.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+  RUN by `sdd-apply`** — same executor-boundary reason as every prior slice (1.38/2.27/3.x/4.x):
+  `judgment-day` is an orchestrator-level dual-review protocol this executor cannot invoke. Left for
+  the orchestrator to run before merge.
 - [ ] 5.20 Branch `feat/stage16-slice5-lectura` off `main` (parent: slice 4); PR; merge
-  stacked-to-main.
+  stacked-to-main. **PARTIAL**: the worktree was already provisioned on
+  `feat/stage16-slice5-lectura` off `main` (`6f8a25f`, slice 4 merged) before this phase started —
+  branching is done. PR creation/merge is explicitly out of scope (`NO pushees` instruction) — left
+  for the orchestrator.
 
 **Test plan**: pagination + tiebreaker (5.6); filters (5.7); read-model rules 12a/12c (5.8);
 projection fidelity (5.9); price deviation incl. honest nulls (5.10-5.11); pre-load (5.12);

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -1492,7 +1492,7 @@ deviation) if this slice overflows — decision 3 above.
   `OrdenesCompraLecturaTests.NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1`); zero
   new files under `Migraciones/` (`git diff --stat main -- src/Ways.Infrastructure/Persistencia/
   Migraciones/` empty). Gate holds, no deviation.
-- [ ] 5.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+- [x] 5.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
   RUN by `sdd-apply`** — same executor-boundary reason as every prior slice (1.38/2.27/3.x/4.x):
   `judgment-day` is an orchestrator-level dual-review protocol this executor cannot invoke. Left for
   the orchestrator to run before merge.

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -201,7 +201,9 @@
       slice. El merge three-way preserva la regla en main. Regla de proceso nueva: los diffs de
       judgment se congelan con `main...HEAD`.
 
-20. **Slice 5 apply-phase decisions and deviations (decision 15 discipline).**
+24. **Slice 5 apply-phase decisions and deviations (decision 15 discipline).**
+    (Renumerada por el orquestador: el apply la registró como "20", colisionando con la 20 del
+    slice 3 — la secuencia real llegaba a 23.)
     - **Pre-load (tasks 5.4/5.12) is NOT a backend method — deviation from this file's own prior
       wording, resolved in favor of `design.md`.** `design.md:347-351` (the Web section) and its
       Testing Strategy row for "Web (vitest)" place the reposición→OC mapping — `{IdArticulo,

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -261,6 +261,43 @@
       non-regression criterion (mutation target #34's trailing row) holds across the whole tree, not
       only the `ComprasConfirmar`/`ComprasAnular` suites named there.
 
+25. **`judgment-day` round confirmed 3 CRITICAL (juez B) on `OrdenesCompraLecturaTests.cs` —
+    closed with focused fixes, tests-only, producción intacta.** Tercera ocurrencia registrada en
+    el programa de una violación de la regla 12b de `mutation-proof-tests` (design.md:420, "every
+    projected money/date field asserted with per-row discriminating values") — las dos previas
+    incluyen stage-15 slice 4 ("15-s4"); esta, la tercera, en esta slice.
+    - **CRITICAL 1**: `CoberturaDeArticulo.Pendiente` solo se asserteaba en `0` (7-7 en el fixture
+      rico y `Math.Max(0-1,0)` en el recibido-no-pedido) — un `var pendiente = 0m;` fijo en
+      `ObtenerCoberturaAsync` sobrevivía 11/11. **Fix**: nuevo test dedicado
+      `CoberturaPendienteEsPositivaCuandoLaRecepcionNoCompletaLoPedido` (pedida 7, recibida 5 ⇒
+      Pendiente 2, asserteado explícitamente).
+    - **CRITICAL 2**: `OrdenDeCompraDetalle.TotalEstimado`/`TotalReal`/`DesvioTotal` jamás se
+      asserteaban con valores positivos (un solo `Assert.Null` en el fixture "nunca cotizada") — un
+      `12345m` fijo sobrevivía. **Fix**: en el fixture rico
+      (`CoberturaPorArticuloDiscriminaCorrectamenteYLaProyeccionCoincideConLaColumna`) se agregaron
+      los tres agregados calculados a mano: `TotalEstimado = 700m` (100×7), `TotalReal = 834m`
+      (112×7 + 50×1), `DesvioTotal = 19.14m` ((834-700)/700×100) — pairwise-distintos.
+    - **CRITICAL 3**: `IdProveedor`/`IdPuntoVenta` del detalle (dos `int` posicionales adyacentes
+      en un record de 17 parámetros) jamás se leían de vuelta — un SWAP de ambos en el constructor
+      de `OrdenDeCompraDetalle` sobrevivía 197/197. **Fix**: nuevo test integral
+      `DetalleDevuelveCadaCampoPosicionalConSuVerdad` que assertea ambos ids contra
+      `IdProveedor2`/`IdPuntoVenta2` (desincronizados, con una precondición `Assert.NotEqual` que
+      falla ruidosamente si algún día colisionaran) y, por ser la misma causa raíz (ningún campo
+      posicional leído de vuelta), extiende la lectura a TODOS los campos hasta ahora sin cobertura
+      del detalle y de la fila del listado: `Numero`, `FechaEnvio`, `FechaEsperada`, `FechaCierre`,
+      `CierreManual`, `Observaciones`, `Estado` (detalle) y `Estado` (fila de `PaginaDeOrdenesDeCompra`) —
+      todos con valores distintos entre sí.
+    - **Evidencia de mutación** (tres ciclos, `dotnet build --no-incremental` + test filtrado +
+      `git checkout -- src/` + rebuild entre cada uno, `git status` limpio en cada punto): (a)
+      `pendiente = 0m` fijo → `CoberturaPendienteEsPositivaCuandoLaRecepcionNoCompletaLoPedido`
+      FALLA (`Expected: 2, Actual: 0`) → revert verificado; (b) `totalEstimado = 12345m` fijo →
+      `CoberturaPorArticuloDiscriminaCorrectamenteYLaProyeccionCoincideConLaColumna` FALLA
+      (`Expected: 700, Actual: 12345`) → revert verificado; (c) swap de
+      `IdProveedor`/`IdPuntoVenta` en el constructor de `OrdenDeCompraDetalle` →
+      `DetalleDevuelveCadaCampoPosicionalConSuVerdad` FALLA (`Expected: 2, Actual: 4`) → revert
+      verificado. Corrida final completa del archivo: **13/13 verde**, `git status` con solo el
+      archivo de test modificado.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-

--- a/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
+++ b/src/Ways.Api/Endpoints/OrdenesDeCompraEndpoints.cs
@@ -1,5 +1,6 @@
 using Ways.Api.Seguridad;
 using Ways.Application.Compras;
+using Ways.Domain.Compras;
 
 namespace Ways.Api.Endpoints;
 
@@ -13,7 +14,11 @@ namespace Ways.Api.Endpoints;
 /// (numeración propia). Slice 4: <c>POST /{id}/cerrar</c> (cierre manual), <c>POST /{id}/anular</c>
 /// (gobernada por el libro, design decisión 9) — mismo gate que las tres rutas de arriba (task
 /// 4.11, matriz de autorización: las CINCO rutas de escritura apilan <c>GestionDeCatalogo</c>).
-/// <c>GET /</c>/<c>GET /{id}</c> llegan en slice 5 (necesitan el detalle con cobertura).
+///
+/// Slice 5 (design: API Surface, decisiones 12-15): <c>GET /</c> (listado paginado) y
+/// <c>GET /{id}</c> (detalle con cobertura por artículo + desvío) — SIN apilar
+/// <c>GestionDeCatalogo</c>: son lecturas, mismo gate que <c>ComprasEndpoints.cs:24, 67</c>
+/// (Vendedor lee, no escribe).
 /// </summary>
 public static class OrdenesDeCompraEndpoints
 {
@@ -22,6 +27,23 @@ public static class OrdenesDeCompraEndpoints
         var grupo = app.MapGroup("/api/ordenes-compra")
             .WithTags("OrdenesDeCompra")
             .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapGet("/", (
+            ServicioDeOrdenesDeCompra servicio,
+            int? idProveedor,
+            int? idPuntoVenta,
+            EstadoOrdenCompra? estado,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idProveedor, idPuntoVenta, estado, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Lista órdenes de compra con filtros y paginado.");
+
+        grupo.MapGet("/{id:int}", (ServicioDeOrdenesDeCompra servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerDetalleAsync(id, ct))
+        .WithSummary("Detalle de una orden de compra: header + items + cobertura por artículo + desvío de precio.");
 
         grupo.MapPost("/", async (
             ServicioDeOrdenesDeCompra servicio, SolicitudDeOrdenDeCompra solicitud, CancellationToken ct) =>

--- a/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
+++ b/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
@@ -90,11 +90,16 @@ public sealed record CoberturaDeArticulo(
 /// Testing Strategy de design.md, task 5.9 — no la reutilización de SQL: la escritura solo
 /// necesita dos booleanos agregados por su propio <c>WITH</c>, mientras que esta lectura necesita
 /// las filas per-artículo incluyendo recibido-no-pedido, un shape distinto). <see
-/// cref="TotalEstimado"/>/<see cref="TotalReal"/>/<see cref="DesvioTotal"/> agregan <see
-/// cref="CoberturaDeArticulo"/> ponderando por <c>Pedida</c>/<c>Recibida</c> respectivamente,
-/// <c>null</c> cuando ningún artículo tiene el lado comparable. <see cref="ComprobantesLigados"/>
-/// son TODOS los comprobantes con <c>id_orden_compra</c> = esta orden (cualquier estado —
-/// informativo, design: API Surface "linked comprobante ids").</summary>
+/// cref="TotalEstimado"/> es el total estimado de la PORCIÓN COTIZADA, sumado a NIVEL LÍNEA
+/// (<c>CostoUnitarioEstimado * CantidadPedida</c> sobre los items con costo seteado — judgment-day
+/// ronda 2: jamás el promedio por-artículo de <see cref="CoberturaDeArticulo.CostoEstimado"/>
+/// multiplicado por la <c>Pedida</c> total del artículo, que extrapolaría en silencio el costo de
+/// una línea nunca cotizada). <see cref="TotalReal"/>/<see cref="DesvioTotal"/> SÍ agregan <see
+/// cref="CoberturaDeArticulo"/> ponderando por <c>Recibida</c> (población coherente: <c>CostoReal</c>
+/// y <c>Recibida</c> derivan siempre del mismo grupo de items recibidos, sin línea "recibida sin
+/// costo" que las desacople), <c>null</c> cuando ningún artículo tiene el lado comparable. <see
+/// cref="ComprobantesLigados"/> son TODOS los comprobantes con <c>id_orden_compra</c> = esta orden
+/// (cualquier estado — informativo, design: API Surface "linked comprobante ids").</summary>
 public sealed record OrdenDeCompraDetalle(
     int Id,
     int IdProveedor,

--- a/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
+++ b/src/Ways.Application/Compras/ContratosDeOrdenDeCompra.cs
@@ -60,3 +60,78 @@ public sealed record OrdenDeCompraBorrador(
     string? Observaciones,
     EstadoOrdenCompra Estado,
     IReadOnlyList<ItemDeOrden> Items);
+
+/// <summary>Slice 5 (design decisión 13, task 5.1): cobertura POR ARTÍCULO, nunca por línea —
+/// agrupar por <c>id_articulo</c> en ambos lados (design decisión 3) hace que un desglose por
+/// línea sea un número que el sistema no tiene (<c>dto-contract-honesty</c> regla 1).
+/// <see cref="Pedida"/> puede ser <c>0</c>: es la forma en que un artículo recibido-pero-no-pedido
+/// se vuelve visible en vez de desaparecer en silencio. <see cref="Pendiente"/> nunca es negativo
+/// (<c>Math.Max(Pedida - Recibida, 0)</c>): una sobre-entrega (decisión de diseño 3, T9) no genera
+/// un "pendiente negativo" — <c>CompraEditor.tsx</c> (slice 6) usa <c>Pendiente &gt; 0</c> para
+/// decidir qué líneas pre-llenar. <see cref="CostoEstimado"/>/<see cref="CostoReal"/>/
+/// <see cref="Desvio"/> son promedios ponderados por cantidad, <c>null</c> cuando no hay dato
+/// comparable de ese lado — JAMÁS <c>0</c> (design decisión 14, spec: "no comparable, never
+/// zero").</summary>
+public sealed record CoberturaDeArticulo(
+    int IdArticulo,
+    decimal Pedida,
+    decimal Recibida,
+    decimal Pendiente,
+    decimal? CostoEstimado,
+    decimal? CostoReal,
+    decimal? Desvio);
+
+/// <summary>Slice 5 (design: Interfaces/Contracts, task 5.1) — <c>GET /api/ordenes-compra/{id}</c>.
+/// <see cref="Estado"/> es SIEMPRE la columna proyectada por <see
+/// cref="EscriturasDeOrdenDeCompra"/> (slice 3/4) — este tipo NUNCA re-deriva el estado (design
+/// decisión 12). <see cref="Cobertura"/> es la derivación per-artículo (LINQ, propia de esta
+/// lectura — deliberadamente SEPARADA de la derivación raw-ADO de escritura de <see
+/// cref="EscriturasDeOrdenDeCompra"/>, cuya prueba de consistencia es la "projection fidelity" del
+/// Testing Strategy de design.md, task 5.9 — no la reutilización de SQL: la escritura solo
+/// necesita dos booleanos agregados por su propio <c>WITH</c>, mientras que esta lectura necesita
+/// las filas per-artículo incluyendo recibido-no-pedido, un shape distinto). <see
+/// cref="TotalEstimado"/>/<see cref="TotalReal"/>/<see cref="DesvioTotal"/> agregan <see
+/// cref="CoberturaDeArticulo"/> ponderando por <c>Pedida</c>/<c>Recibida</c> respectivamente,
+/// <c>null</c> cuando ningún artículo tiene el lado comparable. <see cref="ComprobantesLigados"/>
+/// son TODOS los comprobantes con <c>id_orden_compra</c> = esta orden (cualquier estado —
+/// informativo, design: API Surface "linked comprobante ids").</summary>
+public sealed record OrdenDeCompraDetalle(
+    int Id,
+    int IdProveedor,
+    int IdPuntoVenta,
+    long? Numero,
+    DateTimeOffset FechaEmision,
+    DateTimeOffset? FechaEnvio,
+    DateOnly? FechaEsperada,
+    DateTimeOffset? FechaCierre,
+    bool CierreManual,
+    string? Observaciones,
+    EstadoOrdenCompra Estado,
+    IReadOnlyList<ItemDeOrden> Items,
+    IReadOnlyList<CoberturaDeArticulo> Cobertura,
+    decimal? TotalEstimado,
+    decimal? TotalReal,
+    decimal? DesvioTotal,
+    IReadOnlyList<int> ComprobantesLigados);
+
+/// <summary>Slice 5 (design decisión 15, task 5.1/5.2) — <c>GET /api/ordenes-compra</c>, una fila
+/// del listado. Nunca lleva <c>Cobertura</c>/desvío: esos campos son costosos de derivar (dos
+/// consultas agregadas por orden) y el listado no los muestra — mismo criterio que
+/// <c>CompraListada</c> frente a <c>CompraDetalle</c>.</summary>
+public sealed record OrdenDeCompraListada(
+    int Id,
+    int IdProveedor,
+    int IdPuntoVenta,
+    long? Numero,
+    DateTimeOffset FechaEmision,
+    DateOnly? FechaEsperada,
+    EstadoOrdenCompra Estado);
+
+/// <summary>Slice 5 (design decisión 15, task 5.2) — mismo shape que
+/// <c>PaginaDeEstadoDeCuentaDeProveedor</c>/<c>PaginaDeCompras</c>: <c>CountAsync</c> +
+/// <c>Skip/Take</c> sobre el mismo <c>ConstruirQuery</c> que el <c>COUNT</c>.</summary>
+public sealed record PaginaDeOrdenesDeCompra(
+    IReadOnlyList<OrdenDeCompraListada> Items,
+    int Total,
+    int Pagina,
+    int Tamanio);

--- a/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
+++ b/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
@@ -31,6 +31,230 @@ namespace Ways.Application.Compras;
 /// </summary>
 public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto)
 {
+    // ---- lectura: listado paginado (design decisión 15, task 5.2) ---------------------------------
+
+    /// <summary>design: Interfaces/Contracts — <c>ConstruirQuery</c> (mismo patrón que
+    /// <c>ServicioDeCuentaCorrienteDeProveedor.ObtenerEstadoDeCuentaAsync</c>/<c>ServicioDeCompras.
+    /// ListarAsync</c>): <c>CountAsync</c> sobre el mismo <see cref="IQueryable{T}"/> que después
+    /// pagina. Orden <c>fecha_emision DESC, id_orden_compra DESC</c> (design decisión 15) — el
+    /// desempate por <c>Id</c> NO es cosmético: <c>fecha_emision</c> es un solo <c>reloj.Ahora</c>
+    /// por operación, así que un fixture entero bajo <c>RelojFijo</c> empata por construcción y la
+    /// paginación duplica/saltea filas sin él (mutation target #34b, parte 1).</summary>
+    public async Task<PaginaDeOrdenesDeCompra> ListarAsync(
+        int? idProveedor = null,
+        int? idPuntoVenta = null,
+        EstadoOrdenCompra? estado = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = ConstruirQuery(idProveedor, idPuntoVenta, estado, desde, hasta);
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(o => o.FechaEmision)
+            .ThenByDescending(o => o.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .Select(o => new OrdenDeCompraListada(
+                o.Id, o.IdProveedor, o.IdPuntoVenta, o.Numero, o.FechaEmision, o.FechaEsperada, o.Estado))
+            .ToListAsync(ct);
+
+        return new PaginaDeOrdenesDeCompra(items, total, pagina, tamanio);
+    }
+
+    /// <summary>Cláusulas bajo prueba (<c>mutation-proof-tests</c>, design.md:194-204, mutation
+    /// target #34b), en orden de daño si se pierden:
+    ///   <c>Where(o => o.IdProveedor == p)</c> / <c>Where(o => o.Id == id)</c> → una OC filtra las
+    ///                                                                          de otra entidad
+    ///   <c>ThenByDescending(o => o.Id)</c> → con <c>fecha_emision</c> empatada (<c>RelojFijo</c>)
+    ///                                        la paginación duplica y saltea
+    ///   cada <c>if (idProveedor/idPuntoVenta/estado/desde/hasta is { } x)</c> → un filtro ignorado
+    ///                                                                          devuelve de más, en silencio
+    /// </summary>
+    private IQueryable<OrdenCompra> ConstruirQuery(
+        int? idProveedor, int? idPuntoVenta, EstadoOrdenCompra? estado, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var query = db.OrdenesCompra.AsQueryable();
+
+        if (idProveedor is { } p)
+        {
+            query = query.Where(o => o.IdProveedor == p);
+        }
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(o => o.IdPuntoVenta == pv);
+        }
+
+        if (estado is { } e)
+        {
+            query = query.Where(o => o.Estado == e);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(o => o.FechaEmision >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(o => o.FechaEmision <= h);
+        }
+
+        return query;
+    }
+
+    // ---- lectura: detalle con cobertura por artículo + desvío informativo (design decisiones 12-14, task 5.3) ----
+
+    /// <summary>design decisión 12: <see cref="OrdenCompra.Estado"/> se LEE de la columna — esta
+    /// clase NUNCA re-deriva el estado (lo escribe únicamente <see
+    /// cref="EscriturasDeOrdenDeCompra"/>, slices 3/4). <c>mutation-proof-tests</c> regla 12(a) se
+    /// prueba literal: un <c>UPDATE</c> crudo que desincroniza <c>estado</c> a un sentinela hace que
+    /// este endpoint devuelva el sentinela (task 5.8/5.9).
+    ///
+    /// La cobertura (design decisión 13) y el desvío (decisión 14) SÍ tienen su propia derivación
+    /// LINQ, deliberadamente separada de la derivación raw-ADO de <see
+    /// cref="EscriturasDeOrdenDeCompra.ProyectarEstadoAsync"/>: esa clase solo necesita dos
+    /// booleanos agregados (<c>completa</c>/<c>algoRecibido</c>) para decidir una transición; esta
+    /// lectura necesita las filas per-artículo completas, incluyendo recibido-no-pedido (<c>Pedida
+    /// = 0</c>) y los costos, que la derivación de escritura ni calcula. La consistencia entre
+    /// ambas la prueba la fixture de "projection fidelity" (design: Testing Strategy, task 5.9):
+    /// recomputar <c>ProyectorDeEstadoDeOrden.Proyectar</c> desde los números de ESTA lectura debe
+    /// coincidir con la columna — nunca compartir SQL entre escritura y lectura.</summary>
+    public async Task<OrdenDeCompraDetalle> ObtenerDetalleAsync(int id, CancellationToken ct = default)
+    {
+        var orden = await db.OrdenesCompra.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la orden de compra {id}.");
+
+        var items = await db.ItemsOrdenCompra.AsNoTracking()
+            .Where(i => i.IdOrdenCompra == id)
+            .OrderBy(i => i.Orden)
+            .Select(i => new ItemDeOrden(i.Orden, i.IdArticulo, i.Descripcion, i.CantidadPedida, i.CostoUnitarioEstimado))
+            .ToListAsync(ct);
+
+        var cobertura = await ObtenerCoberturaAsync(id, ct);
+
+        // TotalEstimado/TotalReal: agregan Cobertura ponderando por Pedida/Recibida
+        // respectivamente, sumando SOLO los artículos con ese lado comparable (dto-contract-
+        // honesty: un total que mezclara ceros fabricados con datos reales sería deshonesto).
+        // null cuando NINGÚN artículo aporta ese lado.
+        var conCostoEstimado = cobertura.Where(c => c.CostoEstimado is not null).ToList();
+        decimal? totalEstimado = conCostoEstimado.Count > 0
+            ? conCostoEstimado.Sum(c => c.CostoEstimado!.Value * c.Pedida)
+            : null;
+
+        var conCostoReal = cobertura.Where(c => c.CostoReal is not null).ToList();
+        decimal? totalReal = conCostoReal.Count > 0
+            ? conCostoReal.Sum(c => c.CostoReal!.Value * c.Recibida)
+            : null;
+
+        decimal? desvioTotal = totalEstimado is { } te && te != 0m && totalReal is { } tr
+            ? Math.Round((tr - te) / te * 100m, 2, MidpointRounding.AwayFromZero)
+            : null;
+
+        var comprobantesLigados = await db.ComprobantesCompra.AsNoTracking()
+            .Where(c => c.IdOrdenCompra == id)
+            .OrderBy(c => c.Id)
+            .Select(c => c.Id)
+            .ToListAsync(ct);
+
+        return new OrdenDeCompraDetalle(
+            orden.Id, orden.IdProveedor, orden.IdPuntoVenta, orden.Numero, orden.FechaEmision, orden.FechaEnvio,
+            orden.FechaEsperada, orden.FechaCierre, orden.IdEmpleadoCierre is not null, orden.Observaciones,
+            orden.Estado, items, cobertura, totalEstimado, totalReal, desvioTotal, comprobantesLigados);
+    }
+
+    /// <summary>Deriva la cobertura per-artículo (design decisión 13): agrupa <c>items_orden_compra</c>
+    /// (pedido) e <c>items_comprobante_compra</c> de comprobantes CONFIRMADOS ligados a esta orden
+    /// (recibido) — mismo criterio de "confirmada" que <see
+    /// cref="EscriturasDeOrdenDeCompra"/>. Ambos lados se traen materializados (<c>ToListAsync</c>)
+    /// porque <see cref="CalculadorDeCompra.CalcularCostoEfectivoDesdeItem"/> es Domain puro en C#,
+    /// no traducible a SQL — el promedio ponderado por artículo se calcula en memoria, LINQ-to-
+    /// Objects (design decisión 14). La unión de artículos pedidos ∪ recibidos es lo que hace
+    /// visible un recibido-no-pedido con <c>Pedida = 0</c> (decisión 13).</summary>
+    private async Task<IReadOnlyList<CoberturaDeArticulo>> ObtenerCoberturaAsync(int idOrdenCompra, CancellationToken ct)
+    {
+        // deleted_at IS NULL explícito en ambos lados — mismo defense-in-depth que la derivación
+        // raw-ADO de EscriturasDeOrdenDeCompra.DerivarAsync (design decisión 3). Ninguna entidad de
+        // este repo tiene HasQueryFilter global (RLS cubre tenant, nada cubre soft-delete acá), así
+        // que sin este filtro explícito una recepción soft-deleted contaría en esta lectura pero NO
+        // en la derivación de escritura — exactamente la divergencia que la fixture de "soft-deleted
+        // reception" (design: Testing Strategy) y la prueba de projection fidelity (task 5.9) están
+        // para atrapar.
+        var itemsPedido = await db.ItemsOrdenCompra.AsNoTracking()
+            .Where(i => i.IdOrdenCompra == idOrdenCompra && i.DeletedAt == null)
+            .Select(i => new { i.IdArticulo, i.CantidadPedida, i.CostoUnitarioEstimado })
+            .ToListAsync(ct);
+
+        var itemsRecibido = await (
+            from ic in db.ItemsComprobanteCompra.AsNoTracking()
+            join c in db.ComprobantesCompra.AsNoTracking() on ic.IdComprobanteCompra equals c.Id
+            join t in db.TiposComprobante.AsNoTracking() on c.IdTipoComprobante equals t.Id
+            where c.IdOrdenCompra == idOrdenCompra && c.Estado == EstadoCompra.Confirmada
+                  && c.DeletedAt == null && ic.DeletedAt == null
+            select new { ic.IdArticulo, ic.Cantidad, ic.Total, ic.PorcentajeIva, t.DiscriminaIva })
+            .ToListAsync(ct);
+
+        var pedidaPorArticulo = itemsPedido
+            .GroupBy(i => i.IdArticulo)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.CantidadPedida));
+
+        // Promedio ponderado por cantidad SOLO sobre las líneas cotizadas (CostoUnitarioEstimado
+        // != null) — una línea sin cotizar no aporta ceros al promedio del artículo.
+        var costoEstimadoPorArticulo = itemsPedido
+            .Where(i => i.CostoUnitarioEstimado is not null)
+            .GroupBy(i => i.IdArticulo)
+            .ToDictionary(g => g.Key, g =>
+            {
+                var cantidad = g.Sum(x => x.CantidadPedida);
+                return cantidad > 0m
+                    ? g.Sum(x => x.CostoUnitarioEstimado!.Value * x.CantidadPedida) / cantidad
+                    : (decimal?)null;
+            });
+
+        var recibidoPorArticulo = itemsRecibido
+            .GroupBy(i => i.IdArticulo)
+            .ToDictionary(g => g.Key, g =>
+            {
+                var cantidad = g.Sum(x => x.Cantidad);
+                var totalEfectivo = g.Sum(x =>
+                    CalculadorDeCompra.CalcularCostoEfectivoDesdeItem(x.Total, x.Cantidad, x.PorcentajeIva, x.DiscriminaIva) * x.Cantidad);
+                return (Cantidad: cantidad, CostoReal: cantidad > 0m ? (decimal?)(totalEfectivo / cantidad) : null);
+            });
+
+        var idsArticulo = pedidaPorArticulo.Keys.Union(recibidoPorArticulo.Keys).OrderBy(x => x);
+
+        var resultado = new List<CoberturaDeArticulo>();
+        foreach (var idArticulo in idsArticulo)
+        {
+            var pedida = pedidaPorArticulo.GetValueOrDefault(idArticulo, 0m);
+            var costoEstimado = costoEstimadoPorArticulo.GetValueOrDefault(idArticulo);
+
+            var tieneRecibido = recibidoPorArticulo.TryGetValue(idArticulo, out var recibidoDeArticulo);
+            var recibida = tieneRecibido ? recibidoDeArticulo.Cantidad : 0m;
+            var costoReal = tieneRecibido ? recibidoDeArticulo.CostoReal : null;
+
+            var pendiente = Math.Max(pedida - recibida, 0m);
+
+            // Desvio null cuando cualquiera de los dos lados no es comparable — JAMÁS 0
+            // (mutation target #34b, parte 3; ordenes-de-compra/spec.md: "no comparable, never 0").
+            decimal? desvio = costoEstimado is { } ce && ce != 0m && costoReal is { } cr
+                ? Math.Round((cr - ce) / ce * 100m, 2, MidpointRounding.AwayFromZero)
+                : null;
+
+            resultado.Add(new CoberturaDeArticulo(idArticulo, pedida, recibida, pendiente, costoEstimado, costoReal, desvio));
+        }
+
+        return resultado;
+    }
+
     // ---- borrador: crear + replace-set (mismo criterio que ServicioDeCompras) --------------------
 
     public async Task<OrdenDeCompraBorrador> CrearBorradorAsync(

--- a/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
+++ b/src/Ways.Application/Compras/ServicioDeOrdenesDeCompra.cs
@@ -141,15 +141,29 @@ public class ServicioDeOrdenesDeCompra(IWaysDbContext db, IRelojDelSistema reloj
 
         var cobertura = await ObtenerCoberturaAsync(id, ct);
 
-        // TotalEstimado/TotalReal: agregan Cobertura ponderando por Pedida/Recibida
-        // respectivamente, sumando SOLO los artículos con ese lado comparable (dto-contract-
-        // honesty: un total que mezclara ceros fabricados con datos reales sería deshonesto).
-        // null cuando NINGÚN artículo aporta ese lado.
-        var conCostoEstimado = cobertura.Where(c => c.CostoEstimado is not null).ToList();
-        decimal? totalEstimado = conCostoEstimado.Count > 0
-            ? conCostoEstimado.Sum(c => c.CostoEstimado!.Value * c.Pedida)
+        // TotalEstimado: el total estimado de la PORCIÓN COTIZADA, calculado a NIVEL LÍNEA — sum
+        // (CostoUnitarioEstimado * CantidadPedida) SOLO sobre los items que tienen costo seteado;
+        // null cuando ninguno lo tiene. Judgment-day (juez A, ronda 2): NO puede agregarse desde
+        // Cobertura (CostoEstimado por-artículo × Pedida TOTAL del artículo) — CostoEstimado ya es
+        // un promedio ponderado que promedia SOLO las líneas cotizadas, mientras que Pedida suma
+        // TODAS las líneas del artículo, cotizadas o no; multiplicarlos extrapola en silencio el
+        // costo de una línea nunca cotizada (p.ej. 3 unidades a 100 + 4 sin costo del mismo
+        // artículo daría 100×7=700 en vez de los 300 reales). La suma línea a línea es inmune: cada
+        // línea aporta su propio costo×cantidad, o nada si no está cotizada — cero extrapolación,
+        // nulls honestos de verdad.
+        var itemsConCostoEstimado = items.Where(i => i.CostoUnitarioEstimado is not null).ToList();
+        decimal? totalEstimado = itemsConCostoEstimado.Count > 0
+            ? itemsConCostoEstimado.Sum(i => i.CostoUnitarioEstimado!.Value * i.CantidadPedida)
             : null;
 
+        // TotalReal: SÍ puede agregar desde Cobertura, a diferencia de TotalEstimado — verificado
+        // en la misma ronda. CostoReal y Recibida por artículo (ObtenerCoberturaAsync,
+        // recibidoPorArticulo) derivan SIEMPRE de la MISMA población de itemsRecibido para ese
+        // artículo (mismo GroupBy, mismo Cantidad agregado) — no hay línea "recibida sin costo" que
+        // desacople a las dos poblaciones como pasa del lado estimado, así que no hay extrapolación
+        // posible acá. Sumando SOLO los artículos con ese lado comparable (dto-contract-honesty: un
+        // total que mezclara ceros fabricados con datos reales sería deshonesto). null cuando
+        // NINGÚN artículo aporta ese lado.
         var conCostoReal = cobertura.Where(c => c.CostoReal is not null).ToList();
         decimal? totalReal = conCostoReal.Count > 0
             ? conCostoReal.Sum(c => c.CostoReal!.Value * c.Recibida)

--- a/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
@@ -309,14 +309,12 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
 
         // desde/hasta — ventana estrictamente futura no debe traer la orden objetivo
         var manana = DateTimeOffset.UtcNow.AddDays(1);
-        var pasadoManana = DateTimeOffset.UtcNow.AddDays(2);
         var porDesde = await ListarAsync(ctx, $"?desde={Uri.EscapeDataString(manana.ToString("O"))}");
         Assert.DoesNotContain(porDesde.Items, i => i.Id == objetivo.Id);
 
         var haceUnDia = DateTimeOffset.UtcNow.AddDays(-1);
         var porHasta = await ListarAsync(ctx, $"?hasta={Uri.EscapeDataString(haceUnDia.ToString("O"))}");
         Assert.DoesNotContain(porHasta.Items, i => i.Id == objetivo.Id);
-        _ = pasadoManana;
     }
 
     // ====================================================================================================
@@ -389,15 +387,16 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
             ]);
 
         // Recepción partida: 2 luego 5 (completa exactamente 7), costo real 112 (⇒ desvío +12%).
-        await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 2m, costoUnitario: 112m);
+        var confirmadaPrimera = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 2m, costoUnitario: 112m);
         var confirmadaFinal = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 5m, costoUnitario: 112m);
         Assert.Equal(EstadoCompra.Confirmada, confirmadaFinal.Estado);
 
         // Recibido-no-pedido: articulo2, jamás en items_orden_compra de esta orden.
         var reciboExtra = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 1m, costoUnitario: 50m, idArticulo: ctx.IdArticulo2);
 
-        // Un comprobante ligado todavía en borrador — NO debe contar (solo confirmados cuentan).
-        await CrearBorradorDeCompraAsync(
+        // Un comprobante ligado todavía en borrador — NO debe contar en la cobertura (solo
+        // confirmados cuentan) pero SÍ debe aparecer en ComprobantesLigados (cualquier estado).
+        var comprobanteBorrador = await CrearBorradorDeCompraAsync(
             ctx,
             new SolicitudDeCompra(
                 ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, $"0001-{Guid.NewGuid():N}"[..8],
@@ -447,8 +446,16 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.Equal(834m, detalle.TotalReal);
         Assert.Equal(19.14m, detalle.DesvioTotal);
 
-        // ComprobantesLigados incluye el borrador (todo comprobante ligado, cualquier estado).
-        Assert.True(detalle.ComprobantesLigados.Count >= 4);
+        // ComprobantesLigados: CONJUNTO EXACTO (judgment-day, juez A, ronda 2 — WARNING) — los
+        // CINCO comprobantes ligados a esta orden, incluido el borrador (todo estado cuenta), nunca
+        // solo un Count.Count >= N que un extra silencioso pasaría igual.
+        Assert.Equal(
+            new[]
+            {
+                confirmadaPrimera.Id, confirmadaFinal.Id, reciboExtra.Id, comprobanteBorrador.Id,
+                recepcionSoftDeleted.Id
+            }.OrderBy(x => x),
+            detalle.ComprobantesLigados.OrderBy(x => x));
 
         // ---- fidelidad de proyección (task 5.9): recomputar Proyectar desde ESTA lectura ----------
         var completa = detalle.Cobertura.All(c => c.Pendiente <= 0m);
@@ -525,6 +532,39 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.NotNull(cobertura.CostoReal);
         Assert.Null(cobertura.Desvio); // NUNCA 0m
         Assert.Null(detalle.TotalEstimado); // ningún artículo comparable del lado estimado
+    }
+
+    // ====================================================================================================
+    // CRITICAL 1 (judgment-day, juez A, ronda 2): TotalEstimado fabricaba costo — agregaba desde
+    // Cobertura (promedio ponderado por-artículo, que promedia SOLO las líneas cotizadas) ×
+    // Pedida TOTAL del artículo (incluidas las líneas SIN cotizar), extrapolando en silencio.
+    // Fixture dedicado: mismo artículo, una línea cotizada + una sin cotizar.
+    // ====================================================================================================
+
+    [Fact]
+    public async Task TotalEstimadoSumaSoloLasLineasCotizadasSinExtrapolarAlPromedioDelArticulo()
+    {
+        var ctx = await PrepararAsync(nameof(TotalEstimadoSumaSoloLasLineasCotizadasSinExtrapolarAlPromedioDelArticulo));
+
+        // Mismo artículo, dos líneas: 3 unidades cotizadas a 100 + 4 unidades SIN cotizar (null).
+        // Cobertura.CostoEstimado (promedio ponderado, SOLO sobre la línea cotizada) = 100 — sigue
+        // siendo un display por-artículo correcto. Pedida total del artículo = 7. El bug agregaba
+        // TotalEstimado = 100 * 7 = 700 (extrapolando el costo a las 4 unidades nunca cotizadas);
+        // el total honesto es la suma línea a línea SOLO de lo cotizado: 100 * 3 = 300.
+        var orden = await CrearYEnviarOrdenAsync(
+            ctx,
+            [
+                new LineaDeOrdenSolicitada(ctx.IdArticulo, "Cotizada", 3m, 100m),
+                new LineaDeOrdenSolicitada(ctx.IdArticulo, "Sin cotizar", 4m, null)
+            ]);
+
+        var detalle = await ObtenerDetalleAsync(ctx, orden.Id);
+
+        var cobertura = Assert.Single(detalle.Cobertura);
+        Assert.Equal(7m, cobertura.Pedida);
+        Assert.Equal(100m, cobertura.CostoEstimado); // el promedio por-artículo sigue siendo 100
+
+        Assert.Equal(300m, detalle.TotalEstimado); // JAMÁS 700 (100*7) ni 233.33 (100*7/3)
     }
 
     // ====================================================================================================
@@ -656,6 +696,13 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         var pagina = await ListarAsync(ctx, $"?idProveedor={ctx.IdProveedor2}");
         var filaListado = Assert.Single(pagina.Items, i => i.Id == creada.Id);
         Assert.Equal(EstadoOrdenCompra.Cerrada, filaListado.Estado);
+
+        // CRITICAL 2 (judgment-day, juez A, ronda 2): IdProveedor/IdPuntoVenta de la fila del
+        // listado tampoco se leían de vuelta — mismo hueco de causa raíz que el swap del detalle,
+        // pero en el Select de ListarAsync. Ids desincronizados (IdProveedor2/IdPuntoVenta2)
+        // discriminan un swap en ese Select.
+        Assert.Equal(ctx.IdProveedor2, filaListado.IdProveedor);
+        Assert.Equal(ctx.IdPuntoVenta2, filaListado.IdPuntoVenta);
     }
 
     // ---- gate guard (task 5.18) --------------------------------------------------------------------

--- a/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
@@ -1,0 +1,584 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Compras;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Compras;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Proveedores;
+using Ways.Domain.Usuarios;
+using Ways.Application.Reportes;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-16-ordenes-de-compra, Slice 5 (tasks 5.6-5.17; design decisiones 12-15). Listado
+/// paginado + detalle con cobertura por artículo y desvío de precio informativo — el read model
+/// que cierra el ciclo de vida de la OC.
+///
+/// <c>mutation-proof-tests</c> regla 12 (la central en un read model): (a) <see
+/// cref="DetalleLeeElEstadoDeLaColumnaSinRederivarloConUnaDesincronizacionCruda"/> desincroniza
+/// <c>estado</c> con una escritura EF cruda (sin pasar por <see cref="EscriturasDeOrdenDeCompra"/>)
+/// y prueba que el endpoint devuelve el sentinela, nunca el estado re-derivado; (b) toda proyección
+/// devuelta se assertea con valores discriminantes por fila (nunca un fixture 1-línea/1-recepción
+/// donde cualquier número en scope pasaría); (c) toda lectura siembra una OC hermana del mismo
+/// tenant con sus propios items y assertea que queda intacta.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdPuntoVenta, int IdPuntoVenta2, HttpClient Admin, HttpClient Vendedor,
+        int IdProveedor, int IdProveedor2, int IdArticulo, int IdArticulo2, string MailAdmin,
+        string PasswordAdmin, int IdTipoCFB, int IdAlicuotaIva21);
+
+    /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados — cada entidad nace en
+    /// su propia tabla, nunca forzada a coincidir numéricamente con otra.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre, WebApplicationFactory<Program>? factory = null)
+    {
+        var host = factory ?? fixture;
+
+        using var root = host.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = host.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var idEmpresa = await db.PuntosVenta.Where(pv => pv.Id == resultado.IdPuntoVenta).Select(pv => pv.IdEmpresa).FirstAsync();
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = idEmpresa, Nombre = $"{nombre}-PV2", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "OC-lectura-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva21 = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var proveedor1 = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"{nombre}-prov1", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var proveedor2 = new Proveedor
+        {
+            IdTenant = resultado.IdTenant, RazonSocial = $"{nombre}-prov2", IdCondicionFiscal = condicionFiscal.Id,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Proveedores.AddRange(proveedor1, proveedor2);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-lec-1-{Guid.NewGuid():N}", Nombre = "Lectura Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-lec-2-{Guid.NewGuid():N}", Nombre = "Lectura Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva21, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        // C-FB (DiscriminaIva = false) — elegido a propósito para mantener la aritmética de
+        // CostoReal simple (costoEfectivo = total/cantidad, sin IVA de por medio) en las pruebas de
+        // desvío de precio.
+        var idTipoCFB = await db.TiposComprobante.Where(t => t.Codigo == "C-FB").Select(t => t.Id).SingleAsync();
+
+        var vendedor = host.CreateClient();
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        var alta = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario("Vendedor lectura", mailVendedor, (int)RolConocido.Vendedor, "vendedor-password-larga"));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+        var loginVendedor = await vendedor.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailVendedor, "vendedor-password-larga"));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdPuntoVenta, puntoVenta2.Id, admin, vendedor,
+            proveedor1.Id, proveedor2.Id, articulo1.Id, articulo2.Id, mailAdmin, resultado.PasswordTemporal,
+            idTipoCFB, idAlicuotaIva21);
+    }
+
+    // ---- helpers: órdenes de compra ------------------------------------------------------------------
+
+    private static async Task<OrdenDeCompraBorrador> CrearBorradorDeOrdenAsync(
+        Contexto ctx, SolicitudDeOrdenDeCompra solicitud, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsJsonAsync("/api/ordenes-compra", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> EnviarOrdenAsync(Contexto ctx, int id, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsync($"/api/ordenes-compra/{id}/enviar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<OrdenDeCompraBorrador> CrearYEnviarOrdenAsync(
+        Contexto ctx, IReadOnlyList<LineaDeOrdenSolicitada> items, int? idProveedor = null,
+        int? idPuntoVenta = null, DateOnly? fechaEsperada = null)
+    {
+        var solicitud = new SolicitudDeOrdenDeCompra(
+            idProveedor ?? ctx.IdProveedor, idPuntoVenta ?? ctx.IdPuntoVenta, fechaEsperada, null, items);
+        var creada = await CrearBorradorDeOrdenAsync(ctx, solicitud);
+        return await EnviarOrdenAsync(ctx, creada.Id);
+    }
+
+    private static async Task<OrdenDeCompraDetalle> ObtenerDetalleAsync(Contexto ctx, int id, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).GetAsync($"/api/ordenes-compra/{id}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<PaginaDeOrdenesDeCompra> ListarAsync(Contexto ctx, string query, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).GetAsync($"/api/ordenes-compra{query}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<PaginaDeOrdenesDeCompra>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- helpers: comprobantes de compra (recepción) --------------------------------------------------
+
+    private static async Task<CompraDetalle> CrearBorradorDeCompraAsync(Contexto ctx, SolicitudDeCompra solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/compras", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static async Task<CompraDetalle> ConfirmarCompraAsync(Contexto ctx, int id)
+    {
+        var respuesta = await ctx.Admin.PostAsync($"/api/compras/{id}/confirmar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<CompraDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    /// <summary>Confirma una recepción completa de <paramref name="cantidad"/> unidades del
+    /// artículo (por defecto <c>ctx.IdArticulo</c>) ligada a <paramref name="idOrdenCompra"/>, con
+    /// costo unitario controlado (para que el desvío de precio salga exacto en las pruebas).</summary>
+    private static async Task<CompraDetalle> RecibirYConfirmarAsync(
+        Contexto ctx, int idOrdenCompra, decimal cantidad, decimal costoUnitario, int? idArticulo = null)
+    {
+        var creada = await CrearBorradorDeCompraAsync(
+            ctx,
+            new SolicitudDeCompra(
+                ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, $"0001-{Guid.NewGuid():N}"[..8],
+                DateOnly.FromDateTime(DateTime.UtcNow), null,
+                [new LineaDeCompraSolicitada(idArticulo ?? ctx.IdArticulo, "Item de recepción", cantidad, null, null, costoUnitario, 0m, ctx.IdAlicuotaIva21, false)],
+                idOrdenCompra));
+        return await ConfirmarCompraAsync(ctx, creada.Id);
+    }
+
+    private async Task<OrdenCompra> LeerOrdenAsync(Contexto ctx, int idOrdenCompra)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        return await db.OrdenesCompra.AsNoTracking().FirstAsync(o => o.Id == idOrdenCompra);
+    }
+
+    // ====================================================================================================
+    // task 5.6/5.15 — paginación con fecha_emision empatada (RelojFijo); mutation target #34b parte 1
+    // ====================================================================================================
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    [Fact]
+    public async Task PaginacionConFechaEmisionEmpatadaNoDuplicaNiSalteaFilas()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararAsync(nameof(PaginacionConFechaEmisionEmpatadaNoDuplicaNiSalteaFilas), factory);
+
+        // Tres OCs, misma fecha_emision (RelojFijo) — solo el id las distingue.
+        var ordenA = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]);
+        var ordenB = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]);
+        var ordenC = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]);
+
+        var pagina1 = await ListarAsync(ctx, "?tamanio=2&pagina=1", ctx.Admin);
+        var pagina2 = await ListarAsync(ctx, "?tamanio=2&pagina=2", ctx.Admin);
+
+        Assert.Equal(3, pagina1.Total);
+        Assert.Equal(2, pagina1.Items.Count);
+        Assert.Single(pagina2.Items);
+
+        // Orden esperado: id DESC como desempate — C, B en la página 1; A en la página 2. Sin
+        // duplicados ni huecos entre las dos páginas.
+        Assert.Equal([ordenC.Id, ordenB.Id], pagina1.Items.Select(i => i.Id).ToArray());
+        Assert.Equal([ordenA.Id], pagina2.Items.Select(i => i.Id).ToArray());
+    }
+
+    // ====================================================================================================
+    // task 5.7/5.16 — cada filtro con semillas asimétricas; mutation target #34b parte 2
+    // ====================================================================================================
+
+    [Fact]
+    public async Task CadaFiltroIgnoradoDevolveriaDeMasConSemillasAsimetricas()
+    {
+        var ctx = await PrepararAsync(nameof(CadaFiltroIgnoradoDevolveriaDeMasConSemillasAsimetricas));
+
+        var objetivo = await CrearYEnviarOrdenAsync(
+            ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)],
+            idProveedor: ctx.IdProveedor, idPuntoVenta: ctx.IdPuntoVenta);
+
+        // Ruido: proveedor distinto, PV distinto, mismo request no debería aparecer bajo ningún filtro del objetivo.
+        var ruidoProveedor = await CrearYEnviarOrdenAsync(
+            ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)],
+            idProveedor: ctx.IdProveedor2, idPuntoVenta: ctx.IdPuntoVenta);
+        var ruidoPuntoVenta = await CrearYEnviarOrdenAsync(
+            ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)],
+            idProveedor: ctx.IdProveedor, idPuntoVenta: ctx.IdPuntoVenta2);
+
+        // idProveedor
+        var porProveedor = await ListarAsync(ctx, $"?idProveedor={ctx.IdProveedor}");
+        Assert.DoesNotContain(porProveedor.Items, i => i.Id == ruidoProveedor.Id);
+        Assert.Contains(porProveedor.Items, i => i.Id == objetivo.Id);
+
+        // idPuntoVenta
+        var porPuntoVenta = await ListarAsync(ctx, $"?idPuntoVenta={ctx.IdPuntoVenta}");
+        Assert.DoesNotContain(porPuntoVenta.Items, i => i.Id == ruidoPuntoVenta.Id);
+        Assert.Contains(porPuntoVenta.Items, i => i.Id == objetivo.Id);
+
+        // estado — una orden borrador (nunca enviada) no debe aparecer bajo estado=Enviada
+        var borrador = await CrearBorradorDeOrdenAsync(
+            ctx, new SolicitudDeOrdenDeCompra(ctx.IdProveedor, ctx.IdPuntoVenta, null, null, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]));
+        var porEstado = await ListarAsync(ctx, "?estado=Enviada");
+        Assert.DoesNotContain(porEstado.Items, i => i.Id == borrador.Id);
+        Assert.Contains(porEstado.Items, i => i.Id == objetivo.Id);
+
+        // desde/hasta — ventana estrictamente futura no debe traer la orden objetivo
+        var manana = DateTimeOffset.UtcNow.AddDays(1);
+        var pasadoManana = DateTimeOffset.UtcNow.AddDays(2);
+        var porDesde = await ListarAsync(ctx, $"?desde={Uri.EscapeDataString(manana.ToString("O"))}");
+        Assert.DoesNotContain(porDesde.Items, i => i.Id == objetivo.Id);
+
+        var haceUnDia = DateTimeOffset.UtcNow.AddDays(-1);
+        var porHasta = await ListarAsync(ctx, $"?hasta={Uri.EscapeDataString(haceUnDia.ToString("O"))}");
+        Assert.DoesNotContain(porHasta.Items, i => i.Id == objetivo.Id);
+        _ = pasadoManana;
+    }
+
+    // ====================================================================================================
+    // task 5.8/5.9 — regla 12(a): el detalle LEE la columna, nunca la re-deriva
+    // ====================================================================================================
+
+    [Fact]
+    public async Task DetalleLeeElEstadoDeLaColumnaSinRederivarloConUnaDesincronizacionCruda()
+    {
+        var ctx = await PrepararAsync(nameof(DetalleLeeElEstadoDeLaColumnaSinRederivarloConUnaDesincronizacionCruda));
+
+        // Enviada, sin ninguna recepción — la derivación honesta sería "enviada" para siempre.
+        var enviada = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 10m, 100m)]);
+
+        // Regla 12c: hermana del mismo tenant, con sus propios items — no debe verse afectada.
+        var hermana = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo2, "L2", 5m, 50m)]);
+
+        // Desincronización cruda (EF, sin pasar por EscriturasDeOrdenDeCompra): fuerza la columna a
+        // RecibidaParcial, un valor que la derivación real jamás produciría para esta orden (cero
+        // comprobantes ligados). numero/fecha_envio ya satisfacen ck_ordenes_compra_envio_completo;
+        // fecha_cierre/id_empleado_cierre siguen NULL, satisfaciendo ck_ordenes_compra_cierre.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var orden = await db.OrdenesCompra.FirstAsync(o => o.Id == enviada.Id);
+            orden.Estado = EstadoOrdenCompra.RecibidaParcial;
+            await db.SaveChangesAsync();
+        }
+
+        var detalle = await ObtenerDetalleAsync(ctx, enviada.Id);
+        Assert.Equal(EstadoOrdenCompra.RecibidaParcial, detalle.Estado);
+
+        var detalleHermana = await ObtenerDetalleAsync(ctx, hermana.Id);
+        Assert.Equal(EstadoOrdenCompra.Enviada, detalleHermana.Estado);
+    }
+
+    // ====================================================================================================
+    // task 5.9 — cobertura por artículo + fidelidad de proyección (regla 11: fixture discriminante)
+    // ====================================================================================================
+
+    /// <summary>design: Testing Strategy — "derivation fidelity (rule 11)". Un solo fixture rico:
+    /// dos líneas de OC del mismo artículo (3+4 ⇒ 7 pedidas), una recepción partida (2 luego 5,
+    /// completando exactamente 7), un artículo recibido pero jamás pedido (Pedida = 0), una
+    /// recepción soft-deleted (excluida), un comprobante ligado todavía en borrador (excluido —
+    /// nunca confirmado), y una recepción de OTRA orden del mismo proveedor (excluida — scoping por
+    /// id_orden_compra). Cierra con la prueba de projection fidelity: <c>ProyectorDeEstadoDeOrden.
+    /// Proyectar</c> recomputado desde LOS NÚMEROS DE ESTA LECTURA coincide con la columna
+    /// persistida (la escribió <see cref="EscriturasDeOrdenDeCompra"/> en <c>ConfirmarAsync</c>,
+    /// una derivación totalmente separada — ver <see cref="ServicioDeOrdenesDeCompra.
+    /// ObtenerCoberturaAsync"/>).</summary>
+    [Fact]
+    public async Task CoberturaPorArticuloDiscriminaCorrectamenteYLaProyeccionCoincideConLaColumna()
+    {
+        var ctx = await PrepararAsync(nameof(CoberturaPorArticuloDiscriminaCorrectamenteYLaProyeccionCoincideConLaColumna));
+
+        // Regla 12c: OC hermana del mismo tenant, jamás tocada por este fixture.
+        var hermana = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo2, "L2", 3m, 30m)]);
+
+        // Otra OC del MISMO proveedor — su propia recepción NO debe contarse en la cobertura de la
+        // orden objetivo (scoping por id_orden_compra, no por proveedor).
+        var otraOrden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L-otra", 100m, 1m)]);
+        await RecibirYConfirmarAsync(ctx, otraOrden.Id, cantidad: 100m, costoUnitario: 1m);
+
+        // La orden objetivo: DOS líneas del mismo artículo, 3 + 4 = 7 pedidas, mismo costo
+        // estimado (100) para que el promedio ponderado sea trivialmente 100.
+        var objetivo = await CrearYEnviarOrdenAsync(
+            ctx,
+            [
+                new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea A", 3m, 100m),
+                new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea B", 4m, 100m)
+            ]);
+
+        // Recepción partida: 2 luego 5 (completa exactamente 7), costo real 112 (⇒ desvío +12%).
+        await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 2m, costoUnitario: 112m);
+        var confirmadaFinal = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 5m, costoUnitario: 112m);
+        Assert.Equal(EstadoCompra.Confirmada, confirmadaFinal.Estado);
+
+        // Recibido-no-pedido: articulo2, jamás en items_orden_compra de esta orden.
+        var reciboExtra = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 1m, costoUnitario: 50m, idArticulo: ctx.IdArticulo2);
+
+        // Un comprobante ligado todavía en borrador — NO debe contar (solo confirmados cuentan).
+        await CrearBorradorDeCompraAsync(
+            ctx,
+            new SolicitudDeCompra(
+                ctx.IdProveedor, ctx.IdTipoCFB, ctx.IdPuntoVenta, $"0001-{Guid.NewGuid():N}"[..8],
+                DateOnly.FromDateTime(DateTime.UtcNow), null,
+                [new LineaDeCompraSolicitada(ctx.IdArticulo, "No confirmado", 9m, null, null, 999m, 0m, ctx.IdAlicuotaIva21, false)],
+                objetivo.Id));
+
+        // Una recepción soft-deleted del artículo 1 — excluida de la cobertura (defense-in-depth,
+        // mismo criterio que EscriturasDeOrdenDeCompra.DerivarAsync).
+        var recepcionSoftDeleted = await RecibirYConfirmarAsync(ctx, objetivo.Id, cantidad: 999m, costoUnitario: 1m);
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var itemsDeEsaCompra = await db.ItemsComprobanteCompra
+                .Where(i => i.IdComprobanteCompra == recepcionSoftDeleted.Id)
+                .ToListAsync();
+            foreach (var item in itemsDeEsaCompra)
+            {
+                item.DeletedAt = DateTimeOffset.UtcNow;
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var detalle = await ObtenerDetalleAsync(ctx, objetivo.Id);
+
+        var coberturaArticulo1 = Assert.Single(detalle.Cobertura, c => c.IdArticulo == ctx.IdArticulo);
+        Assert.Equal(7m, coberturaArticulo1.Pedida);
+        Assert.Equal(7m, coberturaArticulo1.Recibida); // 2 + 5, jamás 999 (soft-deleted) ni 100 (otra orden)
+        Assert.Equal(0m, coberturaArticulo1.Pendiente);
+        Assert.Equal(100m, coberturaArticulo1.CostoEstimado);
+        Assert.Equal(112m, coberturaArticulo1.CostoReal);
+        Assert.Equal(12.00m, coberturaArticulo1.Desvio);
+
+        var coberturaArticulo2 = Assert.Single(detalle.Cobertura, c => c.IdArticulo == ctx.IdArticulo2);
+        Assert.Equal(0m, coberturaArticulo2.Pedida); // recibido-no-pedido
+        Assert.Equal(1m, coberturaArticulo2.Recibida);
+        Assert.Equal(0m, coberturaArticulo2.Pendiente); // Math.Max(0 - 1, 0), nunca negativo
+        Assert.Null(coberturaArticulo2.CostoEstimado); // nunca pedido ⇒ nunca cotizado
+        Assert.NotNull(coberturaArticulo2.CostoReal);
+        Assert.Null(coberturaArticulo2.Desvio); // no comparable — un lado ausente, nunca 0
+
+        // ComprobantesLigados incluye el borrador (todo comprobante ligado, cualquier estado).
+        Assert.True(detalle.ComprobantesLigados.Count >= 4);
+
+        // ---- fidelidad de proyección (task 5.9): recomputar Proyectar desde ESTA lectura ----------
+        var completa = detalle.Cobertura.All(c => c.Pendiente <= 0m);
+        var algoRecibido = detalle.Cobertura.Any(c => c.Recibida > 0m);
+        var recomputado = ProyectorDeEstadoDeOrden.Proyectar(
+            EstadoOrdenCompra.Enviada, cierreManual: false, completa: completa, algoRecibido: algoRecibido);
+
+        var persistida = await LeerOrdenAsync(ctx, objetivo.Id);
+        Assert.Equal(persistida.Estado, recomputado);
+        Assert.Equal(persistida.Estado, detalle.Estado);
+
+        // Hermana intacta.
+        var detalleHermana = await ObtenerDetalleAsync(ctx, hermana.Id);
+        Assert.Equal(EstadoOrdenCompra.Enviada, detalleHermana.Estado);
+        Assert.Equal(3m, Assert.Single(detalleHermana.Cobertura).Pedida);
+    }
+
+    // ====================================================================================================
+    // task 5.10 — un aumento de precio se muestra, jamás bloquea
+    // ====================================================================================================
+
+    [Fact]
+    public async Task UnAumentoDePrecioEntreOrdenYFacturaSeSurfaceaNoSeBloquea()
+    {
+        var ctx = await PrepararAsync(nameof(UnAumentoDePrecioEntreOrdenYFacturaSeSurfaceaNoSeBloquea));
+
+        var orden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 100m)]);
+        var confirmada = await RecibirYConfirmarAsync(ctx, orden.Id, cantidad: 1m, costoUnitario: 112m);
+        Assert.Equal(EstadoCompra.Confirmada, confirmada.Estado); // nunca bloqueada por el desvío
+
+        var detalle = await ObtenerDetalleAsync(ctx, orden.Id);
+        var cobertura = Assert.Single(detalle.Cobertura);
+        Assert.Equal(100m, cobertura.CostoEstimado);
+        Assert.Equal(112m, cobertura.CostoReal);
+        Assert.Equal(12.00m, cobertura.Desvio);
+    }
+
+    // ====================================================================================================
+    // task 5.11/5.17 — una línea nunca cotizada reporta "no comparable", jamás 0; mutation target #34b parte 3
+    // ====================================================================================================
+
+    [Fact]
+    public async Task UnaLineaNuncaCotizadaReportaNoComparableNuncaCero()
+    {
+        var ctx = await PrepararAsync(nameof(UnaLineaNuncaCotizadaReportaNoComparableNuncaCero));
+
+        var orden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, null)]);
+        await RecibirYConfirmarAsync(ctx, orden.Id, cantidad: 1m, costoUnitario: 55m);
+
+        var detalle = await ObtenerDetalleAsync(ctx, orden.Id);
+        var cobertura = Assert.Single(detalle.Cobertura);
+        Assert.Null(cobertura.CostoEstimado);
+        Assert.NotNull(cobertura.CostoReal);
+        Assert.Null(cobertura.Desvio); // NUNCA 0m
+        Assert.Null(detalle.TotalEstimado); // ningún artículo comparable del lado estimado
+    }
+
+    // ====================================================================================================
+    // task 5.13 — GET /api/reportes/stock/reposicion mantiene su shape y sus figuras (regresión stage 13)
+    // ====================================================================================================
+
+    [Fact]
+    public async Task ReposicionMantieneSuShapeYSusFigurasSinCambios()
+    {
+        var ctx = await PrepararAsync(nameof(ReposicionMantieneSuShapeYSusFigurasSinCambios));
+
+        var respuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/reposicion?idPuntoVenta={ctx.IdPuntoVenta}");
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        // Etapa 13 nunca vio una OC — el shape (IdPuntoVenta/Hoy/DiasDeRotacion/ZonaHoraria/Filas)
+        // es el mismo antes y después de esta etapa: solo lectura, cero mutación de este endpoint
+        // (ordenes-de-compra/spec.md: "Etapa 13 stays a read-only source").
+        var reposicion = JsonSerializer.Deserialize<Reposicion>(cuerpo, OpcionesJson)!;
+        Assert.Equal(ctx.IdPuntoVenta, reposicion.IdPuntoVenta);
+        Assert.Equal(DateOnly.FromDateTime(DateTime.UtcNow), reposicion.Hoy);
+        Assert.NotNull(reposicion.ZonaHoraria);
+        Assert.NotNull(reposicion.Filas);
+    }
+
+    // ====================================================================================================
+    // task 5.14 — el límite del offset -03:00 (nunca Z) assertea filas Y período mostrado
+    // ====================================================================================================
+
+    [Fact]
+    public async Task ListadoConOffsetMenosTresAsertaFilasYPeriodoMostrado()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+        var mismoInstanteConOffset = new DateTimeOffset(2026, 8, 19, 9, 0, 0, TimeSpan.FromHours(-3));
+        Assert.Equal(instanteFijo, mismoInstanteConOffset);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararAsync(nameof(ListadoConOffsetMenosTresAsertaFilasYPeriodoMostrado), factory);
+        var orden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]);
+
+        var desde = mismoInstanteConOffset.AddHours(-1);
+        var hasta = mismoInstanteConOffset.AddHours(1);
+        var pagina = await ListarAsync(
+            ctx, $"?desde={Uri.EscapeDataString(desde.ToString("O"))}&hasta={Uri.EscapeDataString(hasta.ToString("O"))}");
+
+        Assert.Contains(pagina.Items, i => i.Id == orden.Id);
+        var fila = pagina.Items.First(i => i.Id == orden.Id);
+        Assert.Equal(instanteFijo, fila.FechaEmision);
+    }
+
+    // ---- autorización — Vendedor lee, no escribe (matriz completa la cierra un test dedicado) --------
+
+    [Fact]
+    public async Task VendedorLeeAmbosEndpointsDeLectura()
+    {
+        var ctx = await PrepararAsync(nameof(VendedorLeeAmbosEndpointsDeLectura));
+        var orden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 1m, 10m)]);
+
+        var lista = await ctx.Vendedor.GetAsync("/api/ordenes-compra");
+        Assert.Equal(HttpStatusCode.OK, lista.StatusCode);
+
+        var detalle = await ctx.Vendedor.GetAsync($"/api/ordenes-compra/{orden.Id}");
+        Assert.Equal(HttpStatusCode.OK, detalle.StatusCode);
+    }
+
+    // ---- cross-tenant — ADR-8: 404 uniforme ------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaOrdenDeOtroTenantResponde404()
+    {
+        var ctxA = await PrepararAsync(nameof(UnaOrdenDeOtroTenantResponde404) + "A");
+        var ctxB = await PrepararAsync(nameof(UnaOrdenDeOtroTenantResponde404) + "B");
+
+        var ordenDeA = await CrearYEnviarOrdenAsync(ctxA, [new LineaDeOrdenSolicitada(ctxA.IdArticulo, "L", 1m, 10m)]);
+
+        var respuesta = await ctxB.Admin.GetAsync($"/api/ordenes-compra/{ordenDeA.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ---- gate guard (task 5.18) --------------------------------------------------------------------
+
+    /// <summary>Gate guard (task 5.18, decisión 2 de tasks.md): esta slice no agrega DDL — el
+    /// modelo EF sigue coincidiendo exactamente con la migración de slice 1.</summary>
+    [Fact]
+    public async Task NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1()
+    {
+        using var _ = fixture.CreateClient();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var hayPendientes = db.Database.HasPendingModelChanges();
+        Assert.False(hayPendientes);
+    }
+}

--- a/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
@@ -159,6 +159,14 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
     }
 
+    private static async Task<OrdenDeCompraBorrador> CerrarOrdenAsync(Contexto ctx, int id, HttpClient? cliente = null)
+    {
+        var respuesta = await (cliente ?? ctx.Admin).PostAsync($"/api/ordenes-compra/{id}/cerrar", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        return JsonSerializer.Deserialize<OrdenDeCompraBorrador>(cuerpo, OpcionesJson)!;
+    }
+
     private static async Task<OrdenDeCompraBorrador> CrearYEnviarOrdenAsync(
         Contexto ctx, IReadOnlyList<LineaDeOrdenSolicitada> items, int? idProveedor = null,
         int? idPuntoVenta = null, DateOnly? fechaEsperada = null)
@@ -430,6 +438,15 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         Assert.NotNull(coberturaArticulo2.CostoReal);
         Assert.Null(coberturaArticulo2.Desvio); // no comparable — un lado ausente, nunca 0
 
+        // CRITICAL 2 (judgment-day, juez B): TotalEstimado/TotalReal/DesvioTotal del detalle,
+        // calculados a mano desde el fixture de arriba. Solo articulo1 tiene CostoEstimado (100,
+        // pedida 7) ⇒ TotalEstimado = 100*7 = 700. TotalReal suma AMBOS artículos con CostoReal
+        // (articulo1: 112*7 = 784; articulo2: 50*1 = 50) ⇒ TotalReal = 834. DesvioTotal =
+        // (834-700)/700*100 = 19.14. Los tres valores son pairwise-distintos entre sí.
+        Assert.Equal(700m, detalle.TotalEstimado);
+        Assert.Equal(834m, detalle.TotalReal);
+        Assert.Equal(19.14m, detalle.DesvioTotal);
+
         // ComprobantesLigados incluye el borrador (todo comprobante ligado, cualquier estado).
         Assert.True(detalle.ComprobantesLigados.Count >= 4);
 
@@ -447,6 +464,27 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         var detalleHermana = await ObtenerDetalleAsync(ctx, hermana.Id);
         Assert.Equal(EstadoOrdenCompra.Enviada, detalleHermana.Estado);
         Assert.Equal(3m, Assert.Single(detalleHermana.Cobertura).Pedida);
+    }
+
+    // ====================================================================================================
+    // CRITICAL 1 (judgment-day, juez B, regla 12b): Pendiente solo se asserteaba en 0 (7-7 y
+    // Math.Max(0-1,0)) — un `var pendiente = 0m;` fijo en producción sobrevivía. Fixture dedicado
+    // con Pendiente POSITIVO discriminante.
+    // ====================================================================================================
+
+    [Fact]
+    public async Task CoberturaPendienteEsPositivaCuandoLaRecepcionNoCompletaLoPedido()
+    {
+        var ctx = await PrepararAsync(nameof(CoberturaPendienteEsPositivaCuandoLaRecepcionNoCompletaLoPedido));
+
+        var orden = await CrearYEnviarOrdenAsync(ctx, [new LineaDeOrdenSolicitada(ctx.IdArticulo, "L", 7m, 10m)]);
+        await RecibirYConfirmarAsync(ctx, orden.Id, cantidad: 5m, costoUnitario: 10m);
+
+        var detalle = await ObtenerDetalleAsync(ctx, orden.Id);
+        var cobertura = Assert.Single(detalle.Cobertura);
+        Assert.Equal(7m, cobertura.Pedida);
+        Assert.Equal(5m, cobertura.Recibida);
+        Assert.Equal(2m, cobertura.Pendiente); // Math.Max(7 - 5, 0) = 2, nunca 0 fijo
     }
 
     // ====================================================================================================
@@ -566,6 +604,58 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
 
         var respuesta = await ctxB.Admin.GetAsync($"/api/ordenes-compra/{ordenDeA.Id}");
         Assert.Equal(HttpStatusCode.NotFound, respuesta.StatusCode);
+    }
+
+    // ====================================================================================================
+    // CRITICAL 3 (judgment-day, juez B, regla 12b): IdProveedor/IdPuntoVenta del detalle son dos
+    // ints posicionales adyacentes en un record de 17 parámetros que jamás se leían de vuelta — el
+    // SWAP de ambos en el constructor sobrevivía 197/197. Ya que la causa raíz es la misma (ningún
+    // campo posicional del detalle/listado leído de vuelta), un solo test integral asserta CADA
+    // campo posicional hoy sin cobertura (Numero, FechaEnvio, FechaCierre, CierreManual,
+    // Observaciones, FechaEsperada, y el Estado de la fila del listado) con valores todos
+    // distintos entre sí.
+    // ====================================================================================================
+
+    [Fact]
+    public async Task DetalleDevuelveCadaCampoPosicionalConSuVerdad()
+    {
+        var ctx = await PrepararAsync(nameof(DetalleDevuelveCadaCampoPosicionalConSuVerdad));
+
+        // Precondición (regla 11): IdProveedor2/IdPuntoVenta2 nacen en tablas distintas — si algún
+        // día colisionaran numéricamente el swap quedaría indetectable. Falla acá primero, ruidosamente,
+        // en vez de dar un verde falso más abajo.
+        Assert.NotEqual(ctx.IdProveedor2, ctx.IdPuntoVenta2);
+
+        var fechaEsperada = new DateOnly(2027, 3, 15);
+        const string observaciones = "observacion-distintiva-critical-3";
+
+        var solicitud = new SolicitudDeOrdenDeCompra(
+            ctx.IdProveedor2, ctx.IdPuntoVenta2, fechaEsperada, observaciones,
+            [new LineaDeOrdenSolicitada(ctx.IdArticulo, "Linea unica", 6m, 60m)]);
+        var creada = await CrearBorradorDeOrdenAsync(ctx, solicitud);
+        var enviada = await EnviarOrdenAsync(ctx, creada.Id);
+        var cerrada = await CerrarOrdenAsync(ctx, creada.Id);
+
+        var detalle = await ObtenerDetalleAsync(ctx, creada.Id);
+
+        Assert.Equal(creada.Id, detalle.Id);
+        Assert.Equal(ctx.IdProveedor2, detalle.IdProveedor);
+        Assert.Equal(ctx.IdPuntoVenta2, detalle.IdPuntoVenta);
+        Assert.NotNull(detalle.Numero);
+        Assert.Equal(enviada.Numero, detalle.Numero);
+        Assert.NotNull(detalle.FechaEnvio);
+        Assert.Equal(enviada.FechaEnvio, detalle.FechaEnvio);
+        Assert.Equal(fechaEsperada, detalle.FechaEsperada);
+        Assert.NotNull(detalle.FechaCierre);
+        Assert.Equal(cerrada.FechaCierre, detalle.FechaCierre);
+        Assert.True(detalle.CierreManual);
+        Assert.Equal(observaciones, detalle.Observaciones);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, detalle.Estado);
+
+        // Estado de la fila del listado — nunca asserteado hasta ahora.
+        var pagina = await ListarAsync(ctx, $"?idProveedor={ctx.IdProveedor2}");
+        var filaListado = Assert.Single(pagina.Items, i => i.Id == creada.Id);
+        Assert.Equal(EstadoOrdenCompra.Cerrada, filaListado.Estado);
     }
 
     // ---- gate guard (task 5.18) --------------------------------------------------------------------


### PR DESCRIPTION
## Resumen

- `GET /api/ordenes-compra` paginado (OFFSET, fecha_emision DESC + desempate id DESC, filtros de estado/proveedor/fechas con offset real) y `GET /{id}` con la lista de COBERTURA por artículo (pedido/recibido/pendiente — `Math.Max(pedida-recibida, 0)`), desvío de precio INFORMATIVO con nulls honestos, y `ComprobantesLigados`. Lecturas bajo `OperacionDePos` (el Vendedor lee).
- Dos derivaciones cross-validadas A PROPÓSITO (raw-ADO de escritura vs LINQ de lectura) con test de fidelidad; el estado se lee de la COLUMNA proyectada (sentinela 12a probándolo).
- **Fix de producción de la ronda 2**: `TotalEstimado` extrapolaba costo de cantidad no cotizada (promedio de cotizadas × pedida total — dos poblaciones mezcladas, alcanzable por POST común); ahora suma A NIVEL LÍNEA solo la porción cotizada, null si nada está cotizado. `TotalReal` verificado estructuralmente sin la trampa (misma población del GroupBy).

## Judgment-day (2 rondas)

- Juez B ronda 1: **3 CRITICALs 12b** (Pendiente solo assertado en 0; totales sin lectura de vuelta — 12345 fijo sobrevivía; swap de IdProveedor/IdPuntoVenta del DETALLE invisible). Fix tests-only `b45a644` — re-ronda B limpia. La clase alimentó el endurecimiento de la regla 12b (todo campo posicional se lee de vuelta; un test integral por response DTO).
- Juez A ronda 1: **1 CRITICAL DE PRODUCCIÓN** (la extrapolación de TotalEstimado) + **1 CRITICAL** (el análogo del LISTADO del swap — el fix del detalle no cubre al listado: cada DTO necesita SU test integral) + WARNING (conjunto exacto de ComprobantesLigados) + SUGGESTION (variable muerta). Fix ronda 2 `aae1622..8033d43` — pasada B y re-ronda A limpias (300 vs 700.0000000 en el kill de la fórmula vieja).
- Bookkeeping: la decisión del slice renumerada a 24 (colisión con la 20 del slice 3) y la afirmación de cobertura de la 25 corregida.

Gate: cero DDL, `has-pending-model-changes` limpio. Full suite del apply: 2216/2216; regresión final 458/458. Protegidos intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)