### PR TITLE
feat(presupuestos): ABM y numeracion con la serie PRES (etapa 17, slice 2)

### DIFF
--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -539,10 +539,10 @@ draft/enviar/anular/list/detail lifecycle over the schema of slice 1, own series
   **DONE** — `git status` shows zero new files under `Migraciones/`;
   `NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1` asserts
   `HasPendingModelChanges() == false`, green.
-- [x] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+- [ ] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
   by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
   `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
-- [x] 2.23 Open PR #2 `feat/stage17-slice2-presupuestos-abm`, merge after a clean round. — **NOT
+- [ ] 2.23 Open PR #2 `feat/stage17-slice2-presupuestos-abm`, merge after a clean round. — **NOT
   run by this apply batch**, same reason as 2.22.
 
 **DEVIATION REGISTERED (process rule 15) — one file outside the slice's own enumerated task list

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -407,65 +407,156 @@ overflows. **Done** = tests green + `judgment-day` clean round + PR merged.
 draft/enviar/anular/list/detail lifecycle over the schema of slice 1, own series `'PRES'`.
 **Rollback**: endpoints + service disappear, schema untouched.
 
-- [ ] 2.1 Create `ContratosDePresupuesto.cs` — `SolicitudDePresupuesto`/`LineaDePresupuesto`/
+- [x] 2.1 Create `ContratosDePresupuesto.cs` — `SolicitudDePresupuesto`/`LineaDePresupuesto`/
   `SolicitudDeEnvio`/`ItemDePresupuesto`/`PresupuestoDetalle`/`PresupuestoParaVenta`. `orden`
   never travels; no money in the create request (`dto-contract-honesty` rule 1).
   *(design.md:180-202)*
-- [ ] 2.2 Create `ServicioDePresupuestos.cs` — `CrearBorradorAsync`: resolves prices via
+
+  **DONE, plus two additions registered (never named by design's Interfaces/Contracts section,
+  same class of gap-filling as OC slice 5's own listado/pagina types)**: `PresupuestoListado`
+  (narrower row DTO for `GET /` — carries `Vencido`/`Convertible` too, cheap here since a zona is
+  resolved once per **distinct** punto de venta of the page, task 2.9) and `PaginaDePresupuestos`
+  (`Items`/`Total`/`Pagina`/`Tamanio`, same shape as `PaginaDeOrdenesDeCompra`). Neither contradicts
+  design — both are the shape `GET /api/presupuestos` (API Surface table) needs and design never
+  spelled out.
+- [x] 2.2 Create `ServicioDePresupuestos.cs` — `CrearBorradorAsync`: resolves prices via
   `ServicioDeOfertas` at save time (mirrors the checkout's own price-at-decide-time rule),
   persists `estado = borrador`, `numero`/`fecha_envio`/`vencimiento` NULL.
   *(presupuestos/spec.md:36-39)*
-- [ ] 2.3 Same file: `EditarAsync` — full item replace-set under `SELECT … FOR UPDATE … WHERE
+- [x] 2.3 Same file: `EditarAsync` — full item replace-set under `SELECT … FOR UPDATE … WHERE
   estado = 'borrador'`; `orden` server-assigned 1..N. *(design.md mutation targets 12-14,
   presupuestos/spec.md:52-66)*
-- [ ] 2.4 Same file: `EnviarAsync` — `CreateExecutionStrategy` ⇒
+- [x] 2.4 Same file: `EnviarAsync` — `CreateExecutionStrategy` ⇒
   `AsignarComprometidoAsync(db, tenant, pv, "PRES")` in its **own** transaction, then
   `EstrategiaSinReintento` ⇒ `BEGIN UPDATE presupuestos SET numero, fecha_envio, vencimiento,
   estado = 'enviado' WHERE id AND tenant AND estado = 'borrador' AND id_punto_venta = $pv
   RETURNING numero`. 0 rows ⇒ reclassify under a read (409). *(design.md:278-283, mutation
   targets 15-17)*
-- [ ] 2.5 Same file: `hoy` resolved via `ParametroConocido.ZonaHoraria` /
+
+  **DONE.** Both branches of the 0-rows reclassification (the pre-check at `preLectura.Estado !=
+  Borrador` and the post-guard `numeroAsignado is null`) reuse the SAME domain code
+  `presupuesto_ya_enviado`, deliberately symmetric — mirrors OC's `orden_compra_no_enviable`
+  reuse (decision 19-class generality, tasks.md precedent).
+- [x] 2.5 Same file: `hoy` resolved via `ParametroConocido.ZonaHoraria` /
   `ResolverZonaAsync`; `vencimiento >= hoy(zona del PV)` required at `enviar`, else
   `400 vencimiento_invalido`. *(design.md:19, mutation targets 18-19)*
-- [ ] 2.6 Same file: `presupuesto_sin_items` guard at `enviar` (400 on an empty draft).
+- [x] 2.6 Same file: `presupuesto_sin_items` guard at `enviar` (400 on an empty draft).
   *(mutation target 21)*
-- [ ] 2.7 Same file: `AnularAsync` — `borrador`/`enviado` → `anulado`; `convertido` → `409`
+- [x] 2.7 Same file: `AnularAsync` — `borrador`/`enviado` → `anulado`; `convertido` → `409`
   (OD8/T1, decision 4 above). *(presupuestos/spec.md:200-214)*
-- [ ] 2.8 Same file: list/detail read model — `ConstruirQuery` with `idPuntoVenta`/`idCliente`/
+
+  **DONE**, domain code `presupuesto_no_anulable` (never named by design/spec — this slice names
+  it, same convention as CONFLICT #3/#4). A single guarded `UPDATE … WHERE estado IN
+  ('borrador','enviado')` is the only statement; `convertido` is structurally excluded from the
+  `IN` (no separate branch needed since it can't exist before Slice 3 ships the writer).
+- [x] 2.8 Same file: list/detail read model — `ConstruirQuery` with `idPuntoVenta`/`idCliente`/
   `estado`/`vencido`/`desde`/`hasta` filters, `ThenByDescending(p => p.Id)` tiebreaker; derived
   `Vencido`/`Convertible` per row. *(design.md:220-227, mutation target 59, presupuesto half)*
-- [ ] 2.9 Same file: `vencido` filter **requires** `idPuntoVenta` (400
+- [x] 2.9 Same file: `vencido` filter **requires** `idPuntoVenta` (400
   `punto_venta_requerido`); `Vencido` resolved per **distinct** `id_punto_venta` of the page
   (OD9/T5). *(design.md:80)*
-- [ ] 2.10 Test: two concurrent `enviar` on **distinct** borrador presupuestos, same PV → two
+
+  **DONE**, with the `vencido` filter itself pushed to SQL using the SAME `ReglaDePresupuestos`
+  formula (`estado = enviado AND vencimiento < hoy`) against the single PV the filter requires —
+  never a second parallel derivation. Per-row `Vencido`/`Convertible` on every returned row
+  (filtered or not) always derive in memory from the distinct-PV zona dictionary, single source
+  of truth.
+- [x] 2.10 Test: two concurrent `enviar` on **distinct** borrador presupuestos, same PV → two
   distinct numbers, no 409. *(presupuestos/spec.md:84-87, mutation target 15)*
-- [ ] 2.11 Test: the assigner call runs **before**, not inside, the `enviar` transaction.
+
+  **DONE** — `ServicioDePresupuestosTests.DosEnviarConcurrentesDePresupuestosDistintosEnElMismoPuntoDeVentaDanNumerosDistintosSin409`.
+- [x] 2.11 Test: the assigner call runs **before**, not inside, the `enviar` transaction.
   *(mutation target 16)*
-- [ ] 2.12 Test: `AND id_punto_venta = $pv` in the `enviar UPDATE` — a concurrent `PUT` moving
+
+  **DONE** — proven by the SAME test as 2.10's burnt-number sibling
+  (`DosEnviarConcurrentesDelMismoPresupuestoDanUn200YUn409ConNumeroQuemado`): the loser's number
+  survives as a permanent gap even though its `EjecutarEnvioAsync` transaction rolls back to
+  nothing — only possible if the draw already committed independently, outside that transaction.
+- [x] 2.12 Test: `AND id_punto_venta = $pv` in the `enviar UPDATE` — a concurrent `PUT` moving
   the PV lands the number in the wrong series if removed. *(mutation target 17)*
-- [ ] 2.13 Test: `-03:00` boundary — `RelojFijo(2026-09-30T02:00:00Z)`, PV
+
+  **DONE** — `ServicioDePresupuestosTests.UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja`,
+  same `DbTransactionInterceptor`-forced-pause shape as OC's own target-#11 test (verbatim
+  precedent, retargeted to `/api/presupuestos`).
+- [x] 2.13 Test: `-03:00` boundary — `RelojFijo(2026-09-30T02:00:00Z)`, PV
   `America/Argentina/Buenos_Aires` ⇒ local `29th`; mirror at `+05:30`. *(mutation target 19,
   `mutation-proof-tests` rule 10)*
-- [ ] 2.14 Test: expiry-day boundary — `vencimiento == hoy` ⇒ still convertible (`v < hoy`, not
+
+  **DONE** — two tests, `EnviarEnLaZonaMenosTresElVencimientoDelDiaLocalEsAceptadoYElDiaAnteriorRechazado`
+  (default zona, no seeding needed) and its `+05:30` (`Asia/Kolkata`, no DST) mirror, which seeds
+  a `Parametro` row directly — the mirror's conclusion inverts, proving only a real-offset fixture
+  can see this class of regression.
+- [x] 2.14 Test: expiry-day boundary — `vencimiento == hoy` ⇒ still convertible (`v < hoy`, not
   `v <= hoy`). *(mutation target 20)*
-- [ ] 2.15 Test: empty-quote `enviar` refused (400), draws no number. *(mutation target 21)*
-- [ ] 2.16 Test: raw duplicate `ux_presupuestos_numero` through the real writer path →
+
+  **DONE** — `EnviarConVencimientoIgualAHoyEsAceptado` (integration-level; the domain truth table
+  itself is Slice 1's `ReglaDePresupuestosTests`).
+- [x] 2.15 Test: empty-quote `enviar` refused (400), draws no number. *(mutation target 21)*
+
+  **DONE** — `EnviarUnPresupuestoSinItemsEsRechazado400PresupuestoSinItemsSinConsumirNumero`.
+- [x] 2.16 Test: raw duplicate `ux_presupuestos_numero` through the real writer path →
   translated `numero_de_presupuesto_duplicado`. *(presupuestos/spec.md:95-99)*
-- [ ] 2.17 Sibling-seed replace-set test (rule 12c): a second presupuesto of the same tenant,
+
+  **SATISFIED BY PRE-EXISTING SLICE 1 COVERAGE, no duplicate test written.**
+  `ManejadorDeErroresPresupuestosTests` (task 1.34) already asserts the raw `23505` → translated
+  `numero_de_presupuesto_duplicado` through both the EF and the raw-ADO exception path — the
+  translation lives entirely in `ManejadorDeErrores` (unmodified this slice) and is unreachable
+  through the real `enviar` writer path under normal operation (the assigner's own atomic
+  `UPDATE … RETURNING` guarantees distinct numbers even under the two races of 2.10-2.12) — the
+  constraint is a schema backstop, proven out-of-band, exactly as designed (Backstop Map).
+- [x] 2.17 Sibling-seed replace-set test (rule 12c): a second presupuesto of the same tenant,
   with its own items, is asserted intact by exact count and identity after a `PUT` on the
   first. *(mutation target 13)*
-- [ ] 2.18 Test: `PUT` on an `enviado` presupuesto → 409 (`borrador`-only mutation).
+
+  **DONE** — `ElReplaceSetReemplazaLosItemsCompletosSinTocarUnPresupuestoHermano`.
+- [x] 2.18 Test: `PUT` on an `enviado` presupuesto → 409 (`borrador`-only mutation).
   *(mutation target 12, presupuestos/spec.md:63-66)*
-- [ ] 2.19 Test: request-supplied `orden` is ignored; `ux_items_presupuesto_orden` is reachable
+
+  **DONE** — `EditarUnPresupuestoEnviadoEsRechazado409PresupuestoNoEditable`, domain code
+  `presupuesto_no_editable` (never named by design/spec — named here, same convention as 2.7).
+- [x] 2.19 Test: request-supplied `orden` is ignored; `ux_items_presupuesto_orden` is reachable
   only out-of-band, race-test exemption documented. *(mutation target 14)*
-- [ ] 2.20 [P] Read-model rules 12b/12c: pagination with tied `fecha_emision` (`RelojFijo`) ⇒
+
+  **FINDING REGISTERED — no dedicated test, and none is possible.** `LineaDePresupuesto` (task
+  2.1) carries no `Orden` field at all — the HTTP contract structurally cannot submit one, so
+  "request-supplied `orden` is ignored" has no falsifiable request to construct (stronger than
+  "ignored": unrepresentable). `ConstruirItems` (`ServicioDePresupuestos.cs`) assigns `Orden =
+  1..N` unconditionally from array position. The out-of-band race-test exemption on
+  `ux_items_presupuesto_orden` is the Backstop Map's own verdict (design.md, same family as
+  `ux_items_orden_compra_orden`) — nothing further to add this slice.
+- [x] 2.20 [P] Read-model rules 12b/12c: pagination with tied `fecha_emision` (`RelojFijo`) ⇒
   page 2 repeats/skips nothing; each filter proven with asymmetric seeds; every positional
   field of `PresupuestoDetalle` read back with pairwise-distinct values. *(design.md:505,
   mutation target 59, presupuesto half)*
-- [ ] 2.21 **GATE GUARD** — zero new files under `Migraciones/`; `has-pending-model-changes`
+
+  **DONE** — `PaginacionConFechaEmisionEmpatadaNoRepiteNiSalteaFilas` (tied-clock pagination) +
+  `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` (every field of
+  `PresupuestoDetalle`/`ItemDePresupuesto`, pairwise-distinct) + the `vencido`/`idPuntoVenta`
+  filter test (`UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina`).
+- [x] 2.21 **GATE GUARD** — zero new files under `Migraciones/`; `has-pending-model-changes`
   clean (schema untouched this slice).
-- [ ] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
-- [ ] 2.23 Open PR #2 `feat/stage17-slice2-presupuestos-abm`, merge after a clean round.
+
+  **DONE** — `git status` shows zero new files under `Migraciones/`;
+  `NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1` asserts
+  `HasPendingModelChanges() == false`, green.
+- [x] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+  by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
+  `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
+- [x] 2.23 Open PR #2 `feat/stage17-slice2-presupuestos-abm`, merge after a clean round. — **NOT
+  run by this apply batch**, same reason as 2.22.
+
+**DEVIATION REGISTERED (process rule 15) — one file outside the slice's own enumerated task list
+touched, expected and necessary.** `tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs`
+gains the four `/api/presupuestos` write routes in its allowlist (`POST /`, `PUT /{id:int}`,
+`POST /{id:int}/enviar`, `POST /{id:int}/anular`) — the omission guard (stage-5 task 1.7) fails the
+build otherwise, since this capability's group is `OperacionDePos` alone with nothing stacked
+(design decision 17/proposal decision 10), same class of entry as `/api/ventas/` already carries.
+Not named by any Slice 2 task individually, but load-bearing: skipping it would either fail this
+slice's own build or force a false-positive `GestionDeCatalogo` stack that contradicts decision 17.
+
+**Program.cs / DependencyInjection.cs**: `MapearPresupuestos()` registered after
+`MapearCuentaCorrienteDeProveedor()`; `ServicioDePresupuestos` registered `AddScoped`, same section
+— both additive, one line each, no other route/service touched.
 
 ---
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -486,6 +486,15 @@ draft/enviar/anular/list/detail lifecycle over the schema of slice 1, own series
   (default zona, no seeding needed) and its `+05:30` (`Asia/Kolkata`, no DST) mirror, which seeds
   a `Parametro` row directly — the mirror's conclusion inverts, proving only a real-offset fixture
   can see this class of regression.
+
+  **FINDING REGISTERED (mutation target 22) — no dedicated test, and none is possible**, same
+  convention as 2.19's target-14 registration. `ParametrosDeComando.Agregar`/`AgregarNulo`
+  (`ParametrosDeComando.cs:31-32`) route every `DateTimeOffset` — including `fecha_envio` — through
+  `Normalizar`, which unconditionally calls `ToUniversalTime()` before the raw-ADO write; there is
+  no hand-built-parameter code path that skips it. The design's own falsifier (design.md:541, "the
+  `-03:00` offset test") could never distinguish a mutant here from the healthy build, because
+  the mutation is structurally unreachable — the centralized helper normalizes every call site,
+  not just this one.
 - [x] 2.14 Test: expiry-day boundary — `vencimiento == hoy` ⇒ still convertible (`v < hoy`, not
   `v <= hoy`). *(mutation target 20)*
 
@@ -533,6 +542,21 @@ draft/enviar/anular/list/detail lifecycle over the schema of slice 1, own series
   `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` (every field of
   `PresupuestoDetalle`/`ItemDePresupuesto`, pairwise-distinct) + the `vencido`/`idPuntoVenta`
   filter test (`UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina`).
+
+  **DEVIATION REGISTERED (judgment-day, MAJOR, fixed) — 2nd variant of the rule-12b coincidence
+  class, this time by zero-discount, not by null/default.** The original
+  `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` asserted the doc-comment's
+  own "pairwise-distinguishable" claim with `Subtotal == Total == 550m` — no fixture seeded a
+  discount, so `DescuentoTotal` was always `0m`, and a `Subtotal`/`Total` field swap at either
+  construction site (`ServicioDePresupuestos.cs:715-717`'s `PresupuestoDetalle`, and its
+  `ProyectarListado` mirror which reads the same swapped `presupuesto.Total`) would have passed
+  green — the same failure shape rule 12b already names for null/default, now hitting a
+  coincidentally-equal non-null value instead. Fixed by seeding a real 20% `Oferta` on
+  `ctx.IdArticulo2` (via `POST /api/ofertas`, same helper shape as `OfertasResolucionTests`) so
+  the header reads `Subtotal = 550m`, `DescuentoTotal = 50m`, `Total = 500m` — pairwise-distinct —
+  asserted both on the detail response and on the matching `/api/presupuestos` listing row's
+  `Total`, closing the `ProyectarListado` mirror gap too. Mutation-proof: reverting the swap at
+  either construction site now fails this test.
 - [x] 2.21 **GATE GUARD** — zero new files under `Migraciones/`; `has-pending-model-changes`
   clean (schema untouched this slice).
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -563,7 +563,7 @@ draft/enviar/anular/list/detail lifecycle over the schema of slice 1, own series
   **DONE** — `git status` shows zero new files under `Migraciones/`;
   `NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1` asserts
   `HasPendingModelChanges() == false`, green.
-- [ ] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+- [x] 2.22 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
   by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
   `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
 - [ ] 2.23 Open PR #2 `feat/stage17-slice2-presupuestos-abm`, merge after a clean round. — **NOT

--- a/src/Ways.Api/Endpoints/PresupuestosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/PresupuestosEndpoints.cs
@@ -1,0 +1,73 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Ventas;
+using Ways.Domain.Ventas;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 2 (design: API Surface, decisión 17/proposal decisión
+/// 10). Grupo bajo <c>Politicas.OperacionDePos</c> ÚNICAMENTE — sin apilar
+/// <c>GestionDeCatalogo</c>, a diferencia de <c>OrdenesDeCompraEndpoints</c>: un Vendedor puede
+/// vender, y quotear/enviar/anular un presupuesto es vender (design: "un Vendedor tiene que poder
+/// vender"). <c>POST /{id:int}/para-venta</c> y la conversión llegan en la Slice 3.
+/// </summary>
+public static class PresupuestosEndpoints
+{
+    public static IEndpointRouteBuilder MapearPresupuestos(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/presupuestos")
+            .WithTags("Presupuestos")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapGet("/", (
+            ServicioDePresupuestos servicio,
+            int? idPuntoVenta,
+            int? idCliente,
+            EstadoPresupuesto? estado,
+            bool? vencido,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, idCliente, estado, vencido, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Lista presupuestos con filtros y paginado. 'vencido' requiere idPuntoVenta.");
+
+        grupo.MapGet("/{id:int}", (ServicioDePresupuestos servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerDetalleAsync(id, ct))
+        .WithSummary("Detalle de un presupuesto: header + items + Vencido/Convertible derivados.");
+
+        grupo.MapPost("/", async (
+            ServicioDePresupuestos servicio, SolicitudDePresupuesto solicitud, CancellationToken ct) =>
+        {
+            var creado = await servicio.CrearBorradorAsync(solicitud, ct);
+            return Results.Created($"/api/presupuestos/{creado.Id}", creado);
+        })
+        .WithSummary("Crea un borrador de presupuesto (header + items opcionales, precio resuelto al guardar).");
+
+        grupo.MapPut("/{id:int}", async (
+            ServicioDePresupuestos servicio, int id, SolicitudDePresupuesto solicitud, CancellationToken ct) =>
+        {
+            var actualizado = await servicio.EditarAsync(id, solicitud, ct);
+            return Results.Ok(actualizado);
+        })
+        .WithSummary("Reemplaza el header y el set completo de items de un borrador (borrador únicamente).");
+
+        grupo.MapPost("/{id:int}/enviar", async (
+            ServicioDePresupuestos servicio, int id, SolicitudDeEnvio solicitud, CancellationToken ct) =>
+        {
+            var enviado = await servicio.EnviarAsync(id, solicitud, ct);
+            return Results.Ok(enviado);
+        })
+        .WithSummary("Asigna numero/fecha_envio propios (serie 'PRES') y pasa el presupuesto a enviado.");
+
+        grupo.MapPost("/{id:int}/anular", async (ServicioDePresupuestos servicio, int id, CancellationToken ct) =>
+        {
+            var anulado = await servicio.AnularAsync(id, ct);
+            return Results.Ok(anulado);
+        })
+        .WithSummary("Anula un presupuesto borrador/enviado. Un presupuesto convertido no puede anularse.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -178,6 +178,9 @@ app.MapearCompras();
 app.MapearOrdenesDeCompra();
 // stage-15-cc-proveedores-ledger, Slice 4: estado de cuenta paginado del proveedor.
 app.MapearCuentaCorrienteDeProveedor();
+// stage-17-presupuestos-y-remitos, Slice 2: ABM + numeración de presupuestos (serie 'PRES').
+// OperacionDePos únicamente, nada apilado (proposal decisión 10) — la conversión llega en Slice 3.
+app.MapearPresupuestos();
 app.MapearReportes();
 app.MapearAuditoria();
 

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -97,6 +97,11 @@ public static class DependencyInjection
         // estado de cuenta paginado (task 4.3).
         services.AddScoped<ServicioDeCuentaCorrienteDeProveedor>();
 
+        // stage-17-presupuestos-y-remitos, Slice 2: ABM + enviar (numeración propia, serie
+        // 'PRES', vía AsignadorDeNumeroComprobante — no se toca) + anular. La conversión
+        // (EscriturasDePresupuesto, llamada desde ServicioDeVentas) llega en Slice 3.
+        services.AddScoped<ServicioDePresupuestos>();
+
         // stage-10-agregacion-dashboard, Slice 2: LectorDeSerieTemporal es la única superficie de
         // SQL crudo de toda la etapa (design decisión 2) — ServicioDeReportesDeVentas es su
         // primer consumidor.

--- a/src/Ways.Application/Ventas/ContratosDePresupuesto.cs
+++ b/src/Ways.Application/Ventas/ContratosDePresupuesto.cs
@@ -1,0 +1,114 @@
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>Una línea del cuerpo de <c>POST/PUT /api/presupuestos</c> (design: Interfaces/
+/// Contracts). <c>orden</c> NO viaja: es server-asignado 1..N dentro del replace-set (mismo
+/// criterio que <c>LineaDeOrdenSolicitada</c>/<c>LineaDeVenta</c>). Sin dinero en la solicitud —
+/// el precio lo resuelve <c>ServicioDeOfertas</c> al guardar el borrador, igual que el checkout
+/// (design decisión 2, <c>dto-contract-honesty</c> regla 1).</summary>
+public sealed record LineaDePresupuesto(int IdArticulo, decimal Cantidad);
+
+/// <summary>Cuerpo de <c>POST /api/presupuestos</c> (crea un borrador) y de <c>PUT
+/// /api/presupuestos/{id}</c> (replace-set completo del header + los items — un PUT reemplaza
+/// <see cref="Lineas"/> entero, nunca un CRUD incremental por item). <see cref="IdCliente"/>
+/// omitido resuelve a Consumidor Final, mismo criterio que <c>SolicitudDeVenta</c>.</summary>
+public sealed record SolicitudDePresupuesto(
+    int IdPuntoVenta, int? IdCliente, string? Observaciones, IReadOnlyList<LineaDePresupuesto> Lineas);
+
+/// <summary>Cuerpo de <c>POST /{id}/enviar</c> — el único dato que el cliente aporta al enviar:
+/// el vencimiento. <c>numero</c>/<c>fecha_envio</c> son enteramente server-derivados (design:
+/// Interfaces/Contracts).</summary>
+public sealed record SolicitudDeEnvio(DateOnly Vencimiento);
+
+/// <summary>Un item ya persistido — <see cref="Orden"/> es el valor server-asignado; el resto es
+/// la procedencia de precio congelada al guardar el borrador (design: Interfaces/Contracts).</summary>
+public sealed record ItemDePresupuesto(
+    int Orden,
+    int IdArticulo,
+    string Descripcion,
+    decimal Cantidad,
+    decimal PrecioUnitario,
+    decimal Descuento,
+    decimal Total,
+    int IdListaPrecio,
+    int? IdOferta,
+    int IdAlicuotaIva,
+    decimal PorcentajeIva);
+
+/// <summary>Respuesta de <c>POST/PUT /api/presupuestos</c>, <c>POST /{id}/enviar</c>,
+/// <c>POST /{id}/anular</c> y <c>GET /{id}</c> — el shape completo (design: Interfaces/Contracts):
+/// <see cref="Vencido"/>/<see cref="Convertible"/> son DERIVADOS en cada lectura
+/// (<c>ReglaDePresupuestos</c>, zona horaria del punto de venta — decisión 16), nunca columnas.
+/// <see cref="IdComprobanteVenta"/> es honesto por construcción: la columna que lo respalda
+/// (<c>comprobantes_venta.id_presupuesto_origen</c>) existe desde la Slice 1 y esta lectura
+/// SIEMPRE la consulta — en esta slice no hay escritor todavía (Slice 3), así que siempre
+/// devuelve <c>null</c>, pero no es relleno: el día que la Slice 3 convierta un presupuesto, este
+/// mismo camino de lectura, sin ningún cambio, empieza a devolver el id real
+/// (<c>dto-contract-honesty</c> regla 1 — un campo real con un escritor todavía no mergeado no es
+/// lo mismo que un campo sin escritor posible).</summary>
+public sealed record PresupuestoDetalle(
+    int Id,
+    int IdPuntoVenta,
+    int IdCliente,
+    int IdEmpleado,
+    long? Numero,
+    string? NumeroFormateado,
+    DateTimeOffset FechaEmision,
+    DateTimeOffset? FechaEnvio,
+    DateOnly? Vencimiento,
+    bool Vencido,
+    bool Convertible,
+    string ZonaId,
+    string? Observaciones,
+    decimal Subtotal,
+    decimal DescuentoTotal,
+    decimal Total,
+    EstadoPresupuesto Estado,
+    int? IdComprobanteVenta,
+    IReadOnlyList<ItemDePresupuesto> Items);
+
+/// <summary><c>GET /{id}/para-venta</c> (Slice 3 — el endpoint se cablea recién ahí, design:
+/// Slicing). El contrato se declara ACÁ, junto al resto de <c>ContratosDePresupuesto</c>, porque
+/// es lectura pura del mismo agregado. Deliberadamente NO es un <c>SolicitudDeVenta</c>
+/// pre-armado (<c>dto-contract-honesty</c> regla 1 — design: Interfaces/Contracts): un shape que
+/// el POS pudiera postear tal cual haría creíble al carrito para el dinero, exactamente lo que la
+/// congelación de precio (decisión 4 del proposal) existe para impedir.</summary>
+public sealed record PresupuestoParaVenta(
+    int IdPresupuesto,
+    long? Numero,
+    int IdPuntoVenta,
+    int IdCliente,
+    DateOnly? Vencimiento,
+    bool Vencido,
+    bool Convertible,
+    decimal Subtotal,
+    decimal DescuentoTotal,
+    decimal Total,
+    IReadOnlyList<ItemDePresupuesto> Items);
+
+/// <summary><c>GET /api/presupuestos</c>, una fila del listado (design: API Surface — decisión
+/// 15/16, mismo criterio que <c>OrdenDeCompraListada</c>). Lleva <see cref="Vencido"/>/
+/// <see cref="Convertible"/> — a diferencia de <c>OrdenDeCompraListada</c>, acá son baratos: ya
+/// se resuelve una zona por punto de venta DISTINTO de la página completa (decisión 16), no una
+/// consulta agregada por fila.</summary>
+public sealed record PresupuestoListado(
+    int Id,
+    int IdPuntoVenta,
+    int IdCliente,
+    long? Numero,
+    string? NumeroFormateado,
+    DateTimeOffset FechaEmision,
+    DateOnly? Vencimiento,
+    bool Vencido,
+    bool Convertible,
+    decimal Total,
+    EstadoPresupuesto Estado);
+
+/// <summary>Mismo shape que <c>PaginaDeOrdenesDeCompra</c>: <c>CountAsync</c> +
+/// <c>Skip/Take</c> sobre el mismo <c>ConstruirQuery</c> que el <c>COUNT</c>.</summary>
+public sealed record PaginaDePresupuestos(
+    IReadOnlyList<PresupuestoListado> Items,
+    int Total,
+    int Pagina,
+    int Tamanio);

--- a/src/Ways.Application/Ventas/ServicioDePresupuestos.cs
+++ b/src/Ways.Application/Ventas/ServicioDePresupuestos.cs
@@ -1,0 +1,778 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Application.Parametros;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 2 (design: Technical Approach; API Surface). Borrador
+/// CRUD (replace-set completo bajo <c>SELECT … FOR UPDATE … WHERE estado='borrador'</c>, mismo
+/// criterio que <see cref="Compras.ServicioDeOrdenesDeCompra"/>) + <see cref="EnviarAsync"/>
+/// (numeración propia, serie <c>'PRES'</c>, número comprometido ANTES de la transacción vía
+/// <see cref="AsignadorDeNumeroComprobante.AsignarComprometidoAsync"/> — el patrón de
+/// <c>ServicioDeOrdenesDeCompra.EnviarAsync</c>, pineando <c>id_punto_venta = $pv</c> en el
+/// <c>UPDATE</c> final) + <see cref="AnularAsync"/> (guardado por estado, sin coupling con la
+/// conversión — decisión 4/9 del proposal, OD8/T1: <c>convertido</c> es terminal, la anulación de
+/// la venta resultante NO revive el presupuesto, así que <c>AnularAsync</c> no necesita saberlo).
+///
+/// La conversión (<c>estado = 'convertido'</c>, escrita por <c>EscriturasDePresupuesto</c> desde
+/// <c>ServicioDeVentas</c>) y <c>/para-venta</c> llegan en la Slice 3 — esta clase nunca escribe
+/// <c>convertido</c> ni conoce <c>ServicioDeVentas</c> (design: "la contención ES el producto").
+///
+/// OD9 (orquestador, apply de esta slice, precedente stage-16 slice 2): los resolvers 404 de
+/// punto de venta/cliente son PRIVADOS y PROPIOS de esta clase — copian la forma exacta de
+/// <c>ServicioDeVentas.ResolverPuntoVentaAsync</c>/<c>ResolverClienteAsync</c> (privados ahí
+/// también) en vez de promoverlos a un helper compartido.
+///
+/// <c>vencido</c>/<c>convertible</c> son SIEMPRE derivados en la lectura (<see
+/// cref="ReglaDePresupuestos"/>, design decisión 11) — nunca una columna. La zona horaria del
+/// punto de venta se resuelve vía <see cref="ServicioDeParametros"/> (design decisión 16):
+/// una vez por punto de venta involucrado, nunca por fila.
+/// </summary>
+public class ServicioDePresupuestos(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas,
+    ServicioDeParametros servicioDeParametros)
+{
+    // ---- lectura: listado paginado + detalle (design decisión 15/16, task 2.8/2.9) ----------------
+
+    /// <summary>design decisión 16: el filtro <c>vencido</c> EXIGE <c>idPuntoVenta</c> (400
+    /// <c>punto_venta_requerido</c>) — sin él, "hoy" no tiene una zona única con la que
+    /// traducir el predicado a SQL. Con el punto de venta fijo, el filtro se empuja a la
+    /// consulta usando la MISMA fórmula que <see cref="ReglaDePresupuestos.EstaVencido"/>
+    /// (`estado = enviado AND vencimiento &lt; hoy`) — nunca una segunda derivación paralela.
+    /// El campo <c>Vencido</c>/<c>Convertible</c> de CADA fila devuelta, en cambio, siempre se
+    /// deriva en memoria contra la zona de SU PROPIO punto de venta (task 2.9: "Vencido resuelto
+    /// por PV DISTINTO de la página") — la página puede mezclar puntos de venta aunque el filtro
+    /// no esté presente.</summary>
+    public async Task<PaginaDePresupuestos> ListarAsync(
+        int? idPuntoVenta = null,
+        int? idCliente = null,
+        EstadoPresupuesto? estado = null,
+        bool? vencido = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        if (vencido is not null && idPuntoVenta is null)
+        {
+            throw new ErrorDominio(
+                "punto_venta_requerido", "El filtro 'vencido' requiere especificar un punto de venta.", 400);
+        }
+
+        var momento = reloj.Ahora;
+        var query = ConstruirQuery(idPuntoVenta, idCliente, estado, desde, hasta);
+
+        if (vencido is { } v)
+        {
+            var (_, zonaDelFiltro) = await ResolverZonaAsync(idPuntoVenta!.Value, ct);
+            var hoyDelFiltro = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(momento, zonaDelFiltro).DateTime);
+
+            query = v
+                ? query.Where(p => p.Estado == EstadoPresupuesto.Enviado && p.Vencimiento < hoyDelFiltro)
+                : query.Where(p => !(p.Estado == EstadoPresupuesto.Enviado && p.Vencimiento < hoyDelFiltro));
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var pagados = await query
+            .OrderByDescending(p => p.FechaEmision)
+            .ThenByDescending(p => p.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .ToListAsync(ct);
+
+        var zonasPorPuntoVenta = await ResolverZonasPorPuntoVentaAsync(
+            pagados.Select(p => p.IdPuntoVenta).Distinct().ToList(), ct);
+
+        var items = pagados.Select(p => ProyectarListado(p, zonasPorPuntoVenta, momento)).ToList();
+
+        return new PaginaDePresupuestos(items, total, pagina, tamanio);
+    }
+
+    /// <summary>Cláusulas bajo prueba (<c>mutation-proof-tests</c>, mutation target #59, mitad
+    /// presupuesto), en orden de daño si se pierden:
+    ///   <c>Where(p => p.IdPuntoVenta == pv)</c> / <c>Where(p => p.IdCliente == c)</c> → un
+    ///                                                                    presupuesto filtra los de otro
+    ///   <c>ThenByDescending(p => p.Id)</c> → con <c>fecha_emision</c> empatada (<c>RelojFijo</c>)
+    ///                                        la paginación duplica y saltea
+    ///   cada <c>if (idPuntoVenta/idCliente/estado/desde/hasta is { } x)</c> → filtro ignorado
+    /// </summary>
+    private IQueryable<Presupuesto> ConstruirQuery(
+        int? idPuntoVenta, int? idCliente, EstadoPresupuesto? estado, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var query = db.Presupuestos.AsQueryable();
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(p => p.IdPuntoVenta == pv);
+        }
+
+        if (idCliente is { } c)
+        {
+            query = query.Where(p => p.IdCliente == c);
+        }
+
+        if (estado is { } e)
+        {
+            query = query.Where(p => p.Estado == e);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(p => p.FechaEmision >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(p => p.FechaEmision <= h);
+        }
+
+        return query;
+    }
+
+    public async Task<PresupuestoDetalle> ObtenerDetalleAsync(int id, CancellationToken ct = default)
+    {
+        var presupuesto = await db.Presupuestos.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el presupuesto {id}.");
+
+        var items = await db.ItemsPresupuesto.AsNoTracking()
+            .Where(i => i.IdPresupuesto == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        return await ProyectarDetalleAsync(presupuesto, items, ct);
+    }
+
+    // ---- borrador: crear + replace-set (mismo criterio que ServicioDeOrdenesDeCompra) -------------
+
+    /// <summary>design: Technical Approach (fact 1), task 2.2: los precios se resuelven al
+    /// GUARDAR el borrador — la misma <see cref="ServicioDeOfertas"/> que usa el checkout, nunca
+    /// una segunda autoridad. Con cero líneas persiste igual (spec: "A borrador presupuesto is
+    /// created with no items yet").</summary>
+    public async Task<PresupuestoDetalle> CrearBorradorAsync(
+        SolicitudDePresupuesto solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
+        ExigirCantidadesValidas(solicitud.Lineas);
+
+        var (lineasMaterializadas, totales) = await ResolverYMaterializarAsync(
+            solicitud.Lineas, puntoVenta.IdEmpresa, cliente.IdListaPrecio, momento, ct);
+
+        var presupuesto = new Presupuesto
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdCliente = cliente.Id,
+            IdEmpleado = idEmpleado,
+            Numero = null,
+            FechaEmision = momento,
+            FechaEnvio = null,
+            Vencimiento = null,
+            Observaciones = NormalizarOpcional(solicitud.Observaciones),
+            Subtotal = totales.Subtotal,
+            DescuentoTotal = totales.DescuentoTotal,
+            Total = totales.Total,
+            Estado = EstadoPresupuesto.Borrador,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.Presupuestos.Add(presupuesto);
+        await db.SaveChangesAsync(ct);
+
+        var items = ConstruirItems(presupuesto.Id, idTenant, momento, lineasMaterializadas);
+        db.ItemsPresupuesto.AddRange(items);
+        await db.SaveChangesAsync(ct);
+
+        return await ProyectarDetalleAsync(presupuesto, items, ct);
+    }
+
+    /// <summary>Mismo criterio que <c>ServicioDeOrdenesDeCompra.ActualizarBorradorAsync</c>:
+    /// replace-set completo bajo <c>SELECT … FOR UPDATE … WHERE estado='borrador'</c> (mutation
+    /// target #12) — el predicado de estado en el mismo statement hace que editar un presupuesto
+    /// ya enviado sea estructuralmente imposible. El <c>RemoveRange</c> está scopeado por
+    /// <c>IdPresupuesto</c> (mutation target #13) — un presupuesto hermano del mismo tenant, con
+    /// sus propios items, queda intacto (rule 12c, task 2.17).</summary>
+    public async Task<PresupuestoDetalle> EditarAsync(
+        int id, SolicitudDePresupuesto solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
+        ExigirCantidadesValidas(solicitud.Lineas);
+
+        var (lineasMaterializadas, totales) = await ResolverYMaterializarAsync(
+            solicitud.Lineas, puntoVenta.IdEmpresa, cliente.IdListaPrecio, momento, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarEdicionAsync(id, idTenant, solicitud, cliente.Id, lineasMaterializadas, totales, momento, ct));
+    }
+
+    private async Task<PresupuestoDetalle> EjecutarEdicionAsync(
+        int id, int idTenant, SolicitudDePresupuesto solicitud, int idCliente,
+        IReadOnlyList<LineaMaterializada> lineasMaterializadas, TotalesCalculados totales, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var bloqueado = await BloquearBorradorAsync(conexion, transaccionCruda, id, idTenant, ct);
+        if (!bloqueado)
+        {
+            var existe = await db.Presupuestos.AsNoTracking().AnyAsync(p => p.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el presupuesto {id}.");
+            }
+
+            throw new ErrorDominio(
+                "presupuesto_no_editable", "Solo un presupuesto en borrador puede editarse.", 409);
+        }
+
+        // El lock de fila crudo de arriba ya serializa cualquier escritor concurrente sobre este
+        // header — misma lógica que EjecutarActualizacionAsync de ServicioDeOrdenesDeCompra.
+        var presupuesto = await db.Presupuestos.FirstAsync(p => p.Id == id, ct);
+
+        var itemsExistentes = await db.ItemsPresupuesto.Where(i => i.IdPresupuesto == id).ToListAsync(ct);
+        db.ItemsPresupuesto.RemoveRange(itemsExistentes);
+
+        presupuesto.IdPuntoVenta = solicitud.IdPuntoVenta;
+        presupuesto.IdCliente = idCliente;
+        presupuesto.Observaciones = NormalizarOpcional(solicitud.Observaciones);
+        presupuesto.Subtotal = totales.Subtotal;
+        presupuesto.DescuentoTotal = totales.DescuentoTotal;
+        presupuesto.Total = totales.Total;
+        presupuesto.UpdatedAt = momento;
+
+        var itemsNuevos = ConstruirItems(id, idTenant, momento, lineasMaterializadas);
+        db.ItemsPresupuesto.AddRange(itemsNuevos);
+
+        await db.SaveChangesAsync(ct);
+        await transaccion.CommitAsync(ct);
+
+        return await ProyectarDetalleAsync(presupuesto, itemsNuevos, ct);
+    }
+
+    // ---- enviar: numeración propia consumida ANTES de la transacción (mismo criterio que OC) -----
+
+    /// <summary>Mismo shape que <c>ServicioDeOrdenesDeCompra.EnviarAsync</c>: el número (serie
+    /// <c>'PRES'</c>) se asigna y comitea en su PROPIA transacción chica ANTES de abrir la que
+    /// escribe el presupuesto (design: Transactions — "ENVIAR PRESUPUESTO"). El <c>UPDATE</c>
+    /// final pinea <c>id_punto_venta = $pv</c> (mutation target #17): sin el segundo conjunto, un
+    /// <c>PUT</c> concurrente que mueve el presupuesto a otro punto de venta haría aterrizar el
+    /// número en la serie equivocada. 0 filas puede deberse a un doble-enviar o a ese relink
+    /// concurrente — en ambos casos el número YA se comiteó y queda quemado, residuo aceptado
+    /// (design decisión 15/proposal decisión 6).</summary>
+    public async Task<PresupuestoDetalle> EnviarAsync(
+        int id, SolicitudDeEnvio solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var preLectura = await db.Presupuestos.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el presupuesto {id}.");
+
+        if (preLectura.Estado != EstadoPresupuesto.Borrador)
+        {
+            throw new ErrorDominio(
+                "presupuesto_ya_enviado", "El presupuesto ya no está en borrador.", 409);
+        }
+
+        // Conflicto de esta slice: un presupuesto sin items nunca debería consumir un número
+        // (mutation target #21) — se rechaza ACÁ, antes de gastar uno.
+        var tieneItems = await db.ItemsPresupuesto.AsNoTracking().AnyAsync(i => i.IdPresupuesto == id, ct);
+        if (!tieneItems)
+        {
+            throw new ErrorDominio(
+                "presupuesto_sin_items", "El presupuesto no tiene items para enviar.", 400);
+        }
+
+        var idPuntoVenta = preLectura.IdPuntoVenta;
+
+        // design decisión 10/11: "hoy" SIEMPRE resuelto en la zona del punto de venta (mutation
+        // target #19) — jamás DateTime.UtcNow/reloj.Ahora.UtcDateTime.
+        var (_, zona) = await ResolverZonaAsync(idPuntoVenta, ct);
+        var hoy = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(momento, zona).DateTime);
+
+        if (solicitud.Vencimiento < hoy)
+        {
+            throw new ErrorDominio(
+                "vencimiento_invalido", "El vencimiento tiene que ser hoy o una fecha futura.", 400);
+        }
+
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, idTenant, idPuntoVenta, "PRES", ct));
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarEnvioAsync(id, idTenant, idPuntoVenta, numero, solicitud.Vencimiento, momento, ct));
+    }
+
+    private async Task<PresupuestoDetalle> EjecutarEnvioAsync(
+        int id, int idTenant, int idPuntoVenta, long numero, DateOnly vencimiento, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var numeroAsignado = await EnviarHeaderAsync(
+            conexion, transaccionCruda, id, idTenant, idPuntoVenta, numero, vencimiento, momento, ct);
+        if (numeroAsignado is null)
+        {
+            var existe = await db.Presupuestos.AsNoTracking().AnyAsync(p => p.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el presupuesto {id}.");
+            }
+
+            throw new ErrorDominio(
+                "presupuesto_ya_enviado", "El presupuesto ya no está en borrador en ese punto de venta.", 409);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerDetalleAsync(id, ct);
+    }
+
+    // ---- anular: guardado por estado, sin coupling con la conversión (proposal decisión 9) --------
+
+    /// <summary>OD8/T1 (tasks.md decisión 4, proposal decisión 9): <c>convertido</c> es terminal
+    /// — esta clase JAMÁS lo revierte, y por eso el <c>WHERE</c> de abajo solo admite
+    /// <c>borrador</c>/<c>enviado</c> (spec: "Anulación Is Rejected For A Convertido
+    /// Presupuesto"). Un único <c>UPDATE … RETURNING</c> (mismo criterio que
+    /// <c>ServicioDeOrdenesDeCompra.MarcarOrdenAnuladaAsync</c>, sin lock previo — no hay ningún
+    /// segundo invariante que verificar bajo lock, a diferencia de la OC gobernada por el
+    /// libro).</summary>
+    public async Task<PresupuestoDetalle> AnularAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarAnulacionAsync(id, idTenant, momento, ct));
+    }
+
+    private async Task<PresupuestoDetalle> EjecutarAnulacionAsync(
+        int id, int idTenant, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var anulado = await MarcarAnuladoAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
+        if (!anulado)
+        {
+            var existe = await db.Presupuestos.AsNoTracking().AnyAsync(p => p.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el presupuesto {id}.");
+            }
+
+            throw new ErrorDominio("presupuesto_no_anulable", "El presupuesto no puede anularse.", 409);
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerDetalleAsync(id, ct);
+    }
+
+    // ---- statements crudos (sibling raw SQL, mismo criterio que ServicioDeOrdenesDeCompra) --------
+
+    private static async Task<bool> BloquearBorradorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT 1 FROM presupuestos " +
+            "WHERE id_presupuesto = $1 AND id_tenant = $2 AND estado = 'borrador'::estado_presupuesto " +
+            "FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    /// <summary>design: Transactions — ENVIAR PRESUPUESTO, único statement de la transacción de
+    /// escritura. El predicado pinea <c>estado='borrador'</c> Y <c>id_punto_venta=$pv</c>
+    /// (mutation target #17). <c>fecha_envio</c>/<c>vencimiento</c> viajan SIEMPRE por
+    /// <see cref="ParametrosDeComando.Agregar"/> (mutation target #22) — nunca un parámetro
+    /// armado a mano sin <c>ToUniversalTime()</c>.</summary>
+    private static async Task<long?> EnviarHeaderAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, int idPuntoVenta, long numero,
+        DateOnly vencimiento, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE presupuestos SET numero = $1, fecha_envio = $2, vencimiento = $3, " +
+            "estado = 'enviado'::estado_presupuesto, updated_at = $2 " +
+            "WHERE id_presupuesto = $4 AND id_tenant = $5 AND estado = 'borrador'::estado_presupuesto " +
+            "AND id_punto_venta = $6 " +
+            "RETURNING numero";
+
+        ParametrosDeComando.Agregar(comando, numero);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, vencimiento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return lector.IsDBNull(0) ? null : lector.GetInt64(0);
+    }
+
+    /// <summary>design: Transactions — ANULAR PRESUPUESTO, único statement — la ÚNICA autoridad
+    /// de transición a <c>anulado</c>. <c>convertido</c> queda deliberadamente afuera del
+    /// <c>IN</c> (OD8/T1): un presupuesto ya convertido nunca matchea, así que 0 filas colapsa
+    /// "convertido"/"ya anulado"/"no existe para este tenant" en el mismo código de dominio de
+    /// rechazo, distinguido de 404 solo por la existencia de la fila.</summary>
+    private static async Task<bool> MarcarAnuladoAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE presupuestos SET estado = 'anulado'::estado_presupuesto, updated_at = $1 " +
+            "WHERE id_presupuesto = $2 AND id_tenant = $3 " +
+            "AND estado IN ('borrador'::estado_presupuesto, 'enviado'::estado_presupuesto) " +
+            "RETURNING estado";
+
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    // ---- resolución de precio (mismo criterio que ServicioDeVentas, sin signo — nunca NCX) -------
+
+    /// <summary>design: Technical Approach (fact 1). Con cero líneas devuelve totales en cero sin
+    /// consultar nada (<c>CalculadorDeTotales.Calcular([])</c> ya es válido — la invariante de
+    /// consistencia interna pasa trivialmente).</summary>
+    private async Task<(IReadOnlyList<LineaMaterializada> Lineas, TotalesCalculados Totales)> ResolverYMaterializarAsync(
+        IReadOnlyList<LineaDePresupuesto> lineas, int idEmpresa, int idListaPrecio, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        if (lineas.Count == 0)
+        {
+            return (Array.Empty<LineaMaterializada>(), CalculadorDeTotales.Calcular([]));
+        }
+
+        // La autoridad de precio ÚNICA (design decisión 2/checkout, fact 1) — nunca lo que
+        // mandó el cliente.
+        var lineasDeResolucion = lineas
+            .Select(l => new LineaDeResolucion(l.IdArticulo, idEmpresa, idListaPrecio, l.Cantidad))
+            .ToList();
+        var resolucion = await servicioDeOfertas.ResolverAsync(lineasDeResolucion, momento, ct);
+
+        var idsArticulo = lineas.Select(l => l.IdArticulo).Distinct().ToList();
+        var articuloPorId = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, ct);
+
+        var idsAlicuota = articuloPorId.Values.Select(a => a.IdAlicuotaIva).Distinct().ToList();
+        var porcentajePorAlicuota = await db.AlicuotasIva
+            .Where(a => idsAlicuota.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, a => a.Porcentaje, ct);
+
+        return MaterializarLineas(lineas, resolucion, articuloPorId, porcentajePorAlicuota, idListaPrecio);
+    }
+
+    private static (IReadOnlyList<LineaMaterializada> Lineas, TotalesCalculados Totales) MaterializarLineas(
+        IReadOnlyList<LineaDePresupuesto> lineas,
+        IReadOnlyList<ResultadoDeResolucion> resolucion,
+        IReadOnlyDictionary<int, Articulo> articuloPorId,
+        IReadOnlyDictionary<int, decimal> porcentajePorAlicuota,
+        int idListaPrecio)
+    {
+        var lineasParaCalcular = new List<LineaParaCalcular>(lineas.Count);
+
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var resultado = resolucion[i];
+
+            if (resultado.PrecioOriginal is null)
+            {
+                throw new ErrorDominio(
+                    "articulo_sin_precio_vigente",
+                    $"El artículo {lineas[i].IdArticulo} no tiene un precio vigente en la lista del cliente.",
+                    400);
+            }
+
+            lineasParaCalcular.Add(new LineaParaCalcular(
+                lineas[i].Cantidad, resultado.PrecioOriginal.Value, resultado.DescuentoUnitario));
+        }
+
+        var totales = CalculadorDeTotales.Calcular(lineasParaCalcular);
+
+        var resultadoFinal = new List<LineaMaterializada>(lineas.Count);
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var linea = lineas[i];
+            var resultado = resolucion[i];
+            var calculado = totales.Items[i];
+            var articulo = articuloPorId[linea.IdArticulo];
+
+            // Solo UNA columna id_oferta por item (esquema): cuando se acumulan varias ofertas en
+            // la misma línea, se snapshotea la de mayor prioridad — mismo criterio que
+            // ServicioDeVentas.MaterializarItems.
+            var idOferta = resultado.Aplicadas.Count > 0 ? resultado.Aplicadas[0].IdOferta : (int?)null;
+
+            resultadoFinal.Add(new LineaMaterializada(
+                articulo.Id, articulo.Nombre, calculado.Cantidad, calculado.PrecioUnitario, calculado.Descuento,
+                calculado.Total, idListaPrecio, idOferta, articulo.IdAlicuotaIva,
+                porcentajePorAlicuota[articulo.IdAlicuotaIva]));
+        }
+
+        return (resultadoFinal, totales);
+    }
+
+    private static List<ItemPresupuesto> ConstruirItems(
+        int idPresupuesto, int idTenant, DateTimeOffset momento, IReadOnlyList<LineaMaterializada> lineas)
+    {
+        var resultado = new List<ItemPresupuesto>(lineas.Count);
+        var orden = 1;
+
+        foreach (var linea in lineas)
+        {
+            resultado.Add(new ItemPresupuesto
+            {
+                IdTenant = idTenant,
+                IdPresupuesto = idPresupuesto,
+                Orden = orden++,
+                IdArticulo = linea.IdArticulo,
+                Descripcion = linea.Descripcion,
+                Cantidad = linea.Cantidad,
+                PrecioUnitario = linea.PrecioUnitario,
+                Descuento = linea.Descuento,
+                Total = linea.Total,
+                IdListaPrecio = linea.IdListaPrecio,
+                IdOferta = linea.IdOferta,
+                IdAlicuotaIva = linea.IdAlicuotaIva,
+                PorcentajeIva = linea.PorcentajeIva,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            });
+        }
+
+        return resultado;
+    }
+
+    /// <summary>Backstop de servicio para <c>ck_items_presupuesto_cantidad_positiva</c> (400
+    /// <c>cantidad_de_linea_invalida</c>, ANTES de tocar la base — <c>db-error-backstops</c>: el
+    /// CHECK de esquema queda como defensa en profundidad, solo alcanzable fuera de banda).</summary>
+    private static void ExigirCantidadesValidas(IReadOnlyList<LineaDePresupuesto> lineas)
+    {
+        foreach (var linea in lineas)
+        {
+            if (linea.Cantidad <= 0)
+            {
+                throw new ErrorDominio(
+                    "cantidad_de_linea_invalida", "La cantidad de una línea de presupuesto tiene que ser positiva.", 400);
+            }
+        }
+    }
+
+    // ---- zona horaria del punto de venta (design decisión 16) --------------------------------------
+
+    private async Task<(string ZonaId, TimeZoneInfo Zona)> ResolverZonaAsync(int idPuntoVenta, CancellationToken ct)
+    {
+        var puntoVenta = await db.PuntosVenta.AsNoTracking()
+            .Where(pv => pv.Id == idPuntoVenta)
+            .Select(pv => new { pv.IdEmpresa })
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+        var resuelto = await servicioDeParametros.ResolverAsync(
+            ParametroConocido.ZonaHoraria.Clave, puntoVenta.IdEmpresa, idPuntoVenta, ct);
+        var zonaId = JsonSerializer.Deserialize<string>(resuelto.Valor)!;
+
+        return (zonaId, TimeZoneInfo.FindSystemTimeZoneById(zonaId));
+    }
+
+    /// <summary>design decisión 16: una zona por punto de venta DISTINTO de la página — el costo
+    /// está acotado por el tamaño de página, nunca por fila.</summary>
+    private async Task<IReadOnlyDictionary<int, TimeZoneInfo>> ResolverZonasPorPuntoVentaAsync(
+        IReadOnlyList<int> idsPuntoVenta, CancellationToken ct)
+    {
+        var resultado = new Dictionary<int, TimeZoneInfo>();
+
+        foreach (var idPuntoVenta in idsPuntoVenta)
+        {
+            var (_, zona) = await ResolverZonaAsync(idPuntoVenta, ct);
+            resultado[idPuntoVenta] = zona;
+        }
+
+        return resultado;
+    }
+
+    // ---- resolución de contexto (fuera de transacción, resolvers PRIVADOS PROPIOS — OD9) ---------
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            // ADR-8: mismo 404 para "no existe" y "es de otro tenant".
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<Cliente> ResolverClienteAsync(int? idCliente, CancellationToken ct)
+    {
+        if (idCliente is { } id)
+        {
+            return await db.Clientes.FirstOrDefaultAsync(c => c.Id == id, ct)
+                ?? throw ErrorDominio.NoEncontrado($"No existe el cliente {id}.");
+        }
+
+        // Spec: "Omitted idCliente defaults to Consumidor Final" — mismo criterio que
+        // ServicioDeVentas.ResolverClienteAsync.
+        return await db.Clientes.FirstOrDefaultAsync(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal, ct)
+            ?? throw new InvalidOperationException("El tenant actual no tiene un Consumidor Final sembrado.");
+    }
+
+    // ---- proyección ----------------------------------------------------------------------------
+
+    private async Task<PresupuestoDetalle> ProyectarDetalleAsync(
+        Presupuesto presupuesto, IReadOnlyList<ItemPresupuesto> items, CancellationToken ct)
+    {
+        var (zonaId, zona) = await ResolverZonaAsync(presupuesto.IdPuntoVenta, ct);
+        var hoy = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(reloj.Ahora, zona).DateTime);
+
+        var vencido = ReglaDePresupuestos.EstaVencido(presupuesto.Estado, presupuesto.Vencimiento, hoy);
+        var convertible = ReglaDePresupuestos.EsConvertible(presupuesto.Estado, presupuesto.Vencimiento, hoy);
+
+        // dto-contract-honesty regla 1: la columna existe desde la Slice 1, pero ningún escritor
+        // la puebla todavía (Slice 3) — SIEMPRE null en esta slice, honesto por construcción (ver
+        // el doc-comment de PresupuestoDetalle.IdComprobanteVenta).
+        var idComprobanteVenta = await db.ComprobantesVenta.AsNoTracking()
+            .Where(c => c.IdPresupuestoOrigen == presupuesto.Id)
+            .Select(c => (int?)c.Id)
+            .FirstOrDefaultAsync(ct);
+
+        return new PresupuestoDetalle(
+            presupuesto.Id,
+            presupuesto.IdPuntoVenta,
+            presupuesto.IdCliente,
+            presupuesto.IdEmpleado,
+            presupuesto.Numero,
+            presupuesto.Numero is { } n ? NumeroDeComprobante.Formatear(presupuesto.IdPuntoVenta, n) : null,
+            presupuesto.FechaEmision,
+            presupuesto.FechaEnvio,
+            presupuesto.Vencimiento,
+            vencido,
+            convertible,
+            zonaId,
+            presupuesto.Observaciones,
+            presupuesto.Subtotal,
+            presupuesto.DescuentoTotal,
+            presupuesto.Total,
+            presupuesto.Estado,
+            idComprobanteVenta,
+            items
+                .OrderBy(i => i.Orden)
+                .Select(i => new ItemDePresupuesto(
+                    i.Orden, i.IdArticulo, i.Descripcion, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total,
+                    i.IdListaPrecio, i.IdOferta, i.IdAlicuotaIva, i.PorcentajeIva))
+                .ToList());
+    }
+
+    private static PresupuestoListado ProyectarListado(
+        Presupuesto presupuesto, IReadOnlyDictionary<int, TimeZoneInfo> zonasPorPuntoVenta, DateTimeOffset momento)
+    {
+        var zona = zonasPorPuntoVenta[presupuesto.IdPuntoVenta];
+        var hoy = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(momento, zona).DateTime);
+
+        var vencido = ReglaDePresupuestos.EstaVencido(presupuesto.Estado, presupuesto.Vencimiento, hoy);
+        var convertible = ReglaDePresupuestos.EsConvertible(presupuesto.Estado, presupuesto.Vencimiento, hoy);
+
+        return new PresupuestoListado(
+            presupuesto.Id,
+            presupuesto.IdPuntoVenta,
+            presupuesto.IdCliente,
+            presupuesto.Numero,
+            presupuesto.Numero is { } n ? NumeroDeComprobante.Formatear(presupuesto.IdPuntoVenta, n) : null,
+            presupuesto.FechaEmision,
+            presupuesto.Vencimiento,
+            vencido,
+            convertible,
+            presupuesto.Total,
+            presupuesto.Estado);
+    }
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDePresupuestos requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    /// <summary>Forma intermedia entre la resolución de precio y la entidad persistida — todavía
+    /// no conoce <c>IdPresupuesto</c> (no existe hasta el primer <c>SaveChangesAsync</c> del
+    /// header, mismo problema de orden que <c>ServicioDeVentas.MaterializarItems</c> resuelve con
+    /// <c>LineaDelPlan</c>) ni <c>IdTenant</c>/timestamps (los agrega <see cref="ConstruirItems"/>
+    /// al construir las entidades reales).</summary>
+    private readonly record struct LineaMaterializada(
+        int IdArticulo,
+        string Descripcion,
+        decimal Cantidad,
+        decimal PrecioUnitario,
+        decimal Descuento,
+        decimal Total,
+        int IdListaPrecio,
+        int? IdOferta,
+        int IdAlicuotaIva,
+        decimal PorcentajeIva);
+}

--- a/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
@@ -1,0 +1,839 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 2 (tasks 2.1-2.23; design: Transactions — ENVIAR
+/// PRESUPUESTO; API Surface). Borrador CRUD (replace-set) + <c>enviar</c> con numeración propia
+/// (serie <c>'PRES'</c>, consumida ANTES de la transacción de escritura — mismo patrón que
+/// <see cref="ServicioDeOrdenesDeCompraTests"/>) + <c>anular</c> + el listado/detalle con
+/// <c>Vencido</c>/<c>Convertible</c> derivados en la zona horaria del punto de venta.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordVendedor = "vendedor-password-larga";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdPuntoVenta2, HttpClient Root, HttpClient Admin,
+        HttpClient Vendedor, int IdArea, int IdAlicuotaIva, int IdListaPrecio, int IdCliente, int IdArticulo,
+        int IdArticulo2, string MailAdmin, string PasswordAdmin);
+
+    /// <summary>Decisión 13 (tasks.md): ids deliberadamente desincronizados — cada entidad nace en
+    /// su propia tabla con su propia identidad autoincremental, nunca forzada a coincidir.</summary>
+    private async Task<Contexto> PrepararAsync(string nombre) => await PrepararConFactoryAsync(nombre, null);
+
+    private async Task<Contexto> PrepararConFactoryAsync(string nombre, WebApplicationFactory<Program>? factory)
+    {
+        var root = factory is null ? fixture.CreateClient() : factory.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = factory is null ? fixture.CreateClient() : factory.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, Nombre = $"{nombre}-PV2",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Pres-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista de Presupuestos", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 1000 + Random.Shared.Next(1, 100_000), Nombre = $"{nombre}-cliente",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 0,
+            CreditoIlimitado = true, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var articulo1 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-pres-1-{Guid.NewGuid():N}", Nombre = "Pres Articulo 1",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var articulo2 = new Articulo
+        {
+            IdTenant = resultado.IdTenant, CodigoInterno = $"{nombre}-pres-2-{Guid.NewGuid():N}", Nombre = "Pres Articulo 2",
+            IdArea = area.Id, IdAlicuotaIva = idAlicuotaIva, UnidadVenta = UnidadVenta.Unidad, EsProducto = true,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.AddRange(articulo1, articulo2);
+        await db.SaveChangesAsync();
+
+        db.Precios.AddRange(
+            new Precio
+            {
+                IdTenant = resultado.IdTenant, IdArticulo = articulo1.Id, IdListaPrecio = lista.Id, Monto = 100m,
+                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            },
+            new Precio
+            {
+                IdTenant = resultado.IdTenant, IdArticulo = articulo2.Id, IdListaPrecio = lista.Id, Monto = 250m,
+                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            });
+        await db.SaveChangesAsync();
+
+        var hasheador = new HasheadorPbkdf2();
+        var mailVendedor = $"{nombre.ToLowerInvariant()}-vend@ways.test";
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = resultado.IdTenant, NombreUsuario = "pres-vendedor", Mail = mailVendedor, RolId = (int)RolConocido.Vendedor,
+            PasswordHash = hasheador.Hashear(PasswordVendedor), PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        var vendedor = factory is null ? fixture.CreateClient() : factory.CreateClient();
+        var loginVendedor = await vendedor.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailVendedor, PasswordVendedor));
+        Assert.Equal(HttpStatusCode.OK, loginVendedor.StatusCode);
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, puntoVenta2.Id, root, admin, vendedor,
+            area.Id, idAlicuotaIva, lista.Id, cliente.Id, articulo1.Id, articulo2.Id, mailAdmin, resultado.PasswordTemporal);
+    }
+
+    private static SolicitudDePresupuesto SolicitudSimple(Contexto ctx, decimal cantidad = 2m, int? idPuntoVenta = null) =>
+        new(idPuntoVenta ?? ctx.IdPuntoVenta, ctx.IdCliente, "obs", [new LineaDePresupuesto(ctx.IdArticulo, cantidad)]);
+
+    private static SolicitudDePresupuesto SolicitudSinItems(Contexto ctx, int? idPuntoVenta = null) =>
+        new(idPuntoVenta ?? ctx.IdPuntoVenta, ctx.IdCliente, null, []);
+
+    private static async Task<PresupuestoDetalle> CrearBorradorAsync(HttpClient cliente, SolicitudDePresupuesto solicitud)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/presupuestos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<PresupuestoDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 2.2: crear borrador, precio resuelto al guardar --------------------------------------
+
+    [Fact]
+    public async Task UnBorradorSinItemsPersisteConNumeroYVencimientoNulos()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorSinItemsPersisteConNumeroYVencimientoNulos));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        Assert.Null(creado.Numero);
+        Assert.Null(creado.NumeroFormateado);
+        Assert.Null(creado.Vencimiento);
+        Assert.Empty(creado.Items);
+        Assert.Equal(EstadoPresupuesto.Borrador, creado.Estado);
+    }
+
+    [Fact]
+    public async Task UnBorradorConItemsResuelveElPrecioVigenteAlGuardar()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorConItemsResuelveElPrecioVigenteAlGuardar));
+        var creado = await CrearBorradorAsync(
+            ctx.Admin,
+            new SolicitudDePresupuesto(
+                ctx.IdPuntoVenta, ctx.IdCliente, null,
+                [new LineaDePresupuesto(ctx.IdArticulo, 3m), new LineaDePresupuesto(ctx.IdArticulo2, 2m)]));
+
+        Assert.Equal(2, creado.Items.Count);
+        var item1 = creado.Items.Single(i => i.IdArticulo == ctx.IdArticulo);
+        var item2 = creado.Items.Single(i => i.IdArticulo == ctx.IdArticulo2);
+        Assert.Equal(100m, item1.PrecioUnitario);
+        Assert.Equal(300m, item1.Total);
+        Assert.Equal(250m, item2.PrecioUnitario);
+        Assert.Equal(500m, item2.Total);
+        Assert.Equal(800m, creado.Total);
+        Assert.Equal(1, item1.Orden);
+        Assert.Equal(2, item2.Orden);
+    }
+
+    // ---- task 2.3/2.17: replace-set completo, hermana intacta (mutation targets #12/#13) -----------
+
+    [Fact]
+    public async Task ElReplaceSetReemplazaLosItemsCompletosSinTocarUnPresupuestoHermano()
+    {
+        var ctx = await PrepararAsync(nameof(ElReplaceSetReemplazaLosItemsCompletosSinTocarUnPresupuestoHermano));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, cantidad: 1m));
+        Assert.Single(creado.Items);
+
+        // Regla 12c: un presupuesto HERMANO del mismo tenant, con sus propios items — el
+        // replace-set de "creado" nunca debe tocarlo (mutation target #13: el RemoveRange tiene
+        // que quedar scopeado a IdPresupuesto, jamás ensanchado a toda la tabla).
+        var hermano = await CrearBorradorAsync(
+            ctx.Admin,
+            new SolicitudDePresupuesto(
+                ctx.IdPuntoVenta, ctx.IdCliente, null,
+                [new LineaDePresupuesto(ctx.IdArticulo, 7m), new LineaDePresupuesto(ctx.IdArticulo2, 8m)]));
+        Assert.Equal(2, hermano.Items.Count);
+
+        var conDosItems = new SolicitudDePresupuesto(
+            ctx.IdPuntoVenta, ctx.IdCliente, "editado",
+            [new LineaDePresupuesto(ctx.IdArticulo, 5m), new LineaDePresupuesto(ctx.IdArticulo2, 4m)]);
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/presupuestos/{creado.Id}", conDosItems);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var editado = JsonSerializer.Deserialize<PresupuestoDetalle>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(2, editado.Items.Count);
+        Assert.Equal("editado", editado.Observaciones);
+        Assert.Equal(1, editado.Items.Single(i => i.IdArticulo == ctx.IdArticulo).Orden);
+        Assert.Equal(2, editado.Items.Single(i => i.IdArticulo == ctx.IdArticulo2).Orden);
+
+        // El hermano sigue intacto: mismo count, mismos items, por identidad.
+        var hermanoActual = await ctx.Admin.GetFromJsonAsync<PresupuestoDetalle>(
+            $"/api/presupuestos/{hermano.Id}", OpcionesJson);
+        Assert.Equal(2, hermanoActual!.Items.Count);
+        Assert.Equal(7m, hermanoActual.Items.Single(i => i.IdArticulo == ctx.IdArticulo).Cantidad);
+        Assert.Equal(8m, hermanoActual.Items.Single(i => i.IdArticulo == ctx.IdArticulo2).Cantidad);
+    }
+
+    // ---- task 2.18: mutation target #12 — editar un no-borrador es rechazado -----------------------
+
+    [Fact]
+    public async Task EditarUnPresupuestoEnviadoEsRechazado409PresupuestoNoEditable()
+    {
+        var ctx = await PrepararAsync(nameof(EditarUnPresupuestoEnviadoEsRechazado409PresupuestoNoEditable));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var enviar = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
+        Assert.Equal(HttpStatusCode.OK, enviar.StatusCode);
+
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/presupuestos/{creado.Id}", SolicitudSimple(ctx));
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("presupuesto_no_editable", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.6/2.15: enviar un presupuesto sin items --------------------------------------------
+
+    [Fact]
+    public async Task EnviarUnPresupuestoSinItemsEsRechazado400PresupuestoSinItemsSinConsumirNumero()
+    {
+        var ctx = await PrepararAsync(nameof(EnviarUnPresupuestoSinItemsEsRechazado400PresupuestoSinItemsSinConsumirNumero));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("presupuesto_sin_items", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.Presupuestos.FirstAsync(p => p.Id == creado.Id);
+        Assert.Equal(EstadoPresupuesto.Borrador, actual.Estado);
+        Assert.Null(actual.Numero);
+    }
+
+    // ---- task 2.5: enviar con un vencimiento en el pasado ------------------------------------------
+
+    [Fact]
+    public async Task EnviarConUnVencimientoEnElPasadoEsRechazado400VencimientoInvalidoSinConsumirNumero()
+    {
+        var ctx = await PrepararAsync(nameof(EnviarConUnVencimientoEnElPasadoEsRechazado400VencimientoInvalidoSinConsumirNumero));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var vencimientoPasado = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-5);
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(vencimientoPasado));
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("vencimiento_invalido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.Presupuestos.FirstAsync(p => p.Id == creado.Id);
+        Assert.Null(actual.Numero);
+    }
+
+    // ---- task 2.14: borde del día de vencimiento — convertible EN el día exacto --------------------
+
+    [Fact]
+    public async Task EnviarConVencimientoIgualAHoyEsAceptado()
+    {
+        var ctx = await PrepararAsync(nameof(EnviarConVencimientoIgualAHoyEsAceptado));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        // Default zona_horaria: America/Argentina/Buenos_Aires (-03:00) — "hoy" local, sin
+        // seedear ningún parametro.
+        var hoyLocal = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(
+            DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("America/Argentina/Buenos_Aires")).DateTime);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(hoyLocal));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+    }
+
+    // ---- task 2.13/2.9: el borde -03:00 vs +05:30 (mutation-proof-tests rule 10) -------------------
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>Mutation target #19 (design: decisión 10/11, mutation-proof-tests rule 10):
+    /// <c>RelojFijo</c> en <c>2026-09-30T02:00:00Z</c>. En Buenos Aires (-03:00, zona DEFAULT sin
+    /// seedear ningún parametro) el día local es el 29 — un presupuesto con <c>vencimiento =
+    /// 2026-09-29</c> es aceptado (>= hoy local) y uno con el 28 es rechazado. Si <c>hoy</c> se
+    /// resolviera con <c>reloj.Ahora.UtcDateTime</c> en vez de la zona del PV, el día "visto" sería
+    /// el 30 y el 29 se rechazaría — el test discrimina exactamente esa mutación.</summary>
+    [Fact]
+    public async Task EnviarEnLaZonaMenosTresElVencimientoDelDiaLocalEsAceptadoYElDiaAnteriorRechazado()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 9, 30, 2, 0, 0, TimeSpan.Zero);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararConFactoryAsync(
+            nameof(EnviarEnLaZonaMenosTresElVencimientoDelDiaLocalEsAceptadoYElDiaAnteriorRechazado), factory);
+
+        var aceptado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var respuestaAceptada = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{aceptado.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 9, 29)));
+        var cuerpoAceptada = await respuestaAceptada.Content.ReadAsStringAsync();
+        Assert.True(respuestaAceptada.StatusCode == HttpStatusCode.OK, cuerpoAceptada);
+
+        var rechazado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var respuestaRechazada = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{rechazado.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 9, 28)));
+        Assert.Equal(HttpStatusCode.BadRequest, respuestaRechazada.StatusCode);
+    }
+
+    /// <summary>El espejo a <c>+05:30</c> (<c>Asia/Kolkata</c>, sin horario de verano): al MISMO
+    /// instante UTC, el día local es el 30 — la conclusión se INVIERTE respecto del test anterior.
+    /// Solo un fixture con offset real (nunca <c>Z</c>) puede ver esta clase de regresión.</summary>
+    [Fact]
+    public async Task EnviarEnLaZonaMasCincoYMediaElVencimientoDelDiaLocalEsAceptadoYElDiaAnteriorRechazado()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 9, 30, 2, 0, 0, TimeSpan.Zero);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararConFactoryAsync(
+            nameof(EnviarEnLaZonaMasCincoYMediaElVencimientoDelDiaLocalEsAceptadoYElDiaAnteriorRechazado), factory);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            db.Parametros.Add(new Parametro
+            {
+                IdTenant = ctx.IdTenant, IdEmpresa = ctx.IdEmpresa, IdPuntoVenta = ctx.IdPuntoVenta,
+                Clave = ParametroConocido.ZonaHoraria.Clave, Valor = JsonSerializer.Serialize("Asia/Kolkata"),
+                CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var aceptado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var respuestaAceptada = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{aceptado.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 9, 30)));
+        var cuerpoAceptada = await respuestaAceptada.Content.ReadAsStringAsync();
+        Assert.True(respuestaAceptada.StatusCode == HttpStatusCode.OK, cuerpoAceptada);
+
+        var rechazado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var respuestaRechazada = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{rechazado.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 9, 29)));
+        Assert.Equal(HttpStatusCode.BadRequest, respuestaRechazada.StatusCode);
+    }
+
+    // ---- task 2.10/2.11: los DOS binding gate tests de concurrencia del enviar ---------------------
+
+    /// <summary>Binding gate test, parte 1 (spec: "Two concurrent enviar calls at the same punto de
+    /// venta never collide"; mutation target #15): dos presupuestos DISTINTOS del mismo PV,
+    /// enviados en simultáneo, sacan números distintos — NINGUNO responde 409. Si
+    /// <c>AsignarComprometidoAsync</c> se reemplazara por <c>MAX(numero)+1</c>, ambos leerían el
+    /// mismo máximo y colisionarían.</summary>
+    [Fact]
+    public async Task DosEnviarConcurrentesDePresupuestosDistintosEnElMismoPuntoDeVentaDanNumerosDistintosSin409()
+    {
+        var ctx = await PrepararAsync(nameof(DosEnviarConcurrentesDePresupuestosDistintosEnElMismoPuntoDeVentaDanNumerosDistintosSin409));
+        var presupuestoA = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var presupuestoB = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var vencimiento = FechaFutura();
+        var tareaA = ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{presupuestoA.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        var tareaB = ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{presupuestoB.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        foreach (var respuesta in respuestas)
+        {
+            Assert.NotEqual(HttpStatusCode.Conflict, respuesta.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        }
+
+        var enviadoA = await respuestas[0].Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson);
+        var enviadoB = await respuestas[1].Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson);
+
+        Assert.NotNull(enviadoA!.Numero);
+        Assert.NotNull(enviadoB!.Numero);
+        Assert.NotEqual(enviadoA.Numero, enviadoB.Numero);
+    }
+
+    /// <summary>Interceptor de rendezvous DETERMINÍSTICO (mutation-proof-tests regla 2 — un
+    /// <c>Task.WhenAll</c> desnudo demostró, corrido repetidas veces, que la ventana de carrera
+    /// entre el pre-chequeo de <c>EnviarAsync</c> y el <c>UPDATE</c> guardado de
+    /// <c>EjecutarEnvioAsync</c> puede resolverse ANTES de que el perdedor llegue a dibujar un
+    /// número — un resultado igualmente válido del diseño (ambas ramas devuelven el mismo
+    /// <c>presupuesto_ya_enviado</c> a propósito), pero que no prueba el hueco. Este interceptor
+    /// distingue, por identidad del <see cref="DbContext"/> de cada request (uno por HTTP request,
+    /// scoped), la SEGUNDA transacción que abre — la de <c>EjecutarEnvioAsync</c>, nunca la
+    /// primera (la mini-transacción de <c>AsignadorDeNumeroComprobante</c>, que comitea sola y no
+    /// se pausa) — y hace que la primera petición en llegar a esa segunda transacción ESPERE a que
+    /// la segunda también llegue: garantiza que AMBAS ya dibujaron su número antes de que
+    /// cualquiera intente el <c>UPDATE</c> final.</summary>
+    private sealed class InterceptorDeRendezvousEnLaSegundaTransaccion : DbTransactionInterceptor
+    {
+        private readonly HashSet<object> _contextosVistos = [];
+        private readonly TaskCompletionSource _primeraLlego = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _segundaLlego = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            bool esLaSegundaTransaccionDeEsteContexto;
+            lock (_contextosVistos)
+            {
+                esLaSegundaTransaccionDeEsteContexto = eventData.Context is not null
+                    && !_contextosVistos.Add(eventData.Context);
+            }
+
+            if (esLaSegundaTransaccionDeEsteContexto)
+            {
+                if (!_primeraLlego.TrySetResult())
+                {
+                    // Ya había una esperando: esta es la segunda — libera a ambas.
+                    _segundaLlego.TrySetResult();
+                }
+                else
+                {
+                    await _segundaLlego.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+                }
+            }
+
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Binding gate test, parte 2 (design: Failure Semantics, "el número queda quemado —
+    /// residuo aceptado"): dos <c>enviar</c> concurrentes del MISMO presupuesto producen un
+    /// <c>200</c> + un <c>409</c> — nunca dos <c>200</c>. El interceptor de rendezvous fuerza que
+    /// AMBAS peticiones ya hayan dibujado su número antes de que cualquiera corra el <c>UPDATE</c>
+    /// final, así que el número del perdedor queda quemado por construcción: el siguiente
+    /// presupuesto enviado del mismo PV salta el hueco exacto.</summary>
+    [Fact]
+    public async Task DosEnviarConcurrentesDelMismoPresupuestoDanUn200YUn409ConNumeroQuemado()
+    {
+        var interceptor = new InterceptorDeRendezvousEnLaSegundaTransaccion();
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        var ctx = await PrepararConFactoryAsync(nameof(DosEnviarConcurrentesDelMismoPresupuestoDanUn200YUn409ConNumeroQuemado), factory);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+
+        var vencimiento = FechaFutura();
+        var tareaA = ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        var tareaB = ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+
+        var ganadores = respuestas.Count(r => r.StatusCode == HttpStatusCode.OK);
+        var perdedores = respuestas.Count(r => r.StatusCode == HttpStatusCode.Conflict);
+        Assert.Equal(1, ganadores);
+        Assert.Equal(1, perdedores);
+
+        var perdedor = respuestas.First(r => r.StatusCode == HttpStatusCode.Conflict);
+        var problema = await perdedor.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("presupuesto_ya_enviado", problema.GetProperty("codigo").GetString());
+
+        // El hueco: el ganador se llevó 1, el perdedor quemó 2 (comitea igual, incondicional), el
+        // SIGUIENTE presupuesto del mismo PV salta directo a 3.
+        var siguiente = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var siguienteEnvio = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{siguiente.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        Assert.Equal(HttpStatusCode.OK, siguienteEnvio.StatusCode);
+        var siguienteEnviado = (await siguienteEnvio.Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson))!;
+        Assert.Equal(3, siguienteEnviado.Numero);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoPresupuesto.Enviado, (await db.Presupuestos.FirstAsync(p => p.Id == creado.Id)).Estado);
+    }
+
+    // ---- task 2.12: mutation target #17 — la carrera del relink de PV ------------------------------
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target #17 (task 2.12, mismo patrón que
+    /// <c>ServicioDeOrdenesDeCompraTests.UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja</c>):
+    /// un <c>PUT</c> que mueve el presupuesto del PV 1 al PV 2 gana la carrera y COMMITEA DESPUÉS
+    /// de que el número ya fue dibujado (serie del PV 1) pero ANTES de que el <c>UPDATE</c> final
+    /// de <c>enviar</c> corra — pausado justo tras <c>BeginTransactionAsync</c> de
+    /// <c>EjecutarEnvioAsync</c>. El <c>WHERE id_punto_venta = $pv</c> (pineado al PV 1, capturado
+    /// en la pre-lectura) no matchea la fila ya movida al PV 2 ⇒ 0 filas ⇒ <c>409</c>, el número
+    /// dibujado para el PV 1 queda quemado SIN aparecer en ninguna orden — nunca aterriza en la
+    /// serie del PV 2.</summary>
+    [Fact]
+    public async Task UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja()
+    {
+        var ctx = await PrepararAsync(nameof(UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idPuntoVenta: ctx.IdPuntoVenta));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteEnviar = factory.CreateClient();
+        var login = await clienteEnviar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var vencimiento = FechaFutura();
+        var tareaEnviar = clienteEnviar.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+
+        await transaccionIniciada.Task;
+
+        // El PUT gana la carrera: mueve el presupuesto al PV 2 y COMMITEA antes de que el UPDATE
+        // final de enviar corra.
+        var solicitudRelink = new SolicitudDePresupuesto(
+            ctx.IdPuntoVenta2, ctx.IdCliente, null, [new LineaDePresupuesto(ctx.IdArticulo, 2m)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/presupuestos/{creado.Id}", solicitudRelink);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaEnviar = await tareaEnviar;
+        var cuerpoEnviar = await respuestaEnviar.Content.ReadAsStringAsync();
+        Assert.True(respuestaEnviar.StatusCode == HttpStatusCode.Conflict, cuerpoEnviar);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoEnviar, OpcionesJson);
+        Assert.Equal("presupuesto_ya_enviado", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.Presupuestos.FirstAsync(p => p.Id == creado.Id);
+        Assert.Equal(EstadoPresupuesto.Borrador, actual.Estado);
+        Assert.Null(actual.Numero);
+        Assert.Equal(ctx.IdPuntoVenta2, actual.IdPuntoVenta);
+
+        // El número quemado (serie del PV 1) nunca aparece en ningún presupuesto de ese punto de
+        // venta: un envío siguiente del PV 1 salta directo al 2.
+        var siguientePv1 = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idPuntoVenta: ctx.IdPuntoVenta));
+        var siguienteEnvioPv1 = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{siguientePv1.Id}/enviar", new SolicitudDeEnvio(vencimiento));
+        Assert.Equal(HttpStatusCode.OK, siguienteEnvioPv1.StatusCode);
+        var siguienteEnviadaPv1 = (await siguienteEnvioPv1.Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson))!;
+        Assert.Equal(2, siguienteEnviadaPv1.Numero);
+    }
+
+    // ---- task 2.7: anular ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task AnularUnPresupuestoEnviadoLoPasaAAnulado()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnPresupuestoEnviadoLoPasaAAnulado));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var enviar = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
+        Assert.Equal(HttpStatusCode.OK, enviar.StatusCode);
+
+        var anular = await ctx.Admin.PostAsync($"/api/presupuestos/{creado.Id}/anular", null);
+        var cuerpo = await anular.Content.ReadAsStringAsync();
+        Assert.True(anular.StatusCode == HttpStatusCode.OK, cuerpo);
+        var anulado = JsonSerializer.Deserialize<PresupuestoDetalle>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoPresupuesto.Anulado, anulado.Estado);
+    }
+
+    /// <summary>Una segunda anulación sobre un presupuesto ya <c>anulado</c> es rechazada — el
+    /// <c>WHERE estado IN ('borrador','enviado')</c> del <c>UPDATE</c> no matchea una fila ya
+    /// <c>anulado</c>, mismo criterio de "OD8/T1" (convertido/anulado ambos quedan fuera del
+    /// IN).</summary>
+    [Fact]
+    public async Task AnularDosVecesElMismoPresupuestoEsRechazadoLaSegundaVez409PresupuestoNoAnulable()
+    {
+        var ctx = await PrepararAsync(nameof(AnularDosVecesElMismoPresupuestoEsRechazadoLaSegundaVez409PresupuestoNoAnulable));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        var primeraAnulacion = await ctx.Admin.PostAsync($"/api/presupuestos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, primeraAnulacion.StatusCode);
+
+        var segundaAnulacion = await ctx.Admin.PostAsync($"/api/presupuestos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Conflict, segundaAnulacion.StatusCode);
+        var problema = await segundaAnulacion.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("presupuesto_no_anulable", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 2.9: el filtro vencido exige idPuntoVenta ---------------------------------------------
+
+    [Fact]
+    public async Task ListarConVencidoSinIdPuntoVentaEsRechazado400PuntoVentaRequerido()
+    {
+        var ctx = await PrepararAsync(nameof(ListarConVencidoSinIdPuntoVentaEsRechazado400PuntoVentaRequerido));
+
+        var respuesta = await ctx.Admin.GetAsync("/api/presupuestos?vencido=true");
+
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("punto_venta_requerido", problema.GetProperty("codigo").GetString());
+    }
+
+    /// <summary>task 2.8/2.9: un presupuesto <c>enviado</c> con <c>vencimiento</c> pasado reporta
+    /// <c>Vencido = true</c> en la lectura, y el filtro <c>vencido=true</c> lo incluye mientras que
+    /// <c>vencido=false</c> lo excluye — ambos resueltos en la zona DEFAULT del punto de venta
+    /// (Buenos Aires), sin seedear ningún parametro.</summary>
+    [Fact]
+    public async Task UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararConFactoryAsync(
+            nameof(UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina), factory);
+
+        // Enviado con vencimiento HOY (no vencido todavía) — luego lo "vencemos" escribiendo
+        // directo la columna, porque enviar exige vencimiento >= hoy.
+        var vencido = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var enviarVencido = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{vencido.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 8, 19)));
+        Assert.Equal(HttpStatusCode.OK, enviarVencido.StatusCode);
+
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var fila = await db.Presupuestos.FirstAsync(p => p.Id == vencido.Id);
+            fila.Vencimiento = new DateOnly(2026, 8, 10);
+            await db.SaveChangesAsync();
+        }
+
+        var vigente = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx));
+        var enviarVigente = await ctx.Admin.PostAsJsonAsync(
+            $"/api/presupuestos/{vigente.Id}/enviar", new SolicitudDeEnvio(new DateOnly(2026, 12, 31)));
+        Assert.Equal(HttpStatusCode.OK, enviarVigente.StatusCode);
+
+        var detalleVencido = await ctx.Admin.GetFromJsonAsync<PresupuestoDetalle>($"/api/presupuestos/{vencido.Id}", OpcionesJson);
+        Assert.True(detalleVencido!.Vencido);
+        Assert.False(detalleVencido.Convertible);
+
+        var detalleVigente = await ctx.Admin.GetFromJsonAsync<PresupuestoDetalle>($"/api/presupuestos/{vigente.Id}", OpcionesJson);
+        Assert.False(detalleVigente!.Vencido);
+        Assert.True(detalleVigente.Convertible);
+
+        var pageVencidos = await ctx.Admin.GetFromJsonAsync<PaginaDePresupuestos>(
+            $"/api/presupuestos?idPuntoVenta={ctx.IdPuntoVenta}&vencido=true", OpcionesJson);
+        Assert.Contains(pageVencidos!.Items, p => p.Id == vencido.Id);
+        Assert.DoesNotContain(pageVencidos.Items, p => p.Id == vigente.Id);
+
+        var pageVigentes = await ctx.Admin.GetFromJsonAsync<PaginaDePresupuestos>(
+            $"/api/presupuestos?idPuntoVenta={ctx.IdPuntoVenta}&vencido=false", OpcionesJson);
+        Assert.Contains(pageVigentes!.Items, p => p.Id == vigente.Id);
+        Assert.DoesNotContain(pageVigentes.Items, p => p.Id == vencido.Id);
+    }
+
+    // ---- task 2.20: paginación con fecha_emision empatada + campos posicionales --------------------
+
+    /// <summary>Regla 12b (mutation-proof-tests): con <c>fecha_emision</c> EMPATADA
+    /// (<c>RelojFijo</c>) en toda la tanda, el desempate por <c>Id DESC</c> hace que la página 2 no
+    /// repita ni saltee filas — sin él, un orden solo por <c>fecha_emision</c> es indeterminado
+    /// entre filas empatadas.</summary>
+    [Fact]
+    public async Task PaginacionConFechaEmisionEmpatadaNoRepiteNiSalteaFilas()
+    {
+        var instanteFijo = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararConFactoryAsync(nameof(PaginacionConFechaEmisionEmpatadaNoRepiteNiSalteaFilas), factory);
+
+        var ids = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+            ids.Add(creado.Id);
+        }
+
+        var pagina1 = await ctx.Admin.GetFromJsonAsync<PaginaDePresupuestos>(
+            $"/api/presupuestos?idPuntoVenta={ctx.IdPuntoVenta}&pagina=1&tamanio=3", OpcionesJson);
+        var pagina2 = await ctx.Admin.GetFromJsonAsync<PaginaDePresupuestos>(
+            $"/api/presupuestos?idPuntoVenta={ctx.IdPuntoVenta}&pagina=2&tamanio=3", OpcionesJson);
+
+        Assert.Equal(3, pagina1!.Items.Count);
+        Assert.Equal(2, pagina2!.Items.Count);
+        Assert.Equal(5, pagina1.Total);
+
+        var idsDePaginas = pagina1.Items.Select(p => p.Id).Concat(pagina2.Items.Select(p => p.Id)).ToList();
+        Assert.Equal(ids.OrderByDescending(x => x), idsDePaginas);
+    }
+
+    /// <summary>Regla 12b: cada campo posicional de <see cref="PresupuestoDetalle"/>/
+    /// <see cref="ItemDePresupuesto"/> se lee de vuelta con un valor DISTINTO al de sus vecinos —
+    /// un test que solo comparara con <c>null</c>/default no discriminaría un mapeo de campos
+    /// desordenado (p.ej. <c>Subtotal</c>/<c>Total</c> swappeados).</summary>
+    [Fact]
+    public async Task TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles()
+    {
+        var ctx = await PrepararAsync(nameof(TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles));
+        var creado = await CrearBorradorAsync(
+            ctx.Admin,
+            new SolicitudDePresupuesto(
+                ctx.IdPuntoVenta, ctx.IdCliente, "observacion distinguible",
+                [new LineaDePresupuesto(ctx.IdArticulo, 3m), new LineaDePresupuesto(ctx.IdArticulo2, 1m)]));
+
+        Assert.Equal(ctx.IdPuntoVenta, creado.IdPuntoVenta);
+        Assert.Equal(ctx.IdCliente, creado.IdCliente);
+        Assert.True(creado.IdEmpleado > 0);
+        Assert.Null(creado.Numero);
+        Assert.Null(creado.NumeroFormateado);
+        Assert.Null(creado.FechaEnvio);
+        Assert.Null(creado.Vencimiento);
+        Assert.False(creado.Vencido);
+        Assert.False(creado.Convertible);
+        Assert.Equal("America/Argentina/Buenos_Aires", creado.ZonaId);
+        Assert.Equal("observacion distinguible", creado.Observaciones);
+        // item1: 3 * 100 = 300; item2: 1 * 250 = 250; header Subtotal/Total = 550 (sin descuento).
+        Assert.Equal(550m, creado.Subtotal);
+        Assert.Equal(0m, creado.DescuentoTotal);
+        Assert.Equal(550m, creado.Total);
+        Assert.Equal(EstadoPresupuesto.Borrador, creado.Estado);
+        Assert.Null(creado.IdComprobanteVenta);
+
+        var item1 = creado.Items.Single(i => i.IdArticulo == ctx.IdArticulo);
+        Assert.Equal(1, item1.Orden);
+        Assert.Equal("Pres Articulo 1", item1.Descripcion);
+        Assert.Equal(3m, item1.Cantidad);
+        Assert.Equal(100m, item1.PrecioUnitario);
+        Assert.Equal(0m, item1.Descuento);
+        Assert.Equal(300m, item1.Total);
+        Assert.Equal(ctx.IdListaPrecio, item1.IdListaPrecio);
+        Assert.Null(item1.IdOferta);
+        Assert.Equal(ctx.IdAlicuotaIva, item1.IdAlicuotaIva);
+        Assert.Equal(21m, item1.PorcentajeIva);
+
+        var enviar = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
+        var enviado = (await enviar.Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson))!;
+        Assert.Equal(1, enviado.Numero);
+        Assert.Equal($"{ctx.IdPuntoVenta:D4}-00000001", enviado.NumeroFormateado);
+        Assert.NotNull(enviado.FechaEnvio);
+        Assert.Equal(EstadoPresupuesto.Enviado, enviado.Estado);
+    }
+
+    // ---- autorización — matriz explícita (Vendedor SÍ escribe; Root 403; sin token 401) ------------
+
+    [Fact]
+    public async Task LaMatrizDeAutorizacionEsOperacionDePosVendedorEscribeRootBloqueadoSinTokenNoAutenticado()
+    {
+        var ctx = await PrepararAsync(nameof(LaMatrizDeAutorizacionEsOperacionDePosVendedorEscribeRootBloqueadoSinTokenNoAutenticado));
+
+        // Vendedor: ciclo de vida completo, todo 2xx.
+        var crear = await ctx.Vendedor.PostAsJsonAsync("/api/presupuestos", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Created, crear.StatusCode);
+        var creado = (await crear.Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson))!;
+
+        var editar = await ctx.Vendedor.PutAsJsonAsync($"/api/presupuestos/{creado.Id}", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.OK, editar.StatusCode);
+
+        var enviar = await ctx.Vendedor.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
+        Assert.Equal(HttpStatusCode.OK, enviar.StatusCode);
+
+        var anular = await ctx.Vendedor.PostAsync($"/api/presupuestos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anular.StatusCode);
+
+        var listar = await ctx.Vendedor.GetAsync("/api/presupuestos");
+        Assert.Equal(HttpStatusCode.OK, listar.StatusCode);
+
+        // Root: bloqueado — OperacionDePos no admite plataforma.
+        var rootCrear = await ctx.Root.PostAsJsonAsync("/api/presupuestos", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Forbidden, rootCrear.StatusCode);
+
+        // Sin token: no autenticado.
+        using var sinToken = fixture.CreateClient();
+        var sinTokenRespuesta = await sinToken.PostAsJsonAsync("/api/presupuestos", SolicitudSimple(ctx));
+        Assert.Equal(HttpStatusCode.Unauthorized, sinTokenRespuesta.StatusCode);
+    }
+
+    // ---- gate guard (task 2.21) ----------------------------------------------------------------------
+
+    /// <summary>Gate guard (task 2.21, decisión 2 de tasks.md): esta slice no agrega DDL — el
+    /// modelo EF sigue coincidiendo exactamente con la migración de Slice 1.</summary>
+    [Fact]
+    public async Task NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice1()
+    {
+        using var _ = fixture.CreateClient();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var hayPendientes = db.Database.HasPendingModelChanges();
+        Assert.False(hayPendientes);
+    }
+
+    private static DateOnly FechaFutura() => DateOnly.FromDateTime(DateTime.UtcNow).AddDays(30);
+}

--- a/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
 using Ways.Application.Usuarios;
 using Ways.Application.Ventas;
@@ -163,6 +164,20 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
         Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
         return JsonSerializer.Deserialize<PresupuestoDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    /// <summary>Mismo shape que <c>OfertasResolucionTests.OfertaDeArticulo</c> — oferta directa
+    /// (sin <c>cantidad_minima</c>), sin ventana de vigencia, alcance a un único artículo.</summary>
+    private static AltaOferta OfertaDeArticulo(int idArticulo, decimal porcentaje) => new(
+        Nombre: "oferta de prueba", IdEmpresa: null, IdArticulo: idArticulo, IdGrupo: null, IdCategoria: null,
+        FechaDesde: null, FechaHasta: null, HoraDesde: null, HoraHasta: null, DiasSemana: null,
+        CantidadMinima: null, PrecioUnitario: null, Porcentaje: porcentaje, ImporteFijo: null,
+        Prioridad: 0, Acumulable: false);
+
+    private static async Task CrearOfertaAsync(HttpClient cliente, AltaOferta datos)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/ofertas", datos);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
     }
 
     // ---- task 2.2: crear borrador, precio resuelto al guardar --------------------------------------
@@ -738,11 +753,19 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
     /// <summary>Regla 12b: cada campo posicional de <see cref="PresupuestoDetalle"/>/
     /// <see cref="ItemDePresupuesto"/> se lee de vuelta con un valor DISTINTO al de sus vecinos —
     /// un test que solo comparara con <c>null</c>/default no discriminaría un mapeo de campos
-    /// desordenado (p.ej. <c>Subtotal</c>/<c>Total</c> swappeados).</summary>
+    /// desordenado (p.ej. <c>Subtotal</c>/<c>Total</c> swappeados). Variante por descuento-cero
+    /// (judgment-day, mismo mecanismo pero con un valor no-null coincidentemente igual): sin una
+    /// oferta real sembrada, <c>DescuentoTotal</c> es siempre <c>0m</c> y <c>Subtotal == Total</c>
+    /// — un swap de esos dos campos en el sitio de construcción (<c>ServicioDePresupuestos.cs</c>,
+    /// tanto el <see cref="PresupuestoDetalle"/> como su espejo en <c>ProyectarListado</c>)
+    /// pasaría verde. Se siembra una oferta del 20% sobre <c>ctx.IdArticulo2</c> para que los tres
+    /// valores del header sean pairwise-distintos.</summary>
     [Fact]
     public async Task TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles()
     {
         var ctx = await PrepararAsync(nameof(TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles));
+        await CrearOfertaAsync(ctx.Admin, OfertaDeArticulo(ctx.IdArticulo2, porcentaje: 20m));
+
         var creado = await CrearBorradorAsync(
             ctx.Admin,
             new SolicitudDePresupuesto(
@@ -760,10 +783,11 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
         Assert.False(creado.Convertible);
         Assert.Equal("America/Argentina/Buenos_Aires", creado.ZonaId);
         Assert.Equal("observacion distinguible", creado.Observaciones);
-        // item1: 3 * 100 = 300; item2: 1 * 250 = 250; header Subtotal/Total = 550 (sin descuento).
+        // item1: 3 * 100 = 300 (sin oferta); item2: 1 * 250 con oferta 20% = 250 - 50 = 200;
+        // header Subtotal = 550, DescuentoTotal = 50, Total = 500 — los tres pairwise-distintos.
         Assert.Equal(550m, creado.Subtotal);
-        Assert.Equal(0m, creado.DescuentoTotal);
-        Assert.Equal(550m, creado.Total);
+        Assert.Equal(50m, creado.DescuentoTotal);
+        Assert.Equal(500m, creado.Total);
         Assert.Equal(EstadoPresupuesto.Borrador, creado.Estado);
         Assert.Null(creado.IdComprobanteVenta);
 
@@ -778,6 +802,13 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
         Assert.Null(item1.IdOferta);
         Assert.Equal(ctx.IdAlicuotaIva, item1.IdAlicuotaIva);
         Assert.Equal(21m, item1.PorcentajeIva);
+
+        // Mismo swap Subtotal/Total en el sitio de construcción también pasaría verde en el
+        // listado (ProyectarListado lee presupuesto.Total) — se confirma la fila.
+        var listado = await ctx.Admin.GetFromJsonAsync<PaginaDePresupuestos>(
+            $"/api/presupuestos?idPuntoVenta={ctx.IdPuntoVenta}&pagina=1&tamanio=10", OpcionesJson);
+        var filaListado = listado!.Items.Single(p => p.Id == creado.Id);
+        Assert.Equal(500m, filaListado.Total);
 
         var enviar = await ctx.Admin.PostAsJsonAsync($"/api/presupuestos/{creado.Id}/enviar", new SolicitudDeEnvio(FechaFutura()));
         var enviado = (await enviar.Content.ReadFromJsonAsync<PresupuestoDetalle>(OpcionesJson))!;

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -85,6 +85,14 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // SupervisionDeCuentaDeProveedor en vez de GestionDeCatalogo. 403 Vendedor cubierto en
         // AjusteDeCuentaCorrienteDeProveedorTests.
         ("POST", "/api/proveedores/{idProveedor:int}/cuenta-corriente/ajustes"),
+        // stage-17-presupuestos-y-remitos (Slice 2, design decisión 17/proposal decisión 10):
+        // /api/presupuestos agrupa SOLO bajo OperacionDePos, nada apilado — a diferencia de
+        // /api/ordenes-compra, que SÍ apila GestionDeCatalogo. Un Vendedor tiene que poder
+        // quotear/enviar/anular un presupuesto, mismo criterio que "/api/ventas/".
+        ("POST", "/api/presupuestos/"),
+        ("PUT", "/api/presupuestos/{id:int}"),
+        ("POST", "/api/presupuestos/{id:int}/enviar"),
+        ("POST", "/api/presupuestos/{id:int}/anular"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

- `ServicioDePresupuestos`: borrador CRUD (replace-set bajo `FOR UPDATE WHERE estado='borrador'`, orden server-asignado, resolvers 404 privados propios), `EnviarAsync` con la serie `'PRES'` (número ANTES de la transacción + WHERE con estado Y PV pineados — el patrón OC), `AnularAsync`, y el read model con `Vencido`/`Convertible` DERIVADOS de la regla pura con la zona del PV (jamás columnas).
- Endpoints `/api/presupuestos` bajo `OperacionDePos` SOLO (el Vendedor escribe — la diferencia deliberada con OC, decisión 10).
- Los 2 vinculantes de concurrencia (presupuestos distintos sin 409; mismo presupuesto 200+409 con hueco assertado — rendezvous determinista con interceptor tras cazar que el `Task.WhenAll` desnudo resolvía en el pre-chequeo) + los 2 tests de zona (-03:00/+05:30). Targets 12-22 con evidencia; 14/19/22 estructuralmente inalcanzables registrados con su prueba.

## Judgment-day

- Juez B: 0 hallazgos en 5 ciclos (replace-set con hermana, el WHERE del enviar, la zona a UTC fijo, el swap 12b, dto-honesty del PUT).
- Juez A: **1 MAJOR** — el test del swap Subtotal/Total assertaba valores IGUALES (550==550: nadie sembraba descuento — 2da variante de la clase de coincidencia). Fix `00b2505`: oferta real del 20% vía POST /api/ofertas ⇒ 550/50/500 pairwise-distintos, con el espejo del listado también discriminado (ambas mutaciones mueren). Re-ronda A limpia. + 1 SUGGESTION (target 22 registrado con su evidencia estructural).

Gate: cero DDL, `has-pending-model-changes` limpio, ServicioDeVentas/ManejadorDeErrores/VentasCheckoutTests byte-idénticos. Regresión completa verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)