### PR TITLE
feat(remitos): consolidacion TXR — N remitos en un comprobante sin items (etapa 17, slice 6)

### DIFF
--- a/openspec/changes/stage-17-presupuestos-y-remitos/state.yaml
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/state.yaml
@@ -174,6 +174,20 @@ phases:
     status: pending
     artifact: tasks.md + PRs
     depends_on: [tasks]
+    notes: >
+      ORCHESTRATOR DECISION 10 (judgment slice 6, juez A — WARNING de
+      contrato): el delta spec de comprobantes-venta exige que el
+      detalle del TXR se lea de items_remito ("shows all 5 lines,
+      sourced from items_remito") y el design T11 lo AFIRMA ("the
+      printed detail joins the remitos" — lo deferido por el proposal
+      es imprimir/emailear, NO el detalle de lectura), pero NINGUNA
+      tarea lo implementaba: requirement sin task, gap de planning.
+      RESUELTO: tarea nueva 8.10b en el slice 8 (join de items_remito
+      en el read model del comprobante TXR + test), junto con los dos
+      SUGGESTIONs del mismo veredicto (N=1 nombrado como borde
+      deliberado; anulacion de TXR con turno cerrado probada
+      independientemente). El presupuesto de 2 rondas de fix del
+      slice 6 ya estaba agotado — por eso via slice 8, no via fix.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1729,9 +1729,18 @@ reverts to pre-stage.
   `RETURNING` widening + the one guarded call at position 1.6) — no other line changed. Focused
   filter `VentasCheckoutTests|VentasAnulacionTests|VentasAtomicidadYConcurrenciaTests|SuperficieDeAutorizacionTests|RemitosSchemaTests|ServicioDeRemitosTests|ServicioDeFacturacionDeRemitosTests`
   — 110/110 green. See Work Unit Evidence for the full-suite runs.
-- [ ] 6.25 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
-  by this apply batch**: `sdd-apply` never launches Judgment Day (the parent orchestrator runs
-  it after apply, per the executor boundary in `skills/sdd-apply/SKILL.md`).
+- [x] 6.25 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **DONE by
+  the orchestrator**: juez B REJECT (2 MAJOR: `DesligarAsync` sin red de hermanos intactos —
+  cross-contaminación entre TXRs invisible 15/15 — y el target 48 cerrado por texto-fuente sin
+  intentar la red `pg_locks` liviana) → ronda 1 `41b18fe` (los 3 fixes; el probe liviano SÍ
+  funciona: el "ruido" original era un filtro por `relation` cuando la espera aparece como
+  `locktype='transactionid'`) → re-ronda B ESCALATED (el probe se colgaba bajo el mutante DESC)
+  → ronda 2 `8982be9` (cota total: try/finally + `Task.WhenAny` 10s; RED limpio 3/3 con 55P03)
+  → confirmación B APPROVE. Juez A APPROVE: 1 WARNING de contrato (detalle del TXR desde
+  `items_remito` — requirement sin task) resuelto como **OD10** → tarea nueva 8.10b, junto con
+  sus 2 SUGGESTIONs (N=1 nombrado, anulación TXR con turno cerrado); target 54 → backlog
+  (clase preexistente, el checkout tampoco la tiene). Presupuesto de 2 rondas de fix agotado
+  exactamente — por eso el WARNING va por slice 8 y no por fix.
 - [ ] 6.26 Open PR #6 `feat/stage17-slice6-consolidacion`, merge after a clean round. — **NOT
   run by this apply batch**, same reason; pending the orchestrator's clean `judgment-day` round
   on this diff.
@@ -1949,6 +1958,14 @@ serves the shape.
 - [ ] 8.8 Multi-select reducer test.
 - [ ] 8.9 Disabled-action matrix by `estado` (`borrador`/`emitido`/`facturado`/`anulado`).
 - [ ] 8.10 Test: double click on `emitir`/`anular`/`facturar` issues exactly one POST each.
+- [ ] 8.10b **[OD10, judgment slice 6 juez A]** The TXR read model sources its detail from
+  `items_remito`: `GET /api/ventas/{id}` (or the shape the web consumes for a TXR) joins the
+  linked remitos' frozen lines instead of returning `items: []` — the spec scenario
+  (comprobantes-venta: *"shows all 5 lines, sourced from items_remito, not from
+  items_comprobante_venta"*) and design T11 both mandate it; no prior task implemented it.
+  Ships with: the API test of the spec scenario, an N=1 consolidation test NAMED as the
+  deliberate boundary, and a TXR-annulment-with-closed-turno test (the two SUGGESTIONs of the
+  same verdict). Mutation evidence per mutation-proof-tests v1.1.
 - [ ] 8.11 **STAGE CLOSE** — full solution test suite run once end-to-end
   (`dotnet test`, no filter) — confirms non-regression across the whole tree.
 - [ ] 8.12 **STAGE CLOSE** — full web suite end-to-end (`npx vitest run`, no filter),

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1794,6 +1794,74 @@ this guard.
 | Mutation evidence (apply-time, all real, applied then reverted) | **Target 50** (`LigarAsync`'s `estado`/`id_comprobante_venta` conjuncts + rowcount): dropped both from the `WHERE` → `FacturarXFacturarSobreSetsSuperpuestosDaExactamenteUn201YUn409` RED (both sides showed 201) → reverted, green. **Target 48** (ascending `ORDER BY`): `id_remito` → `id_remito DESC` → `ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente` RED → reverted, green (see FINDING above for why the rendezvous test alone doesn't discriminate this). **Target 49** (lock position): moved after the CC loop → `ServicioDeFacturacionDeRemitosPosicionDeLockTests` RED → reverted, green (see FINDING above). **Target 51** (agreement guard, all four conjuncts at once): `todosFacturables = true` → cliente/PV tests RED, already-facturado test SURVIVED (documented finding above) → reverted, green. **Target 52** (itemless + no stock loop): inserted one raw `movimientos_stock` row before commit → `DosRemitosConsolidanEnUnTxrItemlessConTotalIgualALaSumaDeLosHeadersYCeroMovimientosDeStock`, `AnularUnTxrDevuelveSusRemitosAEmitidoLimpiaLaLigaduraYNoEscribeMovimientosDeStock`, `LaAnulacionDeUnTxrConCuentaCorrienteOriginalRevierteAmbasMitadesJuntasEnUnaSolaTransaccion` all RED → reverted, green (the itemless half is proven by construction — `Proyectar` hardcodes `[]`, no items-write code exists to mutate). **Target 53** (credit-limit backstop): removed the `if` block → `LimiteDeCreditoExcedidoPorConsolidacionConcurrenteEntrePreChequeoYCommit` RED → reverted, green. **Target 58** (desligue position): moved `EscriturasDeRemito.DesligarAsync`'s guarded call from position 1.6 to after the CC loop in `ServicioDeVentas.cs` → `ServicioDeVentasPosicionDeDesligueTests.ElDesligueDeRemitosVaInmediatamenteDespuesDeMarcarAnuladoYAntesDeLaAuditoria` RED → reverted, green. **Target 57**: proven directly by task 6.22's own real-remito raw-`UPDATE` test (no separate apply-time mutation needed — the test IS the mutation). **Target 54** (in-tx turno re-check): not independently race-tested this batch — see the FINDING under task 6.18 (same accepted boundary as the identical pattern elsewhere in this codebase). **Targets 55/56**: verified via source-text tests only (`ServicioDeVentasPosicionDeDesligueTests`), consistent with target 34's own precedent that `ContadorDeComandos` cannot see raw-ADO statements. |
 | Rollback boundary | `git revert` of this slice's commit(s) alone: `EscriturasDeRemito.cs`/`ServicioDeFacturacionDeRemitos.cs`/`ServicioDeFacturacionDeRemitosTests.cs`/the two positional test files deleted; the `MapPost("/facturacion", ...)` line and `AddScoped<ServicioDeFacturacionDeRemitos>()` line and the one allowlist entry revert; `ServicioDeVentas.cs`'s `MarcarAnuladoAsync` `RETURNING` widening and the one guarded call at position 1.6 revert cleanly (both isolated to that one file, no schema touched, no other slice's file touched) |
 
+**judgment-day Slice 6, ronda 1 — juez B (2 MAJOR + 1 SUGGESTION fixed; WARNING target 54 →
+backlog, clase preexistente).** Los tres fixes son TEST-ONLY (`ServicioDeFacturacionDeRemitosTests.cs`
+únicamente — cero cambio de producción salvo mutar-y-revertir como evidencia):
+
+- **MAJOR — `DesligarAsync` sin red de hermanos intactos (regla 12c, mutation target 57).** Ningún
+  fixture existente tenía DOS TXRs activos a la vez, así que un mutante que borra
+  `id_comprobante_venta = $1` del `WHERE` de `DesligarAsync` sobrevivía 15/15 — "WHERE id_tenant =
+  $2 AND estado = 'facturado'" solo desliga CUALQUIER remito facturado del tenant, no solo los de
+  ESTE TXR. Fijado: `AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrActivo`
+  — factura DOS consolidaciones independientes (TXR-A: remitos 1-2; TXR-B: remitos 3-4, mismo
+  tenant/cliente/PV, medio cuenta corriente en ambos), anula SOLO TXR-A, y prueba exact count AND
+  identity sobre los hermanos de B (siguen `facturado`, siguen ligados a `txrB.Id`, count exacto
+  de 2) más la CC (el saldo baja exactamente el total de A, los movimientos de B — conteo Y
+  ligadura — quedan intactos). EVIDENCIA DE MUTACIÓN: quitado `id_comprobante_venta = $1` del
+  `WHERE` de `DesligarAsync` (`EscriturasDeRemito.cs:114`) → `dotnet build --no-incremental` +
+  filtro `FullyQualifiedName~AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrActivo`
+  → ROJO (`Expected: Facturado / Actual: Emitido` — el mutante desligó también los remitos de B).
+  Revertido (`git checkout --`): VERDE.
+- **MAJOR — target 48, red pg_locks liviana RETRY (la nota original de arriba solo documentó el
+  intento contra el harness completo, WebApplicationFactory + `AbrirConexionCrudaAsync`; el juez
+  señaló que la variante liviana — `DbContextOptionsBuilder` directo contra
+  `fixture.AppConnectionString`, patrón `ServicioDeRemitosTests.EmitirRemitoObservandoOrdenDeLocksAsync`
+  — nunca se había intentado de verdad).** Intentada honestamente esta vez: SÍ reprodujo, de forma
+  determinística. Fijado: `BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido`
+  — sesión bloqueadora sostiene `FOR UPDATE` sobre el remito MENOR sin comitear; el backend bajo
+  prueba invoca `EscriturasDeRemito.BloquearAscendenteAsync` DIRECTO (sin HTTP) con el array de
+  entrada INVERTIDO (`[mayor, menor]`); confirmado el bloqueo real vía `pg_locks`; una tercera
+  conexión intenta `FOR UPDATE NOWAIT` sobre el MAYOR — bajo la implementación correcta (ASC)
+  todavía no lo tocó (NOWAIT libre); bajo el mutante (DESC) ya lo habría tomado (NOWAIT choca con
+  `55P03`). Diagnóstico real del primer intento del poll (no descartado en silencio): la primera
+  versión filtraba `pg_locks` por `relation = 'remitos'::regclass AND NOT granted` (la receta
+  literal del juez) y NUNCA detectó el bloqueo (timeout de 5s, 0/1 corridas) — causa confirmada, no
+  ruido de timing: el wait real es `locktype = 'transactionid'` (esperando el fin de la
+  transacción bloqueadora), un lock SIN `relation` asociada. Corregido a `pid = $1 AND NOT
+  granted` (sin filtro de relación): 4/4 corridas en verde tras el fix. EVIDENCIA DE MUTACIÓN:
+  `ORDER BY id_remito` → `ORDER BY id_remito DESC` (`EscriturasDeRemito.cs:52`) → `dotnet build
+  --no-incremental` + filtro
+  `FullyQualifiedName~BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido`
+  → ROJO real (`Npgsql.PostgresException: 55P03: could not obtain lock on row in relation
+  "remitos"`, exactamente el probe NOWAIT sobre el mayor chocando — el mutante ya lo había tomado).
+  Revertido: VERDE. La red de texto-fuente existente
+  (`ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente`) se queda igual, son
+  redes complementarias — no se retira ninguna cobertura previa.
+- **SUGGESTION — fidelidad de totales (barata, `ServicioDeFacturacionDeRemitos.cs:100-107`).**
+  Fijado: `FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio` —
+  raw `UPDATE remitos SET total = $1` (sentinel `remito.Total + 999`, nunca 0, nunca el valor
+  original) ANTES de facturar; assertea el contrato EXACTO que el chequeo de fidelidad emite:
+  `InvalidOperationException`, que `ManejadorDeErrores` traduce al catch-all genérico
+  (`500`/`error_interno`, nunca un 409 de negocio) porque el desacuerdo solo puede significar una
+  escritura fuera de banda. EVIDENCIA DE MUTACIÓN: el `if` de fidelidad mutado a `if (false)`
+  (`ServicioDeFacturacionDeRemitos.cs:100`) → `dotnet build --no-incremental` + filtro
+  `FullyQualifiedName~FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio`
+  → ROJO (`Expected: InternalServerError / Actual: BadRequest` — sin el chequeo, cae en
+  `ValidadorDePagos` con un código de rechazo distinto). Revertido: VERDE.
+- **WARNING (target 54, in-tx turno re-check) → NO fixed, backlog explícito.** El juez confirmó
+  que el checkout (`ServicioDeVentas`) tampoco tiene una red de carrera para su propio
+  re-chequeo de turno bajo lock — misma clase preexistente en todo el codebase, no una regresión
+  de esta slice. Queda como backlog: agregar una red de carrera para el re-chequeo de turno
+  bajo `FOR SHARE`/`FOR UPDATE` (aplica tanto a `ServicioDeFacturacionDeRemitos` como a
+  `ServicioDeVentas`), en cualquier slice futura que toque turnos/caja.
+
+Tests dirigidos finales tras la ronda 1: `dotnet test tests/Ways.IntegrationTests --filter
+"FullyQualifiedName~ServicioDeFacturacionDeRemitosTests"` — **18/18 VERDE** (15 preexistentes + 3
+nuevos: `AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrActivo`,
+`BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido`,
+`FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio`). Nunca full
+suite, per regla 15/mutation-proof-tests (reminder post-checkout tras cada revert = ruido benigno).
+
 ---
 
 ## Slice 7: web presupuestos + POS banner (PR 7)

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1559,64 +1559,240 @@ stock movements, including the OD8/T3 discriminant test. **Budget note**: pre-au
 `6a`/`6b` (decision 3 above). **Rollback**: guarded call + service disappear, checkout anulación
 reverts to pre-stage.
 
-- [ ] 6.1 Create `EscriturasDeRemito.cs` — `BloquearAscendenteAsync` (`FOR UPDATE ORDER BY
+- [x] 6.1 Create `EscriturasDeRemito.cs` — `BloquearAscendenteAsync` (`FOR UPDATE ORDER BY
   id_remito`) + `LigarAsync` (guarded N-row `UPDATE`) + `DesligarAsync`. *(design.md:131-149,
   mutation targets 48-50)*
-- [ ] 6.2 Create `ServicioDeFacturacionDeRemitos.cs` — pre-tx: load remitos + items, same
+
+  **DONE.** `BloquearAscendenteAsync` returns the locked rows' `(IdRemito, Estado, IdComprobante)`
+  for the caller's use, but deliberately does **not** re-validate/throw on them itself — see
+  the class doc-comment: doing so would create a guard EQUIVALENT to `LigarAsync`'s under the
+  SAME lock (nothing can change those rows between the SELECT and the UPDATE within one
+  transaction), which would make a mutant that deletes `LigarAsync`'s own guard undetectable by
+  any race test. `LigarAsync`/`DesligarAsync` use `ExecuteNonQueryAsync` (rowcount authority),
+  matching `ServicioDeReliquidacion.MarcarConsumosCubiertosAsync`'s `= ANY($n)` precedent.
+- [x] 6.2 Create `ServicioDeFacturacionDeRemitos.cs` — pre-tx: load remitos + items, same
   tenant/cliente/PV, all `emitido` and unlinked; `totales := Σ headers` asserted against `Σ
   items`; `ValidadorDePagos`; turno-abierto check.
-- [ ] 6.3 Same file: `EstrategiaSinReintento` ⇒ `BEGIN ExigirTurnoAbiertoBajoLockAsync` as
+
+  **DONE**, plus two gap-filling additions (never named by design's Interfaces/Contracts
+  section, same class as prior slices' listado/pagina gaps): `SolicitudDeFacturacionDeRemitos`
+  added to `ContratosDeRemito.cs` (design.md:211-212 specs it but it was never actually
+  declared); domain code `remitos_no_seleccionados` (400) for an empty `IdsRemito` — no task
+  names it, added defensively so `BloquearAscendenteAsync`'s `= ANY(empty array)` can never
+  silently produce a zero-total, zero-item TXR. Endpoint wiring
+  (`POST /api/remitos/facturacion` in `RemitosEndpoints.cs` + `AddScoped<ServicioDeFacturacionDeRemitos>()`
+  in `DependencyInjection.cs`) — **DEVIATION REGISTERED**, no task 6.x names these files
+  individually, same convention `RemitosEndpoints.cs`'s own doc-comment already registered for
+  Slice 5: without them the service is unreachable by HTTP. `SuperficieDeAutorizacionTests.cs`
+  allowlist gained the one new route (same group, `Politicas.OperacionDePos` only).
+
+  The totals-fidelity assertion (Σ headers vs. Σ items recomputed via `CalculadorDeTotales`) is
+  implemented as an `InvalidOperationException` (defense in depth, structurally unreachable
+  under normal operation), not a domain `ErrorDominio` — no task/design names a dedicated test
+  for it (unlike the presupuesto-side `presupuesto_inconsistente` 409 of Slice 3, which Task 3.9
+  explicitly required); registered here as a deliberate scope boundary, not an omission.
+- [x] 6.3 Same file: `EstrategiaSinReintento` ⇒ `BEGIN ExigirTurnoAbiertoBajoLockAsync` as
   statement 0 (decision 13 of the proposal — unlike the plain remito, which requires none).
   *(design.md:313, mutation target 54)*
-- [ ] 6.4 `BloquearAscendenteAsync` **before** the comprobante `INSERT` and before `clientes` —
+- [x] 6.4 `BloquearAscendenteAsync` **before** the comprobante `INSERT` and before `clientes` —
   the `INSERT` is not a lock-order position (T10). *(design.md decision 12, mutation target 49)*
-- [ ] 6.5 Itemless `TXR` comprobante `INSERT` — `RC` precedent, **zero items by construction**.
+- [x] 6.5 Itemless `TXR` comprobante `INSERT` — `RC` precedent, **zero items by construction**.
   *(design.md decision 5, mutation target 52)*
-- [ ] 6.6 Pagos + cuenta corriente via the existing `EscriturasDeCuentaCorriente` (unchanged).
+- [x] 6.6 Pagos + cuenta corriente via the existing `EscriturasDeCuentaCorriente` (unchanged).
   *(design.md:317)*
-- [ ] 6.7 **Credit-limit backstop re-implemented inside the transaction** (parity with
+- [x] 6.7 **Credit-limit backstop re-implemented inside the transaction** (parity with
   `ServicioDeVentas.cs:901-908` — OD9/T9). *(design.md decision 13, mutation target 53)*
-- [ ] 6.8 `LigarAsync` — filas == N or `409 remito_no_facturable` (CONFLICT #4).
+- [x] 6.8 `LigarAsync` — filas == N or `409 remito_no_facturable` (CONFLICT #4).
   *(design.md:318, mutation target 50)*
-- [ ] 6.9 `AsignadorDeNumeroComprobante` reused with `'TXR'`. *(design.md:311)*
-- [ ] 6.10 Widen `MarcarAnuladoAsync`'s `RETURNING` with a scalar subquery — `(SELECT t.codigo
+- [x] 6.9 `AsignadorDeNumeroComprobante` reused with `'TXR'`. *(design.md:311)*
+- [x] 6.10 Widen `MarcarAnuladoAsync`'s `RETURNING` with a scalar subquery — `(SELECT t.codigo
   FROM tipos_comprobante t WHERE t.id_tipo_comprobante = comprobantes_venta.id_tipo_comprobante)
   AS codigo_tipo`. *(design.md decision 7, mutation target 55)*
-- [ ] 6.11 Guarded call at **POSITION 1.6** in `EjecutarAnulacionAsync` — `if (codigoTipo ==
+
+  **DONE.** `MarcarAnuladoAsync`'s return type widened from `int?` to `(int IdPuntoVenta, string
+  CodigoTipo)?`, switched from `ExecuteScalarAsync` to `ExecuteReaderAsync` (two columns now) —
+  same SQL statement, same lock, one extra column via the scalar subquery, never a second
+  `SELECT`.
+- [x] 6.11 Guarded call at **POSITION 1.6** in `EjecutarAnulacionAsync` — `if (codigoTipo ==
   "TXR")` ⇒ `EscriturasDeRemito.DesligarAsync`, never after the CC loop. *(design.md decision
   4/7, mutation targets 56, 58)*
-- [ ] 6.12 `DesligarAsync` — clears `estado` **and** `id_comprobante_venta` **together**
+- [x] 6.12 `DesligarAsync` — clears `estado` **and** `id_comprobante_venta` **together**
   (`ck_remitos_facturacion`). *(design.md:146-148, mutation target 57)*
-- [ ] 6.13 Test: consolidating two remitos emits **one** itemless `TXR`, total == Σ frozen
+- [x] 6.13 Test: consolidating two remitos emits **one** itemless `TXR`, total == Σ frozen
   lines, **zero** `movimientos_stock` rows. *(remitos/spec.md:135-139, mutation target 52)*
-- [ ] 6.14 Test: **facturar × facturar** race over overlapping sets — exactly one 201 + one
+
+  **DONE** — `DosRemitosConsolidanEnUnTxrItemlessConTotalIgualALaSumaDeLosHeadersYCeroMovimientosDeStock`.
+- [x] 6.14 Test: **facturar × facturar** race over overlapping sets — exactly one 201 + one
   409, ascending lock order. *(mutation targets 48, 50; remitos/spec.md:141-145)*
-- [ ] 6.15 Test: **facturar × anular-remito** race, both orders. *(mutation target 49)*
-- [ ] 6.16 Test: mixed-customer / mixed-PV / already-invoiced set refused 409 before any write.
+
+  **DONE** — `FacturarXFacturarSobreSetsSuperpuestosDaExactamenteUn201YUn409` (the race, same
+  `DbTransactionInterceptor`-pause pattern as `ServicioDeRemitosTests`'s own precedent — target
+  50) + `ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente` (source-text, the
+  ASC-order half — target 48; see the FINDING below on why the pause-based rendezvous alone
+  cannot discriminate lock order).
+- [x] 6.15 Test: **facturar × anular-remito** race, both orders. *(mutation target 49)*
+
+  **DONE**, two tests: `FacturarGanaLaCarreraContraAnularRemitoYAnularRecibe409RemitoFacturado`
+  and `AnularRemitoGanaLaCarreraContraFacturarYFacturarRecibe409RemitoNoFacturable`. Both
+  correctly assert the OUTCOME (whoever's transaction runs unimpeded wins) — see the FINDING
+  below on why this pause-based shape cannot discriminate the lock's exact intra-transaction
+  POSITION, closed instead by `ServicioDeFacturacionDeRemitosPosicionDeLockTests` (source-text).
+- [x] 6.16 Test: mixed-customer / mixed-PV / already-invoiced set refused 409 before any write.
   *(mutation target 51)*
-- [ ] 6.17 Test: credit-limit exceeded by a **concurrent** sale between pre-check and commit →
+
+  **DONE**, three tests (mutation-proof-tests regla 3, one kill per conjunct):
+  `UnSetConClientesMixtosEsRechazado409AntesDeEscribir`,
+  `UnSetConPuntosDeVentaMixtosEsRechazado409AntesDeEscribir`,
+  `UnRemitoYaFacturadoDentroDelSetEsRechazado409AntesDeEscribir`. See the FINDING below: the
+  third test's own conjunct (`estado`/`IdComprobanteVenta`) is backstopped by `LigarAsync` and
+  survives the pre-tx guard's removal alone — registered, not silently accepted.
+- [x] 6.17 Test: credit-limit exceeded by a **concurrent** sale between pre-check and commit →
   400. *(mutation target 53)*
-- [ ] 6.18 Test: closed-turno 409 for the consolidation; deliberate **absence** of that
+
+  **DONE** — `LimiteDeCreditoExcedidoPorConsolidacionConcurrenteEntrePreChequeoYCommit`, same
+  `Task.WhenAll`-of-two-identical-requests shape as
+  `VentasAtomicidadYConcurrenciaTests.DosVentasConcurrentesDeCuentaCorrienteNuncaSuperanElLimite`
+  (no interceptor needed — the natural row-lock serialization on `clientes.saldo`'s `UPDATE …
+  RETURNING` is the rendezvous).
+- [x] 6.18 Test: closed-turno 409 for the consolidation; deliberate **absence** of that
   requirement for plain `emitir` (decision 13, both directions asserted). *(mutation target 54)*
-- [ ] 6.19 Test: an **ordinary** anulación (non-`TXR`) issues the exact pre-stage command
+
+  **DONE**, two tests: `LaConsolidacionSinTurnoAbiertoEsRechazada409TurnoNoAbierto` +
+  `EmitirUnRemitoNoExigeNingunTurnoAbierto`. **FINDING REGISTERED**: both directions are killed
+  by the PRE-tx `ResolverTurnoAbiertoAsync` check (outside the transaction, always evaluated) —
+  the in-tx `ExigirTurnoAbiertoBajoLockAsync` re-check (statement 0, the actual mutation-target-54
+  guard) is defense-in-depth for the TOCTOU race (turno closes between pre-check and commit) and
+  is NOT independently race-tested in this batch, same accepted boundary as the identical
+  pre-check+in-tx-recheck pattern already shipped, unraced, in `ServicioDeVentas`/
+  `ServicioDeCuentaCorriente`/`ServicioDeTurnos.RegistrarMovimientoAsync` (no dedicated race test
+  exists for any of those either — grep-verified against `VentasTurnoWiringTests.cs`).
+- [x] 6.19 Test: an **ordinary** anulación (non-`TXR`) issues the exact pre-stage command
   count. *(mutation targets 55-56)*
-- [ ] 6.20 Test: annulling a `TXR` returns its remitos to `emitido`, clears
+
+  **DONE via source-text, not `ContadorDeComandos`** — `ServicioDeVentasPosicionDeDesligueTests.cs`
+  (three tests). **FINDING REGISTERED, mirrors Slice 3's own target-34 finding verbatim**:
+  `EscriturasDeRemito.DesligarAsync` runs raw SQL via `ExecuteNonQueryAsync` on a manually
+  created `DbCommand` (`conexion.CreateCommand()`) — this NEVER passes through EF Core's
+  `DbCommandInterceptor.ReaderExecuting[Async]` pipeline (that pipeline only sees commands EF's
+  own LINQ/`SaveChanges` machinery issues), so `ContadorDeComandos` would report the IDENTICAL
+  query count whether the guarded call is present, absent, or unconditional — a real
+  equivalence, not an instrumentation gap. Same resolution as
+  `ServicioDeVentasPosicionDeConversionTests`/`LaLlamadaAMarcarConvertidoAsyncNuncaOcurreFueraDelGuardNuloDeIdPresupuestoOrigen`:
+  source-text proves (a) `DesligarAsync` sits strictly inside `if (codigoTipoAnulado == "TXR")`,
+  never outside it (mutation target 56); (b) that position is immediately after
+  `MarcarAnuladoAsync` and strictly before the stock/CC loops (mutation target 58); (c)
+  `codigoTipoAnulado` is sourced only from the widened `RETURNING`'s scalar subquery, never a
+  second `SELECT` against `tipos_comprobante` (mutation target 55).
+- [x] 6.20 Test: annulling a `TXR` returns its remitos to `emitido`, clears
   `id_comprobante_venta`, reverses CC, **zero** stock movements — the double-decrement and
   phantom-restock traps proven unreachable. *(comprobantes-venta/spec.md:79-83, mutation
   target 52)*
-- [ ] 6.21 **[OD8/T3, discriminant test]** TXR-anulación composition: a `TXR` whose original
+
+  **DONE** — `AnularUnTxrDevuelveSusRemitosAEmitidoLimpiaLaLigaduraYNoEscribeMovimientosDeStock`.
+- [x] 6.21 **[OD8/T3, discriminant test]** TXR-anulación composition: a `TXR` whose original
   consolidation used cuenta corriente, annulled — the test asserts **both** halves together in
   one transaction: (a) zero `movimientos_stock` rows created, AND (b) the CC balance reversed by
   the **exact** original amount. Proves the composition is not "plausible by construction"
   (state.yaml OD8/T3, stage-16-slice-3 lesson).
-- [ ] 6.22 Test: `ck_remitos_facturacion` — `DesligarAsync` clearing only one of the two
+
+  **DONE** — `LaAnulacionDeUnTxrConCuentaCorrienteOriginalRevierteAmbasMitadesJuntasEnUnaSolaTransaccion`.
+  mutation-proof-tests regla 11 (discriminant prior debt): cliente seeded at `Saldo = 800m`
+  BEFORE the TXR (never a fresh 0-balance cliente) — saldo after facturar is `800 + 1500 = 2300`
+  (not the coincidental `0 + 1500`), and after anulación the assert is the exact prior debt
+  `800m`, never the reversal's own importe `-1500m` in isolation. Both halves asserted from the
+  SAME post-anulación read.
+- [x] 6.22 Test: `ck_remitos_facturacion` — `DesligarAsync` clearing only one of the two
   columns → `23514`. *(mutation target 57)*
-- [ ] 6.23 Test: **anular-TXR × facturar** race — whoever takes `comprobantes_venta`/`remitos`
+
+  **DONE** — `UnUpdateQueLimpiaSoloUnaDeLasDosColumnasDeLaLigaduraViolaCkRemitosFacturacion`, run
+  against TWO real remitos actually facturados via the service (never a synthetic raw `INSERT`,
+  unlike `RemitosSchemaTests`'s own Slice-4 CHECK tests) — this IS the literal mutation of
+  `DesligarAsync` the task names: one raw `UPDATE` per direction (`estado` only / `id_comprobante_venta`
+  only), both asserting `23514`/`ck_remitos_facturacion`.
+- [x] 6.23 Test: **anular-TXR × facturar** race — whoever takes `comprobantes_venta`/`remitos`
   first wins, no cycle (T10). *(mutation target 58)*
-- [ ] 6.24 [P] Non-regression: existing anulación suites green and not edited beyond the one
+
+  **DONE** — `AnularUnTxrXFacturarLosMismosRemitosNoDeadlockeaYAmbosResuelvenEnTiempoAcotado`:
+  anular-TXR paused (interceptor) right after opening its transaction — the remito is still
+  `facturado`/linked at that instant, so a concurrent `facturar` on the SAME remito reads that
+  state at its own (unlocked) pre-tx guard and rejects `409 remito_no_facturable` WITHOUT ever
+  attempting a lock (`SELECT` under READ COMMITTED never blocks on another session's uncommitted
+  row lock) — proving no deadlock is possible by construction (facturar never takes
+  `comprobantes_venta` as a lock position, T10), both requests resolve inside a bounded 15s
+  `WaitAsync` timeout, and a genuinely-unblocked follow-up `facturar` afterward confirms the
+  remito was left truly free.
+- [x] 6.24 [P] Non-regression: existing anulación suites green and not edited beyond the one
   guarded call.
-- [ ] 6.25 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
-- [ ] 6.26 Open PR #6 `feat/stage17-slice6-consolidacion`, merge after a clean round.
+
+  **DONE** — `git diff --stat` confirms `ServicioDeVentas.cs` is the only pre-existing file
+  touched in this slice, and its diff is exactly the two named surfaces (`MarcarAnuladoAsync`'s
+  `RETURNING` widening + the one guarded call at position 1.6) — no other line changed. Focused
+  filter `VentasCheckoutTests|VentasAnulacionTests|VentasAtomicidadYConcurrenciaTests|SuperficieDeAutorizacionTests|RemitosSchemaTests|ServicioDeRemitosTests|ServicioDeFacturacionDeRemitosTests`
+  — 110/110 green. See Work Unit Evidence for the full-suite runs.
+- [ ] 6.25 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **NOT run
+  by this apply batch**: `sdd-apply` never launches Judgment Day (the parent orchestrator runs
+  it after apply, per the executor boundary in `skills/sdd-apply/SKILL.md`).
+- [ ] 6.26 Open PR #6 `feat/stage17-slice6-consolidacion`, merge after a clean round. — **NOT
+  run by this apply batch**, same reason; pending the orchestrator's clean `judgment-day` round
+  on this diff.
+
+**DEVIATION REGISTERED (mutation-proof-tests regla 2/3, apply-time — target 48 lock ORDER, run
+for real).** The facturar×facturar rendezvous of task 6.14 (a `DbTransactionInterceptor` pauses
+one request right after `BeginTransactionAsync`, before it attempts any lock, while the other
+runs to full completion unimpeded) was run against the REAL mutation `ORDER BY id_remito DESC`
+in `BloquearAscendenteAsync` — the full `ServicioDeFacturacionDeRemitosTests` suite stayed
+green, confirmed empirically, not reasoned. Root cause: that rendezvous shape never puts two
+transactions in genuine concurrent contention over rows in reverse order — one side is
+completely idle until the other has already committed, so the ACQUISITION ORDER is never
+externally observable through it, regardless of direction. A below-the-confound two-connection
+NOWAIT-probe test (same technique as `ServicioDeRemitosTests.EmitirRemitoObservandoOrdenDeLocksAsync`,
+target 40) was attempted; an isolated two-session `psql` experiment against a throwaway 2-row
+table FIRST confirmed Postgres genuinely locks `ORDER BY id FOR UPDATE` rows incrementally in
+ascending order (a NOWAIT probe on the lower id failed with `55P03` while the higher id was
+still held by a separate blocking session) — but the SAME technique reimplemented against the
+full `WebApplicationFactory` harness could not reliably reproduce the signal (a leftover DESC
+mutation from the earlier real-mutation run turned out to be the actual cause once diagnosed,
+not harness noise — corrected). Given the added complexity/fragility of a live two-connection
+harness test for marginal gain over an already-real SQL-level confirmation, the shipped kill
+test is a stable source-text assertion
+(`ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente`) — run for real against
+both the correct code (green) and the `DESC` mutation (red, confirmed, reverted).
+
+**DEVIATION REGISTERED (mutation-proof-tests regla 2/3, apply-time — target 49 lock POSITION,
+run for real; same class as judgment-day slice-3 juez B's finding on the presupuesto-conversion
+POSITION 1.5).** `EscriturasDeRemito.BloquearAscendenteAsync` was moved for real from position 1
+(before the comprobante `INSERT`) to just before `LigarAsync` (after the CC loop) — BOTH task
+6.15 rendezvous tests, and the task 6.23 rendezvous, stayed green. Confirmed: the position is
+FAIL-FAST DEFENSIVE (saves materializing comprobante/pagos/CC for a consolidation that would
+fail anyway) and keeps the Lock order table's documented total order, never a correctness
+guarantee — the transaction's own atomicity (any throw reverts everything already written) plus
+`LigarAsync`'s final guard (mutation target 50) are what actually make the outcome correct
+regardless of exactly which line takes this lock. Closed with a source-text positional test,
+`ServicioDeFacturacionDeRemitosPosicionDeLockTests.ElLockAscendenteVaAntesDelInsertDelComprobanteYAntesDeLaCuentaCorriente`
+— run for real against both the correct position (green) and the moved position (red,
+confirmed, reverted).
+
+**DEVIATION REGISTERED (mutation-proof-tests regla 3, apply-time — target 51's third conjunct,
+run for real).** Removing the ENTIRE pre-tx agreement guard (`todosFacturables`) was run for
+real: `UnSetConClientesMixtosEsRechazado409AntesDeEscribir` and
+`UnSetConPuntosDeVentaMixtosEsRechazado409AntesDeEscribir` both went RED (confirmed, reverted) —
+these two conjuncts have NO backstop anywhere else (`LigarAsync`'s `WHERE` never checks
+cliente/PV). `UnRemitoYaFacturadoDentroDelSetEsRechazado409AntesDeEscribir` SURVIVED the same
+mutation (stayed green) — its conjunct (`estado`/`IdComprobanteVenta`) IS independently
+backstopped by `LigarAsync`'s own guarded `UPDATE` (mutation target 50), so removing only the
+pre-tx half still leaves the request correctly rejected, just later (via a rolled-back
+transaction instead of a pre-tx read) — a real, accepted redundancy (defense in depth by
+design), not a gap. The cliente/PV conjuncts remain the load-bearing, uniquely-tested half of
+this guard.
+
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and result | `dotnet test tests/Ways.Application.Tests` — 297/297 green; `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~ServicioDeFacturacionDeRemitosTests"` — 15/15 green |
+| Runtime harness command/scenario and result | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~ServicioDeRemitosTests\|FullyQualifiedName~VentasCheckoutTests\|FullyQualifiedName~VentasAnulacionTests\|FullyQualifiedName~VentasAtomicidadYConcurrenciaTests\|FullyQualifiedName~SuperficieDeAutorizacionTests\|FullyQualifiedName~RemitosSchemaTests\|FullyQualifiedName~ServicioDeFacturacionDeRemitosTests"` (non-regression: remitos ABM/emitir/anular, checkout, checkout anulación, checkout concurrency, the authorization allowlist, the remitos schema/backstop suite, plus this slice's own suite) — 110/110 green, real Postgres 17 via Testcontainers. **Full suite** `dotnet test tests/Ways.IntegrationTests` (no filter): first pass — 1575/1575 green, 11m21s, clean single pass; a post-pass fix (a self-caught regression from the target-49 mutation-revert cycle — `BloquearAscendenteAsync`'s call briefly dropped, caught before commit by re-running the focused filters, never shipped) required a second full pass — 1575/1575 green, 11m18s, clean single pass, zero flakiness either run (rule 17's isolated-re-run clause never triggered). |
+| Mutation evidence (apply-time, all real, applied then reverted) | **Target 50** (`LigarAsync`'s `estado`/`id_comprobante_venta` conjuncts + rowcount): dropped both from the `WHERE` → `FacturarXFacturarSobreSetsSuperpuestosDaExactamenteUn201YUn409` RED (both sides showed 201) → reverted, green. **Target 48** (ascending `ORDER BY`): `id_remito` → `id_remito DESC` → `ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente` RED → reverted, green (see FINDING above for why the rendezvous test alone doesn't discriminate this). **Target 49** (lock position): moved after the CC loop → `ServicioDeFacturacionDeRemitosPosicionDeLockTests` RED → reverted, green (see FINDING above). **Target 51** (agreement guard, all four conjuncts at once): `todosFacturables = true` → cliente/PV tests RED, already-facturado test SURVIVED (documented finding above) → reverted, green. **Target 52** (itemless + no stock loop): inserted one raw `movimientos_stock` row before commit → `DosRemitosConsolidanEnUnTxrItemlessConTotalIgualALaSumaDeLosHeadersYCeroMovimientosDeStock`, `AnularUnTxrDevuelveSusRemitosAEmitidoLimpiaLaLigaduraYNoEscribeMovimientosDeStock`, `LaAnulacionDeUnTxrConCuentaCorrienteOriginalRevierteAmbasMitadesJuntasEnUnaSolaTransaccion` all RED → reverted, green (the itemless half is proven by construction — `Proyectar` hardcodes `[]`, no items-write code exists to mutate). **Target 53** (credit-limit backstop): removed the `if` block → `LimiteDeCreditoExcedidoPorConsolidacionConcurrenteEntrePreChequeoYCommit` RED → reverted, green. **Target 58** (desligue position): moved `EscriturasDeRemito.DesligarAsync`'s guarded call from position 1.6 to after the CC loop in `ServicioDeVentas.cs` → `ServicioDeVentasPosicionDeDesligueTests.ElDesligueDeRemitosVaInmediatamenteDespuesDeMarcarAnuladoYAntesDeLaAuditoria` RED → reverted, green. **Target 57**: proven directly by task 6.22's own real-remito raw-`UPDATE` test (no separate apply-time mutation needed — the test IS the mutation). **Target 54** (in-tx turno re-check): not independently race-tested this batch — see the FINDING under task 6.18 (same accepted boundary as the identical pattern elsewhere in this codebase). **Targets 55/56**: verified via source-text tests only (`ServicioDeVentasPosicionDeDesligueTests`), consistent with target 34's own precedent that `ContadorDeComandos` cannot see raw-ADO statements. |
+| Rollback boundary | `git revert` of this slice's commit(s) alone: `EscriturasDeRemito.cs`/`ServicioDeFacturacionDeRemitos.cs`/`ServicioDeFacturacionDeRemitosTests.cs`/the two positional test files deleted; the `MapPost("/facturacion", ...)` line and `AddScoped<ServicioDeFacturacionDeRemitos>()` line and the one allowlist entry revert; `ServicioDeVentas.cs`'s `MarcarAnuladoAsync` `RETURNING` widening and the one guarded call at position 1.6 revert cleanly (both isolated to that one file, no schema touched, no other slice's file touched) |
 
 ---
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1862,6 +1862,28 @@ nuevos: `AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrAc
 `FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio`). Nunca full
 suite, per regla 15/mutation-proof-tests (reminder post-checkout tras cada revert = ruido benigno).
 
+**judgment-day Slice 6, ronda 2 — juez B (1 MAJOR fixed, cota del probe de pg_locks).** El test
+`BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido`
+(agregado en la ronda 1) se COLGABA indefinidamente bajo el mutante DESC en vez de fallar limpio:
+al lockear primero el MAYOR (libre) y bloquearse en el MENOR (retenido por `transaccionBloqueo`),
+el `Assert.Null(excepcionDelProbe)` lanzaba ANTES de la línea que liberaba ese lock — el `await
+using` del método intentaba entonces disponer `db`/`transaccionRemito` con el comando de
+`bloquearTask` todavía en vuelo sobre la MISMA conexión, y ese choque colgaba el proceso entero
+(no un fallo limpio y acotado — viola mutation-proof-tests regla 2, "una red que no termina no es
+evidencia válida"). Fijado TEST-ONLY (`ServicioDeFacturacionDeRemitosTests.cs`, cero cambio de
+producción salvo mutar-y-revertir como evidencia): todo el tramo poll+probe se movió a un `try`, y
+un `finally` incondicional ahora (a) libera `transaccionBloqueo` SIEMPRE, pase lo que pase arriba,
+y (b) espera `bloquearTask` con una cota de `Task.WhenAny(bloquearTask, Task.Delay(10s))` en vez de
+un `await` desnudo, antes de que el `await using` del método pueda tocar esas conexiones. EVIDENCIA
+DE MUTACIÓN: `ORDER BY id_remito` → `ORDER BY id_remito DESC` (`EscriturasDeRemito.cs:52`) →
+`dotnet build --no-incremental` + filtro
+`FullyQualifiedName~BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido`
+— **3/3 ROJO limpio y acotado** (`Assert.Null() Failure` sobre `Npgsql.PostgresException: 55P03:
+could not obtain lock on row in relation "remitos"`, duración de test ~5-6s, proceso completo
+~12-13s, sin cuelgue). Revertido: `dotnet build --no-incremental` + mismo filtro — **3/3 VERDE**
+(duración de test ~3s, proceso completo ~8.5s). Suite dirigida completa tras el fix:
+`FullyQualifiedName~ServicioDeFacturacionDeRemitosTests` — **18/18 VERDE**.
+
 ---
 
 ## Slice 7: web presupuestos + POS banner (PR 7)

--- a/src/Ways.Api/Endpoints/RemitosEndpoints.cs
+++ b/src/Ways.Api/Endpoints/RemitosEndpoints.cs
@@ -11,8 +11,13 @@ namespace Ways.Api.Endpoints;
 /// individually, but load-bearing"): sin esto <c>ServicioDeRemitos</c> queda inalcanzable por
 /// HTTP. Grupo bajo <c>Politicas.OperacionDePos</c> ÚNICAMENTE — sin apilar
 /// <c>GestionDeCatalogo</c>, mismo criterio que <c>PresupuestosEndpoints</c>/<c>VentasEndpoints</c>:
-/// un Vendedor tiene que poder despachar un remito (design decisión 17). La consolidación
-/// (<c>POST /api/remitos/facturacion</c>) llega en Slice 6.
+/// un Vendedor tiene que poder despachar un remito (design decisión 17).
+///
+/// stage-17-presupuestos-y-remitos, Slice 6 (design: API Surface — "POST /api/remitos/facturacion").
+/// **DEVIATION REGISTERED** — ninguna tarea 6.x nombra este archivo individualmente, mismo criterio
+/// que el párrafo de arriba: sin esta ruta, <c>ServicioDeFacturacionDeRemitos</c> queda
+/// inalcanzable por HTTP. Mismo grupo, mismo criterio de autorización (un Vendedor consolida
+/// remitos igual que despacha uno).
 /// </summary>
 public static class RemitosEndpoints
 {
@@ -68,6 +73,14 @@ public static class RemitosEndpoints
             return Results.Ok(anulado);
         })
         .WithSummary("Anula un remito borrador/emitido, revirtiendo stock si ya había salido. Un remito facturado no puede anularse directamente.");
+
+        grupo.MapPost("/facturacion", async (
+            ServicioDeFacturacionDeRemitos servicio, SolicitudDeFacturacionDeRemitos solicitud, CancellationToken ct) =>
+        {
+            var facturado = await servicio.FacturarAsync(solicitud, ct);
+            return Results.Created($"/api/ventas/{facturado.Id}", facturado);
+        })
+        .WithSummary("Consolida N remitos emitidos del mismo cliente/punto de venta en un comprobante TXR sin items.");
 
         return app;
     }

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -103,9 +103,12 @@ public static class DependencyInjection
         services.AddScoped<ServicioDePresupuestos>();
 
         // stage-17-presupuestos-y-remitos, Slice 5: ABM + emitir (numeración propia, serie 'REM',
-        // FEFO, el cuarto write site de stock) + anular. La consolidación
-        // (ServicioDeFacturacionDeRemitos) llega en Slice 6.
+        // FEFO, el cuarto write site de stock) + anular.
         services.AddScoped<ServicioDeRemitos>();
+
+        // stage-17-presupuestos-y-remitos, Slice 6: la consolidación — N remitos emitidos en UN
+        // comprobante TXR itemless (serie 'TXR', vía AsignadorDeNumeroComprobante — no se toca).
+        services.AddScoped<ServicioDeFacturacionDeRemitos>();
 
         // stage-10-agregacion-dashboard, Slice 2: LectorDeSerieTemporal es la única superficie de
         // SQL crudo de toda la etapa (design decisión 2) — ServicioDeReportesDeVentas es su

--- a/src/Ways.Application/Ventas/ContratosDeRemito.cs
+++ b/src/Ways.Application/Ventas/ContratosDeRemito.cs
@@ -91,3 +91,16 @@ public sealed record PaginaDeRemitos(
     int Total,
     int Pagina,
     int Tamanio);
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (design.md:211-212, task 6.2). Cuerpo de
+/// <c>POST /api/remitos/facturacion</c> — consolida <see cref="IdsRemito"/> (N remitos, mismo
+/// cliente/PV, todos <c>emitido</c> y sin ligar) en UN comprobante <c>TXR</c> itemless. Sin
+/// <c>IdCliente</c> (dto-contract-honesty regla 1): el cliente se DERIVA de los remitos mismos
+/// (todos comparten uno, guard de <c>ServicioDeFacturacionDeRemitos</c>) — un valor en conflicto
+/// no tendría destino real, así que el campo ni siquiera existe en el contrato. <see cref="Pagos"/>
+/// mismo shape que <see cref="PagoDeVenta"/> del checkout — <see cref="ValidadorDePagos"/> los
+/// valida igual, incluido el backstop de límite de crédito re-implementado dentro de la
+/// transacción (OD9/T9).</summary>
+public sealed record SolicitudDeFacturacionDeRemitos(
+    int IdPuntoVenta, IReadOnlyList<int> IdsRemito, IReadOnlyList<PagoDeVenta> Pagos, string? Observaciones);

--- a/src/Ways.Application/Ventas/EscriturasDeRemito.cs
+++ b/src/Ways.Application/Ventas/EscriturasDeRemito.cs
@@ -1,0 +1,122 @@
+using System.Data.Common;
+using Ways.Application.Abstracciones;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (design.md:131-149/162-175, tasks 6.1/6.4/6.8/6.11-6.12,
+/// mutation targets 48-50/57). La ÚNICA clase que liga y desliga remitos de un comprobante — misma
+/// forma estructural que <see cref="EscriturasDePresupuesto"/>: <c>static</c>, misma postura de
+/// conexión/transacción del llamador, nunca abre/flushea/comitea nada.
+///
+/// <see cref="BloquearAscendenteAsync"/> corre en la POSICIÓN 1 de <see cref="ServicioDeFacturacionDeRemitos"/>
+/// (design decisión 12, mutation target 49) — ANTES del INSERT del comprobante y ANTES de
+/// <c>clientes</c>: un <c>INSERT</c> de fila nueva NO es una posición del orden de locks (T10), así
+/// que este es el único lock EXISTENTE que la consolidación toma. Su rol es doble: (a) tomar el lock
+/// en orden ASCENDENTE por <c>id_remito</c> (mutation target 48 — sin esto, dos consolidaciones
+/// concurrentes sobre sets superpuestos podrían deadlockear); (b) establecer el orden total contra
+/// un <c>anular</c> de remito concurrente (la rendezvous de la tarea 6.15). NO es, por sí sola, la
+/// autoridad de negocio de "¿este set sigue facturable?" — esa autoridad, la única que este archivo
+/// deja atómica bajo el MISMO lock que la escritura final, es <see cref="LigarAsync"/> (mutation
+/// target 50): re-validar acá con los valores leídos crearía un guard EQUIVALENTE al de
+/// <see cref="LigarAsync"/> bajo el mismo lock (nada puede cambiar esas filas entre este SELECT y
+/// ese UPDATE dentro de la MISMA transacción) — un mutante que borre el guard de
+/// <see cref="LigarAsync"/> sobreviviría indetectado si este método también lo re-implementara
+/// (mutation-proof-tests regla 3, la clase "pre-check que espeja un guard transaccional" — acá el
+/// espejo sería DENTRO de la misma transacción, mismo lock, así que ninguna prueba de carrera podría
+/// discriminar cuál de los dos guards mató al mutante). El único chequeo que sí corre acá es
+/// defensivo (invariante de fila, nunca un caso de negocio alcanzable): si el conteo de filas
+/// bloqueadas no matchea <c>idsRemito.Count</c>, algo desapareció bajo el lock — el llamador lo trata
+/// como un invariante roto, no como un 409 de negocio (ese guard "mismo cliente/PV/tenant, todos
+/// <c>emitido</c> y sin ligar, antes de cualquier escritura" vive en la fase de decisión de
+/// <see cref="ServicioDeFacturacionDeRemitos"/>, task 6.16 — SIN lock, así que sí puede quedar
+/// obsoleto ante una carrera real, que <see cref="LigarAsync"/> atrapa).
+/// </summary>
+public static class EscriturasDeRemito
+{
+    /// <summary>Lock ascendente explícito (design decisión 12, mutation target 48) — <c>ORDER BY
+    /// id_remito</c> en el propio <c>SELECT ... FOR UPDATE</c>, nunca ordenado por el llamador: es
+    /// Postgres quien toma los locks de fila en el orden que la cláusula <c>ORDER BY</c> evalúa,
+    /// sin importar el orden de <paramref name="idsRemito"/> en el array de entrada. Devuelve los
+    /// estados leídos bajo el lock (diagnóstico/futuro uso del llamador) — la autoridad de negocio
+    /// vive en <see cref="LigarAsync"/>, ver el doc-comment de la clase.</summary>
+    public static async Task<IReadOnlyList<(int IdRemito, string Estado, int? IdComprobante)>> BloquearAscendenteAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, IReadOnlyList<int> idsRemito,
+        CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "SELECT id_remito, estado::text, id_comprobante_venta FROM remitos " +
+            "WHERE id_remito = ANY($1) AND id_tenant = $2 AND deleted_at IS NULL " +
+            "ORDER BY id_remito FOR UPDATE";
+
+        ParametrosDeComando.Agregar(comando, idsRemito.ToArray());
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        var resultado = new List<(int, string, int?)>(idsRemito.Count);
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        while (await lector.ReadAsync(ct))
+        {
+            var idRemito = lector.GetInt32(0);
+            var estado = lector.GetString(1);
+            var idComprobante = lector.IsDBNull(2) ? (int?)null : lector.GetInt32(2);
+            resultado.Add((idRemito, estado, idComprobante));
+        }
+
+        return resultado;
+    }
+
+    /// <summary>UPDATE guardado de N filas EN UN statement (design decisión 12, mutation target
+    /// 50) — la autoridad final de "¿este set sigue facturable?", bajo el MISMO lock ascendente que
+    /// <see cref="BloquearAscendenteAsync"/> ya tomó sobre estas filas EN ESTA transacción.
+    /// <c>estado = 'emitido' AND id_comprobante_venta IS NULL</c> son los dos conjuntos guardados
+    /// (además de tenant/ids/soft-delete) — filas devueltas != <c>idsRemito.Count</c> ⇒ el llamador
+    /// lanza <c>409 remito_no_facturable</c> (otro consolidado ganó la carrera, o alguien anuló uno
+    /// de los remitos — CONFLICT #4).</summary>
+    public static async Task<int> LigarAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, IReadOnlyList<int> idsRemito,
+        int idComprobanteVenta, DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE remitos SET estado = 'facturado'::estado_remito, id_comprobante_venta = $3, updated_at = $4 " +
+            "WHERE id_remito = ANY($1) AND id_tenant = $2 " +
+            "AND estado = 'emitido'::estado_remito AND id_comprobante_venta IS NULL AND deleted_at IS NULL";
+
+        ParametrosDeComando.Agregar(comando, idsRemito.ToArray());
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idComprobanteVenta);
+        ParametrosDeComando.Agregar(comando, momento);
+
+        return await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>Desligue de la anulación de un <c>TXR</c> (design.md:170-174, task 6.12, mutation
+    /// target 57): <c>estado</c> y <c>id_comprobante_venta</c> vuelven JUNTOS, en el MISMO statement
+    /// — separarlos en dos <c>UPDATE</c>s dejaría una ventana donde <c>ck_remitos_facturacion</c>
+    /// (estado y link tienen que viajar juntos, en las dos direcciones) podría ver una fila a medio
+    /// actualizar bajo una lectura concurrente sin lock, o directamente tirar <c>23514</c> si el
+    /// segundo statement nunca corre (fallo a mitad de camino). <c>WHERE id_comprobante_venta = $1
+    /// AND ... AND estado = 'facturado'</c> es idempotente por construcción: una segunda invocación
+    /// sobre el mismo comprobante ya desligado no matchea ninguna fila (0 filas, no un error) — el
+    /// llamador (<c>EjecutarAnulacionAsync</c>) solo llega acá una vez, guardado por
+    /// <c>MarcarAnuladoAsync</c>'s propio <c>WHERE estado = 'emitido'</c>.</summary>
+    public static async Task<int> DesligarAsync(
+        DbConnection conexion, DbTransaction? transaccion, int idTenant, int idComprobanteVenta,
+        DateTimeOffset momento, CancellationToken ct)
+    {
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = transaccion;
+        comando.CommandText =
+            "UPDATE remitos SET estado = 'emitido'::estado_remito, id_comprobante_venta = NULL, updated_at = $3 " +
+            "WHERE id_comprobante_venta = $1 AND id_tenant = $2 AND estado = 'facturado'::estado_remito";
+
+        ParametrosDeComando.Agregar(comando, idComprobanteVenta);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, momento);
+
+        return await comando.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/src/Ways.Application/Ventas/ServicioDeFacturacionDeRemitos.cs
+++ b/src/Ways.Application/Ventas/ServicioDeFacturacionDeRemitos.cs
@@ -1,0 +1,365 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Application.Caja;
+using Ways.Application.CuentaCorriente;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Common;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Ventas;
+
+namespace Ways.Application.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (design: Transactions — "FACTURAR REMITOS
+/// (consolidación)"; tasks 6.2-6.9). Consolida N remitos <c>emitido</c> del MISMO cliente/PV/tenant
+/// en UN comprobante <c>TXR</c> itemless — precedente <c>RC</c> (<see cref="CuentaCorriente.ServicioDeCuentaCorriente.RegistrarPagoAsync"/>):
+/// dedicado y lean, no una extensión de <see cref="ServicioDeVentas"/> (misma razón que RC — sin
+/// líneas, sin ofertas, precios YA congelados en <c>items_remito</c> desde el cuarto write site).
+/// Reusa, tal cual, las mismas cuatro piezas que RC: <see cref="AsignadorDeNumeroComprobante"/>
+/// (serie propia <c>'TXR'</c>), <see cref="ServicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync"/> (a
+/// diferencia del cuarto write site — decisión 13 del proposal, un remito mueve mercadería, la
+/// consolidación mueve dinero), <see cref="EscriturasDeCuentaCorriente"/> (sin cambios) y
+/// <see cref="ValidadorDePagos"/> (mismo backstop de límite de crédito re-implementado DENTRO de la
+/// transacción que <c>ServicioDeVentas.EjecutarTransaccionAsync</c>, OD9/T9). La pieza NUEVA de este
+/// archivo es <see cref="EscriturasDeRemito"/> — el lock ascendente + el guard atómico de N filas
+/// que decide si el set sigue facturable (ver su propio doc-comment).
+/// </summary>
+public class ServicioDeFacturacionDeRemitos(
+    IWaysDbContext db, IRelojDelSistema reloj, IContextoDeUsuario contexto, ServicioDeTurnos servicioDeTurnos)
+{
+    public async Task<ComprobanteEmitido> FacturarAsync(
+        SolicitudDeFacturacionDeRemitos solicitud, CancellationToken ct = default)
+    {
+        var idTenant = ExigirTenantDeLaSesion();
+        var idEmpleado = contexto.UsuarioId;
+        var momento = reloj.Ahora;
+
+        var idsRemitoDistintos = (solicitud.IdsRemito ?? []).Distinct().ToList();
+        if (idsRemitoDistintos.Count == 0)
+        {
+            throw new ErrorDominio(
+                "remitos_no_seleccionados", "Tenés que seleccionar al menos un remito para facturar.", 400);
+        }
+
+        var puntoVenta = await ResolverPuntoVentaAsync(solicitud.IdPuntoVenta, ct);
+
+        // fuera: remitos + items · mismo tenant/cliente/PV · todos 'emitido' y sin ligar (design:
+        // Transactions — "FACTURAR REMITOS", tasks 6.16, mutation target 51). SIN lock — este guard
+        // puede quedar obsoleto ante una carrera real; EscriturasDeRemito.LigarAsync (dentro de la
+        // transacción, bajo el lock ascendente) es la autoridad race-safe, ver su doc-comment.
+        var remitos = await db.Remitos.AsNoTracking()
+            .Where(r => idsRemitoDistintos.Contains(r.Id))
+            .ToListAsync(ct);
+
+        if (remitos.Count != idsRemitoDistintos.Count)
+        {
+            var idsEncontrados = remitos.Select(r => r.Id).ToHashSet();
+            var idFaltante = idsRemitoDistintos.First(id => !idsEncontrados.Contains(id));
+            throw ErrorDominio.NoEncontrado($"No existe el remito {idFaltante}.");
+        }
+
+        var idCliente = remitos[0].IdCliente;
+        var todosFacturables = remitos.All(r =>
+            r.IdPuntoVenta == puntoVenta.Id && r.IdCliente == idCliente
+            && r.Estado == EstadoRemito.Emitido && r.IdComprobanteVenta is null);
+
+        if (!todosFacturables)
+        {
+            throw new ErrorDominio(
+                "remito_no_facturable",
+                "Los remitos seleccionados tienen que compartir cliente y punto de venta, y estar emitidos sin facturar.",
+                409);
+        }
+
+        var items = await db.ItemsRemito.AsNoTracking()
+            .Where(i => idsRemitoDistintos.Contains(i.IdRemito))
+            .ToListAsync(ct);
+
+        // totales := Σ headers, aserción contra Σ items congelados (design: Transactions —
+        // "FACTURAR REMITOS"). Defensa en profundidad, nunca un caso de negocio alcanzable bajo
+        // operación normal: cada header ya fue computado por CalculadorDeTotales al crear/editar/
+        // emitir su propio remito — un desacuerdo acá solo puede significar una escritura cruda
+        // que desincronizó remitos.total de items_remito (mismo criterio que el
+        // presupuesto_inconsistente de Slice 3, pero sin domain code propio — esta clase nunca
+        // recibió un test dedicado que lo exija, mismo criterio de tasks.md).
+        var lineasParaCalcular = items
+            .Select(i => new LineaParaCalcular(i.Cantidad, i.PrecioUnitario, i.Cantidad == 0m ? 0m : i.Descuento / i.Cantidad))
+            .ToList();
+        var totalesRecomputados = CalculadorDeTotales.Calcular(lineasParaCalcular);
+
+        var subtotal = remitos.Sum(r => r.Subtotal);
+        var descuentoTotal = remitos.Sum(r => r.DescuentoTotal);
+        var total = remitos.Sum(r => r.Total);
+
+        if (totalesRecomputados.Subtotal != subtotal
+            || totalesRecomputados.DescuentoTotal != descuentoTotal
+            || totalesRecomputados.Total != total)
+        {
+            throw new InvalidOperationException(
+                $"Los totales recomputados de los items de los remitos [{string.Join(",", idsRemitoDistintos)}] " +
+                "no coinciden con la suma de sus headers — invariante de escritura violado.");
+        }
+
+        var cliente = await db.Clientes.AsNoTracking().FirstAsync(c => c.Id == idCliente, ct);
+
+        var pagos = solicitud.Pagos ?? [];
+        var idsMedioPago = pagos.Select(p => p.IdMedioPago).Distinct().ToList();
+        var medioPorId = await db.MediosPago
+            .Where(m => idsMedioPago.Contains(m.Id))
+            .ToDictionaryAsync(m => m.Id, ct);
+
+        var idsMedioFaltantes = idsMedioPago.Except(medioPorId.Keys).ToList();
+        if (idsMedioFaltantes.Count > 0)
+        {
+            throw new ErrorDominio("referencia_invalida", $"No existe el medio de pago {idsMedioFaltantes[0]}.", 400);
+        }
+
+        var pagosAValidar = pagos
+            .Select(p =>
+            {
+                var medio = medioPorId[p.IdMedioPago];
+                return new PagoAValidar(
+                    p.IdMedioPago, medio.Comportamiento, medio.AdmiteVuelto, medio.RequiereReferencia,
+                    p.Importe, p.Vuelto, p.Referencia);
+            })
+            .ToList();
+
+        var (toleranciaPago, vueltoMaximo) = await ResolverParametrosDeFacturacionAsync(puntoVenta.IdEmpresa, puntoVenta.Id, ct);
+
+        ValidadorDePagos.Validar(
+            total, pagosAValidar, toleranciaPago, vueltoMaximo,
+            cliente.EsConsumidorFinal, cliente.Saldo, cliente.LimiteCredito, cliente.CreditoIlimitado);
+
+        // Turno SIEMPRE resuelto server-side (decisión 13 del proposal: la consolidación mueve
+        // dinero — a diferencia del cuarto write site, que no exige turno). Pre-chequeo rápido,
+        // FUERA de la transacción de escritura; el re-chequeo bajo FOR SHARE (mutation target 54)
+        // es el PRIMER statement de EjecutarFacturacionAsync.
+        var turno = await servicioDeTurnos.ResolverTurnoAbiertoAsync(puntoVenta.Id, ct);
+
+        var tipo = await ResolverTipoTxrAsync(ct);
+
+        // Misma corrección que ServicioDeVentas/ServicioDeCuentaCorriente: el número se reserva y
+        // COMITEA en su propia transacción, ANTES de la que escribe el resto.
+        var estrategiaNumeracion = db.Database.CreateExecutionStrategy();
+        var numero = await estrategiaNumeracion.ExecuteAsync(async () =>
+            await AsignadorDeNumeroComprobante.AsignarComprometidoAsync(db, idTenant, puntoVenta.Id, tipo.Codigo, ct));
+
+        var estrategia = FabricaDeEstrategiaSinReintento.CrearEstrategiaSinReintento(db);
+        return await estrategia.ExecuteAsync(async () =>
+            await EjecutarFacturacionAsync(
+                idTenant, idEmpleado, momento, tipo.Id, numero, puntoVenta.Id, turno.Id, idCliente,
+                idsRemitoDistintos, subtotal, descuentoTotal, total, pagos, medioPorId,
+                cliente.LimiteCredito, cliente.CreditoIlimitado, NormalizarOpcional(solicitud.Observaciones), ct));
+    }
+
+    /// <summary>design: Transactions — "FACTURAR REMITOS", orden de statements pineado (decisión
+    /// 12/13). El comprobante <c>TXR</c> nace SIN items por construcción (precedente <c>RC</c>) —
+    /// cero movimientos de stock: la mercadería ya salió por los cuatro write sites de los remitos
+    /// individuales.</summary>
+    private async Task<ComprobanteEmitido> EjecutarFacturacionAsync(
+        int idTenant, int idEmpleado, DateTimeOffset momento, int idTipoComprobante, long numero, int idPuntoVenta,
+        int idTurnoCaja, int idCliente, IReadOnlyList<int> idsRemito, decimal subtotal, decimal descuentoTotal,
+        decimal total, IReadOnlyList<PagoDeVenta> pagos, IReadOnlyDictionary<int, MedioPago> medioPorId,
+        decimal clienteLimiteCredito, bool clienteCreditoIlimitado, string? observaciones, CancellationToken ct)
+    {
+        await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+        var conexion = await ObtenerConexionAbiertaAsync(ct);
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        // 0. Turno — re-chequeo bajo FOR SHARE, PRIMER statement (decisión 13 del proposal,
+        // mutation target 54): a diferencia del cuarto write site (ServicioDeRemitos.EmitirAsync,
+        // que NO lo exige — un remito mueve mercadería, no dinero), la consolidación sí toca cuenta
+        // corriente.
+        await servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(idTurnoCaja, ct);
+
+        // 1. EscriturasDeRemito.BloquearAscendenteAsync — ANTES del INSERT del comprobante y ANTES
+        // de clientes (design decisión 12, mutation target 49): el INSERT de fila nueva no es una
+        // posición del orden de locks (T10), así que este es el único lock EXISTENTE que esta
+        // transacción toma. Ver el doc-comment de EscriturasDeRemito sobre por qué el chequeo de
+        // negocio real vive en LigarAsync (paso 5), no acá.
+        //
+        // Honestidad documental (mismo hallazgo que judgment-day slice-3, juez B, sobre la
+        // POSICIÓN 1.5 de la conversión de presupuesto — ver
+        // ServicioDeVentasPosicionDeConversionTests): esta POSICIÓN es FAIL-FAST DEFENSIVO, nunca
+        // una cuestión de correctitud. Mutación real corrida y confirmada (mutation-proof-tests
+        // regla 2): mover este bloque a después del loop de CC (justo antes de LigarAsync) NO tira
+        // en rojo ninguno de los rendezvous de la tarea 6.15/6.23 — la ATOMICIDAD de la transacción
+        // (cualquier throw revierte TODO lo ya escrito) más el guard final de LigarAsync siguen
+        // garantizando la misma corrección observable sin importar en qué línea se tome este lock.
+        // La posición SÍ importa por eficiencia (ahorra materializar comprobante/pagos/CC para una
+        // consolidación que de todos modos va a fallar) y por mantener el orden total documentado
+        // en el Lock order table del design — pineada acá por ese motivo real, sin afirmar una
+        // correctitud que la posición no otorga. Ver
+        // ServicioDeFacturacionDeRemitosPosicionDeLockTests (fuente de texto) para la prueba
+        // estructural de esta posición.
+        var filasBloqueadas = await EscriturasDeRemito.BloquearAscendenteAsync(conexion, transaccionCruda, idTenant, idsRemito, ct);
+        if (filasBloqueadas.Count != idsRemito.Count)
+        {
+            throw new InvalidOperationException(
+                $"Uno o más remitos de [{string.Join(",", idsRemito)}] desaparecieron bajo el lock — " +
+                "invariante de escritura violado (ya se validaron fuera de la transacción).");
+        }
+
+        // 2. Comprobante TXR — CERO items por construcción (precedente RC). Subtotal/DescuentoTotal/
+        // Total son la suma de los headers ya asertada contra la suma de los items congelados,
+        // arriba, fuera de la transacción.
+        var comprobante = new ComprobanteVenta
+        {
+            IdTipoComprobante = idTipoComprobante,
+            Numero = numero,
+            Fecha = momento,
+            IdPuntoVenta = idPuntoVenta,
+            IdTurnoCaja = idTurnoCaja,
+            IdEmpleado = idEmpleado,
+            IdCliente = idCliente,
+            Subtotal = subtotal,
+            DescuentoTotal = descuentoTotal,
+            Total = total,
+            Observaciones = observaciones,
+            Estado = EstadoComprobante.Emitido,
+            CreatedAt = momento,
+            UpdatedAt = momento
+        };
+        db.ComprobantesVenta.Add(comprobante);
+        await db.SaveChangesAsync(ct);
+
+        // 3. Pagos.
+        var pagosEntidad = pagos
+            .Select(p => new PagoComprobante
+            {
+                IdComprobanteVenta = comprobante.Id,
+                IdMedioPago = p.IdMedioPago,
+                Importe = p.Importe,
+                Referencia = p.Referencia,
+                Vuelto = p.Vuelto,
+                CreatedAt = momento,
+                UpdatedAt = momento
+            })
+            .ToList();
+        db.PagosComprobante.AddRange(pagosEntidad);
+        await db.SaveChangesAsync(ct);
+
+        // 4. Cuenta corriente — mismo criterio, mismo loop que ServicioDeVentas.EjecutarTransaccionAsync
+        // paso 6 (EscriturasDeCuentaCorriente sin cambios): el backstop de límite de crédito se
+        // RE-IMPLEMENTA acá, dentro de la transacción (OD9/T9, mutation target 53) — el
+        // ValidadorDePagos de arriba ya corrió AFUERA, contra el saldo de ESE momento; esto atrapa
+        // una venta concurrente del mismo cliente que subió el saldo entre el pre-chequeo y este
+        // commit.
+        for (var i = 0; i < pagos.Count; i++)
+        {
+            var pago = pagos[i];
+            if (medioPorId[pago.IdMedioPago].Comportamiento != ComportamientoMedioPago.CuentaCorriente)
+            {
+                continue;
+            }
+
+            var nuevoSaldo = await EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(
+                conexion, transaccionCruda, idTenant, idCliente, pago.Importe, ct);
+
+            if (!clienteCreditoIlimitado && nuevoSaldo > clienteLimiteCredito)
+            {
+                throw new ErrorDominio("limite_credito_excedido", "El pago supera el límite de crédito del cliente.", 400);
+            }
+
+            await EscriturasDeCuentaCorriente.InsertarMovimientoCcAsync(
+                conexion, transaccionCruda, idTenant, idCliente, momento, idPuntoVenta, idEmpleado,
+                TipoMovimientoCc.Consumo, comprobante.Id, pagosEntidad[i].Id, pago.Importe, nuevoSaldo,
+                detalle: null, ct);
+        }
+
+        // 5. LigarAsync — filas == N o 409 remito_no_facturable (CONFLICT #4, mutation target 50).
+        // La autoridad final: nada pudo cambiar estas filas entre el lock del paso 1 y este UPDATE
+        // dentro de la MISMA transacción — bajo operación normal esta guardia nunca reduce el
+        // rowcount; lo hace exactamente cuando otra consolidación (o una anulación de remito) ganó
+        // la carrera del paso 1 sobre un set superpuesto.
+        var filasLigadas = await EscriturasDeRemito.LigarAsync(conexion, transaccionCruda, idTenant, idsRemito, comprobante.Id, momento, ct);
+        if (filasLigadas != idsRemito.Count)
+        {
+            throw new ErrorDominio(
+                "remito_no_facturable",
+                "Uno o más remitos ya no están disponibles para facturar (otra consolidación ganó, o fueron anulados).",
+                409);
+        }
+
+        // (CERO movimientos_stock — la mercadería ya salió por los remitos.)
+
+        await transaccion.CommitAsync(ct);
+
+        return Proyectar(comprobante, pagosEntidad);
+    }
+
+    // ---- Resolución de datos, fuera de la transacción -----------------------------------------
+
+    private async Task<PuntoVenta> ResolverPuntoVentaAsync(int idPuntoVenta, CancellationToken ct) =>
+        await db.PuntosVenta.AsNoTracking().FirstOrDefaultAsync(pv => pv.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+    private async Task<TipoComprobante> ResolverTipoTxrAsync(CancellationToken ct) =>
+        await db.TiposComprobante.AsNoTracking().FirstOrDefaultAsync(t => t.Codigo == "TXR", ct)
+            // Sembrado idempotente para todo tenant desde la migración de Slice 4 (proposal §I data
+            // statement 2) — su ausencia es un bug de aprovisionamiento, no un caso de negocio
+            // alcanzable (mismo criterio que ResolverTipoRcAsync).
+            ?? throw new InvalidOperationException("El tenant actual no tiene el tipo de comprobante TXR sembrado.");
+
+    private async Task<(decimal ToleranciaPago, decimal VueltoMaximo)> ResolverParametrosDeFacturacionAsync(
+        int idEmpresa, int idPuntoVenta, CancellationToken ct)
+    {
+        ParametroConocido[] conocidos = [ParametroConocido.ToleranciaPago, ParametroConocido.VueltoMaximo];
+        var claves = conocidos.Select(c => c.Clave).ToList();
+
+        var candidatos = await db.Parametros
+            .Where(p => claves.Contains(p.Clave) && p.IdEmpresa == idEmpresa
+                && (p.IdPuntoVenta == null || p.IdPuntoVenta == idPuntoVenta))
+            .ToListAsync(ct);
+
+        var resueltoPorClave = conocidos.ToDictionary(
+            c => c.Clave,
+            c => ResolucionDeParametros.Resolver(c.Clave, candidatos.Where(p => p.Clave == c.Clave).ToList(), idPuntoVenta));
+
+        return (
+            JsonSerializer.Deserialize<decimal>(resueltoPorClave[ParametroConocido.ToleranciaPago.Clave]),
+            JsonSerializer.Deserialize<decimal>(resueltoPorClave[ParametroConocido.VueltoMaximo.Clave]));
+    }
+
+    private async Task<DbConnection> ObtenerConexionAbiertaAsync(CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+
+    private int ExigirTenantDeLaSesion() =>
+        contexto.IdTenant
+            ?? throw new InvalidOperationException(
+                "ServicioDeFacturacionDeRemitos requiere un actor de tenant; OperacionDePos no admite plataforma.");
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        var limpio = valor?.Trim();
+        return string.IsNullOrEmpty(limpio) ? null : limpio;
+    }
+
+    private static ComprobanteEmitido Proyectar(
+        ComprobanteVenta comprobante, IReadOnlyList<PagoComprobante> pagos) => new(
+        comprobante.Id, comprobante.Numero,
+        NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
+        comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
+        comprobante.IdComprobanteAsociado, comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.Total,
+        comprobante.DireccionEntrega, comprobante.Observaciones,
+        [],
+        pagos
+            .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
+            .ToList());
+}

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -594,9 +594,9 @@ public class ServicioDeVentas(
         // Postgres toma el row lock de la primera, la segunda espera y, al retomarlo, re-evalúa
         // el WHERE contra el estado YA COMITEADO por la primera — 'anulado' no matchea 'emitido',
         // 0 filas, nunca un 500 ni una condición de carrera silenciosa.
-        var idPuntoVentaAnulacion = await MarcarAnuladoAsync(conexion, transaccionCruda, idTenant, id, ct);
+        var resultadoAnulacion = await MarcarAnuladoAsync(conexion, transaccionCruda, idTenant, id, ct);
 
-        if (idPuntoVentaAnulacion is null)
+        if (resultadoAnulacion is null)
         {
             // ADR-8: mismo 404 para "no existe" y "es de otro tenant" (filtro de EF + RLS ya
             // deja invisible un comprobante ajeno) — solo si NINGUNA fila visible tiene ese id
@@ -609,6 +609,23 @@ public class ServicioDeVentas(
             }
 
             throw new ErrorDominio("comprobante_ya_anulado", "El comprobante ya está anulado.", 409);
+        }
+
+        var (idPuntoVentaAnulacion, codigoTipoAnulado) = resultadoAnulacion.Value;
+
+        // stage-17-presupuestos-y-remitos, Slice 6 (design: Transactions — "ANULAR VENTA", decisión
+        // 4/7, mutation targets 55/56/58): POSICIÓN 1.6 — inmediatamente DESPUÉS de MarcarAnuladoAsync
+        // (paso 1) y ANTES de la auditoría (paso 1.5, preexistente) — nunca después del loop de stock
+        // ni de cuenta corriente (design: "posición 2, nunca después de stock/clientes"). El `if` de
+        // abajo es ESTRUCTURAL (mutation target 56): para una anulación ordinaria (`codigoTipoAnulado
+        // != "TXR"`) esto es CERO statements extra — mismo criterio que la rama del snapshot de la
+        // conversión (Slice 3, `if (plan.IdPresupuestoOrigen is { } ...)`). `codigoTipoAnulado` sale
+        // del scalar subquery ensanchado de `MarcarAnuladoAsync` (mutation target 55) — nunca un
+        // `SELECT` separado, que agregaría un statement extra a TODA anulación, no solo a la de un
+        // TXR.
+        if (codigoTipoAnulado == "TXR")
+        {
+            await EscriturasDeRemito.DesligarAsync(conexion, transaccionCruda, idTenant, id, momento, ct);
         }
 
         // 1.5. Auditoría (stage-14-auditoria-trazabilidad, Slice 3; spec auditoria-de-operaciones;
@@ -807,8 +824,17 @@ public class ServicioDeVentas(
     /// 3 (design decisión 8, precedente exacto <c>ServicioDeTurnos.MarcarCerradoAsync</c>):
     /// <c>RETURNING id_punto_venta</c> en vez de <c>id_comprobante_venta</c> — el mismo lock que
     /// ya decide "¿pasó la transición?" contesta también "¿en qué PV?", sin una lectura extra ni
-    /// confiar en el pre-read <c>AsNoTracking()</c>.</summary>
-    private static async Task<int?> MarcarAnuladoAsync(
+    /// confiar en el pre-read <c>AsNoTracking()</c>.
+    ///
+    /// stage-17-presupuestos-y-remitos, Slice 6 (design decisión 7, mutation target 55):
+    /// <c>RETURNING</c> ensanchado con un SUBQUERY ESCALAR — <c>(SELECT t.codigo FROM
+    /// tipos_comprobante t WHERE t.id_tipo_comprobante = comprobantes_venta.id_tipo_comprobante)</c>,
+    /// nunca una columna nueva — el mismo <c>UPDATE</c> guardado que ya decide la transición
+    /// también contesta "¿de qué tipo es?", sin un <c>SELECT</c> separado que agregaría un
+    /// statement extra a TODA anulación (no solo a la de un <c>TXR</c>). El llamador usa
+    /// <c>codigoTipo</c> para el guard estructural de la posición 1.6 (¿hay que desligar
+    /// remitos?).</summary>
+    private static async Task<(int IdPuntoVenta, string CodigoTipo)?> MarcarAnuladoAsync(
         DbConnection conexion, DbTransaction? transaccion, int idTenant, int idComprobanteVenta, CancellationToken ct)
     {
         await using var comando = conexion.CreateCommand();
@@ -816,15 +842,21 @@ public class ServicioDeVentas(
         comando.CommandText =
             "UPDATE comprobantes_venta SET estado = $1 " +
             "WHERE id_comprobante_venta = $2 AND id_tenant = $3 AND estado = $4 " +
-            "RETURNING id_punto_venta";
+            "RETURNING id_punto_venta, " +
+            "(SELECT t.codigo FROM tipos_comprobante t WHERE t.id_tipo_comprobante = comprobantes_venta.id_tipo_comprobante)";
 
         ParametrosDeComando.Agregar(comando, EstadoComprobante.Anulado);
         ParametrosDeComando.Agregar(comando, idComprobanteVenta);
         ParametrosDeComando.Agregar(comando, idTenant);
         ParametrosDeComando.Agregar(comando, EstadoComprobante.Emitido);
 
-        var resultado = await comando.ExecuteScalarAsync(ct);
-        return resultado is null ? null : Convert.ToInt32(resultado);
+        await using var lector = await comando.ExecuteReaderAsync(ct);
+        if (!await lector.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return (lector.GetInt32(0), lector.GetString(1));
     }
 
     // ---- La transacción (design: The Sale Transaction, orden de statements pineado) ----------

--- a/tests/Ways.Application.Tests/Ventas/ServicioDeFacturacionDeRemitosPosicionDeLockTests.cs
+++ b/tests/Ways.Application.Tests/Ventas/ServicioDeFacturacionDeRemitosPosicionDeLockTests.cs
@@ -1,0 +1,80 @@
+namespace Ways.Application.Tests.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (design decisión 12, mutation target 49; task 6.4).
+/// Mismo criterio que <see cref="ServicioDeVentasPosicionDeConversionTests"/> — extracción de texto
+/// fuente + búsqueda de substring inequívoca, nunca comportamiento.
+///
+/// **Por qué texto fuente (mutation-proof-tests regla 3)**: se corrió la mutación REAL — mover
+/// <c>EscriturasDeRemito.BloquearAscendenteAsync</c> de la posición 1 (antes del INSERT del
+/// comprobante) a justo antes de <c>LigarAsync</c> (después del loop de CC, posición 4.5) — y la
+/// suite completa de <c>ServicioDeFacturacionDeRemitosTests</c>, incluidas las dos rendezvous de la
+/// tarea 6.15 (facturar × anular-remito, ambos órdenes) y la de la tarea 6.23 (anular-TXR ×
+/// facturar), siguió en verde. Mismo hallazgo EXACTO que judgment-day slice-3, juez B, sobre la
+/// posición 1.5 de la conversión de presupuesto: la POSICIÓN no es lo que garantiza la corrección
+/// observable — eso lo da la ATOMICIDAD de la transacción (cualquier <c>throw</c> revierte TODO lo
+/// ya escrito, sin importar en qué línea esté) más el guard final de <c>LigarAsync</c> (mutation
+/// target 50), que sigue siendo la autoridad race-safe sin importar cuándo se tomó el lock
+/// ascendente dentro de la MISMA transacción. Ningún test de comportamiento puede discriminar "en
+/// posición 1" de "justo antes de LigarAsync" sin mentir sobre qué prueba — esta clase pinea la
+/// posición por el motivo REAL (fail-fast defensivo: ahorra materializar comprobante/pagos/CC para
+/// una consolidación que de todos modos va a fallar, y mantiene el orden total de locks documentado
+/// en el Lock order table del design), así un move accidental se caza sin afirmar una correctitud
+/// que la posición no otorga.
+/// </summary>
+public class ServicioDeFacturacionDeRemitosPosicionDeLockTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "Ventas", "ServicioDeFacturacionDeRemitos.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
+
+    /// <summary>Design: "EscriturasDeRemito.BloquearAscendenteAsync ANTES del INSERT del
+    /// comprobante y ANTES de clientes" (decisión 12, mutation target 49) — verificado en orden:
+    /// turno (paso 0) → lock ascendente (paso 1) → INSERT del comprobante (paso 2) → pagos (paso 3)
+    /// → cuenta corriente (paso 4) → LigarAsync (paso 5).</summary>
+    [Fact]
+    public void ElLockAscendenteVaAntesDelInsertDelComprobanteYAntesDeLaCuentaCorriente()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente,
+            "private async Task<ComprobanteEmitido> EjecutarFacturacionAsync(",
+            "// ---- Resolución de datos, fuera de la transacción");
+
+        var indiceTurno = metodo.IndexOf("servicioDeTurnos.ExigirTurnoAbiertoBajoLockAsync(", StringComparison.Ordinal);
+        var indiceLockAscendente = metodo.IndexOf("EscriturasDeRemito.BloquearAscendenteAsync(", StringComparison.Ordinal);
+        var indiceInsertComprobante = metodo.IndexOf("db.ComprobantesVenta.Add(comprobante)", StringComparison.Ordinal);
+        var indiceCc = metodo.IndexOf("EscriturasDeCuentaCorriente.ActualizarSaldoClienteAsync(", StringComparison.Ordinal);
+        var indiceLigar = metodo.IndexOf("EscriturasDeRemito.LigarAsync(", StringComparison.Ordinal);
+
+        Assert.True(indiceTurno >= 0, "No se encontró el guard de turno (paso 0).");
+        Assert.True(indiceLockAscendente >= 0, "No se encontró la llamada a BloquearAscendenteAsync.");
+        Assert.True(indiceInsertComprobante >= 0, "No se encontró el INSERT del comprobante (paso 2).");
+        Assert.True(indiceCc >= 0, "No se encontró el loop de cuenta corriente (paso 4).");
+        Assert.True(indiceLigar >= 0, "No se encontró la llamada a LigarAsync (paso 5).");
+
+        Assert.True(indiceLockAscendente > indiceTurno, "El lock ascendente debe ir DESPUÉS del guard de turno.");
+        Assert.True(indiceInsertComprobante > indiceLockAscendente, "El INSERT del comprobante debe ir DESPUÉS del lock ascendente.");
+        Assert.True(indiceCc > indiceLockAscendente, "La cuenta corriente debe seguir siendo posterior al lock ascendente.");
+        Assert.True(indiceLigar > indiceCc, "LigarAsync debe seguir siendo el último statement, después de la cuenta corriente.");
+    }
+}

--- a/tests/Ways.Application.Tests/Ventas/ServicioDeVentasPosicionDeDesligueTests.cs
+++ b/tests/Ways.Application.Tests/Ventas/ServicioDeVentasPosicionDeDesligueTests.cs
@@ -1,0 +1,180 @@
+using System.Text.RegularExpressions;
+
+namespace Ways.Application.Tests.Ventas;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (design: Transactions — "ANULAR VENTA", decisión 4/7;
+/// mutation targets 55/56/58; task 6.19). Mismo criterio que
+/// <see cref="ServicioDeVentasPosicionDeConversionTests"/> — extracción de texto fuente + búsqueda
+/// de substring inequívoca, nunca comportamiento.
+///
+/// **Por qué texto fuente (mutation-proof-tests regla 3)**: el guard estructural
+/// <c>if (codigoTipoAnulado == "TXR")</c> alrededor de <c>EscriturasDeRemito.DesligarAsync</c> —
+/// igual que el guard nulo de <c>IdPresupuestoOrigen</c> de Slice 3 — llama a un método que corre
+/// SQL crudo vía <c>ExecuteNonQueryAsync</c> sobre un <c>DbCommand</c> creado directo con
+/// <c>conexion.CreateCommand()</c>: ese camino NUNCA pasa por el pipeline de
+/// <c>DbCommandInterceptor.ReaderExecuting[Async]</c> de EF Core, así que un
+/// <c>ContadorDeComandos</c> (el mismo usado por <c>ServicioDeVentasConversionTests</c>) vería el
+/// MISMO conteo de consultas EF con o sin este bloque, guardado o no — es ciego por construcción,
+/// no una falla de instrumentación. La única red real de "cero statements extra para una
+/// anulación ordinaria" (mutation targets 55/56) es estructural: la llamada real a
+/// <c>EscriturasDeRemito.DesligarAsync(</c> solo puede aparecer DENTRO del guard
+/// <c>codigoTipoAnulado == "TXR"</c> en todo el método, nunca incondicional — exactamente el mismo
+/// argumento que <c>LaLlamadaAMarcarConvertidoAsyncNuncaOcurreFueraDelGuardNuloDeIdPresupuestoOrigen</c>.
+/// </summary>
+public class ServicioDeVentasPosicionDeDesligueTests
+{
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuente()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "..", "src", "Ways.Application", "Ventas", "ServicioDeVentas.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    private static string ExtraerMetodo(string fuente, string firma, string siguiente)
+    {
+        var inicio = fuente.IndexOf(firma, StringComparison.Ordinal);
+        Assert.True(inicio >= 0, $"No se encontró el método '{firma}'.");
+
+        var fin = fuente.IndexOf(siguiente, inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, $"No se encontró '{siguiente}' después de '{firma}'.");
+
+        return fuente[inicio..fin];
+    }
+
+    private static int EncontrarCierreBalanceado(string texto, int indiceApertura)
+    {
+        var profundidad = 0;
+        for (var i = indiceApertura; i < texto.Length; i++)
+        {
+            if (texto[i] == '{')
+            {
+                profundidad++;
+            }
+            else if (texto[i] == '}')
+            {
+                profundidad--;
+                if (profundidad == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>Design: "posición 1.6 — inmediatamente DESPUÉS de MarcarAnuladoAsync (paso 1) y
+    /// ANTES de la auditoría (paso 1.5, preexistente) — nunca después del loop de stock ni de
+    /// cuenta corriente" (mutation target 58: la rendezvous anular-TXR × facturar depende de que
+    /// el desligue corra ANTES, no después, de esas escrituras).</summary>
+    [Fact]
+    public void ElDesligueDeRemitosVaInmediatamenteDespuesDeMarcarAnuladoYAntesDeLaAuditoria()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente,
+            "private async Task<ComprobanteEmitido> EjecutarAnulacionAsync(",
+            "private static async Task ExigirTurnoNoCerradoAsync(");
+
+        var indiceMarcarAnulado = metodo.IndexOf("var resultadoAnulacion = await MarcarAnuladoAsync(", StringComparison.Ordinal);
+        var indiceGuardTxr = metodo.IndexOf("if (codigoTipoAnulado == \"TXR\")", StringComparison.Ordinal);
+        var indiceDesligar = metodo.IndexOf("EscriturasDeRemito.DesligarAsync(", StringComparison.Ordinal);
+        var indiceAuditoria = metodo.IndexOf("var servicioDeAuditoriaAnulacion = new", StringComparison.Ordinal);
+        var indiceStock = metodo.IndexOf("var movimientosOriginales = await db.MovimientosStock", StringComparison.Ordinal);
+        var indiceCc = metodo.IndexOf("var movimientosCcOriginales = await db.MovimientosCuentaCorriente", StringComparison.Ordinal);
+
+        Assert.True(indiceMarcarAnulado >= 0, "No se encontró la llamada a MarcarAnuladoAsync.");
+        Assert.True(indiceGuardTxr >= 0, "No se encontró el guard codigoTipoAnulado == \"TXR\".");
+        Assert.True(indiceDesligar >= 0, "No se encontró la llamada a EscriturasDeRemito.DesligarAsync.");
+        Assert.True(indiceAuditoria >= 0, "No se encontró el bloque de auditoría (paso 1.5).");
+        Assert.True(indiceStock >= 0, "No se encontró la reversa de stock (paso 2).");
+        Assert.True(indiceCc >= 0, "No se encontró el contramovimiento de CC (paso 3).");
+
+        Assert.True(indiceGuardTxr > indiceMarcarAnulado, "El guard TXR debe ir DESPUÉS de MarcarAnuladoAsync.");
+        Assert.True(indiceDesligar > indiceGuardTxr, "DesligarAsync debe estar DENTRO del guard TXR.");
+        Assert.True(indiceAuditoria > indiceDesligar, "La auditoría debe ir DESPUÉS del desligue (posición 1.6, no 1.5).");
+        Assert.True(indiceStock > indiceAuditoria, "La reversa de stock debe seguir siendo posterior.");
+        Assert.True(indiceCc > indiceStock, "El contramovimiento de CC debe seguir siendo el último.");
+
+        // Nunca DESPUÉS de stock/CC (design: "posición 2, nunca después de stock/clientes") —
+        // mutation target 58, el mutante concreto que la rendezvous anular-TXR × facturar mata.
+        Assert.True(indiceDesligar < indiceStock, "DesligarAsync no puede correr después de la reversa de stock.");
+        Assert.True(indiceDesligar < indiceCc, "DesligarAsync no puede correr después del contramovimiento de CC.");
+    }
+
+    /// <summary>Mutation targets 55/56 (RED estructural del "cero statements extra"): ver el
+    /// doc-comment de la clase sobre por qué <c>ContadorDeComandos</c> es ciego a esta llamada
+    /// (SQL crudo vía <c>ExecuteNonQueryAsync</c>, nunca pasa por el pipeline de EF). La red REAL
+    /// es que <c>EscriturasDeRemito.DesligarAsync(</c> solo puede aparecer DENTRO del guard
+    /// <c>codigoTipoAnulado == "TXR"</c> — nunca incondicional, nunca fuera de él.</summary>
+    [Fact]
+    public void LaLlamadaADesligarAsyncNuncaOcurreFueraDelGuardCodigoTipoTxr()
+    {
+        var fuente = LeerFuente();
+        var metodo = ExtraerMetodo(
+            fuente,
+            "private async Task<ComprobanteEmitido> EjecutarAnulacionAsync(",
+            "private static async Task ExigirTurnoNoCerradoAsync(");
+
+        const string guardIf = "if (codigoTipoAnulado == \"TXR\")";
+        var indiceGuard = metodo.IndexOf(guardIf, StringComparison.Ordinal);
+        Assert.True(indiceGuard >= 0, "No se encontró el guard codigoTipoAnulado == \"TXR\".");
+
+        var indiceApertura = metodo.IndexOf('{', indiceGuard + guardIf.Length);
+        var indiceCierre = EncontrarCierreBalanceado(metodo, indiceApertura);
+        Assert.True(indiceApertura > 0 && indiceCierre > indiceApertura, "No se pudo delimitar el bloque del guard TXR.");
+
+        var antesDelGuard = metodo[..indiceGuard];
+        var dentroDelGuard = metodo[indiceGuard..(indiceCierre + 1)];
+        var despuesDelGuard = metodo[(indiceCierre + 1)..];
+
+        var patronLlamadaReal = new Regex(
+            @"EscriturasDeRemito\.DesligarAsync\(\s*conexion,", RegexOptions.None, TimeSpan.FromSeconds(5));
+
+        Assert.False(patronLlamadaReal.IsMatch(antesDelGuard), "La llamada real no debe aparecer ANTES del guard TXR.");
+        Assert.False(patronLlamadaReal.IsMatch(despuesDelGuard), "La llamada real no debe aparecer DESPUÉS del guard TXR.");
+        Assert.True(patronLlamadaReal.IsMatch(dentroDelGuard), "La llamada real debe estar DENTRO del guard TXR.");
+    }
+
+    /// <summary>Mutation target 55: el <c>codigoTipo</c> tiene que salir del scalar subquery
+    /// ensanchado de <c>MarcarAnuladoAsync</c> — nunca un <c>SELECT</c> separado (eso agregaría un
+    /// statement extra a TODA anulación, no solo a la de un TXR). Prueba de texto fuente: el
+    /// método <c>MarcarAnuladoAsync</c> contiene el subquery escalar en su propio
+    /// <c>CommandText</c>, y <c>EjecutarAnulacionAsync</c> nunca declara un segundo <c>comando</c>
+    /// separado antes del guard TXR.</summary>
+    [Fact]
+    public void ElCodigoTipoSaleDelSubqueryEscalarDeMarcarAnuladoNuncaDeUnSelectSeparado()
+    {
+        var fuente = LeerFuente();
+
+        var metodoMarcarAnulado = ExtraerMetodo(
+            fuente,
+            "private static async Task<(int IdPuntoVenta, string CodigoTipo)?> MarcarAnuladoAsync(",
+            "// ---- La transacción");
+
+        Assert.Contains(
+            "(SELECT t.codigo FROM tipos_comprobante t WHERE t.id_tipo_comprobante = comprobantes_venta.id_tipo_comprobante)",
+            metodoMarcarAnulado);
+
+        var metodoAnulacion = ExtraerMetodo(
+            fuente,
+            "private async Task<ComprobanteEmitido> EjecutarAnulacionAsync(",
+            "private static async Task ExigirTurnoNoCerradoAsync(");
+
+        var indiceGuardTxr = metodoAnulacion.IndexOf("if (codigoTipoAnulado == \"TXR\")", StringComparison.Ordinal);
+        Assert.True(indiceGuardTxr >= 0);
+
+        var antesDelGuard = metodoAnulacion[..indiceGuardTxr];
+
+        // Ningún SELECT/comando adicional a tipos_comprobante antes del guard TXR — el ÚNICO lugar
+        // que resuelve el código del tipo es el subquery escalar dentro del RETURNING de
+        // MarcarAnuladoAsync.
+        Assert.DoesNotContain("tipos_comprobante", antesDelGuard, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Ways.Application.Abstracciones;
@@ -16,6 +17,7 @@ using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
+using Ways.Domain.Stock;
 using Ways.Domain.Usuarios;
 using Ways.Domain.Ventas;
 using Ways.Infrastructure.Multitenancy;
@@ -281,10 +283,14 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
     // — ruido de pool/timing del harness, no una falla de la implementación (la evidencia SQL
     // aislada ya la prueba). Se descartó esa prueba en vez de dejarla flaky/incorrecta.
     //
-    // Red REAL para este target (below-the-confound, estable): fuente de texto, mismo criterio que
+    // Red de texto fuente (below-the-confound, estable): fuente de texto, mismo criterio que
     // <c>PresupuestosSchemaTests.ElTextoFuenteDeLaMigracionConservaLosDosFiltrosParcialesTargets4Y5</c>
     // y <c>ServicioDeVentasPosicionDeConversionTests</c> — el ORDER BY exacto tiene que estar en el
-    // texto fuente de <c>BloquearAscendenteAsync</c>, nunca invertido.
+    // texto fuente de <c>BloquearAscendenteAsync</c>, nunca invertido. UPDATE (judgment-day Slice
+    // 6, ronda 1, juez B): la variante LIVIANA (sin WebApplicationFactory, DbContextOptionsBuilder
+    // directo) SÍ reprodujo la señal below-the-confound — ver
+    // <c>BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido</c>,
+    // más abajo — así que este target queda con DOS redes complementarias, no solo la de texto.
     // =============================================================================================
 
     [Fact]
@@ -309,6 +315,174 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
     }
 
     private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    // =============================================================================================
+    // judgment-day Slice 6, ronda 1, juez B — MAJOR (mutation target 48, RETRY liviano): la nota
+    // de arriba solo documentó el intento CONTRA EL HARNESS COMPLETO (WebApplicationFactory +
+    // fixture.AbrirConexionCrudaAsync); el juez señaló, con razón, que la variante LIVIANA —
+    // DbContextOptionsBuilder directo contra fixture.AppConnectionString, mismo patrón que
+    // ServicioDeRemitosTests.EmitirRemitoObservandoOrdenDeLocksAsync — nunca se había intentado de
+    // verdad. Se intentó acá, honestamente, y ESTA VEZ SÍ REPRODUJO de forma determinística: sin
+    // WebApplicationFactory ni el pool de ~250 conexiones nuevas del harness completo, el ruido que
+    // mataba el experimento anterior desaparece. Técnica (below-the-confound, sin necesitar
+    // correlacionar ctid/page/tuple de pg_locks): sesión bloqueadora sostiene FOR UPDATE sobre el
+    // remito MENOR; el backend bajo prueba invoca BloquearAscendenteAsync DIRECTO con el array de
+    // entrada INVERTIDO ([mayor, menor]); confirmado que está genuinamente bloqueado, una tercera
+    // conexión intenta FOR UPDATE NOWAIT sobre el MAYOR — bajo la implementación correcta (ORDER BY
+    // id_remito ASC) todavía no lo tocó, así que el NOWAIT prueba libre; bajo el mutante (DESC) ya
+    // lo habría tomado ANTES de bloquearse en el menor, y el NOWAIT choca con 55P03.
+    //
+    // Diagnóstico real del primer intento (no descartado en silencio, mutation-proof-tests regla
+    // 2): la primera versión de este poll filtraba `pg_locks` por `relation =
+    // 'remitos'::regclass AND NOT granted` (la receta literal del juez) y NUNCA detectó el
+    // bloqueo — timeout de 5s, 0/1 corridas. Causa real, confirmada leyendo el resultado: el wait
+    // que Postgres expone acá es `locktype = 'transactionid'` (esperando a que termine la
+    // transacción bloqueadora), un lock SIN `relation` asociada — filtrar por `relation` produce
+    // un falso negativo permanente, no ruido de timing. Corregido a `pid = $1 AND NOT granted`
+    // (sin filtro de relación): 4/4 corridas en verde tras el fix, evidencia REAL contra el
+    // mutante DESC (55P03 exacto en el probe, ver tasks.md) — no razonado.
+    // =============================================================================================
+
+    [Fact]
+    public async Task BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido()
+    {
+        var ctx = await PrepararAsync(nameof(BloquearAscendenteAsyncTomaLosLocksEnOrdenAscendentePorIdRemitoAunConElArrayDeEntradaInvertido));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Orden Lock Ascendente", 30m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var remitoMenor = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remitoMayor = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        Assert.True(remitoMenor.Id < remitoMayor.Id);
+
+        // Sesión bloqueadora: sostiene FOR UPDATE sobre el remito MENOR, sin comitear.
+        await using var conexionBloqueo = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionBloqueo.OpenAsync();
+        await using (var comandoGuc = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
+            conexionBloqueo))
+        {
+            comandoGuc.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGuc.ExecuteNonQueryAsync();
+        }
+        await using var transaccionBloqueo = await conexionBloqueo.BeginTransactionAsync();
+        await using (var comandoBloqueo = new NpgsqlCommand(
+            "SELECT 1 FROM remitos WHERE id_remito = $1 FOR UPDATE", conexionBloqueo, transaccionBloqueo))
+        {
+            comandoBloqueo.Parameters.AddWithValue(remitoMenor.Id);
+            await comandoBloqueo.ExecuteScalarAsync();
+        }
+
+        // Backend bajo prueba: DbContextOptionsBuilder directo contra fixture.AppConnectionString
+        // (patrón liviano de EmitirRemitoObservandoOrdenDeLocksAsync) — array de entrada
+        // INVERTIDO ([mayor, menor]) para que un sort estable que preservara el orden de arribo no
+        // enmascare al mutante.
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<Ways.Domain.Caja.TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<Ways.Domain.Gastos.CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<Ways.Domain.Compras.EstadoCompra>("estado_compra");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
+                npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
+                npgsql.MapEnum<Ways.Domain.Ventas.EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+        await db.Database.OpenConnectionAsync();
+        var conexionRemito = (NpgsqlConnection)db.Database.GetDbConnection();
+        var pidRemito = (int)(await new NpgsqlCommand("SELECT pg_backend_pid()", conexionRemito).ExecuteScalarAsync())!;
+
+        await using var transaccionRemito = await db.Database.BeginTransactionAsync();
+        var transaccionCruda = db.Database.CurrentTransaction?.GetDbTransaction();
+
+        var bloquearTask = EscriturasDeRemito.BloquearAscendenteAsync(
+            conexionRemito, transaccionCruda, ctx.IdTenant, [remitoMayor.Id, remitoMenor.Id], CancellationToken.None);
+
+        // Confirmamos que el backend bajo prueba está REALMENTE bloqueado (pg_locks,
+        // granted=false) antes de lanzar el probe — sin esto, un probe prematuro no discrimina
+        // nada (mismo riesgo que la rendezvous de task 6.14 documentó arriba).
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync();
+
+        var bloqueado = false;
+        var limite = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < limite)
+        {
+            // NOT granted alcanza — el bloqueo real que Postgres expone acá es un wait por
+            // locktype='transactionid' (esperando que termine la transacción bloqueadora), no un
+            // locktype='relation'/'tuple' sobre remitos: filtrar por relation acá habría dejado
+            // este poll en falso negativo permanente (diagnosticado empíricamente, ver nota del
+            // método).
+            await using var comandoPoll = new NpgsqlCommand(
+                "SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = $1 AND NOT granted)",
+                conexionPoll);
+            comandoPoll.Parameters.AddWithValue(pidRemito);
+            bloqueado = (bool)(await comandoPoll.ExecuteScalarAsync())!;
+            if (bloqueado)
+            {
+                break;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Assert.True(bloqueado, "El backend bajo prueba nunca quedó bloqueado — el experimento no discrimina nada.");
+
+        // Probe NOWAIT sobre el MAYOR mientras el backend bajo prueba sigue bloqueado en el
+        // menor: bajo la implementación correcta (ASC) todavía no lo tocó, así que prueba libre
+        // (sin excepción). Bajo el mutante (DESC) ya lo habría tomado, y esto chocaría con 55P03.
+        await using var conexionProbe = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionProbe.OpenAsync();
+        await using (var comandoGucProbe = new NpgsqlCommand(
+            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
+            conexionProbe))
+        {
+            comandoGucProbe.Parameters.AddWithValue(ctx.IdTenant.ToString());
+            await comandoGucProbe.ExecuteNonQueryAsync();
+        }
+        await using var transaccionProbe = await conexionProbe.BeginTransactionAsync();
+        PostgresException? excepcionDelProbe = null;
+        try
+        {
+            await using var comandoProbe = new NpgsqlCommand(
+                "SELECT 1 FROM remitos WHERE id_remito = $1 FOR UPDATE NOWAIT", conexionProbe, transaccionProbe);
+            comandoProbe.Parameters.AddWithValue(remitoMayor.Id);
+            await comandoProbe.ExecuteScalarAsync();
+        }
+        catch (PostgresException ex)
+        {
+            excepcionDelProbe = ex;
+        }
+        finally
+        {
+            await transaccionProbe.RollbackAsync();
+        }
+
+        Assert.Null(excepcionDelProbe);
+
+        // Libera el lock retenido — el backend bajo prueba, hasta acá bloqueado, ahora completa.
+        await transaccionBloqueo.RollbackAsync();
+        var filas = await bloquearTask;
+        Assert.Equal(2, filas.Count);
+
+        await transaccionRemito.RollbackAsync();
+    }
 
     // =============================================================================================
     // task 6.14: facturar × facturar sobre sets superpuestos — exactamente un 201 + un 409
@@ -740,6 +914,83 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         Assert.Equal(movimientosAntes, movimientosDespues);
     }
 
+    // =============================================================================================
+    // judgment-day Slice 6, ronda 1, juez B — MAJOR (mutation target 57, regla 12c): sin esta red,
+    // un mutante que borra `id_comprobante_venta = $1` del WHERE de DesligarAsync sobrevive 15/15
+    // — ningún fixture existente tenía DOS TXRs activos a la vez, así que "WHERE id_tenant = $2
+    // AND estado = 'facturado'" solo, sin el filtro por comprobante, desliga CUALQUIER remito
+    // facturado del tenant, no solo los de ESTE TXR. Facturamos DOS consolidaciones
+    // independientes (TXR-A: remitos 1-2; TXR-B: remitos 3-4, mismo tenant/cliente/PV), anulamos
+    // SOLO TXR-A, y probamos exact count AND identity (mutation-proof-tests regla 12c) sobre los
+    // hermanos de B: siguen 'facturado', siguen ligados a B (no a null, no a A), y su saldo/
+    // movimientos de CC (medio cuenta corriente en ambos TXR) no se mueven un centavo — solo el
+    // de A revierte.
+    // =============================================================================================
+
+    [Fact]
+    public async Task AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrActivo()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnTxrDesligaSoloSusPropiosRemitosYDejaIntactosLosDeUnSegundoTxrActivo));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Hermanos Intactos", 50m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 40m);
+
+        var remito1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remito2 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remito3 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remito4 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        var facturadoA = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remito1.Id, remito2.Id], remito1.Total + remito2.Total, ctx.IdMedioCuentaCorriente));
+        Assert.Equal(HttpStatusCode.Created, facturadoA.StatusCode);
+        var txrA = (await facturadoA.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var facturadoB = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remito3.Id, remito4.Id], remito3.Total + remito4.Total, ctx.IdMedioCuentaCorriente));
+        Assert.Equal(HttpStatusCode.Created, facturadoB.StatusCode);
+        var txrB = (await facturadoB.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldoTrasAmbas = await dbAntes.Clientes.Where(c => c.Id == ctx.IdCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(txrA.Total + txrB.Total, saldoTrasAmbas); // cliente fresco, discriminante contra 0.
+        var movimientosDeBAntes = await dbAntes.MovimientosCuentaCorriente.CountAsync(m => m.IdComprobanteVenta == txrB.Id);
+
+        // Anulamos SOLO A.
+        var anuladoA = await ctx.Admin.PostAsync($"/api/ventas/{txrA.Id}/anulacion", null);
+        var cuerpoAnuladoA = await anuladoA.Content.ReadAsStringAsync();
+        Assert.True(anuladoA.StatusCode == HttpStatusCode.OK, cuerpoAnuladoA);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Los de A vuelven a emitido, ligadura limpia.
+        var r1 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito1.Id);
+        var r2 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito2.Id);
+        Assert.Equal(EstadoRemito.Emitido, r1.Estado);
+        Assert.Equal(EstadoRemito.Emitido, r2.Estado);
+        Assert.Null(r1.IdComprobanteVenta);
+        Assert.Null(r2.IdComprobanteVenta);
+
+        // Los de B siguen 'facturado' Y ligados a B — exact count AND identity (regla 12c): el
+        // mutante que borra `id_comprobante_venta = $1` del WHERE de DesligarAsync desligaría
+        // TAMBIÉN estos dos, dejándolos en 0/null — cualquiera de las dos aserciones de abajo por
+        // sí sola ya lo mata, las dos juntas cierran el par completo (count Y quién).
+        var r3 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito3.Id);
+        var r4 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito4.Id);
+        Assert.Equal(EstadoRemito.Facturado, r3.Estado);
+        Assert.Equal(EstadoRemito.Facturado, r4.Estado);
+        Assert.Equal(txrB.Id, r3.IdComprobanteVenta);
+        Assert.Equal(txrB.Id, r4.IdComprobanteVenta);
+        Assert.Equal(2, await db.Remitos.CountAsync(r => r.IdComprobanteVenta == txrB.Id));
+
+        // La CC solo revierte lo de A: el saldo baja exactamente el total de A, los movimientos
+        // de B (conteo Y ligadura por id_comprobante_venta) quedan exactamente como estaban.
+        var saldoFinal = await db.Clientes.Where(c => c.Id == ctx.IdCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(txrB.Total, saldoFinal);
+        var movimientosDeBDespues = await db.MovimientosCuentaCorriente.CountAsync(m => m.IdComprobanteVenta == txrB.Id);
+        Assert.Equal(movimientosDeBAntes, movimientosDeBDespues);
+    }
+
     /// <summary>[OD8/T3, discriminant test] tasks.md decisión 6: un TXR anulado prueba AMBAS
     /// mitades de la composición JUNTAS, en la misma transacción — (a) cero
     /// <c>movimientos_stock</c> creados Y (b) el saldo de CC revertido por el importe EXACTO
@@ -929,5 +1180,50 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         var facturarSiguiente = await ctx.Admin.PostAsJsonAsync(
             "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
         Assert.Equal(HttpStatusCode.Created, facturarSiguiente.StatusCode);
+    }
+
+    // =============================================================================================
+    // judgment-day Slice 6, ronda 1, juez B — SUGGESTION (fidelidad de totales, :100-107 de
+    // ServicioDeFacturacionDeRemitos): desincronizamos `remitos.total` por escritura cruda ANTES
+    // de facturar (sentinel distinto de la suma de items_remito congelados) y probamos el
+    // contrato EXACTO que el chequeo de fidelidad emite — InvalidOperationException, que
+    // ManejadorDeErrores traduce al catch-all genérico (500/"error_interno", nunca un 409 de
+    // negocio) porque un desacuerdo acá solo puede significar una escritura fuera de banda, no un
+    // caso de negocio alcanzable.
+    // =============================================================================================
+
+    [Fact]
+    public async Task FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio()
+    {
+        var ctx = await PrepararAsync(nameof(FacturarRechazaCuandoElTotalDelHeaderDeUnRemitoFueDesincronizadoPorFueraDelServicio));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Fidelidad Total", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        // Sentinel: total crudo distinto de la suma de items_remito congelados (nunca 0, nunca el
+        // valor original) — simula exactamente la escritura cruda/fuera de banda que el chequeo
+        // de fidelidad defiende.
+        var totalSentinel = remito.Total + 999m;
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant))
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "UPDATE remitos SET total = $1 WHERE id_remito = $2";
+            comando.Parameters.Add(new NpgsqlParameter { Value = totalSentinel });
+            comando.Parameters.Add(new NpgsqlParameter { Value = remito.Id });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.InternalServerError, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("error_interno", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Emitido, r.Estado);
+        Assert.Null(r.IdComprobanteVenta);
     }
 }

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -1,0 +1,933 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Application.Ventas;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Precios;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-17-presupuestos-y-remitos, Slice 6 (tasks 6.13-6.24; design: Transactions — "FACTURAR
+/// REMITOS (consolidación)"; mutation targets 48-58). <see cref="ServicioDeFacturacionDeRemitos.FacturarAsync"/>
+/// consolida N remitos <c>emitido</c> en UN comprobante <c>TXR</c> itemless (precedente <c>RC</c>) —
+/// este archivo prueba cero items/cero stock en ambas direcciones (emisión y anulación), las tres
+/// razas (facturar × facturar, facturar × anular-remito, anular-TXR × facturar), el backstop de
+/// límite de crédito re-implementado, el guard de turno (y su ausencia deliberada en el cuarto
+/// write site), el desligue guardado y el discriminante OD8/T3.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdPuntoVenta2, HttpClient Admin, int IdArea,
+        int IdAlicuotaIva, int IdListaPrecio, int IdCliente, int IdMedioEfectivo, int IdMedioCuentaCorriente,
+        int IdUsuarioAdmin, string MailAdmin, string PasswordAdmin);
+
+    private async Task<Contexto> PrepararAsync(string nombre, bool conTurnoAbierto = true)
+    {
+        using var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, resultado.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var area = new Area { IdTenant = resultado.IdTenant, Nombre = "Txr-area", Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Areas.Add(area);
+        await db.SaveChangesAsync();
+
+        var idAlicuotaIva = await db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.Id).FirstAsync();
+
+        var lista = new ListaPrecio
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Lista TXR", EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(lista);
+        await db.SaveChangesAsync();
+
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+        var cliente = new Cliente
+        {
+            IdTenant = resultado.IdTenant, Numero = 3000 + Random.Shared.Next(1, 100_000), Nombre = $"{nombre}-cliente",
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = lista.Id, LimiteCredito = 0,
+            CreditoIlimitado = true, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var idMedioEfectivo = await db.MediosPago
+            .Where(m => m.Comportamiento == ComportamientoMedioPago.Efectivo)
+            .Select(m => m.Id).FirstAsync();
+
+        var medioCc = new MedioPago
+        {
+            IdTenant = resultado.IdTenant, Nombre = "Cuenta corriente TXR", Orden = 3,
+            Comportamiento = ComportamientoMedioPago.CuentaCorriente, AdmiteVuelto = false, RequiereReferencia = false,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.MediosPago.Add(medioCc);
+        await db.SaveChangesAsync();
+
+        var puntoVenta2 = new PuntoVenta
+        {
+            IdTenant = resultado.IdTenant, IdEmpresa = resultado.IdEmpresa, Nombre = $"{nombre}-PV2",
+            CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta2);
+        await db.SaveChangesAsync();
+
+        if (conTurnoAbierto)
+        {
+            db.TurnosCaja.Add(new TurnoCaja
+            {
+                IdTenant = resultado.IdTenant, IdPuntoVenta = resultado.IdPuntoVenta,
+                IdEmpleadoApertura = resultado.IdUsuarioAdmin, FechaApertura = ahora, FondoInicial = 0m,
+                Estado = EstadoTurno.Abierto, CreatedAt = ahora, UpdatedAt = ahora
+            });
+            await db.SaveChangesAsync();
+        }
+
+        return new Contexto(
+            resultado.IdTenant, resultado.IdEmpresa, resultado.IdPuntoVenta, puntoVenta2.Id, admin, area.Id,
+            idAlicuotaIva, lista.Id, cliente.Id, idMedioEfectivo, medioCc.Id, resultado.IdUsuarioAdmin, mailAdmin,
+            resultado.PasswordTemporal);
+    }
+
+    private async Task<int> SembrarArticuloAsync(Contexto ctx, string nombre, decimal precio)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+
+        var articulo = new Articulo
+        {
+            IdTenant = ctx.IdTenant, CodigoInterno = $"{nombre}-{Guid.NewGuid():N}", Nombre = nombre,
+            IdArea = ctx.IdArea, IdAlicuotaIva = ctx.IdAlicuotaIva, UnidadVenta = UnidadVenta.Unidad,
+            EsProducto = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Articulos.Add(articulo);
+        await db.SaveChangesAsync();
+
+        db.Precios.Add(new Precio
+        {
+            IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
+            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+
+        return articulo.Id;
+    }
+
+    private async Task SembrarStockAgregadoAsync(Contexto ctx, int idArticulo, decimal cantidad, int? idPuntoVenta = null)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        db.Stock.Add(new Ways.Domain.Stock.Stock
+        {
+            IdArticulo = idArticulo, IdPuntoVenta = idPuntoVenta ?? ctx.IdPuntoVenta, IdTenant = ctx.IdTenant, Cantidad = cantidad
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> SembrarClienteAsync(Contexto ctx, string nombre, decimal limiteCredito = 0, bool creditoIlimitado = false)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var ahora = DateTimeOffset.UtcNow;
+        var idCondicionFiscal = await db.CondicionesFiscales.Select(c => c.Id).FirstAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = ctx.IdTenant, Numero = 4000 + Random.Shared.Next(1, 100_000), Nombre = nombre,
+            IdCondicionFiscal = idCondicionFiscal, IdListaPrecio = ctx.IdListaPrecio, LimiteCredito = limiteCredito,
+            CreditoIlimitado = creditoIlimitado, Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        return cliente.Id;
+    }
+
+    private static SolicitudDeRemito SolicitudRemitoSimple(
+        Contexto ctx, int idArticulo, decimal cantidad, int? idCliente = null, int? idPuntoVenta = null) =>
+        new(idPuntoVenta ?? ctx.IdPuntoVenta, idCliente ?? ctx.IdCliente, null, null, [new LineaDeRemito(idArticulo, cantidad, null)]);
+
+    /// <summary>Crea + emite un remito vía HTTP, devolviendo el <see cref="RemitoDetalle"/> ya
+    /// <c>emitido</c> — helper compartido por todos los tests de este archivo.</summary>
+    private static async Task<RemitoDetalle> CrearYEmitirRemitoAsync(HttpClient cliente, SolicitudDeRemito solicitud)
+    {
+        var creado = await cliente.PostAsJsonAsync("/api/remitos", solicitud);
+        var cuerpoCreado = await creado.Content.ReadAsStringAsync();
+        Assert.True(creado.StatusCode == HttpStatusCode.Created, cuerpoCreado);
+        var detalle = JsonSerializer.Deserialize<RemitoDetalle>(cuerpoCreado, OpcionesJson)!;
+
+        var emitido = await cliente.PostAsync($"/api/remitos/{detalle.Id}/emitir", null);
+        var cuerpoEmitido = await emitido.Content.ReadAsStringAsync();
+        Assert.True(emitido.StatusCode == HttpStatusCode.OK, cuerpoEmitido);
+        return JsonSerializer.Deserialize<RemitoDetalle>(cuerpoEmitido, OpcionesJson)!;
+    }
+
+    private static SolicitudDeFacturacionDeRemitos SolicitudFacturacion(
+        Contexto ctx, IReadOnlyList<int> idsRemito, decimal importe, int? idMedio = null) =>
+        new(ctx.IdPuntoVenta, idsRemito, [new PagoDeVenta(idMedio ?? ctx.IdMedioEfectivo, importe, null, 0m)], "obs-txr");
+
+    // =============================================================================================
+    // task 6.13: consolidación básica — itemless, total == Σ headers, cero movimientos_stock
+    // =============================================================================================
+
+    [Fact]
+    public async Task DosRemitosConsolidanEnUnTxrItemlessConTotalIgualALaSumaDeLosHeadersYCeroMovimientosDeStock()
+    {
+        var ctx = await PrepararAsync(nameof(DosRemitosConsolidanEnUnTxrItemlessConTotalIgualALaSumaDeLosHeadersYCeroMovimientosDeStock));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Art 1", 100m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Art 2", 250m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 20m);
+
+        var remito1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 3m));
+        var remito2 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 2m));
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientosAntes = await dbAntes.MovimientosStock.CountAsync();
+
+        var totalEsperado = remito1.Total + remito2.Total;
+        var solicitud = SolicitudFacturacion(ctx, [remito1.Id, remito2.Id], totalEsperado);
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/remitos/facturacion", solicitud);
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+        Assert.True(respuesta.StatusCode == HttpStatusCode.Created, cuerpo);
+        var txr = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpo, OpcionesJson)!;
+
+        Assert.Empty(txr.Items);
+        Assert.Equal(totalEsperado, txr.Total);
+        Assert.Equal(remito1.Subtotal + remito2.Subtotal, txr.Subtotal);
+        Assert.Equal(remito1.DescuentoTotal + remito2.DescuentoTotal, txr.DescuentoTotal);
+        Assert.Equal(ctx.IdCliente, txr.IdCliente);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r1 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito1.Id);
+        var r2 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito2.Id);
+        Assert.Equal(EstadoRemito.Facturado, r1.Estado);
+        Assert.Equal(EstadoRemito.Facturado, r2.Estado);
+        Assert.Equal(txr.Id, r1.IdComprobanteVenta);
+        Assert.Equal(txr.Id, r2.IdComprobanteVenta);
+
+        // Mutation target 52 (mitad "cero items"): cero movimientos_stock adicionales — la
+        // mercadería ya salió por los remitos individuales (write site 4), la consolidación no
+        // toca stock por construcción.
+        var movimientosDespues = await db.MovimientosStock.CountAsync();
+        Assert.Equal(movimientosAntes, movimientosDespues);
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == txr.Id));
+
+        var itemsDelTxr = await db.ItemsComprobanteVenta.CountAsync(i => i.IdComprobanteVenta == txr.Id);
+        Assert.Equal(0, itemsDelTxr);
+    }
+
+    // =============================================================================================
+    // mutation target 48 — FINDING REGISTERED (mutation-proof-tests regla 2/3, "run it, don't
+    // reason it" + "route below the confound"). La rendezvous pausada-vs-libre de task 6.14 (más
+    // abajo) NO discrimina el orden: corrida bajo la mutación REAL (ORDER BY id_remito DESC en
+    // BloquearAscendenteAsync), la suite completa de este archivo siguió en verde — confirmado
+    // EMPÍRICAMENTE (`dotnet test` con la mutación aplicada, revertida después), no razonado. Motivo
+    // estructural: esa rendezvous nunca pone dos transacciones a competir de verdad por filas en
+    // orden inverso — una queda pausada ANTES de intentar cualquier lock mientras la otra corre
+    // completa y sin contención, así que el ORDEN de adquisición nunca queda expuesto (mismo
+    // "pre-check que espeja un guard transaccional" que rule 3 documenta, salvo que acá el espejo es
+    // la ausencia total de contención real).
+    //
+    // Se intentó una prueba below-the-confound de dos conexiones (bloqueadora + probe NOWAIT desde
+    // una tercera conexión), mismo patrón que <c>ServicioDeRemitosTests.EmitirRemitoObservandoOrdenDeLocksAsync</c>
+    // (target 40) — un experimento psql de dos sesiones AISLADO (dos <c>psql -c</c> concurrentes
+    // contra una tabla mínima de 2 filas) confirmó que Postgres SÍ lockea en orden ascendente para
+    // <c>ORDER BY id FOR UPDATE</c> (el probe NOWAIT de la fila menor falló con <c>55P03</c> mientras
+    // la fila mayor seguía bloqueada por la conexión bloqueadora — la fila menor YA estaba tomada).
+    // Pero la MISMA técnica reimplementada contra el harness completo (WebApplicationFactory +
+    // fixture.AbrirConexionCrudaAsync abriendo ~250 conexiones nuevas en 8s) nunca reprodujo la señal
+    // — ruido de pool/timing del harness, no una falla de la implementación (la evidencia SQL
+    // aislada ya la prueba). Se descartó esa prueba en vez de dejarla flaky/incorrecta.
+    //
+    // Red REAL para este target (below-the-confound, estable): fuente de texto, mismo criterio que
+    // <c>PresupuestosSchemaTests.ElTextoFuenteDeLaMigracionConservaLosDosFiltrosParcialesTargets4Y5</c>
+    // y <c>ServicioDeVentasPosicionDeConversionTests</c> — el ORDER BY exacto tiene que estar en el
+    // texto fuente de <c>BloquearAscendenteAsync</c>, nunca invertido.
+    // =============================================================================================
+
+    [Fact]
+    public void ElOrderByDeBloquearAscendenteEsAscendentePorIdRemitoNuncaDescendente()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Application", "Ventas", "EscriturasDeRemito.cs");
+        Assert.True(File.Exists(ruta), $"No se encontró {ruta}");
+        var fuente = File.ReadAllText(ruta);
+
+        var inicio = fuente.IndexOf(
+            "public static async Task<IReadOnlyList<(int IdRemito, string Estado, int? IdComprobante)>> BloquearAscendenteAsync(",
+            StringComparison.Ordinal);
+        Assert.True(inicio >= 0, "No se encontró el método BloquearAscendenteAsync.");
+        var fin = fuente.IndexOf("public static async Task<int> LigarAsync(", inicio, StringComparison.Ordinal);
+        Assert.True(fin > inicio, "No se encontró el cierre de BloquearAscendenteAsync.");
+
+        var metodo = fuente[inicio..fin];
+        Assert.Contains("ORDER BY id_remito FOR UPDATE", metodo, StringComparison.Ordinal);
+        Assert.DoesNotContain("id_remito DESC", metodo, StringComparison.Ordinal);
+    }
+
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    // =============================================================================================
+    // task 6.14: facturar × facturar sobre sets superpuestos — exactamente un 201 + un 409
+    // (mutation targets 48/50)
+    // =============================================================================================
+
+    private sealed class InterceptorDePausaTrasIniciarLaTransaccion(
+        TaskCompletionSource transaccionIniciada, TaskCompletionSource puedeContinuar) : DbTransactionInterceptor
+    {
+        public override async ValueTask<System.Data.Common.DbTransaction> TransactionStartedAsync(
+            System.Data.Common.DbConnection connection, TransactionEndEventData eventData,
+            System.Data.Common.DbTransaction transaction, CancellationToken cancellationToken = default)
+        {
+            transaccionIniciada.TrySetResult();
+            await puedeContinuar.Task;
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    /// <summary>Mismo patrón que <c>ServicioDeRemitosTests.DobleEmitirConcurrenteEsRechazado409ViaElGuardNoViaElPreCheck</c>:
+    /// el primer <c>facturar</c> pausa justo tras abrir SU transacción — antes de tomar el lock
+    /// ascendente de <see cref="EscriturasDeRemito.BloquearAscendenteAsync"/> — mientras un segundo
+    /// <c>facturar</c> sobre un set SUPERPUESTO (comparte el remito 2) corre completo y commitea.
+    /// Al reanudar, el primero toma el lock (ahora libre, remito 2 ya <c>facturado</c>), pero
+    /// <see cref="EscriturasDeRemito.LigarAsync"/> (mutation target 50: <c>estado='emitido' AND
+    /// id_comprobante_venta IS NULL</c> + el rowcount == N) solo matchea 1 de 2 filas ⇒
+    /// <c>409 remito_no_facturable</c>, con TODO lo que esa transacción ya escribió (comprobante,
+    /// pagos) revertido por la atomicidad — nunca un TXR fantasma.</summary>
+    [Fact]
+    public async Task FacturarXFacturarSobreSetsSuperpuestosDaExactamenteUn201YUn409()
+    {
+        var ctx = await PrepararAsync(nameof(FacturarXFacturarSobreSetsSuperpuestosDaExactamenteUn201YUn409));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Solap 1", 50m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Solap 2", 70m);
+        var idArticulo3 = await SembrarArticuloAsync(ctx, "Txr Solap 3", 90m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo3, 10m);
+
+        var remito1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 1m));
+        var remito2 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 1m)); // compartido
+        var remito3 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo3, 1m));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clientePrimero = factory.CreateClient();
+        var login = await clientePrimero.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        // Primero: remitos [1,2], pausado tras abrir su transacción.
+        var solicitudPrimero = SolicitudFacturacion(ctx, [remito1.Id, remito2.Id], remito1.Total + remito2.Total);
+        var tareaPrimero = clientePrimero.PostAsJsonAsync("/api/remitos/facturacion", solicitudPrimero);
+
+        await transaccionIniciada.Task;
+
+        // Segundo: remitos [2,3] — SUPERPUESTO en el remito 2 — corre completo, fuera del interceptor.
+        var solicitudSegundo = SolicitudFacturacion(ctx, [remito2.Id, remito3.Id], remito2.Total + remito3.Total);
+        var respuestaSegundo = await ctx.Admin.PostAsJsonAsync("/api/remitos/facturacion", solicitudSegundo);
+        var cuerpoSegundo = await respuestaSegundo.Content.ReadAsStringAsync();
+        Assert.True(respuestaSegundo.StatusCode == HttpStatusCode.Created, cuerpoSegundo);
+        var txrSegundo = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoSegundo, OpcionesJson)!;
+
+        puedeContinuar.TrySetResult();
+
+        var respuestaPrimero = await tareaPrimero;
+        var cuerpoPrimero = await respuestaPrimero.Content.ReadAsStringAsync();
+        Assert.True(respuestaPrimero.StatusCode == HttpStatusCode.Conflict, cuerpoPrimero);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoPrimero, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r1 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito1.Id);
+        var r2 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito2.Id);
+        var r3 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito3.Id);
+
+        // El perdedor (primero) nunca escribió NADA: remito 1 sigue emitido, sin ligar.
+        Assert.Equal(EstadoRemito.Emitido, r1.Estado);
+        Assert.Null(r1.IdComprobanteVenta);
+        // El ganador (segundo) ligó 2 y 3 a SU comprobante.
+        Assert.Equal(EstadoRemito.Facturado, r2.Estado);
+        Assert.Equal(EstadoRemito.Facturado, r3.Estado);
+        Assert.Equal(txrSegundo.Id, r2.IdComprobanteVenta);
+        Assert.Equal(txrSegundo.Id, r3.IdComprobanteVenta);
+
+        // Exactamente UN comprobante TXR fue creado — el rollback del perdedor no dejó rastro.
+        var idTipoTxr = await db.TiposComprobante.Where(t => t.Codigo == "TXR").Select(t => t.Id).FirstAsync();
+        Assert.Equal(1, await db.ComprobantesVenta.CountAsync(c => c.IdTipoComprobante == idTipoTxr));
+    }
+
+    // =============================================================================================
+    // task 6.15: facturar × anular-remito, ambos órdenes (mutation target 49)
+    // =============================================================================================
+
+    [Fact]
+    public async Task FacturarGanaLaCarreraContraAnularRemitoYAnularRecibe409RemitoFacturado()
+    {
+        var ctx = await PrepararAsync(nameof(FacturarGanaLaCarreraContraAnularRemitoYAnularRecibe409RemitoFacturado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Vs Anular A", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        // El ANULAR es el pausado (tras abrir SU transacción, antes de tomar ningún lock) — el
+        // facturar CONCURRENTE, sin interceptor, corre completo y gana la carrera del lock
+        // ascendente (mutation target 49: el lock del remito antes del INSERT/clientes le permite
+        // ganar sin contienda). Al reanudar, el anular retoma bajo el MISMO row lock que su propio
+        // UPDATE ya iba a tomar — lo ve libre, pero el estado ya cambió a 'facturado'.
+        var tareaAnular = clienteAnular.PostAsync($"/api/remitos/{remito.Id}/anular", null);
+
+        await transaccionIniciada.Task;
+
+        var respuestaFacturar = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+
+        puedeContinuar.TrySetResult();
+
+        var cuerpoFacturar = await respuestaFacturar.Content.ReadAsStringAsync();
+        var respuestaAnular = await tareaAnular;
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+
+        Assert.True(respuestaFacturar.StatusCode == HttpStatusCode.Created, cuerpoFacturar);
+        Assert.Equal(HttpStatusCode.Conflict, respuestaAnular.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoAnular, OpcionesJson);
+        Assert.Equal("remito_facturado", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Facturado, r.Estado);
+    }
+
+    [Fact]
+    public async Task AnularRemitoGanaLaCarreraContraFacturarYFacturarRecibe409RemitoNoFacturable()
+    {
+        var ctx = await PrepararAsync(nameof(AnularRemitoGanaLaCarreraContraFacturarYFacturarRecibe409RemitoNoFacturable));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Vs Anular B", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteFacturar = factory.CreateClient();
+        var login = await clienteFacturar.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        // Esta vez el FACTURAR es el pausado (tras abrir su transacción, antes de tomar el lock
+        // ascendente) — el anular CONCURRENTE, sin interceptor, corre completo y gana el row lock
+        // del remito primero. Al reanudar, BloquearAscendenteAsync toma el lock ya libre, pero
+        // LigarAsync (mutation target 50) ve el estado 'anulado' — no matchea, 0 filas ⇒ 409.
+        var tareaFacturar = clienteFacturar.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+
+        await transaccionIniciada.Task;
+
+        var respuestaAnular = await ctx.Admin.PostAsync($"/api/remitos/{remito.Id}/anular", null);
+
+        puedeContinuar.TrySetResult();
+
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+        var respuestaFacturar = await tareaFacturar;
+        var cuerpoFacturar = await respuestaFacturar.Content.ReadAsStringAsync();
+
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.OK, cuerpoAnular);
+        Assert.Equal(HttpStatusCode.Conflict, respuestaFacturar.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoFacturar, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Anulado, r.Estado);
+        Assert.Null(r.IdComprobanteVenta);
+    }
+
+    // =============================================================================================
+    // task 6.16: sets mixtos — 409 ANTES de escribir (mutation target 51). Un test por conjunto,
+    // mutation-proof-tests regla 3: enumerar cada conjunto del guard "mismo cliente/PV/tenant,
+    // todos emitido y sin ligar" y aparear cada uno con su propio kill.
+    // =============================================================================================
+
+    [Fact]
+    public async Task UnSetConClientesMixtosEsRechazado409AntesDeEscribir()
+    {
+        var ctx = await PrepararAsync(nameof(UnSetConClientesMixtosEsRechazado409AntesDeEscribir));
+        var idCliente2 = await SembrarClienteAsync(ctx, "Cliente TXR Mixto", creditoIlimitado: true);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Mixto Cliente", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var remitoCliente1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remitoCliente2 = await CrearYEmitirRemitoAsync(
+            ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m, idCliente: idCliente2));
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var comprobantesAntes = await dbAntes.ComprobantesVenta.CountAsync();
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remitoCliente1.Id, remitoCliente2.Id], remitoCliente1.Total + remitoCliente2.Total));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(comprobantesAntes, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(EstadoRemito.Emitido, (await db.Remitos.FirstAsync(r => r.Id == remitoCliente1.Id)).Estado);
+        Assert.Equal(EstadoRemito.Emitido, (await db.Remitos.FirstAsync(r => r.Id == remitoCliente2.Id)).Estado);
+    }
+
+    [Fact]
+    public async Task UnSetConPuntosDeVentaMixtosEsRechazado409AntesDeEscribir()
+    {
+        var ctx = await PrepararAsync(nameof(UnSetConPuntosDeVentaMixtosEsRechazado409AntesDeEscribir));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Mixto PV", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m, idPuntoVenta: ctx.IdPuntoVenta2);
+
+        var remitoPv1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var remitoPv2 = await CrearYEmitirRemitoAsync(
+            ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m, idPuntoVenta: ctx.IdPuntoVenta2));
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var comprobantesAntes = await dbAntes.ComprobantesVenta.CountAsync();
+
+        // idPuntoVenta de la solicitud fija el PV1 — remitoPv2 no coincide.
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remitoPv1.Id, remitoPv2.Id], remitoPv1.Total + remitoPv2.Total));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(comprobantesAntes, await db.ComprobantesVenta.CountAsync());
+    }
+
+    [Fact]
+    public async Task UnRemitoYaFacturadoDentroDelSetEsRechazado409AntesDeEscribir()
+    {
+        var ctx = await PrepararAsync(nameof(UnRemitoYaFacturadoDentroDelSetEsRechazado409AntesDeEscribir));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Ya Facturado 1", 40m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Ya Facturado 2", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+
+        var remitoYaFacturado = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 1m));
+        var primeraFacturacion = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remitoYaFacturado.Id], remitoYaFacturado.Total));
+        Assert.Equal(HttpStatusCode.Created, primeraFacturacion.StatusCode);
+
+        var remitoNuevo = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 1m));
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var comprobantesAntes = await dbAntes.ComprobantesVenta.CountAsync();
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remitoYaFacturado.Id, remitoNuevo.Id], remitoYaFacturado.Total + remitoNuevo.Total));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(comprobantesAntes, await db.ComprobantesVenta.CountAsync());
+        Assert.Equal(EstadoRemito.Emitido, (await db.Remitos.FirstAsync(r => r.Id == remitoNuevo.Id)).Estado);
+    }
+
+    // =============================================================================================
+    // task 6.17: límite de crédito excedido por consolidación CONCURRENTE (mutation target 53) —
+    // mismo patrón (sin interceptor) que VentasAtomicidadYConcurrenciaTests.
+    // DosVentasConcurrentesDeCuentaCorrienteNuncaSuperanElLimite: dos facturaciones IDÉNTICAS,
+    // cada una individualmente bajo el límite, juntas lo superan — el pre-chequeo de
+    // ValidadorDePagos (fuera de la transacción) pasa las DOS, el backstop DENTRO de la
+    // transacción (re-implementado, OD9/T9) atrapa a la perdedora de la carrera del UPDATE...
+    // RETURNING sobre clientes.saldo.
+    // =============================================================================================
+
+    [Fact]
+    public async Task LimiteDeCreditoExcedidoPorConsolidacionConcurrenteEntrePreChequeoYCommit()
+    {
+        var ctx = await PrepararAsync(nameof(LimiteDeCreditoExcedidoPorConsolidacionConcurrenteEntrePreChequeoYCommit));
+        var idClienteLimitado = await SembrarClienteAsync(ctx, "Cliente TXR Limitado", limiteCredito: 1000m);
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Credito 1", 600m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Credito 2", 600m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+
+        var remitoA = await CrearYEmitirRemitoAsync(
+            ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 1m, idCliente: idClienteLimitado));
+        var remitoB = await CrearYEmitirRemitoAsync(
+            ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 1m, idCliente: idClienteLimitado));
+
+        var solicitudA = SolicitudFacturacion(ctx, [remitoA.Id], remitoA.Total, ctx.IdMedioCuentaCorriente);
+        var solicitudB = SolicitudFacturacion(ctx, [remitoB.Id], remitoB.Total, ctx.IdMedioCuentaCorriente);
+
+        var tareaA = ctx.Admin.PostAsJsonAsync("/api/remitos/facturacion", solicitudA);
+        var tareaB = ctx.Admin.PostAsJsonAsync("/api/remitos/facturacion", solicitudB);
+
+        var respuestas = await Task.WhenAll(tareaA, tareaB);
+        var estados = respuestas.Select(r => r.StatusCode).ToList();
+
+        Assert.Contains(HttpStatusCode.Created, estados);
+        Assert.Contains(HttpStatusCode.BadRequest, estados);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldo = await db.Clientes.Where(c => c.Id == idClienteLimitado).Select(c => c.Saldo).FirstAsync();
+        var sumaDeMovimientos = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdCliente == idClienteLimitado).SumAsync(m => m.Importe);
+
+        Assert.Equal(600m, saldo);
+        Assert.Equal(saldo, sumaDeMovimientos);
+        Assert.True(saldo <= 1000m, $"El saldo ({saldo}) no puede superar el límite de crédito (1000).");
+    }
+
+    // =============================================================================================
+    // task 6.18: turno cerrado 409 para la consolidación; ausencia deliberada para emitir de
+    // remito (decisión 13, ambas direcciones)
+    // =============================================================================================
+
+    [Fact]
+    public async Task LaConsolidacionSinTurnoAbiertoEsRechazada409TurnoNoAbierto()
+    {
+        var ctx = await PrepararAsync(nameof(LaConsolidacionSinTurnoAbiertoEsRechazada409TurnoNoAbierto), conTurnoAbierto: false);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Sin Turno", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        // ServicioDeRemitos.EmitirAsync (decisión 13, mismo test que abajo) NO exige turno — el
+        // remito se emite igual, sin turno abierto en todo el punto de venta.
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        var cuerpo = await respuesta.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuesta.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpo, OpcionesJson);
+        Assert.Equal("turno_no_abierto", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(EstadoRemito.Emitido, (await db.Remitos.FirstAsync(r => r.Id == remito.Id)).Estado);
+    }
+
+    [Fact]
+    public async Task EmitirUnRemitoNoExigeNingunTurnoAbierto()
+    {
+        // Mutation target 54, mitad "ausencia deliberada": la creación + emisión de un remito
+        // (el cuarto write site) tiene que suceder aunque el punto de venta no tenga NINGÚN turno
+        // abierto — a diferencia de la consolidación (test de arriba), decisión 13 del proposal:
+        // "un remito mueve mercadería, no dinero".
+        var ctx = await PrepararAsync(nameof(EmitirUnRemitoNoExigeNingunTurnoAbierto), conTurnoAbierto: false);
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Emitir Sin Turno", 40m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        Assert.Equal(EstadoRemito.Emitido, remito.Estado);
+    }
+
+    // =============================================================================================
+    // task 6.20/6.21: anular un TXR — devuelve remitos a emitido, limpia ligadura, revierte CC,
+    // cero movimientos de stock. 6.21 es el discriminante OD8/T3: ambas mitades juntas, en una
+    // sola transacción.
+    // =============================================================================================
+
+    [Fact]
+    public async Task AnularUnTxrDevuelveSusRemitosAEmitidoLimpiaLaLigaduraYNoEscribeMovimientosDeStock()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnTxrDevuelveSusRemitosAEmitidoLimpiaLaLigaduraYNoEscribeMovimientosDeStock));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Anular 1", 30m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Anular 2", 30m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+
+        var remito1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 1m));
+        var remito2 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 1m));
+
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remito1.Id, remito2.Id], remito1.Total + remito2.Total));
+        Assert.Equal(HttpStatusCode.Created, facturado.StatusCode);
+        var txr = (await facturado.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientosAntes = await dbAntes.MovimientosStock.CountAsync();
+
+        var anulado = await ctx.Admin.PostAsync($"/api/ventas/{txr.Id}/anulacion", null);
+        var cuerpoAnulado = await anulado.Content.ReadAsStringAsync();
+        Assert.True(anulado.StatusCode == HttpStatusCode.OK, cuerpoAnulado);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r1 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito1.Id);
+        var r2 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito2.Id);
+
+        Assert.Equal(EstadoRemito.Emitido, r1.Estado);
+        Assert.Equal(EstadoRemito.Emitido, r2.Estado);
+        Assert.Null(r1.IdComprobanteVenta);
+        Assert.Null(r2.IdComprobanteVenta);
+
+        // Mutation target 52 (mitad "cero movimientos_stock" en la anulación): el read set de la
+        // reversa de stock de ServicioDeVentas.EjecutarAnulacionAsync es VACÍO por construcción
+        // (un TXR nunca tuvo items ⇒ nunca tuvo movimientos motivo='venta') — la trampa de doble
+        // decremento y el stock fantasma quedan estructuralmente inalcanzables.
+        var movimientosDespues = await db.MovimientosStock.CountAsync();
+        Assert.Equal(movimientosAntes, movimientosDespues);
+    }
+
+    /// <summary>[OD8/T3, discriminant test] tasks.md decisión 6: un TXR anulado prueba AMBAS
+    /// mitades de la composición JUNTAS, en la misma transacción — (a) cero
+    /// <c>movimientos_stock</c> creados Y (b) el saldo de CC revertido por el importe EXACTO
+    /// original. Ninguna mitad sola alcanza (stage-16-slice-3, "las composiciones se
+    /// prueban").</summary>
+    [Fact]
+    public async Task LaAnulacionDeUnTxrConCuentaCorrienteOriginalRevierteAmbasMitadesJuntasEnUnaSolaTransaccion()
+    {
+        var ctx = await PrepararAsync(nameof(LaAnulacionDeUnTxrConCuentaCorrienteOriginalRevierteAmbasMitadesJuntasEnUnaSolaTransaccion));
+        // mutation-proof-tests regla 11: deuda previa DISCRIMINANTE — nunca un cliente fresco
+        // (saldo 0), donde saldo_resultante == importe por coincidencia aritmética.
+        var idCliente = await SembrarClienteAsync(ctx, "Cliente TXR CC Discriminante", creditoIlimitado: true);
+
+        await using (var dbSeed = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant)))
+        {
+            var cliente = await dbSeed.Clientes.FirstAsync(c => c.Id == idCliente);
+            cliente.Saldo = 800m;
+            await dbSeed.SaveChangesAsync();
+        }
+
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Cc Discriminante", 1500m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        var remito = await CrearYEmitirRemitoAsync(
+            ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m, idCliente: idCliente));
+
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remito.Id], remito.Total, ctx.IdMedioCuentaCorriente));
+        var cuerpoFacturado = await facturado.Content.ReadAsStringAsync();
+        Assert.True(facturado.StatusCode == HttpStatusCode.Created, cuerpoFacturado);
+        var txr = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoFacturado, OpcionesJson)!;
+
+        await using var dbTrasFacturar = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var saldoTrasFacturar = await dbTrasFacturar.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(800m + remito.Total, saldoTrasFacturar); // 800 + 1500 = 2300, discriminante (nunca 0 + 1500).
+
+        var movimientosStockAntes = await dbTrasFacturar.MovimientosStock.CountAsync();
+
+        var anulado = await ctx.Admin.PostAsync($"/api/ventas/{txr.Id}/anulacion", null);
+        Assert.Equal(HttpStatusCode.OK, anulado.StatusCode);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+
+        // Mitad (a): cero movimientos_stock — la misma transacción de anulación.
+        var movimientosStockDespues = await db.MovimientosStock.CountAsync();
+        Assert.Equal(movimientosStockAntes, movimientosStockDespues);
+
+        // Mitad (b): el saldo vuelve EXACTO a la deuda previa — ni el importe original (1500,
+        // arithmetic-coincidence si el cliente fuera fresco) ni cualquier otro valor.
+        var saldoFinal = await db.Clientes.Where(c => c.Id == idCliente).Select(c => c.Saldo).FirstAsync();
+        Assert.Equal(800m, saldoFinal);
+
+        var contramovimiento = await db.MovimientosCuentaCorriente
+            .Where(m => m.IdComprobanteVenta == txr.Id && m.Tipo == TipoMovimientoCc.Ajuste)
+            .SingleAsync();
+        Assert.Equal(-remito.Total, contramovimiento.Importe);
+        Assert.Equal(800m, contramovimiento.SaldoResultante);
+
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Emitido, r.Estado);
+        Assert.Null(r.IdComprobanteVenta);
+    }
+
+    // =============================================================================================
+    // task 6.22: ck_remitos_facturacion — la mutación real de DesligarAsync (limpiar solo UNA de
+    // las dos columnas) tira 23514. Corrido contra un remito REALMENTE facturado (nunca un INSERT
+    // sintético) — simula exactamente lo que un DesligarAsync mal escrito produciría.
+    // =============================================================================================
+
+    [Fact]
+    public async Task UnUpdateQueLimpiaSoloUnaDeLasDosColumnasDeLaLigaduraViolaCkRemitosFacturacion()
+    {
+        var ctx = await PrepararAsync(nameof(UnUpdateQueLimpiaSoloUnaDeLasDosColumnasDeLaLigaduraViolaCkRemitosFacturacion));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Check Desligue 1", 20m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Check Desligue 2", 20m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+
+        var remito1 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo1, 1m));
+        var remito2 = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo2, 1m));
+
+        var facturado1 = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito1.Id], remito1.Total));
+        Assert.Equal(HttpStatusCode.Created, facturado1.StatusCode);
+        var facturado2 = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito2.Id], remito2.Total));
+        Assert.Equal(HttpStatusCode.Created, facturado2.StatusCode);
+
+        // Dirección 1: limpia SOLO `estado` (vuelve a 'emitido'), deja id_comprobante_venta ligado.
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant))
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "UPDATE remitos SET estado = 'emitido'::estado_remito WHERE id_remito = $1";
+            comando.Parameters.Add(new NpgsqlParameter { Value = remito1.Id });
+
+            var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+            Assert.Equal("23514", excepcion.SqlState);
+            Assert.Equal("ck_remitos_facturacion", excepcion.ConstraintName);
+        }
+
+        // Dirección 2: limpia SOLO id_comprobante_venta, deja estado='facturado'.
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", ctx.IdTenant))
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "UPDATE remitos SET id_comprobante_venta = NULL WHERE id_remito = $1";
+            comando.Parameters.Add(new NpgsqlParameter { Value = remito2.Id });
+
+            var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+            Assert.Equal("23514", excepcion.SqlState);
+            Assert.Equal("ck_remitos_facturacion", excepcion.ConstraintName);
+        }
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r1 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito1.Id);
+        var r2 = await db.Remitos.AsNoTracking().FirstAsync(r => r.Id == remito2.Id);
+        Assert.Equal(EstadoRemito.Facturado, r1.Estado); // el UPDATE fallido no dejó rastro
+        Assert.Equal(EstadoRemito.Facturado, r2.Estado);
+        Assert.NotNull(r1.IdComprobanteVenta);
+        Assert.NotNull(r2.IdComprobanteVenta);
+    }
+
+    // =============================================================================================
+    // task 6.23: anular-TXR × facturar — sin ciclo (T10): el desligue de un TXR (comprobantes_venta
+    // → remitos) nunca contiende por el MISMO recurso que un facturar sobre esos remitos podría
+    // tomar en orden inverso, porque facturar nunca toma comprobantes_venta como lock (el INSERT
+    // no es una posición del orden). Ambos completan en tiempo acotado, sin deadlock.
+    // =============================================================================================
+
+    [Fact]
+    public async Task AnularUnTxrXFacturarLosMismosRemitosNoDeadlockeaYAmbosResuelvenEnTiempoAcotado()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnTxrXFacturarLosMismosRemitosNoDeadlockeaYAmbosResuelvenEnTiempoAcotado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Anular Vs Facturar", 25m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        Assert.Equal(HttpStatusCode.Created, facturado.StatusCode);
+        var txr = (await facturado.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var transaccionIniciada = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var puedeContinuar = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new InterceptorDePausaTrasIniciarLaTransaccion(transaccionIniciada, puedeContinuar);
+
+        await using var factory = fixture.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddDbContext<WaysDbContext>((_, options) => options.AddInterceptors(interceptor))));
+
+        using var clienteAnular = factory.CreateClient();
+        var login = await clienteAnular.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(ctx.MailAdmin, ctx.PasswordAdmin));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        // Anular-TXR pausado tras abrir su transacción — el remito sigue 'facturado' en este
+        // instante, así que un facturar CONCURRENTE sobre el mismo remito lo ve todavía ligado
+        // (pre-chequeo, sin lock) y se rechaza limpio, sin nunca intentar tomar un lock que
+        // colisione con el de la anulación — no hay ventana de deadlock por construcción (T10).
+        var tareaAnular = clienteAnular.PostAsync($"/api/ventas/{txr.Id}/anulacion", null);
+
+        await transaccionIniciada.Task;
+
+        var tareaFacturarConcurrente = ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+
+        var respuestaFacturarConcurrente = await tareaFacturarConcurrente.WaitAsync(TimeSpan.FromSeconds(15));
+        var cuerpoFacturarConcurrente = await respuestaFacturarConcurrente.Content.ReadAsStringAsync();
+
+        puedeContinuar.TrySetResult();
+        var respuestaAnular = await tareaAnular.WaitAsync(TimeSpan.FromSeconds(15));
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+
+        // Ninguna de las dos requests colgó (bounded timeout arriba, sin 40P01) — el facturar
+        // concurrente ve el remito todavía facturado (pre-chequeo sin lock) y se rechaza; el
+        // anular, sin contención, completa limpio.
+        Assert.True(respuestaAnular.StatusCode == HttpStatusCode.OK, cuerpoAnular);
+        Assert.Equal(HttpStatusCode.Conflict, respuestaFacturarConcurrente.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoFacturarConcurrente, OpcionesJson);
+        Assert.Equal("remito_no_facturable", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Emitido, r.Estado);
+        Assert.Null(r.IdComprobanteVenta);
+
+        // Un facturar SIGUIENTE (sin contención) recién ahora sí lo consolida — confirma que la
+        // anulación dejó el remito genuinamente libre.
+        var facturarSiguiente = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        Assert.Equal(HttpStatusCode.Created, facturarSiguiente.StatusCode);
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -414,74 +414,112 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         var bloquearTask = EscriturasDeRemito.BloquearAscendenteAsync(
             conexionRemito, transaccionCruda, ctx.IdTenant, [remitoMayor.Id, remitoMenor.Id], CancellationToken.None);
 
-        // Confirmamos que el backend bajo prueba está REALMENTE bloqueado (pg_locks,
-        // granted=false) antes de lanzar el probe — sin esto, un probe prematuro no discrimina
-        // nada (mismo riesgo que la rendezvous de task 6.14 documentó arriba).
-        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
-        await conexionPoll.OpenAsync();
-
-        var bloqueado = false;
-        var limite = DateTime.UtcNow.AddSeconds(5);
-        while (DateTime.UtcNow < limite)
-        {
-            // NOT granted alcanza — el bloqueo real que Postgres expone acá es un wait por
-            // locktype='transactionid' (esperando que termine la transacción bloqueadora), no un
-            // locktype='relation'/'tuple' sobre remitos: filtrar por relation acá habría dejado
-            // este poll en falso negativo permanente (diagnosticado empíricamente, ver nota del
-            // método).
-            await using var comandoPoll = new NpgsqlCommand(
-                "SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = $1 AND NOT granted)",
-                conexionPoll);
-            comandoPoll.Parameters.AddWithValue(pidRemito);
-            bloqueado = (bool)(await comandoPoll.ExecuteScalarAsync())!;
-            if (bloqueado)
-            {
-                break;
-            }
-
-            await Task.Delay(25);
-        }
-
-        Assert.True(bloqueado, "El backend bajo prueba nunca quedó bloqueado — el experimento no discrimina nada.");
-
-        // Probe NOWAIT sobre el MAYOR mientras el backend bajo prueba sigue bloqueado en el
-        // menor: bajo la implementación correcta (ASC) todavía no lo tocó, así que prueba libre
-        // (sin excepción). Bajo el mutante (DESC) ya lo habría tomado, y esto chocaría con 55P03.
-        await using var conexionProbe = new NpgsqlConnection(fixture.AppConnectionString);
-        await conexionProbe.OpenAsync();
-        await using (var comandoGucProbe = new NpgsqlCommand(
-            "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
-            conexionProbe))
-        {
-            comandoGucProbe.Parameters.AddWithValue(ctx.IdTenant.ToString());
-            await comandoGucProbe.ExecuteNonQueryAsync();
-        }
-        await using var transaccionProbe = await conexionProbe.BeginTransactionAsync();
+        // judgment-day Slice 6, ronda 2, juez B — MAJOR: bajo el mutante (DESC), el backend
+        // bajo prueba toma primero el MAYOR (libre) y queda bloqueado esperando el MENOR, que
+        // sigue retenido por `transaccionBloqueo` hasta que este método lo libera explícitamente
+        // más abajo. Si algo entre medio (el `Assert.True`/`Assert.Null` de esta sección) lanza
+        // ANTES de esa liberación, el `finally` de más abajo es el ÚNICO camino que la sigue
+        // liberando — sin él, `transaccionBloqueo` nunca se rollbackea, `bloquearTask` nunca
+        // termina, y el `await using` de `db`/`transaccionRemito` al final del método intenta
+        // disponer la MISMA conexión que `bloquearTask` sigue usando: eso cuelga el test entero
+        // en vez de fallar limpio (mutation-proof-tests regla 2, "una red que no termina no es
+        // evidencia válida"). Por eso: (a) todo lo que puede lanzar acá corre en `try`, y (b) el
+        // `finally` libera el lock y espera `bloquearTask` con una COTA (Task.WhenAny) — nunca un
+        // `await` desnudo — antes de dejar que el método termine de disponer sus recursos.
         PostgresException? excepcionDelProbe = null;
+        Exception? excepcionDelBackend = null;
+        var backendTerminoATiempo = false;
+        IReadOnlyList<(int IdRemito, string Estado, int? IdComprobante)>? filas = null;
         try
         {
-            await using var comandoProbe = new NpgsqlCommand(
-                "SELECT 1 FROM remitos WHERE id_remito = $1 FOR UPDATE NOWAIT", conexionProbe, transaccionProbe);
-            comandoProbe.Parameters.AddWithValue(remitoMayor.Id);
-            await comandoProbe.ExecuteScalarAsync();
-        }
-        catch (PostgresException ex)
-        {
-            excepcionDelProbe = ex;
+            // Confirmamos que el backend bajo prueba está REALMENTE bloqueado (pg_locks,
+            // granted=false) antes de lanzar el probe — sin esto, un probe prematuro no discrimina
+            // nada (mismo riesgo que la rendezvous de task 6.14 documentó arriba).
+            await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+            await conexionPoll.OpenAsync();
+
+            var bloqueado = false;
+            var limite = DateTime.UtcNow.AddSeconds(5);
+            while (DateTime.UtcNow < limite)
+            {
+                // NOT granted alcanza — el bloqueo real que Postgres expone acá es un wait por
+                // locktype='transactionid' (esperando que termine la transacción bloqueadora), no un
+                // locktype='relation'/'tuple' sobre remitos: filtrar por relation acá habría dejado
+                // este poll en falso negativo permanente (diagnosticado empíricamente, ver nota del
+                // método).
+                await using var comandoPoll = new NpgsqlCommand(
+                    "SELECT EXISTS(SELECT 1 FROM pg_locks WHERE pid = $1 AND NOT granted)",
+                    conexionPoll);
+                comandoPoll.Parameters.AddWithValue(pidRemito);
+                bloqueado = (bool)(await comandoPoll.ExecuteScalarAsync())!;
+                if (bloqueado)
+                {
+                    break;
+                }
+
+                await Task.Delay(25);
+            }
+
+            Assert.True(bloqueado, "El backend bajo prueba nunca quedó bloqueado — el experimento no discrimina nada.");
+
+            // Probe NOWAIT sobre el MAYOR mientras el backend bajo prueba sigue bloqueado en el
+            // menor: bajo la implementación correcta (ASC) todavía no lo tocó, así que prueba libre
+            // (sin excepción). Bajo el mutante (DESC) ya lo habría tomado, y esto chocaría con 55P03.
+            await using var conexionProbe = new NpgsqlConnection(fixture.AppConnectionString);
+            await conexionProbe.OpenAsync();
+            await using (var comandoGucProbe = new NpgsqlCommand(
+                "SELECT set_config('app.acceso', 'tenant', false), set_config('app.tenant_id', $1, false)",
+                conexionProbe))
+            {
+                comandoGucProbe.Parameters.AddWithValue(ctx.IdTenant.ToString());
+                await comandoGucProbe.ExecuteNonQueryAsync();
+            }
+            await using var transaccionProbe = await conexionProbe.BeginTransactionAsync();
+            try
+            {
+                await using var comandoProbe = new NpgsqlCommand(
+                    "SELECT 1 FROM remitos WHERE id_remito = $1 FOR UPDATE NOWAIT", conexionProbe, transaccionProbe);
+                comandoProbe.Parameters.AddWithValue(remitoMayor.Id);
+                await comandoProbe.ExecuteScalarAsync();
+            }
+            catch (PostgresException ex)
+            {
+                excepcionDelProbe = ex;
+            }
+            finally
+            {
+                await transaccionProbe.RollbackAsync();
+            }
         }
         finally
         {
-            await transaccionProbe.RollbackAsync();
+            // Libera el lock retenido SIEMPRE — pase lo que pase arriba — y espera a
+            // `bloquearTask` con una cota de 10s en vez de un `await` desnudo: bajo el mutante,
+            // liberar el menor alcanza para que el backend (ya con el mayor tomado) complete; la
+            // cota es la red de seguridad para un cuelgue real que sobreviviera a la liberación.
+            await transaccionBloqueo.RollbackAsync();
+            var completo = await Task.WhenAny(bloquearTask, Task.Delay(TimeSpan.FromSeconds(10)));
+            backendTerminoATiempo = ReferenceEquals(completo, bloquearTask);
+            if (backendTerminoATiempo)
+            {
+                try
+                {
+                    filas = await bloquearTask;
+                }
+                catch (Exception ex)
+                {
+                    excepcionDelBackend = ex;
+                }
+            }
+
+            await transaccionRemito.RollbackAsync();
         }
 
         Assert.Null(excepcionDelProbe);
-
-        // Libera el lock retenido — el backend bajo prueba, hasta acá bloqueado, ahora completa.
-        await transaccionBloqueo.RollbackAsync();
-        var filas = await bloquearTask;
-        Assert.Equal(2, filas.Count);
-
-        await transaccionRemito.RollbackAsync();
+        Assert.True(backendTerminoATiempo,
+            "El backend bajo prueba no terminó tras liberar el lock retenido — probable cuelgue bajo el mutante.");
+        Assert.Null(excepcionDelBackend);
+        Assert.Equal(2, filas!.Count);
     }
 
     // =============================================================================================

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -100,6 +100,9 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         ("PUT", "/api/remitos/{id:int}"),
         ("POST", "/api/remitos/{id:int}/emitir"),
         ("POST", "/api/remitos/{id:int}/anular"),
+        // stage-17-presupuestos-y-remitos (Slice 6, design decisión 17/proposal decisión 10): la
+        // consolidación — mismo grupo, mismo criterio que las cuatro rutas de arriba.
+        ("POST", "/api/remitos/facturacion"),
 
         // Aprovisionamiento y administración de tenants — SoloPlataforma, root-only, jamás
         // admite Vendedor (Politicas.cs).


### PR DESCRIPTION
## Resumen

Slice 6 de la etapa 17: N remitos consolidan en UN comprobante `TXR` sin items; su anulación los des-liga y revierte CC con CERO movimientos de stock (el stock ya salió por los remitos).

- `EscriturasDeRemito.cs`: `BloquearAscendenteAsync` (`FOR UPDATE ORDER BY id_remito`), `LigarAsync` (UPDATE guardeado de N filas — filas == N o `409 remito_no_facturable`), `DesligarAsync` (estado + `id_comprobante_venta` limpiados JUNTOS, vigilado por `ck_remitos_facturacion`).
- `ServicioDeFacturacionDeRemitos.cs`: pre-tx set homogéneo + fidelidad de totales (Σ headers vs Σ items congelados); tx: turno bajo lock PRIMERO → N-locks ascendentes → `TXR` sin items (precedente `RC`) → pagos → CC con el backstop de límite de crédito RE-IMPLEMENTADO en transacción (paridad exacta con el checkout, T9) → `LigarAsync`.
- Cirugía de `ServicioDeVentas.cs`: `MarcarAnuladoAsync` con RETURNING ensanchado por subquery escalar de `codigo_tipo` + guarded call `DesligarAsync` en posición 1.6 — anulación ordinaria intacta, probada por tests posicionales dedicados.
- 18 tests de integración + 4 estructurales; gate guard: CERO migraciones nuevas.

## Judgment-day (2 rondas de fix, limpia al cierre)

- **Juez B (mutador) REJECT ronda 1**: `DesligarAsync` sin red de hermanos intactos (quitar el conjunct de identidad desligaba TODOS los facturados del tenant con 15/15 verdes — regla 12c) + target 48 sin intentar la red `pg_locks` liviana. Fixes `41b18fe` — hallazgo: el probe liviano SÍ funciona; el diagnóstico original de "fragilidad" era un filtro por `relation` cuando Postgres expone la espera como `locktype='transactionid'`.
- **Re-ronda B ESCALATED**: el probe se colgaba indefinidamente bajo el mutante DESC (assert antes de liberar la transacción bloqueante). Fix `8982be9`: try/finally incondicional + `Task.WhenAny` acotado — RED limpio 3/3 (~5s, `55P03` exacto). **Confirmación B: APPROVE.**
- **Juez A APPROVE**: 1 WARNING de contrato — el detalle del TXR debe leerse de `items_remito` (spec + design T11 lo mandan, ninguna tarea lo implementaba: requirement sin task) — resuelto como **OD10** en state.yaml → tarea nueva 8.10b del slice 8, junto con sus 2 SUGGESTIONs (N=1 como borde nombrado, anulación TXR con turno cerrado). Target 54 → backlog (clase preexistente, paridad con el checkout).

## Suites

- Apply: full Integration 1575/1575 DOS veces, cero flakiness. Post-fixes: `ServicioDeFacturacionDeRemitosTests` 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)