### PR TITLE
feat(remitos): schema de remitos + ALTER TYPE aislado + tipo TXR (etapa 17, slice 4)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -105,6 +105,16 @@ filas existentes. Los dos nets se prueban de forma independiente (mutation targe
 tercera red, en el resolver de `ServicioDeVentas` (`|| !tipo.AfectaStock`, slice 3), refuerza el
 cierre contra cualquier tipo `afecta_stock = false` futuro, no solo `PRE`.
 
+**`TXR` (etapa 17 — consolidación de remitos, doc 10 §4 "Remitos"):** mismo perfil que `RC`/`PRE`
+— `letra 'X'`, `es_fiscal false`, `afecta_stock false`, `discrimina_iva false` —, pero `signo +1`
+(el comprobante consolida N remitos SIN items por construcción, precedente `RC`). Nace `activo
+true` pero **inemitible por mostrador**: `afecta_stock = false` lo bloquea el mismo guard del
+resolver que cierra `PRE` (`ServicioDeVentas`, `|| !tipo.AfectaStock`, slice 3) — el único
+escritor legítimo es `ServicioDeFacturacionDeRemitos` (slice 6), nunca `POST /api/ventas`. Se
+siembra dos veces: en la lista de arriba para una base nueva y, de forma idempotente, dentro de
+la migración `RemitosEtapa17` para una base ya migrada — este seed corre solo cuando la tabla
+está vacía.
+
 **`RC` (etapa 7 — pago a cuenta, doc 10 §8):** mismo perfil que `PRE` — `letra NULL`,
 `es_fiscal false`, `afecta_stock false`, `discrimina_iva false` —, pero `signo +1` porque el
 dinero entra (el signo negativo vive en el movimiento de cuenta corriente, nunca en el total
@@ -486,6 +496,67 @@ zona horaria del punto de venta. `ServicioDePresupuestos` (draft CRUD, `enviar` 
 `'PRES'`, `anular`, la lectura con `vencido` derivado) es slice 2; la conversión dentro de la
 transacción de venta (`EscriturasDePresupuesto`, el guard en `ServicioDeVentas`) es slice 3.
 
+### Remitos (Etapa 17)
+
+La mercadería que sale bajo su propio documento, ANTES de la factura que la consolida
+(doc-11:307-324, proposal decisión 6/7 del explore). Estructural mirror de `presupuestos`: vive
+en su propia tabla, nunca en `comprobantes_venta` — la consolidación (`ServicioDeFacturacionDeRemitos`,
+slice 6) recién crea el `comprobantes_venta` (tipo `TXR`, SIN items, N remitos → 1) que la
+factura.
+
+```sql
+remitos (                      -- [operativa]
+    id_remito, id_tenant, id_punto_venta,
+    id_cliente, id_empleado,
+    numero                  bigint      NULL,       -- correlativo propio por PV, serie 'REM';
+                                                     -- se asigna únicamente al EMITIR
+    fecha_emision            timestamptz NOT NULL,   -- creación del borrador (IRelojDelSistema)
+    fecha_salida             timestamptz NULL,       -- par de `numero`: cuándo salió la mercadería
+    direccion_entrega        text NULL,
+    observaciones,
+    subtotal, descuento_total, total,
+    estado estado_remito NOT NULL,                  -- enum: borrador | emitido | facturado
+                                                     --     | anulado
+    id_comprobante_venta     integer NULL           -- la factura consolidada (N remitos → 1);
+                                                     -- id_tipo_comprobante = 'TXR'
+);
+
+items_remito (
+    id_item, id_tenant, id_remito, orden,
+    id_articulo,                        -- NOT NULL: un remito entrega mercadería, nunca un
+                                         -- servicio
+    descripcion text,
+    cantidad         numeric(12,3),
+    precio_unitario  numeric(14,2),
+    descuento        numeric(14,2) NOT NULL DEFAULT 0,
+    total            numeric(14,2),
+    id_lista_precio  integer,
+    id_oferta        integer NULL,
+    id_alicuota_iva  integer, porcentaje_iva numeric(5,2),
+    costo_unitario    numeric(14,2) NULL,     -- congelado al SALIR la mercadería (etapa 9)
+    costo_es_estimado boolean NOT NULL DEFAULT false,
+    id_lote           integer NULL            -- FEFO resuelto y congelado, como el ítem de venta
+    -- A diferencia de items_presupuesto, ESTA línea SÍ congela costo y lote: la mercadería
+    -- efectivamente sale por este write site.
+);
+```
+
+**Estado (Etapa 17, slice 4 — schema + backstops, DB CHANGE GATE ejercido y aprobado):
+implementada — schema.** Creadas por la migración `RemitosEtapa17`, junto con el `ALTER TYPE
+motivo_stock ADD VALUE 'remito'` (§6, **el único artefacto IRREVERSIBLE de la etapa**, aceptado y
+registrado) y el ALTER de `movimientos_stock` (§6, `id_remito`). `EntidadBase`: **SÍ** en las dos
+tablas, mismo criterio que `presupuestos`. `ux_remitos_numero` es **UNIQUE PARCIAL** `WHERE
+numero IS NOT NULL`; `ck_remitos_salida_completa` exige que `numero`/`fecha_salida` lleguen
+juntos, salvo `anulado`; `ck_remitos_facturacion` exige que `estado = 'facturado'` y
+`id_comprobante_venta` viajen JUNTOS, en ambas direcciones — el desligue de la anulación de un
+`TXR` (slice 6) los limpia a la vez. `estado_remito` se registra únicamente vía
+`npgsql.MapEnum<EstadoRemito>` en `DependencyInjection.cs`/`WaysDbContextFactory.cs` — nunca
+también con `HasPostgresEnum`. `ManejadorDeErrores.cs` gana 7 ramas exactas: 2 `23505`
+(`ux_remitos_numero` → `numero_de_remito_duplicado`, **quinta ocurrencia** del ordering trap;
+`ux_items_remito_orden` → `orden_de_item_duplicado`) + 5 `23514` (las cinco CHECKs de este
+slice). `ServicioDeRemitos` (draft CRUD, `emitir` — el cuarto write site — con la serie `'REM'`,
+`anular`) es slice 5; la consolidación (`ServicioDeFacturacionDeRemitos`) es slice 6.
+
 ## 5. Comprobantes de compra
 
 Hoy las compras se cargan como gastos sin detalle; esta es la pieza nueva completa.
@@ -677,9 +748,11 @@ movimientos_stock (           -- [operativa]
     motivo   motivo_stock,                   -- enum: venta | compra | anulacion | ajuste
                                              --     | transferencia | inventario
                                              --     | decomiso | reclasificacion (Etapa 12)
+                                             --     | remito (Etapa 17, noveno valor)
     id_comprobante_venta NULL, id_comprobante_compra NULL,
     id_punto_venta_destino NULL,             -- transferencias entre locales (nuevo)
     id_lote NULL,                            -- dimensión de lote (Etapa 12)
+    id_remito NULL,                          -- documento del cuarto write site (Etapa 17)
     id_empleado, observaciones, creado_el
 );
 
@@ -754,6 +827,22 @@ stock_lotes (                  -- [operativa] (Etapa 12)
 > Control efectivo = `articulos.controla_lote` AND parámetro `lotes_habilitado` (empresa);
 > selección FEFO particionada no-vencidos-primero (`ReglaDeLotes.ElegirFefo`); vencido =
 > `fecha_vencimiento < hoy` estricto, con "hoy" en la zona horaria del punto de venta.
+>
+> **Estado (Etapa 17, slice 4 — schema + backstops, DB CHANGE GATE ejercido y aprobado):
+> `movimientos_stock.id_remito` implementada — sin escritor todavía (abre en slice 5).**
+> `ALTER TABLE movimientos_stock ADD COLUMN id_remito integer NULL` + `fk_movimientos_stock_remito`
+> compuesta MATCH SIMPLE + `ix_movimientos_stock_remito` — mismo shape exacto que
+> `fk_movimientos_stock_comprobante_venta`/`..._comprobante_compra`. Metadata-only en PG 11+
+> (columna nullable sin default), sin table rewrite. Sin esta columna, una fila de `motivo =
+> remito` sería la única inatribuible de un ledger append-only cuyo propósito es la
+> reconstrucción. `motivo_stock` gana su **noveno** valor, `'remito'`, vía `ALTER TYPE ... ADD
+> VALUE` en `RemitosEtapa17` — **el único artefacto IRREVERSIBLE de la etapa** (Postgres no
+> soporta `DROP VALUE`; mismo mecanismo y misma aceptación que `decomiso`/`reclasificacion` en
+> la Etapa 12, precedente citado por el proposal §B) — ningún `Sql()` de esa misma migración
+> puede nombrarlo. `motivo = remito` abre camino de escritura recién en slice 5
+> (`ServicioDeRemitos.EmitirAsync`, el cuarto write site — la garantía de "tres write sites" del
+> spec de stock se enmienda explícitamente a cuatro, mismo contrato/lock order duplicado
+> intencional).
 
 `stock.cantidad` es un cache mantenido en la misma transacción del movimiento.
 Transferencia entre locales: dos movimientos espejados — feature nueva que el legacy

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -132,6 +132,22 @@
   `cantidad_de_linea_invalida` (backstop tables, tasks 1.27/4.28) are all domain codes the
   proposal/spec left unnamed and `design` names — adopted verbatim, no further reconciliation
   needed per the established convention.
+- **CONFLICT #5 — NEW, found this apply batch (Slice 4).** This file's own decision 9 (Orchestrator
+  Decision, above) claims Slice 4 ships "3 exact-name `23514`" CHECK branches. The literal task
+  text of 4.24-4.26 also only names three (`ck_remitos_salida_completa`, `ck_remitos_facturacion`,
+  `ck_items_remito_cantidad_positiva`), and task 4.26's own parenthetical explicitly exempts
+  `ck_items_remito_costo_no_negativo`/`ck_items_remito_estimado_con_costo` as "generic-mapped."
+  This contradicts **two** higher-priority sources that agree with each other: `proposal.md`'s
+  own §J table (the gate contract) groups CHECK 2/5/6/7 into one row requiring exact-name
+  `23514` mapping for ALL FOUR (cantidad AND costo), and `design.md`'s own Backstop Map lists
+  CHECK 6/7 with the identical exact-name treatment. It is also inconsistent with THIS FILE's own
+  math at task 1.25 (registered in slice 1), which already reconciled proposal §J's stage total
+  (7 exact-name `23514`) as `2 (slice 1) + 5 (slice 4: ck_remitos_salida_completa,
+  ck_remitos_facturacion, and the THREE items_remito CHECKs)` — anticipating five, not three.
+  **Resolved in favor of the gate contract + design's Backstop Map + this file's own prior
+  reconciliation** (task 4.26): implemented as FIVE exact-name branches. The "3" in decision 9
+  above is registered as the same class of drafting artifact task 1.25 already named for slice 1's
+  "4" — a count carried forward without re-deriving it from the concrete DDL.
 - **No further conflicts found.** Every other design decision either restates the proposal's
   gate contract verbatim (checked line-by-line against `proposal.md` §A-K) or is one of the
   twelve tensions OD9 already ratifies.
@@ -951,92 +967,258 @@ green (27/27) after both fixes, `--no-incremental` rebuild.
 
 **Branch**: `feat/stage17-slice4-schema-remitos`. **Start**: PR 3 merged. **Finish**:
 `estado_remito` + both tables + the `movimientos_stock` ALTER exist with standard RLS, **30
-cumulative** new indexes, 5 `ManejadorDeErrores` branches proven out-of-band, `motivo_stock`
+cumulative** new indexes, **7** `ManejadorDeErrores` branches proven out-of-band (2 `23505` + 5
+`23514` — corrected from this section's original "5", see CONFLICT #5 below), `motivo_stock`
 gains `'remito'`. **Rollback**: `ALTER TABLE movimientos_stock DROP CONSTRAINT
 fk_movimientos_stock_remito` → `DROP COLUMN id_remito` → `DROP TABLE items_remito` → `DROP TABLE
 remitos` → `DROP TYPE estado_remito` → deactivate `TXR` (never delete). **The `motivo_stock`
 value `'remito'` is NOT reverted — irreversible, accepted, registered** (`proposal.md:1097-1099`).
 **Budget note**: pre-authorized split `4a`/`4b` (decision 3 above) if this slice overflows.
 
-- [ ] 4.1 Migration `RemitosEtapa17`, **first statement**: `ALTER TYPE motivo_stock ADD VALUE
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and result | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~RemitosSchemaTests\|FullyQualifiedName~ManejadorDeErroresRemitosTests\|FullyQualifiedName~ServicioDeVentasConversionTests"` — 74/74 green (resumption-batch run, this exact command; supersedes any earlier narrower-filter number) |
+| Runtime harness command/scenario and result | `dotnet test tests/Ways.IntegrationTests` (full suite, real Postgres 17 via Testcontainers, single run) — 1506/1533 green, 27 failed on the first pass, all 5 pre-existing-catalog fixes below already included in that pass. Isolated re-run (`--filter` scoped to the 3 affected classes, `--logger trx`, per apply protocol's flakiness rule) — 39/40 green: **26 of the 27** were `Npgsql`/Testcontainers socket-reset flakiness (`BackstopClientesYProveedoresTests` ×16, `AjustesDeCuentaCorrienteTests` ×10 — all "Exception while writing to stream" / connection aborted during fixture init, all green on isolated retry, counted GREEN per the flakiness rule). **1 remaining failure is NOT flaky and NOT this slice's**: `OrdenesCompraLecturaTests.ReposicionMantieneSuShapeYSusFigurasSinCambios` — a pre-existing UTC-vs-local midnight-boundary assertion (`Assert.Equal(DateOnly.FromDateTime(DateTime.UtcNow), reposicion.Hoy)`, line 588; failed identically both runs because UTC had already rolled to the next calendar day while the API's local zone had not). Untouched by this slice, no remitos/schema relation, registered here as a known pre-existing issue and deliberately NOT fixed (out of this work unit's scope) — net honest result: **1532/1533** accounted for, 1 pre-existing unrelated defect logged |
+| Mutation evidence (apply-time, reverted via `git checkout --` after each) | Data statement 2 (task 4.11): guarded `TXR` `INSERT` deleted → `UnaBaseYaMigradaGanaElTipoTxrAlAplicarLaMigracionDeEstaEtapa` RED (`activo`/`afecta_stock` assert fails, row never inserted) → reverted, green. Partial filter on `ux_remitos_numero`: `filter: "numero IS NOT NULL"` deleted → `DosBorradoresDeRemitoSinNumeroEnElMismoPuntoDeVentaConvivenSinConflicto` stayed GREEN (PROVABLY EQUIVALENT AT RUNTIME, same class as `PresupuestosSchemaTests` targets 4/5) → the discriminating text-source test (`ElTextoFuenteDeLaMigracionConservaElFiltroParcialDeUxRemitosNumero`) confirmed RED under the same mutation → reverted, both back to their real state. `MotivoStock.Remito` declaration order (task 4.14/4.31, mutation target 39): moved to the middle of the enum → the round-trip test stayed GREEN (design.md's premise does not hold — Npgsql's `MapEnum<T>` resolves by name, not ordinal position, confirmed empirically, no ordinal cast of `MotivoStock` exists in the repo) → `ElTextoFuenteDeMotivoStockDeclaraRemitoUltimo` confirmed RED under the same mutation → reverted via `git diff --stat` clean check. The five raw-insert CHECK backstop tests are self-proving by construction (a deleted constraint cannot produce that exact SQLSTATE+ConstraintName), same treatment slice 1 gave its own two CHECKs — not independently mutation-run this batch. (Evidence produced during the original implementation batch, referenced here unchanged per tasks 4.11/4.31 — not reproduced by this closing/resumption batch.) |
+| Rollback boundary | `git revert` of the schema commit (`3eab5ee`) plus this closing batch's follow-up test/fixture commit: `Remito`/`ItemRemito`/`EstadoRemito` disappear, `MotivoStock.cs` reverts to eight values (the native `'remito'` label stays a dead member — irreversible, accepted), `MovimientoStockConfiguration.cs`/`MovimientoStock.cs` revert to no `IdRemito`, the migration file and its `Designer.cs` are deleted, `WaysDbContext.cs`/`IWaysDbContext.cs`/`WaysDbContextFactory.cs`/`DependencyInjection.cs` revert their four additions, `ManejadorDeErrores.cs` drops the 7 branches, `InicializadorDeBaseDeDatos.cs` drops the `TXR` tuple, `docs/10-modelo-de-datos.md` drops the Remitos subsection + Stock blockquote + TXR note. No slice 1-3 file touched except the 5 pre-existing test fixes (registered deviations, all additive/expectation-only). The `motivo_stock` value `'remito'` itself is NOT reverted by any of this — irreversible, accepted, registered separately above |
+
+- [x] 4.1 Migration `RemitosEtapa17`, **first statement**: `ALTER TYPE motivo_stock ADD VALUE
   'remito'` — named by **nothing else** in this migration (Postgres forbids using a value in
   the transaction that adds it). *(proposal.md:636-643, decision 11, dependency for mutation
   target 39)*
-- [ ] 4.2 Same migration: `CREATE TYPE estado_remito AS ENUM
+- [x] 4.2 Same migration: `CREATE TYPE estado_remito AS ENUM
   ('borrador','emitido','facturado','anulado')`. *(proposal.md:626)*
-- [ ] 4.3 Same migration: `CREATE TABLE remitos` — 18 columns exactly per §E; `pk_remitos`.
+
+  **DONE, hand-reordered as anticipated (same class of desvío as slice 1 task 1.11)**: `dotnet
+  ef migrations add` emitted the `estado_remito` enum ALPHABETIZED
+  (`anulado,borrador,emitido,facturado`), and grouped every `CreateIndex` at the end instead of
+  interleaved per-table — both hand-fixed. The `ALTER TYPE motivo_stock ADD VALUE 'remito'`
+  itself required **no** hand-editing: it is executed automatically by the SAME
+  `migrationBuilder.AlterDatabase()` call (Npgsql's enum-diff mechanism — confirmed against the
+  stage-12 `decomiso`/`reclasificacion` precedent, which used the identical mechanism with zero
+  raw `Sql()`). Verified empirically that `motivo_stock`'s native member order has ALWAYS been
+  alphabetical (checked the original `VentasStockYCuentaCorrienteEtapa5` migration) — unlike
+  `EstadoPresupuesto`/`EstadoOrdenCompra`, `MotivoStock`'s own doc comment never claims "member
+  order = native order", so no hand-correction was needed for that enum's Annotation string.
+  Full statement order hand-fixed to the gate's prescription: `AlterDatabase` (ALTER TYPE +
+  CREATE TYPE) → `CreateTable remitos` + its 6 indexes → `CreateTable items_remito` + its 8
+  indexes → `AddColumn`/`AddForeignKey`/`CreateIndex` of `movimientos_stock.id_remito` → data
+  statement 2 (`TXR`, EF never auto-generates `Sql()`/RLS, added by hand) → `HabilitarRlsDeTenant`
+  on both new tables, last. `Down()` reactivation-avoidance for `TXR` (deactivate, never delete)
+  added by hand, mirroring `RC`/`C-*`; `motivo_stock`'s `'remito'` value is NOT reverted (comment
+  registered in `Down()`, same as `LotesYVencimientosEtapa12`).
+- [x] 4.3 Same migration: `CREATE TABLE remitos` — 18 columns exactly per §E; `pk_remitos`.
   *(proposal.md:771-791)*
-- [ ] 4.4 Same migration: 5 named FKs on `remitos` + `ak_remitos_id_remito_id_tenant`.
+- [x] 4.4 Same migration: 5 named FKs on `remitos` + `ak_remitos_id_remito_id_tenant`.
   *(proposal.md:796-803)*
-- [ ] 4.5 Same migration: `ck_remitos_salida_completa` + `ck_remitos_facturacion` exactly per
+- [x] 4.5 Same migration: `ck_remitos_salida_completa` + `ck_remitos_facturacion` exactly per
   §E's table. *(proposal.md:804-805)*
-- [ ] 4.6 Same migration: 7 named indexes — 5 FK-support/listing + `ux_remitos_numero`
+- [x] 4.6 Same migration: 7 named indexes — 5 FK-support/listing + `ux_remitos_numero`
   **UNIQUE PARTIAL** — plus the implicit AK index. *(proposal.md:808-819)*
-- [ ] 4.7 Same migration: `CREATE TABLE items_remito` — 20 columns exactly per §F, including
+- [x] 4.7 Same migration: `CREATE TABLE items_remito` — 20 columns exactly per §F, including
   `fk_items_remito_lote` MATCH SIMPLE; `pk_items_remito`. *(proposal.md:826-848, 857-864)*
-- [ ] 4.8 Same migration: `ck_items_remito_cantidad_positiva`, `ck_items_remito_costo_no_negativo`,
+- [x] 4.8 Same migration: `ck_items_remito_cantidad_positiva`, `ck_items_remito_costo_no_negativo`,
   `ck_items_remito_estimado_con_costo`. *(proposal.md:865-867)*
-- [ ] 4.9 Same migration: 8 named indexes — 7 FK-support + `ux_items_remito_orden` **UNIQUE**.
+- [x] 4.9 Same migration: 8 named indexes — 7 FK-support + `ux_items_remito_orden` **UNIQUE**.
   *(proposal.md:873-881)*
-- [ ] 4.10 Same migration: `ALTER TABLE movimientos_stock ADD COLUMN id_remito integer NULL` +
+- [x] 4.10 Same migration: `ALTER TABLE movimientos_stock ADD COLUMN id_remito integer NULL` +
   `fk_movimientos_stock_remito` composite MATCH SIMPLE + named `ix_movimientos_stock_remito`.
   *(proposal.md:916-928)*
-- [ ] 4.11 Same migration, data statement 2: guarded `INSERT` of `TXR` for already-migrated
+- [x] 4.11 Same migration, data statement 2: guarded `INSERT` of `TXR` for already-migrated
   databases (`EXISTS`/`NOT EXISTS` guard, `RC`/`C-*` precedent); `Down` statement 3 deactivates
   it (never deletes). *(proposal.md:946-954)*
-- [ ] 4.12 Same migration: `HabilitarRlsDeTenant` on both new tables, **LAST**; verify ordering
+
+  **Evidence (mutation-proof-tests rule 2)**: statement deleted → `RemitosSchemaTests.
+  UnaBaseYaMigradaGanaElTipoTxrAlAplicarLaMigracionDeEstaEtapa` RED (assert on `activo`/
+  `afecta_stock` fails, row never inserted) → reverted via `git checkout --`, green again.
+- [x] 4.12 Same migration: `HabilitarRlsDeTenant` on both new tables, **LAST**; verify ordering
   matches gate §K exactly. *(proposal.md:1014-1016)*
-- [ ] 4.13 Create `src/Ways.Domain/Ventas/EstadoRemito.cs` — 4 values, native type order.
+- [x] 4.13 Create `src/Ways.Domain/Ventas/EstadoRemito.cs` — 4 values, native type order.
   *(design.md:92)*
-- [ ] 4.14 Modify `MotivoStock.cs` — `Remito` declared **LAST**, ninth value, with its
+- [x] 4.14 Modify `MotivoStock.cs` — `Remito` declared **LAST**, ninth value, with its
   irreversibility comment. *(design.md:96-97, mutation target 39)*
-- [ ] 4.15 Create `Remito.cs` / `ItemRemito.cs` — `EntidadTenant` ⇒ `EntidadBase`.
+
+  **FINDING REGISTERED (mutation-proof-tests rule 2 — "run it, don't reason it")**: design.md's
+  own premise for mutation target 39 ("insert it in the middle" ⇒ "every motivo round-trip:
+  existing rows read back as the wrong value") does **NOT** hold empirically.
+  `npgsql.MapEnum<T>()` resolves by NAME (`NpgsqlSnakeCaseNameTranslator`, the default with no
+  third argument — each C# member translates to its native label by STRING, never by ordinal
+  position). Confirmed by REAL mutation: moved `Remito` between `Ajuste`/`Transferencia`, ran
+  `RemitosSchemaTests.TodoMotivoPreexistenteSeLeeDeVueltaConElValorCorrectoConRemitoYaAgregadoAlTipoNativo`
+  — stayed **GREEN** (confirmed via `git diff --stat` clean revert afterward, no reasoning). No
+  ordinal cast of `MotivoStock` exists anywhere in the repo (`grep` confirmed) — declaration
+  order is documentation of intent (mirrors the native pg order for `ORDER BY`/comparison
+  semantics, never exercised today), not a round-trip invariant. The genuinely discriminating
+  test is `ElTextoFuenteDeMotivoStockDeclaraRemitoUltimo` (text-source, same "PROVABLY EQUIVALENT
+  AT RUNTIME" pattern as `PresupuestosSchemaTests` targets 4/5) — verified RED under the same
+  reorder mutation, green after revert. The round-trip test stays as legitimate regression
+  coverage (the eight pre-existing motivos still read back correctly with `'remito'` already
+  added to the native type) but does not itself discriminate this mutant.
+- [x] 4.15 Create `Remito.cs` / `ItemRemito.cs` — `EntidadTenant` ⇒ `EntidadBase`.
   *(design.md:440, gate §E-§F)*
-- [ ] 4.16 Create `RemitoConfiguration.cs` / `ItemRemitoConfiguration.cs` — every support index
+- [x] 4.16 Create `RemitoConfiguration.cs` / `ItemRemitoConfiguration.cs` — every support index
   declared by hand. *(design.md:445)*
-- [ ] 4.17 Modify `MovimientoStockConfiguration.cs` — `IdRemito` + FK24 + named
+- [x] 4.17 Modify `MovimientoStockConfiguration.cs` — `IdRemito` + FK24 + named
   `ix_movimientos_stock_remito`. *(design.md:447)*
-- [ ] 4.18 Modify `WaysDbContext.cs` / `IWaysDbContext.cs` — two new `DbSet`s.
-- [ ] 4.19 Modify `WaysDbContextFactory.cs` **and** `DependencyInjection.cs` —
+- [x] 4.18 Modify `WaysDbContext.cs` / `IWaysDbContext.cs` — two new `DbSet`s.
+
+  **DONE, both files** — same precedent slice 1 task 1.17 already chose (literal task text names
+  both), for consistency.
+- [x] 4.19 Modify `WaysDbContextFactory.cs` **and** `DependencyInjection.cs` —
   `MapEnum<EstadoRemito>` in both. *(design.md:449, mutation target 38 family)*
-- [ ] 4.20 Modify `InicializadorDeBaseDeDatos.cs` — `TXR` tuple (`clase venta`, `letra 'X'`,
+
+  **DONE, plus the same test-fixture propagation slice 1's task 1.41 registered**:
+  `WaysApiFixture.cs` (3 sites), `ComprasTipoSeedTests.cs`, `CuentaCorrienteEtapa7BackstopTests.cs`,
+  `CuentaCorrienteProveedorBackfillTests.cs` all gained `MapEnum<EstadoRemito>("estado_remito")`
+  alongside their existing `MapEnum<EstadoPresupuesto>` line — same four files, same precedent.
+  `ServicioDeVentasConversionTests.cs`'s own ad-hoc `DbContextOptionsBuilder` (line ~739) was
+  checked and deliberately **NOT** touched: it never carried `MapEnum<EstadoOrdenCompra>` either
+  (a pre-existing, harmless gap for entities that ad-hoc options instance never queries) — adding
+  `EstadoRemito` there would be inconsistent with that established gap, not a fix.
+- [x] 4.20 Modify `InicializadorDeBaseDeDatos.cs` — `TXR` tuple (`clase venta`, `letra 'X'`,
   `signo +1`, `discrimina_iva false`, `es_fiscal false`, `afecta_stock false`, `activo true`).
   *(proposal.md:957-962)*
-- [ ] 4.21 Modify `docs/10-modelo-de-datos.md` — `remitos` + `items_remito` tables,
+- [x] 4.21 Modify `docs/10-modelo-de-datos.md` — `remitos` + `items_remito` tables,
   `movimientos_stock.id_remito`, `TXR` catalog note, "Estado (Etapa 17)" header for remitos
   **OPENED** (closes at slice 8). *(design.md:465)*
-- [ ] 4.22 Modify `ManejadorDeErrores.cs` — exact-name `ux_remitos_numero` →
+
+  **DONE** as a `### Remitos (Etapa 17)` subsection nested under `## 4. Comprobantes de venta`,
+  immediately after `### Presupuestos (Etapa 17)` — same precedent as slice 1 task 1.20. The
+  `movimientos_stock.id_remito`/ninth-motivo note landed as a new blockquote under `## 6. Stock`,
+  after the existing Etapa 12 blockquote (never replacing it) — same nested-annotation
+  convention. `TXR` catalog note added to §1 immediately after the `PRE` deactivation note,
+  before the `RC` note.
+- [x] 4.22 Modify `ManejadorDeErrores.cs` — exact-name `ux_remitos_numero` →
   `numero_de_remito_duplicado`, 409, **ABOVE** `ClasificarUnicidad` — **5th** `_numero`
   ordering-trap occurrence. *(design.md:382)*
-- [ ] 4.23 Same file: exact-name `ux_items_remito_orden` → `orden_de_item_duplicado`, 409.
-- [ ] 4.24 Same file: exact-name `ck_remitos_salida_completa` → `remito_salida_incompleta`, 409.
-- [ ] 4.25 Same file: exact-name `ck_remitos_facturacion` → `remito_facturacion_incoherente`, 409.
-- [ ] 4.26 Same file: exact-name `ck_items_remito_cantidad_positiva` →
-  `cantidad_de_linea_invalida`, 400. (`ck_items_remito_costo_no_negativo`/
-  `ck_items_remito_estimado_con_costo` are generic-mapped, exemption documented — server-derived,
-  no client path.)
-- [ ] 4.27 [P] RLS test on `remitos`/`items_remito`. *(mutation target 38)*
-- [ ] 4.28 [P] Raw-insert CHECK3/CHECK4/CHECK5 tests → `23514` with translated codes.
+- [x] 4.23 Same file: exact-name `ux_items_remito_orden` → `orden_de_item_duplicado`, 409.
+- [x] 4.24 Same file: exact-name `ck_remitos_salida_completa` → `remito_salida_incompleta`, 409.
+- [x] 4.25 Same file: exact-name `ck_remitos_facturacion` → `remito_facturacion_incoherente`, 409.
+- [x] 4.26 Same file: exact-name `ck_items_remito_cantidad_positiva` →
+  `cantidad_de_linea_invalida`, 400.
+
+  **CORRECTION REGISTERED (process rule 15) — this task's own parenthetical text vs. the gate
+  contract.** The literal text of this task claims `ck_items_remito_costo_no_negativo`/
+  `ck_items_remito_estimado_con_costo` are "generic-mapped, exemption documented — server-derived,
+  no client path." This contradicts **two** higher-priority sources that agree with each other:
+  (1) `proposal.md`'s own §J table (THE gate contract) groups CHECK 2/5/6/7 (cantidad AND costo)
+  into ONE row: *"Service validation first ... exact-name 23514 mapping as the out-of-band
+  backstop, one test each"* — no exemption for costo; (2) `design.md`'s own Backstop Map
+  explicitly lists CHECK 6/7 with "Exact-name 23514" mapping and "Raw insert per direction" as
+  their test. Cross-checked against slice 1's OWN registered deviation (task 1.25): its
+  reconciliation math for proposal §J's stage total ("3 new 23505 ... 7 exact-name 23514") is
+  `2 (slice 1) + 5 (slice 4: ck_remitos_salida_completa, ck_remitos_facturacion, and the THREE
+  items_remito CHECKs) = 7` — already anticipating 5 CHECKs for this slice, not 3. **Resolved in
+  favor of the gate contract + design's Backstop Map** (same class as CONFLICT #3/#4 in this
+  file's own Orchestrator Decisions): implemented as **FIVE** exact-name `23514` branches, not
+  three — `ck_items_remito_costo_no_negativo` → `400 costo_de_linea_invalido`,
+  `ck_items_remito_estimado_con_costo` → `400 costo_estimado_invalido`, both added to
+  `ClasificarCheckDeRemitos` alongside the three named in this task's own title. This is
+  registered as **CONFLICT #5**, added to the "Conflicts found and reconciled this phase"
+  section below.
+- [x] 4.27 [P] RLS test on `remitos`/`items_remito`. *(mutation target 38)*
+- [x] 4.28 [P] Raw-insert CHECK3/CHECK4/CHECK5 tests → `23514` with translated codes.
   *(mutation target 38)*
-- [ ] 4.29 `pg_indexes` audit — **cumulative 30** new indexes verified by definition (14 from
+
+  **DONE, expanded to all FIVE CHECKs per the 4.26 correction above** (CHECK3
+  `ck_remitos_salida_completa` — 3 violating directions + 1 positive; CHECK4
+  `ck_remitos_facturacion` — 2 violating directions + 1 positive; CHECK5
+  `ck_items_remito_cantidad_positiva`; CHECK6 `ck_items_remito_costo_no_negativo`; CHECK7
+  `ck_items_remito_estimado_con_costo` + 1 positive). Raw-insert SQLSTATE/ConstraintName
+  assertions are self-proving per this codebase's own established convention (a deleted
+  constraint cannot produce that exact `PostgresException`) — no separate deliberate-deletion
+  mutation run recorded for these five, same treatment slice 1 gave its own two CHECKs
+  (tasks 1.29/1.30, no extra mutation evidence beyond the raw-insert assert itself).
+- [x] 4.29 `pg_indexes` audit — **cumulative 30** new indexes verified by definition (14 from
   slice 1 + 15 remito-side + 1 `movimientos_stock` support), including that the partial
   `ux_comprobantes_venta_presupuesto_origen` from slice 1 still resolves as the sole covering
   index for FK23. *(design.md binding verify criterion 1)*
-- [ ] 4.30 Test: raw duplicate `ux_remitos_numero` → translated `numero_de_remito_duplicado`
+
+  **DONE** — `ElConteoTotalDeIndicesNuevosAcumuladoEsExactamenteTreinta` (per-table breakdown +
+  autogenerated-sibling exclusion check) + `LasDefinicionesDeLosIndicesCompuestosDeRemitosRespetanElOrdenDeColumnasDelContrato`
+  (full `indexdef` column-order/filter/unique audit, same rigor as `PresupuestosSchemaTests`'s
+  judgment-day-driven equivalent).
+- [x] 4.30 Test: raw duplicate `ux_remitos_numero` → translated `numero_de_remito_duplicado`
   (5th trap). *(mutation target 38)*
-- [ ] 4.31 Test: `MotivoStock.Remito` last — every existing `motivo` round-trip test still
+- [x] 4.31 Test: `MotivoStock.Remito` last — every existing `motivo` round-trip test still
   reads the correct value (no shift). *(mutation target 39)*
-- [ ] 4.32 Test: the `TXR` guarded `INSERT` (already-migrated DB) and the seed's `TXR` tuple
+
+  **DONE, see the finding registered at task 4.14** — the round-trip test
+  (`TodoMotivoPreexistenteSeLeeDeVueltaConElValorCorrectoConRemitoYaAgregadoAlTipoNativo`)
+  provides the regression coverage this task names; the mutant it was expected to discriminate
+  turned out equivalent at runtime, closed instead by `ElTextoFuenteDeMotivoStockDeclaraRemitoUltimo`.
+- [x] 4.32 Test: the `TXR` guarded `INSERT` (already-migrated DB) and the seed's `TXR` tuple
   (fresh DB) both produce a usable, `afecta_stock = false` row.
-- [ ] 4.33 **GATE GUARD** — exactly **two** migration files total across the whole stage
+
+  **DONE** — `LaBaseFrescaSiembraTxrActivoConAfectaStockFalse` (fresh `WaysApiFixture` DB, the
+  seed path) + `UnaBaseYaMigradaGanaElTipoTxrAlAplicarLaMigracionDeEstaEtapa` (dedicated database
+  migrated only to `PresupuestosEtapa17`, then `RemitosEtapa17` alone — the seeder never runs on
+  this path, mutation-evidence recorded at task 4.11).
+- [x] 4.33 **GATE GUARD** — exactly **two** migration files total across the whole stage
   (`PresupuestosEtapa17` + `RemitosEtapa17`), no third; `has-pending-model-changes` clean.
   *(state.yaml CRITERIO DE VERIFY VINCULANTE)*
-- [ ] 4.34 **GATE GUARD** — re-run task 3.3's *"venta fantasma 400 SIEMPRE"* test unchanged and
+
+  **DONE** — `ExistenExactamenteDosMigracionesDeEstaEtapaYNingunaTercera` (filesystem-level
+  filename audit, excludes `.Designer.cs`) + `dotnet ef migrations has-pending-model-changes`
+  confirmed clean via CLI (`"No changes have been made to the model since the last migration."`).
+- [x] 4.34 **GATE GUARD** — re-run task 3.3's *"venta fantasma 400 SIEMPRE"* test unchanged and
   still green at this point in the stack — regression check across the schema boundary.
-- [ ] 4.35 [P] Non-regression: full stock/lotes suites green and unedited (the
+
+  **DONE** — `ServicioDeVentasConversionTests.UnaVentaConElTipoPreSembradoInactivoEsRechazada400SinEscribirNada`
+  (task 3.3's own test, file untouched except for the ONE new sibling test added below it) still
+  green after this slice's migration. **PUNTOS CLAVE addition, registered here (process rule
+  15)**: `UnaVentaConElTipoTxrEsRechazada400SinEscribirNada` added to the SAME file — `TXR` is
+  seeded for the first time in THIS slice, and `ServicioDeVentas.cs` itself remains completely
+  untouched (protected, per the apply prompt) — net 2 (the resolver's generic
+  `|| !tipo.AfectaStock` clause, already shipped in slice 3) rejects it with zero new production
+  code, proving the guard is genuinely type-agnostic, not a `PRE`-specific special case.
+- [x] 4.35 [P] Non-regression: full stock/lotes suites green and unedited (the
   `movimientos_stock` ALTER is additive-only, metadata-only).
-- [ ] 4.36 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
-- [ ] 4.37 Open PR #4 `feat/stage17-slice4-schema-remitos`, merge after a clean round.
+
+  **DONE** — `git status` shows zero diff on any stock/lotes production or test file besides
+  `MovimientoStockConfiguration.cs`/`MovimientoStock.cs` (both touched ONLY to add the additive
+  `IdRemito` column/FK/index, per gate §H) and `MotivoStock.cs` (the `Remito` enum value, per
+  gate §B) — no existing stock/lotes test file edited.
+
+  **DEVIATION REGISTERED (process rule 15, precedent: slice 1 task 1.41) — five PRE-EXISTING test
+  files broke and were fixed, outside this slice's own enumerated task list, expected and
+  necessary.** A full-suite run surfaced 5 failures (out of 1533), all the SAME class as slice
+  1's own registered finding: pre-existing tests hard-coded an exact count/list of the catalog
+  BEFORE this slice legitimately grew it.
+  - `LotesMigracionTests.ElEnumMotivoStockTieneLosOchoValores` — renamed to
+    `...LosNueveValores`, asserted `9` instead of `8` (`motivo_stock` gains `'remito'`, gate §B).
+  - `CuentaCorrienteEtapa7BackstopTests.UnaBaseFrescaTerminaConElCatalogoCompletoDeTiposIncluidoRc`
+    — asserted `15` instead of `14`, added `Assert.Contains("TXR", ...)` (the seed gains `TXR`).
+  - `ComprasTipoSeedTests.UnaBaseFrescaSiembraLosTresTiposDeCompraSinTocarElCatalogoDeVenta` /
+    `...LosTiposDeCompraAterrizanEnUnaBaseYaMigradaDesdeStage7SinDuplicarYSinTocarVenta` — the
+    shared `CodigosDeVentaEsperados` array is used for TWO purposes in this file (seeding a
+    "pre-stage-8" catalog snapshot AND asserting the post-migration catalog) — adding `TXR`
+    directly to it would have silently defeated the SECOND test's own guarded-`INSERT`
+    idempotency check (pre-seeding `TXR` before migrating means the guard's `NOT EXISTS` finds it
+    already there, never proving the data statement itself is what adds it). Fixed correctly with
+    a SEPARATE `CodigosDeVentaEsperadosTrasRemitosEtapa17` array (`[.. CodigosDeVentaEsperados,
+    "TXR"]`), used only at the two post-migration assertion sites — the original array stays
+    untouched for its seeding role.
+  - `PresupuestosSchemaTests.cs`'s TWO ad-hoc `DbContextOptionsBuilder` blocks (tasks 1.38/1.39's
+    own vehicles) gained `MapEnum<EstadoRemito>("estado_remito")` alongside their existing
+    `MapEnum<EstadoPresupuesto>` line — WITHOUT it, `IMigrator.MigrateAsync()` against those
+    hand-curated options threw `PendingModelChangesWarning` (the live `WaysDbContext` model, via
+    `ApplyConfigurationsFromAssembly`, now includes `Remito`/`ItemRemito` regardless of which
+    enums a given `NpgsqlDataSourceBuilder` maps — an incomplete enum-mapping list on one of
+    these ad-hoc options diverges from the migrations snapshot's own complete model). Same root
+    cause and same fix shape as slice 1's own finding at task 1.19 (`WaysDbContextFactory.cs`'s
+    `MapEnum` requirement) — confirmed this is a REAL, observable failure (not the
+    `DependencyInjection.cs` half's own documented non-observable gap): reproduced red, fixed,
+    confirmed green (19/19 `PresupuestosSchemaTests`).
+  - Full suite confirmed green after all five fixes: **1533/1533**, run TWICE (once mid-batch to
+    surface the failures, once final to confirm — never concurrently, per the apply protocol).
+- [ ] 4.36 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+  by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
+  `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
+- [ ] 4.37 Open PR #4 `feat/stage17-slice4-schema-remitos`, merge after a clean round. — **NOT
+  run by this apply batch**, same reason as 4.36.
 
 ---
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1214,11 +1214,37 @@ value `'remito'` is NOT reverted — irreversible, accepted, registered** (`prop
     confirmed green (19/19 `PresupuestosSchemaTests`).
   - Full suite confirmed green after all five fixes: **1533/1533**, run TWICE (once mid-batch to
     surface the failures, once final to confirm — never concurrently, per the apply protocol).
-- [ ] 4.36 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
-  by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
-  `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
+- [x] 4.36 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
 - [ ] 4.37 Open PR #4 `feat/stage17-slice4-schema-remitos`, merge after a clean round. — **NOT
   run by this apply batch**, same reason as 4.36.
+
+**DEVIATION REGISTERED (judgment-day, Slice 4, ronda 1 — 1 WARNING de juez B + 1 SUGGESTION de
+juez A, ambos APPROVE, fixed anyway per protocol).**
+
+- **WARNING (juez B) — faltaba el espejo WITH CHECK de RLS para `items_remito`.**
+  `RemitosSchemaTests.cs` ya cubría el lado SELECT de `items_remito`
+  (`UnaSesionDeOtroTenantNoVeLosItemsDeRemitoPorSelect`) y el lado WITH CHECK de `remitos`
+  (`UnInsertConIdTenantAjenoEnRemitosSeRechaza`), pero nunca el WITH CHECK de `items_remito`.
+  Agregado `UnInsertConIdTenantAjenoEnItemsRemitoSeRechaza`, calcado del patrón de
+  `UnInsertConIdTenantAjenoEnRemitosSeRechaza` (mismo assert de SQLSTATE `42501`), con un remito
+  padre sembrado por la sesión A como fixture mínimo. Evidencia de mutación
+  (mutation-proof-tests regla 2): con `HabilitarRlsDeTenant("items_remito")` quitado de la
+  migración, `dotnet build --no-incremental` + `dotnet test ... --filter
+  "FullyQualifiedName~RemitosSchemaTests"` cayeron 2/28 en ROJO — el test nuevo (`42501` esperado,
+  `23503` real: sin RLS el INSERT llega hasta la FK, que también choca porque la combinación
+  `id_remito`/`id_tenant` ajena no existe) y el SELECT preexistente
+  (`UnaSesionDeOtroTenantNoVeLosItemsDeRemitoPorSelect`, esperaba 0 filas y vio 1). Revertido el
+  `HabilitarRlsDeTenant("items_remito")`, rebuild `--no-incremental`, 28/28 VERDE de nuevo.
+- **SUGGESTION (juez A) — el `Down()` de la migración ejecutaba la desactivación de `TXR` PRIMERO,
+  no ÚLTIMO como narra el Rollback Plan del proposal (`proposal.md:1092-1095`).** Movido el
+  `Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo = 'TXR';")` al final del `Down()`,
+  después del `AlterDatabase()` que revierte `estado_remito`/`motivo_stock` — el resto del orden
+  inverso (`DropForeignKey`/`DropIndex`/`DropColumn`/`DropTable`) queda intacto. Verificación:
+  `dotnet build --no-incremental` limpio + `RemitosSchemaTests` 28/28 verde (incluye el fixture
+  `WaysApiFixture` que aplica esta migración completa al levantar el host).
+
+Ambos hallazgos, ambos jueces en APPROVE — fixeados igual per protocolo (findings baratos que el
+protocolo corrige aunque no bloqueen el merge).
 
 ---
 

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -231,6 +231,28 @@ public class ManejadorDeErrores(
                 when string.Equals(uxItemPresupuesto, "ux_items_presupuesto_orden", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "Ya existe un ítem con ese orden en este presupuesto.", "orden_de_item_duplicado"),
 
+            // stage-17-presupuestos-y-remitos (Slice 4, task 4.22, db-error-backstops, design
+            // decisión 18, proposal §J): ux_remitos_numero tiene que resolverse por nombre
+            // EXACTO, ANTES de ClasificarUnicidad — su nombre contiene "_numero", así que la
+            // rama genérica de más abajo lo atraparía primero y lo clasificaría como
+            // "numero_duplicado" (el mensaje de ux_clientes_numero). QUINTA ocurrencia del
+            // ordering trap, mismo tratamiento exacto que ux_presupuestos_numero (:209-211) —
+            // bajo operación normal esta rama es inalcanzable (el único escritor es
+            // AsignadorDeNumeroComprobante con la serie 'REM'), queda como backstop de esquema
+            // puro, probado por un INSERT crudo out-of-band (slice 4) y por la concurrencia real
+            // de dos `emitir` simultáneos en un mismo punto de venta (slice 5).
+            { SqlState: "23505", ConstraintName: string uxRemitoNumero }
+                when string.Equals(uxRemitoNumero, "ux_remitos_numero", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un remito con ese número en este punto de venta.", "numero_de_remito_duplicado"),
+
+            // stage-17-presupuestos-y-remitos (Slice 4, task 4.23, db-error-backstops): orden es
+            // server-asignado dentro del replace-set del borrador (slice 5) — exención
+            // documentada de prueba de carrera, misma familia que
+            // ux_items_presupuesto_orden/ux_items_orden_compra_orden.
+            { SqlState: "23505", ConstraintName: string uxItemRemito }
+                when string.Equals(uxItemRemito, "ux_items_remito_orden", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un ítem con ese orden en este remito.", "orden_de_item_duplicado"),
+
             // Backstop genérico (judgment-day, slice 3 ronda 1) para las ~10 unicidades nuevas
             // de catálogos/parámetros/catálogos fiscales: mismo mecanismo de carrera que los
             // dos casos de arriba, pero agrupado por familia (a partir del nombre del índice,
@@ -357,6 +379,24 @@ public class ManejadorDeErrores(
                         || ckPresupuesto.StartsWith("ck_items_presupuesto_", StringComparison.Ordinal))
                     && ClasificarCheckDePresupuestos(ckPresupuesto) is { } checkPresupuesto =>
                 (checkPresupuesto.EstadoHttp, checkPresupuesto.Titulo, checkPresupuesto.Codigo),
+
+            // stage-17-presupuestos-y-remitos (Slice 4, tasks 4.24-4.26, db-error-backstops,
+            // design decisión 18/Backstop Map, proposal §J): switch por nombre EXACTO detrás de
+            // un guard de prefijo "ck_remitos_"/"ck_items_remito_" — mismo criterio que
+            // ckPresupuesto de arriba. CINCO ramas (no tres): proposal §J agrupa las CHECKs 2/5/6/7
+            // (cantidad Y costo) en una sola fila "exact-name 23514 mapping ... one test each", y
+            // design.md's Backstop Map lista explícitamente CHECK 6/7 (costo) con la misma
+            // mapping — el conteo de "3" de la Orchestrator Decision 9 de este archivo es un
+            // artefacto de redacción (registrado como desvío, no una omisión): reconciliado a 5
+            // para que el total del proposal (7 = 2 slice 1 + 5 slice 4) cierre. Todas
+            // alcanzables solo por escritura cruda/fuera de banda — ServicioDeRemitos (slice 5)
+            // ya valida cantidad en el camino de servicio antes de escribir; costo es
+            // server-derivado, ningún input de cliente lo dispara.
+            { SqlState: "23514", ConstraintName: string ckRemito }
+                when (ckRemito.StartsWith("ck_remitos_", StringComparison.Ordinal)
+                        || ckRemito.StartsWith("ck_items_remito_", StringComparison.Ordinal))
+                    && ClasificarCheckDeRemitos(ckRemito) is { } checkRemito =>
+                (checkRemito.EstadoHttp, checkRemito.Titulo, checkRemito.Codigo),
 
             // Backstop genérico (db-error-backstops, judgment-day slice 3 ronda 1): cualquier
             // valor numérico que desborda la precisión/escala de su columna (p.ej. un margen o
@@ -821,6 +861,48 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status400BadRequest,
                     "La cantidad de una línea de presupuesto tiene que ser positiva.",
                     "cantidad_de_linea_invalida"),
+
+            _ => null
+        };
+
+    /// <summary>stage-17-presupuestos-y-remitos (Slice 4, tasks 4.24-4.26, design decisión 18,
+    /// proposal §J): switch por nombre EXACTO de las cinco CHECKs nuevas de
+    /// <c>remitos</c>/<c>items_remito</c>, detrás del guard de prefijo del caso de arriba.
+    /// <c>ck_remitos_salida_completa</c>/<c>ck_remitos_facturacion</c> son server-derivadas
+    /// (ningún input de cliente las dispara directo) → 409, mismo criterio que
+    /// <c>ck_presupuestos_envio_completo</c>. <c>ck_items_remito_cantidad_positiva</c> recibe
+    /// input real de cliente y el servicio ya la valida primero con el mismo código de dominio
+    /// (<c>cantidad_de_linea_invalida</c>) → 400. <c>ck_items_remito_costo_no_negativo</c>/
+    /// <c>ck_items_remito_estimado_con_costo</c> son server-derivadas (el costo se congela al
+    /// emitir, slice 5) → 400, mismo criterio que
+    /// <see cref="ClasificarCheckDeVentas"/>'s CHECKs de costo.</summary>
+    private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeRemitos(string nombreDeCheck) =>
+        nombreDeCheck switch
+        {
+            "ck_remitos_salida_completa" =>
+                (StatusCodes.Status409Conflict,
+                    "El número y la fecha de salida del remito tienen que llegar juntos.",
+                    "remito_salida_incompleta"),
+
+            "ck_remitos_facturacion" =>
+                (StatusCodes.Status409Conflict,
+                    "El estado facturado y la factura ligada del remito tienen que llegar juntos.",
+                    "remito_facturacion_incoherente"),
+
+            "ck_items_remito_cantidad_positiva" =>
+                (StatusCodes.Status400BadRequest,
+                    "La cantidad de una línea de remito tiene que ser positiva.",
+                    "cantidad_de_linea_invalida"),
+
+            "ck_items_remito_costo_no_negativo" =>
+                (StatusCodes.Status400BadRequest,
+                    "El costo de una línea de remito no puede ser negativo.",
+                    "costo_de_linea_invalido"),
+
+            "ck_items_remito_estimado_con_costo" =>
+                (StatusCodes.Status400BadRequest,
+                    "Una línea de remito marcada como costo estimado tiene que tener un costo.",
+                    "costo_estimado_invalido"),
 
             _ => null
         };

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -131,6 +131,12 @@ public interface IWaysDbContext
     DbSet<Presupuesto> Presupuestos { get; }
     DbSet<ItemPresupuesto> ItemsPresupuesto { get; }
 
+    // stage-17-presupuestos-y-remitos, Slice 4 (task 4.18, design.md:448): expuestos desde esta
+    // slice, mismo criterio que Presupuesto/ItemPresupuesto (task 1.17) — ServicioDeRemitos
+    // (slice 5) es el primer consumidor real.
+    DbSet<Remito> Remitos { get; }
+    DbSet<ItemRemito> ItemsRemito { get; }
+
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>
     /// y <c>BeginTransactionAsync</c> no tienen un equivalente más angosto en este proyecto.

--- a/src/Ways.Domain/Stock/MotivoStock.cs
+++ b/src/Ways.Domain/Stock/MotivoStock.cs
@@ -14,6 +14,15 @@ namespace Ways.Domain.Stock;
 /// dentro de la misma transacción que lo agregó). <see cref="Decomiso"/> abre camino de
 /// escritura recién en slice 11 (<c>ServicioDeStock.EjecutarDecomisoAsync</c>);
 /// <see cref="Reclasificacion"/> en slice 4 (<c>ServicioDeLotes.ReconciliarAsync</c>).
+///
+/// <see cref="Remito"/> (etapa 17, proposal §B, decisión 5 del explore/gate §B): NOVENO valor,
+/// declarado ÚLTIMO — mismo mecanismo que <see cref="Decomiso"/>/<see cref="Reclasificacion"/>,
+/// agregado vía <c>ALTER TYPE ... ADD VALUE 'remito'</c> en <c>RemitosEtapa17</c> (slice 4);
+/// ningún <c>Sql()</c> de esa misma migración puede nombrarlo. **IRREVERSIBLE, aceptado y
+/// registrado** (proposal §B): Postgres no soporta <c>DROP VALUE</c>, así que el <c>Down()</c>
+/// de <c>RemitosEtapa17</c> no lo revierte — el valor nace CON su escritor en la misma slice
+/// (<c>ServicioDeRemitos.EmitirAsync</c>, el cuarto write site, slice 5), a diferencia de
+/// <see cref="Decomiso"/>/<see cref="Reclasificacion"/> (schema-only en su slice de origen).
 /// </summary>
 public enum MotivoStock
 {
@@ -24,5 +33,6 @@ public enum MotivoStock
     Transferencia,
     Inventario,
     Decomiso,
-    Reclasificacion
+    Reclasificacion,
+    Remito
 }

--- a/src/Ways.Domain/Stock/MovimientoStock.cs
+++ b/src/Ways.Domain/Stock/MovimientoStock.cs
@@ -57,6 +57,15 @@ public class MovimientoStock
     /// slices 4-12 (ningún escritor nuevo en esta slice: schema + seed gate).</summary>
     public int? IdLote { get; set; }
 
+    /// <summary>Etapa 17 (proposal §H, decisión 5 del explore): documento del cuarto write site
+    /// — poblado solo cuando <see cref="Motivo"/> es <see cref="MotivoStock.Remito"/> o la
+    /// <see cref="MotivoStock.Anulacion"/> que lo revierte, mismo criterio que
+    /// <see cref="IdComprobanteCompra"/>. Sin este link, un movimiento de remito sería la única
+    /// fila inatribuible de un ledger append-only cuyo propósito es la reconstrucción. Columna
+    /// creada en esta slice (schema + seed gate), escrita recién desde slice 5
+    /// (<c>ServicioDeRemitos.EmitirAsync</c>/<c>AnularAsync</c>).</summary>
+    public int? IdRemito { get; set; }
+
     public int IdEmpleado { get; set; }
 
     public string? Observaciones { get; set; }

--- a/src/Ways.Domain/Ventas/EstadoRemito.cs
+++ b/src/Ways.Domain/Ventas/EstadoRemito.cs
@@ -1,0 +1,26 @@
+namespace Ways.Domain.Ventas;
+
+/// <summary>
+/// Ciclo de vida de un <see cref="Remito"/> (proposal: Modelo de datos propuesto — §A, design:
+/// Domain — pure, no database). Enum nativo de Postgres (<c>estado_remito</c>), registrado por
+/// <c>npgsql.MapEnum&lt;EstadoRemito&gt;("estado_remito")</c> en ambos sitios (slice 4, task
+/// 4.19) — nunca también vía <c>HasPostgresEnum</c>. El ORDEN de los miembros ES el orden de
+/// valores del tipo nativo — <c>dotnet ef migrations add</c> los serializa alfabéticamente por
+/// defecto, corregido a mano en la migración (mismo residuo documentado en
+/// <c>EstadoPresupuesto</c>/stage 17 slice 1).
+///
+/// Un solo escritor por valor: <see cref="Borrador"/> ← <c>POST /api/remitos</c> (slice 5);
+/// <see cref="Emitido"/> ← <c>POST /{id}/emitir</c> (slice 5, el cuarto write site);
+/// <see cref="Facturado"/> ← la consolidación (slice 6, <c>ServicioDeFacturacionDeRemitos</c>);
+/// <see cref="Anulado"/> ← <c>POST /{id}/anular</c> (slice 5). <see cref="Facturado"/> puede
+/// volver a <see cref="Emitido"/> únicamente por el desligue guardado de la anulación de su
+/// <c>TXR</c> (<c>ck_remitos_facturacion</c> — estado y link vuelven JUNTOS, slice 6). Ningún
+/// valor especulativo.
+/// </summary>
+public enum EstadoRemito
+{
+    Borrador,
+    Emitido,
+    Facturado,
+    Anulado
+}

--- a/src/Ways.Domain/Ventas/ItemRemito.cs
+++ b/src/Ways.Domain/Ventas/ItemRemito.cs
@@ -1,0 +1,67 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Ventas;
+
+/// <summary>
+/// Línea de un <see cref="Remito"/> (proposal: Modelo de datos propuesto — §F). Child scope:
+/// <c>id_tenant</c> únicamente, sin FK propia a <c>puntos_venta</c> — se deriva del remito
+/// padre, mismo criterio que <see cref="ItemPresupuesto"/>/<c>ItemComprobanteVentaConfiguration.cs:13-15</c>.
+/// <c>EntidadBase</c>: SÍ, mismo razonamiento que <see cref="ItemPresupuesto"/>.
+///
+/// A diferencia de <see cref="ItemPresupuesto"/>, esta línea SÍ congela costo y lote (proposal
+/// §F): la mercadería efectivamente sale por este write site (slice 5), así que
+/// <see cref="CostoUnitario"/>/<see cref="CostoEsEstimado"/> y <see cref="IdLote"/> viajan
+/// desde acá — un costo es irrecuperable una vez que la mercadería salió (el argumento de la
+/// etapa 9, aplicado), y el FEFO resuelto y congelado es el mismo criterio que la línea de
+/// venta.
+/// </summary>
+public class ItemRemito : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdRemito { get; set; }
+
+    /// <summary>Asignado por el servidor en cada replace-set (mismo criterio que
+    /// <c>ItemPresupuesto.Orden</c>/<c>ItemComprobanteVenta.Orden</c>) — nunca input de
+    /// cliente.</summary>
+    public int Orden { get; set; }
+
+    /// <summary><c>NOT NULL</c> (proposal §F): un remito entrega mercadería, nunca un
+    /// servicio.</summary>
+    public int IdArticulo { get; set; }
+
+    public required string Descripcion { get; set; }
+
+    /// <summary><c>numeric(12,3)</c> (proposal §F, doc-10 principio 5) — <c>&gt; 0</c>
+    /// (<c>ck_items_remito_cantidad_positiva</c>).</summary>
+    public decimal Cantidad { get; set; }
+
+    public decimal PrecioUnitario { get; set; }
+
+    public decimal Descuento { get; set; }
+
+    public decimal Total { get; set; }
+
+    public int IdListaPrecio { get; set; }
+
+    public int? IdOferta { get; set; }
+
+    public int IdAlicuotaIva { get; set; }
+
+    public decimal PorcentajeIva { get; set; }
+
+    /// <summary>Congelado al SALIR la mercadería (etapa 9, aplicado — proposal §F): <c>NULL</c>
+    /// hasta que <c>emitir</c> (slice 5) lo escribe, nunca re-derivado después.
+    /// <c>ck_items_remito_costo_no_negativo</c> lo respalda a nivel esquema.</summary>
+    public decimal? CostoUnitario { get; set; }
+
+    /// <summary><c>ck_items_remito_estimado_con_costo</c>: una marca "estimado" sin costo es
+    /// irrepresentable, mismo criterio que <c>ItemComprobanteVenta.CostoEsEstimado</c>.</summary>
+    public bool CostoEsEstimado { get; set; }
+
+    /// <summary>FEFO resuelto y congelado al <c>emitir</c> (proposal §F) — <c>NULL</c> para un
+    /// artículo que no controla lote, poblado para uno lot-effective (invariante cruzado entre
+    /// tablas, probado con un test de integración dedicado, mismo criterio que
+    /// <c>MovimientoStock.IdLote</c>).</summary>
+    public int? IdLote { get; set; }
+}

--- a/src/Ways.Domain/Ventas/Remito.cs
+++ b/src/Ways.Domain/Ventas/Remito.cs
@@ -1,0 +1,59 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Ventas;
+
+/// <summary>
+/// Remito (doc 10 §4-adjacent, proposal: Modelo de datos propuesto — §E). Operativa-scoped
+/// (<c>id_tenant</c> + <c>id_punto_venta</c>, doc 09) — la misma categoría que
+/// <see cref="Presupuesto"/>/<see cref="ComprobanteVenta"/>: la mercadería sale bajo su propio
+/// documento, la consolidación (slice 6) recién crea el <c>comprobantes_venta</c> que la
+/// factura (N remitos → 1, proposal decisión 6 del explore).
+///
+/// <c>EntidadBase</c>: SÍ — mismo razonamiento que <see cref="Presupuesto"/> (proposal §E): un
+/// remito es mutable durante <see cref="EstadoRemito.Borrador"/> (replace-set completo bajo
+/// <c>SELECT … FOR UPDATE</c>), se edita de nuevo en <c>emitir</c>/<c>anular</c>/la
+/// consolidación — hereda <see cref="EntidadTenant"/> con el filtro de tenant estándar y
+/// <c>EstamparTenant()</c>, sin filtro clonado.
+/// </summary>
+public class Remito : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdPuntoVenta { get; set; }
+
+    public int IdCliente { get; set; }
+
+    /// <summary>Quién lo creó — <c>IContextoDeUsuario.UsuarioId</c>, FK simple (proposal §E, FK
+    /// 14), mismo criterio que <c>Presupuesto.IdEmpleado</c>/<c>ComprobanteVenta.IdEmpleado</c>.</summary>
+    public int IdEmpleado { get; set; }
+
+    /// <summary>Correlativo propio por punto de venta, serie <c>'REM'</c> — <c>NULL</c> mientras
+    /// <see cref="EstadoRemito.Borrador"/>, asignado únicamente al <c>emitir</c>
+    /// (<c>AsignadorDeNumeroComprobante</c>, slice 5).</summary>
+    public long? Numero { get; set; }
+
+    /// <summary><c>IRelojDelSistema.Ahora</c> al crear el borrador — sin <c>DEFAULT now()</c> en
+    /// la columna (proposal §E, mismo criterio que <c>Presupuesto.FechaEmision</c>).</summary>
+    public DateTimeOffset FechaEmision { get; set; }
+
+    /// <summary>Se estampa junto con <see cref="Numero"/> en el mismo <c>UPDATE</c> del
+    /// <c>emitir</c> (proposal §E, <c>ck_remitos_salida_completa</c>) — cuándo salió la
+    /// mercadería.</summary>
+    public DateTimeOffset? FechaSalida { get; set; }
+
+    public string? DireccionEntrega { get; set; }
+
+    public string? Observaciones { get; set; }
+
+    public decimal Subtotal { get; set; }
+    public decimal DescuentoTotal { get; set; }
+    public decimal Total { get; set; }
+
+    public EstadoRemito Estado { get; set; } = EstadoRemito.Borrador;
+
+    /// <summary>La factura consolidada (proposal §E, decisión 6/7 del explore): NULL salvo en
+    /// <see cref="EstadoRemito.Facturado"/> — <c>ck_remitos_facturacion</c> exige que estado y
+    /// link vayan JUNTOS, en ambas direcciones (el desligue de la anulación de un <c>TXR</c> los
+    /// limpia a la vez, slice 6).</summary>
+    public int? IdComprobanteVenta { get; set; }
+}

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -112,6 +112,7 @@ public static class DependencyInjection
             npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
             npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
             npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+            npgsql.MapEnum<EstadoRemito>("estado_remito");
             npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
         });
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemRemitoConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ItemRemitoConfiguration.cs
@@ -1,0 +1,158 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Ofertas;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Ventas;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="ItemRemito"/> (proposal: Modelo de datos propuesto — §F, DB CHANGE GATE
+/// aprobado). Shaped on <c>ItemComprobanteVentaConfiguration.cs</c> (a diferencia de
+/// <see cref="ItemPresupuestoConfiguration"/>: esta línea SÍ congela costo y lote, la mercadería
+/// efectivamente sale por este write site). Todos los índices de soporte se declaran a mano
+/// (conteo vinculante: 8 índices en esta tabla, incl. la unicidad de <c>orden</c>).
+/// </summary>
+public class ItemRemitoConfiguration : IEntityTypeConfiguration<ItemRemito>
+{
+    public void Configure(EntityTypeBuilder<ItemRemito> builder)
+    {
+        builder.ToTable("items_remito", t =>
+        {
+            // CHECK 5 (proposal §F): mirrors ck_items_presupuesto_cantidad_positiva/
+            // ck_items_comprobante_venta_cantidad_positiva.
+            t.HasCheckConstraint("ck_items_remito_cantidad_positiva", "cantidad > 0");
+
+            // CHECK 6 (proposal §F): costo NULL es "desconocido" (aún no salió), nunca colapsa a
+            // cero — mirrors ck_items_comprobante_venta_costo_no_negativo.
+            t.HasCheckConstraint(
+                "ck_items_remito_costo_no_negativo",
+                "costo_unitario IS NULL OR costo_unitario >= 0");
+
+            // CHECK 7 (proposal §F): una marca "estimado" sin costo es irrepresentable — mirrors
+            // ck_items_comprobante_venta_estimado_con_costo.
+            t.HasCheckConstraint(
+                "ck_items_remito_estimado_con_costo",
+                "NOT costo_es_estimado OR costo_unitario IS NOT NULL");
+        });
+
+        builder.HasKey(i => i.Id).HasName("pk_items_remito");
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id_item")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(i => i.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(i => i.IdRemito).HasColumnName("id_remito").IsRequired();
+        builder.Property(i => i.Orden).HasColumnName("orden").IsRequired();
+
+        // Deliberadamente NOT NULL (proposal §F): un remito entrega mercadería, nunca un
+        // servicio — mismo criterio que ItemPresupuesto.IdArticulo.
+        builder.Property(i => i.IdArticulo).HasColumnName("id_articulo").IsRequired();
+
+        builder.Property(i => i.Descripcion).HasColumnName("descripcion").HasColumnType("text").IsRequired();
+
+        builder.Property(i => i.Cantidad).HasColumnName("cantidad").HasColumnType("numeric(12,3)").IsRequired();
+        builder.Property(i => i.PrecioUnitario).HasColumnName("precio_unitario").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(i => i.Descuento).HasColumnName("descuento").HasColumnType("numeric(14,2)").HasDefaultValue(0m).IsRequired();
+        builder.Property(i => i.Total).HasColumnName("total").HasColumnType("numeric(14,2)").IsRequired();
+
+        builder.Property(i => i.IdListaPrecio).HasColumnName("id_lista_precio").IsRequired();
+        builder.Property(i => i.IdOferta).HasColumnName("id_oferta");
+        builder.Property(i => i.IdAlicuotaIva).HasColumnName("id_alicuota_iva").IsRequired();
+        builder.Property(i => i.PorcentajeIva).HasColumnName("porcentaje_iva").HasColumnType("numeric(5,2)").IsRequired();
+
+        builder.Property(i => i.CostoUnitario).HasColumnName("costo_unitario").HasColumnType("numeric(14,2)");
+
+        builder.Property(i => i.CostoEsEstimado)
+            .HasColumnName("costo_es_estimado")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(i => i.IdLote).HasColumnName("id_lote");
+
+        builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(i => i.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(i => i.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(i => i.EstaEliminada);
+
+        builder.HasIndex(i => i.IdTenant).HasDatabaseName("ix_items_remito_tenant");
+        builder.HasIndex(i => new { i.IdRemito, i.IdTenant }).HasDatabaseName("ix_items_remito_remito");
+        builder.HasIndex(i => new { i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_remito_articulo");
+        builder.HasIndex(i => new { i.IdListaPrecio, i.IdTenant }).HasDatabaseName("ix_items_remito_lista_precio");
+        builder.HasIndex(i => new { i.IdOferta, i.IdTenant }).HasDatabaseName("ix_items_remito_oferta");
+
+        // Simple: alicuotas_iva es global (ADR-11) — mismo criterio que
+        // fk_items_presupuesto_alicuota_iva/fk_items_comprobante_venta_alicuota_iva.
+        builder.HasIndex(i => i.IdAlicuotaIva).HasDatabaseName("ix_items_remito_alicuota_iva");
+
+        // Soporte de fk_items_remito_lote (FK 22) — mismo criterio que
+        // ix_items_comprobante_venta_lote.
+        builder.HasIndex(i => new { i.IdLote, i.IdArticulo, i.IdTenant }).HasDatabaseName("ix_items_remito_lote");
+
+        // ux_items_remito_orden: mirrors ux_items_presupuesto_orden/ux_items_comprobante_venta_orden
+        // — NO cubre la FK 17 (segunda columna difiere), por lo que ix_items_remito_remito existe
+        // aparte.
+        builder.HasIndex(i => new { i.IdRemito, i.Orden })
+            .HasDatabaseName("ux_items_remito_orden")
+            .IsUnique();
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(i => i.IdTenant)
+            .HasConstraintName("fk_items_remito_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Remito>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdRemito, i.IdTenant })
+            .HasPrincipalKey(r => new { r.Id, r.IdTenant })
+            .HasConstraintName("fk_items_remito_remito")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Articulo>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdArticulo, i.IdTenant })
+            .HasPrincipalKey(a => new { a.Id, a.IdTenant })
+            .HasConstraintName("fk_items_remito_articulo")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<ListaPrecio>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdListaPrecio, i.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdTenant })
+            .HasConstraintName("fk_items_remito_lista_precio")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Nullable, MATCH SIMPLE (default) — mismo criterio que fk_items_presupuesto_oferta.
+        builder.HasOne<Oferta>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdOferta, i.IdTenant })
+            .HasPrincipalKey(o => new { o.Id, o.IdTenant })
+            .HasConstraintName("fk_items_remito_oferta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // alicuotas_iva es global (ADR-11) — FK simple, sin id_tenant.
+        builder.HasOne<AlicuotaIva>()
+            .WithMany()
+            .HasForeignKey(i => i.IdAlicuotaIva)
+            .HasConstraintName("fk_items_remito_alicuota_iva")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // FK 22 (proposal §F): MATCH SIMPLE — garantiza a nivel de base que el lote de la línea
+        // pertenece a su mismo artículo, mismo criterio que fk_items_comprobante_venta_lote.
+        builder.HasOne<Lote>()
+            .WithMany()
+            .HasForeignKey(i => new { i.IdLote, i.IdArticulo, i.IdTenant })
+            .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
+            .HasConstraintName("fk_items_remito_lote")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/MovimientoStockConfiguration.cs
@@ -56,6 +56,10 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
         // slice 4.
         builder.Property(m => m.IdLote).HasColumnName("id_lote");
 
+        // Etapa 17 (proposal §H, decisión 5 del explore): columna creada acá, escrita recién
+        // desde slice 5 (ServicioDeRemitos.EmitirAsync/AnularAsync, el cuarto write site).
+        builder.Property(m => m.IdRemito).HasColumnName("id_remito");
+
         builder.Property(m => m.IdEmpleado).HasColumnName("id_empleado").IsRequired();
         builder.Property(m => m.Observaciones).HasColumnName("observaciones").HasColumnType("text");
 
@@ -83,6 +87,10 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
         // Etapa 12 (proposal decisión 5, gate §C): soporte de fk_movimientos_stock_lote y
         // reconstrucción del ledger por lote.
         builder.HasIndex(m => new { m.IdLote, m.IdArticulo, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_lote");
+
+        // Etapa 17 (proposal §H, index 30, gate §H): soporte de FK 24 + la lectura "los
+        // movimientos de este remito", mirrors ix_movimientos_stock_comprobante_venta.
+        builder.HasIndex(m => new { m.IdRemito, m.IdTenant }).HasDatabaseName("ix_movimientos_stock_remito");
 
         builder.HasOne<Tenant>()
             .WithMany()
@@ -134,6 +142,16 @@ public class MovimientoStockConfiguration : IEntityTypeConfiguration<MovimientoS
             .HasForeignKey(m => new { m.IdLote, m.IdArticulo, m.IdTenant })
             .HasPrincipalKey(l => new { l.Id, l.IdArticulo, l.IdTenant })
             .HasConstraintName("fk_movimientos_stock_lote")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // FK 24 (proposal §H): composite, nullable, MATCH SIMPLE — el documento del cuarto
+        // write site, misma forma exacta que fk_movimientos_stock_comprobante_venta/
+        // ..._comprobante_compra.
+        builder.HasOne<Remito>()
+            .WithMany()
+            .HasForeignKey(m => new { m.IdRemito, m.IdTenant })
+            .HasPrincipalKey(r => new { r.Id, r.IdTenant })
+            .HasConstraintName("fk_movimientos_stock_remito")
             .OnDelete(DeleteBehavior.Restrict);
 
         // id_empleado: FK SIMPLE (no compuesta), misma deviación deliberada que

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/RemitoConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/RemitoConfiguration.cs
@@ -1,0 +1,149 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="Remito"/> (proposal: Modelo de datos propuesto — §E, DB CHANGE GATE
+/// aprobado). Shaped on <c>PresupuestoConfiguration.cs</c>. Todos los índices de soporte se
+/// declaran a mano con nombres doc-10 — cero sorpresa de <c>ForeignKeyIndexConvention</c>
+/// (conteo vinculante: 7 índices en esta tabla, incl. el implícito de la AK).
+/// </summary>
+public class RemitoConfiguration : IEntityTypeConfiguration<Remito>
+{
+    public void Configure(EntityTypeBuilder<Remito> builder)
+    {
+        builder.ToTable("remitos", t =>
+        {
+            // CHECK 3 (proposal §E): numero y fecha_salida llegan JUNTOS, y todo estado
+            // distinto de borrador/anulado tiene numero — mismo criterio que
+            // ck_presupuestos_envio_completo (sin vencimiento, un remito no expira).
+            t.HasCheckConstraint(
+                "ck_remitos_salida_completa",
+                "((numero IS NULL) = (fecha_salida IS NULL)) AND (estado IN ('borrador','anulado') OR numero IS NOT NULL)");
+
+            // CHECK 4 (proposal §E): facturado y su link viajan JUNTOS, en las dos direcciones —
+            // el desligue de la anulación del TXR (slice 6) limpia estado y
+            // id_comprobante_venta a la vez o esta CHECK tira 23514.
+            t.HasCheckConstraint(
+                "ck_remitos_facturacion",
+                "(id_comprobante_venta IS NULL) = (estado <> 'facturado')");
+        });
+
+        builder.HasKey(r => r.Id).HasName("pk_remitos");
+
+        builder.Property(r => r.Id)
+            .HasColumnName("id_remito")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(r => r.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        // Habilita la FK compuesta de items_remito y el soporte de FK 24 de
+        // movimientos_stock.id_remito (§H) — mismo patrón que
+        // ak_presupuestos_id_presupuesto_id_tenant.
+        builder.HasAlternateKey(r => new { r.Id, r.IdTenant })
+            .HasName("ak_remitos_id_remito_id_tenant");
+
+        builder.Property(r => r.IdPuntoVenta).HasColumnName("id_punto_venta").IsRequired();
+        builder.Property(r => r.IdCliente).HasColumnName("id_cliente").IsRequired();
+        builder.Property(r => r.IdEmpleado).HasColumnName("id_empleado").IsRequired();
+
+        builder.Property(r => r.Numero).HasColumnName("numero").HasColumnType("bigint");
+
+        builder.Property(r => r.FechaEmision).HasColumnName("fecha_emision").IsRequired();
+        builder.Property(r => r.FechaSalida).HasColumnName("fecha_salida");
+
+        builder.Property(r => r.DireccionEntrega).HasColumnName("direccion_entrega").HasColumnType("text");
+        builder.Property(r => r.Observaciones).HasColumnName("observaciones").HasColumnType("text");
+
+        builder.Property(r => r.Subtotal).HasColumnName("subtotal").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(r => r.DescuentoTotal).HasColumnName("descuento_total").HasColumnType("numeric(14,2)").IsRequired();
+        builder.Property(r => r.Total).HasColumnName("total").HasColumnType("numeric(14,2)").IsRequired();
+
+        builder.Property(r => r.Estado)
+            .HasColumnName("estado")
+            .HasColumnType("estado_remito")
+            .IsRequired();
+
+        builder.Property(r => r.IdComprobanteVenta).HasColumnName("id_comprobante_venta");
+
+        builder.Property(r => r.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(r => r.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(r => r.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(r => r.EstaEliminada);
+
+        builder.HasIndex(r => r.IdTenant).HasDatabaseName("ix_remitos_tenant");
+
+        // Cubre la listing por PV Y el soporte de FK 12 por prefijo de columna líder — mismo
+        // criterio que ix_presupuestos_punto_venta_fecha/ix_comprobantes_venta_punto_venta_fecha.
+        builder.HasIndex(r => new { r.IdPuntoVenta, r.IdTenant, r.FechaEmision })
+            .HasDatabaseName("ix_remitos_punto_venta_fecha");
+
+        // Per-customer listing + la lectura de la consolidación ("los remitos emitidos de este
+        // cliente, sin ligar") + soporte de FK 13.
+        builder.HasIndex(r => new { r.IdCliente, r.IdTenant }).HasDatabaseName("ix_remitos_cliente");
+
+        // Simple, no compuesto: un índice liderado por id_tenant NO cubre una FK simple (mismo
+        // criterio que ix_presupuestos_empleado, la trampa documentada de la enmienda etapa 14).
+        builder.HasIndex(r => r.IdEmpleado).HasDatabaseName("ix_remitos_empleado");
+
+        // Soporte de FK 15 + la lectura "qué remitos cubre esta factura".
+        builder.HasIndex(r => new { r.IdComprobanteVenta, r.IdTenant }).HasDatabaseName("ix_remitos_comprobante_venta");
+
+        // ux_remitos_numero: UNIQUE PARCIAL (proposal §E, gate §A) WHERE numero IS NOT NULL — un
+        // borrador no tiene número. ⚠ Su nombre contiene "_numero" — ManejadorDeErrores tiene
+        // que resolverla por nombre EXACTO ANTES de ClasificarUnicidad, QUINTA ocurrencia del
+        // ordering trap (design decisión 18).
+        builder.HasIndex(r => new { r.IdTenant, r.IdPuntoVenta, r.Numero })
+            .HasDatabaseName("ux_remitos_numero")
+            .IsUnique()
+            .HasFilter("numero IS NOT NULL");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(r => r.IdTenant)
+            .HasConstraintName("fk_remitos_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(r => new { r.IdPuntoVenta, r.IdTenant })
+            .HasPrincipalKey(pv => new { pv.Id, pv.IdTenant })
+            .HasConstraintName("fk_remitos_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Cliente>()
+            .WithMany()
+            .HasForeignKey(r => new { r.IdCliente, r.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_remitos_cliente")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // FK simple, deliberada (proposal §E): una AK compuesta forzaría id_tenant NOT NULL en
+        // usuarios y rompería el sentinel NULL de staff de plataforma — mismo criterio que
+        // fk_presupuestos_empleado/fk_comprobantes_venta_empleado.
+        builder.HasOne<Usuario>()
+            .WithMany()
+            .HasForeignKey(r => r.IdEmpleado)
+            .HasConstraintName("fk_remitos_empleado")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Nullable, MATCH SIMPLE (default) — contra la AK YA existente de ComprobanteVenta
+        // (ak_comprobantes_venta_id_comprobante_venta_id_tenant, verificado
+        // ComprobanteVentaConfiguration.cs:40). NULL salvo en estado facturado
+        // (ck_remitos_facturacion).
+        builder.HasOne<ComprobanteVenta>()
+            .WithMany()
+            .HasForeignKey(r => new { r.IdComprobanteVenta, r.IdTenant })
+            .HasPrincipalKey(c => new { c.Id, c.IdTenant })
+            .HasConstraintName("fk_remitos_comprobante_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -74,7 +74,17 @@ public class InicializadorDeBaseDeDatos(
     /// base VACÍA (<c>:432</c>) — sin el <c>Activo = false</c> de acá, el `PRE` recién sembrado
     /// quedaría activo de nuevo. Net 1 (la migración) y net 1b (este seed) se prueban
     /// INDEPENDIENTEMENTE (mutation targets 10/11, task 1.38/1.39): remover cualquiera de los
-    /// dos, solo, tiene que fallar su propio test.</summary>
+    /// dos, solo, tiene que fallar su propio test.
+    ///
+    /// stage-17-presupuestos-y-remitos (Slice 4, proposal §I data statement 2, task 4.20):
+    /// <c>TXR</c> — el comprobante consolidado de la facturación de remitos (slice 6), SIN items
+    /// por construcción (precedente <c>RC</c>) — cierra el doble decremento de stock y el stock
+    /// fantasma de <c>AnularAsync</c> por diseño, nunca por flag. <c>afecta_stock = false</c> lo
+    /// vuelve inemitible por mostrador: el guard del resolver de <c>ServicioDeVentas</c> (slice
+    /// 3, <c>|| !tipo.AfectaStock</c>) lo rechaza igual que <c>PRE</c>. Se siembra dos veces,
+    /// mismo mecanismo que <c>RC</c>/<c>C-*</c>: acá para una base nueva y, de forma idempotente,
+    /// dentro de la migración <c>RemitosEtapa17</c> para una base ya migrada — ese seed corre
+    /// solo cuando la tabla está vacía.</summary>
     private static readonly (ClaseComprobante Clase, string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock, bool Activo)[] TiposComprobanteBase =
     [
         (ClaseComprobante.Venta, "FA", "Factura A", 'A', 1, true, true, true, true),
@@ -90,6 +100,10 @@ public class InicializadorDeBaseDeDatos(
         // (explore.md): un tipo activo, afecta_stock=false, colaba como venta fantasma.
         (ClaseComprobante.Venta, "PRE", "Presupuesto", null, 1, false, false, false, false),
         (ClaseComprobante.Venta, "RC", "Recibo de cobranza", null, 1, false, false, false, true),
+        // stage-17-presupuestos-y-remitos (proposal §I, decisión 2/7 del explore): comprobante
+        // consolidado de facturación de remitos, sin items por construcción — nace ACTIVO pero
+        // INEMITIBLE por mostrador (afecta_stock=false, mismo guard del resolver que bloquea PRE).
+        (ClaseComprobante.Venta, "TXR", "Ticket X por remitos", 'X', 1, false, false, false, true),
 
         // stage-8-compras-transferencias-inventario (design decisión 12/7 del proposal): solo
         // tres tipos — notas de crédito de proveedor están fuera de alcance (anulación es la

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -22,9 +23,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820004658_RemitosEtapa17")]
+    partial class RemitosEtapa17
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.cs
@@ -339,11 +339,6 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            // gate §I, data statement 3 (proposal.md:952-954) — desactiva en vez de borrar, para
-            // que un TXR ya emitido siga siendo legible después de un rollback (mismo criterio
-            // que CuentaCorrienteEtapa7/ComprasYTransferenciasEtapa8 con RC/C-*).
-            migrationBuilder.Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo = 'TXR';");
-
             migrationBuilder.DropForeignKey(
                 name: "fk_movimientos_stock_remito",
                 table: "movimientos_stock");
@@ -407,6 +402,12 @@ namespace Ways.Infrastructure.Persistencia.Migraciones
                 .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
                 .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
                 .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            // gate §I, data statement 3 (proposal.md:952-954) — desactiva en vez de borrar, para
+            // que un TXR ya emitido siga siendo legible después de un rollback (mismo criterio
+            // que CuentaCorrienteEtapa7/ComprasYTransferenciasEtapa8 con RC/C-*). Último paso del
+            // Down (proposal.md:1092-1095, rollback plan), después de revertir todo lo demás.
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo = 'TXR';");
         }
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260820004658_RemitosEtapa17.cs
@@ -1,0 +1,412 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class RemitosEtapa17 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Orden de statements per gate (binding, proposal.md:1014-1016): 1) AlterDatabase —
+            // ESTE statement es quien ejecuta `ALTER TYPE motivo_stock ADD VALUE 'remito'`
+            // (noveno valor, IRREVERSIBLE — Postgres no soporta DROP VALUE, mismo mecanismo y
+            // misma aceptación que decomiso/reclasificacion de la Etapa 12) seguido de `CREATE
+            // TYPE estado_remito` — ningún `Sql()` de ESTA migración puede nombrar 'remito'
+            // (Postgres prohíbe usar un valor de enum agregado dentro de la misma transacción
+            // que lo agregó, decisión 11). 2) CreateTable remitos + sus índices. 3) CreateTable
+            // items_remito + sus índices. 4) AddColumn/AddForeignKey/CreateIndex de
+            // movimientos_stock.id_remito. 5) Data statement 2 (TXR guardado). 6)
+            // HabilitarRlsDeTenant sobre las dos tablas nuevas, al final.
+            //
+            // `dotnet ef migrations add` serializa `estado_remito` en orden ALFABÉTICO por
+            // defecto (mismo residuo ya documentado en PresupuestosEtapa17/las migraciones de
+            // las etapas 15/16) — corregido a mano acá para que el CREATE TYPE resultante sea
+            // VERBATIM al gate (task 4.1/4.2, registrado como desvío esperado, no un hallazgo).
+            // El AddColumn/CreateIndex/AddForeignKey de movimientos_stock y las 15 CreateIndex de
+            // remitos/items_remito también llegaron reordenadas/agrupadas por tabla a mano — EF
+            // las emite todas juntas al final, no intercaladas por tabla (mismo hallazgo que
+            // PresupuestosEtapa17 task 1.11).
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .Annotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .Annotation("Npgsql:Enum:estado_remito", "borrador,emitido,facturado,anulado")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .OldAnnotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            // gate §E (proposal.md:771-819): remitos — 18 columnas, PK, AK (habilita la FK
+            // compuesta de items_remito y el soporte de FK 24 de movimientos_stock.id_remito, más
+            // abajo), 5 FKs, 2 CHECKs, 5 índices nombrados a mano + el implícito de la AK.
+            migrationBuilder.CreateTable(
+                name: "remitos",
+                columns: table => new
+                {
+                    id_remito = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    id_cliente = table.Column<int>(type: "integer", nullable: false),
+                    id_empleado = table.Column<int>(type: "integer", nullable: false),
+                    numero = table.Column<long>(type: "bigint", nullable: true),
+                    fecha_emision = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    fecha_salida = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    direccion_entrega = table.Column<string>(type: "text", nullable: true),
+                    observaciones = table.Column<string>(type: "text", nullable: true),
+                    subtotal = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    descuento_total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    estado = table.Column<EstadoRemito>(type: "estado_remito", nullable: false),
+                    id_comprobante_venta = table.Column<int>(type: "integer", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_remitos", x => x.id_remito);
+                    table.UniqueConstraint("ak_remitos_id_remito_id_tenant", x => new { x.id_remito, x.id_tenant });
+                    table.CheckConstraint("ck_remitos_facturacion", "(id_comprobante_venta IS NULL) = (estado <> 'facturado')");
+                    table.CheckConstraint("ck_remitos_salida_completa", "((numero IS NULL) = (fecha_salida IS NULL)) AND (estado IN ('borrador','anulado') OR numero IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_remitos_cliente",
+                        columns: x => new { x.id_cliente, x.id_tenant },
+                        principalTable: "clientes",
+                        principalColumns: new[] { "id_cliente", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_remitos_comprobante_venta",
+                        columns: x => new { x.id_comprobante_venta, x.id_tenant },
+                        principalTable: "comprobantes_venta",
+                        principalColumns: new[] { "id_comprobante_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_remitos_empleado",
+                        column: x => x.id_empleado,
+                        principalTable: "usuarios",
+                        principalColumn: "id_usuario",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_remitos_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_remitos_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "items_remito",
+                columns: table => new
+                {
+                    id_item = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_remito = table.Column<int>(type: "integer", nullable: false),
+                    orden = table.Column<int>(type: "integer", nullable: false),
+                    id_articulo = table.Column<int>(type: "integer", nullable: false),
+                    descripcion = table.Column<string>(type: "text", nullable: false),
+                    cantidad = table.Column<decimal>(type: "numeric(12,3)", nullable: false),
+                    precio_unitario = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    descuento = table.Column<decimal>(type: "numeric(14,2)", nullable: false, defaultValue: 0m),
+                    total = table.Column<decimal>(type: "numeric(14,2)", nullable: false),
+                    id_lista_precio = table.Column<int>(type: "integer", nullable: false),
+                    id_oferta = table.Column<int>(type: "integer", nullable: true),
+                    id_alicuota_iva = table.Column<int>(type: "integer", nullable: false),
+                    porcentaje_iva = table.Column<decimal>(type: "numeric(5,2)", nullable: false),
+                    costo_unitario = table.Column<decimal>(type: "numeric(14,2)", nullable: true),
+                    costo_es_estimado = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    id_lote = table.Column<int>(type: "integer", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_items_remito", x => x.id_item);
+                    table.CheckConstraint("ck_items_remito_cantidad_positiva", "cantidad > 0");
+                    table.CheckConstraint("ck_items_remito_costo_no_negativo", "costo_unitario IS NULL OR costo_unitario >= 0");
+                    table.CheckConstraint("ck_items_remito_estimado_con_costo", "NOT costo_es_estimado OR costo_unitario IS NOT NULL");
+                    table.ForeignKey(
+                        name: "fk_items_remito_alicuota_iva",
+                        column: x => x.id_alicuota_iva,
+                        principalTable: "alicuotas_iva",
+                        principalColumn: "id_alicuota_iva",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_articulo",
+                        columns: x => new { x.id_articulo, x.id_tenant },
+                        principalTable: "articulos",
+                        principalColumns: new[] { "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_lista_precio",
+                        columns: x => new { x.id_lista_precio, x.id_tenant },
+                        principalTable: "listas_precio",
+                        principalColumns: new[] { "id_lista_precio", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_lote",
+                        columns: x => new { x.id_lote, x.id_articulo, x.id_tenant },
+                        principalTable: "lotes",
+                        principalColumns: new[] { "id_lote", "id_articulo", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_oferta",
+                        columns: x => new { x.id_oferta, x.id_tenant },
+                        principalTable: "ofertas",
+                        principalColumns: new[] { "id_oferta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_remito",
+                        columns: x => new { x.id_remito, x.id_tenant },
+                        principalTable: "remitos",
+                        principalColumns: new[] { "id_remito", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_items_remito_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_remitos_tenant",
+                table: "remitos",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_remitos_punto_venta_fecha",
+                table: "remitos",
+                columns: new[] { "id_punto_venta", "id_tenant", "fecha_emision" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_remitos_cliente",
+                table: "remitos",
+                columns: new[] { "id_cliente", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_remitos_empleado",
+                table: "remitos",
+                column: "id_empleado");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_remitos_comprobante_venta",
+                table: "remitos",
+                columns: new[] { "id_comprobante_venta", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_remitos_numero",
+                table: "remitos",
+                columns: new[] { "id_tenant", "id_punto_venta", "numero" },
+                unique: true,
+                filter: "numero IS NOT NULL");
+
+            // gate §F (proposal.md:826-881): items_remito — 20 columnas, PK, 7 FKs (la
+            // compuesta contra la AK de arriba), 3 CHECKs, 7 índices nombrados a mano + la
+            // unicidad de orden.
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_tenant",
+                table: "items_remito",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_remito",
+                table: "items_remito",
+                columns: new[] { "id_remito", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_articulo",
+                table: "items_remito",
+                columns: new[] { "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_lista_precio",
+                table: "items_remito",
+                columns: new[] { "id_lista_precio", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_oferta",
+                table: "items_remito",
+                columns: new[] { "id_oferta", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_alicuota_iva",
+                table: "items_remito",
+                column: "id_alicuota_iva");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_items_remito_lote",
+                table: "items_remito",
+                columns: new[] { "id_lote", "id_articulo", "id_tenant" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_items_remito_orden",
+                table: "items_remito",
+                columns: new[] { "id_remito", "orden" },
+                unique: true);
+
+            // gate §H (proposal.md:914-938): ALTER aditivo sobre movimientos_stock — el
+            // documento del cuarto write site. Metadata-only en PG 11+ (columna nullable sin
+            // default), FK compuesta MATCH SIMPLE e índice de soporte declarado a mano. DESPUÉS
+            // de las dos CREATE TABLE de arriba (orden topológico: la FK necesita que remitos y
+            // su AK ya existan).
+            migrationBuilder.AddColumn<int>(
+                name: "id_remito",
+                table: "movimientos_stock",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_movimientos_stock_remito",
+                table: "movimientos_stock",
+                columns: new[] { "id_remito", "id_tenant" },
+                principalTable: "remitos",
+                principalColumns: new[] { "id_remito", "id_tenant" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_movimientos_stock_remito",
+                table: "movimientos_stock",
+                columns: new[] { "id_remito", "id_tenant" });
+
+            // gate §I, data statement 2 (proposal.md:946-950) — TXR para bases YA MIGRADAS,
+            // mismo guard EXISTS/NOT EXISTS que RC (CuentaCorrienteEtapa7)/C-*
+            // (ComprasYTransferenciasEtapa8): el seeder de InicializadorDeBaseDeDatos.
+            // TiposComprobanteBase (task 4.20) siembra TXR para una base FRESCA, este statement
+            // cierra el mismo hueco en una base que YA tenía tipos_comprobante poblado antes de
+            // esta etapa.
+            migrationBuilder.Sql(
+                """
+                INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, created_at, updated_at)
+                SELECT 'venta', 'TXR', 'Ticket X por remitos', 'X', 1, false, false, false, true, now(), now()
+                WHERE EXISTS (SELECT 1 FROM tipos_comprobante)
+                  AND NOT EXISTS (SELECT 1 FROM tipos_comprobante WHERE codigo = 'TXR');
+                """);
+
+            // RLS al final, en las DOS tablas nuevas (ADR-15 / la convención de las etapas
+            // 12/14/15/16/17-slice-1): la conexión de migración no tiene app_tenant_actual()
+            // seteado y el data statement de arriba no depende de RLS estar activo todavía.
+            migrationBuilder.HabilitarRlsDeTenant("remitos");
+            migrationBuilder.HabilitarRlsDeTenant("items_remito");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // gate §I, data statement 3 (proposal.md:952-954) — desactiva en vez de borrar, para
+            // que un TXR ya emitido siga siendo legible después de un rollback (mismo criterio
+            // que CuentaCorrienteEtapa7/ComprasYTransferenciasEtapa8 con RC/C-*).
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET activo = false WHERE codigo = 'TXR';");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_movimientos_stock_remito",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropIndex(
+                name: "ix_movimientos_stock_remito",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropColumn(
+                name: "id_remito",
+                table: "movimientos_stock");
+
+            migrationBuilder.DropTable(
+                name: "items_remito");
+
+            migrationBuilder.DropTable(
+                name: "remitos");
+
+            // Sin reversa de `motivo_stock` (proposal §B, gate §B): Postgres no soporta DROP
+            // VALUE, así que 'remito' queda como miembro muerto documentado tras el rollback —
+            // el resto de la reversa (FKs, tablas, índices, CHECKs, columna, tipo estado_remito)
+            // sí se ejecuta. Mismo criterio que LotesYVencimientosEtapa12 con
+            // decomiso/reclasificacion.
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .Annotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .OldAnnotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .OldAnnotation("Npgsql:Enum:estado_remito", "borrador,emitido,facturado,anulado")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -145,6 +145,12 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<Presupuesto> Presupuestos => Set<Presupuesto>();
     public DbSet<ItemPresupuesto> ItemsPresupuesto => Set<ItemPresupuesto>();
 
+    // stage-17-presupuestos-y-remitos, Slice 4 (schema + backstops, DB CHANGE GATE aprobado):
+    // mismo trámite que Presupuesto/ItemPresupuesto en slice 1 — ServicioDeRemitos (slice 5) es
+    // el primer consumidor de Application.
+    public DbSet<Remito> Remitos => Set<Remito>();
+    public DbSet<ItemRemito> ItemsRemito => Set<ItemRemito>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
@@ -48,6 +48,7 @@ public class WaysDbContextFactory : IDesignTimeDbContextFactory<WaysDbContext>
                 npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
             })
             .Options;
 

--- a/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
@@ -42,8 +42,21 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
 {
     private const string MigracionStage7 = "20260805050151_CuentaCorrienteEtapa7";
 
+    // Los once códigos de venta previos a esta etapa — usado tal cual para SEMBRAR el catálogo
+    // "como si fuera stage 7" (línea ~144, ANTES de que RemitosEtapa17 exista) — nunca debe
+    // ganar "TXR" acá, o el data statement guardado de RemitosEtapa17 lo encontraría ya
+    // presente y el test dejaría de probar que ESE statement es quien realmente lo agrega.
     private static readonly string[] CodigosDeVentaEsperados =
         ["FA", "FB", "FC", "NCA", "NCB", "NCC", "NDA", "TX", "NCX", "PRE", "RC"];
+
+    // stage-17-presupuestos-y-remitos (Slice 4, proposal §I): TXR se agrega al catálogo de venta
+    // DESPUÉS de sembrar/migrar — tanto por el seed estático (fresh-host-boot,
+    // TiposComprobanteBase) como por el data statement 2 guardado de RemitosEtapa17 (una base
+    // migrada hasta el final, sin pasar por el seeder, también lo gana) — mismo mecanismo exacto
+    // que PRE/RC ya cubren en este archivo. Usado solo en las dos ASERCIONES post-migración,
+    // nunca en el seed de arriba.
+    private static readonly string[] CodigosDeVentaEsperadosTrasRemitosEtapa17 =
+        [.. CodigosDeVentaEsperados, "TXR"];
 
     private static readonly string[] CodigosDeCompraEsperados = ["C-FA", "C-FB", "C-FC"];
 
@@ -66,7 +79,7 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
             .OrderBy(c => c)
             .ToListAsync();
 
-        Assert.Equal(CodigosDeVentaEsperados.OrderBy(c => c), venta);
+        Assert.Equal(CodigosDeVentaEsperadosTrasRemitosEtapa17.OrderBy(c => c), venta);
         Assert.Equal(CodigosDeCompraEsperados.OrderBy(c => c), compra);
 
         // stage-17-presupuestos-y-remitos (Slice 1, net 1b del PRE latente): PRE nace inactivo
@@ -177,7 +190,7 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
             }
 
             Assert.Equal(CodigosDeCompraEsperados.OrderBy(c => c), await ListarCodigosAsync("compra"));
-            Assert.Equal(CodigosDeVentaEsperados.OrderBy(c => c), await ListarCodigosAsync("venta"));
+            Assert.Equal(CodigosDeVentaEsperadosTrasRemitosEtapa17.OrderBy(c => c), await ListarCodigosAsync("venta"));
 
             // Re-ejecuta a mano el mismo INSERT idempotente de la migración (simula un reintento
             // de arranque) y confirma que sigue sin duplicar.

--- a/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
@@ -125,6 +125,7 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                     // estado_orden_compra (slice 1).
                     npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                    npgsql.MapEnum<EstadoRemito>("estado_remito");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -202,6 +202,7 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
                     // PendingModelChangesWarning.
                     npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                    npgsql.MapEnum<EstadoRemito>("estado_remito");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -137,6 +137,10 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
     // mismo motivo que RC en su momento: TiposComprobanteBase ahora también incluye C-FA/C-FB/
     // C-FC (design: Table Shapes — E), y el mismo guard AND EXISTS del seed de compra deja una
     // base fresca intacta para que este seeder la puebla completa y atómica.
+    //
+    // stage-17-presupuestos-y-remitos (Slice 4, proposal §I): el total pasa de 14 a 15 — TXR se
+    // agrega al mismo seed estático (TiposComprobanteBase), mismo mecanismo exacto que C-FA/C-FB/
+    // C-FC en su momento.
     [Fact]
     public async Task UnaBaseFrescaTerminaConElCatalogoCompletoDeTiposIncluidoRc()
     {
@@ -147,10 +151,11 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
 
         var codigos = await db.TiposComprobante.Select(t => t.Codigo).OrderBy(c => c).ToListAsync();
 
-        Assert.Equal(14, codigos.Count);
+        Assert.Equal(15, codigos.Count);
         Assert.Contains("RC", codigos);
         Assert.Contains("FA", codigos);
         Assert.Contains("TX", codigos);
+        Assert.Contains("TXR", codigos);
         Assert.Contains("C-FA", codigos);
         Assert.Contains("C-FB", codigos);
         Assert.Contains("C-FC", codigos);

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
@@ -67,6 +67,7 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
                 npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                 // stage-17-presupuestos-y-remitos, Slice 1: mismo gap, mismo motivo.
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
             })
             .Options;
 

--- a/tests/Ways.IntegrationTests/LotesMigracionTests.cs
+++ b/tests/Ways.IntegrationTests/LotesMigracionTests.cs
@@ -77,9 +77,16 @@ public class LotesMigracionTests(WaysApiFixture fixture) : IClassFixture<WaysApi
     }
 
     /// <summary>Ocho motivos en total (seis previos + los dos de esta etapa) — asegura que la
-    /// migración no perdió ninguno de los preexistentes al reescribir el enum.</summary>
+    /// migración no perdió ninguno de los preexistentes al reescribir el enum.
+    ///
+    /// stage-17-presupuestos-y-remitos (Slice 4, proposal §B): el conteo real sobre la base
+    /// COMPARTIDA de <c>WaysApiFixture</c> pasa a NUEVE — <c>RemitosEtapa17</c> agrega
+    /// <c>'remito'</c> vía otro <c>ALTER TYPE ... ADD VALUE</c>, mismo mecanismo que
+    /// <c>decomiso</c>/<c>reclasificacion</c>. Actualizado para no romper por un tipo que sigue
+    /// preexistiendo — el punto de esta prueba (ningún valor previo se pierde) sigue
+    /// intacto.</summary>
     [Fact]
-    public async Task ElEnumMotivoStockTieneLosOchoValores()
+    public async Task ElEnumMotivoStockTieneLosNueveValores()
     {
         await using var cruda = await AbrirAsync();
         await using var comando = cruda.CreateCommand();
@@ -88,6 +95,6 @@ public class LotesMigracionTests(WaysApiFixture fixture) : IClassFixture<WaysApi
             "WHERE t.typname = 'motivo_stock'";
 
         var total = (long)(await comando.ExecuteScalarAsync())!;
-        Assert.Equal(8, total);
+        Assert.Equal(9, total);
     }
 }

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresRemitosTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 4 (tasks 4.22-4.26, db-error-backstops, design
+/// decisión 18, proposal §J): mismo patrón unit-style que
+/// <see cref="ManejadorDeErroresPresupuestosTests"/> — sin <c>WaysApiFixture</c> ni Postgres
+/// real, la <see cref="PostgresException"/> se construye "a mano". No hay endpoint todavía en
+/// esta slice (<c>ServicioDeRemitos</c> es slice 5, la consolidación es slice 6) para ejercer el
+/// round-trip HTTP completo; la prueba de que <c>ux_remitos_numero</c> gana la rama nueva ANTES
+/// de caer en la familia genérica de <c>ClasificarUnicidad</c> — la **quinta** ocurrencia del
+/// ordering trap — vive acá, junto con <c>ux_items_remito_orden</c> y las cinco CHECKs nuevas
+/// (CORRECCIÓN registrada en tasks.md: son CINCO, no tres — proposal §J agrupa CHECK 2/5/6/7 en
+/// una sola fila "exact-name mapping" y design.md's Backstop Map lista CHECK 6/7 explícitamente;
+/// el "3" de la Orchestrator Decision 9 de tasks.md es un artefacto de redacción).
+/// </summary>
+public class ManejadorDeErroresRemitosTests
+{
+    private sealed class ServicioDeProblemDetailsFalso : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Ultimo { get; private set; }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.FromResult(true);
+        }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static PostgresException CrearExcepcion(string sqlState, string constraintName) =>
+        new(
+            messageText: "mensaje de prueba",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: null,
+            columnName: null,
+            dataTypeName: null,
+            constraintName: constraintName,
+            file: null,
+            line: null,
+            routine: null);
+
+    private static async Task<(int Estado, string? Codigo)> ManejarAsync(Exception excepcion)
+    {
+        var servicioDeProblemDetails = new ServicioDeProblemDetailsFalso();
+        var manejador = new ManejadorDeErrores(servicioDeProblemDetails, NullLogger<ManejadorDeErrores>.Instance);
+        var contexto = new DefaultHttpContext();
+
+        var manejado = await manejador.TryHandleAsync(contexto, excepcion, CancellationToken.None);
+
+        Assert.True(manejado);
+        Assert.NotNull(servicioDeProblemDetails.Ultimo);
+
+        var problema = servicioDeProblemDetails.Ultimo!.ProblemDetails;
+        return (contexto.Response.StatusCode, problema.Extensions["codigo"] as string);
+    }
+
+    // ---- ux_remitos_numero (el trap de ordering, QUINTA ocurrencia) ----------------------------
+
+    /// <summary>Mutation target #38: prueba tanto el camino EF (<c>DbUpdateException</c>) como el
+    /// camino raw-ADO (<c>PostgresException</c> pelada, <c>emitir</c> usa SQL crudo, slice 5).</summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UxRemitosNumeroGanaLaRamaNuevaAntesQueLaFamiliaGenericaDeNumero(bool caminoRawAdo)
+    {
+        var postgres = CrearExcepcion("23505", "ux_remitos_numero");
+        Exception excepcion = caminoRawAdo ? postgres : new DbUpdateException("dup", postgres);
+
+        var (estado, codigo) = await ManejarAsync(excepcion);
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("numero_de_remito_duplicado", codigo);
+        // La prueba negativa que cierra el trap: NUNCA el código genérico de ux_clientes_numero
+        // — sin la rama exacta ANTES de ClasificarUnicidad, la substring "_numero" la atraparía
+        // primero y la clasificaría como "numero_duplicado".
+        Assert.NotEqual("numero_duplicado", codigo);
+    }
+
+    [Fact]
+    public async Task UxItemsRemitoOrdenSeTraduceA409OrdenDeItemDuplicado()
+    {
+        var postgres = CrearExcepcion("23505", "ux_items_remito_orden");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("orden_de_item_duplicado", codigo);
+    }
+
+    // ---- ClasificarCheckDeRemitos (detrás del guard de prefijo) — CINCO ramas -------------------
+
+    [Fact]
+    public async Task CkRemitosSalidaCompletaSeTraduceA409RemitoSalidaIncompleta()
+    {
+        var postgres = CrearExcepcion("23514", "ck_remitos_salida_completa");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("remito_salida_incompleta", codigo);
+    }
+
+    [Fact]
+    public async Task CkRemitosFacturacionSeTraduceA409RemitoFacturacionIncoherente()
+    {
+        var postgres = CrearExcepcion("23514", "ck_remitos_facturacion");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("remito_facturacion_incoherente", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsRemitoCantidadPositivaSeTraduceA400CantidadDeLineaInvalida()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_remito_cantidad_positiva");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("cantidad_de_linea_invalida", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsRemitoCostoNoNegativoSeTraduceA400CostoDeLineaInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_remito_costo_no_negativo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("costo_de_linea_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkItemsRemitoEstimadoConCostoSeTraduceA400CostoEstimadoInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_items_remito_estimado_con_costo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("costo_estimado_invalido", codigo);
+    }
+
+    // ---- FKs exentas: el match genérico por prefijo "fk_" ya las cubre, sin cambio de código ---
+
+    [Theory]
+    [InlineData("fk_remitos_tenant")]
+    [InlineData("fk_remitos_punto_venta")]
+    [InlineData("fk_remitos_cliente")]
+    [InlineData("fk_remitos_empleado")]
+    [InlineData("fk_remitos_comprobante_venta")]
+    [InlineData("fk_items_remito_tenant")]
+    [InlineData("fk_items_remito_remito")]
+    [InlineData("fk_items_remito_articulo")]
+    [InlineData("fk_items_remito_lista_precio")]
+    [InlineData("fk_items_remito_oferta")]
+    [InlineData("fk_items_remito_alicuota_iva")]
+    [InlineData("fk_items_remito_lote")]
+    [InlineData("fk_movimientos_stock_remito")]
+    public async Task CadaFkNuevaSeTraduceA400ReferenciaInvalida(string nombreDeFk)
+    {
+        var postgres = CrearExcepcion("23503", nombreDeFk);
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("fk", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("referencia_invalida", codigo);
+    }
+
+    // ---- AK exenta: estructuralmente inviolable, sin rama de 23505 ------------------------------
+
+    [Fact]
+    public async Task AkRemitosSinRamaDe23505CaeAlDefaultDe500()
+    {
+        var postgres = CrearExcepcion("23505", "ak_remitos_id_remito_id_tenant");
+        var (estado, _) = await ManejarAsync(new DbUpdateException("ak", postgres));
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, estado);
+    }
+}

--- a/tests/Ways.IntegrationTests/PresupuestosSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/PresupuestosSchemaTests.cs
@@ -760,6 +760,7 @@ public class PresupuestosSchemaTests(WaysApiFixture fixture) : IClassFixture<Way
                     npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                     npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                    npgsql.MapEnum<EstadoRemito>("estado_remito");
                 })
                 .Options;
 
@@ -857,6 +858,7 @@ public class PresupuestosSchemaTests(WaysApiFixture fixture) : IClassFixture<Way
                     npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                     npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                    npgsql.MapEnum<EstadoRemito>("estado_remito");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
@@ -1,0 +1,1063 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 4 (tasks 4.27-4.35, mutation targets #38-#39,
+/// db-error-backstops skill, design decisiones 5/11/18): RLS, las cinco CHECKs nuevas, la
+/// partición parcial de <c>ux_remitos_numero</c>, el conteo vinculante de 30 índices nuevos
+/// ACUMULADOS de la etapa, los nombres exactos de constraint (QUINTA ocurrencia del ordering
+/// trap), el ALTER TYPE aislado, el orden del enum <c>MotivoStock</c> y el <c>TXR</c> guardado —
+/// todos sobre la base COMPARTIDA de <see cref="WaysApiFixture"/> (mismo criterio que
+/// <c>PresupuestosSchemaTests</c>: no depende del momento exacto de una migración de datos,
+/// salvo el <c>TXR</c> guardado, que sí lo hace y se prueba aparte más abajo).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class RemitosSchemaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private sealed record Escenario(
+        int IdTenant, int IdPuntoVenta, int IdCliente, int IdEmpleado, int IdArticulo,
+        int IdListaPrecio, int IdAlicuotaIva);
+
+    private async Task<Escenario> SembrarEscenarioAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host: siembra roles/alicuotas/tipos de comprobante
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var listaPrecio = new ListaPrecio
+        {
+            IdTenant = tenant.Id, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(listaPrecio);
+        await db.SaveChangesAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = tenant.Id, Numero = 601, Nombre = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            IdListaPrecio = listaPrecio.Id, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var empleado = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = $"{nombre.ToLowerInvariant()}-empleado",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(empleado);
+        await db.SaveChangesAsync();
+
+        var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Select(a => a.Id).FirstAsync();
+
+        var articulo = new Articulo
+        {
+            IdTenant = tenant.Id,
+            CodigoInterno = $"{nombre}-cod",
+            Nombre = $"{nombre}-articulo",
+            IdArea = area.Id,
+            IdAlicuotaIva = idAlicuotaIva,
+            UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        return new Escenario(
+            tenant.Id, puntoVenta.Id, cliente.Id, empleado.Id, articulo.Id, listaPrecio.Id, idAlicuotaIva);
+    }
+
+    private const string ColumnasRemito =
+        "(id_tenant, id_punto_venta, id_cliente, id_empleado, numero, fecha_emision, fecha_salida, " +
+        " direccion_entrega, observaciones, subtotal, descuento_total, total, estado, id_comprobante_venta, " +
+        " created_at, updated_at, deleted_at)";
+
+    private static async Task<int> InsertarBorradorAsync(NpgsqlConnection cruda, Escenario e)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), NULL, NULL, NULL, 0, 0, 0, 'borrador'::estado_remito, NULL, now(), now(), NULL) " +
+            "RETURNING id_remito";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<int> ObtenerIdTipoComprobanteAsync(NpgsqlConnection cruda, string codigo)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT id_tipo_comprobante FROM tipos_comprobante WHERE codigo = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = codigo });
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<int> InsertarVentaAsync(
+        NpgsqlConnection cruda, Escenario e, int idTipoComprobante, long numero)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_venta " +
+            "(id_tenant, id_tipo_comprobante, numero, fecha, id_punto_venta, id_turno_caja, id_empleado, " +
+            " id_cliente, id_comprobante_asociado, id_presupuesto_origen, subtotal, descuento_total, total, " +
+            " neto_gravado, iva_total, direccion_entrega, observaciones, estado, created_at, updated_at, deleted_at) " +
+            "VALUES ($1, $2, $3, now(), $4, NULL, $5, $6, NULL, NULL, 10, 0, 10, NULL, NULL, NULL, NULL, " +
+            " 'emitido'::estado_comprobante, now(), now(), NULL) RETURNING id_comprobante_venta";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTipoComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = numero });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // RLS (task 4.27, mutation target #38)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeLosRemitosPorSelect()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosRemitosPorSelect) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosRemitosPorSelect) + "-B");
+
+        int idRemito;
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant))
+        {
+            idRemito = await InsertarBorradorAsync(cruda, a);
+        }
+
+        await using var comoB = await fixture.AbrirConexionCrudaAsync("tenant", b.IdTenant);
+        await using var comando = comoB.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM remitos WHERE id_remito = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idRemito });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeLosItemsDeRemitoPorSelect()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosItemsDeRemitoPorSelect) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosItemsDeRemitoPorSelect) + "-B");
+
+        int idItem;
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant))
+        {
+            var idRemito = await InsertarBorradorAsync(cruda, a);
+
+            await using var insertarItem = cruda.CreateCommand();
+            insertarItem.CommandText =
+                "INSERT INTO items_remito " +
+                "(id_tenant, id_remito, orden, id_articulo, descripcion, cantidad, precio_unitario, " +
+                " descuento, total, id_lista_precio, id_oferta, id_alicuota_iva, porcentaje_iva, " +
+                " costo_unitario, costo_es_estimado, id_lote, created_at, updated_at, deleted_at) " +
+                "VALUES ($1, $2, 1, $3, 'seed', 2, 10, 0, 20, $4, NULL, $5, 21, NULL, false, NULL, now(), now(), NULL) " +
+                "RETURNING id_item";
+            insertarItem.Parameters.Add(new NpgsqlParameter { Value = a.IdTenant });
+            insertarItem.Parameters.Add(new NpgsqlParameter { Value = idRemito });
+            insertarItem.Parameters.Add(new NpgsqlParameter { Value = a.IdArticulo });
+            insertarItem.Parameters.Add(new NpgsqlParameter { Value = a.IdListaPrecio });
+            insertarItem.Parameters.Add(new NpgsqlParameter { Value = a.IdAlicuotaIva });
+            idItem = (int)(await insertarItem.ExecuteScalarAsync())!;
+        }
+
+        await using var comoB = await fixture.AbrirConexionCrudaAsync("tenant", b.IdTenant);
+        await using var comando = comoB.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM items_remito WHERE id_item = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = idItem });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnInsertConIdTenantAjenoEnRemitosSeRechaza()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnRemitosSeRechaza) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnRemitosSeRechaza) + "-B");
+
+        await using var comoA = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant);
+        await using var comando = comoA.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), NULL, NULL, NULL, 0, 0, 0, 'borrador'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = b.IdTenant }); // ajeno a la sesión (tenant A)
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ck_remitos_salida_completa (task 4.28, mutation target #38)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnNumeroSinFechaDeSalidaViolaLaCheckDeSalidaCompleta()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnNumeroSinFechaDeSalidaViolaLaCheckDeSalidaCompleta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, 601, now(), NULL, NULL, NULL, 0, 0, 0, 'emitido'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_remitos_salida_completa", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaFechaDeSalidaSinNumeroViolaLaCheckDeSalidaCompleta()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnaFechaDeSalidaSinNumeroViolaLaCheckDeSalidaCompleta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), now(), NULL, NULL, 0, 0, 0, 'emitido'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_remitos_salida_completa", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnEstadoEmitidoSinNumeroViolaLaCheckDeSalidaCompleta()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnEstadoEmitidoSinNumeroViolaLaCheckDeSalidaCompleta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), NULL, NULL, NULL, 0, 0, 0, 'emitido'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_remitos_salida_completa", excepcion.ConstraintName);
+    }
+
+    /// <summary>Dirección permitida explícita: <c>anulado</c> sin número/fecha_salida es
+    /// admitido — un borrador puede anularse antes de ser emitido.</summary>
+    [Fact]
+    public async Task UnEstadoAnuladoSinNumeroNoViolaLaCheckDeSalidaCompleta()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnEstadoAnuladoSinNumeroNoViolaLaCheckDeSalidaCompleta));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), NULL, NULL, NULL, 0, 0, 0, 'anulado'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ck_remitos_facturacion (task 4.28, mutation target #38)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UnEstadoFacturadoSinComprobanteLigadoViolaLaCheckDeFacturacion()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnEstadoFacturadoSinComprobanteLigadoViolaLaCheckDeFacturacion));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, 602, now(), now(), NULL, NULL, 0, 0, 0, 'facturado'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_remitos_facturacion", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnComprobanteLigadoConEstadoNoFacturadoViolaLaCheckDeFacturacion()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnComprobanteLigadoConEstadoNoFacturadoViolaLaCheckDeFacturacion));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipoComprobante = await ObtenerIdTipoComprobanteAsync(cruda, "TXR");
+        var idComprobante = await InsertarVentaAsync(cruda, e, idTipoComprobante, numero: 1);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, 603, now(), now(), NULL, NULL, 0, 0, 0, 'emitido'::estado_remito, $5, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_remitos_facturacion", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnEstadoFacturadoConComprobanteLigadoNoViolaLaCheckDeFacturacion()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnEstadoFacturadoConComprobanteLigadoNoViolaLaCheckDeFacturacion));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipoComprobante = await ObtenerIdTipoComprobanteAsync(cruda, "TXR");
+        var idComprobante = await InsertarVentaAsync(cruda, e, idTipoComprobante, numero: 2);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, 604, now(), now(), NULL, NULL, 0, 0, 0, 'facturado'::estado_remito, $5, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idComprobante });
+
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ck_items_remito_cantidad_positiva / costo_no_negativo / estimado_con_costo (task 4.28)
+    // ---------------------------------------------------------------------------------------
+
+    private static async Task<NpgsqlCommand> ComandoInsertarItemAsync(
+        NpgsqlConnection cruda, Escenario e, int idRemito, decimal cantidad, decimal? costoUnitario, bool costoEsEstimado)
+    {
+        var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_remito " +
+            "(id_tenant, id_remito, orden, id_articulo, descripcion, cantidad, precio_unitario, " +
+            " descuento, total, id_lista_precio, id_oferta, id_alicuota_iva, porcentaje_iva, " +
+            " costo_unitario, costo_es_estimado, id_lote, created_at, updated_at, deleted_at) " +
+            "VALUES ($1, $2, 1, $3, 'seed', $4, 10, 0, 0, $5, NULL, $6, 21, $7, $8, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idRemito });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = cantidad });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdListaPrecio });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdAlicuotaIva });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)costoUnitario ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = costoEsEstimado });
+        return comando;
+    }
+
+    [Fact]
+    public async Task UnaCantidadNoPositivaViolaLaCheckDeItemsRemito()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnaCantidadNoPositivaViolaLaCheckDeItemsRemito));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idRemito = await InsertarBorradorAsync(cruda, e);
+
+        await using var comando = await ComandoInsertarItemAsync(cruda, e, idRemito, cantidad: 0, costoUnitario: null, costoEsEstimado: false);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_remito_cantidad_positiva", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCostoNegativoViolaLaCheckDeCostoNoNegativo()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCostoNegativoViolaLaCheckDeCostoNoNegativo));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idRemito = await InsertarBorradorAsync(cruda, e);
+
+        await using var comando = await ComandoInsertarItemAsync(cruda, e, idRemito, cantidad: 1, costoUnitario: -10m, costoEsEstimado: false);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_remito_costo_no_negativo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCostoEstimadoSinCostoViolaLaCheckDeEstimadoConCosto()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCostoEstimadoSinCostoViolaLaCheckDeEstimadoConCosto));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idRemito = await InsertarBorradorAsync(cruda, e);
+
+        await using var comando = await ComandoInsertarItemAsync(cruda, e, idRemito, cantidad: 1, costoUnitario: null, costoEsEstimado: true);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_items_remito_estimado_con_costo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCostoEstimadoConCostoNoViolaLaCheck()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCostoEstimadoConCostoNoViolaLaCheck));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idRemito = await InsertarBorradorAsync(cruda, e);
+
+        await using var comando = await ComandoInsertarItemAsync(cruda, e, idRemito, cantidad: 1, costoUnitario: 15m, costoEsEstimado: true);
+
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Partición parcial de ux_remitos_numero (task 4.28, mutation target #38)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DosBorradoresDeRemitoSinNumeroEnElMismoPuntoDeVentaConvivenSinConflicto()
+    {
+        var e = await SembrarEscenarioAsync(nameof(DosBorradoresDeRemitoSinNumeroEnElMismoPuntoDeVentaConvivenSinConflicto));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await InsertarBorradorAsync(cruda, e);
+        await InsertarBorradorAsync(cruda, e); // no debe tirar — ambos numero NULL, filtro parcial
+    }
+
+    /// <summary>Mismo hallazgo estructural que
+    /// <c>PresupuestosSchemaTests.ElTextoFuenteDeLaMigracionConservaLosDosFiltrosParcialesTargets4Y5</c>
+    /// (mutation-proof-tests regla 3 exhausted, PROVABLY EQUIVALENT AT RUNTIME): Postgres nunca
+    /// considera dos filas duplicadas bajo UNIQUE si cualquier columna indexada es NULL en
+    /// cualquiera de las dos, y <c>numero</c> es la única columna nullable de
+    /// <c>ux_remitos_numero</c> — quitar <c>filter: "numero IS NOT NULL"</c> no cambia nada
+    /// observable en la prueba de arriba. Confirmado empíricamente (no razonado — regla 2): con
+    /// el filtro borrado de la migración, la prueba de arriba sigue en VERDE. Prueba de TEXTO
+    /// FUENTE en su lugar.</summary>
+    [Fact]
+    public void ElTextoFuenteDeLaMigracionConservaElFiltroParcialDeUxRemitosNumero()
+    {
+        var rutaMigracion = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Infrastructure", "Persistencia", "Migraciones",
+            "20260820004658_RemitosEtapa17.cs");
+
+        Assert.True(File.Exists(rutaMigracion), $"No se encontró la migración en {rutaMigracion}");
+
+        var fuente = File.ReadAllText(rutaMigracion);
+
+        Assert.Contains("name: \"ux_remitos_numero\"", fuente);
+        Assert.Contains("filter: \"numero IS NOT NULL\"", fuente);
+    }
+
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    // ---------------------------------------------------------------------------------------
+    // Conteo vinculante de índices ACUMULADO (task 4.29, gate — VINCULANTE, 30 acumulado)
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>Gate guard VINCULANTE (task 4.29, state.yaml db_gate_approval): el conteo total
+    /// de índices nuevos ACUMULADO de la etapa tiene que ser EXACTAMENTE 30 — 14 de slice 1 (6
+    /// presupuestos + 7 items_presupuesto + 1 comprobantes_venta) + 16 de esta slice (7 remitos
+    /// incl. AK implícita + 8 items_remito + 1 movimientos_stock). Verificado por DEFINICIÓN
+    /// contra <c>pg_indexes</c>, nunca por nombre.</summary>
+    [Fact]
+    public async Task ElConteoTotalDeIndicesNuevosAcumuladoEsExactamenteTreinta()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        var indicesPresupuestos = await ListarIndicesAsync(cruda, "presupuestos");
+        var indicesItemsPresupuesto = await ListarIndicesAsync(cruda, "items_presupuesto");
+        var indicesDeSoportePresupuestos = indicesPresupuestos.Where(n => n != "pk_presupuestos").ToList();
+        var indicesDeSoporteItemsPresupuesto = indicesItemsPresupuesto.Where(n => n != "pk_items_presupuesto").ToList();
+        Assert.Equal(6, indicesDeSoportePresupuestos.Count);
+        Assert.Equal(7, indicesDeSoporteItemsPresupuesto.Count);
+
+        await using var comandoComprobantes = cruda.CreateCommand();
+        comandoComprobantes.CommandText =
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'comprobantes_venta' AND indexname = 'ux_comprobantes_venta_presupuesto_origen'";
+        var indiceComprobantes = (long)(await comandoComprobantes.ExecuteScalarAsync())!;
+        Assert.Equal(1, indiceComprobantes);
+
+        var indicesRemitos = await ListarIndicesAsync(cruda, "remitos");
+        var indicesDeSoporteRemitos = indicesRemitos.Where(n => n != "pk_remitos").ToList();
+        Assert.Equal(7, indicesDeSoporteRemitos.Count);
+        Assert.Equal(
+            new[]
+            {
+                "ak_remitos_id_remito_id_tenant",
+                "ix_remitos_cliente",
+                "ix_remitos_comprobante_venta",
+                "ix_remitos_empleado",
+                "ix_remitos_punto_venta_fecha",
+                "ix_remitos_tenant",
+                "ux_remitos_numero"
+            },
+            indicesDeSoporteRemitos.OrderBy(n => n));
+
+        var indicesItemsRemito = await ListarIndicesAsync(cruda, "items_remito");
+        var indicesDeSoporteItemsRemito = indicesItemsRemito.Where(n => n != "pk_items_remito").ToList();
+        Assert.Equal(8, indicesDeSoporteItemsRemito.Count);
+        Assert.Equal(
+            new[]
+            {
+                "ix_items_remito_alicuota_iva",
+                "ix_items_remito_articulo",
+                "ix_items_remito_lista_precio",
+                "ix_items_remito_lote",
+                "ix_items_remito_oferta",
+                "ix_items_remito_remito",
+                "ix_items_remito_tenant",
+                "ux_items_remito_orden"
+            },
+            indicesDeSoporteItemsRemito.OrderBy(n => n));
+
+        await using var comandoMovimientos = cruda.CreateCommand();
+        comandoMovimientos.CommandText =
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'movimientos_stock' AND indexname = 'ix_movimientos_stock_remito'";
+        var indiceMovimientos = (long)(await comandoMovimientos.ExecuteScalarAsync())!;
+        Assert.Equal(1, indiceMovimientos);
+
+        // No debe existir NINGÚN índice extra sobre id_remito más allá del nombrado a mano.
+        await using var comandoSinAutogenerado = cruda.CreateCommand();
+        comandoSinAutogenerado.CommandText =
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'movimientos_stock' " +
+            "AND indexname ILIKE '%remito%' AND indexname <> 'ix_movimientos_stock_remito'";
+        var autogenerados = (long)(await comandoSinAutogenerado.ExecuteScalarAsync())!;
+        Assert.Equal(0, autogenerados);
+
+        var totalAcumulado =
+            indicesDeSoportePresupuestos.Count + indicesDeSoporteItemsPresupuesto.Count + (int)indiceComprobantes +
+            indicesDeSoporteRemitos.Count + indicesDeSoporteItemsRemito.Count + (int)indiceMovimientos;
+
+        Assert.Equal(30, totalAcumulado);
+    }
+
+    [Fact]
+    public async Task LasDefinicionesDeLosIndicesCompuestosDeRemitosRespetanElOrdenDeColumnasDelContrato()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "remitos", "ix_remitos_punto_venta_fecha"),
+            "id_punto_venta", "id_tenant", "fecha_emision");
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "remitos", "ix_remitos_cliente"),
+            "id_cliente", "id_tenant");
+
+        var defNumero = await ObtenerIndexDefAsync(cruda, "remitos", "ux_remitos_numero");
+        AssertOrdenDeColumnas(defNumero, "id_tenant", "id_punto_venta", "numero");
+        Assert.Contains("CREATE UNIQUE INDEX", defNumero);
+        Assert.Contains("WHERE (numero IS NOT NULL)", defNumero);
+
+        var defAk = await ObtenerIndexDefAsync(cruda, "remitos", "ak_remitos_id_remito_id_tenant");
+        AssertOrdenDeColumnas(defAk, "id_remito", "id_tenant");
+        Assert.Contains("CREATE UNIQUE INDEX", defAk);
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "items_remito", "ix_items_remito_remito"),
+            "id_remito", "id_tenant");
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "items_remito", "ix_items_remito_articulo"),
+            "id_articulo", "id_tenant");
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "items_remito", "ix_items_remito_lote"),
+            "id_lote", "id_articulo", "id_tenant");
+
+        var defUxOrden = await ObtenerIndexDefAsync(cruda, "items_remito", "ux_items_remito_orden");
+        AssertOrdenDeColumnas(defUxOrden, "id_remito", "orden");
+        Assert.Contains("CREATE UNIQUE INDEX", defUxOrden);
+
+        AssertOrdenDeColumnas(
+            await ObtenerIndexDefAsync(cruda, "movimientos_stock", "ix_movimientos_stock_remito"),
+            "id_remito", "id_tenant");
+
+        var compuestosSinLiderarPorTenant = new[]
+        {
+            ("remitos", "ix_remitos_punto_venta_fecha"),
+            ("remitos", "ix_remitos_cliente"),
+            ("remitos", "ak_remitos_id_remito_id_tenant"),
+            ("items_remito", "ix_items_remito_remito"),
+            ("items_remito", "ix_items_remito_articulo"),
+            ("items_remito", "ux_items_remito_orden"),
+            ("movimientos_stock", "ix_movimientos_stock_remito")
+        };
+
+        foreach (var (tabla, nombre) in compuestosSinLiderarPorTenant)
+        {
+            var columnas = await ObtenerColumnasDelIndiceAsync(cruda, tabla, nombre);
+            Assert.NotEqual("id_tenant", columnas[0]);
+        }
+    }
+
+    private static async Task<string> ObtenerIndexDefAsync(NpgsqlConnection cruda, string tabla, string indexname)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT indexdef FROM pg_indexes WHERE tablename = $1 AND indexname = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+        comando.Parameters.Add(new NpgsqlParameter { Value = indexname });
+
+        var indexdef = (string?)await comando.ExecuteScalarAsync();
+        Assert.NotNull(indexdef);
+        return indexdef!;
+    }
+
+    private static void AssertOrdenDeColumnas(string indexdef, params string[] columnasEsperadas)
+    {
+        Assert.Equal(columnasEsperadas, ExtraerColumnas(indexdef));
+    }
+
+    private static async Task<string[]> ObtenerColumnasDelIndiceAsync(NpgsqlConnection cruda, string tabla, string indexname)
+    {
+        return ExtraerColumnas(await ObtenerIndexDefAsync(cruda, tabla, indexname));
+    }
+
+    private static string[] ExtraerColumnas(string indexdef)
+    {
+        var match = Regex.Match(indexdef, @"USING btree \(([^)]*)\)");
+        Assert.True(match.Success, $"No se pudo parsear el orden de columnas de: {indexdef}");
+        return match.Groups[1].Value.Split(", ", StringSplitOptions.TrimEntries);
+    }
+
+    private static async Task<List<string>> ListarIndicesAsync(NpgsqlConnection cruda, string tabla)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT indexname FROM pg_indexes WHERE tablename = $1 ORDER BY indexname";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+
+        var indices = new List<string>();
+        await using var lector = await comando.ExecuteReaderAsync();
+        while (await lector.ReadAsync())
+        {
+            indices.Add(lector.GetString(0));
+        }
+
+        return indices;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // db-error-backstops — traducción de constraints exactas (tasks 4.22/4.23/4.30)
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>Prueba SOLO el SQLSTATE/ConstraintName crudo — la traducción a
+    /// <c>409 numero_de_remito_duplicado</c> (QUINTA ocurrencia del ordering trap) se prueba
+    /// contra el <c>ManejadorDeErrores</c> REAL en <c>ManejadorDeErroresRemitosTests.cs</c>.</summary>
+    [Fact]
+    public async Task UnDuplicadoRawDeUxRemitosNumeroDisparaElSqlstateCorrecto()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnDuplicadoRawDeUxRemitosNumeroDisparaElSqlstateCorrecto));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        async Task InsertarEmitidoAsync(long numero)
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO remitos " + ColumnasRemito +
+                " VALUES ($1, $2, $3, $4, $5, now(), now(), NULL, NULL, 0, 0, 0, 'emitido'::estado_remito, NULL, now(), now(), NULL)";
+            comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+            comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+            comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+            comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+            comando.Parameters.Add(new NpgsqlParameter { Value = numero });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await InsertarEmitidoAsync(700);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => InsertarEmitidoAsync(700));
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_remitos_numero", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnIdClienteInexistenteEnRemitosViolaLaFkGenerica23503()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnIdClienteInexistenteEnRemitosViolaLaFkGenerica23503));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO remitos " + ColumnasRemito +
+            " VALUES ($1, $2, $3, $4, NULL, now(), NULL, NULL, NULL, 0, 0, 0, 'borrador'::estado_remito, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = 999_999_999 }); // id_cliente inexistente
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_remitos_cliente", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnIdArticuloInexistenteEnItemsDeRemitoViolaLaFkGenerica23503()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnIdArticuloInexistenteEnItemsDeRemitoViolaLaFkGenerica23503));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idRemito = await InsertarBorradorAsync(cruda, e);
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_remito " +
+            "(id_tenant, id_remito, orden, id_articulo, descripcion, cantidad, precio_unitario, " +
+            " descuento, total, id_lista_precio, id_oferta, id_alicuota_iva, porcentaje_iva, " +
+            " costo_unitario, costo_es_estimado, id_lote, created_at, updated_at, deleted_at) " +
+            "VALUES ($1, $2, 1, $3, 'seed', 2, 10, 0, 20, $4, NULL, $5, 21, NULL, false, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idRemito });
+        comando.Parameters.Add(new NpgsqlParameter { Value = 999_999_999 }); // id_articulo inexistente
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdListaPrecio });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23503", excepcion.SqlState);
+        Assert.Equal("fk_items_remito_articulo", excepcion.ConstraintName);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // MotivoStock.Remito — orden del enum (task 4.31, mutation target #39)
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>Mutation target #39 — CORRECCIÓN REGISTRADA (mutation-proof-tests regla 2, "run
+    /// it, don't reason it"): design.md's propia premisa ("insertarlo en el medio haría que
+    /// TODOS los valores existentes se lean con el valor incorrecto") NO se sostiene en tiempo
+    /// de ejecución. <c>npgsql.MapEnum&lt;T&gt;()</c> resuelve por NOMBRE (vía
+    /// <c>NpgsqlSnakeCaseNameTranslator</c>, el default sin tercer argumento — cada miembro C#
+    /// se traduce a su label nativo por STRING, nunca por posición ordinal), así que
+    /// reordenar <see cref="MotivoStock.Remito"/> al medio del enum es un mutante GENUINAMENTE
+    /// EQUIVALENTE para el round-trip de EF, confirmado empíricamente: la prueba de abajo siguió
+    /// en VERDE con <c>Remito</c> movido entre <c>Ajuste</c> y <c>Transferencia</c> (revertido
+    /// vía <c>git diff --stat</c> limpio después). Ningún cast ordinal de <c>MotivoStock</c>
+    /// existe en el repo (`grep` confirmado) — el orden del enum C# es documentación de intención
+    /// (mirrors el orden nativo de Postgres para semántica de <c>ORDER BY</c>/comparación, nunca
+    /// ejercida hoy), no un invariante de round-trip. La prueba de round-trip de abajo queda como
+    /// cobertura de regresión legítima (los ocho motivos pre-existentes siguen leyendo el valor
+    /// sembrado), pero NO discrimina este mutante específico — la prueba que sí lo hace es la de
+    /// TEXTO FUENTE inmediatamente después (mismo patrón "PROVABLY EQUIVALENT AT RUNTIME" que
+    /// <c>PresupuestosSchemaTests</c> targets 4/5).</summary>
+    [Fact]
+    public async Task TodoMotivoPreexistenteSeLeeDeVueltaConElValorCorrectoConRemitoYaAgregadoAlTipoNativo()
+    {
+        var e = await SembrarEscenarioAsync(nameof(TodoMotivoPreexistenteSeLeeDeVueltaConElValorCorrectoConRemitoYaAgregadoAlTipoNativo));
+
+        var motivos = new[]
+        {
+            ("venta", MotivoStock.Venta),
+            ("compra", MotivoStock.Compra),
+            ("anulacion", MotivoStock.Anulacion),
+            ("ajuste", MotivoStock.Ajuste),
+            ("transferencia", MotivoStock.Transferencia),
+            ("inventario", MotivoStock.Inventario),
+            ("decomiso", MotivoStock.Decomiso),
+            ("reclasificacion", MotivoStock.Reclasificacion)
+        };
+
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant))
+        {
+            foreach (var (literal, _) in motivos)
+            {
+                await using var comando = cruda.CreateCommand();
+                comando.CommandText =
+                    "INSERT INTO movimientos_stock " +
+                    "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_empleado, observaciones, creado_el) " +
+                    "VALUES ($1, $2, $3, 1, $4::motivo_stock, $5, $6, now())";
+                comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+                comando.Parameters.Add(new NpgsqlParameter { Value = e.IdArticulo });
+                comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+                comando.Parameters.Add(new NpgsqlParameter { Value = literal });
+                comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+                comando.Parameters.Add(new NpgsqlParameter { Value = literal });
+                await comando.ExecuteNonQueryAsync();
+            }
+        }
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, e.IdTenant));
+        var leidos = await db.MovimientosStock
+            .Where(m => m.IdTenant == e.IdTenant)
+            .OrderBy(m => m.Id)
+            .ToListAsync();
+
+        Assert.Equal(motivos.Length, leidos.Count);
+        for (var i = 0; i < motivos.Length; i++)
+        {
+            Assert.Equal(motivos[i].Item2, leidos[i].Motivo);
+            Assert.Equal(motivos[i].Item1, leidos[i].Observaciones);
+        }
+    }
+
+    /// <summary>El discriminante real del target #39 (ver el hallazgo registrado en la prueba de
+    /// arriba): texto fuente, no round-trip de EF.</summary>
+    [Fact]
+    public void ElTextoFuenteDeMotivoStockDeclaraRemitoUltimo()
+    {
+        var rutaEnum = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Domain", "Stock", "MotivoStock.cs");
+
+        Assert.True(File.Exists(rutaEnum), $"No se encontró el enum en {rutaEnum}");
+
+        var fuente = File.ReadAllText(rutaEnum);
+        var indiceReclasificacion = fuente.IndexOf("Reclasificacion,", StringComparison.Ordinal);
+        var indiceRemito = fuente.IndexOf("Remito\n", StringComparison.Ordinal);
+
+        Assert.True(indiceReclasificacion >= 0, "No se encontró 'Reclasificacion,' en el enum.");
+        Assert.True(indiceRemito >= 0, "No se encontró 'Remito' como último miembro del enum.");
+        Assert.True(indiceRemito > indiceReclasificacion, "Remito tiene que declararse DESPUÉS de Reclasificacion (último miembro).");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // TXR — el comprobante consolidado guardado (task 4.32, gate §I data statement 2)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LaBaseFrescaSiembraTxrActivoConAfectaStockFalse()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT activo, afecta_stock, letra, signo, es_fiscal, discrimina_iva FROM tipos_comprobante WHERE codigo = 'TXR'";
+        await using var lector = await comando.ExecuteReaderAsync();
+        Assert.True(await lector.ReadAsync());
+        Assert.True(lector.GetBoolean(0)); // activo
+        Assert.False(lector.GetBoolean(1)); // afecta_stock
+        Assert.Equal("X", lector.GetString(2));
+        Assert.Equal((short)1, lector.GetInt16(3));
+        Assert.False(lector.GetBoolean(4)); // es_fiscal
+        Assert.False(lector.GetBoolean(5)); // discrimina_iva
+    }
+
+    private const string MigracionAnteriorARemitosEtapa17 = "20260819195638_PresupuestosEtapa17";
+
+    /// <summary>GATE GUARD, data statement 2 (task 4.32): una base YA MIGRADA (con
+    /// <c>tipos_comprobante</c> ya poblado ANTES de esta etapa) tiene que ganar la fila
+    /// <c>TXR</c> — con <c>afecta_stock = false</c> — al aplicar <c>RemitosEtapa17</c>, SIN pasar
+    /// por el seeder (que nunca corre en este camino, mismo patrón que el test net-1 del
+    /// <c>PRE</c> en <c>PresupuestosSchemaTests</c>).</summary>
+    [Fact]
+    public async Task UnaBaseYaMigradaGanaElTipoTxrAlAplicarLaMigracionDeEstaEtapa()
+    {
+        var nombreBase = $"ways_stage17_txr_{Guid.NewGuid():N}";
+        var cadenaAdmin = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = "postgres" }.ConnectionString;
+        var cadenaNueva = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = nombreBase }.ConnectionString;
+
+        await using (var admin = new NpgsqlConnection(cadenaAdmin))
+        {
+            await admin.OpenAsync();
+            await using var crear = admin.CreateCommand();
+            crear.CommandText = $"CREATE DATABASE \"{nombreBase}\"";
+            await crear.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+                .UseNpgsql(cadenaNueva, npgsql =>
+                {
+                    npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                    npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                    npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                    npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                    npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                    npgsql.MapEnum<ModoLista>("modo_lista");
+                    npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                    npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                    npgsql.MapEnum<MotivoStock>("motivo_stock");
+                    npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                    npgsql.MapEnum<EstadoTurno>("estado_turno");
+                    npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                    npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                    npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                    npgsql.MapEnum<EstadoCompra>("estado_compra");
+                    npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
+                    npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
+                    npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                    npgsql.MapEnum<EstadoRemito>("estado_remito");
+                })
+                .Options;
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(MigracionAnteriorARemitosEtapa17);
+            }
+
+            // Simula el catálogo de una base real ya operando desde antes de esta etapa: al
+            // menos un tipo_comprobante existente (el guard EXISTS del data statement lo exige).
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+                await using var comando = conexion.CreateCommand();
+                comando.CommandText =
+                    "INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, " +
+                    "es_fiscal, afecta_stock, activo, created_at, updated_at) " +
+                    "VALUES ('venta', 'TX', 'Ticket X', 'X', 1, false, false, true, true, now(), now())";
+                await comando.ExecuteNonQueryAsync();
+            }
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(); // aplica RemitosEtapa17, la única pendiente — el seeder NUNCA corre acá
+            }
+
+            await using var verificacion = new NpgsqlConnection(cadenaNueva);
+            await verificacion.OpenAsync();
+
+            await using var comandoVerificar = verificacion.CreateCommand();
+            comandoVerificar.CommandText = "SELECT activo, afecta_stock FROM tipos_comprobante WHERE codigo = 'TXR'";
+            await using var lector = await comandoVerificar.ExecuteReaderAsync();
+
+            Assert.True(await lector.ReadAsync());
+            Assert.True(lector.GetBoolean(0));
+            Assert.False(lector.GetBoolean(1));
+        }
+        finally
+        {
+            await using var admin = new NpgsqlConnection(cadenaAdmin);
+            await admin.OpenAsync();
+            await using var dropear = admin.CreateCommand();
+            dropear.CommandText = $"DROP DATABASE IF EXISTS \"{nombreBase}\" WITH (FORCE)";
+            await dropear.ExecuteNonQueryAsync();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // GATE GUARD — exactamente dos migraciones en toda la etapa (task 4.33)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExistenExactamenteDosMigracionesDeEstaEtapaYNingunaTercera()
+    {
+        var directorioMigraciones = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Infrastructure", "Persistencia", "Migraciones");
+
+        var archivos = Directory.GetFiles(directorioMigraciones, "*.cs")
+            .Select(Path.GetFileName)
+            .Where(n => n is not null && !n.EndsWith(".Designer.cs", StringComparison.Ordinal) && n.Contains("Etapa17"))
+            .Select(n => n!)
+            .OrderBy(n => n)
+            .ToList();
+
+        Assert.Equal(2, archivos.Count);
+        Assert.Contains(archivos, n => n.Contains("PresupuestosEtapa17"));
+        Assert.Contains(archivos, n => n.Contains("RemitosEtapa17"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Non-regression (task 4.35): stock/lotes intactos, ALTER aditivo-only
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LaColumnaIdRemitoDeMovimientosStockEsNullablePorDefectoSinRomperInsertsExistentes()
+    {
+        var e = await SembrarEscenarioAsync(nameof(LaColumnaIdRemitoDeMovimientosStockEsNullablePorDefectoSinRomperInsertsExistentes));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, e.IdTenant));
+        db.MovimientosStock.Add(new MovimientoStock
+        {
+            IdTenant = e.IdTenant,
+            IdArticulo = e.IdArticulo,
+            IdPuntoVenta = e.IdPuntoVenta,
+            Cantidad = -1m,
+            Motivo = MotivoStock.Ajuste,
+            IdEmpleado = e.IdEmpleado,
+            CreadoEl = DateTimeOffset.UtcNow
+        });
+
+        await db.SaveChangesAsync(); // no debe tirar — id_remito queda NULL, motivo ajuste no lo toca
+    }
+}

--- a/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
@@ -251,6 +251,32 @@ public class RemitosSchemaTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
         Assert.Equal("42501", excepcion.SqlState);
     }
 
+    [Fact]
+    public async Task UnInsertConIdTenantAjenoEnItemsRemitoSeRechaza()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnItemsRemitoSeRechaza) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnItemsRemitoSeRechaza) + "-B");
+
+        await using var comoA = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant);
+        var idRemito = await InsertarBorradorAsync(comoA, a);
+
+        await using var comando = comoA.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO items_remito " +
+            "(id_tenant, id_remito, orden, id_articulo, descripcion, cantidad, precio_unitario, " +
+            " descuento, total, id_lista_precio, id_oferta, id_alicuota_iva, porcentaje_iva, " +
+            " costo_unitario, costo_es_estimado, id_lote, created_at, updated_at, deleted_at) " +
+            "VALUES ($1, $2, 1, $3, 'seed', 2, 10, 0, 20, $4, NULL, $5, 21, NULL, false, NULL, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = b.IdTenant }); // ajeno a la sesión (tenant A)
+        comando.Parameters.Add(new NpgsqlParameter { Value = idRemito });
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdArticulo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdListaPrecio });
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdAlicuotaIva });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
     // ---------------------------------------------------------------------------------------
     // ck_remitos_salida_completa (task 4.28, mutation target #38)
     // ---------------------------------------------------------------------------------------

--- a/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
@@ -275,6 +275,36 @@ public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFix
         Assert.Equal("tipo_comprobante_invalido", problema.GetProperty("codigo").GetString());
     }
 
+    /// <summary>stage-17-presupuestos-y-remitos, Slice 4 (proposal §I/§J, design decisión 1/18,
+    /// PUNTOS CLAVE del apply): <c>TXR</c> — sembrado por primera vez en esta slice
+    /// (<c>InicializadorDeBaseDeDatos.TiposComprobanteBase</c>), <c>afecta_stock = false</c> —
+    /// es el mismo net 2 (la cláusula del resolver, target 23, ya vigente desde slice 3) el que
+    /// lo rechaza, sin cambio alguno a <c>ServicioDeVentas.cs</c> en esta slice: el guard es
+    /// genérico sobre cualquier tipo <c>afecta_stock = false</c>, no una lista de códigos. Test
+    /// agregado a este archivo (nunca a <c>ServicioDeVentas.cs</c>, protegido) porque reutiliza
+    /// el helper <see cref="PrepararAsync"/> — mismo criterio que la prueba hermana de
+    /// <c>PRE</c> inmediatamente arriba, mismo dominio de código, ninguna escritura.</summary>
+    [Fact]
+    public async Task UnaVentaConElTipoTxrEsRechazada400SinEscribirNada()
+    {
+        var ctx = await PrepararAsync(nameof(UnaVentaConElTipoTxrEsRechazada400SinEscribirNada));
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TXR", null,
+            [new LineaDeVenta(ctx.IdArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 100m, null, 0m)], null, null);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("tipo_comprobante_invalido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(0, await db.MovimientosStock.CountAsync());
+        Assert.Equal(0, await db.MovimientosCuentaCorriente.CountAsync());
+    }
+
     // ---- task 3.14: fidelidad del precio congelado — fixture DISCRIMINANTE -------------------------
 
     /// <summary>Mutation targets 24-28 (mutation-proof-tests rule 11): el fixture NUNCA deja que

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -217,6 +217,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
                 npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
             })
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
@@ -254,6 +255,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;
@@ -292,6 +294,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;


### PR DESCRIPTION
## Resumen

Slice 4 de la etapa 17 (presupuestos y remitos): la segunda y ÚLTIMA migración de la etapa (`RemitosEtapa17`, gate de DOS migraciones aprobado en state.yaml).

- `ALTER TYPE motivo_stock ADD VALUE 'remito'` — primera sentencia, aislado (nada más lo usa en la migración), IRREVERSIBLE aceptado y registrado; ejecutado por el mecanismo de enum-diff de Npgsql (precedente etapa 12).
- `CREATE TYPE estado_remito` + tablas `remitos` (18 col, 2 CHECKs, 5 FKs, AK, 7 índices) e `items_remito` (20 col, 3 CHECKs, FK de lote MATCH SIMPLE, 8 índices) — 30 índices acumulados de la etapa verificados por DEFINICIÓN.
- `movimientos_stock.id_remito` aditivo + FK compuesta + índice.
- Tipo `TXR` con dos redes: INSERT guardeado para bases ya migradas + seed para bases frescas (`afecta_stock = false` — el resolver genérico del slice 3 lo rechaza en `/api/ventas` sin tocar `ServicioDeVentas.cs`).
- RLS al FINAL sobre ambas tablas; `Down()` en orden inverso exacto del Rollback Plan (TXR se desactiva, jamás se borra; `'remito'` no se revierte, comentado).
- Entidades/Configurations/DbSets/MapEnum, 7 ramas nuevas de `ManejadorDeErrores` (2×23505 + 5×23514, resolución por nombre exacto — 5ta ocurrencia de la trampa `_numero`), doc 10 actualizado.
- ~1300 líneas de tests: RLS ambos lados (SELECT + WITH CHECK en ambas tablas), 5 CHECKs con SQLSTATE traducido, auditoría de `indexdef`, gate guards (exactamente dos migraciones; `has-pending-model-changes` limpio), no-regresión del checkout.

## Judgment-day (ronda limpia)

- **Juez B (mutador)**: APPROVE — 10 mutantes sobre migración/ManejadorDeErrores (orden de columnas, unique, filtro parcial, nombre exacto, guard TXR, afecta_stock, CHECK invertido, RLS×2, prefijo de CHECKs), TODOS muertos con `--no-incremental`.
- **Juez A (read-only)**: APPROVE — 1 SUGGESTION documental (orden del `Down()` vs Rollback Plan).
- **Ronda 1 de fixes** (`05840a5`): espejo WITH CHECK de `items_remito` (evidencia RED/verde mutando el RLS de la migración) + `Down()` reordenado. **Pasada acotada de B sobre el delta: APPROVE** (byte a byte, 28/28 verdes).

## Suites

- Dirigidos: 74/74. Post-fix `RemitosSchemaTests`: 28/28.
- Full Integration: 1532/1533 contabilizados verdes (26 fallas de flakiness Testcontainers verdes en re-corrida aislada — regla 17; la restante era el bug preexistente del borde UTC en reposición, ya cerrado aparte en #149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)