### PR TITLE
test(ordenes-compra): reloj pineado en el borde del dia UTC para el shape de reposicion

### DIFF
--- a/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
+++ b/tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs
@@ -574,7 +574,17 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
     [Fact]
     public async Task ReposicionMantieneSuShapeYSusFigurasSinCambios()
     {
-        var ctx = await PrepararAsync(nameof(ReposicionMantieneSuShapeYSusFigurasSinCambios));
+        // Reloj pineado en el borde del día UTC: 01:30Z ya es "mañana" en UTC pero sigue siendo
+        // 2026-08-19 22:30 en America/Argentina/Buenos_Aires (la zona sembrada del PV). El
+        // contrato del endpoint resuelve "hoy" en la zona del PV, nunca en UTC (spec de la
+        // etapa 13, vinculante) — assertar la fecha UTC del reloj de pared hacía fallar este
+        // test todas las noches en la franja 21:00-00:00 locales.
+        var instanteFijo = new DateTimeOffset(2026, 8, 20, 1, 30, 0, TimeSpan.Zero);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        var ctx = await PrepararAsync(nameof(ReposicionMantieneSuShapeYSusFigurasSinCambios), factory);
 
         var respuesta = await ctx.Admin.GetAsync($"/api/reportes/stock/reposicion?idPuntoVenta={ctx.IdPuntoVenta}");
         var cuerpo = await respuesta.Content.ReadAsStringAsync();
@@ -585,8 +595,8 @@ public class OrdenesCompraLecturaTests(WaysApiFixture fixture) : IClassFixture<W
         // (ordenes-de-compra/spec.md: "Etapa 13 stays a read-only source").
         var reposicion = JsonSerializer.Deserialize<Reposicion>(cuerpo, OpcionesJson)!;
         Assert.Equal(ctx.IdPuntoVenta, reposicion.IdPuntoVenta);
-        Assert.Equal(DateOnly.FromDateTime(DateTime.UtcNow), reposicion.Hoy);
-        Assert.NotNull(reposicion.ZonaHoraria);
+        Assert.Equal("America/Argentina/Buenos_Aires", reposicion.ZonaHoraria);
+        Assert.Equal(new DateOnly(2026, 8, 19), reposicion.Hoy);
         Assert.NotNull(reposicion.Filas);
     }
 


### PR DESCRIPTION
## Resumen

`ReposicionMantieneSuShapeYSusFigurasSinCambios` assertaba `reposicion.Hoy` contra `DateOnly.FromDateTime(DateTime.UtcNow)` del reloj de pared, pero el endpoint resuelve "hoy" en la zona del punto de venta (spec vinculante de la etapa 13). Resultado: el test fallaba de forma REPRODUCIBLE todas las noches entre las 21:00 y las 00:00 hora local (-03:00) — detectado en las dos full suites del 2026-08-19 ~22:30 (no era flakiness Testcontainers).

## Cambios

| Archivo | Cambio |
|---|---|
| `tests/Ways.IntegrationTests/OrdenesCompraLecturaTests.cs` | `RelojFijo` en `2026-08-20T01:30Z` (== 2026-08-19 22:30 en Buenos Aires — el borde exacto) + asserts exactos de `ZonaHoraria` y `Hoy` |

El defecto era SOLO del test: `ServicioDeReportesDeStock.ResolverContextoAsync` cumple el contrato y tiene su propio test de zona de la etapa 13.

## Evidencia (mutation-proof-tests)

- Producción mutada a `reloj.Ahora.UtcDateTime` → RED (`Expected: 19/08/2026 / Actual: 20/08/2026`) → revert → verde.
- `ZonaHoraria` falseada a `"UTC"` en el return → RED → revert → verde (juez B).
- Clase completa `OrdenesCompraLecturaTests`: 14/14 verdes.

## Judgment-day

Ronda limpia: juez B APPROVE (2 mutantes RED + análisis del borde: para una zona -03 fija sin DST el espacio de fallas tiene un solo lado, cubierto), juez A APPROVE. Deuda registrada, preexistente y fuera del diff: el mutante `AddHours(-3)` sobrevive por limitación del fixture (única zona sembrada); `Filas` vacías y `DiasDeRotacion` sin assert en el test original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)