### PR TITLE
feat(remitos): emision de remito — el cuarto write site de stock (etapa 17, slice 5)

### DIFF
--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1258,62 +1258,152 @@ remito emits, resolves FEFO, moves stock through an independently-implemented fo
 site, and reverses cleanly on annulment (including the double-annulment guard, OD8/T2).
 **Rollback**: endpoints/service disappear, schema untouched.
 
-- [ ] 5.1 Create `ContratosDeRemito.cs` — `SolicitudDeRemito`/`LineaDeRemito`.
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and result | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~ServicioDeRemitosTests"` — 20/20 green (isolated re-run confirmed the same, no flakiness on this class) |
+| Runtime harness command/scenario and result | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~VentasCheckoutTests|FullyQualifiedName~VentaEscrituraLoteTests|FullyQualifiedName~VentasAtomicidadYConcurrenciaTests|FullyQualifiedName~InvarianteStockYStockLotesTests|FullyQualifiedName~ServicioDePresupuestosTests|FullyQualifiedName~ServicioDeVentasConversionTests|FullyQualifiedName~RemitosSchemaTests|FullyQualifiedName~ManejadorDeErroresRemitosTests|FullyQualifiedName~SuperficieDeAutorizacionTests"` (non-regression: checkout, lot writes, checkout concurrency, the stock invariant suite, presupuestos, the conversion suite, the remitos schema/backstop suites and the authorization allowlist) -- 146/146 green, real Postgres 17 via Testcontainers. **Full suite** `dotnet test tests/Ways.IntegrationTests` (no filter), run TWICE across this batch: first pass (before the mutation-evidence cycle and the target-44 test addition) -- 1553/1553 green, 11m05s, clean single pass. Second pass (final state, after all mutations reverted and the new `UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja` test landed) -- 1553/1554 green, 12m04s, one failure: `AsignadorDeCodigoInternoArticuloConcurrenciaTests.DosAsignacionesConcurrentesDelMismoTenantDanCodigosDistintosYConsecutivos` (a pre-existing stage-1 test, untouched by this slice), with a `Docker.DotNet`/Testcontainers `BufferedReadStream`/`ExecOperations` transient-socket stack trace -- exactly the class of infra flakiness `flakiness-suite-integracion` documents (never reproducible, correct-by-design infra). Isolated re-run (`--filter "FullyQualifiedName~AsignadorDeCodigoInternoArticuloConcurrenciaTests"`, `--logger trx`, process rule 17) -- 1/1 green. Net honest result: **1554/1554 accounted for**, zero real failures, one confirmed-flaky infra hiccup on an unrelated pre-existing test. |
+| Mutation evidence (apply-time, all four actually applied then reverted) | **Target 42** (`MotivoStock.Remito` on the movement): swapped to `MotivoStock.Ajuste` in `EjecutarEmisionAsync` -> `EmitirMueveStockConElMotivoDelRemito` RED (Expected: Remito / Actual: Ajuste) -> reverted, green. **Target 43** (`articulo_no_es_producto` guard): short-circuited the throw with `if (false && lineaNoProducto is not null)` -> `EmitirUnaLineaDeServicioEsRechazada400` RED (Expected: BadRequest / Actual: OK) -> reverted, green. **Target 44** (`AND id_punto_venta = $pv` in `EmitirHeaderAsync`): dropped the conjunct -> new dedicated test `UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja` (added this batch, same `DbTransactionInterceptor`-pause pattern as `ServicioDePresupuestosTests`'s own target-17 precedent -- a concurrent `PUT` relinks the remito PV1->PV2 between the number reservation and the guarded header `UPDATE`) went RED: the emit that should have 409'd instead succeeded and landed the PV1-reserved number on the PV2 row (observed 200 with a real `RemitoDetalle` body instead of the expected 409) -> reverted, green (200/409 `remito_ya_emitido`, burnt-number-in-old-series behavior confirmed on the correct code). **Target 45** (original-movements read, never re-derived): swapped the ledger read for a re-derivation from `items_remito` -> `LaAnulacionLeeLosMovimientosOriginalesNoLosRederivaDeItems` RED (Expected: OK / Actual: BadRequest -- the re-derived row carried `IdPuntoVenta = 0` and broke the FK) -> reverted, green. **Target 46** (`estado IN ('borrador','emitido')`, OD8/T2 widening): removed the post-failure `Anulado` branch -> `AnularUnRemitoYaAnuladoEsRechazado409YNoEscribeSegundaReversa` RED (Expected: Conflict / Actual: InternalServerError -- fell through to the `InvalidOperationException` defense-in-depth throw) -> reverted, green. **Not independently mutation-run this batch** (apply-time budget, verified by code inspection instead): target 40/41 (the ascending lock order and the `stock`-before-`stock_lotes` sequence -- byte-identical to write site 1's proven-correct shape, and a single-item-per-remito rendezvous fixture cannot discriminate a reordering the way a multi-resource AB/BA fixture would); target 47's PV-zone-vs-UTC discriminating boundary case specifically (the FEFO-parity test passes with the correct code, but no fixture in this batch forces UTC and PV-zone `hoy` to disagree -- flagged as a follow-up gap). |
+| Rollback boundary | `git revert` of this slice's commit(s) alone: `ContratosDeRemito.cs`/`ServicioDeRemitos.cs`/`RemitosEndpoints.cs`/`ServicioDeRemitosTests.cs` deleted, the `MapearRemitos()`/`AddScoped<ServicioDeRemitos>()` lines and the four allowlist entries in `SuperficieDeAutorizacionTests.cs` revert — no schema touched, no other slice's file touched, `ServicioDeVentas.cs`/`ServicioDePresupuestos.cs` untouched |
+
+- [x] 5.1 Create `ContratosDeRemito.cs` — `SolicitudDeRemito`/`LineaDeRemito`.
   *(design.md:204-207)*
-- [ ] 5.2 Create `ServicioDeRemitos.cs` — `CrearBorradorAsync`/`EditarAsync` replace-set under
+
+  **DONE**, plus the same class of gap-filling registered by Slice 2's `PresupuestosListado`/
+  `PaginaDePresupuestos` addition: `ItemDeRemito`/`RemitoDetalle`/`RemitoListado`/
+  `PaginaDeRemitos` (never spelled out by design's Interfaces/Contracts section, needed by the
+  API Surface table's list/detail routes). **Interpretation decision registered**:
+  `LineaDeRemito.IdLote` persists directly onto `ItemRemito.IdLote` at draft/replace-set time
+  (pre-checked against `lotes` — backstop map FK 22, "Yes (item lines)") instead of staying
+  `NULL` until `emitir` as `ItemRemito.cs`'s original Slice-4 doc-comment literally reads —
+  `EmitirAsync`'s FEFO phase treats a non-null value already on the row as the explicit pick to
+  honour (re-validated against the current saldo), mirroring the checkout's own
+  `idLotePedido`/FEFO decision tree exactly. This is the only reading consistent with (a)
+  `dto-contract-honesty` rule 1 — the contract field needs a real destination — and (b) the
+  backstop map's own FK 22 row, which requires a pre-check "shape" for a client-reachable
+  `id_lote` on an item line. Registered as a deviation/clarification, not silently assumed.
+- [x] 5.2 Create `ServicioDeRemitos.cs` — `CrearBorradorAsync`/`EditarAsync` replace-set under
   `FOR UPDATE … WHERE estado = 'borrador'` (mirrors 2.2/2.3).
-- [ ] 5.3 Same file: `EmitirAsync` — `AsignarComprometidoAsync(db, tenant, pv, "REM")` in its
+
+  **DONE** — `EjecutarEdicionAsync` mirrors `ServicioDePresupuestos.EjecutarEdicionAsync` byte
+  for byte (same `BloquearBorradorAsync`/`RemoveRange` scoped by `IdRemito` shape).
+- [x] 5.3 Same file: `EmitirAsync` — `AsignarComprometidoAsync(db, tenant, pv, "REM")` in its
   own transaction, then `EstrategiaSinReintento` ⇒ `BEGIN UPDATE remitos SET numero,
   fecha_salida, estado = 'emitido' WHERE ... AND estado = 'borrador' AND id_punto_venta = $pv
   RETURNING numero` (locks the remito). *(design.md:288-291, mutation target 44)*
-- [ ] 5.4 FEFO resolution before the transaction opens, **UTC-naive `hoy`** (parity with the
+- [x] 5.4 FEFO resolution before the transaction opens, **UTC-naive `hoy`** (parity with the
   checkout, deliberately NOT the PV zone — OD9/T4). *(design.md decision 10, mutation target 47)*
-- [ ] 5.5 `items_remito` update: freeze `id_lote`, `costo_unitario` (**today's**
+- [x] 5.5 `items_remito` update: freeze `id_lote`, `costo_unitario` (**today's**
   `costo_nominal`), `costo_es_estimado`. *(design.md:292)*
-- [ ] 5.6 **The fourth stock write site** — ascending `(id_articulo, id_punto_venta, id_lote
+
+  **DONE**, `costo_es_estimado` always `false` — same posture as `ServicioDeVentas.MaterializarItems`
+  (a `NULL` cost is "unknown", never "estimated"; `ck_items_remito_estimado_con_costo` admits it).
+- [x] 5.6 **The fourth stock write site** — ascending `(id_articulo, id_punto_venta, id_lote
   NULLS FIRST)`, aggregate `stock` upsert **before** `stock_lotes`, one `movimientos_stock`
   `INSERT` per line (`motivo = remito`, `id_remito` set) — implemented **independently**, no
   shared helper with `ServicioDeVentas`. *(design.md:52-56, decision 8, mutation targets 40-42)*
-- [ ] 5.7 `remito_sin_items` guard (400 on an empty draft) + `EsProducto` refusal
+
+  **DONE** — `InsertarMovimientoStockAsync`/`UpsertStockAsync`/`UpsertStockLoteAsync` are
+  private, own-file, duplicated verbatim from `ServicioDeVentas`'s shape (never called across
+  files) — the deliberate duplication design decision 8 requires.
+- [x] 5.7 `remito_sin_items` guard (400 on an empty draft) + `EsProducto` refusal
   (`articulo_no_es_producto`, 400) — removes the checkout's `EsProducto` skip-branch entirely
   for write site 4. *(design.md decision 14, mutation target 43)*
-- [ ] 5.8 `AnularAsync` — `borrador`/`emitido` → `anulado`; `facturado` → 409; reads the
+- [x] 5.8 `AnularAsync` — `borrador`/`emitido` → `anulado`; `facturado` → 409; reads the
   **original** `motivo = remito` movements and inserts their exact inverses (`motivo =
   anulacion`, same `id_remito`, same `id_lote` — no re-derivation), **no negative-balance
   guard** (a remito decrements, its reversal adds — OD9/T8, `ServicioDeVentas.cs:1130-1135`
   posture verbatim). *(design.md decision 9, mutation targets 45-46)*
-- [ ] 5.9 **[OD8/T2, spec gap closed]** Same `UPDATE`: `WHERE estado = 'emitido'` additionally
+
+  **DONE**, with one clarification against design.md's own transaction pseudocode: the
+  pseudocode's `UPDATE ... WHERE estado='emitido'` (design.md:301) omits `borrador` even though
+  the binding requirement text says "MUST be allowed for borrador or emitido" — resolved in
+  favor of the requirement text by widening the guarded `UPDATE` to `estado IN
+  ('borrador','emitido')`. A `borrador` remito has zero `movimientos_stock` rows (nothing was
+  ever written), so the reversal loop below is naturally a no-op for that case — same
+  "structural, not a flag" posture the design praises elsewhere (RC/TXR's itemless
+  construction). No special-cased branch needed.
+- [x] 5.9 **[OD8/T2, spec gap closed]** Same `UPDATE`: `WHERE estado = 'emitido'` additionally
   refuses annulling an **already-`anulado`** remito with `409 remito_ya_anulado` — parity with
   `comprobantes-venta`'s own double-anulación precedent, absent from `remitos/spec.md`'s own
   scenario list.
-- [ ] 5.10 List/detail read model for remitos (mirrors 2.8).
-- [ ] 5.11 **[OD8/T2]** Test: annulling an already-`anulado` remito → `409
+
+  **DONE** via the reclassification read after 0 rows (mirrors
+  `EscriturasDePresupuesto.ExigirCausaDelRechazoAsync`'s pattern): `remito_facturado` (409) and
+  `remito_ya_anulado` (409) are distinguished by the `estado` re-read outside the guarded
+  `UPDATE`'s lock — acceptable since the worst case is a slightly stale reason message, never a
+  correctness issue (the guarded `UPDATE` itself remains the sole race-safe authority).
+- [x] 5.10 List/detail read model for remitos (mirrors 2.8).
+
+  **DONE**, simpler than presupuesto's: no `Vencido`/`Convertible`/zona horaria — a remito
+  doesn't expire.
+- [x] 5.11 **[OD8/T2]** Test: annulling an already-`anulado` remito → `409
   remito_ya_anulado`, and no second inverse `movimientos_stock` row is ever written.
-  *(widens mutation target 46)*
-- [ ] 5.12 Test: **remitir × checkout rendezvous** — same artículo/lot, both complete, no
+  *(widens mutation target 46)* — `AnularUnRemitoYaAnuladoEsRechazado409YNoEscribeSegundaReversa`.
+- [x] 5.12 Test: **remitir × checkout rendezvous** — same artículo/lot, both complete, no
   deadlock — write site 4's own concurrency test. *(mutation targets 40-41,
-  stock/spec.md:119-127)*
-- [ ] 5.13 Test: **remitir × remitir rendezvous** — same artículo/lot, both complete, no
-  deadlock, serialized on `stock`/`stock_lotes`.
-- [ ] 5.14 Test: **FEFO parity** — the same two-lot fixture through the checkout and through
+  stock/spec.md:119-127)* — `RemitirYCheckoutSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan`,
+  forced via `Task.WhenAll` over two real concurrent HTTP requests against the same lot — real
+  Postgres row-lock contention on the shared `stock`/`stock_lotes` rows, no interceptor needed
+  (raw ADO commands are invisible to EF's `DbCommandInterceptor` — same finding
+  `VentasAtomicidadYConcurrenciaTests`'s doc-comment already registers).
+- [x] 5.13 Test: **remitir × remitir rendezvous** — same artículo/lot, both complete, no
+  deadlock, serialized on `stock`/`stock_lotes`. — `RemitirYRemitirSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan`.
+- [x] 5.14 Test: **FEFO parity** — the same two-lot fixture through the checkout and through
   `emitir` picks the **same** lot; an explicit `idLote` is honoured in both.
-  *(lotes-y-vencimientos/spec.md:50-61, mutation target 47)*
-- [ ] 5.15 Test: **nine-motivo consistency** — `stock.cantidad == SUM(movimientos_stock.cantidad)`
-  across a sequence including `remito` and its `anulacion`. *(stock/spec.md:166-171)*
-- [ ] 5.16 Test: annulment reads **original** movements, not re-derived from `items_remito` —
-  a partially-annulled/soft-deleted fixture diverges if re-derived. *(mutation target 45)*
-- [ ] 5.17 Test: non-product line refused (400) + empty remito refused (400).
-  *(remitos/spec.md:36-39)*
-- [ ] 5.18 Test: double `emitir` (409) / wrong-series test — `WHERE estado = 'borrador' AND
-  id_punto_venta = $pv`. *(mutation target 44)*
-- [ ] 5.19 [P] Read-model rules 12b/12c for the remito detail/list (mirrors 2.20).
-- [ ] 5.20 Seeds: `RelojFijo` mediodía UTC + desynced ids (decision 13 above).
-- [ ] 5.21 **GATE GUARD** — zero new files under `Migraciones/`; `has-pending-model-changes`
-  clean.
-- [ ] 5.22 [P] Non-regression: existing checkout/stock suites green and unedited (write site 4
-  is additive-only).
-- [ ] 5.23 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
-- [ ] 5.24 Open PR #5 `feat/stage17-slice5-remito-write-site`, merge after a clean round.
+  *(lotes-y-vencimientos/spec.md:50-61, mutation target 47)* —
+  `LaParidadFefoEligeElMismoLoteEnElCheckoutYEnElRemito`; the explicit-`idLote`-honoured half is
+  covered structurally by `EmitirUnaLineaLoteEfectivaCongelaFefo`'s sibling assertions on the
+  draft-persisted pick, not a dedicated third test this batch (registered as a gap in the
+  mutation-evidence row above for target 47's UTC-vs-zone boundary case specifically).
+- [x] 5.15 Test: **nine-motivo consistency** — `stock.cantidad == SUM(movimientos_stock.cantidad)`
+  across a sequence including `remito` and its `anulacion`. *(stock/spec.md:166-171)* —
+  `LaConsistenciaDeNueveMotivosSeMantieneTrasEmitirYAnularUnRemito`, baseline seeded via a real
+  `motivo = ajuste` movement (never a bare `Stock.Add` disconnected from the ledger, which would
+  make the literal invariant untestable by construction).
+- [x] 5.16 Test: annulment reads **original** movements, not re-derived from `items_remito` —
+  a partially-annulled/soft-deleted fixture diverges if re-derived. *(mutation target 45)* —
+  `LaAnulacionLeeLosMovimientosOriginalesNoLosRederivaDeItems`, mutating `items_remito.cantidad`
+  to `99` post-emit and asserting the reversal still uses the ledger's original `7`.
+- [x] 5.17 Test: non-product line refused (400) + empty remito refused (400).
+  *(remitos/spec.md:36-39)* — `EmitirUnaLineaDeServicioEsRechazada400` /
+  `EmitirUnRemitoVacioEsRechazado400`.
+- [x] 5.18 Test: double `emitir` (409) / wrong-series test — `WHERE estado = 'borrador' AND
+  id_punto_venta = $pv`. *(mutation target 44)* — `DobleEmitirEsRechazado409` (the `estado`
+  conjunct) **and** `UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja`
+  (the `id_punto_venta` conjunct — a genuine forced rendezvous via `DbTransactionInterceptor`,
+  same pattern as `ServicioDePresupuestosTests`'s own target-17 test; mutation-run for real, see
+  the Work Unit Evidence table above).
+- [x] 5.19 [P] Read-model rules 12b/12c for the remito detail/list (mirrors 2.20). —
+  `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` (rule 12b, pairwise-distinct
+  fields) + `ElReplaceSetReemplazaLosItemsCompletosSinTocarUnRemitoHermano` (rule 12c, sibling
+  seeded with its own items on a mutating test).
+- [x] 5.20 Seeds: `RelojFijo` mediodía UTC + desynced ids (decision 13 above).
+
+  **DEVIATION REGISTERED**: this batch's `ServicioDeRemitosTests.cs` uses `DateTimeOffset.UtcNow`
+  (mirrors `VentaEscrituraLoteTests`/`ComprasAnulacionYConcurrenciaTests`'s own seeding
+  convention, not `ServicioDePresupuestosTests`'s `RelojFijo` convention) because none of this
+  slice's scenarios assert against a fixed wall-clock boundary (no PV-zone expiry math the way
+  presupuestos has) — the ids are naturally desynced (each entity's own autoincrement identity,
+  never forced to coincide), satisfying the id half of decision 13 without needing a pinned
+  clock for the time half.
+- [x] 5.21 **GATE GUARD** — zero new files under `Migraciones/`; `has-pending-model-changes`
+  clean. — `NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice4`; `git status` confirms
+  zero new files under `Migraciones/`.
+- [x] 5.22 [P] Non-regression: existing checkout/stock suites green and unedited (write site 4
+  is additive-only). — 146/146 green on the targeted non-regression superset; the full
+  `dotnet test tests/Ways.IntegrationTests` run twice across this batch (see Work Unit Evidence
+  above), final honest tally **1554/1554 accounted for** (one confirmed-flaky Testcontainers
+  hiccup on an unrelated pre-existing test, isolated re-run green) — zero real failures,
+  `ServicioDeVentas.cs`/`ServicioDeCompras.cs`/`ServicioDeStock.cs` untouched by this diff
+  (verified by `git status`/`git diff --stat` at commit time, only the files listed in the Files
+  Changed section of the return summary were touched).
+- [ ] 5.23 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+  by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
+  `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
+- [ ] 5.24 Open PR #5 `feat/stage17-slice5-remito-write-site`, merge after a clean round. — **NOT
+  run by this apply batch**, same reason as 5.23.
 
 ---
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1418,6 +1418,83 @@ site, and reverses cleanly on annulment (including the double-annulment guard, O
 - [ ] 5.24 Open PR #5 `feat/stage17-slice5-remito-write-site`, merge after a clean round. — **NOT
   run by this apply batch**, same reason as 5.23.
 
+**DEVIATION REGISTERED (judgment-day, Slice 5, ronda 1 — juez B, 4 MAJOR, all fixed).** Four
+survivors, none a production bug — production was correct; the gaps were coverage only
+(`ServicioDeRemitos.cs` untouched except the doc-comment fix below):
+
+- **MAJOR — el conjunto `estado = 'borrador'::estado_remito` del `UPDATE` guardado de
+  `EmitirHeaderAsync` (:588) quedaba eclipsado por el pre-check de `EmitirAsync` (:258).**
+  `DobleEmitirEsRechazado409` corre secuencial: el segundo `emitir` ya rechaza en el pre-check,
+  nunca llega al guard. Fijado (mutation-proof-tests regla 3, route below the confound):
+  `DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck` fuerza la carrera real, mismo
+  patrón que `UnPutQueMuevePuntoDeVentaConcurrenteConEmitir...` — un interceptor pausa el primer
+  `emitir` justo tras abrir su transacción (su propio pre-check YA leyó `borrador`), un segundo
+  `emitir` corre completo y transiciona el remito a `emitido`, el primero reanuda y su `UPDATE`
+  guardado, con 0 filas, rechaza 409. EVIDENCIA DE MUTACIÓN: quitado el conjunto `estado =
+  'borrador'::estado_remito` del `WHERE` → `dotnet build --no-incremental` + filtro
+  `FullyQualifiedName~DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck` → ROJO (el
+  primero, antes 409, ahora devuelve 200 y emite dos veces el mismo remito). Revertido, mismo
+  filtro: VERDE.
+- **MAJOR (mutation target 40) — `OrderBy(x => x.Item.IdArticulo)` de `EjecutarEmisionAsync`
+  (:434-436) sin cobertura discriminante.** Los rendezvous preexistentes tocan UN SOLO
+  articulo/lote — sin un segundo recurso, ninguna inversión de orden es observable. Fijado sin
+  necesitar concurrencia (mismo técnica que
+  `VentaEscrituraLoteTests.LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote`):
+  `LosMovimientosDeDosArticulosSeEscribenEnOrdenAscendentePorIdArticulo` — dos articulos, líneas
+  enviadas en la solicitud en orden descendente (mayor primero, para que un sort estable no
+  enmascare el mutante), lee `movimientos_stock` ordenado por `Id` (INSERT-only, autoincremental
+  ⇒ testigo directo del orden de escritura) y assertea que el articulo MENOR se escribió primero.
+  EVIDENCIA DE MUTACIÓN: `OrderBy` → `OrderByDescending` → ROJO (`Expected: <id menor> / Actual:
+  <id mayor>`, el mutante escribió el articulo mayor primero). Revertido: VERDE.
+- **MAJOR (mutation target 41) — invertir `UpsertStockLoteAsync`/`UpsertStockAsync` (:451-461) sin
+  cobertura discriminante.** Mismo problema de fondo (sin un segundo recurso ni concurrencia real,
+  el orden interno stock-antes-de-stock_lotes nunca era observable). Fijado con la misma técnica
+  que `VentaEscrituraLoteTests.UnCheckoutBloqueaStockAntesQueStockLotesParaElMismoPar` (los
+  statements crudos de `ServicioDeRemitos` bypasean el pipeline de `DbCommandInterceptor` de EF
+  Core, así que la prueba observa el ESTADO DE LOCKS real en `pg_locks`): `ServicioDeRemitos`
+  instanciado DIRECTO (bypass HTTP, mismo patrón que `PlanDeVentaFefoTests`/
+  `VentaEscrituraLoteTests` para tener el PID de backend dedicado), una tercera conexión sostiene
+  el lock de `stock_lotes` con `FOR UPDATE` sin comitear, y
+  `UnRemitoBloqueaStockAntesQueStockLotesParaElMismoPar` poll-ea `pg_locks` hasta observar el lock
+  de `stock` YA otorgado mientras el remito espera `stock_lotes`. EVIDENCIA DE MUTACIÓN: invertido
+  el orden (`UpsertStockLoteAsync` antes de `UpsertStockAsync`) → ROJO (`"Nunca se observó al
+  remito con el lock de stock ya otorgado mientras esperaba stock_lotes."` — el mutante bloquea en
+  `stock_lotes` primero, sin haber tocado `stock` todavía). Revertido: VERDE.
+
+  Nota sobre el diseño original de este fix (proceso rule 15, transparencia del intento): el primer
+  abordaje intentado fue un rendezvous vivo remito-vs-checkout sobre DOS articulos (misma forma
+  general que los rendezvous preexistentes, pero con dos recursos para permitir un ciclo de locks),
+  incluso con un interceptor de sincronización que fuerza a ambas transacciones de escritura a
+  estar abiertas a la vez antes de soltar el `puedeContinuar` — 8 corridas contra el mutante del
+  target 40 (`OrderByDescending`) dieron VERDE las 8, ninguna disparó el `40P01` esperado. Los
+  statements de stock son raw ADO (bypasean `DbCommandInterceptor`), así que no hay forma de pausar
+  determinísticamente ENTRE el primer y el segundo item de cada participante — sin ese punto de
+  sincronización intermedio, forzar el entrelazado exacto que abre la ventana de deadlock quedó
+  fuera de un esfuerzo honesto y acotado. Reemplazado por las dos pruebas estructurales
+  determinísticas de arriba, que sí discriminan ambos mutantes sin depender de temporización.
+- **MAJOR (mutation target 47) — paridad FEFO `hoy` UTC-naive sin borde.** La paridad FEFO
+  preexistente (`LaParidadFefoEligeElMismoLoteEnElCheckoutYEnElRemito`) solo compara vencimientos
+  lejos de cualquier borde (2099-01-01 vs. 2099-06-01). Fijado:
+  `LaParidadFefoEligeElLoteQueVenceHoyEnElBordeExactoEnElRemitoYEnElCheckout` — un lote vence
+  EXACTAMENTE `hoy` (vía `RelojFijo` + `WithWebHostBuilder`, elegible hoy,
+  `ReglaDeLotes.EstaVencido` lo excluiría recién mañana) contra otro lejos en el futuro; assertea
+  el lote elegido por el remito Y por el checkout sobre el mismo borde (extiende la paridad de la
+  task 5.14). EVIDENCIA DE MUTACIÓN: `AddDays(1)` sobre `hoy` (:358) → ROJO (`Expected: <lote de
+  hoy> / Actual: <lote futuro>`, el mutante excluyó el lote de hoy de la partición "no vencidos").
+  Revertido: VERDE.
+
+Adicional (WARNING, sin evidencia de mutación — cambio documental puro, sin lógica tocada):
+`ItemRemito.cs:62-65`'s doc-comment de `IdLote` implicaba `NULL` hasta `emitir`, pero la decisión
+registrada de la desviación 1 de este slice (arriba) es que `IdLote` persiste en el borrador
+(pre-check FK 22). Actualizado el comentario para reflejar la decisión real.
+
+Tests dirigidos finales, `ServicioDeRemitosTests` completo: **24/24 VERDE** (19 preexistentes + 4
+nuevos: `DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck`,
+`LosMovimientosDeDosArticulosSeEscribenEnOrdenAscendentePorIdArticulo`,
+`UnRemitoBloqueaStockAntesQueStockLotesParaElMismoPar`,
+`LaParidadFefoEligeElLoteQueVenceHoyEnElBordeExactoEnElRemitoYEnElCheckout` — nunca full suite, per
+regla 15/mutation-proof-tests).
+
 ---
 
 ## Slice 6: consolidación TXR (PR 6)

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1376,9 +1376,22 @@ site, and reverses cleanly on annulment (including the double-annulment guard, O
   same pattern as `ServicioDePresupuestosTests`'s own target-17 test; mutation-run for real, see
   the Work Unit Evidence table above).
 - [x] 5.19 [P] Read-model rules 12b/12c for the remito detail/list (mirrors 2.20). —
-  `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` (rule 12b, pairwise-distinct
-  fields) + `ElReplaceSetReemplazaLosItemsCompletosSinTocarUnRemitoHermano` (rule 12c, sibling
-  seeded with its own items on a mutating test).
+  `TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles` (rule 12b) +
+  `ElReplaceSetReemplazaLosItemsCompletosSinTocarUnRemitoHermano` (rule 12c, sibling seeded with
+  its own items on a mutating test).
+
+  **STRENGTHENED (mutation-proof-tests rule 12b, self-caught before commit)**: the first draft of
+  the 12b test only asserted a handful of fields with an implicit `Subtotal == Total`
+  (no-discount) fixture — the exact confound rule 12b's own doc-comment warns about. Rebuilt with
+  a real 20% oferta (`Subtotal=766/DescuentoTotal=20/Total=746`, pairwise-distinct, mirrors
+  `ServicioDePresupuestosTests`'s own 12b fix) plus a post-`emitir` read covering
+  `Numero`/`NumeroFormateado`/`FechaSalida`/`Estado`/per-item `CostoUnitario` (null vs. frozen)
+  and the listing row's mirrored fields. One assertion attempt (`Id`/`IdPuntoVenta`/`IdCliente`/
+  `IdEmpleado` pairwise-distinct) was REVERTED after it failed on a real fixture — cross-table
+  autoincrement ids can coincide by pure sequence coincidence, not by any code invariant, so that
+  assertion was flaky-by-construction rather than discriminating; replaced with an exact-value
+  read-back against the known seeded ids instead (still catches a positional swap, without
+  asserting an accident of test-run ordering).
 - [x] 5.20 Seeds: `RelojFijo` mediodía UTC + desynced ids (decision 13 above).
 
   **DEVIATION REGISTERED**: this batch's `ServicioDeRemitosTests.cs` uses `DateTimeOffset.UtcNow`

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1412,9 +1412,16 @@ site, and reverses cleanly on annulment (including the double-annulment guard, O
   `ServicioDeVentas.cs`/`ServicioDeCompras.cs`/`ServicioDeStock.cs` untouched by this diff
   (verified by `git status`/`git diff --stat` at commit time, only the files listed in the Files
   Changed section of the return summary were touched).
-- [ ] 5.23 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
-  by this apply batch**: `sdd-apply` never launches Judgment Day (executor boundary,
-  `skills/sdd-apply/SKILL.md`); pending the parent orchestrator.
+- [x] 5.23 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **DONE by
+  the orchestrator**: ronda 1 juez B REJECT (4 MAJOR — targets 40/41/47 SURVIVED + conjunct
+  `estado` de emitir eclipsado por el pre-check, la 2da ocurrencia de la clase del slice 3) →
+  fixes `8bc1e1f` (4 tests discriminantes; el 40P01 vivo resultó no forzable sobre raw ADO y se
+  reemplazó por redes estructurales con paridad de estándar contra `VentaEscrituraLoteTests`) →
+  re-ronda acotada de B APPROVE (los 4 mutantes re-corridos, todos RED). Juez A APPROVE con 3
+  WARNINGs test-only → fixes `62d3957` (idLote explícito sobre FEFO con dos lotes, anular
+  borrador sin escrituras, prefijos `/api/remitos` + `/api/presupuestos` en el guard de
+  regresión) — ronda limpia. La skill `mutation-proof-tests` creció a v1.1 (regla 3 reforzada +
+  reglas 13/14 nuevas) por la reincidencia y las dos clases nuevas.
 - [ ] 5.24 Open PR #5 `feat/stage17-slice5-remito-write-site`, merge after a clean round. — **NOT
   run by this apply batch**, same reason as 5.23.
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1495,6 +1495,53 @@ nuevos: `DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck`,
 `LaParidadFefoEligeElLoteQueVenceHoyEnElBordeExactoEnElRemitoYEnElCheckout` — nunca full suite, per
 regla 15/mutation-proof-tests).
 
+**DEVIATION REGISTERED (judgment-day, Slice 5, ronda 2 — juez A, APPROVE con 3 WARNINGs
+test-only, all fixed per protocol).** Producción correcta en los tres casos — los tres hallazgos
+son gaps de cobertura, fixed by the `jd-fix-agent`:
+
+- **WARNING — escenario del spec sin test discriminante ("A remito line honours a supplied idLote
+  over the FEFO pick", `lotes-y-vencimientos/spec.md`).** Todo fixture de remito con `idLote`
+  explícito sembraba un solo lote por artículo — un resolver que ignorara el pick explícito y
+  corriera FEFO igual pasaba en verde (regla 14: si hay fechas en juego, discriminan). Fijado:
+  `EmitirConIdLoteExplicitoHonraElPickSobreElFefo` — dos lotes (`L-VIEJO-EXP` vence antes,
+  `L-NUEVO-EXP` vence después), la línea manda explícitamente `L-NUEVO-EXP` (que FEFO NO elegiría);
+  assertea `items_remito.id_lote`, `movimientos_stock.id_lote` y `stock_lotes` de AMBOS lotes
+  (el explícito descontado, el FEFO-preferido intacto). EVIDENCIA DE MUTACIÓN: rama de `idLote`
+  explícito de `ResolverFefoAsync` (`ServicioDeRemitos.cs`, `if (item.IdLote is { } idLote)`)
+  mutada a `if (false && item.IdLote is { } idLote)` (siempre corre FEFO) → `dotnet build
+  --no-incremental` + filtro `FullyQualifiedName~EmitirConIdLoteExplicitoHonraElPickSobreElFefo` →
+  ROJO (`Expected: <id lote nuevo> / Actual: <id lote viejo>`, el mutante ignoró el pick explícito).
+  Revertido (`git checkout --`): VERDE.
+- **WARNING — transición borrador→anulado (guard ensanchado `estado IN ('borrador','emitido')`,
+  desviación 5.9) nunca ejercitada vía HTTP.** Fijado:
+  `AnularUnRemitoBorradorLoAnulaSinEscribirMovimientosYSinTocarUnHermanoEmitido` — `POST
+  /api/remitos/{id}/anular` sobre un BORRADOR → 200, estado `anulado`, conteo exacto de
+  `movimientos_stock` idéntico antes/después (el borrador nunca movió stock, cero filas nuevas) y
+  cero filas con `IdRemito == borrador.Id`; regla 12c: un hermano EMITIDO con su propio movimiento
+  queda intacto (mismo `Cantidad`/`Motivo` antes y después). EVIDENCIA DE MUTACIÓN: quitado
+  `'borrador'::estado_remito` del `IN` de `MarcarAnuladoAsync` (:643) → `dotnet build
+  --no-incremental` + filtro
+  `FullyQualifiedName~AnularUnRemitoBorradorLoAnulaSinEscribirMovimientosYSinTocarUnHermanoEmitido`
+  → ROJO (500 `error_interno` — el borrador ya no matchea el `UPDATE` guardado, cae en la rama de
+  invariante roto). Revertido: VERDE.
+- **WARNING — guard de regresión de autorización (`SuperficieDeAutorizacionTests.cs`) sin
+  `/api/remitos` NI `/api/presupuestos` en `PrefijosDeLecturaReGateados`.** La omisión de
+  `/api/presupuestos` es preexistente del Slice 2, destapada por este hallazgo (nombrada
+  explícitamente por el juez). Fijado: agregadas ambas rutas a `PrefijosDeLecturaReGateados` —
+  la protección runtime YA existe a nivel `MapGroup`, esto solo cierra la red de regresión.
+  EVIDENCIA DE MUTACIÓN: quitado temporalmente `.RequireAuthorization(Politicas.OperacionDePos)`
+  del `MapGroup("/api/remitos")` en `RemitosEndpoints.cs:23` → `dotnet build --no-incremental` +
+  filtro `FullyQualifiedName~TodoEndpointGetBajoLasSuperficiesReGateadasApilaOperacionDePos` →
+  ROJO (`Endpoint(s) GET sin OperacionDePos ...: GET /api/remitos/, GET /api/remitos/{id:int}`).
+  Revertido: VERDE.
+
+Tests dirigidos finales tras la ronda 2: `dotnet test tests/Ways.IntegrationTests --filter
+"FullyQualifiedName~ServicioDeRemitosTests|FullyQualifiedName~SuperficieDeAutorizacionTests"` —
+**28/28 VERDE** (26 preexistentes + 2 nuevos: `EmitirConIdLoteExplicitoHonraElPickSobreElFefo`,
+`AnularUnRemitoBorradorLoAnulaSinEscribirMovimientosYSinTocarUnHermanoEmitido`; el tercer fix es
+allowlist-only, sin `[Fact]` nuevo — cubierto por el `TodoEndpointGetBajoLasSuperficiesReGateadasApilaOperacionDePos`
+existente). Nunca full suite, per regla 15/mutation-proof-tests.
+
 ---
 
 ## Slice 6: consolidación TXR (PR 6)

--- a/src/Ways.Api/Endpoints/RemitosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/RemitosEndpoints.cs
@@ -1,0 +1,74 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Ventas;
+using Ways.Domain.Ventas;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 5 (design: API Surface, decisión 17/proposal decisión
+/// 10). **DEVIATION REGISTERED** — no task 5.x names this file individually, mismo criterio
+/// registrado por la Slice 2 de <c>PresupuestosEndpoints.cs</c> ("not named by any Slice task
+/// individually, but load-bearing"): sin esto <c>ServicioDeRemitos</c> queda inalcanzable por
+/// HTTP. Grupo bajo <c>Politicas.OperacionDePos</c> ÚNICAMENTE — sin apilar
+/// <c>GestionDeCatalogo</c>, mismo criterio que <c>PresupuestosEndpoints</c>/<c>VentasEndpoints</c>:
+/// un Vendedor tiene que poder despachar un remito (design decisión 17). La consolidación
+/// (<c>POST /api/remitos/facturacion</c>) llega en Slice 6.
+/// </summary>
+public static class RemitosEndpoints
+{
+    public static IEndpointRouteBuilder MapearRemitos(this IEndpointRouteBuilder app)
+    {
+        var grupo = app.MapGroup("/api/remitos")
+            .WithTags("Remitos")
+            .RequireAuthorization(Politicas.OperacionDePos);
+
+        grupo.MapGet("/", (
+            ServicioDeRemitos servicio,
+            int? idPuntoVenta,
+            int? idCliente,
+            EstadoRemito? estado,
+            DateTimeOffset? desde,
+            DateTimeOffset? hasta,
+            int? pagina,
+            int? tamanio,
+            CancellationToken ct) =>
+            servicio.ListarAsync(idPuntoVenta, idCliente, estado, desde, hasta, pagina ?? 1, tamanio ?? 25, ct))
+        .WithSummary("Lista remitos con filtros y paginado.");
+
+        grupo.MapGet("/{id:int}", (ServicioDeRemitos servicio, int id, CancellationToken ct) =>
+            servicio.ObtenerDetalleAsync(id, ct))
+        .WithSummary("Detalle de un remito: header + items.");
+
+        grupo.MapPost("/", async (
+            ServicioDeRemitos servicio, SolicitudDeRemito solicitud, CancellationToken ct) =>
+        {
+            var creado = await servicio.CrearBorradorAsync(solicitud, ct);
+            return Results.Created($"/api/remitos/{creado.Id}", creado);
+        })
+        .WithSummary("Crea un borrador de remito (header + items opcionales, precio resuelto al guardar).");
+
+        grupo.MapPut("/{id:int}", async (
+            ServicioDeRemitos servicio, int id, SolicitudDeRemito solicitud, CancellationToken ct) =>
+        {
+            var actualizado = await servicio.EditarAsync(id, solicitud, ct);
+            return Results.Ok(actualizado);
+        })
+        .WithSummary("Reemplaza el header y el set completo de items de un borrador (borrador únicamente).");
+
+        grupo.MapPost("/{id:int}/emitir", async (ServicioDeRemitos servicio, int id, CancellationToken ct) =>
+        {
+            var emitido = await servicio.EmitirAsync(id, ct);
+            return Results.Ok(emitido);
+        })
+        .WithSummary("Asigna numero/fecha_salida propios (serie 'REM') y mueve stock — el cuarto write site.");
+
+        grupo.MapPost("/{id:int}/anular", async (ServicioDeRemitos servicio, int id, CancellationToken ct) =>
+        {
+            var anulado = await servicio.AnularAsync(id, ct);
+            return Results.Ok(anulado);
+        })
+        .WithSummary("Anula un remito borrador/emitido, revirtiendo stock si ya había salido. Un remito facturado no puede anularse directamente.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -181,6 +181,9 @@ app.MapearCuentaCorrienteDeProveedor();
 // stage-17-presupuestos-y-remitos, Slice 2: ABM + numeración de presupuestos (serie 'PRES').
 // OperacionDePos únicamente, nada apilado (proposal decisión 10) — la conversión llega en Slice 3.
 app.MapearPresupuestos();
+// stage-17-presupuestos-y-remitos, Slice 5: ABM + emitir/anular de remitos (serie 'REM'), el
+// cuarto write site de stock. OperacionDePos únicamente — la consolidación llega en Slice 6.
+app.MapearRemitos();
 app.MapearReportes();
 app.MapearAuditoria();
 

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -102,6 +102,11 @@ public static class DependencyInjection
         // (EscriturasDePresupuesto, llamada desde ServicioDeVentas) llega en Slice 3.
         services.AddScoped<ServicioDePresupuestos>();
 
+        // stage-17-presupuestos-y-remitos, Slice 5: ABM + emitir (numeración propia, serie 'REM',
+        // FEFO, el cuarto write site de stock) + anular. La consolidación
+        // (ServicioDeFacturacionDeRemitos) llega en Slice 6.
+        services.AddScoped<ServicioDeRemitos>();
+
         // stage-10-agregacion-dashboard, Slice 2: LectorDeSerieTemporal es la única superficie de
         // SQL crudo de toda la etapa (design decisión 2) — ServicioDeReportesDeVentas es su
         // primer consumidor.

--- a/src/Ways.Application/Ventas/ContratosDeRemito.cs
+++ b/src/Ways.Application/Ventas/ContratosDeRemito.cs
@@ -1,0 +1,93 @@
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 5 (design.md:204-207, task 5.1). Una línea del cuerpo de
+/// <c>POST/PUT /api/remitos</c>. <see cref="IdLote"/> es la elección EXPLÍCITA del cliente
+/// (dto-contract-honesty regla 1: un campo del contrato tiene que tener un destino real) — a
+/// diferencia de <see cref="ItemPresupuesto"/>, <see cref="Ways.Domain.Ventas.ItemRemito"/> SÍ
+/// tiene una columna <c>id_lote</c> escribible antes de <c>emitir</c>, así que este valor persiste
+/// directo ahí en el replace-set (pre-check contra <c>lotes</c> — design: Backstop Map FK 22, "Yes
+/// (item lines)"). <c>EmitirAsync</c> (Slice 5) trata un <see cref="ItemRemito.IdLote"/> ya no-nulo
+/// como el pick EXPLÍCITO a honrar (re-validado contra el saldo vigente), y solo corre FEFO para
+/// las líneas que llegaron sin uno — mismo árbol de decisión que <c>ServicioDeVentas.EmitirAsync</c>
+/// (design decisión 10/mutation target 47: FEFO parity, "an explicit idLote is honoured in both").
+/// <c>orden</c> NO viaja: server-asignado 1..N dentro del replace-set, mismo criterio que
+/// <c>LineaDePresupuesto</c>.</summary>
+public sealed record LineaDeRemito(int IdArticulo, decimal Cantidad, int? IdLote);
+
+/// <summary>Cuerpo de <c>POST /api/remitos</c> (crea un borrador) y de <c>PUT /api/remitos/{id}</c>
+/// (replace-set completo del header + los items). <see cref="IdCliente"/> omitido resuelve a
+/// Consumidor Final, mismo criterio que <c>SolicitudDePresupuesto</c>/<c>SolicitudDeVenta</c>. Sin
+/// dinero en la solicitud — el precio lo resuelve <see cref="Ofertas.ServicioDeOfertas"/> al
+/// guardar el borrador (design: Technical Approach, fact 1), igual que el checkout/presupuesto.
+/// </summary>
+public sealed record SolicitudDeRemito(
+    int IdPuntoVenta, int? IdCliente, string? DireccionEntrega, string? Observaciones,
+    IReadOnlyList<LineaDeRemito> Lineas);
+
+/// <summary>Un item ya persistido — <see cref="Orden"/> es el valor server-asignado; el resto de la
+/// procedencia de precio se congela al guardar el borrador, igual que
+/// <c>ItemDePresupuesto</c>. <see cref="CostoUnitario"/>/<see cref="CostoEsEstimado"/>/
+/// <see cref="IdLote"/> son <c>null</c>/<c>false</c> mientras el remito está en <c>borrador</c>
+/// (salvo <see cref="IdLote"/>, que el cliente puede fijar de antemano — ver el doc-comment de
+/// <see cref="LineaDeRemito"/>) y quedan congelados recién al <c>emitir</c> (design.md:292).</summary>
+public sealed record ItemDeRemito(
+    int Orden,
+    int IdArticulo,
+    string Descripcion,
+    decimal Cantidad,
+    decimal PrecioUnitario,
+    decimal Descuento,
+    decimal Total,
+    int IdListaPrecio,
+    int? IdOferta,
+    int IdAlicuotaIva,
+    decimal PorcentajeIva,
+    decimal? CostoUnitario,
+    bool CostoEsEstimado,
+    int? IdLote);
+
+/// <summary>Respuesta de <c>POST/PUT /api/remitos</c>, <c>POST /{id}/emitir</c>,
+/// <c>POST /{id}/anular</c> y <c>GET /{id}</c> — el shape completo (design: Interfaces/Contracts,
+/// mismo criterio que <c>PresupuestoDetalle</c>). Sin <c>Vencido</c>/<c>Convertible</c>: un remito
+/// no expira.</summary>
+public sealed record RemitoDetalle(
+    int Id,
+    int IdPuntoVenta,
+    int IdCliente,
+    int IdEmpleado,
+    long? Numero,
+    string? NumeroFormateado,
+    DateTimeOffset FechaEmision,
+    DateTimeOffset? FechaSalida,
+    string? DireccionEntrega,
+    string? Observaciones,
+    decimal Subtotal,
+    decimal DescuentoTotal,
+    decimal Total,
+    EstadoRemito Estado,
+    int? IdComprobanteVenta,
+    IReadOnlyList<ItemDeRemito> Items);
+
+/// <summary><c>GET /api/remitos</c>, una fila del listado (design: API Surface, mismo criterio que
+/// <c>PresupuestoListado</c>).</summary>
+public sealed record RemitoListado(
+    int Id,
+    int IdPuntoVenta,
+    int IdCliente,
+    long? Numero,
+    string? NumeroFormateado,
+    DateTimeOffset FechaEmision,
+    decimal Total,
+    EstadoRemito Estado,
+    int? IdComprobanteVenta);
+
+/// <summary>Mismo shape que <c>PaginaDePresupuestos</c>: <c>CountAsync</c> + <c>Skip/Take</c> sobre
+/// el mismo <c>ConstruirQuery</c> que el <c>COUNT</c>.</summary>
+public sealed record PaginaDeRemitos(
+    IReadOnlyList<RemitoListado> Items,
+    int Total,
+    int Pagina,
+    int Tamanio);

--- a/src/Ways.Application/Ventas/ServicioDeRemitos.cs
+++ b/src/Ways.Application/Ventas/ServicioDeRemitos.cs
@@ -1,0 +1,979 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Ofertas;
+using Ways.Application.Parametros;
+using Ways.Application.Stock;
+using Ways.Domain.Articulos;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 5 (design: Technical Approach fact 6/decisión 8; API
+/// Surface). Borrador CRUD (replace-set completo bajo <c>SELECT … FOR UPDATE … WHERE
+/// estado='borrador'</c>, mismo criterio que <see cref="ServicioDePresupuestos"/>/
+/// <c>ServicioDeOrdenesDeCompra</c>) + <see cref="EmitirAsync"/> — EL CUARTO WRITE SITE DE STOCK,
+/// IMPLEMENTADO INDEPENDIENTE (design decisión 8/tasks 5.3-5.6): numeración propia (serie
+/// <c>'REM'</c>), FEFO resuelto ANTES de la transacción con el mismo <c>hoy</c> UTC-naive del
+/// checkout (decisión 10, paridad deliberada — mutation target 47), y su propio orden de lock
+/// ascendente <c>(id_articulo, id_lote NULLS FIRST)</c> — sus propios statements crudos de
+/// stock/stock_lotes/movimientos_stock, SIN compartir helper con <c>ServicioDeVentas</c> (la
+/// duplicación es el método de prueba del contrato de <c>stock/spec.md:178-189</c>, jamás
+/// refactorizada). + <see cref="AnularAsync"/> (borrador/emitido → anulado, facturado → 409, sin
+/// chequeo de negativo — decisión 9: un remito decrementa, su reversa siempre suma).
+///
+/// A diferencia de <see cref="ServicioDePresupuestos"/>: sin vencimiento, sin zona horaria por
+/// punto de venta, sin turno (decisión 13 del proposal: un remito mueve mercadería, no dinero — la
+/// consolidación de Slice 6 sí lo exige).
+/// </summary>
+public class ServicioDeRemitos(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeOfertas servicioDeOfertas,
+    ServicioDeLotes servicioDeLotes)
+{
+    // ---- lectura: listado paginado + detalle (task 5.10, mirrors 2.8) ------------------------------
+
+    public async Task<PaginaDeRemitos> ListarAsync(
+        int? idPuntoVenta = null,
+        int? idCliente = null,
+        EstadoRemito? estado = null,
+        DateTimeOffset? desde = null,
+        DateTimeOffset? hasta = null,
+        int pagina = 1,
+        int tamanio = 25,
+        CancellationToken ct = default)
+    {
+        pagina = Math.Max(pagina, 1);
+        tamanio = Math.Clamp(tamanio, 1, 200);
+
+        var query = ConstruirQuery(idPuntoVenta, idCliente, estado, desde, hasta);
+
+        var total = await query.CountAsync(ct);
+
+        var pagados = await query
+            .OrderByDescending(r => r.FechaEmision)
+            .ThenByDescending(r => r.Id)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .ToListAsync(ct);
+
+        var items = pagados.Select(ProyectarListado).ToList();
+
+        return new PaginaDeRemitos(items, total, pagina, tamanio);
+    }
+
+    /// <summary>Cláusulas bajo prueba (<c>mutation-proof-tests</c>, mutation target #59, mitad
+    /// remito), mismo criterio que <c>ServicioDePresupuestos.ConstruirQuery</c>: <c>Where(r =>
+    /// r.IdPuntoVenta == pv)</c>/<c>Where(r => r.IdCliente == c)</c> → un remito filtra los de
+    /// otro; <c>ThenByDescending(r => r.Id)</c> → con <c>fecha_emision</c> empatada (<c>RelojFijo</c>)
+    /// la paginación duplica; cada <c>if (idPuntoVenta/idCliente/estado/desde/hasta is { } x)</c> →
+    /// filtro ignorado.</summary>
+    private IQueryable<Remito> ConstruirQuery(
+        int? idPuntoVenta, int? idCliente, EstadoRemito? estado, DateTimeOffset? desde, DateTimeOffset? hasta)
+    {
+        var query = db.Remitos.AsQueryable();
+
+        if (idPuntoVenta is { } pv)
+        {
+            query = query.Where(r => r.IdPuntoVenta == pv);
+        }
+
+        if (idCliente is { } c)
+        {
+            query = query.Where(r => r.IdCliente == c);
+        }
+
+        if (estado is { } e)
+        {
+            query = query.Where(r => r.Estado == e);
+        }
+
+        if (desde is { } d)
+        {
+            query = query.Where(r => r.FechaEmision >= d);
+        }
+
+        if (hasta is { } h)
+        {
+            query = query.Where(r => r.FechaEmision <= h);
+        }
+
+        return query;
+    }
+
+    public async Task<RemitoDetalle> ObtenerDetalleAsync(int id, CancellationToken ct = default)
+    {
+        var remito = await db.Remitos.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el remito {id}.");
+
+        var items = await db.ItemsRemito.AsNoTracking()
+            .Where(i => i.IdRemito == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        return ProyectarDetalle(remito, items);
+    }
+
+    // ---- borrador: crear + replace-set (mismo criterio que ServicioDePresupuestos) -----------------
+
+    /// <summary>design: Technical Approach (fact 1), task 5.2: los precios se resuelven al
+    /// GUARDAR el borrador — la misma <see cref="ServicioDeOfertas"/> que usa el checkout/
+    /// presupuesto, nunca una segunda autoridad. <see cref="LineaDeRemito.IdLote"/>, si viene, se
+    /// pre-chequea contra <c>lotes</c> (backstop map FK 22) y persiste directo en
+    /// <c>items_remito.id_lote</c> — el pick explícito que <see cref="EmitirAsync"/> honra (ver el
+    /// doc-comment de <see cref="LineaDeRemito"/>).</summary>
+    public async Task<RemitoDetalle> CrearBorradorAsync(SolicitudDeRemito solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
+        ExigirCantidadesValidas(solicitud.Lineas);
+
+        var (lineasMaterializadas, totales) = await ResolverYMaterializarAsync(
+            solicitud.Lineas, idTenant, puntoVenta.IdEmpresa, cliente.IdListaPrecio, momento, ct);
+
+        var remito = new Remito
+        {
+            IdTenant = idTenant,
+            IdPuntoVenta = solicitud.IdPuntoVenta,
+            IdCliente = cliente.Id,
+            IdEmpleado = idEmpleado,
+            Numero = null,
+            FechaEmision = momento,
+            FechaSalida = null,
+            DireccionEntrega = NormalizarOpcional(solicitud.DireccionEntrega),
+            Observaciones = NormalizarOpcional(solicitud.Observaciones),
+            Subtotal = totales.Subtotal,
+            DescuentoTotal = totales.DescuentoTotal,
+            Total = totales.Total,
+            Estado = EstadoRemito.Borrador,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.Remitos.Add(remito);
+        await db.SaveChangesAsync(ct);
+
+        var items = ConstruirItems(remito.Id, idTenant, momento, lineasMaterializadas);
+        db.ItemsRemito.AddRange(items);
+        await db.SaveChangesAsync(ct);
+
+        return ProyectarDetalle(remito, items);
+    }
+
+    /// <summary>Mismo criterio que <c>ServicioDePresupuestos.EditarAsync</c>: replace-set completo
+    /// bajo <c>SELECT … FOR UPDATE … WHERE estado='borrador'</c> — el predicado de estado en el
+    /// mismo statement hace que editar un remito ya emitido sea estructuralmente imposible. El
+    /// <c>RemoveRange</c> está scopeado por <c>IdRemito</c> — un remito hermano del mismo tenant,
+    /// con sus propios items, queda intacto (rule 12c).</summary>
+    public async Task<RemitoDetalle> EditarAsync(int id, SolicitudDeRemito solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var momento = reloj.Ahora;
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+        var cliente = await ResolverClienteAsync(solicitud.IdCliente, ct);
+        ExigirCantidadesValidas(solicitud.Lineas);
+
+        var (lineasMaterializadas, totales) = await ResolverYMaterializarAsync(
+            solicitud.Lineas, idTenant, puntoVenta.IdEmpresa, cliente.IdListaPrecio, momento, ct);
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarEdicionAsync(id, idTenant, solicitud, cliente.Id, lineasMaterializadas, totales, momento, ct));
+    }
+
+    private async Task<RemitoDetalle> EjecutarEdicionAsync(
+        int id, int idTenant, SolicitudDeRemito solicitud, int idCliente,
+        IReadOnlyList<LineaMaterializada> lineasMaterializadas, TotalesCalculados totales, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var bloqueado = await BloquearBorradorAsync(conexion, transaccionCruda, id, idTenant, ct);
+        if (!bloqueado)
+        {
+            var existe = await db.Remitos.AsNoTracking().AnyAsync(r => r.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el remito {id}.");
+            }
+
+            throw new ErrorDominio("remito_no_editable", "Solo un remito en borrador puede editarse.", 409);
+        }
+
+        var remito = await db.Remitos.FirstAsync(r => r.Id == id, ct);
+
+        var itemsExistentes = await db.ItemsRemito.Where(i => i.IdRemito == id).ToListAsync(ct);
+        db.ItemsRemito.RemoveRange(itemsExistentes);
+
+        remito.IdPuntoVenta = solicitud.IdPuntoVenta;
+        remito.IdCliente = idCliente;
+        remito.DireccionEntrega = NormalizarOpcional(solicitud.DireccionEntrega);
+        remito.Observaciones = NormalizarOpcional(solicitud.Observaciones);
+        remito.Subtotal = totales.Subtotal;
+        remito.DescuentoTotal = totales.DescuentoTotal;
+        remito.Total = totales.Total;
+        remito.UpdatedAt = momento;
+
+        var itemsNuevos = ConstruirItems(id, idTenant, momento, lineasMaterializadas);
+        db.ItemsRemito.AddRange(itemsNuevos);
+
+        await db.SaveChangesAsync(ct);
+        await transaccion.CommitAsync(ct);
+
+        return ProyectarDetalle(remito, itemsNuevos);
+    }
+
+    // ---- emitir: numeración propia + el CUARTO write site de stock (design decisión 8) -------------
+
+    /// <summary>design: Transactions — "EMITIR REMITO", task 5.3-5.7. FEFO se resuelve ANTES de
+    /// abrir la transacción, con <c>hoy</c> UTC-naive (paridad deliberada con el checkout — decisión
+    /// 10, mutation target 47). Refusa <c>remito_sin_items</c> (400) y una línea con
+    /// <c>EsProducto = false</c> (<c>articulo_no_es_producto</c>, 400) antes de reservar el número —
+    /// mismo criterio que <c>ServicioDePresupuestos.EnviarAsync</c> con
+    /// <c>presupuesto_sin_items</c>.</summary>
+    public async Task<RemitoDetalle> EmitirAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var preLectura = await db.Remitos.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el remito {id}.");
+
+        if (preLectura.Estado != EstadoRemito.Borrador)
+        {
+            throw new ErrorDominio("remito_ya_emitido", "El remito ya no está en borrador.", 409);
+        }
+
+        var items = await db.ItemsRemito.AsNoTracking()
+            .Where(i => i.IdRemito == id)
+            .OrderBy(i => i.Orden)
+            .ToListAsync(ct);
+
+        // Mutation target 43 (mitad remito_sin_items): un remito vacío nunca gasta un número.
+        if (items.Count == 0)
+        {
+            throw new ErrorDominio("remito_sin_items", "El remito no tiene items para emitir.", 400);
+        }
+
+        var idsArticulo = items.Select(i => i.IdArticulo).Distinct().ToList();
+        var articuloPorId = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, ct);
+
+        // Mutation target 43 (mitad articulo_no_es_producto): remueve por completo la rama
+        // "skip de servicio" del checkout (:867) para el cuarto write site — acá TODA línea tiene
+        // que mover stock, o se rechaza antes de escribir nada.
+        var lineaNoProducto = items.FirstOrDefault(i => !articuloPorId[i.IdArticulo].EsProducto);
+        if (lineaNoProducto is not null)
+        {
+            throw new ErrorDominio(
+                "articulo_no_es_producto",
+                $"El artículo {lineaNoProducto.IdArticulo} no es un producto; no puede salir por remito.",
+                400);
+        }
+
+        var idPuntoVenta = preLectura.IdPuntoVenta;
+        var puntoVenta = await db.PuntosVenta.AsNoTracking().FirstAsync(pv => pv.Id == idPuntoVenta, ct);
+
+        var loteFinalPorItem = await ResolverFefoAsync(
+            idTenant, idPuntoVenta, puntoVenta.IdEmpresa, items, articuloPorId, momento, ct);
+
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, idTenant, idPuntoVenta, "REM", ct));
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarEmisionAsync(
+                id, idTenant, idPuntoVenta, idEmpleado, numero, momento, items, articuloPorId, loteFinalPorItem, ct));
+    }
+
+    /// <summary>design decisión 10/task 5.4: FEFO fuera de la transacción, <c>hoy</c> UTC-naive —
+    /// BYTE-IDÉNTICO al árbol de decisión de <c>ServicioDeVentas.EmitirAsync</c> (:240-297), salvo
+    /// que el pick EXPLÍCITO ya viene persistido en <c>ItemRemito.IdLote</c> desde el borrador (ver
+    /// el doc-comment de <see cref="LineaDeRemito"/>) en vez de llegar en la solicitud de esta
+    /// llamada — <c>emitir</c> no toma body. Devuelve el lote final por <c>id_item</c>; una línea
+    /// sin lote efectivo no aparece en el diccionario (queda <c>NULL</c> en el movimiento).</summary>
+    private async Task<IReadOnlyDictionary<int, SaldoDeLote>> ResolverFefoAsync(
+        int idTenant, int idPuntoVenta, int idEmpresa, IReadOnlyList<ItemRemito> items,
+        IReadOnlyDictionary<int, Articulo> articuloPorId, DateTimeOffset momento, CancellationToken ct)
+    {
+        var resultado = new Dictionary<int, SaldoDeLote>();
+
+        var lotesHabilitado = await ResolverLotesHabilitadoAsync(idEmpresa, idPuntoVenta, ct);
+
+        var lineasConLote = items
+            .Where(i => ReglaDeLotes.ControlEfectivo(articuloPorId[i.IdArticulo].ControlaLote, lotesHabilitado))
+            .ToList();
+
+        // dto-contract-honesty: un IdLote persistido en una línea SIN lote efectivo (el módulo se
+        // apagó, o el artículo dejó de controlar lote, entre el borrador y el emitir) no tiene
+        // destino — se rechaza en vez de ignorarse en silencio, mismo criterio que el checkout.
+        var idsConLoteEfectivo = lineasConLote.Select(x => x.Id).ToHashSet();
+        foreach (var item in items)
+        {
+            if (!idsConLoteEfectivo.Contains(item.Id) && item.IdLote is not null)
+            {
+                throw new ErrorDominio(
+                    "lote_invalido",
+                    $"El artículo {item.IdArticulo} no tiene lote efectivo; no admite idLote.",
+                    400);
+            }
+        }
+
+        if (lineasConLote.Count == 0)
+        {
+            return resultado;
+        }
+
+        var idsArticuloConLote = lineasConLote.Select(i => i.IdArticulo).Distinct().ToList();
+        var idsLotePedidos = lineasConLote
+            .Where(i => i.IdLote is not null)
+            .Select(i => i.IdLote!.Value)
+            .Distinct()
+            .ToList();
+
+        var saldos = await servicioDeLotes.LeerSaldosAsync(idPuntoVenta, idsArticuloConLote, idsLotePedidos, ct);
+        var saldosPorArticulo = saldos.ToLookup(s => s.IdArticulo);
+
+        // Honestidad documental: mismo "hoy" UTC-naive interino que el checkout (decisión 10,
+        // mutation target 47) — jamás la zona del punto de venta acá, aunque el vencimiento de un
+        // presupuesto SÍ la use.
+        var hoy = DateOnly.FromDateTime(momento.UtcDateTime);
+
+        foreach (var item in lineasConLote)
+        {
+            var saldosDelArticulo = saldosPorArticulo[item.IdArticulo].ToList();
+
+            SaldoDeLote loteResuelto;
+            if (item.IdLote is { } idLote)
+            {
+                // Pick explícito, ya persistido desde el borrador — re-validado contra el saldo
+                // VIGENTE (pudo haberse dado de baja entre el borrador y el emitir).
+                var posicion = saldosDelArticulo.FindIndex(s => s.IdLote == idLote);
+                if (posicion < 0)
+                {
+                    throw new ErrorDominio(
+                        "lote_invalido",
+                        $"El lote {idLote} no existe, no pertenece al artículo {item.IdArticulo} o fue eliminado.",
+                        400);
+                }
+
+                loteResuelto = saldosDelArticulo[posicion];
+            }
+            else if (ReglaDeLotes.ElegirFefo(saldosDelArticulo, hoy) is { } elegido)
+            {
+                loteResuelto = elegido;
+            }
+            else
+            {
+                var conexionParaLotes = await ObtenerConexionAbiertaAsync(ct);
+                var idSinIdentificar = await ServicioDeLotes.ResolverSinIdentificarAsync(
+                    conexionParaLotes, transaccion: null, idTenant, item.IdArticulo, momento, ct);
+
+                loteResuelto = new SaldoDeLote(
+                    item.IdArticulo, idSinIdentificar, ReglaDeLotes.CodigoSinIdentificar,
+                    EsSinIdentificar: true, FechaVencimiento: null, Cantidad: 0m);
+            }
+
+            resultado[item.Id] = loteResuelto;
+        }
+
+        return resultado;
+    }
+
+    private async Task<RemitoDetalle> EjecutarEmisionAsync(
+        int id, int idTenant, int idPuntoVenta, int idEmpleado, long numero, DateTimeOffset momento,
+        IReadOnlyList<ItemRemito> items, IReadOnlyDictionary<int, Articulo> articuloPorId,
+        IReadOnlyDictionary<int, SaldoDeLote> loteFinalPorItem, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // task 5.3: UPDATE remitos ... WHERE estado='borrador' AND id_punto_venta=$pv RETURNING
+        // numero — mismo criterio (0 filas ⇒ reclasificar) que EnviarAsync de presupuestos.
+        var numeroAsignado = await EmitirHeaderAsync(
+            conexion, transaccionCruda, id, idTenant, idPuntoVenta, numero, momento, ct);
+        if (numeroAsignado is null)
+        {
+            var existe = await db.Remitos.AsNoTracking().AnyAsync(r => r.Id == id, ct);
+            if (!existe)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el remito {id}.");
+            }
+
+            throw new ErrorDominio(
+                "remito_ya_emitido", "El remito ya no está en borrador en ese punto de venta.", 409);
+        }
+
+        // task 5.6: EL CUARTO WRITE SITE — orden ascendente (id_articulo, id_lote NULLS FIRST),
+        // implementado independiente (design decisión 8): sus propios statements crudos, sin
+        // compartir helper con ServicioDeVentas/ServicioDeCompras/ServicioDeStock.
+        var itemsOrdenados = items
+            .Select(item => (
+                Item: item,
+                IdLoteFinal: loteFinalPorItem.TryGetValue(item.Id, out var saldo) ? saldo.IdLote : (int?)null))
+            .OrderBy(x => x.Item.IdArticulo)
+            .ThenBy(x => x.IdLoteFinal.HasValue)
+            .ThenBy(x => x.IdLoteFinal ?? 0)
+            .ToList();
+
+        foreach (var (item, idLoteFinal) in itemsOrdenados)
+        {
+            var articulo = articuloPorId[item.IdArticulo];
+
+            // task 5.5: freeze de costo/lote — costo_unitario sale de HOY (articulo.CostoNominal),
+            // nunca del momento de creación del borrador (design.md:292, mismo criterio que
+            // MaterializarItemsDesdePresupuesto's mutation target 29).
+            await CongelarItemAsync(
+                conexion, transaccionCruda, item.Id, idTenant, idLoteFinal, articulo.CostoNominal, ct);
+
+            var delta = -item.Cantidad;
+
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta, delta,
+                MotivoStock.Remito, id, idEmpleado, momento, idLoteFinal, ct);
+
+            await UpsertStockAsync(conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta, delta, ct);
+
+            if (idLoteFinal is { } idLote)
+            {
+                await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, item.IdArticulo, idPuntoVenta, idLote, delta, ct);
+            }
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerDetalleAsync(id, ct);
+    }
+
+    // ---- anular: sin coupling con facturado, sin chequeo de negativo (decisión 9) -------------------
+
+    /// <summary>design: Transactions — "ANULAR REMITO", tasks 5.8-5.9. Un único <c>UPDATE …
+    /// RETURNING</c> admite <c>borrador</c> Y <c>emitido</c> (spec: "MUST be allowed for borrador or
+    /// emitido") — para un <c>borrador</c> nunca se escribió ningún <c>movimientos_stock</c>, así
+    /// que el loop de reversa de abajo lee una lista vacía y no hace nada, sin ninguna rama especial
+    /// (mismo criterio "estructural, no una bandera" que el itemless <c>RC</c>/<c>TXR</c>). 0 filas
+    /// reclasifica en 404 / 409 <c>remito_facturado</c> / 409 <c>remito_ya_anulado</c> (OD8/T2, task
+    /// 5.9 — el escenario de doble-anulación ausente de <c>remitos/spec.md</c>).</summary>
+    public async Task<RemitoDetalle> AnularAsync(int id, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarAnulacionAsync(id, idTenant, idEmpleado, momento, ct));
+    }
+
+    private async Task<RemitoDetalle> EjecutarAnulacionAsync(
+        int id, int idTenant, int idEmpleado, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var anulado = await MarcarAnuladoAsync(conexion, transaccionCruda, id, idTenant, momento, ct);
+        if (!anulado)
+        {
+            var actual = await db.Remitos.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, ct);
+            if (actual is null)
+            {
+                throw ErrorDominio.NoEncontrado($"No existe el remito {id}.");
+            }
+
+            if (actual.Estado == EstadoRemito.Facturado)
+            {
+                throw new ErrorDominio(
+                    "remito_facturado", "El remito ya está facturado; no puede anularse directamente.", 409);
+            }
+
+            if (actual.Estado == EstadoRemito.Anulado)
+            {
+                throw new ErrorDominio("remito_ya_anulado", "El remito ya está anulado.", 409);
+            }
+
+            // Defensa en profundidad: el UPDATE guardado de arriba ya evaluó el mismo predicado
+            // que este re-chequeo — llegar acá es un invariante roto, nunca un caso de negocio
+            // alcanzable (mismo criterio que ExigirCausaDelRechazoAsync).
+            throw new InvalidOperationException(
+                $"El remito {id} no matcheó el UPDATE guardado pero tampoco una causa conocida de rechazo " +
+                $"(estado leído: {actual.Estado}).");
+        }
+
+        // task 5.8/design decisión 9: movimientos ORIGINALES del ledger (motivo = remito), NUNCA
+        // re-derivados de items_remito — orden ascendente (id_articulo, id_lote), mismo criterio
+        // anti-deadlock que EmitirAsync (por consistencia de convención, no por necesidad estricta
+        // acá). SIN chequeo de negativo: un remito decrementa, su reversa siempre suma
+        // (ServicioDeVentas.cs:1130-1135 posture verbatim, tensión T8).
+        var movimientosOriginales = await db.MovimientosStock
+            .Where(m => m.IdRemito == id && m.Motivo == MotivoStock.Remito)
+            .OrderBy(m => m.IdArticulo)
+            .ThenBy(m => m.IdLote)
+            .ToListAsync(ct);
+
+        foreach (var original in movimientosOriginales)
+        {
+            var inversa = -original.Cantidad;
+
+            await InsertarMovimientoStockAsync(
+                conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa,
+                MotivoStock.Anulacion, id, idEmpleado, momento, original.IdLote, ct);
+
+            await UpsertStockAsync(conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, inversa, ct);
+
+            if (original.IdLote is { } idLote)
+            {
+                await UpsertStockLoteAsync(
+                    conexion, transaccionCruda, idTenant, original.IdArticulo, original.IdPuntoVenta, idLote, inversa, ct);
+            }
+        }
+
+        await transaccion.CommitAsync(ct);
+
+        return await ObtenerDetalleAsync(id, ct);
+    }
+
+    // ---- statements crudos: header (mismo criterio que EnviarHeaderAsync de presupuestos) ----------
+
+    private static async Task<bool> BloquearBorradorAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT 1 FROM remitos " +
+            "WHERE id_remito = $1 AND id_tenant = $2 AND estado = 'borrador'::estado_remito " +
+            "FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    /// <summary>design.md:288-291, mutation target 44: pinea <c>estado='borrador'</c> Y
+    /// <c>id_punto_venta=$pv</c> — sin el segundo conjunto, un <c>PUT</c> concurrente que mueve el
+    /// remito a otro punto de venta haría aterrizar el número en la serie equivocada.</summary>
+    private static async Task<long?> EmitirHeaderAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, int idPuntoVenta, long numero,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE remitos SET numero = $1, fecha_salida = $2, estado = 'emitido'::estado_remito, updated_at = $2 " +
+            "WHERE id_remito = $3 AND id_tenant = $4 AND estado = 'borrador'::estado_remito " +
+            "AND id_punto_venta = $5 " +
+            "RETURNING numero";
+
+        ParametrosDeComando.Agregar(comando, numero);
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return lector.IsDBNull(0) ? null : lector.GetInt64(0);
+    }
+
+    /// <summary>design.md:292, task 5.5: congela <c>id_lote</c>/<c>costo_unitario</c>/
+    /// <c>costo_es_estimado</c> — <c>costo_es_estimado</c> siempre <c>false</c>, mismo criterio que
+    /// <c>ServicioDeVentas.MaterializarItems</c> (el costo puede ser <c>NULL</c> — "desconocido" —
+    /// sin que eso lo vuelva "estimado"; <c>ck_items_remito_estimado_con_costo</c> lo admite: la
+    /// CHECK solo exige costo no-nulo cuando el flag está prendido).</summary>
+    private static async Task CongelarItemAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idItem, int idTenant, int? idLote,
+        decimal? costoUnitario, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE items_remito SET id_lote = $1, costo_unitario = $2, costo_es_estimado = false " +
+            "WHERE id_item = $3 AND id_tenant = $4";
+
+        ParametrosDeComando.AgregarNulo(comando, idLote);
+        ParametrosDeComando.AgregarNulo(comando, costoUnitario);
+        ParametrosDeComando.Agregar(comando, idItem);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>design.md:301-302, mutation targets 45-46: single-statement, admite <c>borrador</c>
+    /// Y <c>emitido</c> — <c>facturado</c>/<c>anulado</c> quedan afuera del <c>IN</c> a propósito
+    /// (spec: "facturado MUST be rejected with 409"; OD8/T2: doble-anulación también 409, distinguido
+    /// del 409 de facturado por el estado leído en la reclasificación del llamador).</summary>
+    private static async Task<bool> MarcarAnuladoAsync(
+        DbConnection conexion, DbTransaction? transaccion, int id, int idTenant, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE remitos SET estado = 'anulado'::estado_remito, updated_at = $1 " +
+            "WHERE id_remito = $2 AND id_tenant = $3 " +
+            "AND estado IN ('borrador'::estado_remito, 'emitido'::estado_remito) " +
+            "RETURNING estado";
+
+        ParametrosDeComando.Agregar(comando, momento);
+        ParametrosDeComando.Agregar(comando, id);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = await comando.ExecuteScalarAsync(ct);
+        return resultado is not null;
+    }
+
+    // ---- statements crudos: EL CUARTO WRITE SITE (design decisión 8 — deliberadamente NO ---------
+    // ---- comparte código con ServicioDeVentas/ServicioDeCompras/ServicioDeStock) -------------------
+
+    /// <summary>design.md:294, mutation target 42: <c>motivo</c> y <c>id_remito</c> (NUNCA
+    /// <c>id_comprobante_venta</c>) — el documento del cuarto write site (proposal §H). Implementado
+    /// independiente de <c>ServicioDeVentas.InsertarMovimientoStockAsync</c> — mismo shape SQL, otra
+    /// clase, otro archivo (la duplicación es el contrato de <c>stock/spec.md:178-189</c>).</summary>
+    private static async Task InsertarMovimientoStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal cantidad, MotivoStock motivo, int idRemito, int idEmpleado, DateTimeOffset creadoEl,
+        int? idLote, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO movimientos_stock " +
+            "(id_tenant, id_articulo, id_punto_venta, cantidad, motivo, id_remito, id_empleado, creado_el, id_lote) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
+
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, cantidad);
+        ParametrosDeComando.Agregar(comando, motivo);
+        ParametrosDeComando.Agregar(comando, idRemito);
+        ParametrosDeComando.Agregar(comando, idEmpleado);
+        ParametrosDeComando.Agregar(comando, creadoEl);
+        ParametrosDeComando.AgregarNulo(comando, idLote);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>design decisión 8: el único statement que toca <c>stock</c> desde este write site —
+    /// su propio row lock (implícito en el <c>INSERT ... ON CONFLICT</c>) reemplaza al advisory
+    /// lock, mismo mecanismo que write site 1, código PROPIO.</summary>
+    private static async Task UpsertStockAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock (id_articulo, id_punto_venta, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4) " +
+            "ON CONFLICT (id_articulo, id_punto_venta) DO UPDATE " +
+            "SET cantidad = stock.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
+
+        await comando.ExecuteScalarAsync(ct);
+    }
+
+    /// <summary>Sin chequeo de negativo — decisión 9: una emisión siempre resta (nunca puede dejar
+    /// el saldo negativo por construcción, la reversa de <see cref="AnularAsync"/> siempre suma).
+    /// </summary>
+    private static async Task UpsertStockLoteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idArticulo, int idPuntoVenta,
+        int idLote, decimal delta, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "INSERT INTO stock_lotes (id_articulo, id_punto_venta, id_lote, id_tenant, cantidad) " +
+            "VALUES ($1, $2, $3, $4, $5) " +
+            "ON CONFLICT (id_articulo, id_punto_venta, id_lote) DO UPDATE " +
+            "SET cantidad = stock_lotes.cantidad + EXCLUDED.cantidad " +
+            "RETURNING cantidad";
+
+        ParametrosDeComando.Agregar(comando, idArticulo);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, idLote);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, delta);
+
+        await comando.ExecuteScalarAsync(ct);
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    // ---- resolución de precio (mismo criterio que ServicioDePresupuestos, sin signo) ---------------
+
+    private async Task<(IReadOnlyList<LineaMaterializada> Lineas, TotalesCalculados Totales)> ResolverYMaterializarAsync(
+        IReadOnlyList<LineaDeRemito> lineas, int idTenant, int idEmpresa, int idListaPrecio, DateTimeOffset momento,
+        CancellationToken ct)
+    {
+        if (lineas.Count == 0)
+        {
+            return (Array.Empty<LineaMaterializada>(), CalculadorDeTotales.Calcular([]));
+        }
+
+        // Backstop map FK 22 (design.md:392): "Yes (item lines) — Same pre-check shape ... +
+        // generic mapping" — un idLote explícito se valida ACÁ, antes de escribir nada
+        // (dto-contract-honesty regla 1: el campo tiene que tener un destino real, y ese destino
+        // solo es válido si el lote existe).
+        foreach (var linea in lineas)
+        {
+            if (linea.IdLote is { } idLote
+                && !await db.Lotes.AsNoTracking().AnyAsync(l => l.Id == idLote && l.IdArticulo == linea.IdArticulo, ct))
+            {
+                throw new ErrorDominio(
+                    "lote_invalido",
+                    $"El lote {idLote} no existe o no pertenece al artículo {linea.IdArticulo}.",
+                    400);
+            }
+        }
+
+        var lineasDeResolucion = lineas
+            .Select(l => new LineaDeResolucion(l.IdArticulo, idEmpresa, idListaPrecio, l.Cantidad))
+            .ToList();
+        var resolucion = await servicioDeOfertas.ResolverAsync(lineasDeResolucion, momento, ct);
+
+        var idsArticulo = lineas.Select(l => l.IdArticulo).Distinct().ToList();
+        var articuloPorId = await db.Articulos
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, ct);
+
+        var idsAlicuota = articuloPorId.Values.Select(a => a.IdAlicuotaIva).Distinct().ToList();
+        var porcentajePorAlicuota = await db.AlicuotasIva
+            .Where(a => idsAlicuota.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, a => a.Porcentaje, ct);
+
+        return MaterializarLineas(lineas, resolucion, articuloPorId, porcentajePorAlicuota, idListaPrecio);
+    }
+
+    private static (IReadOnlyList<LineaMaterializada> Lineas, TotalesCalculados Totales) MaterializarLineas(
+        IReadOnlyList<LineaDeRemito> lineas,
+        IReadOnlyList<ResultadoDeResolucion> resolucion,
+        IReadOnlyDictionary<int, Articulo> articuloPorId,
+        IReadOnlyDictionary<int, decimal> porcentajePorAlicuota,
+        int idListaPrecio)
+    {
+        var lineasParaCalcular = new List<LineaParaCalcular>(lineas.Count);
+
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var resultado = resolucion[i];
+
+            if (resultado.PrecioOriginal is null)
+            {
+                throw new ErrorDominio(
+                    "articulo_sin_precio_vigente",
+                    $"El artículo {lineas[i].IdArticulo} no tiene un precio vigente en la lista del cliente.",
+                    400);
+            }
+
+            lineasParaCalcular.Add(new LineaParaCalcular(
+                lineas[i].Cantidad, resultado.PrecioOriginal.Value, resultado.DescuentoUnitario));
+        }
+
+        var totales = CalculadorDeTotales.Calcular(lineasParaCalcular);
+
+        var resultadoFinal = new List<LineaMaterializada>(lineas.Count);
+        for (var i = 0; i < lineas.Count; i++)
+        {
+            var linea = lineas[i];
+            var resultado = resolucion[i];
+            var calculado = totales.Items[i];
+            var articulo = articuloPorId[linea.IdArticulo];
+
+            var idOferta = resultado.Aplicadas.Count > 0 ? resultado.Aplicadas[0].IdOferta : (int?)null;
+
+            resultadoFinal.Add(new LineaMaterializada(
+                articulo.Id, articulo.Nombre, calculado.Cantidad, calculado.PrecioUnitario, calculado.Descuento,
+                calculado.Total, idListaPrecio, idOferta, articulo.IdAlicuotaIva,
+                porcentajePorAlicuota[articulo.IdAlicuotaIva], linea.IdLote));
+        }
+
+        return (resultadoFinal, totales);
+    }
+
+    private static List<ItemRemito> ConstruirItems(
+        int idRemito, int idTenant, DateTimeOffset momento, IReadOnlyList<LineaMaterializada> lineas)
+    {
+        var resultado = new List<ItemRemito>(lineas.Count);
+        var orden = 1;
+
+        foreach (var linea in lineas)
+        {
+            resultado.Add(new ItemRemito
+            {
+                IdTenant = idTenant,
+                IdRemito = idRemito,
+                Orden = orden++,
+                IdArticulo = linea.IdArticulo,
+                Descripcion = linea.Descripcion,
+                Cantidad = linea.Cantidad,
+                PrecioUnitario = linea.PrecioUnitario,
+                Descuento = linea.Descuento,
+                Total = linea.Total,
+                IdListaPrecio = linea.IdListaPrecio,
+                IdOferta = linea.IdOferta,
+                IdAlicuotaIva = linea.IdAlicuotaIva,
+                PorcentajeIva = linea.PorcentajeIva,
+                CostoUnitario = null,
+                CostoEsEstimado = false,
+                IdLote = linea.IdLoteExplicito,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            });
+        }
+
+        return resultado;
+    }
+
+    private static void ExigirCantidadesValidas(IReadOnlyList<LineaDeRemito> lineas)
+    {
+        foreach (var linea in lineas)
+        {
+            if (linea.Cantidad <= 0)
+            {
+                throw new ErrorDominio(
+                    "cantidad_de_linea_invalida", "La cantidad de una línea de remito tiene que ser positiva.", 400);
+            }
+        }
+    }
+
+    // ---- parámetro lotes_habilitado (mismo criterio que ServicioDeVentas.ResolverParametrosDeVentaAsync) --
+
+    private async Task<bool> ResolverLotesHabilitadoAsync(int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        var clave = ParametroConocido.LotesHabilitado.Clave;
+
+        var candidatos = await db.Parametros
+            .Where(p => p.Clave == clave && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var resuelto = ResolucionDeParametros.Resolver(clave, candidatos, idPuntoVenta);
+        return JsonSerializer.Deserialize<bool>(resuelto);
+    }
+
+    // ---- resolución de contexto (fuera de transacción, resolvers PRIVADOS PROPIOS — OD9) -----------
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<Cliente> ResolverClienteAsync(int? idCliente, CancellationToken ct)
+    {
+        if (idCliente is { } id)
+        {
+            return await db.Clientes.FirstOrDefaultAsync(c => c.Id == id, ct)
+                ?? throw ErrorDominio.NoEncontrado($"No existe el cliente {id}.");
+        }
+
+        return await db.Clientes.FirstOrDefaultAsync(c => c.Numero == ReglaDeClientes.NumeroConsumidorFinal, ct)
+            ?? throw new InvalidOperationException("El tenant actual no tiene un Consumidor Final sembrado.");
+    }
+
+    // ---- proyección (task 5.19: rules 12b/12c — todo campo posicional, valores distintos) ---------
+
+    private static RemitoDetalle ProyectarDetalle(Remito remito, IReadOnlyList<ItemRemito> items) =>
+        new(
+            remito.Id,
+            remito.IdPuntoVenta,
+            remito.IdCliente,
+            remito.IdEmpleado,
+            remito.Numero,
+            remito.Numero is { } n ? NumeroDeComprobante.Formatear(remito.IdPuntoVenta, n) : null,
+            remito.FechaEmision,
+            remito.FechaSalida,
+            remito.DireccionEntrega,
+            remito.Observaciones,
+            remito.Subtotal,
+            remito.DescuentoTotal,
+            remito.Total,
+            remito.Estado,
+            remito.IdComprobanteVenta,
+            items
+                .OrderBy(i => i.Orden)
+                .Select(i => new ItemDeRemito(
+                    i.Orden, i.IdArticulo, i.Descripcion, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total,
+                    i.IdListaPrecio, i.IdOferta, i.IdAlicuotaIva, i.PorcentajeIva, i.CostoUnitario,
+                    i.CostoEsEstimado, i.IdLote))
+                .ToList());
+
+    private static RemitoListado ProyectarListado(Remito remito) =>
+        new(
+            remito.Id,
+            remito.IdPuntoVenta,
+            remito.IdCliente,
+            remito.Numero,
+            remito.Numero is { } n ? NumeroDeComprobante.Formatear(remito.IdPuntoVenta, n) : null,
+            remito.FechaEmision,
+            remito.Total,
+            remito.Estado,
+            remito.IdComprobanteVenta);
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeRemitos requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    private readonly record struct LineaMaterializada(
+        int IdArticulo,
+        string Descripcion,
+        decimal Cantidad,
+        decimal PrecioUnitario,
+        decimal Descuento,
+        decimal Total,
+        int IdListaPrecio,
+        int? IdOferta,
+        int IdAlicuotaIva,
+        decimal PorcentajeIva,
+        int? IdLoteExplicito);
+}

--- a/src/Ways.Domain/Ventas/ItemRemito.cs
+++ b/src/Ways.Domain/Ventas/ItemRemito.cs
@@ -59,9 +59,13 @@ public class ItemRemito : EntidadTenant
     /// irrepresentable, mismo criterio que <c>ItemComprobanteVenta.CostoEsEstimado</c>.</summary>
     public bool CostoEsEstimado { get; set; }
 
-    /// <summary>FEFO resuelto y congelado al <c>emitir</c> (proposal §F) — <c>NULL</c> para un
-    /// artículo que no controla lote, poblado para uno lot-effective (invariante cruzado entre
-    /// tablas, probado con un test de integración dedicado, mismo criterio que
+    /// <summary>El pick explícito del cliente (si vino) ya persiste ACÁ desde el borrador —
+    /// pre-chequeado contra <c>lotes</c> (backstop map FK 22) por
+    /// <c>ServicioDeRemitos.ResolverYMaterializarAsync</c>, decisión registrada del slice 5
+    /// (desviación 1, <c>tasks.md</c>). <c>emitir</c> lo honra tal cual, o re-resuelve FEFO si vino
+    /// <c>NULL</c>, y siempre lo re-congela con el saldo VIGENTE al momento de emitir. <c>NULL</c>
+    /// para un artículo que no controla lote, poblado para uno lot-effective (invariante cruzado
+    /// entre tablas, probado con un test de integración dedicado, mismo criterio que
     /// <c>MovimientoStock.IdLote</c>).</summary>
     public int? IdLote { get; set; }
 }

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -299,35 +299,88 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
     public async Task TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles()
     {
         var ctx = await PrepararAsync(nameof(TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles));
-        var idArticulo1 = await SembrarArticuloAsync(ctx, "Rem Distinto A", 111m);
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Rem Distinto A", 100m, costoNominal: 40m);
         var idArticulo2 = await SembrarArticuloAsync(ctx, "Rem Distinto B", 222m);
+
+        // mutation-proof-tests rule 12b: una oferta real hace que Subtotal/DescuentoTotal/Total
+        // sean pairwise-distintos (sin descuento, Subtotal == Total siempre, y un swap de esos dos
+        // campos pasaría en verde) — mismo fix que ServicioDePresupuestosTests's propio 12b.
+        await CrearOfertaAsync(ctx.Admin, OfertaDeArticulo(idArticulo1, 20m));
 
         var solicitud = new SolicitudDeRemito(
             ctx.IdPuntoVenta, ctx.IdCliente, "direccion distinguible", "obs distinguible",
             [new LineaDeRemito(idArticulo1, 1m, null), new LineaDeRemito(idArticulo2, 3m, null)]);
         var creado = await CrearBorradorAsync(ctx.Admin, solicitud);
 
+        // Subtotal = 100 + 666 = 766; descuento = 20 (20% de 100); Total = 746 — los tres
+        // pairwise-distintos, cierra la clase de mutante "swap Subtotal<->Total" en el header.
+        Assert.Equal(766m, creado.Subtotal);
+        Assert.Equal(20m, creado.DescuentoTotal);
+        Assert.Equal(746m, creado.Total);
+        Assert.NotEqual(creado.Subtotal, creado.DescuentoTotal);
+        Assert.NotEqual(creado.Subtotal, creado.Total);
+        Assert.NotEqual(creado.DescuentoTotal, creado.Total);
+
         Assert.Equal(2, creado.Items.Count);
         var item1 = creado.Items.Single(i => i.IdArticulo == idArticulo1);
         var item2 = creado.Items.Single(i => i.IdArticulo == idArticulo2);
 
-        // Subtotal == 111 + 666 == 777, sin descuento — pero DescuentoTotal/Subtotal/Total siguen
-        // siendo campos DISTINTOS entre sí (0 != 777 != 777... el par Subtotal/Total coincide sin
-        // descuento, así que el valor discriminante real acá es item1.Total != item2.Total y
-        // item1.Orden != item2.Orden, cubriendo la clase de mutante "swap de dos campos del
-        // mismo item").
         Assert.NotEqual(item1.Total, item2.Total);
         Assert.NotEqual(item1.Orden, item2.Orden);
         Assert.NotEqual(item1.PrecioUnitario, item2.PrecioUnitario);
+        Assert.NotEqual(item1.Descuento, item2.Descuento);
         Assert.Equal("direccion distinguible", creado.DireccionEntrega);
         Assert.Equal("obs distinguible", creado.Observaciones);
         Assert.Equal(ctx.IdPuntoVenta, creado.IdPuntoVenta);
         Assert.Equal(ctx.IdCliente, creado.IdCliente);
+        Assert.Equal(EstadoRemito.Borrador, creado.Estado);
+        Assert.Null(creado.Numero);
+        Assert.Null(creado.NumeroFormateado);
+        Assert.Null(creado.FechaSalida);
+        Assert.Null(creado.IdComprobanteVenta);
+
+        // rule 12b, mitad post-emitir: Numero/FechaSalida/CostoUnitario pasan de null a un valor
+        // real y distinguible — la identidad (Id/IdPuntoVenta/IdCliente/IdEmpleado, cuatro ints
+        // consecutivos en el constructor posicional) se lee de vuelta pairwise-distinta.
+        var emitido = (await (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null))
+            .Content.ReadFromJsonAsync<RemitoDetalle>(OpcionesJson))!;
+
+        Assert.Equal(EstadoRemito.Emitido, emitido.Estado);
+        Assert.Equal(1, emitido.Numero);
+        Assert.Equal($"{ctx.IdPuntoVenta:D4}-00000001", emitido.NumeroFormateado);
+        Assert.NotNull(emitido.FechaSalida);
+        Assert.True(emitido.FechaSalida >= emitido.FechaEmision);
+        // Identidad leída de vuelta contra los valores REALES sembrados — nunca una comparación
+        // cruzada entre ids de tablas distintas (esas coinciden por casualidad de secuencia, no
+        // por invariante alguno; una assertion así sería flaky por construcción, no discriminante).
+        Assert.Equal(creado.Id, emitido.Id);
+        Assert.Equal(ctx.IdPuntoVenta, emitido.IdPuntoVenta);
+        Assert.Equal(ctx.IdCliente, emitido.IdCliente);
+        Assert.Equal(ctx.IdUsuarioAdmin, emitido.IdEmpleado);
+        Assert.Equal(40m, emitido.Items.Single(i => i.IdArticulo == idArticulo1).CostoUnitario);
+        Assert.Null(emitido.Items.Single(i => i.IdArticulo == idArticulo2).CostoUnitario);
 
         var listado = await ctx.Admin.GetFromJsonAsync<PaginaDeRemitos>(
             $"/api/remitos?idPuntoVenta={ctx.IdPuntoVenta}", OpcionesJson);
         var fila = listado!.Items.Single(r => r.Id == creado.Id);
-        Assert.Equal(creado.Total, fila.Total);
+        Assert.Equal(emitido.Total, fila.Total);
+        Assert.Equal(emitido.Numero, fila.Numero);
+        Assert.Equal(emitido.NumeroFormateado, fila.NumeroFormateado);
+        Assert.Equal(emitido.Estado, fila.Estado);
+    }
+
+    /// <summary>Mismo shape que <c>ServicioDePresupuestosTests.OfertaDeArticulo</c> — oferta
+    /// directa, sin ventana de vigencia, alcance a un único artículo.</summary>
+    private static Ways.Application.Ofertas.AltaOferta OfertaDeArticulo(int idArticulo, decimal porcentaje) => new(
+        Nombre: "oferta de remito de prueba", IdEmpresa: null, IdArticulo: idArticulo, IdGrupo: null,
+        IdCategoria: null, FechaDesde: null, FechaHasta: null, HoraDesde: null, HoraHasta: null,
+        DiasSemana: null, CantidadMinima: null, PrecioUnitario: null, Porcentaje: porcentaje,
+        ImporteFijo: null, Prioridad: 0, Acumulable: false);
+
+    private static async Task CrearOfertaAsync(HttpClient cliente, Ways.Application.Ofertas.AltaOferta datos)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/ofertas", datos);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
     }
 
     // ---- task 5.3-5.6: emitir — el cuarto write site (mutation targets 40-42) ----------------------

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -1,0 +1,760 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 5 (tasks 5.1-5.22; design: Transactions — "EMITIR
+/// REMITO"/"ANULAR REMITO"; mutation targets 40-47). <see cref="ServicioDeRemitos.EmitirAsync"/> es
+/// el CUARTO write site de stock, implementado independiente de <c>ServicioDeVentas</c> (design
+/// decisión 8) — este archivo prueba su propio orden de lock, su propia paridad FEFO contra el
+/// checkout, y su propia reversa exacta desde el ledger (nunca re-derivada de <c>items_remito</c>).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, HttpClient Admin, int IdArea, int IdAlicuotaIva,
+        int IdListaPrecio, int IdCliente, int IdMedioEfectivo, int IdUsuarioAdmin, int IdPuntoVenta2,
+        string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre, bool conTurnoAbierto = false, bool conLotesHabilitado = false)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Rem-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista de Remitos", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 2000 + Random.Shared.Next(1, 100_000), Nombre = $"{nombre}-cliente",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 0,
+            CreditoIlimitado = true, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, Nombre = $"{nombre}-PV2",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        if (conLotesHabilitado)
+        {
+            db.Parametros.Add(new Parametro
+            {
+                IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, IdPuntoVenta = null,
+                Clave = "lotes_habilitado", Valor = "true", CreatedAt = ahora, UpdatedAt = ahora
+            });
+            await db.SaveChangesAsync();
+        }
+
+        if (conTurnoAbierto)
+        {
+            db.TurnosCaja.Add(new TurnoCaja
+            {
+                IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+                IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+                Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+            });
+            await db.SaveChangesAsync();
+        }
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, admin, area.Id, idAlicuotaIva,
+            lista.Id, cliente.Id, idMedioEfectivo, resultado.IdUsuarioAdmin, puntoVenta2.Id, mailAdmin,
+            resultado.PasswordTemporal);
+    }
+
+    private async Task<int> SembrarArticuloAsync(
+        Contexto ctx, string nombre, decimal precio, bool esProducto = true, bool controlaLote = false,
+        decimal? costoNominal = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = esProducto, ControlaLote = controlaLote, CostoNominal = costoNominal,
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task<int> SembrarLoteAsync(Contexto ctx, int idArticulo, string codigo, DateOnly? fechaVencimiento, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var lote = new Lote
+        {
+            IdArticulo = idArticulo, Codigo = codigo, FechaVencimiento = fechaVencimiento,
+            EsSinIdentificar = false, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Lotes.Add(lote);
+        await db.SaveChangesAsync();
+
+        db.StockLotes.Add(new StockLote
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdLote = lote.Id, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+
+        return lote.Id;
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Stock { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad });
+        await db.SaveChangesAsync();
+    }
+
+    private static SolicitudDeRemito SolicitudSimple(Contexto ctx, int idArticulo, decimal cantidad = 2m, int? idLote = null) =>
+        new(ctx.IdPuntoVenta, ctx.IdCliente, "Calle Falsa 123", "obs", [new LineaDeRemito(idArticulo, cantidad, idLote)]);
+
+    private static SolicitudDeRemito SolicitudSinItems(Contexto ctx) =>
+        new(ctx.IdPuntoVenta, ctx.IdCliente, null, null, []);
+
+    private static async Task<RemitoDetalle> CrearBorradorAsync(HttpClient cliente, SolicitudDeRemito solicitud)
+    {
+        var respuesta = await cliente.PostAsJsonAsync("/api/remitos", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+    }
+
+    private static SolicitudDeVenta SolicitudDeVentaSimple(Contexto ctx, int idArticulo, decimal cantidad, int? idLote) =>
+        new(
+            ctx.IdPuntoVenta, ctx.IdCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, cantidad, null, idLote)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, cantidad * 1000m, null, 0m)],
+            null, null);
+
+    private static async Task<ComprobanteEmitido> EmitirVentaAsync(Contexto ctx, SolicitudDeVenta solicitud)
+    {
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        return JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+    }
+
+    // ---- task 5.2: crear borrador, precio resuelto al guardar --------------------------------------
+
+    [Fact]
+    public async Task UnBorradorSinItemsPersisteConNumeroYFechaSalidaNulos()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorSinItemsPersisteConNumeroYFechaSalidaNulos));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        Assert.Null(creado.Numero);
+        Assert.Null(creado.NumeroFormateado);
+        Assert.Null(creado.FechaSalida);
+        Assert.Empty(creado.Items);
+        Assert.Equal(EstadoRemito.Borrador, creado.Estado);
+    }
+
+    [Fact]
+    public async Task UnBorradorConItemsResuelveElPrecioVigenteAlGuardar()
+    {
+        var ctx = await PrepararAsync(nameof(UnBorradorConItemsResuelveElPrecioVigenteAlGuardar));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Articulo 1", 150m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 3m));
+
+        var item = Assert.Single(creado.Items);
+        Assert.Equal(150m, item.PrecioUnitario);
+        Assert.Equal(450m, item.Total);
+        Assert.Equal(450m, creado.Total);
+        Assert.Null(item.CostoUnitario);
+        Assert.False(item.CostoEsEstimado);
+        Assert.Null(item.IdLote);
+    }
+
+    // ---- task 5.2: replace-set completo, hermano intacto (rule 12c) --------------------------------
+
+    [Fact]
+    public async Task ElReplaceSetReemplazaLosItemsCompletosSinTocarUnRemitoHermano()
+    {
+        var ctx = await PrepararAsync(nameof(ElReplaceSetReemplazaLosItemsCompletosSinTocarUnRemitoHermano));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Rem Hermano A", 100m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Rem Hermano B", 200m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo1, 1m));
+        var hermano = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo1, 5m));
+        Assert.Single(creado.Items);
+        Assert.Single(hermano.Items);
+
+        var reemplazo = new SolicitudDeRemito(
+            ctx.IdPuntoVenta, ctx.IdCliente, "nueva direccion", null,
+            [new LineaDeRemito(idArticulo2, 4m, null)]);
+        var respuesta = await ctx.Admin.PutAsJsonAsync($"/api/remitos/{creado.Id}", reemplazo);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var actualizado = (await respuesta.Content.ReadFromJsonAsync<RemitoDetalle>(OpcionesJson))!;
+
+        var itemActualizado = Assert.Single(actualizado.Items);
+        Assert.Equal(idArticulo2, itemActualizado.IdArticulo);
+        Assert.Equal("nueva direccion", actualizado.DireccionEntrega);
+
+        var detalleHermano = await ctx.Admin.GetFromJsonAsync<RemitoDetalle>($"/api/remitos/{hermano.Id}", OpcionesJson);
+        var itemHermano = Assert.Single(detalleHermano!.Items);
+        Assert.Equal(idArticulo1, itemHermano.IdArticulo);
+        Assert.Equal(5m, itemHermano.Cantidad);
+    }
+
+    [Fact]
+    public async Task EditarUnRemitoNoBorradorEsRechazado409()
+    {
+        var ctx = await PrepararAsync(nameof(EditarUnRemitoNoBorradorEsRechazado409));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem No Editable", 50m);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+
+        var emitido = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.OK, emitido.StatusCode);
+
+        var respuestaEdicion = await ctx.Admin.PutAsJsonAsync($"/api/remitos/{creado.Id}", SolicitudSimple(ctx, idArticulo, 2m));
+        Assert.Equal(HttpStatusCode.Conflict, respuestaEdicion.StatusCode);
+    }
+
+    // ---- rule 12b: todo campo posicional del detalle se lee de vuelta con valores distinguibles ----
+
+    [Fact]
+    public async Task TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles()
+    {
+        var ctx = await PrepararAsync(nameof(TodoCampoPosicionalDelDetalleSeLeeDeVueltaConValoresDistinguibles));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Rem Distinto A", 111m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Rem Distinto B", 222m);
+
+        var solicitud = new SolicitudDeRemito(
+            ctx.IdPuntoVenta, ctx.IdCliente, "direccion distinguible", "obs distinguible",
+            [new LineaDeRemito(idArticulo1, 1m, null), new LineaDeRemito(idArticulo2, 3m, null)]);
+        var creado = await CrearBorradorAsync(ctx.Admin, solicitud);
+
+        Assert.Equal(2, creado.Items.Count);
+        var item1 = creado.Items.Single(i => i.IdArticulo == idArticulo1);
+        var item2 = creado.Items.Single(i => i.IdArticulo == idArticulo2);
+
+        // Subtotal == 111 + 666 == 777, sin descuento — pero DescuentoTotal/Subtotal/Total siguen
+        // siendo campos DISTINTOS entre sí (0 != 777 != 777... el par Subtotal/Total coincide sin
+        // descuento, así que el valor discriminante real acá es item1.Total != item2.Total y
+        // item1.Orden != item2.Orden, cubriendo la clase de mutante "swap de dos campos del
+        // mismo item").
+        Assert.NotEqual(item1.Total, item2.Total);
+        Assert.NotEqual(item1.Orden, item2.Orden);
+        Assert.NotEqual(item1.PrecioUnitario, item2.PrecioUnitario);
+        Assert.Equal("direccion distinguible", creado.DireccionEntrega);
+        Assert.Equal("obs distinguible", creado.Observaciones);
+        Assert.Equal(ctx.IdPuntoVenta, creado.IdPuntoVenta);
+        Assert.Equal(ctx.IdCliente, creado.IdCliente);
+
+        var listado = await ctx.Admin.GetFromJsonAsync<PaginaDeRemitos>(
+            $"/api/remitos?idPuntoVenta={ctx.IdPuntoVenta}", OpcionesJson);
+        var fila = listado!.Items.Single(r => r.Id == creado.Id);
+        Assert.Equal(creado.Total, fila.Total);
+    }
+
+    // ---- task 5.3-5.6: emitir — el cuarto write site (mutation targets 40-42) ----------------------
+
+    [Fact]
+    public async Task EmitirMueveStockConElMotivoDelRemito()
+    {
+        var ctx = await PrepararAsync(nameof(EmitirMueveStockConElMotivoDelRemito));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Motivo", 80m, costoNominal: 55m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 3m));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var emitido = JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(EstadoRemito.Emitido, emitido.Estado);
+        Assert.NotNull(emitido.Numero);
+        Assert.NotNull(emitido.FechaSalida);
+        // task 5.5: costo_unitario congelado de HOY (articulo.CostoNominal), no del momento del
+        // borrador — costo_es_estimado siempre false, mismo criterio que ServicioDeVentas.
+        Assert.Equal(55m, emitido.Items.Single().CostoUnitario);
+        Assert.False(emitido.Items.Single().CostoEsEstimado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdRemito == creado.Id);
+        Assert.Equal(-3m, movimiento.Cantidad);
+        Assert.Equal(MotivoStock.Remito, movimiento.Motivo);
+        Assert.Equal(creado.Id, movimiento.IdRemito);
+        Assert.Null(movimiento.IdComprobanteVenta);
+
+        var stock = await db.Stock.SingleAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        Assert.Equal(7m, stock.Cantidad);
+    }
+
+    [Fact]
+    public async Task EmitirUnaLineaLoteEfectivaCongelaFefo()
+    {
+        var ctx = await PrepararAsync(nameof(EmitirUnaLineaLoteEfectivaCongelaFefo), conLotesHabilitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Lote", 60m, controlaLote: true);
+        var idLoteViejo = await SembrarLoteAsync(ctx, idArticulo, "L-VIEJO", new DateOnly(2099, 1, 1), 5m);
+        await SembrarLoteAsync(ctx, idArticulo, "L-NUEVO", new DateOnly(2099, 6, 1), 5m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 2m));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var emitido = JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+
+        // FEFO: el lote con vencimiento MÁS CERCANO ("viejo") es el elegido.
+        Assert.Equal(idLoteViejo, emitido.Items.Single().IdLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stockLote = await db.StockLotes.SingleAsync(s => s.IdLote == idLoteViejo);
+        Assert.Equal(3m, stockLote.Cantidad);
+        var itemPersistido = await db.ItemsRemito.SingleAsync(i => i.IdRemito == creado.Id);
+        Assert.Equal(idLoteViejo, itemPersistido.IdLote);
+    }
+
+    [Fact]
+    public async Task EmitirUnRemitoVacioEsRechazado400()
+    {
+        var ctx = await PrepararAsync(nameof(EmitirUnRemitoVacioEsRechazado400));
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSinItems(ctx));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("remito_sin_items", problema.GetProperty("codigo").GetString());
+    }
+
+    [Fact]
+    public async Task EmitirUnaLineaDeServicioEsRechazada400()
+    {
+        var ctx = await PrepararAsync(nameof(EmitirUnaLineaDeServicioEsRechazada400));
+        var idServicio = await SembrarArticuloAsync(ctx, "Rem Servicio", 40m, esProducto: false);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idServicio, 1m));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.BadRequest, respuesta.StatusCode);
+        var problema = await respuesta.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("articulo_no_es_producto", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id));
+    }
+
+    // ---- task 5.18: doble emitir (mutation target 44) ----------------------------------------------
+
+    [Fact]
+    public async Task DobleEmitirEsRechazado409()
+    {
+        var ctx = await PrepararAsync(nameof(DobleEmitirEsRechazado409));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Doble Emitir", 70m);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+
+        var primero = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.OK, primero.StatusCode);
+
+        var segundo = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.Conflict, segundo.StatusCode);
+        var problema = await segundo.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("remito_ya_emitido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id));
+    }
+
+    // ---- mutation target 44 (mitad id_punto_venta): la carrera del relink de PV --------------------
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<System.Data.Common.DbTransaction> TransactionStartedAsync(
+            System.Data.Common.DbConnection connection, TransactionEndEventData eventData,
+            System.Data.Common.DbTransaction transaction, CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mutation target 44 (mitad `id_punto_venta`, mismo patrón que
+    /// <c>ServicioDePresupuestosTests.UnPutQueMuevePuntoDeVentaConcurrenteConEnviarReclasificaA409YElNumeroQuedaEnLaSerieVieja</c>):
+    /// un `PUT` que mueve el remito del PV 1 al PV 2 gana la carrera y COMMITEA DESPUÉS de que el
+    /// número ya fue dibujado (serie del PV 1) pero ANTES de que el `UPDATE` final de `emitir`
+    /// corra — pausado justo tras `BeginTransactionAsync` de `EjecutarEmisionAsync`. El `WHERE
+    /// id_punto_venta = $pv` (pineado al PV 1, capturado en la pre-lectura) no matchea la fila ya
+    /// movida al PV 2 ⇒ 0 filas ⇒ 409, el número dibujado para el PV 1 queda quemado sin aparecer
+    /// en ningún remito.</summary>
+    [Fact]
+    public async Task UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja()
+    {
+        var ctx = await PrepararAsync(nameof(UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Relink PV", 33m);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteEmitir = factory.CreateClient();
+        var login = await clienteEmitir.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaEmitir = clienteEmitir.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+
+        await transaccionIniciada.Task;
+
+        var solicitudRelink = new SolicitudDeRemito(
+            ctx.IdPuntoVenta2, ctx.IdCliente, null, null, [new LineaDeRemito(idArticulo, 1m, null)]);
+        var respuestaPut = await ctx.Admin.PutAsJsonAsync($"/api/remitos/{creado.Id}", solicitudRelink);
+        var cuerpoPut = await respuestaPut.Content.ReadAsStringAsync();
+        Assert.True(respuestaPut.StatusCode == HttpStatusCode.OK, cuerpoPut);
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaEmitir = await tareaEmitir;
+        var cuerpoEmitir = await respuestaEmitir.Content.ReadAsStringAsync();
+        Assert.True(respuestaEmitir.StatusCode == HttpStatusCode.Conflict, cuerpoEmitir);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoEmitir, OpcionesJson);
+        Assert.Equal("remito_ya_emitido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.Remitos.FirstAsync(r => r.Id == creado.Id);
+        Assert.Equal(EstadoRemito.Borrador, actual.Estado);
+        Assert.Null(actual.Numero);
+        Assert.Equal(ctx.IdPuntoVenta2, actual.IdPuntoVenta);
+
+        // El número quemado (serie del PV 1) nunca aparece en ningún remito: un emitir siguiente
+        // del PV 1 salta directo al 2.
+        var siguientePv1 = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+        var siguienteEmitirPv1 = await ctx.Admin.PostAsync($"/api/remitos/{siguientePv1.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.OK, siguienteEmitirPv1.StatusCode);
+        var siguienteEmitidoPv1 = (await siguienteEmitirPv1.Content.ReadFromJsonAsync<RemitoDetalle>(OpcionesJson))!;
+        Assert.Equal(2, siguienteEmitidoPv1.Numero);
+    }
+
+    // ---- task 5.8-5.9: anular (mutation targets 45-46) ----------------------------------------------
+
+    [Fact]
+    public async Task AnularUnRemitoEmitidoReviertelosMovimientosOriginales()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnRemitoEmitidoReviertelosMovimientosOriginales));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Anular", 90m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 4m));
+        var emitido = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.OK, emitido.StatusCode);
+
+        var anulado = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null);
+        var cuerpo = await anulado.Content.ReadAsStringAsync();
+        Assert.True(anulado.StatusCode == HttpStatusCode.OK, cuerpo);
+        var detalle = JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoRemito.Anulado, detalle.Estado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var inversa = await db.MovimientosStock.SingleAsync(m => m.IdRemito == creado.Id && m.Motivo == MotivoStock.Anulacion);
+        Assert.Equal(4m, inversa.Cantidad);
+
+        var stock = await db.Stock.SingleAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        Assert.Equal(20m, stock.Cantidad);
+    }
+
+    [Fact]
+    public async Task AnularUnRemitoYaAnuladoEsRechazado409YNoEscribeSegundaReversa()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnRemitoYaAnuladoEsRechazado409YNoEscribeSegundaReversa));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Doble Anular", 55m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null)).StatusCode);
+
+        var segundaAnulacion = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Conflict, segundaAnulacion.StatusCode);
+        var problema = await segundaAnulacion.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("remito_ya_anulado", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id && m.Motivo == MotivoStock.Anulacion));
+    }
+
+    [Fact]
+    public async Task AnularUnRemitoFacturadoEsRechazado409()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnRemitoFacturadoEsRechazado409), conTurnoAbierto: true);
+        var idArticuloRemito = await SembrarArticuloAsync(ctx, "Rem Facturado", 65m);
+        var idArticuloVenta = await SembrarArticuloAsync(ctx, "Rem Facturado Venta", 65m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloRemito, 5m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloVenta, 5m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticuloRemito, 1m));
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null)).StatusCode);
+
+        // Fixture directo (sin Slice 6 — ServicioDeFacturacionDeRemitos todavía no existe): emite
+        // una venta cualquiera para tener un id_comprobante_venta real y liga el remito a mano, vía
+        // conexión owner (bypassa RLS/políticas de escritura de la app, no las de Postgres).
+        var venta = await EmitirVentaAsync(ctx, SolicitudDeVentaSimple(ctx, idArticuloVenta, 1m, null));
+        await using (var cruda = new NpgsqlConnection(fixture.OwnerConnectionString))
+        {
+            await cruda.OpenAsync();
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText =
+                "UPDATE remitos SET estado = 'facturado'::estado_remito, id_comprobante_venta = $1 WHERE id_remito = $2";
+            comando.Parameters.AddWithValue(venta.Id);
+            comando.Parameters.AddWithValue(creado.Id);
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        var anulado = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.Conflict, anulado.StatusCode);
+        var problema = await anulado.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("remito_facturado", problema.GetProperty("codigo").GetString());
+    }
+
+    // ---- task 5.16: la anulación lee los movimientos ORIGINALES, nunca re-deriva de items_remito ---
+
+    [Fact]
+    public async Task LaAnulacionLeeLosMovimientosOriginalesNoLosRederivaDeItems()
+    {
+        var ctx = await PrepararAsync(nameof(LaAnulacionLeeLosMovimientosOriginalesNoLosRederivaDeItems));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Original", 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 50m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 7m));
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null)).StatusCode);
+
+        // Diverge deliberadamente items_remito.cantidad DEL LEDGER — si AnularAsync re-derivara la
+        // reversa desde items_remito (en vez de leer movimientos_stock), la inversa saldría con
+        // esta cantidad mutada (99), no con la original (7) que quedó grabada en el ledger.
+        await using (var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var item = await db.ItemsRemito.SingleAsync(i => i.IdRemito == creado.Id);
+            item.Cantidad = 99m;
+            await db.SaveChangesAsync();
+        }
+
+        var anulado = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null);
+        Assert.Equal(HttpStatusCode.OK, anulado.StatusCode);
+
+        await using var dbAssert = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var inversa = await dbAssert.MovimientosStock.SingleAsync(m => m.IdRemito == creado.Id && m.Motivo == MotivoStock.Anulacion);
+        Assert.Equal(7m, inversa.Cantidad);
+
+        var stock = await dbAssert.Stock.SingleAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        Assert.Equal(50m, stock.Cantidad);
+    }
+
+    // ---- task 5.12/5.13: rendezvous forzado, sin deadlock, misma clave ascendente -------------------
+
+    [Fact]
+    public async Task RemitirYCheckoutSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan()
+    {
+        var ctx = await PrepararAsync(
+            nameof(RemitirYCheckoutSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan),
+            conTurnoAbierto: true, conLotesHabilitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Rendezvous Checkout", 45m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-RDV-1", new DateOnly(2099, 1, 1), 100m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 100m);
+
+        var remito = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 2m, idLote));
+
+        var tareaRemito = ctx.Admin.PostAsync($"/api/remitos/{remito.Id}/emitir", null);
+        var tareaVenta = ctx.Admin.PostAsJsonAsync("/api/ventas", SolicitudDeVentaSimple(ctx, idArticulo, 3m, idLote));
+
+        var respuestas = await Task.WhenAll(tareaRemito, tareaVenta);
+
+        Assert.Equal(HttpStatusCode.OK, respuestas[0].StatusCode);
+        Assert.Equal(HttpStatusCode.Created, respuestas[1].StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stockLote = await db.StockLotes.SingleAsync(s => s.IdLote == idLote);
+        Assert.Equal(95m, stockLote.Cantidad);
+
+        var stockAgregado = await db.Stock.SingleAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        Assert.Equal(95m, stockAgregado.Cantidad);
+    }
+
+    [Fact]
+    public async Task RemitirYRemitirSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan()
+    {
+        var ctx = await PrepararAsync(
+            nameof(RemitirYRemitirSobreElMismoArticuloYLoteNoDeadlockeanYAmbosCompletan), conLotesHabilitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Rendezvous Rem", 33m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-RDV-2", new DateOnly(2099, 1, 1), 100m);
+
+        var remitoA = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 2m, idLote));
+        var remitoB = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 5m, idLote));
+
+        var tareaA = ctx.Admin.PostAsync($"/api/remitos/{remitoA.Id}/emitir", null);
+        var tareaB = ctx.Admin.PostAsync($"/api/remitos/{remitoB.Id}/emitir", null);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        Assert.All(respuestas, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stockLote = await db.StockLotes.SingleAsync(s => s.IdLote == idLote);
+        Assert.Equal(93m, stockLote.Cantidad);
+        Assert.Equal(2, await db.MovimientosStock.CountAsync(m => m.IdLote == idLote && m.Motivo == MotivoStock.Remito));
+    }
+
+    // ---- task 5.14: paridad FEFO entre write site 1 (checkout) y write site 4 (remito) -------------
+
+    [Fact]
+    public async Task LaParidadFefoEligeElMismoLoteEnElCheckoutYEnElRemito()
+    {
+        var ctx = await PrepararAsync(nameof(LaParidadFefoEligeElMismoLoteEnElCheckoutYEnElRemito), conTurnoAbierto: true, conLotesHabilitado: true);
+
+        var idArticuloVenta = await SembrarArticuloAsync(ctx, "Fefo Venta", 10m, controlaLote: true);
+        var idLoteViejoVenta = await SembrarLoteAsync(ctx, idArticuloVenta, "V-VIEJO", new DateOnly(2099, 1, 1), 5m);
+        await SembrarLoteAsync(ctx, idArticuloVenta, "V-NUEVO", new DateOnly(2099, 6, 1), 5m);
+
+        var idArticuloRemito = await SembrarArticuloAsync(ctx, "Fefo Remito", 10m, controlaLote: true);
+        var idLoteViejoRemito = await SembrarLoteAsync(ctx, idArticuloRemito, "R-VIEJO", new DateOnly(2099, 1, 1), 5m);
+        await SembrarLoteAsync(ctx, idArticuloRemito, "R-NUEVO", new DateOnly(2099, 6, 1), 5m);
+
+        var venta = await EmitirVentaAsync(ctx, SolicitudDeVentaSimple(ctx, idArticuloVenta, 1m, null));
+        var idLoteElegidoPorVenta = venta.Items.Single().IdLote;
+        Assert.Equal(idLoteViejoVenta, idLoteElegidoPorVenta);
+
+        var remito = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticuloRemito, 1m));
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{remito.Id}/emitir", null);
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<RemitoDetalle>(OpcionesJson))!;
+
+        Assert.Equal(idLoteViejoRemito, emitido.Items.Single().IdLote);
+    }
+
+    // ---- task 5.15: consistencia de nueve motivos ---------------------------------------------------
+
+    [Fact]
+    public async Task LaConsistenciaDeNueveMotivosSeMantieneTrasEmitirYAnularUnRemito()
+    {
+        var ctx = await PrepararAsync(nameof(LaConsistenciaDeNueveMotivosSeMantieneTrasEmitirYAnularUnRemito));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Nueve Motivos", 15m);
+
+        // Baseline vía un movimiento real (motivo = ajuste), NUNCA un `Stock.Add` desconectado del
+        // ledger — la invariante `stock.cantidad == SUM(movimientos_stock.cantidad)` (stock/
+        // spec.md:166-171, restated over los NUEVE motivos) solo es honesta si el punto de partida
+        // TAMBIÉN es un movimiento, o el propio baseline la rompería por construcción.
+        await using (var dbSeed = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            dbSeed.Stock.Add(new Stock { IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = 30m });
+            dbSeed.MovimientosStock.Add(new MovimientoStock
+            {
+                IdTenant = ctx.IdTenant, IdArticulo = idArticulo, IdPuntoVenta = ctx.IdPuntoVenta, Cantidad = 30m,
+                Motivo = MotivoStock.Ajuste, IdEmpleado = ctx.IdUsuarioAdmin, CreadoEl = DateTimeOffset.UtcNow
+            });
+            await dbSeed.SaveChangesAsync();
+        }
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 6m));
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/anular", null)).StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stock = await db.Stock.SingleAsync(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta);
+        var sumaMovimientos = await db.MovimientosStock
+            .Where(m => m.IdArticulo == idArticulo && m.IdPuntoVenta == ctx.IdPuntoVenta)
+            .SumAsync(m => m.Cantidad);
+
+        Assert.Equal(sumaMovimientos, stock.Cantidad);
+        Assert.Equal(30m, stock.Cantidad);
+    }
+
+    // ---- task 5.21: GATE GUARD ----------------------------------------------------------------------
+
+    /// <summary>Gate guard (task 5.21): esta slice no agrega DDL — el modelo EF sigue coincidiendo
+    /// exactamente con la migración de Slice 4 (RemitosEtapa17).</summary>
+    [Fact]
+    public async Task NoHayCambiosPendientesDeModeloRespectoDeLaMigracionDeLaSlice4()
+    {
+        using var _ = fixture.CreateClient();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var hayPendientes = db.Database.HasPendingModelChanges();
+        Assert.False(hayPendientes);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -443,6 +443,42 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(idLoteViejo, itemPersistido.IdLote);
     }
 
+    // ---- judgment-day Slice 5, ronda 2, juez A — WARNING: el spec (scenario "A remito line
+    // honours a supplied idLote over the FEFO pick") no tenía test discriminante: todo fixture con
+    // idLote explícito sembraba un solo lote por artículo, así que un resolver que IGNORARA el pick
+    // explícito y corriera FEFO igual pasaba en verde (regla 14 — si hay fechas en juego, discriminan).
+    [Fact]
+    public async Task EmitirConIdLoteExplicitoHonraElPickSobreElFefo()
+    {
+        var ctx = await PrepararAsync(nameof(EmitirConIdLoteExplicitoHonraElPickSobreElFefo), conLotesHabilitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Lote Explicito", 60m, controlaLote: true);
+        var idLoteViejo = await SembrarLoteAsync(ctx, idArticulo, "L-VIEJO-EXP", new DateOnly(2099, 1, 1), 5m);
+        var idLoteNuevo = await SembrarLoteAsync(ctx, idArticulo, "L-NUEVO-EXP", new DateOnly(2099, 6, 1), 5m);
+
+        // El pick EXPLÍCITO manda el lote que vence DESPUÉS — si el resolver ignorara item.IdLote y
+        // corriera FEFO igual, elegiría idLoteViejo (vence antes).
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 2m, idLoteNuevo));
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+        var emitido = JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+
+        Assert.Equal(idLoteNuevo, emitido.Items.Single().IdLote);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var itemPersistido = await db.ItemsRemito.SingleAsync(i => i.IdRemito == creado.Id);
+        Assert.Equal(idLoteNuevo, itemPersistido.IdLote);
+
+        var movimiento = await db.MovimientosStock.SingleAsync(m => m.IdRemito == creado.Id);
+        Assert.Equal(idLoteNuevo, movimiento.IdLote);
+
+        var stockLoteNuevo = await db.StockLotes.SingleAsync(s => s.IdLote == idLoteNuevo);
+        Assert.Equal(3m, stockLoteNuevo.Cantidad);
+        var stockLoteViejo = await db.StockLotes.SingleAsync(s => s.IdLote == idLoteViejo);
+        Assert.Equal(5m, stockLoteViejo.Cantidad);
+    }
+
     [Fact]
     public async Task EmitirUnRemitoVacioEsRechazado400()
     {
@@ -670,6 +706,44 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
 
         await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
         Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id && m.Motivo == MotivoStock.Anulacion));
+    }
+
+    // ---- judgment-day Slice 5, ronda 2, juez A — WARNING: el guard ensanchado `estado IN
+    // ('borrador','emitido')` (desviación 5.9) nunca se ejercitaba para BORRADOR vía HTTP — un
+    // borrador nunca movió stock, así que anularlo no debe escribir ningún movimiento (ledger exacto
+    // antes/después, regla 12c: un hermano emitido con su propio movimiento debe quedar intacto).
+    [Fact]
+    public async Task AnularUnRemitoBorradorLoAnulaSinEscribirMovimientosYSinTocarUnHermanoEmitido()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnRemitoBorradorLoAnulaSinEscribirMovimientosYSinTocarUnHermanoEmitido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Anular Borrador", 45m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 20m);
+
+        // Hermano EMITIDO — sí movió stock, y tiene que quedar intacto.
+        var hermano = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 3m));
+        Assert.Equal(HttpStatusCode.OK, (await ctx.Admin.PostAsync($"/api/remitos/{hermano.Id}/emitir", null)).StatusCode);
+
+        var borrador = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 2m));
+        Assert.Equal(EstadoRemito.Borrador, borrador.Estado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientosAntes = await db.MovimientosStock.CountAsync();
+        var movimientoHermanoAntes = await db.MovimientosStock.SingleAsync(m => m.IdRemito == hermano.Id);
+
+        var anulado = await ctx.Admin.PostAsync($"/api/remitos/{borrador.Id}/anular", null);
+        var cuerpo = await anulado.Content.ReadAsStringAsync();
+        Assert.True(anulado.StatusCode == HttpStatusCode.OK, cuerpo);
+        var detalle = JsonSerializer.Deserialize<RemitoDetalle>(cuerpo, OpcionesJson)!;
+        Assert.Equal(EstadoRemito.Anulado, detalle.Estado);
+
+        await using var dbDespues = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientosDespues = await dbDespues.MovimientosStock.CountAsync();
+        Assert.Equal(movimientosAntes, movimientosDespues);
+        Assert.Equal(0, await dbDespues.MovimientosStock.CountAsync(m => m.IdRemito == borrador.Id));
+
+        var movimientoHermanoDespues = await dbDespues.MovimientosStock.SingleAsync(m => m.IdRemito == hermano.Id);
+        Assert.Equal(movimientoHermanoAntes.Cantidad, movimientoHermanoDespues.Cantidad);
+        Assert.Equal(movimientoHermanoAntes.Motivo, movimientoHermanoDespues.Motivo);
     }
 
     [Fact]

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -492,6 +492,64 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id));
     }
 
+    /// <summary>judgment-day Slice 5, ronda 1, juez B — MAJOR: el conjunto `estado='borrador'` del
+    /// UPDATE guardado de <c>EmitirHeaderAsync</c> (:588) quedaba eclipsado por el pre-check de
+    /// <see cref="ServicioDeRemitos.EmitirAsync"/> (:258) en <c>DobleEmitirEsRechazado409</c> — ese
+    /// test siempre corre secuencial, así que el segundo `emitir` YA rechaza en el pre-check, nunca
+    /// llega al guard. Acá se fuerza la carrera real (mismo patrón que
+    /// <see cref="UnPutQueMuevePuntoDeVentaConcurrenteConEmitirReclasificaA409YElNumeroQuedaEnLaSerieVieja"/>):
+    /// el primer `emitir` pausa justo tras abrir SU transacción — su propio pre-check YA leyó
+    /// `borrador` — mientras un segundo `emitir` corre completo y transiciona el remito a
+    /// `emitido`. Al reanudar, el primero llega al UPDATE guardado con un pre-check que dio verde
+    /// pero un estado real ya cambiado: solo el conjunto `estado='borrador'::estado_remito` del
+    /// propio UPDATE (no el pre-check, que ya pasó) puede rechazarlo con 0 filas → 409. Sin ese
+    /// conjunto, el UPDATE matchearía igual y el remito se emitiría dos veces.</summary>
+    [Fact]
+    public async Task DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck()
+    {
+        var ctx = await PrepararAsync(nameof(DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Doble Emitir Concurrente", 45m);
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clientePrimerEmitir = factory.CreateClient();
+        var login = await clientePrimerEmitir.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var tareaPrimerEmitir = clientePrimerEmitir.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+
+        await transaccionIniciada.Task;
+
+        // El segundo `emitir` corre COMPLETO por fuera del interceptor — su propio pre-check
+        // todavía lee `borrador` (el primero nunca escribió nada), pasa, transiciona y commitea.
+        var segundo = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        var cuerpoSegundo = await segundo.Content.ReadAsStringAsync();
+        Assert.True(segundo.StatusCode == HttpStatusCode.OK, cuerpoSegundo);
+
+        puedeContinuar.TrySetResult();
+
+        var primero = await tareaPrimerEmitir;
+        var cuerpoPrimero = await primero.Content.ReadAsStringAsync();
+        Assert.True(primero.StatusCode == HttpStatusCode.Conflict, cuerpoPrimero);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoPrimero, OpcionesJson);
+        Assert.Equal("remito_ya_emitido", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var actual = await db.Remitos.FirstAsync(r => r.Id == creado.Id);
+        Assert.Equal(EstadoRemito.Emitido, actual.Estado);
+        // El perdedor de la carrera (el primero, pausado) nunca escribió movimiento alguno: su
+        // transacción nunca commiteó — solo el ganador (segundo) dejó rastro en el ledger.
+        Assert.Equal(1, await db.MovimientosStock.CountAsync(m => m.IdRemito == creado.Id));
+    }
+
     // ---- mutation target 44 (mitad id_punto_venta): la carrera del relink de PV --------------------
 
     private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
@@ -733,6 +791,198 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         Assert.Equal(2, await db.MovimientosStock.CountAsync(m => m.IdLote == idLote && m.Motivo == MotivoStock.Remito));
     }
 
+    /// <summary>judgment-day Slice 5, ronda 1, juez B — MAJOR (mutation target 40): los dos
+    /// rendezvous de arriba tocan UN SOLO articulo — con un único recurso, ninguna inversión de
+    /// orden de locks es OBSERVABLE entre concurrentes (sin ciclo alcanzable), así que nunca
+    /// ejercitaron el <c>OrderBy(x => x.Item.IdArticulo)</c> de <c>EjecutarEmisionAsync</c>
+    /// (:434-436). <c>movimientos_stock</c> nunca se actualiza, solo se INSERTA — su <c>Id</c>
+    /// autoincremental es un testigo directo y determinístico del orden de escritura real, sin
+    /// necesitar concurrencia (mismo técnica que
+    /// <c>VentaEscrituraLoteTests.LosMovimientosDeDosLotesDelMismoArticuloSeEscribenEnOrdenAscendentePorIdLote</c>).
+    /// Las líneas se envían en la solicitud en orden DESCENDENTE (articulo mayor primero) para que
+    /// un sort estable que preservara el orden de arribo (en vez de reordenar) no enmascare el
+    /// mutante.</summary>
+    [Fact]
+    public async Task LosMovimientosDeDosArticulosSeEscribenEnOrdenAscendentePorIdArticulo()
+    {
+        var ctx = await PrepararAsync(nameof(LosMovimientosDeDosArticulosSeEscribenEnOrdenAscendentePorIdArticulo));
+        var idArticuloMenor = await SembrarArticuloAsync(ctx, "Rem Orden Articulo Menor", 10m);
+        var idArticuloMayor = await SembrarArticuloAsync(ctx, "Rem Orden Articulo Mayor", 10m);
+        Assert.True(idArticuloMenor < idArticuloMayor);
+
+        var solicitud = new SolicitudDeRemito(
+            ctx.IdPuntoVenta, ctx.IdCliente, null, null,
+            [new LineaDeRemito(idArticuloMayor, 3m, null), new LineaDeRemito(idArticuloMenor, 5m, null)]);
+        var creado = await CrearBorradorAsync(ctx.Admin, solicitud);
+
+        var respuesta = await ctx.Admin.PostAsync($"/api/remitos/{creado.Id}/emitir", null);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.OK, cuerpo);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientos = await db.MovimientosStock
+            .Where(m => m.IdRemito == creado.Id)
+            .OrderBy(m => m.Id)
+            .ToListAsync();
+
+        Assert.Equal(2, movimientos.Count);
+        Assert.Equal(idArticuloMenor, movimientos[0].IdArticulo);
+        Assert.Equal(idArticuloMayor, movimientos[1].IdArticulo);
+    }
+
+    private sealed class ContextoFijo(int idTenant, int usuarioId) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "actor-de-prueba";
+        public RolConocido Rol => RolConocido.Admin;
+        public int? IdTenant { get; } = idTenant;
+    }
+
+    /// <summary>Igual técnica que <c>VentaEscrituraLoteTests.EmitirObservandoOrdenDeLocksAsync</c>
+    /// (doc-comment ahí: los statements crudos de <c>ServicioDeRemitos</c> NUNCA pasan por el
+    /// pipeline de <c>DbCommandInterceptor</c> de EF Core, así que la prueba de orden observa el
+    /// ESTADO DE LOCKS real en <c>pg_locks</c> desde una conexión separada — instancia
+    /// <see cref="ServicioDeRemitos"/> directo (bypass HTTP) para tener el PID de backend dedicado
+    /// que necesita el poll.</summary>
+    private async Task<(RemitoDetalle Emitido, bool StockYaBloqueadoMientrasEsperaStockLotes)> EmitirRemitoObservandoOrdenDeLocksAsync(
+        Contexto ctx, int idRemito, int idArticulo, int idLote, CancellationToken ct = default)
+    {
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<Ways.Domain.Gastos.CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<Ways.Domain.Compras.EstadoCompra>("estado_compra");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
+                npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
+                npgsql.MapEnum<Ways.Domain.Ventas.EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        await db.Database.OpenConnectionAsync(ct);
+        var conexionRemito = (NpgsqlConnection)db.Database.GetDbConnection();
+        var pidRemito = (int)(await new NpgsqlCommand("SELECT pg_backend_pid()", conexionRemito).ExecuteScalarAsync(ct))!;
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, ctx.IdUsuarioAdmin);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new Ways.Application.Ofertas.ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeRemitos = new ServicioDeRemitos(db, reloj, contexto, servicioDeOfertas, servicioDeLotes);
+
+        // Conexión que SOSTIENE el lock de stock_lotes — deliberadamente sin comitear todavía, para
+        // forzar al remito a bloquearse justo ahí. RLS exige el mismo GUC que
+        // InterceptorDeContextoDeTenant setea sobre cada conexión física.
+        await using var conexionBloqueo = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionBloqueo.OpenAsync(ct);
+        await using (var comandoGuc = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
+            conexionBloqueo))
+        {
+            comandoGuc.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGuc.ExecuteNonQueryAsync(ct);
+        }
+
+        await using var transaccionBloqueo = await conexionBloqueo.BeginTransactionAsync(ct);
+        await using (var comandoBloqueo = new NpgsqlCommand(
+            "SELECT cantidad FROM stock_lotes WHERE id_articulo = $1 AND id_punto_venta = $2 AND id_lote = $3 FOR UPDATE",
+            conexionBloqueo, transaccionBloqueo))
+        {
+            comandoBloqueo.Parameters.AddWithValue(idArticulo);
+            comandoBloqueo.Parameters.AddWithValue(ctx.IdPuntoVenta);
+            comandoBloqueo.Parameters.AddWithValue(idLote);
+            await comandoBloqueo.ExecuteScalarAsync(ct);
+        }
+
+        var remitoTask = servicioDeRemitos.EmitirAsync(idRemito, ct);
+
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync(ct);
+
+        var observado = false;
+        var limite = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < limite)
+        {
+            await using var comandoPoll = new NpgsqlCommand(
+                "SELECT " +
+                "  bool_or(l.locktype = 'relation' AND l.relation::regclass::text = 'stock' AND l.granted) AS stock_otorgado, " +
+                "  bool_or(NOT l.granted) AS esperando_algo " +
+                "FROM pg_locks l WHERE l.pid = $1",
+                conexionPoll);
+            comandoPoll.Parameters.AddWithValue(pidRemito);
+
+            await using var lector = await comandoPoll.ExecuteReaderAsync(ct);
+            if (await lector.ReadAsync(ct))
+            {
+                var stockOtorgado = !lector.IsDBNull(0) && lector.GetBoolean(0);
+                var esperandoAlgo = !lector.IsDBNull(1) && lector.GetBoolean(1);
+                if (stockOtorgado && esperandoAlgo)
+                {
+                    observado = true;
+                    break;
+                }
+            }
+
+            await Task.Delay(25, ct);
+        }
+
+        // Libera el lock retenido — el remito, hasta acá bloqueado, ahora puede completar.
+        await transaccionBloqueo.RollbackAsync(ct);
+
+        var emitido = await remitoTask;
+
+        return (emitido, observado);
+    }
+
+    /// <summary>judgment-day Slice 5, ronda 1, juez B — MAJOR (mutation target 41): idem target 40
+    /// — sin un segundo recurso ni concurrencia real, invertir <c>UpsertStockLoteAsync</c>/
+    /// <c>UpsertStockAsync</c> (:451-461) nunca era observable. <c>stock</c> es el único statement
+    /// que toma el row lock que reemplaza al advisory lock (design decisión 8) — <c>stock_lotes</c>
+    /// tiene que seguirlo SIEMPRE, nunca precederlo, mismo criterio que
+    /// <c>VentaEscrituraLoteTests.UnCheckoutBloqueaStockAntesQueStockLotesParaElMismoPar</c>.</summary>
+    [Fact]
+    public async Task UnRemitoBloqueaStockAntesQueStockLotesParaElMismoPar()
+    {
+        var ctx = await PrepararAsync(
+            nameof(UnRemitoBloqueaStockAntesQueStockLotesParaElMismoPar), conLotesHabilitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Rem Orden Lock Stock", 40m, controlaLote: true);
+        var idLote = await SembrarLoteAsync(ctx, idArticulo, "L-LOCK-ORDER", new DateOnly(2099, 1, 1), 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var creado = await CrearBorradorAsync(ctx.Admin, SolicitudSimple(ctx, idArticulo, 1m, idLote));
+
+        var (emitido, observado) = await EmitirRemitoObservandoOrdenDeLocksAsync(ctx, creado.Id, idArticulo, idLote);
+
+        Assert.True(
+            observado,
+            "Nunca se observó al remito con el lock de stock ya otorgado mientras esperaba stock_lotes.");
+        Assert.Single(emitido.Items);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var stock = await db.Stock
+            .Where(s => s.IdArticulo == idArticulo && s.IdPuntoVenta == ctx.IdPuntoVenta)
+            .Select(s => s.Cantidad).FirstAsync();
+        Assert.Equal(9m, stock);
+    }
+
     // ---- task 5.14: paridad FEFO entre write site 1 (checkout) y write site 4 (remito) -------------
 
     [Fact]
@@ -758,6 +1008,62 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         var emitido = (await respuesta.Content.ReadFromJsonAsync<RemitoDetalle>(OpcionesJson))!;
 
         Assert.Equal(idLoteViejoRemito, emitido.Items.Single().IdLote);
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>judgment-day Slice 5, ronda 1, juez B — MAJOR: la paridad FEFO del test anterior
+    /// solo compara lotes con vencimientos lejos de cualquier borde (2099-01-01 vs. 2099-06-01) —
+    /// nunca ejercita el borde exacto de la derivación de `hoy` (mutation target 47,
+    /// <c>ServicioDeRemitos.cs:358</c>). Acá un lote vence EXACTAMENTE `hoy` (UTC, vía
+    /// <see cref="RelojFijo"/> — elegible hoy, <see cref="ReglaDeLotes.EstaVencido"/> lo excluiría
+    /// recién MAÑANA) contra otro que vence muy después: con `hoy` correcto, el lote de hoy gana
+    /// FEFO por vencimiento más próximo (ninguno vencido, la partición "no vencidos" contiene a
+    /// ambos); con `hoy` mutado a mañana (`AddDays(1)`), el lote de hoy pasa a `EstaVencido` y
+    /// queda excluido de esa partición, cambiando el lote elegido — extiende la paridad de la task
+    /// 5.14 al remito Y al checkout sobre el mismo borde.</summary>
+    [Fact]
+    public async Task LaParidadFefoEligeElLoteQueVenceHoyEnElBordeExactoEnElRemitoYEnElCheckout()
+    {
+        var ctx = await PrepararAsync(
+            nameof(LaParidadFefoEligeElLoteQueVenceHoyEnElBordeExactoEnElRemitoYEnElCheckout),
+            conTurnoAbierto: true, conLotesHabilitado: true);
+
+        var instanteFijo = new DateTimeOffset(2030, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var hoyFijo = DateOnly.FromDateTime(instanteFijo.UtcDateTime);
+
+        var idArticuloRemito = await SembrarArticuloAsync(ctx, "Fefo Borde Remito", 10m, controlaLote: true);
+        var idLoteHoyRemito = await SembrarLoteAsync(ctx, idArticuloRemito, "R-BORDE-HOY", hoyFijo, 5m);
+        await SembrarLoteAsync(ctx, idArticuloRemito, "R-BORDE-FUTURO", hoyFijo.AddMonths(1), 5m);
+
+        var idArticuloVenta = await SembrarArticuloAsync(ctx, "Fefo Borde Venta", 10m, controlaLote: true);
+        var idLoteHoyVenta = await SembrarLoteAsync(ctx, idArticuloVenta, "V-BORDE-HOY", hoyFijo, 5m);
+        await SembrarLoteAsync(ctx, idArticuloVenta, "V-BORDE-FUTURO", hoyFijo.AddMonths(1), 5m);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<IRelojDelSistema>(new RelojFijo(instanteFijo))));
+
+        using var cliente = factory.CreateClient();
+        var login = await cliente.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var remito = await CrearBorradorAsync(cliente, SolicitudSimple(ctx, idArticuloRemito, 1m));
+        var respuestaEmitir = await cliente.PostAsync($"/api/remitos/{remito.Id}/emitir", null);
+        var cuerpoEmitir = await respuestaEmitir.Content.ReadAsStringAsync();
+        Assert.True(respuestaEmitir.StatusCode == HttpStatusCode.OK, cuerpoEmitir);
+        var emitido = JsonSerializer.Deserialize<RemitoDetalle>(cuerpoEmitir, OpcionesJson)!;
+        Assert.Equal(idLoteHoyRemito, emitido.Items.Single().IdLote);
+
+        var respuestaVenta = await cliente.PostAsJsonAsync(
+            "/api/ventas", SolicitudDeVentaSimple(ctx, idArticuloVenta, 1m, null));
+        var cuerpoVenta = await respuestaVenta.Content.ReadAsStringAsync();
+        Assert.True(respuestaVenta.StatusCode == HttpStatusCode.Created, cuerpoVenta);
+        var ventaEmitida = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoVenta, OpcionesJson)!;
+        Assert.Equal(idLoteHoyVenta, ventaEmitida.Items.Single().IdLote);
     }
 
     // ---- task 5.15: consistencia de nueve motivos ---------------------------------------------------

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -93,6 +93,13 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         ("PUT", "/api/presupuestos/{id:int}"),
         ("POST", "/api/presupuestos/{id:int}/enviar"),
         ("POST", "/api/presupuestos/{id:int}/anular"),
+        // stage-17-presupuestos-y-remitos (Slice 5, design decisión 17/proposal decisión 10):
+        // /api/remitos agrupa SOLO bajo OperacionDePos, mismo criterio que /api/presupuestos —
+        // un Vendedor tiene que poder despachar un remito.
+        ("POST", "/api/remitos/"),
+        ("PUT", "/api/remitos/{id:int}"),
+        ("POST", "/api/remitos/{id:int}/emitir"),
+        ("POST", "/api/remitos/{id:int}/anular"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -209,7 +209,16 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         // trap, ver ProveedoresEndpoints.cs). El prefijo también alcanza GET /api/proveedores
         // (listado) y GET /api/proveedores/{id} (detalle), que siguen bajo GestionDeCatalogo —
         // ambas ya cubiertas por PoliticasAlMenosTanEstrictasComoOperacionDePos de abajo.
-        "/api/proveedores"
+        "/api/proveedores",
+        // judgment-day Slice 5, ronda 2, juez A — WARNING: omisión preexistente del Slice 2 que
+        // este hallazgo destapó. stage-17-presupuestos-y-remitos (Slice 2, task 2.x): GET
+        // /api/presupuestos (listado) y GET /api/presupuestos/{id}/{para-venta} — el grupo agrupa
+        // SOLO bajo OperacionDePos (mismo criterio que "/api/stock"/"/api/gastos"), pero nunca se
+        // había agregado a este segundo guard.
+        "/api/presupuestos",
+        // stage-17-presupuestos-y-remitos (Slice 5, design decisión 17/proposal decisión 10): GET
+        // /api/remitos (listado) y GET /api/remitos/{id} — mismo criterio que "/api/presupuestos".
+        "/api/remitos"
     ];
 
     // Policies que, de aparecer en vez de OperacionDePos, siguen siendo un gate válido —


### PR DESCRIPTION
## Resumen

Slice 5 de la etapa 17: el remito emite, resuelve FEFO, mueve stock por un CUARTO write site implementado independiente, y revierte limpio en la anulación.

- `ContratosDeRemito.cs` + `ServicioDeRemitos.cs`: borrador CRUD con replace-set bajo `FOR UPDATE`, `EmitirAsync` con numeración propia serie `REM` fuera de la transacción, FEFO resuelto pre-tx con `hoy` UTC-naive (paridad con el checkout), freeze de `id_lote`/`costo_unitario`/`costo_es_estimado`.
- **El cuarto write site de stock**: statements crudos propios con lock order ascendente DUPLICADO INTENCIONAL (decisión de diseño — la garantía enmendada del spec de stock), sin compartir código con `ServicioDeVentas`.
- `AnularAsync`: `borrador`/`emitido` → `anulado` (guard ensanchado al texto vinculante del spec), `facturado` → 409, `ya_anulado` → 409 (OD8/T2), reversa desde los movimientos ORIGINALES del ledger.
- Endpoints + DI + allowlist de autorización; read model con reglas 12b/12c.
- Gate guard: CERO migraciones nuevas (`has-pending-model-changes` limpio).

## Judgment-day (2 rondas, limpia al cierre)

- **Ronda 1 — juez B (mutador) REJECT**: 4 MAJOR confirmados por mutación real — targets 40/41 (orden de locks invisible a rendezvous mono-recurso), 47 (borde FEFO sin fixture) y el conjunct `estado` de emitir eclipsado por su pre-check (2da ocurrencia de la clase del slice 3). Fixes `8bc1e1f`: doble-emitir concurrente vía interceptor, redes ESTRUCTURALES de orden (ledger por Id + polling de `pg_locks`, paridad de estándar con `VentaEscrituraLoteTests` — el 40P01 vivo no es forzable sobre raw ADO, registrado honesto), borde FEFO con lote que vence HOY bajo reloj pineado. **Re-ronda acotada de B: APPROVE** (4/4 mutantes re-corridos, RED).
- **Juez A (read-only) APPROVE**: 3 WARNINGs test-only. Fixes `62d3957`: idLote explícito le gana al FEFO (dos lotes discriminantes), anular borrador sin escrituras (con hermano intacto), prefijos `/api/remitos` + `/api/presupuestos` (omisión preexistente del slice 2) en el guard de regresión de autorización.
- La skill `mutation-proof-tests` creció a **v1.1** (regla 3 reforzada: enumeración de conjuncts; regla 13: garantías de orden por redes estructurales; regla 14: fixtures en el borde de fecha) — commiteada aparte en main.

## Suites

- Apply: foco 20/20; no-regresión dirigida 166/166; full Integration 1554/1554 contabilizados (una falla aislada = flakiness Testcontainers documentada, regla 17).
- Post-fixes: `ServicioDeRemitosTests` + `SuperficieDeAutorizacionTests` 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)