### PR TITLE
feat(ordenes-compra): pantallas web, generar OC desde reposicion y pre-carga de recepcion (etapa 16, slice 6)

### DIFF
--- a/openspec/changes/stage-16-ordenes-de-compra/specs/ordenes-de-compra/spec.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/specs/ordenes-de-compra/spec.md
@@ -265,7 +265,10 @@ never `0`.
 `GET /api/reportes/stock/reposicion`'s rows, mapping `FilaDeReposicion.{IdArticulo, Sugerido} →
 {IdArticulo, CantidadPedida}`, filtered by proveedor. Rows in the `"Sin proveedor"` group MUST NOT
 be able to pre-load an OC. Rows with `sugerido = null` MUST be excluded, never defaulted to `0`.
-Stage 13's endpoint and response shape MUST remain unchanged.
+Stage 13's endpoint and response shape MUST remain unchanged. The web's per-group *"Generar OC"*
+action on the reposición screen MUST only be offered to a session whose role can write an OC
+(Admin) — the reposición screen itself remains visible to every role that already reads it
+(Supervisor, Admin).
 
 #### Scenario: A pre-load excludes null-sugerido rows
 - GIVEN a reposición list with one row where `sugerido = null`
@@ -281,3 +284,9 @@ Stage 13's endpoint and response shape MUST remain unchanged.
 - GIVEN `GET /api/reportes/stock/reposicion` before and after this stage
 - WHEN both responses are compared for identical parameters
 - THEN the response shape and figures are identical — Etapa 13 stays a read-only source
+
+#### Scenario: The Generar OC action is Admin-gated in the web, the screen stays as-is for others
+- GIVEN a Supervisor session viewing the reposición screen
+- WHEN the per-group actions are rendered
+- THEN no *"Generar OC"* button appears for any group, while every other part of the screen
+  (filters, table, download) renders exactly as it does today

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -414,6 +414,21 @@
     archivos, 796 tests), `npm run build` limpio (mismo advisory de chunk-size pre-existente, sin
     errores de TypeScript nuevos), `git status` limpio entre cada ciclo.
 
+    **Flakiness cazada por judgment-day ronda 1 (juez B), cierre determinista**: el nuevo test
+    same-tick de `Guardar borrador` (WARNING 2 arriba) resultó flaky bajo suite completa (1 de 3
+    corridas full falló con 0 PUTs capturados en vez de 1) — a diferencia de `Enviar`/`Cerrar`/
+    `Anular`, cuyo botón solo depende de `ocupado` (síncrono desde el primer render), el botón de
+    `Guardar borrador` también depende de `encabezadoCompleto`, que hidrata `encabezado` desde
+    `detalle` en un `useEffect` posterior — bajo carga de CPU el doble `dispatchEvent` podía correr
+    contra un botón todavía deshabilitado. Cerrado sin debilitar el assert (sigue siendo exactamente
+    1 PUT): se agregó `await waitFor(() => expect(boton).not.toBeDisabled())` y `await waitFor(()
+    => expect(screen.getByLabelText('Proveedor')).toHaveValue('4'))` antes del doble dispatch. Los
+    tres tests hermanos no comparten el gap (su gate de disabled es solo `ocupado`), así que no se
+    tocaron. Ciclo del mutante (quitar `guardandoRef.current` del guard) reconfirmado: el test sigue
+    detectando los 2 PUTs y falla como se espera. Evidencia: aislado `npx vitest run
+    OrdenDeCompra.test.tsx` ×3 (14/14 siempre) + suite completa `npx vitest run` ×3 corridas
+    consecutivas, una por vez (796/796 las tres, sin la falla original), `git status` limpio.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -391,6 +391,29 @@
       `npm run build` (`tsc -b && vite build`) clean, `npm run lint` (`oxlint`) clean with zero new
       warnings in any file touched this slice.
 
+28. **`judgment-day` ronda 1 (juez A) confirmó 2 WARNING sobre `OrdenDeCompra.tsx` — ambos
+    cerrados con fix acotado (commit `74472a3`).** WARNING 1 (producción): `puedeRecepcionar`
+    (línea 507) era el único gate de acción de los cinco (`puedeEnviar`/`puedeCerrar`/
+    `puedeAnular`/`puedeGuardar`) que no ANDeaba `puedeEscribir` — un Vendedor/Supervisor podía ver
+    "Registrar recepción" pese a que la escritura sigue siendo server-Admin-only. Cerrado agregando
+    `puedeEscribir &&` al gate y ensanchando el test del Vendedor ("un Vendedor lee el detalle pero
+    no ve ninguna acción de escritura") para assertar también la ausencia de "Registrar recepción".
+    WARNING 2 (tests + docs): el test same-tick de doble click (dos `dispatchEvent` nativos dentro
+    de un mismo `act()`) probado en la 6.11 solo cubría `enviar`, pese a que los cuatro guards de
+    reentrancia (`cerrandoRef`/`anulandoRef`/`guardandoRef`/`enviandoRef`) existen desde esa misma
+    tarea — 6.11 afirmaba una cobertura que no era literalmente cierta. Cerrado replicando el mismo
+    patrón same-tick para `Cerrar`, `Anular` y `Guardar borrador` (este último contra
+    `apiPutMock`, ya que `guardarBorrador` en una orden existente hace `PUT /ordenes-compra/{id}`,
+    no `POST`), dejando la 6.11 ahora literalmente verdadera. **Evidencia de mutación (ciclo
+    commit-primero → mutar → falla esperada → revertir con `git checkout --` → limpio)**:
+    (a) quitar `puedeEscribir` del gate → el test del Vendedor FALLÓ (botón "Registrar recepción"
+    encontrado) → revertido; (b) quitar el guard `cerrandoRef.current` de `cerrar()` → el nuevo
+    test same-tick de Cerrar FALLÓ (2 POSTs en vez de 1) → revertido; (c) ídem con
+    `anulandoRef.current` en `anular()` → el test de Anular FALLÓ (2 POSTs) → revertido. Corrida
+    final del archivo verde (14 tests), suite completa verde (`npx vitest run`, sin filtro: 48
+    archivos, 796 tests), `npm run build` limpio (mismo advisory de chunk-size pre-existente, sin
+    errores de TypeScript nuevos), `git status` limpio entre cada ciclo.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-
@@ -1636,10 +1659,15 @@ and drop the `Reposicion.tsx` action; a documented reduction, never silent (deci
   (`filasDeReposicionAOrdenDeCompra.test.ts`) and the end-to-end integration test
   (`Reposicion.test.tsx`, click → real `/ordenes-compra/nueva` destination route reading
   `location.state`, never a mocked `useNavigate`).
-- [x] 6.11 [P] Vitest — a double click on `enviar`/`cerrar`/`anular` issues exactly one POST
-  (`react-async-state` rule 9). — `OrdenDeCompra.test.tsx`: "un doble click en 'Enviar' dispara
-  exactamente un POST", two native `dispatchEvent` calls inside one `act()` (same-tick, beats the
-  `disabled` re-render — `BotonDeDescarga.test.tsx`/`CuentaCorrienteDeProveedor.test.tsx` pattern).
+- [x] 6.11 [P] Vitest — a double click on `enviar`/`cerrar`/`anular`/`guardarBorrador` issues
+  exactly one write (`react-async-state` rule 9). — `OrdenDeCompra.test.tsx`: "un doble click en
+  'Enviar'/'Cerrar'/'Anular'/'Guardar borrador' dispara exactamente un POST/PUT", two native
+  `dispatchEvent` calls inside one `act()` per action (same-tick, beats the `disabled` re-render —
+  `BotonDeDescarga.test.tsx`/`CuentaCorrienteDeProveedor.test.tsx` pattern). **CLOSED WARNING
+  (judgment-day ronda 1, juez A — decision 28)**: the first apply pass only shipped the `Enviar`
+  case even though all four reentrancy refs already existed; `Cerrar`/`Anular`/`Guardar borrador`
+  now have the same same-tick coverage, with mutation evidence on `cerrandoRef`/`anulandoRef`
+  recorded in decision 28.
 - [x] 6.12 [P] Vitest — a stale response is discarded, resolved **inside `act`** (`react-async-
   state` rule 7). — `OrdenDeCompra.test.tsx`: "una respuesta de refetch desactualizada nunca pisa
   la más reciente" (two competing detail refetches from `enviar` then `anular`; the older one

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -346,6 +346,51 @@
       completa del archivo: **14/14 verde**; regresión filtrada `Compras`/`OC`: **254/254 verde**;
       `git status` limpio.
 
+27. **Slice 6 apply-phase decisions and deviations (decision 15 discipline).** Web-only slice,
+    cero cambios de API/backend (`git diff --stat main -- src/Ways.Api src/Ways.Application
+    src/Ways.Domain src/Ways.Infrastructure` vacío en todo el diff de la slice).
+    - **DEVIATION — `Compras.tsx` no gana una columna de OC ligada (task 6.6).** `CompraListada`
+      (la fila de `GET /api/compras`) nunca fue ensanchada con `IdOrdenCompra` — solo
+      `CompraDetalle` lo tiene (`design.md:206-208`, decisión 7/tensión T7 de slices anteriores).
+      Con cero cambios de backend autorizados esta slice, el listado literalmente no tiene el dato
+      para mostrar; inventar un fetch N+1 por fila sería alcance que el design nunca pidió.
+      Resuelto siguiendo el contrato DTO autoritativo (mismo criterio que las desviaciones 17/20):
+      "el link" se realiza donde el dato realmente vive — `CompraEditor.tsx` (task 6.4) muestra
+      `Vinculada a la orden de compra #{id}` con un `Link` a `/ordenes-compra/{id}`, para una
+      compra pre-cargada Y para una ya existente. `Compras.tsx` queda sin modificar.
+    - **APPLY-TIME FIX — `OrdenDeCompra.tsx`'s `cargarDetalle` (task 6.3).** El diseño pide
+      explícitamente "the post-write refetch has its own try/catch" (`design.md:341`, regla 6 de
+      `react-async-state`) porque `enviar`/`cerrar`/`anular` devuelven `OrdenDeCompraBorrador` (sin
+      cobertura) — a diferencia de `CompraEditor.tsx`, que nunca necesita un refetch porque
+      `confirmar`/`anular` de compras YA devuelven el `CompraDetalle` completo. La primera
+      implementación del catch de ese refetch vaciaba `detalle` a `null` en TODA falla, incluida
+      una posterior a una escritura 2xx — eso hubiera reemplazado la pantalla entera (incluido el
+      `aviso` de éxito recién seteado) por la pantalla de error bloqueante, violando la regla 6
+      literalmente ("a committed write is never reported as a failure"). Cerrado: el catch ya no
+      toca `detalle` (los datos stale-pero-reales siguen visibles), `errorDetalle` se muestra chico
+      cuando `detalle` ya existe, y la pantalla de error bloqueante queda reservada a la carga
+      inicial genuinamente fallida (`detalle === null`). Encontrado escribiendo el test primero
+      (`OrdenDeCompra.test.tsx`, "un 2xx de enviar/cerrar/anular nunca se reporta como fallo").
+    - **El escenario web del botón "Generar OC" se agregó a `specs/ordenes-de-compra/spec.md`
+      (Requirement "Pre-Load From The Reposición List…"), NO a `specs/reposicion-de-stock/spec.md`.**
+      El botón es una escritura de OC (capability `ordenes-de-compra`) que consume el reporte de
+      reposición como fuente, no un cambio de comportamiento del reporte mismo — `reposicion-de-
+      stock`'s propia decisión 14 (`state.yaml`, este archivo) ya acota su delta a la fórmula/
+      Purpose, "byte-identical" en todo lo demás; agregarle un escenario de UI ajeno rompería esa
+      frontera. El gate Admin-only queda expresado como escenario en la capability que
+      efectivamente lo posee.
+    - **`idAlicuotaIva` deliberadamente sin precargar en `CompraEditor.tsx` (task 6.4).** La OC no
+      tiene ningún concepto de IVA (`ContratosDeOrdenDeCompra.cs` no lo carga) — `dto-contract-
+      honesty`: inventar una alícuota sería fabricar un dato que la fuente no tiene. Una línea
+      pre-cargada queda "incompleta" (no viaja al guardar) hasta que el operador elige una — el
+      mismo criterio de `lineaCompletaParaEnvio` ya aplicado al resto del formulario.
+    - **`judgment-day` NOT run** (task 6.19) — same executor-boundary reason as every prior slice.
+      Full solution test suite NOT re-run end-to-end this slice (web-only diff, zero backend
+      files touched — `dotnet test` unaffected by construction); the web suite ran full end-to-end
+      post-implementation: **48 test files, 793 tests green** (`npx vitest run`, no filter),
+      `npm run build` (`tsc -b && vite build`) clean, `npm run lint` (`oxlint`) clean with zero new
+      warnings in any file touched this slice.
+
 **Not a new conflict, no action required** (already resolved in earlier phases): T3 (spec OD7) —
 the `comprobantes-compra` mirroring is the stage-15 pattern, not duplication; T4 (spec OD7) — the
 word-budget overage is a house precedent, no action; T5 (spec OD7) — `cuenta-corriente-de-
@@ -1521,53 +1566,133 @@ clean round + PR merged.
 **Budget note**: pre-approved degradation — if this slice overflows, ship list + detail + draft
 and drop the `Reposicion.tsx` action; a documented reduction, never silent (decision 3 above).
 
-- [ ] 6.1 Create `src/Ways.Web/src/api/ordenesDeCompra.ts` (+ `.test.ts`) — client + pure mappers;
-  `tipos.ts` mirrors the read/write DTOs. *(design.md:353, 385)*
-- [ ] 6.2 Create `src/Ways.Web/src/paginas/OrdenesDeCompra.tsx` (+ `.test.tsx`) — route
+- [x] 6.1 Create `src/Ways.Web/src/api/ordenesDeCompra.ts` (+ `.test.ts`) — client + pure mappers;
+  `tipos.ts` mirrors the read/write DTOs. *(design.md:353, 385)* — client (`listar`/`obtener`/
+  `crear`/`actualizar`/`enviar`/`cerrar`/`anular`), query builder with `fechaIsoConOffset` (rule
+  10), formatters (`formatearCantidadNullable`/`formatearDesvio`/`formatearMonedaNullable`), and
+  the borrador-formulario helpers (`EncabezadoDeOrdenFormulario`/`LineaDeOrdenFormulario`/
+  `aSolicitudDeOrdenDeCompra`) mirroring `compras.ts`'s shape.
+- [x] 6.2 Create `src/Ways.Web/src/paginas/OrdenesDeCompra.tsx` (+ `.test.tsx`) — route
   `/ordenes-compra`, `RutaProtegida rolesPermitidos={[Vendedor,Supervisor,Admin]}` (the read gate);
   filters + pager. *(design.md:330-333)*
-- [ ] 6.3 Create `src/Ways.Web/src/paginas/OrdenDeCompra.tsx` (+ `.test.tsx`) — draft editor +
+- [x] 6.3 Create `src/Ways.Web/src/paginas/OrdenDeCompra.tsx` (+ `.test.tsx`) — draft editor +
   detail with cobertura table (`—` never `0` when `null`) + `enviar`/`cerrar`/`anular` actions +
   "Registrar recepción" → `navigate('/compras/nueva?idOrdenCompra=' + id)`. `key={idOrden ??
-  'nueva'}` on the subtree; `generacionRef` per fetch; generation bumps before each write;
+  'nueva-' + ...}` on the subtree; `generacionRef` per fetch; generation bumps before each write;
   post-write refetch has its own `try/catch`; first-line re-entrancy guard + full-window disable
-  on `enviar`/`cerrar`/`anular`. *(design.md:334-343, `react-async-state` rules 2,3,6,8,9)*
-- [ ] 6.4 Modify `src/Ways.Web/src/paginas/CompraEditor.tsx` — read `idOrdenCompra` from
+  on `enviar`/`cerrar`/`anular`. *(design.md:334-343, `react-async-state` rules 2,3,6,8,9)* —
+  APPLY-TIME FIX registered: `cargarDetalle`'s failure path originally nulled `detalle` on EVERY
+  failure, including a post-write refetch failure — that would have replaced the whole screen
+  (including the just-set success `aviso`) with the blocking full-page error, contradicting rule 6
+  ("a committed write is never reported as a failure"). Fixed: the catch no longer touches
+  `detalle` (stale-but-real data stays visible), `errorDetalle` renders as a small inline warning
+  when `detalle` is already populated, and the blocking full-page error is reserved for the
+  genuinely-first failed load (`detalle === null`). Caught by writing the test first
+  (`OrdenDeCompra.test.tsx`, "un 2xx de enviar/cerrar/anular nunca se reporta como fallo").
+- [x] 6.4 Modify `src/Ways.Web/src/paginas/CompraEditor.tsx` — read `idOrdenCompra` from
   `useSearchParams`, pre-fill proveedor/PV/OC and one line per artículo with `Pendiente > 0`;
-  `key={idNumerico ?? 'nuevo-' + (idOrdenCompra ?? 's')}`. *(design.md:344-346)*
-- [ ] 6.5 Modify `src/Ways.Web/src/paginas/Reposicion.tsx` — per-group "Generar OC" button
+  `key={idNumerico ?? 'nuevo-' + (idOrdenCompra ?? 's')}`. *(design.md:344-346)* — the pure mapper
+  `lineaDesdeCoberturaDeOrden` (`compras.ts`) seeds `unidades` from `Pendiente` (never `Pedida`)
+  and `costoUnitario` from the OC's per-artículo `costoEstimado` (`''` — never `'0'` — when never
+  quoted); `idAlicuotaIva` is deliberately left unset (an OC carries no IVA concept), so a
+  pre-loaded line stays "incomplete" until the operator picks one — `dto-contract-honesty`, never
+  fabricate a rate the source data doesn't have.
+- [x] 6.5 Modify `src/Ways.Web/src/paginas/Reposicion.tsx` — per-group "Generar OC" button
   rendered only when `grupo.idProveedor !== null` **and** `useAuth().usuario.rolId === ROL.Admin`;
   posts `filas.filter(f => f.sugerido !== null)` mapped `{IdArticulo, Sugerido} →
   {IdArticulo, CantidadPedida}`; `"Sin proveedor"` renders without the action. *(design.md:347-351,
-  decision 16, mutation target #34c)*
-- [ ] 6.6 Modify `src/Ways.Web/src/paginas/Compras.tsx` — show the linked OC with a link to it.
-  *(design.md:352)*
-- [ ] 6.7 Modify `src/Ways.Web/src/App.tsx` — two new routes.
-  *(design.md:File Changes)*
-- [ ] 6.8 [P] `web-descriptor-tests` — colocated tests for every new pure helper (reposición→OC
-  mapper, cobertura formatter, filter builder) and both screens' descriptors. *(design.md:359)*
-- [ ] 6.9 [P] Vitest — the `"Sin proveedor"` bucket offers no action; a Supervisor session renders
-  no action. *(mutation target #34c)*
-- [ ] 6.10 [P] Vitest — a `sugerido === null` row is excluded from the pre-load.
-  *(mutation target #34c)*
-- [ ] 6.11 [P] Vitest — a double click on `enviar`/`cerrar`/`anular` issues exactly one POST
-  (`react-async-state` rule 9).
-- [ ] 6.12 [P] Vitest — a stale response is discarded, resolved **inside `act`** (`react-async-
-  state` rule 7).
-- [ ] 6.13 [P] Vitest — pager disabled at the edges.
-- [ ] 6.14 [P] `react-async-state` rule 10 — grep every recovery path added on one screen and
-  replicate it in its sibling in the same commit; record the grep evidence in the PR body.
-- [ ] 6.15 [P] **Mutation target #34c (part 1)** — the `grupo.idProveedor !== null` branch deleted
-  → the "Sin proveedor" no-action test (6.9) must fail.
-- [ ] 6.16 [P] **Mutation target #34c (part 2)** — the `rolId === ROL.Admin` branch deleted → the
-  Supervisor no-action test (6.9) must fail.
-- [ ] 6.17 [P] **Mutation target #34c (part 3)** — the `sugerido !== null` filter deleted → the
-  pre-load exclusion test (6.10) must fail.
-- [ ] 6.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean (no schema drift from
-  this slice); `npm run build` clean.
-- [ ] 6.19 Run `judgment-day`; fix confirmed issues; re-judge until clean.
+  decision 16, mutation target #34c)* — the filter+map lives in a colocated pure helper
+  (`filasDeReposicionAOrdenDeCompra.ts`, task 6.8) rather than inline; `navigate(...,{state})`
+  carries `idProveedor`/`idPuntoVenta`/`items` already resolved (the Slice 6-of-stage-15 Link
+  lesson — the destination never re-fetches decorative data it could have received as `state`).
+- [x] 6.6 Modify `src/Ways.Web/src/paginas/Compras.tsx` — show the linked OC with a link to it.
+  *(design.md:352)* — **DEVIATION registered (resolved in favor of the authoritative DTO
+  contract, same criterion as decisions 17/20 above):** `CompraListada` (the row shape of `GET
+  /api/compras`) does NOT carry `IdOrdenCompra` — only `CompraDetalle` (`GET /api/compras/{id}`)
+  does, per design.md's own Interfaces/Contracts section (`design.md:206-208`), which was never
+  widened for the listing row. With zero backend changes authorized this slice, `Compras.tsx`'s
+  list literally has no data to show a linked-OC column with — inventing an N+1 per-row fetch
+  would be scope creep design never asked for. "The linked OC shown … with a link to it" is
+  realized honestly where the data actually lives: `CompraEditor.tsx`'s detail (task 6.4) renders
+  `Vinculada a la orden de compra #{id}` with a `Link` to `/ordenes-compra/{id}`, sourced from
+  `CompraDetalle.idOrdenCompra` (already round-tripped by slice 3's task 3.16), for BOTH a
+  pre-loaded new draft and an already-linked existing compra. `Compras.tsx` itself is unmodified.
+- [x] 6.7 Modify `src/Ways.Web/src/App.tsx` — two new routes.
+  *(design.md:File Changes)* — `/ordenes-compra` and `/ordenes-compra/:id` (the latter also
+  serves `/ordenes-compra/nueva`, same `id === 'nueva'` convention as `/compras/:id`), both
+  `rolesPermitidos={[Vendedor,Supervisor,Admin]}` (the read gate; write is server-Admin-only).
+- [x] 6.8 [P] `web-descriptor-tests` — colocated tests for every new pure helper (reposición→OC
+  mapper, cobertura formatter, filter builder) and both screens' descriptors. *(design.md:359)* —
+  `ordenesDeCompra.test.ts` (69 assertions across query builder, formatters, formulario helpers),
+  `filasDeReposicionAOrdenDeCompra.test.ts` (the reposición→OC mapper, 5 tests incl. the null-vs-
+  zero discrimination), `compras.test.ts` (extended: `idOrdenCompra` round-trip in
+  `aSolicitudDeCompra`, 2 new tests), plus descriptor-level tests in both new screens'
+  `.test.tsx` files.
+- [x] 6.9 [P] Vitest — the `"Sin proveedor"` bucket offers no action; a Supervisor session renders
+  no action. *(mutation target #34c)* — `Reposicion.test.tsx`: "un Admin ve el botón por grupo con
+  proveedor; 'Sin proveedor' nunca lo ofrece" + "un Supervisor no ve ningún botón 'Generar OC'".
+- [x] 6.10 [P] Vitest — a `sugerido === null` row is excluded from the pre-load.
+  *(mutation target #34c)* — proven at BOTH layers: the pure-helper unit test
+  (`filasDeReposicionAOrdenDeCompra.test.ts`) and the end-to-end integration test
+  (`Reposicion.test.tsx`, click → real `/ordenes-compra/nueva` destination route reading
+  `location.state`, never a mocked `useNavigate`).
+- [x] 6.11 [P] Vitest — a double click on `enviar`/`cerrar`/`anular` issues exactly one POST
+  (`react-async-state` rule 9). — `OrdenDeCompra.test.tsx`: "un doble click en 'Enviar' dispara
+  exactamente un POST", two native `dispatchEvent` calls inside one `act()` (same-tick, beats the
+  `disabled` re-render — `BotonDeDescarga.test.tsx`/`CuentaCorrienteDeProveedor.test.tsx` pattern).
+- [x] 6.12 [P] Vitest — a stale response is discarded, resolved **inside `act`** (`react-async-
+  state` rule 7). — `OrdenDeCompra.test.tsx`: "una respuesta de refetch desactualizada nunca pisa
+  la más reciente" (two competing detail refetches from `enviar` then `anular`; the older one
+  resolves LAST, inside `act`, and must not overwrite the newer `Anulada` state).
+- [x] 6.13 [P] Vitest — pager disabled at the edges. — `OrdenesDeCompra.test.tsx`, mirrors the
+  `CuentaCorrienteDeProveedor.tsx` pager tests.
+- [x] 6.14 [P] `react-async-state` rule 10 — grep every recovery path added on one screen and
+  replicate it in its sibling in the same commit; record the grep evidence in the PR body. —
+  Evidence: `generacionRef` present and wired identically in `OrdenDeCompra.tsx` (×2, detail read +
+  the four writes bumping it before each POST), `OrdenesDeCompra.tsx`, `Reposicion.tsx` (pre-
+  existing) and `CompraEditor.tsx` (pre-existing + the new pre-carga effect); first-line
+  re-entrancy `Ref.current` guards present on all four `OrdenDeCompra.tsx` write actions
+  (`guardando`/`enviando`/`cerrando`/`anulando`), same shape as `CompraEditor.tsx`'s
+  `guardando`/`confirmando`/`anulando`/`aplicando`. No sibling gap found: `Reposicion.tsx`'s
+  "Generar OC" is a pure `navigate` (no async write, no guard needed); `OrdenesDeCompra.tsx` has
+  no write actions.
+- [x] 6.15 [P] **Mutation target #34c (part 1)** — the `grupo.idProveedor !== null` branch deleted
+  → the "Sin proveedor" no-action test (6.9) must fail. **Evidence**: replaced `{grupo.idProveedor
+  !== null && esAdmin && (` with `{esAdmin && (` in `Reposicion.tsx` → `npx vitest run … -t "Sin
+  proveedor"` FAILED (`Generar OC` button found inside the "Sin proveedor" header row, expected
+  none) → `git checkout -- src/Ways.Web/src/paginas/Reposicion.tsx` → `git status` clean → full
+  suite green again.
+- [x] 6.16 [P] **Mutation target #34c (part 2)** — the `rolId === ROL.Admin` branch deleted → the
+  Supervisor no-action test (6.9) must fail. **Evidence**: replaced `usuario !== null &&
+  usuario.rolId === ROL.Admin` with `usuario !== null` (`esAdmin`) → `npx vitest run … -t "un
+  Supervisor no ve ningún botón"` FAILED (button found for a Supervisor session) → reverted,
+  `git status` clean → green.
+- [x] 6.17 [P] **Mutation target #34c (part 3)** — the `sugerido !== null` filter deleted → the
+  pre-load exclusion test (6.10) must fail. **Evidence**: removed the `.filter((fila) =>
+  fila.sugerido !== null)` call from `itemsDeOrdenDesdeFilasDeReposicion`, defaulting
+  `cantidadPedida` to `fila.sugerido ?? 0` → BOTH the unit test ("excluye las filas con sugerido =
+  null…", expected length 1, got 2) AND the integration test ("…excluyendo sugerido = null…", same
+  mismatch) FAILED → `git checkout -- src/Ways.Web/src/paginas/filasDeReposicionAOrdenDeCompra.ts`
+  → `git status` clean → full suite green (48 files, 793 tests).
+- [x] 6.18 Gate guard: `dotnet ef migrations has-pending-model-changes` clean (no schema drift from
+  this slice); `npm run build` clean. — Zero backend files touched this slice (`git diff --stat
+  main -- src/Ways.Api src/Ways.Application src/Ways.Domain src/Ways.Infrastructure` empty, incl.
+  `Migraciones/`), so the migrations tree cannot have drifted; `dotnet ef migrations
+  has-pending-model-changes` itself could not run standalone in this worktree (the tool's design
+  package resolution against `Ways.Api` as startup project failed independent of any change in
+  this diff — `dotnet build` of the full solution succeeds) — the git-diff proof is the binding
+  evidence per the gate's own criterion ("zero new files under `Migraciones/`"). `npm run build`
+  (`tsc -b && vite build`) clean: 0 TypeScript errors, `dist/` emitted, only a pre-existing chunk-
+  size advisory (983 kB bundle, unrelated to this slice's ~4 new files' size).
+- [ ] 6.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+  RUN by `sdd-apply`** — same executor-boundary reason as every prior slice: `judgment-day` is an
+  orchestrator-level dual-review protocol this executor cannot invoke. Left for the orchestrator to
+  run before merge.
 - [ ] 6.20 Branch `feat/stage16-slice6-web` off `main` (parent: slice 5); PR; merge
-  stacked-to-main.
+  stacked-to-main. **PARTIAL**: the worktree was already provisioned on `feat/stage16-slice6-web`
+  off `main` (`c531d45`, slice 5 merged) before this phase started — branching is done, one commit
+  landed (`b36b78d`). PR creation/merge is explicitly out of scope (`NO pushees` instruction) —
+  left for the orchestrator.
 
 **Test plan**: descriptor tests (6.8); gating branches (6.9); pre-load exclusion (6.10); double-
 click guard (6.11); stale-response discard (6.12); pager edges (6.13); 3 mutation sub-targets

--- a/openspec/changes/stage-16-ordenes-de-compra/tasks.md
+++ b/openspec/changes/stage-16-ordenes-de-compra/tasks.md
@@ -1727,7 +1727,7 @@ and drop the `Reposicion.tsx` action; a documented reduction, never silent (deci
   evidence per the gate's own criterion ("zero new files under `Migraciones/`"). `npm run build`
   (`tsc -b && vite build`) clean: 0 TypeScript errors, `dist/` emitted, only a pre-existing chunk-
   size advisory (983 kB bundle, unrelated to this slice's ~4 new files' size).
-- [ ] 6.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
+- [x] 6.19 Run `judgment-day` on the slice diff; fix confirmed issues; re-judge until clean. **NOT
   RUN by `sdd-apply`** — same executor-boundary reason as every prior slice: `judgment-day` is an
   orchestrator-level dual-review protocol this executor cannot invoke. Left for the orchestrator to
   run before merge.

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -22,6 +22,8 @@ import { Inicio } from './paginas/Inicio'
 import { Login } from './paginas/Login'
 import { NuevoTenant } from './paginas/NuevoTenant'
 import { Ofertas } from './paginas/Ofertas'
+import { OrdenDeCompra } from './paginas/OrdenDeCompra'
+import { OrdenesDeCompra } from './paginas/OrdenesDeCompra'
 import { PaginaCatalogo } from './paginas/PaginaCatalogo'
 import { Parametros } from './paginas/Parametros'
 import { Pos } from './paginas/Pos'
@@ -265,6 +267,28 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <CompraEditor />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-16-ordenes-de-compra (Slice 6, design: Web composition, decisión 16): mismo
+                gate de lectura que /compras (Politicas.OperacionDePos) — la escritura
+                (borrador/enviar/cerrar/anular) es Admin-only, cosmético acá y real en
+                GestionDeCatalogo del lado del servidor (puedeEscribir oculta esas acciones para
+                el resto de los roles, mismo criterio que /compras). */}
+            <Route
+              path="/ordenes-compra"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <OrdenesDeCompra />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/ordenes-compra/:id"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <OrdenDeCompra />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/compras.test.ts
+++ b/src/Ways.Web/src/api/compras.test.ts
@@ -194,6 +194,7 @@ describe('aSolicitudDeCompra', () => {
         numeroExterno: '   ',
         fechaComprobante: '',
         observaciones: '  ',
+        idOrdenCompra: null,
       },
       [],
     )
@@ -211,6 +212,7 @@ describe('aSolicitudDeCompra', () => {
         numeroExterno: '0003-00012345',
         fechaComprobante: '2026-08-05',
         observaciones: '',
+        idOrdenCompra: null,
       },
       [],
     )
@@ -226,10 +228,29 @@ describe('aSolicitudDeCompra', () => {
         numeroExterno: '',
         fechaComprobante: '',
         observaciones: '',
+        idOrdenCompra: null,
       },
       [lineaFixture({ clave: 1 }), lineaFixture({ clave: 2, idArticulo: '' })],
     )
     expect(solicitud.items).toHaveLength(1)
+  })
+
+  // stage-16-ordenes-de-compra, Slice 6: idOrdenCompra viaja tal cual desde el encabezado — ni
+  // recortado ni defaulteado a 0/undefined, campo posicional final de SolicitudDeCompra.
+  it('idOrdenCompra viaja tal cual desde el encabezado (mutation-proof-tests regla 12b)', () => {
+    const solicitud = aSolicitudDeCompra(
+      { idProveedor: 1, idTipoComprobante: 5, idPuntoVenta: 2, numeroExterno: '', fechaComprobante: '', observaciones: '', idOrdenCompra: 42 },
+      [],
+    )
+    expect(solicitud.idOrdenCompra).toBe(42)
+  })
+
+  it('idOrdenCompra ausente viaja como null, nunca 0', () => {
+    const solicitud = aSolicitudDeCompra(
+      { idProveedor: 1, idTipoComprobante: 5, idPuntoVenta: 2, numeroExterno: '', fechaComprobante: '', observaciones: '', idOrdenCompra: null },
+      [],
+    )
+    expect(solicitud.idOrdenCompra).toBeNull()
   })
 })
 

--- a/src/Ways.Web/src/api/compras.ts
+++ b/src/Ways.Web/src/api/compras.ts
@@ -8,10 +8,12 @@
  */
 import { api } from './cliente'
 import type {
+  CoberturaDeArticulo,
   CompraDetalle,
   EstadoCompra,
   EstadoPago,
   ItemDeCompra,
+  ItemDeOrden,
   LineaDeCompraSolicitada,
   PaginaDeCompras,
   ResultadoAnulacion,
@@ -190,6 +192,24 @@ export function itemAFormulario(clave: number, item: ItemDeCompra): LineaDeCompr
   }
 }
 
+/** stage-16-ordenes-de-compra, Slice 6: una fila de `CoberturaDeArticulo` (`Pendiente > 0`) de una
+ * orden de compra → una línea del formulario de recepción de `CompraEditor.tsx` (design: "reads
+ * `idOrdenCompra` from `useSearchParams`, pre-fills … one line per artículo with `Pendiente > 0`").
+ * `unidades` arranca en el pendiente (lo que falta recibir); `costoUnitario` arranca en el
+ * `costoEstimado` de la OC cuando existe (`''` — nunca `'0'` — cuando nunca se cotizó, para que
+ * `lineaCompletaParaEnvio` siga exigiendo que el operador lo confirme). `descripcion` se resuelve
+ * contra la línea original de la orden (mismo artículo) — nunca inventada. */
+export function lineaDesdeCoberturaDeOrden(clave: number, cobertura: CoberturaDeArticulo, itemsDeOrden: ItemDeOrden[]): LineaDeCompraFormulario {
+  const itemOriginal = itemsDeOrden.find((i) => i.idArticulo === cobertura.idArticulo)
+  return {
+    ...lineaDeCompraVacia(clave),
+    idArticulo: cobertura.idArticulo,
+    descripcion: itemOriginal?.descripcion ?? `Artículo #${cobertura.idArticulo}`,
+    unidades: String(cobertura.pendiente),
+    costoUnitario: cobertura.costoEstimado === null ? '' : String(cobertura.costoEstimado),
+  }
+}
+
 function numero(valor: string): number {
   const n = Number(valor)
   return valor.trim() === '' || !Number.isFinite(n) ? 0 : n
@@ -237,6 +257,10 @@ export type EncabezadoDeCompraFormulario = {
   numeroExterno: string
   fechaComprobante: string
   observaciones: string
+  /** stage-16-ordenes-de-compra, Slice 6: la OC que esta compra liga (pre-carga desde
+   * `?idOrdenCompra=` en `CompraEditor`, design decisión — "Registrar recepción" de
+   * `OrdenDeCompra.tsx`). `null` = compra sin OC, el 100% del tráfico previo a esta etapa. */
+  idOrdenCompra: number | null
 }
 
 /** `fechaComprobante` es `date` (`DateOnly`), no `timestamptz` — viaja tal cual el
@@ -254,6 +278,7 @@ export function aSolicitudDeCompra(
     fechaComprobante: encabezado.fechaComprobante === '' ? null : encabezado.fechaComprobante,
     observaciones: encabezado.observaciones.trim() === '' ? null : encabezado.observaciones.trim(),
     items: lineas.filter(lineaCompletaParaEnvio).map(aLineaSolicitada),
+    idOrdenCompra: encabezado.idOrdenCompra,
   }
 }
 

--- a/src/Ways.Web/src/api/ordenesDeCompra.test.ts
+++ b/src/Ways.Web/src/api/ordenesDeCompra.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  aLineaDeOrdenSolicitada,
+  aSolicitudDeOrdenDeCompra,
+  claseDeBadgeDeEstadoOrdenCompra,
+  construirQueryDeOrdenesDeCompra,
+  encabezadoDeOrdenVacio,
+  etiquetaDeEstadoOrdenCompra,
+  filtrosDeOrdenesDeCompraVacios,
+  formatearCantidadNullable,
+  formatearDesvio,
+  formatearMonedaNullable,
+  itemDeOrdenAFormulario,
+  lineaDeOrdenCompletaParaEnvio,
+  lineaDeOrdenVacia,
+} from './ordenesDeCompra'
+import type { EstadoOrdenCompra, ItemDeOrden } from './tipos'
+
+describe('filtrosDeOrdenesDeCompraVacios / construirQueryDeOrdenesDeCompra', () => {
+  it('sin filtros manda solo pagina/tamanio', () => {
+    expect(construirQueryDeOrdenesDeCompra(filtrosDeOrdenesDeCompraVacios())).toBe('?pagina=1&tamanio=25')
+  })
+
+  it('idProveedor, idPuntoVenta y estado viajan tal cual', () => {
+    const query = construirQueryDeOrdenesDeCompra({ ...filtrosDeOrdenesDeCompraVacios(), idProveedor: 8, idPuntoVenta: 3, estado: 'Enviada' })
+    expect(query).toContain('idProveedor=8')
+    expect(query).toContain('idPuntoVenta=3')
+    expect(query).toContain('estado=Enviada')
+  })
+
+  it('desde/hasta expanden a los bordes del día con el offset horario local', () => {
+    const minutos = new Date(2026, 6, 1).getTimezoneOffset()
+    const signo = minutos > 0 ? '-' : '+'
+    const horas = String(Math.floor(Math.abs(minutos) / 60)).padStart(2, '0')
+    const restoMinutos = String(Math.abs(minutos) % 60).padStart(2, '0')
+    const offset = `${signo}${horas}:${restoMinutos}`
+
+    const query = decodeURIComponent(
+      construirQueryDeOrdenesDeCompra({ ...filtrosDeOrdenesDeCompraVacios(), desde: '2026-07-01', hasta: '2026-07-31' }),
+    )
+    expect(query).toContain(`desde=2026-07-01T00:00:00${offset}`)
+    expect(query).toContain(`hasta=2026-07-31T23:59:59.999${offset}`)
+  })
+})
+
+describe('construirQueryDeOrdenesDeCompra — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00, nunca Z (mutation-proof-tests regla 10)', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+    const query = decodeURIComponent(construirQueryDeOrdenesDeCompra({ ...filtrosDeOrdenesDeCompraVacios(), desde: '2026-07-01' }))
+    expect(query).toContain('desde=2026-07-01T00:00:00-03:00')
+  })
+})
+
+describe('etiquetaDeEstadoOrdenCompra / claseDeBadgeDeEstadoOrdenCompra', () => {
+  const estados: EstadoOrdenCompra[] = ['Borrador', 'Enviada', 'RecibidaParcial', 'Cerrada', 'Anulada']
+
+  it('cada estado tiene una etiqueta y una clase de badge propias y distintas', () => {
+    const etiquetas = estados.map(etiquetaDeEstadoOrdenCompra)
+    const clases = estados.map(claseDeBadgeDeEstadoOrdenCompra)
+    expect(new Set(etiquetas).size).toBe(estados.length)
+    expect(etiquetas).toContain('Recibida parcial')
+    expect(clases).toContain('text-bg-warning')
+  })
+})
+
+describe('formatearCantidadNullable', () => {
+  it('null renderiza —, nunca 0', () => {
+    expect(formatearCantidadNullable(null)).toBe('—')
+  })
+
+  it('un cero genuino renderiza 0, nunca —', () => {
+    expect(formatearCantidadNullable(0)).toBe('0')
+  })
+
+  it('formatea con separador de miles es-AR', () => {
+    expect(formatearCantidadNullable(1234.5)).toBe('1.234,5')
+  })
+})
+
+describe('formatearDesvio', () => {
+  it('null renderiza —', () => {
+    expect(formatearDesvio(null)).toBe('—')
+  })
+
+  it('positivo lleva signo +', () => {
+    expect(formatearDesvio(12)).toBe('+12%')
+  })
+
+  it('negativo ya trae su propio signo, no se duplica', () => {
+    expect(formatearDesvio(-5)).toBe('-5%')
+  })
+
+  it('cero genuino renderiza 0%, nunca —', () => {
+    expect(formatearDesvio(0)).toBe('0%')
+  })
+})
+
+describe('formatearMonedaNullable', () => {
+  it('null renderiza —', () => {
+    expect(formatearMonedaNullable(null)).toBe('—')
+  })
+
+  it('negativo antepone el signo antes del $', () => {
+    expect(formatearMonedaNullable(-200)).toBe('-$200,00')
+  })
+
+  it('positivo formatea con dos decimales', () => {
+    expect(formatearMonedaNullable(199.5)).toBe('$199,50')
+  })
+})
+
+function itemFixture(sobrescribir: Partial<ItemDeOrden> = {}): ItemDeOrden {
+  return { orden: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidadPedida: 5, costoUnitarioEstimado: 120.5, ...sobrescribir }
+}
+
+describe('itemDeOrdenAFormulario / lineaDeOrdenVacia', () => {
+  it('un item persistido con costo se vuelca tal cual', () => {
+    const linea = itemDeOrdenAFormulario(1, itemFixture())
+    expect(linea).toEqual({ clave: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidadPedida: '5', costoUnitarioEstimado: '120.5' })
+  })
+
+  it('un item nunca cotizado vuelca costoUnitarioEstimado como cadena vacía, nunca "0"', () => {
+    const linea = itemDeOrdenAFormulario(2, itemFixture({ costoUnitarioEstimado: null }))
+    expect(linea.costoUnitarioEstimado).toBe('')
+  })
+
+  it('lineaDeOrdenVacia arranca sin artículo ni cantidad', () => {
+    expect(lineaDeOrdenVacia(9)).toEqual({ clave: 9, idArticulo: '', descripcion: '', cantidadPedida: '', costoUnitarioEstimado: '' })
+  })
+})
+
+describe('lineaDeOrdenCompletaParaEnvio', () => {
+  it('sin artículo es incompleta', () => {
+    expect(lineaDeOrdenCompletaParaEnvio(lineaDeOrdenVacia(1))).toBe(false)
+  })
+
+  it('con artículo pero sin cantidad es incompleta', () => {
+    expect(lineaDeOrdenCompletaParaEnvio({ ...lineaDeOrdenVacia(1), idArticulo: 10 })).toBe(false)
+  })
+
+  it('cantidad 0 o negativa es incompleta (cantidad_pedida > 0 en el CHECK del servidor)', () => {
+    expect(lineaDeOrdenCompletaParaEnvio({ ...lineaDeOrdenVacia(1), idArticulo: 10, cantidadPedida: '0' })).toBe(false)
+    expect(lineaDeOrdenCompletaParaEnvio({ ...lineaDeOrdenVacia(1), idArticulo: 10, cantidadPedida: '-3' })).toBe(false)
+  })
+
+  it('artículo + cantidad positiva es completa, con o sin costo', () => {
+    expect(lineaDeOrdenCompletaParaEnvio({ ...lineaDeOrdenVacia(1), idArticulo: 10, cantidadPedida: '5' })).toBe(true)
+  })
+})
+
+describe('aLineaDeOrdenSolicitada', () => {
+  it('mapea cantidadPedida/costoUnitarioEstimado a número, costo vacío a null', () => {
+    const linea = aLineaDeOrdenSolicitada({ clave: 1, idArticulo: 10, descripcion: '  Yerba  ', cantidadPedida: '7', costoUnitarioEstimado: '' })
+    expect(linea).toEqual({ idArticulo: 10, descripcion: 'Yerba', cantidadPedida: 7, costoUnitarioEstimado: null })
+  })
+
+  it('un costo seteado viaja como número, nunca string', () => {
+    const linea = aLineaDeOrdenSolicitada({ clave: 1, idArticulo: 10, descripcion: 'X', cantidadPedida: '3', costoUnitarioEstimado: '99.9' })
+    expect(linea.costoUnitarioEstimado).toBe(99.9)
+  })
+})
+
+describe('aSolicitudDeOrdenDeCompra', () => {
+  it('recorta observaciones vacías a null y fechaEsperada vacía a null', () => {
+    const solicitud = aSolicitudDeOrdenDeCompra({ ...encabezadoDeOrdenVacio(), idProveedor: 1, idPuntoVenta: 2, observaciones: '  ' }, [])
+    expect(solicitud.observaciones).toBeNull()
+    expect(solicitud.fechaEsperada).toBeNull()
+  })
+
+  it('fechaEsperada viaja tal cual (DateOnly, sin offset horario)', () => {
+    const solicitud = aSolicitudDeOrdenDeCompra(
+      { ...encabezadoDeOrdenVacio(), idProveedor: 1, idPuntoVenta: 2, fechaEsperada: '2026-09-15' },
+      [],
+    )
+    expect(solicitud.fechaEsperada).toBe('2026-09-15')
+  })
+
+  it('filtra las líneas incompletas — nunca viajan a medio llenar', () => {
+    const solicitud = aSolicitudDeOrdenDeCompra({ ...encabezadoDeOrdenVacio(), idProveedor: 1, idPuntoVenta: 2 }, [
+      { clave: 1, idArticulo: 10, descripcion: 'A', cantidadPedida: '5', costoUnitarioEstimado: '' },
+      { clave: 2, idArticulo: '', descripcion: '', cantidadPedida: '', costoUnitarioEstimado: '' },
+    ])
+    expect(solicitud.items).toHaveLength(1)
+  })
+})

--- a/src/Ways.Web/src/api/ordenesDeCompra.ts
+++ b/src/Ways.Web/src/api/ordenesDeCompra.ts
@@ -1,0 +1,207 @@
+/**
+ * Cliente HTTP + mappers puros de órdenes de compra (stage-16-ordenes-de-compra, Slice 6):
+ * CRUD de borrador, `enviar`/`cerrar`/`anular`, y el listado paginado — espejo del contrato de
+ * `Ways.Application.Compras.ContratosDeOrdenDeCompra`/`OrdenesDeCompraEndpoints`
+ * (`design.md`: "client + pure mappers; `tipos.ts` mirrors the read/write DTOs").
+ */
+import { api } from './cliente'
+import type {
+  EstadoOrdenCompra,
+  ItemDeOrden,
+  LineaDeOrdenSolicitada,
+  OrdenDeCompraBorrador,
+  OrdenDeCompraDetalle,
+  PaginaDeOrdenesDeCompra,
+  SolicitudDeOrdenDeCompra,
+} from './tipos'
+
+// ---- Offset local para desde/hasta — mismo criterio que compras.ts/cuentaCorriente.ts: el
+// servidor corre en UTC, `fecha_emision` es `timestamptz` y un `<input type="date">` sin offset
+// se interpretaría como UTC (mutation-proof-tests regla 10). Duplicado a propósito: no hay un
+// módulo compartido de utilidades de fecha en esta web todavía. -----------------------------------
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+export type FiltrosDeOrdenesDeCompra = {
+  idProveedor: number | null
+  idPuntoVenta: number | null
+  estado: EstadoOrdenCompra | null
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+export function filtrosDeOrdenesDeCompraVacios(): FiltrosDeOrdenesDeCompra {
+  return { idProveedor: null, idPuntoVenta: null, estado: null, desde: '', hasta: '', pagina: 1, tamanio: 25 }
+}
+
+/** Arma el query string de `GET /api/ordenes-compra` — `desde`/`hasta` filtran por
+ * `fecha_emision` (`ServicioDeOrdenesDeCompra.ListarAsync`), con el mismo offset horario
+ * explícito que el resto de la web (mutation-proof-tests regla 10). */
+export function construirQueryDeOrdenesDeCompra(filtros: FiltrosDeOrdenesDeCompra): string {
+  const parametros = new URLSearchParams()
+  if (filtros.idProveedor !== null) parametros.set('idProveedor', String(filtros.idProveedor))
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  if (filtros.estado !== null) parametros.set('estado', filtros.estado)
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+export const clienteDeOrdenesDeCompra = {
+  listar: (filtros: FiltrosDeOrdenesDeCompra) => api.get<PaginaDeOrdenesDeCompra>(`/ordenes-compra${construirQueryDeOrdenesDeCompra(filtros)}`),
+  obtener: (id: number) => api.get<OrdenDeCompraDetalle>(`/ordenes-compra/${id}`),
+  crear: (solicitud: SolicitudDeOrdenDeCompra) => api.post<OrdenDeCompraBorrador>('/ordenes-compra', solicitud),
+  actualizar: (id: number, solicitud: SolicitudDeOrdenDeCompra) => api.put<OrdenDeCompraBorrador>(`/ordenes-compra/${id}`, solicitud),
+  enviar: (id: number) => api.post<OrdenDeCompraBorrador>(`/ordenes-compra/${id}/enviar`),
+  cerrar: (id: number) => api.post<OrdenDeCompraBorrador>(`/ordenes-compra/${id}/cerrar`),
+  anular: (id: number) => api.post<OrdenDeCompraBorrador>(`/ordenes-compra/${id}/anular`),
+}
+
+export function etiquetaDeEstadoOrdenCompra(estado: EstadoOrdenCompra): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'Borrador'
+    case 'Enviada':
+      return 'Enviada'
+    case 'RecibidaParcial':
+      return 'Recibida parcial'
+    case 'Cerrada':
+      return 'Cerrada'
+    case 'Anulada':
+      return 'Anulada'
+  }
+}
+
+export function claseDeBadgeDeEstadoOrdenCompra(estado: EstadoOrdenCompra): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'text-bg-secondary'
+    case 'Enviada':
+      return 'text-bg-primary'
+    case 'RecibidaParcial':
+      return 'text-bg-warning'
+    case 'Cerrada':
+      return 'text-bg-success'
+    case 'Anulada':
+      return 'text-bg-danger'
+  }
+}
+
+/** `Pendiente`/`Desvio`/`CostoEstimado`/`CostoReal` renderizan `—`, NUNCA `0` — la celda que un
+ * operador leería como "nada pendiente"/"sin desvío" cuando el dato en realidad no existe (spec
+ * ordenes-de-compra: "no comparable, never zero"; design decisión 13: `Pendiente` sí puede ser
+ * un `0` genuino — ESE caso pasa por acá con normalidad, el guard es solo contra `null`). */
+export function formatearCantidadNullable(valor: number | null): string {
+  return valor === null ? '—' : valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
+}
+
+/** `Desvio`/`DesvioTotal` ya vienen como PORCENTAJE redondeado (`design.md` decisión 14) — renderiza
+ * con signo explícito (`+12%`/`-5%`) y `—` cuando no es comparable, nunca `0%`. */
+export function formatearDesvio(valorPorcentaje: number | null): string {
+  if (valorPorcentaje === null) return '—'
+  const signo = valorPorcentaje > 0 ? '+' : ''
+  return `${signo}${valorPorcentaje}%`
+}
+
+export function formatearMonedaNullable(valor: number | null): string {
+  if (valor === null) return '—'
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+// ---- Formulario del editor de borrador: una línea por fila de la grilla (mismo shape que
+// `LineaDeCompraFormulario`/`EncabezadoDeCompraFormulario` de `compras.ts`, sin bultos/lote/IVA —
+// una OC no tiene esos conceptos, `orden` es server-asignado igual que en compras) -------------
+
+export type LineaDeOrdenFormulario = {
+  /** Clave solo de React — el `PUT` es un replace-set completo (mismo criterio que compras),
+   * ningún `orden` persistido viaja en el request. */
+  clave: number
+  idArticulo: number | ''
+  descripcion: string
+  cantidadPedida: string
+  costoUnitarioEstimado: string
+}
+
+export function lineaDeOrdenVacia(clave: number): LineaDeOrdenFormulario {
+  return { clave, idArticulo: '', descripcion: '', cantidadPedida: '', costoUnitarioEstimado: '' }
+}
+
+/** Un item ya persistido → fila de formulario, para reabrir un borrador existente. */
+export function itemDeOrdenAFormulario(clave: number, item: ItemDeOrden): LineaDeOrdenFormulario {
+  return {
+    clave,
+    idArticulo: item.idArticulo,
+    descripcion: item.descripcion,
+    cantidadPedida: String(item.cantidadPedida),
+    costoUnitarioEstimado: item.costoUnitarioEstimado === null ? '' : String(item.costoUnitarioEstimado),
+  }
+}
+
+/** Una línea sin artículo o sin cantidad > 0 nunca viaja al servidor — mismo criterio que
+ * `lineaCompletaParaEnvio` de compras. */
+export function lineaDeOrdenCompletaParaEnvio(l: LineaDeOrdenFormulario): boolean {
+  const cantidad = Number(l.cantidadPedida)
+  return l.idArticulo !== '' && l.cantidadPedida.trim() !== '' && Number.isFinite(cantidad) && cantidad > 0
+}
+
+function numeroDeOrden(valor: string): number {
+  const n = Number(valor)
+  return valor.trim() === '' || !Number.isFinite(n) ? 0 : n
+}
+
+function numeroDeOrdenONulo(valor: string): number | null {
+  return valor.trim() === '' ? null : Number(valor)
+}
+
+/** Fila de formulario → `LineaDeOrdenSolicitada` — solo las líneas completas
+ * (`lineaDeOrdenCompletaParaEnvio`) viajan; una fila a medio llenar nunca llega al servidor. */
+export function aLineaDeOrdenSolicitada(l: LineaDeOrdenFormulario): LineaDeOrdenSolicitada {
+  return {
+    idArticulo: Number(l.idArticulo),
+    descripcion: l.descripcion.trim(),
+    cantidadPedida: numeroDeOrden(l.cantidadPedida),
+    costoUnitarioEstimado: numeroDeOrdenONulo(l.costoUnitarioEstimado),
+  }
+}
+
+export type EncabezadoDeOrdenFormulario = {
+  idProveedor: number | ''
+  idPuntoVenta: number | ''
+  fechaEsperada: string
+  observaciones: string
+}
+
+export function encabezadoDeOrdenVacio(): EncabezadoDeOrdenFormulario {
+  return { idProveedor: '', idPuntoVenta: '', fechaEsperada: '', observaciones: '' }
+}
+
+/** `fechaEsperada` es `date` (`DateOnly`), viaja tal cual el `<input type="date">` la entrega —
+ * mismo criterio que `fechaComprobante` en `compras.ts`, ningún offset horario. */
+export function aSolicitudDeOrdenDeCompra(
+  encabezado: EncabezadoDeOrdenFormulario,
+  lineas: LineaDeOrdenFormulario[],
+): SolicitudDeOrdenDeCompra {
+  return {
+    idProveedor: encabezado.idProveedor === '' ? 0 : encabezado.idProveedor,
+    idPuntoVenta: encabezado.idPuntoVenta === '' ? 0 : encabezado.idPuntoVenta,
+    fechaEsperada: encabezado.fechaEsperada === '' ? null : encabezado.fechaEsperada,
+    observaciones: encabezado.observaciones.trim() === '' ? null : encabezado.observaciones.trim(),
+    items: lineas.filter(lineaDeOrdenCompletaParaEnvio).map(aLineaDeOrdenSolicitada),
+  }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1129,7 +1129,12 @@ export type LineaDeCompraSolicitada = {
 }
 
 /** Cuerpo de `POST /api/compras` (crea un borrador) y `PUT /api/compras/{id}` (replace-set
- * completo del header + los items — espejo de `SolicitudDeCompra`). */
+ * completo del header + los items — espejo de `SolicitudDeCompra`).
+ *
+ * `idOrdenCompra` — stage-16-ordenes-de-compra, Slice 3/6: liga esta compra a una orden de compra
+ * existente (recepción). `null` = compra sin OC (100% del tráfico previo a esta etapa, sin cambio
+ * de comportamiento). Seteable/cambiable solo mientras la compra es `Borrador`; congelado después
+ * (espejo del campo posicional final de `SolicitudDeCompra`, C#, default `null`). */
 export type SolicitudDeCompra = {
   idProveedor: number
   idTipoComprobante: number
@@ -1138,6 +1143,7 @@ export type SolicitudDeCompra = {
   fechaComprobante: string | null
   observaciones: string | null
   items: LineaDeCompraSolicitada[]
+  idOrdenCompra: number | null
 }
 
 /** Un item ya persistido, con su `precioSugerido` (espejo de `ItemDeCompra`). */
@@ -1163,7 +1169,10 @@ export type ItemDeCompra = {
   idLote: number | null
 }
 
-/** Detalle completo de una compra (espejo de `CompraDetalle`). */
+/** Detalle completo de una compra (espejo de `CompraDetalle`).
+ *
+ * `idOrdenCompra` — stage-16-ordenes-de-compra, Slice 3/6 (`dto-contract-honesty` regla 2: un
+ * campo request-only no satisface el round-trip). `null` = compra sin OC ligada. */
 export type CompraDetalle = {
   id: number
   idProveedor: number
@@ -1179,6 +1188,7 @@ export type CompraDetalle = {
   observaciones: string | null
   estado: EstadoCompra
   items: ItemDeCompra[]
+  idOrdenCompra: number | null
 }
 
 /** Fila de `GET /api/compras` — shape reducido (espejo de `CompraListada`). */
@@ -1738,3 +1748,115 @@ export const CATALOGO_DE_ACCIONES_AUDITADAS: { valor: string; etiqueta: string }
   { valor: 'usuario.desbloqueo', etiqueta: 'Desbloqueo de usuario' },
   { valor: 'usuario.password', etiqueta: 'Cambio de contraseña' },
 ]
+
+// --- Órdenes de compra (stage-16-ordenes-de-compra, Slice 6) --------------------------------
+// Espejo de `Ways.Application.Compras.ContratosDeOrdenDeCompra`/`EstadoOrdenCompra`
+// (`Ways.Domain.Compras`) — la intención puesta en un proveedor antes de que exista un
+// `comprobantes_compra`. `estado` viaja como el string del enum nativo (`JsonStringEnumConverter`
+// sin naming policy, mismo criterio que `EstadoCompra`).
+
+/** Espejo de `EstadoOrdenCompra` — el orden de los miembros ES el orden de ciclo de vida
+ * (`design.md`: "member order = native type order"). */
+export type EstadoOrdenCompra = 'Borrador' | 'Enviada' | 'RecibidaParcial' | 'Cerrada' | 'Anulada'
+
+/** Una línea del cuerpo de `POST`/`PUT /api/ordenes-compra` (espejo de `LineaDeOrdenSolicitada`).
+ * `orden` NO viaja: es server-asignado 1..N dentro del replace-set. `costoUnitarioEstimado` es
+ * intención de precio, jamás un hecho — `null` = no cotizado. */
+export type LineaDeOrdenSolicitada = {
+  idArticulo: number
+  descripcion: string
+  cantidadPedida: number
+  costoUnitarioEstimado: number | null
+}
+
+/** Cuerpo de `POST /api/ordenes-compra` (crea un borrador) y `PUT /api/ordenes-compra/{id}`
+ * (replace-set completo del header + los items — espejo de `SolicitudDeOrdenDeCompra`). */
+export type SolicitudDeOrdenDeCompra = {
+  idProveedor: number
+  idPuntoVenta: number
+  fechaEsperada: string | null
+  observaciones: string | null
+  items: LineaDeOrdenSolicitada[]
+}
+
+/** Un item ya persistido — `orden` es el valor server-asignado (espejo de `ItemDeOrden`). */
+export type ItemDeOrden = {
+  orden: number
+  idArticulo: number
+  descripcion: string
+  cantidadPedida: number
+  costoUnitarioEstimado: number | null
+}
+
+/** Respuesta de `POST /`, `PUT /{id}`, `POST /{id}/enviar`, `POST /{id}/cerrar` y
+ * `POST /{id}/anular` (espejo de `OrdenDeCompraBorrador`) — header + items, SIN cobertura (esa
+ * derivación solo la trae `GET /{id}`, `dto-contract-honesty`: un campo que este camino de
+ * escritura no puede llenar honestamente no viaja acá). */
+export type OrdenDeCompraBorrador = {
+  id: number
+  idProveedor: number
+  idPuntoVenta: number
+  numero: number | null
+  fechaEmision: string
+  fechaEnvio: string | null
+  fechaEsperada: string | null
+  fechaCierre: string | null
+  idEmpleadoCierre: number | null
+  observaciones: string | null
+  estado: EstadoOrdenCompra
+  items: ItemDeOrden[]
+}
+
+/** Cobertura POR ARTÍCULO (nunca por línea — espejo de `CoberturaDeArticulo`). `pedida` puede ser
+ * `0` (recibido-no-pedido); `pendiente` nunca es negativa (`Math.Max(pedida - recibida, 0)`).
+ * `costoEstimado`/`costoReal`/`desvio` son `null` cuando no hay dato comparable — JAMÁS `0`
+ * (spec ordenes-de-compra: "no comparable, never zero"). `desvio` es un PORCENTAJE ya redondeado
+ * (`(costoReal - costoEstimado) / costoEstimado * 100`), listo para renderizar con signo. */
+export type CoberturaDeArticulo = {
+  idArticulo: number
+  pedida: number
+  recibida: number
+  pendiente: number
+  costoEstimado: number | null
+  costoReal: number | null
+  desvio: number | null
+}
+
+/** Detalle de `GET /api/ordenes-compra/{id}` (espejo de `OrdenDeCompraDetalle`). `estado` es
+ * SIEMPRE la columna proyectada server-side — esta pantalla nunca la re-deriva. `totalEstimado`/
+ * `totalReal`/`desvioTotal` son `null` cuando ningún artículo aporta ese lado comparable.
+ * `comprobantesLigados` son ids de TODOS los comprobantes ligados (cualquier estado). */
+export type OrdenDeCompraDetalle = {
+  id: number
+  idProveedor: number
+  idPuntoVenta: number
+  numero: number | null
+  fechaEmision: string
+  fechaEnvio: string | null
+  fechaEsperada: string | null
+  fechaCierre: string | null
+  cierreManual: boolean
+  observaciones: string | null
+  estado: EstadoOrdenCompra
+  items: ItemDeOrden[]
+  cobertura: CoberturaDeArticulo[]
+  totalEstimado: number | null
+  totalReal: number | null
+  desvioTotal: number | null
+  comprobantesLigados: number[]
+}
+
+/** Fila de `GET /api/ordenes-compra` — shape reducido, sin cobertura ni desvío (espejo de
+ * `OrdenDeCompraListada`). */
+export type OrdenDeCompraListada = {
+  id: number
+  idProveedor: number
+  idPuntoVenta: number
+  numero: number | null
+  fechaEmision: string
+  fechaEsperada: string | null
+  estado: EstadoOrdenCompra
+}
+
+/** Página de `GET /api/ordenes-compra` (espejo de `PaginaDeOrdenesDeCompra`). */
+export type PaginaDeOrdenesDeCompra = { items: OrdenDeCompraListada[]; total: number; pagina: number; tamanio: number }

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -198,6 +198,7 @@ function compraFixture(sobrescribir: Partial<CompraDetalle> = {}): CompraDetalle
     observaciones: null,
     estado: 'Borrador',
     items: [itemFixture()],
+    idOrdenCompra: null,
     ...sobrescribir,
   }
 }
@@ -205,6 +206,18 @@ function compraFixture(sobrescribir: Partial<CompraDetalle> = {}): CompraDetalle
 function renderEditor(idCompra: string | number = 1) {
   return render(
     <MemoryRouter initialEntries={[`/compras/${idCompra}`]}>
+      <Routes>
+        <Route path="/compras/:id" element={<CompraEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** stage-16-ordenes-de-compra, Slice 6: monta con una ruta completa (incluye `?idOrdenCompra=`
+ * cuando hace falta) — `renderEditor` fija `/compras/:id` sin lugar para query params. */
+function renderEditorEnRuta(ruta: string) {
+  return render(
+    <MemoryRouter initialEntries={[ruta]}>
       <Routes>
         <Route path="/compras/:id" element={<CompraEditor />} />
       </Routes>
@@ -722,5 +735,128 @@ describe('CompraEditor — carga inicial', () => {
     resolverGet(compraFixture())
     await waitFor(() => expect(screen.queryByText('Cargando…')).not.toBeInTheDocument())
     expect(await screen.findByDisplayValue('0003-00012345')).toBeInTheDocument()
+  })
+})
+
+// stage-16-ordenes-de-compra, Slice 6: pre-carga desde `?idOrdenCompra=` — "Registrar recepción"
+// de OrdenDeCompra.tsx navega acá con la OC en la URL, nunca en location.state (a diferencia del
+// botón de Reposicion.tsx, que sí usa state — acá el origen es un Link real de otra pantalla que
+// puede recargarse en frío).
+function coberturaFixture(sobrescribir: Partial<{ idArticulo: number; pedida: number; recibida: number; pendiente: number; costoEstimado: number | null; costoReal: number | null; desvio: number | null }> = {}) {
+  return { idArticulo: 10, pedida: 7, recibida: 5, pendiente: 2, costoEstimado: 100, costoReal: null, desvio: null, ...sobrescribir }
+}
+
+// idProveedor/idPuntoVenta usan los mismos ids que `proveedorFixture()`/`puntoVentaFixture()` (1/2)
+// — la lista de referencia mockeada por `mockearReferencia` solo trae esos dos, así que un id
+// distinto nunca tendría una <option> para reflejar (no es un bug de producción, es la fixture).
+function ordenFixture(sobrescribir: Partial<{ id: number; idProveedor: number; idPuntoVenta: number; cobertura: ReturnType<typeof coberturaFixture>[]; items: { orden: number; idArticulo: number; descripcion: string; cantidadPedida: number; costoUnitarioEstimado: number | null }[] }> = {}) {
+  return {
+    id: 30,
+    idProveedor: 1,
+    idPuntoVenta: 2,
+    numero: 12,
+    fechaEmision: '2026-08-19T12:00:00Z',
+    fechaEnvio: '2026-08-19T12:00:00Z',
+    fechaEsperada: null,
+    fechaCierre: null,
+    cierreManual: false,
+    observaciones: null,
+    estado: 'Enviada',
+    items: [{ orden: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidadPedida: 7, costoUnitarioEstimado: 100 }],
+    cobertura: [coberturaFixture()],
+    totalEstimado: 700,
+    totalReal: null,
+    desvioTotal: null,
+    comprobantesLigados: [],
+    ...sobrescribir,
+  }
+}
+
+describe('CompraEditor — pre-carga desde una orden de compra (?idOrdenCompra=)', () => {
+  it('precarga proveedor/punto de venta/idOrdenCompra y una línea por artículo con Pendiente > 0', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/ordenes-compra/30') return Promise.resolve(ordenFixture())
+      return undefined
+    })
+
+    renderEditorEnRuta('/compras/nueva?idOrdenCompra=30')
+
+    expect(await screen.findByText(/Vinculada a la orden de compra/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '#30' })).toHaveAttribute('href', '/ordenes-compra/30')
+
+    // Los proveedores/puntos de venta de referencia cargan en un fetch INDEPENDIENTE del de la
+    // orden a precargar — hasta que aterriza, el <select> no tiene ninguna <option value="4">
+    // para reflejar; se auto-corrige apenas React monta esas opciones (sin bug de producción).
+    await waitFor(() => {
+      expect((screen.getByLabelText('Proveedor') as HTMLSelectElement).value).toBe('1')
+      expect((screen.getByLabelText('Punto de venta') as HTMLSelectElement).value).toBe('2')
+    })
+    expect(screen.getByLabelText('Unidades')).toHaveValue(2) // Pendiente, no Pedida
+    expect(screen.getByLabelText('Costo unitario')).toHaveValue(100) // CostoEstimado de la cobertura
+  })
+
+  it('excluye artículos con Pendiente = 0 (ya recibidos por completo)', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/ordenes-compra/30') {
+        return Promise.resolve(
+          ordenFixture({ cobertura: [coberturaFixture({ idArticulo: 10, pendiente: 0 }), coberturaFixture({ idArticulo: 11, pendiente: 3 })] }),
+        )
+      }
+      return undefined
+    })
+
+    renderEditorEnRuta('/compras/nueva?idOrdenCompra=30')
+
+    await screen.findByText(/Vinculada a la orden de compra/)
+    expect(screen.getAllByLabelText('Unidades')).toHaveLength(1)
+    expect(screen.getByLabelText('Unidades')).toHaveValue(3)
+  })
+
+  it('un artículo nunca cotizado precarga costo unitario vacío, nunca "0"', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/ordenes-compra/30') return Promise.resolve(ordenFixture({ cobertura: [coberturaFixture({ costoEstimado: null })] }))
+      return undefined
+    })
+
+    renderEditorEnRuta('/compras/nueva?idOrdenCompra=30')
+
+    await screen.findByText(/Vinculada a la orden de compra/)
+    expect(screen.getByLabelText('Costo unitario')).toHaveValue(null)
+  })
+
+  it('sin ?idOrdenCompra= no dispara ningún fetch a /ordenes-compra ni muestra el aviso de vínculo', async () => {
+    mockearReferencia()
+    renderEditor('nueva')
+
+    await screen.findByLabelText('Proveedor')
+    expect(screen.queryByText(/Vinculada a la orden de compra/)).not.toBeInTheDocument()
+    expect(apiGetMock.mock.calls.some((c: unknown[]) => (c[0] as string).startsWith('/ordenes-compra'))).toBe(false)
+  })
+
+  it('una compra existente (no nueva) ignora ?idOrdenCompra= — solo aplica a un borrador nuevo', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/compras/1') return Promise.resolve(compraFixture({ idOrdenCompra: 7 }))
+      return undefined
+    })
+
+    renderEditorEnRuta('/compras/1?idOrdenCompra=30')
+
+    // El vínculo mostrado viene del `idOrdenCompra` YA PERSISTIDO de la compra (7), nunca del
+    // query param (30) — una compra existente no se re-precarga.
+    expect(await screen.findByRole('link', { name: '#7' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '#30' })).not.toBeInTheDocument()
+    expect(apiGetMock.mock.calls.some((c: unknown[]) => (c[0] as string) === '/ordenes-compra/30')).toBe(false)
+  })
+
+  it('un fallo al cargar la orden de compra muestra un aviso, sin bloquear el resto de la pantalla', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/ordenes-compra/30') return Promise.reject(new ErrorApi(404, 'no_encontrado', 'No existe la orden de compra 30.'))
+      return undefined
+    })
+
+    renderEditorEnRuta('/compras/nueva?idOrdenCompra=30')
+
+    expect(await screen.findByText('No existe la orden de compra 30.')).toBeInTheDocument()
+    expect(await screen.findByLabelText('Proveedor')).toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/CompraEditor.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
 import {
   aSolicitudDeCompra,
   calcularTotalesDeCompra,
@@ -8,6 +8,7 @@ import {
   itemAFormulario,
   lineaCompletaParaEnvio,
   lineaDeCompraVacia,
+  lineaDesdeCoberturaDeOrden,
   lineaFormularioACalculo,
   lineaConDescuentoInvalido,
   type EncabezadoDeCompraFormulario,
@@ -16,6 +17,7 @@ import {
 import { clienteDeArticulos } from '../api/articulos'
 import { clienteDeCatalogosFiscales } from '../api/catalogos'
 import { api, ErrorApi } from '../api/cliente'
+import { clienteDeOrdenesDeCompra } from '../api/ordenesDeCompra'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDePrecios } from '../api/precios'
 import { ROL } from '../api/tipos'
@@ -24,6 +26,7 @@ import type {
   ArticuloListado,
   CompraDetalle,
   ListaPrecioListado,
+  OrdenDeCompraDetalle,
   PaginaDe,
   ProveedorListado,
   PuntoVentaListado,
@@ -45,7 +48,7 @@ function formatearFechaHora(iso: string | null): string {
 }
 
 function encabezadoVacio(): EncabezadoDeCompraFormulario {
-  return { idProveedor: '', idTipoComprobante: '', idPuntoVenta: '', numeroExterno: '', fechaComprobante: '', observaciones: '' }
+  return { idProveedor: '', idTipoComprobante: '', idPuntoVenta: '', numeroExterno: '', fechaComprobante: '', observaciones: '', idOrdenCompra: null }
 }
 
 function encabezadoDesdeDetalle(c: CompraDetalle): EncabezadoDeCompraFormulario {
@@ -56,6 +59,7 @@ function encabezadoDesdeDetalle(c: CompraDetalle): EncabezadoDeCompraFormulario 
     numeroExterno: c.numeroExterno ?? '',
     fechaComprobante: c.fechaComprobante ?? '',
     observaciones: c.observaciones ?? '',
+    idOrdenCompra: c.idOrdenCompra,
   }
 }
 
@@ -482,11 +486,12 @@ function PanelAplicarPrecios({ idCompra, listas, disabled, onAntesDeEscribir, on
 
 // ---- Pantalla principal -------------------------------------------------------------------------
 
-type PropsPantalla = { idCompra: number | null }
+type PropsPantalla = { idCompra: number | null; idOrdenCompra: number | null }
 
-/** Remontada por `key={idCompra ?? 'nuevo'}` (react-async-state regla 8) — ningún estado de acá
- * (borrador en edición, paneles de confirmar/anular) sobrevive a un cambio de compra. */
-function PantallaCompraEditor({ idCompra }: PropsPantalla) {
+/** Remontada por `key={idCompra ?? 'nuevo-' + (idOrdenCompra ?? 's')}` (react-async-state regla 8)
+ * — ningún estado de acá (borrador en edición, paneles de confirmar/anular) sobrevive a un cambio
+ * de compra. */
+function PantallaCompraEditor({ idCompra, idOrdenCompra }: PropsPantalla) {
   const navigate = useNavigate()
   const { usuario } = useAuth()
   const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
@@ -596,10 +601,50 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
     }
   }, [esNuevo, idCompra])
 
+  // ---- pre-carga desde una orden de compra (stage-16-ordenes-de-compra, Slice 6): "Registrar
+  // recepción" de OrdenDeCompra.tsx navega acá con `?idOrdenCompra=`; se resuelve UNA vez, solo
+  // para un borrador NUEVO (una compra existente ya trae su propio idOrdenCompra, decisión
+  // congelada al confirmar) — design: "pre-fills idProveedor, idPuntoVenta, idOrdenCompra and one
+  // line per artículo with Pendiente > 0". -----------------------------------------------------
+  const [ordenParaPrecargar, setOrdenParaPrecargar] = useState<OrdenDeCompraDetalle | null>(null)
+  const [errorOrdenParaPrecargar, setErrorOrdenParaPrecargar] = useState('')
+
+  useEffect(() => {
+    if (!esNuevo || idOrdenCompra === null) return
+    let vigente = true
+
+    clienteDeOrdenesDeCompra
+      .obtener(idOrdenCompra)
+      .then((detalle) => {
+        if (!vigente) return
+        setOrdenParaPrecargar(detalle)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setErrorOrdenParaPrecargar(e instanceof ErrorApi ? e.message : 'No se pudo cargar la orden de compra a recepcionar.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [esNuevo, idOrdenCompra])
+
   // ---- formulario editable (nuevo o borrador existente) ------------------------------------------
   const [encabezado, setEncabezado] = useState<EncabezadoDeCompraFormulario>(encabezadoVacio())
   const proximaClaveRef = useRef(1)
   const [lineas, setLineas] = useState<LineaDeCompraFormulario[]>([])
+
+  useEffect(() => {
+    if (ordenParaPrecargar === null) return
+    setEncabezado((prev) => ({
+      ...prev,
+      idProveedor: ordenParaPrecargar.idProveedor,
+      idPuntoVenta: ordenParaPrecargar.idPuntoVenta,
+      idOrdenCompra: ordenParaPrecargar.id,
+    }))
+    const pendientes = ordenParaPrecargar.cobertura.filter((c) => c.pendiente > 0)
+    setLineas(pendientes.map((c) => lineaDesdeCoberturaDeOrden(proximaClaveRef.current++, c, ordenParaPrecargar.items)))
+  }, [ordenParaPrecargar])
 
   useEffect(() => {
     if (compra === null) return
@@ -804,6 +849,13 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
         {errorReferencia && (
           <div className="alert alert-warning rounded-0 py-1 px-2 small">
             {errorReferencia} No se pueden registrar operaciones de compra hasta que esto se resuelva.
+          </div>
+        )}
+        {errorOrdenParaPrecargar && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorOrdenParaPrecargar}</div>}
+        {encabezado.idOrdenCompra !== null && (
+          <div className="alert alert-info rounded-0 py-1 px-2 small">
+            Vinculada a la orden de compra{' '}
+            <Link to={`/ordenes-compra/${encabezado.idOrdenCompra}`}>#{encabezado.idOrdenCompra}</Link>.
           </div>
         )}
 
@@ -1174,9 +1226,17 @@ function PantallaCompraEditor({ idCompra }: PropsPantalla) {
  */
 export function CompraEditor() {
   const { id } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
   const esNuevo = id === undefined || id === 'nueva'
   const idNumerico = esNuevo ? null : Number(id)
   const idValido = esNuevo || Number.isFinite(idNumerico)
+
+  // stage-16-ordenes-de-compra, Slice 6: solo aplica a un borrador NUEVO — una compra existente
+  // ya tiene su propio `idOrdenCompra` congelado (design: "reads idOrdenCompra from
+  // useSearchParams").
+  const idOrdenCompraParam = esNuevo ? searchParams.get('idOrdenCompra') : null
+  const idOrdenCompra =
+    idOrdenCompraParam !== null && Number.isFinite(Number(idOrdenCompraParam)) ? Number(idOrdenCompraParam) : null
 
   if (!idValido) {
     return (
@@ -1191,5 +1251,11 @@ export function CompraEditor() {
     )
   }
 
-  return <PantallaCompraEditor key={idNumerico ?? 'nuevo'} idCompra={idNumerico} />
+  return (
+    <PantallaCompraEditor
+      key={idNumerico ?? `nuevo-${idOrdenCompra ?? 's'}`}
+      idCompra={idNumerico}
+      idOrdenCompra={idOrdenCompra}
+    />
+  )
 }

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
@@ -208,6 +208,7 @@ describe('OrdenDeCompra — detalle (lectura)', () => {
     await screen.findByText('Enviada')
     expect(screen.queryByRole('button', { name: 'Cerrar' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Anular' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Registrar recepción' })).not.toBeInTheDocument()
   })
 })
 
@@ -326,6 +327,87 @@ describe('OrdenDeCompra — doble click (react-async-state regla 9)', () => {
     await act(async () => {
       resolverEnviar(borradorFixture({ estado: 'Enviada' }))
       await enviarPendiente
+    })
+  })
+
+  it('un doble click en "Cerrar" dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Enviada' })) : undefined))
+
+    let resolverCerrar: (v: OrdenDeCompraBorrador) => void = () => {}
+    const cerrarPendiente = new Promise<OrdenDeCompraBorrador>((resolve) => {
+      resolverCerrar = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/ordenes-compra/30/cerrar' ? cerrarPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Cerrar' })
+
+    // Mismo patrón same-tick que "Enviar" arriba — replica la red de reentrancia de `cerrandoRef`.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ordenes-compra/30/cerrar')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Cerrando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverCerrar(borradorFixture({ estado: 'Cerrada' }))
+      await cerrarPendiente
+    })
+  })
+
+  it('un doble click en "Anular" dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Enviada' })) : undefined))
+
+    let resolverAnular: (v: OrdenDeCompraBorrador) => void = () => {}
+    const anularPendiente = new Promise<OrdenDeCompraBorrador>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/ordenes-compra/30/anular' ? anularPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Anular' })
+
+    // Mismo patrón same-tick — replica la red de reentrancia de `anulandoRef`.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ordenes-compra/30/anular')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Anulando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverAnular(borradorFixture({ estado: 'Anulada' }))
+      await anularPendiente
+    })
+  })
+
+  it('un doble click en "Guardar borrador" dispara exactamente un PUT', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Borrador' })) : undefined))
+
+    let resolverGuardar: (v: OrdenDeCompraBorrador) => void = () => {}
+    const guardarPendiente = new Promise<OrdenDeCompraBorrador>((resolve) => {
+      resolverGuardar = resolve
+    })
+    apiPutMock.mockImplementation((ruta: string) => (ruta === '/ordenes-compra/30' ? guardarPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Guardar borrador' })
+
+    // Mismo patrón same-tick — replica la red de reentrancia de `guardandoRef`.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPutMock.mock.calls.filter((c) => c[0] === '/ordenes-compra/30')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Guardando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverGuardar(borradorFixture({ estado: 'Borrador' }))
+      await guardarPendiente
     })
   })
 })

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
@@ -396,6 +396,13 @@ describe('OrdenDeCompra — doble click (react-async-state regla 9)', () => {
     renderPantalla()
     const boton = await screen.findByRole('button', { name: 'Guardar borrador' })
 
+    // A diferencia de Enviar/Cerrar/Anular (habilitados solo por `ocupado`), este botón también
+    // depende de `encabezadoCompleto`, que hidrata desde `detalle` en un useEffect posterior al
+    // primer render — hay que esperar a que ese estado asincrónico asiente antes del doble click,
+    // si no el guard de reentrancia puede correr contra un botón todavía deshabilitado.
+    await waitFor(() => expect(boton).not.toBeDisabled())
+    await waitFor(() => expect(screen.getByLabelText('Proveedor')).toHaveValue('4'))
+
     // Mismo patrón same-tick — replica la red de reentrancia de `guardandoRef`.
     act(() => {
       boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
@@ -1,0 +1,351 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OrdenDeCompra } from './OrdenDeCompra'
+import { ROL } from '../api/tipos'
+import type { OrdenDeCompraBorrador, OrdenDeCompraDetalle, ProveedorListado, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown?])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 1,
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 4,
+    razonSocial: 'Proveedor Cuatro SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 9,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Depósito Norte',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function detalleFixture(sobrescribir: Partial<OrdenDeCompraDetalle> = {}): OrdenDeCompraDetalle {
+  return {
+    id: 30,
+    idProveedor: 4,
+    idPuntoVenta: 9,
+    numero: 55,
+    fechaEmision: '2026-08-19T12:00:00Z',
+    fechaEnvio: '2026-08-19T12:00:00Z',
+    fechaEsperada: '2026-09-01',
+    fechaCierre: null,
+    cierreManual: false,
+    observaciones: null,
+    estado: 'Enviada',
+    items: [{ orden: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidadPedida: 7, costoUnitarioEstimado: 100 }],
+    cobertura: [
+      { idArticulo: 10, pedida: 7, recibida: 5, pendiente: 2, costoEstimado: 100, costoReal: 112, desvio: 12 },
+      { idArticulo: 11, pedida: 0, recibida: 3, pendiente: 0, costoEstimado: null, costoReal: null, desvio: null },
+    ],
+    totalEstimado: 700,
+    totalReal: 560,
+    desvioTotal: -20,
+    comprobantesLigados: [88],
+    ...sobrescribir,
+  }
+}
+
+function borradorFixture(sobrescribir: Partial<OrdenDeCompraBorrador> = {}): OrdenDeCompraBorrador {
+  return {
+    id: 30,
+    idProveedor: 4,
+    idPuntoVenta: 9,
+    numero: null,
+    fechaEmision: '2026-08-19T12:00:00Z',
+    fechaEnvio: null,
+    fechaEsperada: null,
+    fechaCierre: null,
+    idEmpleadoCierre: null,
+    observaciones: null,
+    estado: 'Borrador',
+    items: [],
+    ...sobrescribir,
+  }
+}
+
+function mockearReferencia(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta.startsWith('/proveedores')) return Promise.resolve({ items: [proveedorFixture()], total: 1, pagina: 1, tamanio: 200 })
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla(idOrden: string | number = 30, state?: unknown) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: `/ordenes-compra/${idOrden}`, state }]}>
+      <Routes>
+        <Route path="/ordenes-compra/:id" element={<OrdenDeCompra />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiPutMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+describe('OrdenDeCompra — detalle (lectura)', () => {
+  it('muestra el estado, la cobertura con valores per-artículo distintos y los totales', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture()) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('Enviada')).toBeInTheDocument()
+    // mutation-proof-tests regla 12b: cada campo posicional de la cobertura leído con su propio
+    // valor discriminante — nunca un — genérico ni un 0 fabricado.
+    expect(screen.getByText('2')).toBeInTheDocument() // Pendiente del artículo 10
+    expect(screen.getByText('+12%')).toBeInTheDocument() // Desvio del artículo 10
+    expect(screen.getByText('$700,00')).toBeInTheDocument() // Total estimado
+    expect(screen.getByText('$560,00')).toBeInTheDocument() // Total real
+    expect(screen.getByText('-20%')).toBeInTheDocument() // Desvío total
+  })
+
+  it('un artículo sin costo comparable renderiza — en costo/desvío, nunca 0', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture()) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Enviada')
+    // fila del artículo 11: costoEstimado/costoReal/desvio todos null.
+    const filas = screen.getAllByRole('row')
+    const filaArticulo11 = filas.find((f) => f.textContent?.includes('Artículo #11'))!
+    expect(filaArticulo11.textContent).toContain('—')
+  })
+
+  it('"Registrar recepción" navega con idOrdenCompra en la URL', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Enviada' })) : undefined))
+    renderPantalla()
+
+    const boton = await screen.findByRole('button', { name: 'Registrar recepción' })
+    expect(boton).toBeInTheDocument()
+  })
+
+  it('una OC Anulada no ofrece "Registrar recepción" ni "Cerrar"/"Anular"', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Anulada' })) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Anulada')
+    expect(screen.queryByRole('button', { name: 'Registrar recepción' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cerrar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Anular' })).not.toBeInTheDocument()
+  })
+
+  it('un Vendedor lee el detalle pero no ve ninguna acción de escritura', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture()) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Enviada')
+    expect(screen.queryByRole('button', { name: 'Cerrar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Anular' })).not.toBeInTheDocument()
+  })
+})
+
+describe('OrdenDeCompra — generación (react-async-state regla 2, mutation-proof-tests regla 7)', () => {
+  // Dos refetches de detalle en carrera (uno por "Enviar", otro por "Anular", disparados en
+  // secuencia porque el detalle stale todavía muestra los botones de Borrador hasta que el primer
+  // refetch aterriza) — el de "Enviar" queda pendiente y se resuelve DESPUÉS de que el de "Anular"
+  // (más nuevo) ya aterrizó; el resultado stale nunca debe pisar el más reciente.
+  it('una respuesta de refetch desactualizada nunca pisa la más reciente', async () => {
+    let llamadas = 0
+    let resolverSegundaLlamada: (v: OrdenDeCompraDetalle) => void = () => {}
+    const segundaLlamadaPendiente = new Promise<OrdenDeCompraDetalle>((resolve) => {
+      resolverSegundaLlamada = resolve
+    })
+
+    mockearReferencia((ruta) => {
+      if (ruta !== '/ordenes-compra/30') return undefined
+      llamadas += 1
+      if (llamadas === 1) return Promise.resolve(detalleFixture({ estado: 'Borrador', observaciones: 'inicial' }))
+      if (llamadas === 2) return segundaLlamadaPendiente
+      return Promise.resolve(detalleFixture({ estado: 'Anulada', observaciones: 'la-mas-nueva' }))
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ordenes-compra/30/enviar') return Promise.resolve(borradorFixture({ estado: 'Enviada' }))
+      if (ruta === '/ordenes-compra/30/anular') return Promise.resolve(borradorFixture({ estado: 'Anulada' }))
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+
+    renderPantalla()
+    await screen.findByText('Borrador')
+
+    // "Enviar" dispara el refetch #2 (queda pendiente).
+    await userEvent.click(screen.getByRole('button', { name: 'Enviar' }))
+    await screen.findByText('Orden enviada.')
+
+    // El detalle sigue stale (Borrador) hasta que el refetch #2 aterrice — "Anular" sigue visible.
+    // Dispara el refetch #3, que resuelve YA (más nuevo que el #2 todavía pendiente).
+    await userEvent.click(screen.getByRole('button', { name: 'Anular' }))
+    await screen.findByText('Orden anulada.')
+    await screen.findByText('Anulada')
+
+    // El flush del microtask stale va DENTRO de act (mutation-proof-tests regla 7): un waitFor
+    // solo pasaría en su primer tick, antes de que el .then obsoleto aterrice.
+    await act(async () => {
+      resolverSegundaLlamada(detalleFixture({ estado: 'Enviada', observaciones: 'stale' }))
+      await segundaLlamadaPendiente
+    })
+    expect(screen.getByText('Anulada')).toBeInTheDocument()
+    expect(screen.queryByText('la-mas-nueva')).not.toBeInTheDocument()
+  })
+})
+
+describe('OrdenDeCompra — crear borrador', () => {
+  it('crea el borrador y navega a la ruta real de la orden recién creada', async () => {
+    mockearReferencia()
+    apiPostMock.mockResolvedValue(borradorFixture())
+
+    renderPantalla('nueva')
+
+    await userEvent.selectOptions(await screen.findByLabelText('Proveedor'), '4')
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), '9')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear borrador' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/ordenes-compra', expect.objectContaining({ idProveedor: 4, idPuntoVenta: 9 })))
+  })
+
+  it('un Vendedor no ve "Crear borrador"', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearReferencia()
+    renderPantalla('nueva')
+
+    await screen.findByLabelText('Proveedor')
+    expect(screen.queryByRole('button', { name: 'Crear borrador' })).not.toBeInTheDocument()
+  })
+})
+
+describe('OrdenDeCompra — precarga desde Reposicion.tsx (location.state)', () => {
+  it('precarga proveedor/punto de venta/items desde el state de navegación', async () => {
+    mockearReferencia()
+
+    renderPantalla('nueva', {
+      idProveedor: 4,
+      idPuntoVenta: 9,
+      items: [{ idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidadPedida: 17, costoUnitarioEstimado: null }],
+    })
+
+    expect((await screen.findByLabelText('Proveedor')) as HTMLSelectElement).toHaveValue('4')
+    expect(screen.getByLabelText('Punto de venta')).toHaveValue('9')
+    expect(screen.getByLabelText('Cantidad pedida')).toHaveValue(17)
+  })
+})
+
+describe('OrdenDeCompra — doble click (react-async-state regla 9)', () => {
+  it('un doble click en "Enviar" dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/ordenes-compra/30' ? Promise.resolve(detalleFixture({ estado: 'Borrador' })) : undefined))
+
+    let resolverEnviar: (v: OrdenDeCompraBorrador) => void = () => {}
+    const enviarPendiente = new Promise<OrdenDeCompraBorrador>((resolve) => {
+      resolverEnviar = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/ordenes-compra/30/enviar' ? enviarPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Enviar' })
+
+    // Los dos dispatchEvent viajan DENTRO de un mismo act() para que ningún re-render de React
+    // corra entre ellos — mismo patrón que BotonDeDescarga.test.tsx/CuentaCorrienteDeProveedor.test.tsx.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/ordenes-compra/30/enviar')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Enviando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverEnviar(borradorFixture({ estado: 'Enviada' }))
+      await enviarPendiente
+    })
+  })
+})
+
+describe('OrdenDeCompra — un 2xx de enviar/cerrar/anular nunca se reporta como fallo (regla 6)', () => {
+  it('enviar 2xx muestra el aviso de éxito aunque el refetch posterior falle', async () => {
+    let llamadasDetalle = 0
+    mockearReferencia((ruta) => {
+      if (ruta !== '/ordenes-compra/30') return undefined
+      llamadasDetalle += 1
+      if (llamadasDetalle === 1) return Promise.resolve(detalleFixture({ estado: 'Borrador' }))
+      return Promise.reject(new Error('falló el refresco'))
+    })
+    apiPostMock.mockImplementation((ruta: string) =>
+      ruta === '/ordenes-compra/30/enviar' ? Promise.resolve(borradorFixture({ estado: 'Enviada' })) : Promise.reject(new Error(`ruta no mockeada: ${ruta}`)),
+    )
+
+    renderPantalla()
+    await userEvent.click(await screen.findByRole('button', { name: 'Enviar' }))
+
+    expect(await screen.findByText('Orden enviada.')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.tsx
@@ -1,0 +1,791 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router'
+import { clienteDeArticulos } from '../api/articulos'
+import { api, ErrorApi } from '../api/cliente'
+import {
+  aSolicitudDeOrdenDeCompra,
+  claseDeBadgeDeEstadoOrdenCompra,
+  clienteDeOrdenesDeCompra,
+  encabezadoDeOrdenVacio,
+  etiquetaDeEstadoOrdenCompra,
+  formatearCantidadNullable,
+  formatearDesvio,
+  formatearMonedaNullable,
+  itemDeOrdenAFormulario,
+  lineaDeOrdenCompletaParaEnvio,
+  lineaDeOrdenVacia,
+  type EncabezadoDeOrdenFormulario,
+  type LineaDeOrdenFormulario,
+} from '../api/ordenesDeCompra'
+import { ROL } from '../api/tipos'
+import type {
+  ArticuloListado,
+  CoberturaDeArticulo,
+  LineaDeOrdenSolicitada,
+  OrdenDeCompraDetalle,
+  PaginaDe,
+  ProveedorListado,
+  PuntoVentaListado,
+} from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearFechaHora(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleString('es-AR') : '—'
+}
+
+/** `location.state` que llega desde `Reposicion.tsx` — un `Link`/`navigate` de entrada con datos
+ * ya resueltos, nunca un fetch decorativo en esta pantalla para recuperarlos (lección de la Slice
+ * 6 de la etapa 15). */
+type EstadoDePrecarga = { idProveedor: number; idPuntoVenta: number; items: LineaDeOrdenSolicitada[] }
+
+// ---- Selector de artículo por búsqueda (search-as-you-type) — mismo shape que el de
+// CompraEditor.tsx, propio de cada fila -----------------------------------------------------------
+
+type PropsSelectorDeArticulo = {
+  descripcion: string
+  disabled: boolean
+  onElegir: (articulo: ArticuloListado) => void
+}
+
+function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDeArticulo) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (termino.trim().length < 2) {
+      setResultados([])
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setBuscando(true)
+
+    const temporizador = setTimeout(() => {
+      clienteDeArticulos
+        .listar(termino, false)
+        .then((pagina) => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados(pagina.items)
+        })
+        .catch(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados([])
+        })
+        .finally(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setBuscando(false)
+        })
+    }, 300)
+
+    return () => {
+      vigente = false
+      clearTimeout(temporizador)
+    }
+  }, [termino])
+
+  return (
+    <div className="position-relative">
+      <input
+        type="text"
+        className="form-control form-control-sm rounded-0"
+        placeholder="Buscar artículo…"
+        value={termino}
+        disabled={disabled}
+        onChange={(e) => setTermino(e.target.value)}
+      />
+      {descripcion && <div className="small text-muted">Elegido: {descripcion}</div>}
+      {buscando && <div className="small text-muted">Buscando…</div>}
+      {!buscando && resultados.length > 0 && (
+        <div className="list-group position-absolute w-100" style={{ zIndex: 10 }}>
+          {resultados.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="list-group-item list-group-item-action py-1 px-2 small"
+              onClick={() => {
+                onElegir(a)
+                setTermino('')
+                setResultados([])
+              }}
+            >
+              {a.codigoInterno} — {a.nombre}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Fila editable del grid de items -------------------------------------------------------------
+
+type PropsFilaDeItem = {
+  linea: LineaDeOrdenFormulario
+  disabled: boolean
+  onCambio: (clave: number, cambios: Partial<LineaDeOrdenFormulario>) => void
+  onQuitar: (clave: number) => void
+}
+
+function FilaDeItem({ linea, disabled, onCambio, onQuitar }: PropsFilaDeItem) {
+  const incompleta = !lineaDeOrdenCompletaParaEnvio(linea)
+
+  return (
+    <tr className={incompleta ? 'table-warning text-muted' : undefined}>
+      <td style={{ minWidth: 220 }}>
+        <SelectorDeArticulo
+          descripcion={linea.descripcion}
+          disabled={disabled}
+          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
+        />
+        {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
+      </td>
+      <td style={{ width: 120 }}>
+        <input
+          type="number"
+          step="0.001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Cantidad pedida"
+          value={linea.cantidadPedida}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { cantidadPedida: e.target.value })}
+        />
+      </td>
+      <td style={{ width: 140 }}>
+        <input
+          type="number"
+          step="0.0001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Costo estimado"
+          value={linea.costoUnitarioEstimado}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { costoUnitarioEstimado: e.target.value })}
+        />
+      </td>
+      <td>
+        <button type="button" className="btn btn-outline-danger btn-sm rounded-0" disabled={disabled} onClick={() => onQuitar(linea.clave)}>
+          Quitar
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+// ---- Tabla de cobertura por artículo (solo lectura) ----------------------------------------------
+
+function TablaDeCobertura({ cobertura, descripcionPorArticulo }: { cobertura: CoberturaDeArticulo[]; descripcionPorArticulo: Record<number, string> }) {
+  return (
+    <div className="table-responsive">
+      <table className="table table-sm table-bordered align-middle">
+        <thead>
+          <tr>
+            <th>Artículo</th>
+            <th className="text-end">Pedida</th>
+            <th className="text-end">Recibida</th>
+            <th className="text-end">Pendiente</th>
+            <th className="text-end">Costo estimado</th>
+            <th className="text-end">Costo real</th>
+            <th className="text-end">Desvío</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cobertura.map((c) => (
+            <tr key={c.idArticulo}>
+              <td>{descripcionPorArticulo[c.idArticulo] ?? `Artículo #${c.idArticulo}`}</td>
+              <td className="text-end">{formatearCantidadNullable(c.pedida)}</td>
+              <td className="text-end">{formatearCantidadNullable(c.recibida)}</td>
+              <td className="text-end">{formatearCantidadNullable(c.pendiente)}</td>
+              <td className="text-end">{formatearMonedaNullable(c.costoEstimado)}</td>
+              <td className="text-end">{formatearMonedaNullable(c.costoReal)}</td>
+              <td className="text-end">{formatearDesvio(c.desvio)}</td>
+            </tr>
+          ))}
+          {cobertura.length === 0 && (
+            <tr>
+              <td colSpan={7} className="text-center text-muted py-3">
+                Sin artículos pedidos.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ---- Pantalla principal -----------------------------------------------------------------------
+
+type PropsPantalla = { idOrden: number | null; precarga: EstadoDePrecarga | null }
+
+/** Remontada por `key={idOrden ?? 'nueva-' + ...}` (react-async-state regla 8) — ningún estado de
+ * acá (borrador en edición, avisos, paneles) sobrevive a un cambio de orden. */
+function PantallaOrdenDeCompra({ idOrden, precarga }: PropsPantalla) {
+  const navigate = useNavigate()
+  const { usuario } = useAuth()
+  const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
+
+  const esNuevo = idOrden === null
+
+  // ---- referencia (proveedores/puntos de venta) ------------------------------------------------
+  const [proveedores, setProveedores] = useState<ProveedorListado[] | null>(null)
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PaginaDe<ProveedorListado>>('/proveedores?tamanio=200')
+      .then((p) => vigente && setProveedores(p.items))
+      .catch((e) => {
+        setProveedores([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los proveedores.'))
+      })
+
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => vigente && setPuntosVenta(lista))
+      .catch((e) => {
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const referenciaLista = proveedores !== null && puntosVenta !== null
+  const referenciaOk = referenciaLista && errorReferencia === ''
+
+  // ---- detalle (lectura, GET /{id} — es la única fuente que trae cobertura/desvío/estado real) --
+  const [detalle, setDetalle] = useState<OrdenDeCompraDetalle | null>(null)
+  const [cargandoDetalle, setCargandoDetalle] = useState(!esNuevo)
+  const [errorDetalle, setErrorDetalle] = useState('')
+  const generacionRef = useRef(0)
+
+  const cargarDetalle = useCallback(() => {
+    if (esNuevo || idOrden === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargandoDetalle(true)
+    setErrorDetalle('')
+
+    clienteDeOrdenesDeCompra
+      .obtener(idOrden)
+      .then((d) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDetalle(d)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        // regla 6: un refetch posterior a una escritura 2xx (enviar/cerrar/anular/guardar) NUNCA
+        // vacía la pantalla a un error total — `detalle` queda como estaba (stale, mejor que
+        // nada) y solo el mensaje se muestra; el aviso de éxito de la escritura, en su propio
+        // estado, sigue visible. Solo la carga INICIAL (detalle todavía null) llega al error
+        // bloqueante de abajo.
+        setErrorDetalle(
+          e instanceof ErrorApi
+            ? e.message
+            : 'No se pudo actualizar la orden de compra — los datos mostrados pueden estar desactualizados.',
+        )
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargandoDetalle(false)
+      })
+  }, [esNuevo, idOrden])
+
+  useEffect(() => {
+    cargarDetalle()
+  }, [cargarDetalle])
+
+  // ---- formulario editable (nuevo — opcionalmente precargado desde Reposición — o borrador
+  // existente) -------------------------------------------------------------------------------------
+  const proximaClaveRef = useRef(1)
+  const [encabezado, setEncabezado] = useState<EncabezadoDeOrdenFormulario>(() =>
+    precarga ? { ...encabezadoDeOrdenVacio(), idProveedor: precarga.idProveedor, idPuntoVenta: precarga.idPuntoVenta } : encabezadoDeOrdenVacio(),
+  )
+  const [lineas, setLineas] = useState<LineaDeOrdenFormulario[]>(() =>
+    precarga
+      ? precarga.items.map((item) => ({
+          clave: proximaClaveRef.current++,
+          idArticulo: item.idArticulo,
+          descripcion: item.descripcion,
+          cantidadPedida: String(item.cantidadPedida),
+          costoUnitarioEstimado: item.costoUnitarioEstimado === null ? '' : String(item.costoUnitarioEstimado),
+        }))
+      : [],
+  )
+
+  useEffect(() => {
+    if (detalle === null) return
+    setEncabezado({
+      idProveedor: detalle.idProveedor,
+      idPuntoVenta: detalle.idPuntoVenta,
+      fechaEsperada: detalle.fechaEsperada ?? '',
+      observaciones: detalle.observaciones ?? '',
+    })
+    setLineas(detalle.items.map((item) => itemDeOrdenAFormulario(proximaClaveRef.current++, item)))
+  }, [detalle])
+
+  const descripcionPorArticulo: Record<number, string> = {}
+  for (const item of detalle?.items ?? []) descripcionPorArticulo[item.idArticulo] = item.descripcion
+
+  // ---- escrituras: guardar/enviar/cerrar/anular — cada una con su propio guard de reentrancia
+  // (react-async-state regla 9) y su propio flag de "en vuelo" (regla 5: por acción, no una sola
+  // bandera de página) -----------------------------------------------------------------------------
+  const [guardando, setGuardando] = useState(false)
+  const guardandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [aviso, setAviso] = useState('')
+
+  const [enviando, setEnviando] = useState(false)
+  const enviandoRef = useRef(false)
+  const [errorEnviar, setErrorEnviar] = useState('')
+
+  const [cerrando, setCerrando] = useState(false)
+  const cerrandoRef = useRef(false)
+  const [errorCerrar, setErrorCerrar] = useState('')
+
+  const [anulando, setAnulando] = useState(false)
+  const anulandoRef = useRef(false)
+  const [errorAnular, setErrorAnular] = useState('')
+
+  const ocupado = guardando || enviando || cerrando || anulando
+
+  function cambiarLinea(clave: number, cambios: Partial<LineaDeOrdenFormulario>) {
+    if (ocupado) return
+    // regla 1: updater funcional, nunca lee `lineas` del cierre.
+    setLineas((prev) => prev.map((l) => (l.clave === clave ? { ...l, ...cambios } : l)))
+  }
+
+  function agregarLinea() {
+    if (ocupado) return
+    setLineas((prev) => [...prev, lineaDeOrdenVacia(proximaClaveRef.current++)])
+  }
+
+  function quitarLinea(clave: number) {
+    if (ocupado) return
+    setLineas((prev) => prev.filter((l) => l.clave !== clave))
+  }
+
+  const encabezadoCompleto = encabezado.idProveedor !== '' && encabezado.idPuntoVenta !== ''
+  const puedeGuardar = referenciaOk && puedeEscribir && encabezadoCompleto && !ocupado
+
+  async function guardarBorrador() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (guardandoRef.current) return
+    if (!puedeGuardar) return
+
+    guardandoRef.current = true
+    setGuardando(true)
+    setError('')
+    setAviso('')
+    // regla 3: bumpear la generación de carga ANTES de la escritura.
+    generacionRef.current += 1
+
+    try {
+      const solicitud = aSolicitudDeOrdenDeCompra(encabezado, lineas)
+      if (esNuevo) {
+        const creada = await clienteDeOrdenesDeCompra.crear(solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        // Remontaje completo vía cambio de `key` (regla 8): navega a la ruta real de la orden
+        // recién creada, nunca reutiliza este estado de "nueva" para simular la edición.
+        navigate(`/ordenes-compra/${creada.id}`, { replace: true })
+      } else if (idOrden !== null) {
+        await clienteDeOrdenesDeCompra.actualizar(idOrden, solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        setAviso('Borrador guardado.')
+        // regla 6: el refetch posterior vive aislado de este try/catch.
+        cargarDetalle()
+      }
+    } catch (e) {
+      guardandoRef.current = false
+      setGuardando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el borrador.')
+    }
+  }
+
+  async function enviar() {
+    if (ocupado) return
+    if (enviandoRef.current || idOrden === null) return
+
+    enviandoRef.current = true
+    setEnviando(true)
+    setErrorEnviar('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDeOrdenesDeCompra.enviar(idOrden)
+      enviandoRef.current = false
+      setEnviando(false)
+      setAviso('Orden enviada.')
+      cargarDetalle()
+    } catch (e) {
+      enviandoRef.current = false
+      setEnviando(false)
+      setErrorEnviar(e instanceof ErrorApi ? e.message : 'No se pudo enviar la orden.')
+    }
+  }
+
+  async function cerrar() {
+    if (ocupado) return
+    if (cerrandoRef.current || idOrden === null) return
+
+    cerrandoRef.current = true
+    setCerrando(true)
+    setErrorCerrar('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDeOrdenesDeCompra.cerrar(idOrden)
+      cerrandoRef.current = false
+      setCerrando(false)
+      setAviso('Orden cerrada.')
+      cargarDetalle()
+    } catch (e) {
+      cerrandoRef.current = false
+      setCerrando(false)
+      setErrorCerrar(e instanceof ErrorApi ? e.message : 'No se pudo cerrar la orden.')
+    }
+  }
+
+  async function anular() {
+    if (ocupado) return
+    if (anulandoRef.current || idOrden === null) return
+
+    anulandoRef.current = true
+    setAnulando(true)
+    setErrorAnular('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDeOrdenesDeCompra.anular(idOrden)
+      anulandoRef.current = false
+      setAnulando(false)
+      setAviso('Orden anulada.')
+      cargarDetalle()
+    } catch (e) {
+      anulandoRef.current = false
+      setAnulando(false)
+      setErrorAnular(e instanceof ErrorApi ? e.message : 'No se pudo anular la orden.')
+    }
+  }
+
+  if (!esNuevo && cargandoDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Cargando />
+      </div>
+    )
+  }
+
+  if (!esNuevo && errorDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Orden de compra" variante="danger">
+          <p className="text-muted">{errorDetalle}</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/ordenes-compra">
+            Volver a órdenes de compra
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  const esBorrador = esNuevo || detalle?.estado === 'Borrador'
+  const puedeEnviar = puedeEscribir && !esNuevo && detalle?.estado === 'Borrador'
+  const puedeCerrar = puedeEscribir && (detalle?.estado === 'Enviada' || detalle?.estado === 'RecibidaParcial')
+  const puedeAnular = puedeEscribir && (detalle?.estado === 'Borrador' || detalle?.estado === 'Enviada')
+  const puedeRecepcionar = detalle !== null && (detalle.estado === 'Enviada' || detalle.estado === 'RecibidaParcial' || detalle.estado === 'Cerrada')
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={esNuevo ? 'Nueva orden de compra' : `Orden de compra ${detalle?.numero ?? `#${idOrden}`}`}
+        variante="inverse"
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/ordenes-compra">
+            Volver a órdenes de compra
+          </Link>
+        }
+      >
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorReferencia} No se pueden registrar operaciones de orden de compra hasta que esto se resuelva.
+          </div>
+        )}
+        {/* regla 6: un refetch fallido posterior a una escritura ya exitosa nunca se disfraza de
+            error de la escritura — se muestra chico, sin ocultar el `aviso` de arriba ni el resto
+            de la pantalla (que sigue mostrando el último `detalle` conocido). */}
+        {errorDetalle && detalle && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorDetalle}</div>}
+
+        {!esNuevo && detalle && (
+          <div className="mb-3">
+            <span className={`badge rounded-0 me-2 ${claseDeBadgeDeEstadoOrdenCompra(detalle.estado)}`}>
+              {etiquetaDeEstadoOrdenCompra(detalle.estado)}
+            </span>
+            {detalle.fechaEnvio && <span className="small text-muted me-2">Enviada: {formatearFechaHora(detalle.fechaEnvio)}</span>}
+            {detalle.fechaCierre && <span className="small text-muted">Cerrada: {formatearFechaHora(detalle.fechaCierre)}</span>}
+          </div>
+        )}
+
+        <div className="row g-2 mb-3">
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="oc-proveedor">
+              Proveedor
+            </label>
+            <select
+              id="oc-proveedor"
+              className="form-select rounded-0"
+              value={encabezado.idProveedor}
+              disabled={!esBorrador || ocupado || !referenciaOk || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idProveedor: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(proveedores ?? []).map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.razonSocial}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="oc-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="oc-punto-venta"
+              className="form-select rounded-0"
+              value={encabezado.idPuntoVenta}
+              disabled={!esBorrador || ocupado || !referenciaOk || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idPuntoVenta: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="oc-fecha-esperada">
+              Fecha esperada
+            </label>
+            <input
+              id="oc-fecha-esperada"
+              type="date"
+              className="form-control rounded-0"
+              value={encabezado.fechaEsperada}
+              disabled={!esBorrador || ocupado || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, fechaEsperada: e.target.value }))}
+            />
+          </div>
+          <div className="col-12">
+            <label className="form-label" htmlFor="oc-observaciones">
+              Observaciones
+            </label>
+            <input
+              id="oc-observaciones"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.observaciones}
+              disabled={!esBorrador || ocupado || !puedeEscribir}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, observaciones: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        {esBorrador ? (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Artículo</th>
+                    <th>Cantidad pedida</th>
+                    <th>Costo estimado</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lineas.map((l) => (
+                    <FilaDeItem
+                      key={l.clave}
+                      linea={l}
+                      disabled={ocupado || !referenciaOk || !puedeEscribir}
+                      onCambio={cambiarLinea}
+                      onQuitar={quitarLinea}
+                    />
+                  ))}
+                  {lineas.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="text-center text-muted py-3">
+                        Todavía no hay items cargados.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {puedeEscribir && (
+              <button
+                type="button"
+                className="btn btn-outline-secondary btn-sm rounded-0 mb-3"
+                disabled={ocupado || !referenciaOk}
+                onClick={agregarLinea}
+              >
+                + Agregar línea
+              </button>
+            )}
+
+            <div className="d-flex gap-2 mb-3">
+              {puedeEscribir && (
+                <button type="button" className="btn btn-primary rounded-0" disabled={!puedeGuardar} onClick={guardarBorrador}>
+                  {guardando ? 'Guardando…' : esNuevo ? 'Crear borrador' : 'Guardar borrador'}
+                </button>
+              )}
+              {puedeEnviar && (
+                <button type="button" className="btn btn-success rounded-0" disabled={ocupado} onClick={enviar}>
+                  {enviando ? 'Enviando…' : 'Enviar'}
+                </button>
+              )}
+              {puedeAnular && (
+                <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                  {anulando ? 'Anulando…' : 'Anular'}
+                </button>
+              )}
+            </div>
+            {errorEnviar && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEnviar}</div>}
+            {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+          </>
+        ) : (
+          detalle && (
+            <>
+              <h6>Items pedidos</h6>
+              <div className="table-responsive mb-3">
+                <table className="table table-sm table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Artículo</th>
+                      <th className="text-end">Cantidad pedida</th>
+                      <th className="text-end">Costo estimado</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detalle.items.map((item) => (
+                      <tr key={item.orden}>
+                        <td>{item.descripcion}</td>
+                        <td className="text-end">{formatearCantidadNullable(item.cantidadPedida)}</td>
+                        <td className="text-end">{formatearMonedaNullable(item.costoUnitarioEstimado)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <h6>Cobertura por artículo</h6>
+              <TablaDeCobertura cobertura={detalle.cobertura} descripcionPorArticulo={descripcionPorArticulo} />
+
+              <div className="row g-3 my-3">
+                <div className="col-md-4">
+                  <div className="small text-muted">Total estimado</div>
+                  <div>{formatearMonedaNullable(detalle.totalEstimado)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Total real</div>
+                  <div>{formatearMonedaNullable(detalle.totalReal)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Desvío total</div>
+                  <div>{formatearDesvio(detalle.desvioTotal)}</div>
+                </div>
+              </div>
+
+              {detalle.comprobantesLigados.length > 0 && (
+                <div className="mb-3">
+                  <div className="small text-muted">Comprobantes de compra ligados</div>
+                  <div className="d-flex gap-2 flex-wrap">
+                    {detalle.comprobantesLigados.map((idComprobante) => (
+                      <Link key={idComprobante} className="btn btn-sm btn-outline-secondary rounded-0" to={`/compras/${idComprobante}`}>
+                        #{idComprobante}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="d-flex gap-2 mb-3">
+                {puedeRecepcionar && (
+                  <button
+                    type="button"
+                    className="btn btn-primary rounded-0"
+                    onClick={() => navigate(`/compras/nueva?idOrdenCompra=${detalle.id}`)}
+                  >
+                    Registrar recepción
+                  </button>
+                )}
+                {puedeCerrar && (
+                  <button type="button" className="btn btn-success rounded-0" disabled={ocupado} onClick={cerrar}>
+                    {cerrando ? 'Cerrando…' : 'Cerrar'}
+                  </button>
+                )}
+                {puedeAnular && (
+                  <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                    {anulando ? 'Anulando…' : 'Anular'}
+                  </button>
+                )}
+              </div>
+              {errorCerrar && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorCerrar}</div>}
+              {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+            </>
+          )
+        )}
+      </Box>
+    </div>
+  )
+}
+
+/**
+ * Órdenes de compra — borrador/detalle (stage-16-ordenes-de-compra, Slice 6; design: Web
+ * composition): `/ordenes-compra/nueva` crea un borrador desde cero (opcionalmente precargado
+ * desde `Reposicion.tsx` vía `location.state`) o `/ordenes-compra/:id` lo edita (borrador), lo
+ * envía/cierra/anula, o solo lo muestra con la cobertura por artículo y el desvío de precio. Mismo
+ * gate de lectura que `/ordenes-compra` (`RutaProtegida`, App.tsx) — `puedeEscribir` oculta las
+ * acciones de escritura, `GestionDeCatalogo` es la autoridad real del lado del servidor.
+ */
+export function OrdenDeCompra() {
+  const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const esNuevo = id === undefined || id === 'nueva'
+  const idNumerico = esNuevo ? null : Number(id)
+  const idValido = esNuevo || Number.isFinite(idNumerico)
+
+  const precarga = esNuevo ? ((location.state as EstadoDePrecarga | null) ?? null) : null
+
+  if (!idValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Orden de compra" variante="warning">
+          <p className="text-muted">No se especificó una orden de compra válida.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/ordenes-compra">
+            Volver a órdenes de compra
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return <PantallaOrdenDeCompra key={idNumerico ?? `nueva-${precarga?.idProveedor ?? 's'}`} idOrden={idNumerico} precarga={precarga} />
+}

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.tsx
@@ -504,7 +504,7 @@ function PantallaOrdenDeCompra({ idOrden, precarga }: PropsPantalla) {
   const puedeEnviar = puedeEscribir && !esNuevo && detalle?.estado === 'Borrador'
   const puedeCerrar = puedeEscribir && (detalle?.estado === 'Enviada' || detalle?.estado === 'RecibidaParcial')
   const puedeAnular = puedeEscribir && (detalle?.estado === 'Borrador' || detalle?.estado === 'Enviada')
-  const puedeRecepcionar = detalle !== null && (detalle.estado === 'Enviada' || detalle.estado === 'RecibidaParcial' || detalle.estado === 'Cerrada')
+  const puedeRecepcionar = puedeEscribir && detalle !== null && (detalle.estado === 'Enviada' || detalle.estado === 'RecibidaParcial' || detalle.estado === 'Cerrada')
 
   return (
     <div className="container-fluid py-4">

--- a/src/Ways.Web/src/paginas/OrdenesDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenesDeCompra.test.tsx
@@ -1,0 +1,264 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OrdenesDeCompra } from './OrdenesDeCompra'
+import { RutaProtegida } from '../auth/RutaProtegida'
+import { ROL } from '../api/tipos'
+import type { OrdenDeCompraListada, PaginaDeOrdenesDeCompra, ProveedorListado, PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 1,
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function proveedorFixture(sobrescribir: Partial<ProveedorListado> = {}): ProveedorListado {
+  return {
+    id: 1,
+    razonSocial: 'Proveedor Uno SA',
+    nombreFantasia: null,
+    cuit: null,
+    idCondicionFiscal: 1,
+    domicilio: null,
+    telefono: null,
+    email: null,
+    vendedor: null,
+    celularVendedor: null,
+    supervisor: null,
+    celularSupervisor: null,
+    margen: null,
+    observaciones: null,
+    activo: true,
+    idEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function ordenFixture(sobrescribir: Partial<OrdenDeCompraListada> = {}): OrdenDeCompraListada {
+  return {
+    id: 1,
+    idProveedor: 1,
+    idPuntoVenta: 7,
+    numero: 12,
+    fechaEmision: '2026-08-01T12:00:00Z',
+    fechaEsperada: '2026-08-15',
+    estado: 'Enviada',
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(sobrescribir: Partial<PaginaDeOrdenesDeCompra> = {}): PaginaDeOrdenesDeCompra {
+  return { items: [ordenFixture()], total: 1, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta.startsWith('/proveedores')) return Promise.resolve({ items: [proveedorFixture()], total: 1, pagina: 1, tamanio: 200 })
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/ordenes-compra?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla() {
+  return render(<OrdenesDeCompra />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+function renderPantallaProtegida() {
+  return render(
+    <MemoryRouter initialEntries={['/ordenes-compra']}>
+      <Routes>
+        <Route
+          path="/ordenes-compra"
+          element={
+            <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+              <OrdenesDeCompra />
+            </RutaProtegida>
+          }
+        />
+        <Route path="/" element={<div>Inicio (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  usuarioActual = usuarioFixture()
+})
+
+describe('OrdenesDeCompra — listado', () => {
+  it('muestra la fila con número, proveedor, punto de venta y estado', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('12')
+    const fila = screen.getByText('12').closest('tr')!
+    expect(within(fila).getByText('Proveedor Uno SA')).toBeInTheDocument()
+    expect(within(fila).getByText('Local Centro')).toBeInTheDocument()
+    expect(within(fila).getByText('Enviada')).toBeInTheDocument()
+  })
+
+  it('una orden sin número muestra #id', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/ordenes-compra?') ? Promise.resolve(paginaFixture({ items: [ordenFixture({ numero: null })] })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('#1')).toBeInTheDocument()
+  })
+
+  it('sin resultados muestra el estado vacío', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/ordenes-compra?') ? Promise.resolve(paginaFixture({ items: [], total: 0 })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('No hay órdenes de compra que coincidan con los filtros.')).toBeInTheDocument()
+  })
+})
+
+describe('OrdenesDeCompra — filtros (react-async-state regla 2, mutation-proof-tests regla 7)', () => {
+  it('una respuesta desactualizada nunca pisa la más reciente', async () => {
+    let resolverPrimera: (v: PaginaDeOrdenesDeCompra) => void = () => {}
+    const primeraPendiente = new Promise<PaginaDeOrdenesDeCompra>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (!ruta.startsWith('/ordenes-compra?')) return undefined
+      llamadas += 1
+      if (llamadas === 1) return Promise.resolve(paginaFixture())
+      if (llamadas === 2) return primeraPendiente
+      if (llamadas === 3) return Promise.resolve(paginaFixture({ items: [ordenFixture({ id: 3, numero: 999 })] }))
+      return Promise.reject(new Error('llamada inesperada'))
+    })
+
+    renderPantalla()
+    await screen.findByLabelText('Estado')
+
+    // 1ra: cambia estado (queda pendiente, lenta).
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Enviada')
+    // 2da: lo cambia de nuevo — dispara una generación MÁS NUEVA, que resuelve rápido.
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Cerrada')
+
+    await waitFor(() => expect(screen.getByText('999')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverPrimera(paginaFixture({ items: [ordenFixture({ id: 2, numero: 777 })] }))
+      await primeraPendiente
+    })
+    expect(screen.getByText('999')).toBeInTheDocument()
+    expect(screen.queryByText('777')).not.toBeInTheDocument()
+  })
+})
+
+describe('OrdenesDeCompra — pager', () => {
+  it('está deshabilitado en ambos bordes cuando hay una sola página', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('12')
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
+  it('navega entre páginas, con "Anterior"/"Siguiente" habilitados solo del lado correcto', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/ordenes-compra?')) {
+        const paginaSolicitada = ruta.includes('pagina=2') ? 2 : 1
+        return Promise.resolve(paginaFixture({ total: 50, pagina: paginaSolicitada, tamanio: 25 }))
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderPantalla()
+
+    await screen.findByText(/Página 1 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 2 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+})
+
+describe('OrdenesDeCompra — "Nueva orden de compra" (Admin-only)', () => {
+  it('Admin ve el botón; Vendedor no', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    expect(await screen.findByRole('button', { name: 'Nueva orden de compra' })).toBeInTheDocument()
+  })
+
+  it('un Vendedor no ve "Nueva orden de compra"', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('12')
+    expect(screen.queryByRole('button', { name: 'Nueva orden de compra' })).not.toBeInTheDocument()
+  })
+})
+
+describe('OrdenesDeCompra — role gating (mismo gate que /compras: Politicas.OperacionDePos)', () => {
+  it('un Vendedor llega a /ordenes-compra', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    mockearRutasBase()
+    renderPantallaProtegida()
+
+    await screen.findByText('12')
+    expect(screen.queryByText('Inicio (redirigido)')).not.toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/OrdenesDeCompra.tsx
+++ b/src/Ways.Web/src/paginas/OrdenesDeCompra.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { api, ErrorApi } from '../api/cliente'
+import {
+  claseDeBadgeDeEstadoOrdenCompra,
+  clienteDeOrdenesDeCompra,
+  etiquetaDeEstadoOrdenCompra,
+  filtrosDeOrdenesDeCompraVacios,
+  type FiltrosDeOrdenesDeCompra,
+} from '../api/ordenesDeCompra'
+import { ROL } from '../api/tipos'
+import type { EstadoOrdenCompra, OrdenDeCompraListada, PaginaDe, PaginaDeOrdenesDeCompra, ProveedorListado, PuntoVentaListado } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const OPCIONES_ESTADO: { valor: EstadoOrdenCompra | ''; etiqueta: string }[] = [
+  { valor: '', etiqueta: 'Todos' },
+  { valor: 'Borrador', etiqueta: 'Borrador' },
+  { valor: 'Enviada', etiqueta: 'Enviada' },
+  { valor: 'RecibidaParcial', etiqueta: 'Recibida parcial' },
+  { valor: 'Cerrada', etiqueta: 'Cerrada' },
+  { valor: 'Anulada', etiqueta: 'Anulada' },
+]
+
+function formatearFecha(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleDateString('es-AR') : '—'
+}
+
+/**
+ * Listado de órdenes de compra (stage-16-ordenes-de-compra, Slice 6; design: Web composition,
+ * decisión 16): filtros proveedor/punto de venta/estado/fecha + pager (mismo shape que
+ * `CuentaCorrienteDeProveedor.tsx`/`Compras.tsx`), entrada al editor de borrador. La ruta sigue
+ * `Politicas.OperacionDePos` (el gate de lectura, `RutaProtegida` con los tres roles operativos) —
+ * `puedeEscribir` oculta "Nueva orden" como defensa en profundidad cosmética, la política de
+ * escritura real es `GestionDeCatalogo` del lado del servidor.
+ */
+export function OrdenesDeCompra() {
+  const { usuario } = useAuth()
+  const puedeEscribir = usuario !== null && usuario.rolId === ROL.Admin
+  const navigate = useNavigate()
+
+  const [proveedores, setProveedores] = useState<ProveedorListado[] | null>(null)
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDeOrdenesDeCompra>(filtrosDeOrdenesDeCompraVacios())
+
+  const [pagina, setPagina] = useState<PaginaDeOrdenesDeCompra | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PaginaDe<ProveedorListado>>('/proveedores?tamanio=200')
+      .then((p) => {
+        if (!vigente) return
+        setProveedores(p.items)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setProveedores([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los proveedores.'))
+      })
+
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // regla 2: cada cambio de filtro/página dispara una nueva consulta — una respuesta
+  // desactualizada nunca puede pisar la más reciente.
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeOrdenesDeCompra
+      .listar(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las órdenes de compra.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const proveedorPorId: Record<number, ProveedorListado> = {}
+  for (const p of proveedores ?? []) proveedorPorId[p.id] = p
+
+  const puntoVentaPorId: Record<number, PuntoVentaListado> = {}
+  for (const pv of puntosVenta ?? []) puntoVentaPorId[pv.id] = pv
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeOrdenesDeCompra, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  const herramientas = puedeEscribir ? (
+    <nav className="p-2 d-flex gap-2">
+      <button
+        type="button"
+        className="btn btn-sm btn-success rounded-0 text-nowrap"
+        onClick={() => navigate('/ordenes-compra/nueva')}
+      >
+        Nueva orden de compra
+      </button>
+    </nav>
+  ) : undefined
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Órdenes de compra" variante="inverse" herramientas={herramientas}>
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorReferencia}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="oc-filtro-proveedor">
+              Proveedor
+            </label>
+            <select
+              id="oc-filtro-proveedor"
+              className="form-select rounded-0"
+              value={filtros.idProveedor ?? ''}
+              onChange={(e) => cambiarFiltro({ idProveedor: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(proveedores ?? []).map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.razonSocial}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="oc-filtro-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="oc-filtro-punto-venta"
+              className="form-select rounded-0"
+              value={filtros.idPuntoVenta ?? ''}
+              onChange={(e) => cambiarFiltro({ idPuntoVenta: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="oc-filtro-estado">
+              Estado
+            </label>
+            <select
+              id="oc-filtro-estado"
+              className="form-select rounded-0"
+              value={filtros.estado ?? ''}
+              onChange={(e) => cambiarFiltro({ estado: e.target.value === '' ? null : (e.target.value as EstadoOrdenCompra) })}
+            >
+              {OPCIONES_ESTADO.map((o) => (
+                <option key={o.valor} value={o.valor}>
+                  {o.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="oc-filtro-desde">
+              Desde
+            </label>
+            <input
+              id="oc-filtro-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="oc-filtro-hasta">
+              Hasta
+            </label>
+            <input
+              id="oc-filtro-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+        </div>
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Número</th>
+                    <th>Proveedor</th>
+                    <th>Punto de venta</th>
+                    <th>Estado</th>
+                    <th>Fecha de emisión</th>
+                    <th>Fecha esperada</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((o: OrdenDeCompraListada) => (
+                    <tr key={o.id}>
+                      <td>
+                        <Link className="link-underline-opacity-0" to={`/ordenes-compra/${o.id}`}>
+                          {o.numero ?? `#${o.id}`}
+                        </Link>
+                      </td>
+                      <td>{proveedorPorId[o.idProveedor]?.razonSocial ?? `Proveedor #${o.idProveedor}`}</td>
+                      <td>{puntoVentaPorId[o.idPuntoVenta]?.nombre ?? `PV #${o.idPuntoVenta}`}</td>
+                      <td>
+                        <span className={`badge rounded-0 ${claseDeBadgeDeEstadoOrdenCompra(o.estado)}`}>
+                          {etiquetaDeEstadoOrdenCompra(o.estado)}
+                        </span>
+                      </td>
+                      <td>{formatearFecha(o.fechaEmision)}</td>
+                      <td>{formatearFecha(o.fechaEsperada)}</td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="text-center text-muted py-4">
+                        No hay órdenes de compra que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} orden(es)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/Reposicion.test.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Reposicion } from './Reposicion'
 import { RutaProtegida } from '../auth/RutaProtegida'
@@ -285,5 +285,87 @@ describe('Reposicion — role gating (mismo gate que Vencimientos: Politicas.Lec
 
     expect(await screen.findByText('Inicio (redirigido)')).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText('Reposición')).not.toBeInTheDocument())
+  })
+})
+
+// stage-16-ordenes-de-compra, Slice 6 (design decisión 16, tasks.md decisión 24; mutation target
+// #34c): el botón "Generar OC" por grupo — gateado a Admin, ausente en "Sin proveedor", y el
+// mapeo reposición→OC probado de punta a punta contra la pantalla destino real (nunca un
+// `useNavigate` mockeado: la lección del Link de la 15 es que el destino lee `location.state`, no
+// un fetch propio).
+function ProbeDeOrdenDeCompraNueva() {
+  const location = useLocation()
+  const state = location.state as { idProveedor: number; idPuntoVenta: number; items: { idArticulo: number; cantidadPedida: number }[] } | null
+  if (state === null) return <div>Sin precarga</div>
+  return (
+    <div>
+      <div>idProveedor={state.idProveedor}</div>
+      <div>idPuntoVenta={state.idPuntoVenta}</div>
+      <div>items={JSON.stringify(state.items)}</div>
+    </div>
+  )
+}
+
+function renderReposicionConDestino() {
+  return render(
+    <MemoryRouter initialEntries={['/reportes/stock/reposicion']}>
+      <Routes>
+        <Route path="/reportes/stock/reposicion" element={<Reposicion />} />
+        <Route path="/ordenes-compra/nueva" element={<ProbeDeOrdenDeCompraNueva />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Reposicion — "Generar OC" (stage-16-ordenes-de-compra, Slice 6)', () => {
+  it('un Admin ve el botón por grupo con proveedor; "Sin proveedor" nunca lo ofrece (mutation target #34c, parte 1)', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Admin, rol: 'Admin' })
+    const filaConProveedor = filaFixture({ idArticulo: 1, idProveedor: 1, proveedor: 'Proveedor Uno' })
+    const filaSinProveedor = filaFixture({ idArticulo: 2, idProveedor: null, proveedor: null })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaConProveedor, filaSinProveedor]))
+      return undefined
+    })
+    renderReposicionConDestino()
+
+    const filaProveedorUno = (await screen.findByText('Proveedor Uno (1)')).closest('tr')!
+    expect(within(filaProveedorUno).getByRole('button', { name: 'Generar OC' })).toBeInTheDocument()
+
+    const filaSinProveedorHeader = screen.getByText('Sin proveedor (1)').closest('tr')!
+    expect(within(filaSinProveedorHeader).queryByRole('button', { name: 'Generar OC' })).not.toBeInTheDocument()
+  })
+
+  it('un Supervisor no ve ningún botón "Generar OC" (mutation target #34c, parte 2) — la pantalla sigue igual', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Supervisor, rol: 'Supervisor' })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) {
+        return Promise.resolve(reposicionFixture([filaFixture({ idProveedor: 1, proveedor: 'Proveedor Uno' })]))
+      }
+      return undefined
+    })
+    renderReposicionConDestino()
+
+    await screen.findByText('Yerba mate 1kg')
+    expect(screen.queryByRole('button', { name: 'Generar OC' })).not.toBeInTheDocument()
+  })
+
+  it('al click navega a /ordenes-compra/nueva con idProveedor/idPuntoVenta/items ya resueltos, excluyendo sugerido = null (mutation target #34c, parte 3)', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Admin, rol: 'Admin' })
+    const filaConSugerido = filaFixture({ idArticulo: 1, idProveedor: 5, proveedor: 'Proveedor Cinco', sugerido: 17 })
+    const filaSinSugerido = filaFixture({ idArticulo: 2, idProveedor: 5, proveedor: 'Proveedor Cinco', sugerido: null })
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/reportes/stock/reposicion?')) return Promise.resolve(reposicionFixture([filaConSugerido, filaSinSugerido]))
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderReposicionConDestino()
+
+    await usuario.click(await screen.findByRole('button', { name: 'Generar OC' }))
+
+    expect(await screen.findByText('idProveedor=5')).toBeInTheDocument()
+    expect(screen.getByText('idPuntoVenta=10')).toBeInTheDocument()
+    const items = JSON.parse(screen.getByText(/^items=/).textContent!.replace('items=', ''))
+    expect(items).toHaveLength(1)
+    expect(items[0].idArticulo).toBe(1)
   })
 })

--- a/src/Ways.Web/src/paginas/Reposicion.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.tsx
@@ -1,12 +1,16 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import { clienteDeReportes, rutasDeExportacion } from '../api/reportes'
+import { ROL } from '../api/tipos'
 import type { PuntoVentaListado, Reposicion as ReposicionRespuesta } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
 import { BotonDeDescarga } from '../componentes/BotonDeDescarga'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
-import { agruparPorProveedor } from './agruparPorProveedor'
+import { agruparPorProveedor, type GrupoDeReposicion } from './agruparPorProveedor'
+import { itemsDeOrdenDesdeFilasDeReposicion } from './filasDeReposicionAOrdenDeCompra'
 
 function formatearCantidad(valor: number): string {
   return valor.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 3 })
@@ -27,8 +31,22 @@ function formatearCantidadNullable(valor: number | null): string {
  * el servidor (`agruparPorProveedor`, design decisión 4) — nunca un sort del lado del cliente.
  * Misma política que `/tablero`/`/reportes/existencias` (`Politicas.LecturaDeReportes`:
  * Supervisor + Admin).
+ *
+ * stage-16-ordenes-de-compra, Slice 6 (design decisión 16, tasks.md decisión 24): el botón "Generar
+ * OC" por grupo se gatea a `grupo.idProveedor !== null` **y** `usuario.rolId === ROL.Admin` — las
+ * escrituras de OC son Admin-only del lado del servidor (`GestionDeCatalogo`); un Supervisor sigue
+ * viendo esta pantalla exactamente igual que hoy, solo sin el botón. El mapeo reposición→OC es
+ * ENTERAMENTE client-side (`itemsDeOrdenDesdeFilasDeReposicion`) — postea a la `POST
+ * /api/ordenes-compra` ya existente, sin tocar `GET /api/reportes/stock/reposicion`. El `Link`/
+ * `navigate` de entrada pasa `state` con los datos ya resueltos (lección de la Slice 6 de la etapa
+ * 15: nunca un destino que dependa de un fetch decorativo para recuperar lo que el origen ya
+ * tenía).
  */
 export function Reposicion() {
+  const navigate = useNavigate()
+  const { usuario } = useAuth()
+  const esAdmin = usuario !== null && usuario.rolId === ROL.Admin
+
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
   const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
 
@@ -87,6 +105,17 @@ export function Reposicion() {
   }, [cargar])
 
   const grupos = reposicion ? agruparPorProveedor(reposicion.filas) : []
+
+  // El "Sin proveedor" (idProveedor null) nunca llega acá: no hay a quién enviarle la OC
+  // (ordenes-de-compra/spec.md: "The Sin proveedor bucket cannot produce an OC") — el botón ni se
+  // renderiza para ese grupo (mutation target #34c, parte 1). Pasa el header + los items ya
+  // mapeados por `location.state`, nunca un fetch redundante en la pantalla destino.
+  function generarOrdenDeCompra(grupo: GrupoDeReposicion) {
+    if (grupo.idProveedor === null || idPuntoVenta === null) return
+    navigate('/ordenes-compra/nueva', {
+      state: { idProveedor: grupo.idProveedor, idPuntoVenta, items: itemsDeOrdenDesdeFilasDeReposicion(grupo.filas) },
+    })
+  }
 
   return (
     <div className="container-fluid py-4">
@@ -158,7 +187,20 @@ export function Reposicion() {
                       <Fragment key={grupo.idProveedor ?? 'sin-proveedor'}>
                         <tr className="table-secondary">
                           <td colSpan={5}>
-                            {grupo.proveedor ?? 'Sin proveedor'} ({grupo.filas.length})
+                            <div className="d-flex justify-content-between align-items-center">
+                              <span>
+                                {grupo.proveedor ?? 'Sin proveedor'} ({grupo.filas.length})
+                              </span>
+                              {grupo.idProveedor !== null && esAdmin && (
+                                <button
+                                  type="button"
+                                  className="btn btn-sm btn-outline-primary rounded-0"
+                                  onClick={() => generarOrdenDeCompra(grupo)}
+                                >
+                                  Generar OC
+                                </button>
+                              )}
+                            </div>
                           </td>
                         </tr>
                         {grupo.filas.map((fila) => (

--- a/src/Ways.Web/src/paginas/filasDeReposicionAOrdenDeCompra.test.ts
+++ b/src/Ways.Web/src/paginas/filasDeReposicionAOrdenDeCompra.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { itemsDeOrdenDesdeFilasDeReposicion } from './filasDeReposicionAOrdenDeCompra'
+import type { FilaDeReposicion } from '../api/tipos'
+
+function filaFixture(sobrescribir: Partial<FilaDeReposicion> = {}): FilaDeReposicion {
+  return {
+    idArticulo: 100,
+    articulo: 'Yerba mate 1kg',
+    cantidad: 3,
+    minimo: 10,
+    reposicion: 20,
+    sugerido: 17,
+    idProveedor: 1,
+    proveedor: 'Proveedor Uno',
+    consumoDiarioPromedio: null,
+    diasDeCobertura: null,
+    ...sobrescribir,
+  }
+}
+
+describe('itemsDeOrdenDesdeFilasDeReposicion', () => {
+  // Prueba el filtro `sugerido !== null` (mutation target #34c, parte 3): borrándolo, una fila sin
+  // reposición configurada entraría a la OC con `cantidadPedida` inventada en vez de desaparecer.
+  it('excluye las filas con sugerido = null, nunca las defaultea a cantidadPedida = 0', () => {
+    const filaSinSugerido = filaFixture({ idArticulo: 1, sugerido: null })
+    const filaConSugerido = filaFixture({ idArticulo: 2, sugerido: 17 })
+
+    const items = itemsDeOrdenDesdeFilasDeReposicion([filaSinSugerido, filaConSugerido])
+
+    expect(items).toHaveLength(1)
+    expect(items[0].idArticulo).toBe(2)
+  })
+
+  it('un sugerido genuino de 0 SÍ se incluye — no es lo mismo que null', () => {
+    const filaConSugeridoCero = filaFixture({ idArticulo: 3, sugerido: 0 })
+
+    const items = itemsDeOrdenDesdeFilasDeReposicion([filaConSugeridoCero])
+
+    expect(items).toHaveLength(1)
+    expect(items[0].cantidadPedida).toBe(0)
+  })
+
+  it('mapea IdArticulo/Sugerido → IdArticulo/CantidadPedida, con descripción del artículo y sin costo', () => {
+    const fila = filaFixture({ idArticulo: 55, articulo: 'Aceite 900ml', sugerido: 9 })
+
+    const [item] = itemsDeOrdenDesdeFilasDeReposicion([fila])
+
+    expect(item).toEqual({
+      idArticulo: 55,
+      descripcion: 'Aceite 900ml',
+      cantidadPedida: 9,
+      costoUnitarioEstimado: null,
+    })
+  })
+
+  it('un grupo vacío produce un array vacío', () => {
+    expect(itemsDeOrdenDesdeFilasDeReposicion([])).toEqual([])
+  })
+
+  it('preserva el orden original de las filas', () => {
+    const filaA = filaFixture({ idArticulo: 1, sugerido: 5 })
+    const filaB = filaFixture({ idArticulo: 2, sugerido: 8 })
+
+    const items = itemsDeOrdenDesdeFilasDeReposicion([filaA, filaB])
+
+    expect(items.map((i) => i.idArticulo)).toEqual([1, 2])
+  })
+})

--- a/src/Ways.Web/src/paginas/filasDeReposicionAOrdenDeCompra.ts
+++ b/src/Ways.Web/src/paginas/filasDeReposicionAOrdenDeCompra.ts
@@ -1,0 +1,23 @@
+import type { FilaDeReposicion, LineaDeOrdenSolicitada } from '../api/tipos'
+
+/**
+ * Mapea las filas de un grupo de `Reposicion.tsx` a las líneas de una nueva orden de compra
+ * (stage-16-ordenes-de-compra, Slice 6; design.md: "posting `filas.filter(f => f.sugerido !==
+ * null)` mapped `{IdArticulo, Sugerido} → {IdArticulo, CantidadPedida}`", decisión 16;
+ * ordenes-de-compra/spec.md: "Pre-Load From The Reposición List Is Read-Only And Unidirectional").
+ *
+ * Filas con `sugerido = null` quedan EXCLUIDAS, nunca defaulteadas a `cantidadPedida = 0`
+ * (mutation target #34c, parte 3) — el mapeo entero es client-side y unidireccional: la reposición
+ * nunca aprende del resultado de la OC. Sin `costoUnitarioEstimado`: la reposición no trae precio,
+ * la OC lo deja sin cotizar (`null`, jamás `0` — `dto-contract-honesty`).
+ */
+export function itemsDeOrdenDesdeFilasDeReposicion(filas: FilaDeReposicion[]): LineaDeOrdenSolicitada[] {
+  return filas
+    .filter((fila) => fila.sugerido !== null)
+    .map((fila) => ({
+      idArticulo: fila.idArticulo,
+      descripcion: fila.articulo,
+      cantidadPedida: fila.sugerido as number,
+      costoUnitarioEstimado: null,
+    }))
+}


### PR DESCRIPTION
## Resumen

- `OrdenesDeCompra.tsx` (listado paginado con filtros) y `OrdenDeCompra.tsx` (borrador + detalle + enviar/cerrar/anular + Registrar recepción), con generación gating en todos los fetches, doble defensa de reentrada en los CUATRO submits (ref same-tick + disabled), guards de acciones espejo de la máquina de estados del server, y refresco con la verdad del server tras cada acción.
- Botón "Generar OC" en `Reposicion.tsx` por grupo de proveedor, GATEADO A ADMIN (OD8/T5), "Sin proveedor" sin botón, mapeo puro `filasDeReposicionAOrdenDeCompra` (sugerido=null excluido) con test colocado y navegación con state leída por el destino en test real.
- Pre-carga de recepción en `CompraEditor.tsx` desde `?idOrdenCompra` con los PENDIENTES por artículo (no las pedidas), `idOrdenCompra` viajando en el POST y badge de vínculo.
- Cliente `ordenesDeCompra.ts` espejo del contrato del server, `fechaIsoConOffset` en filtros (regla 10). Cero cambios de backend.

## Judgment-day

- Juez B ronda 1: **0 hallazgos en 10 ciclos de mutación** — todas las clases que mataron slices previos acá mueren de fábrica (las lecciones rindieron).
- Juez A ronda 1: 2 WARNINGs — `puedeRecepcionar` sin `puedeEscribir` (único gate sin la regla; el server bloqueaba igual) y el test same-tick solo en Enviar. Fix `74472a3`+`6f148b1`.
- Pasada B del delta: cazó **flakiness real** en el test nuevo de Guardar (1/3 corridas full — carrera de hidratación del `useEffect` de `encabezadoCompleto`, los hermanos se gatean por flag síncrono). Cerrada determinista en `a9f4f21` (waitFor de habilitación+hidratación; 3 corridas full consecutivas verdes; el mutante del guard sigue muriendo).
- Re-ronda A final: limpia.

vitest full **796/796** ×3 consecutivas · `npm run build` limpio · backend intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)