### PR TITLE
feat(presupuestos): web de presupuestos + entrada de conversion en el POS (etapa 17, slice 7)

### DIFF
--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -2010,7 +2010,7 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
   31 pre-existing `render(<Pos />)` call sites mechanically became `renderPos()` (a `MemoryRouter`
   wrapper, since `Pos()` now calls `useSearchParams`) with **zero assertion changed**; full file
   green, see Work Unit Evidence.
-- [ ] 7.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
+- [x] 7.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
   juez B REJECT** (1 MAJOR + 2 WARNINGs) → fixes aplicados por el fix-agent: (1) MAJOR — el
   `key={idPresupuesto ?? 'libre'}` de `Pos()` sin cobertura, sobrevivía 53/53; agregado el test
   que rutea por `<Pos/>` real hasta `cobrar()` y `nuevaVenta()`, asertando que el ticket
@@ -2025,6 +2025,25 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
   confirmada estructuralmente inalcanzable por mutación real (54/54 verdes con el chequeo de
   token quitado) — mismo patrón de confound que el `40P01` de la tarea 1.32. Commit
   `<pendiente>`. Pendiente: re-judge acotado a este diff.
+
+  **judgment-day Slice 7, ronda 2 — juez A (1 WARNING fixed, 1 SUGGESTION preexistente →
+  backlog).** WARNING — `Presupuesto.tsx:611-614`: el botón "Convertir en venta" no tenía
+  `disabled={ocupado}`, a diferencia de su hermano "Anular" del mismo grupo (línea 617) y de
+  todos los demás botones de escritura del archivo (`Enviar`/`Guardar`, líneas 550/556) — el
+  click durante una operación en vuelo no-opeaba en silencio (el guard interno de
+  `convertirEnVenta` lo frenaba) pero el botón quedaba visualmente habilitado, violando la
+  regla 5 de `react-async-state` que el resto del archivo aplica de forma consistente. Fix:
+  agregado `disabled={ocupado}` al botón. Test nuevo en `Presupuesto.test.tsx` ("mientras
+  'Anular' está en vuelo, 'Convertir en venta' también queda deshabilitado") — dispara
+  `anular`, deja el POST pendiente y asserta `toBeDisabled()` sobre el botón "Convertir en
+  venta" durante esa ventana. Ciclo RED/verde (mutation-proof-tests regla 2): quitado el
+  `disabled={ocupado}` → RED confirmado (`Received element is not disabled`) → revertido →
+  suite completa `Presupuesto.test.tsx` **12/12 verde**; `npx tsc -b` limpio. SUGGESTION
+  preexistente (no fixeada, registrada como backlog) — `tipos.ts:961` declara
+  `pagos: PagoDeVenta[]` requerido mientras `Contratos.cs` (`SolicitudDeVenta`) lo tiene
+  nullable en C#; mismatch de opcionalidad anterior a este slice, dirección benigna (el
+  cliente TS es más estricto que el server) — no se toca `tipos.ts` en este fix. Commit
+  `<pendiente>`.
 - [ ] 7.15 Open PR #7 `feat/stage17-slice7-web-presupuestos`, merge after a clean round.
 
 ### Work Unit Evidence
@@ -2032,6 +2051,7 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
 | Evidence | Value |
 |---|---|
 | Focused test command and result | `npx vitest run src/api/presupuestos.test.ts src/paginas/Pos.test.tsx src/paginas/Presupuestos.test.tsx src/paginas/Presupuesto.test.tsx src/paginas/CuentaCorriente.test.tsx` — 5 files, 138/138 green |
+| Ronda 2 focused test command and result | `npx vitest run src/paginas/Presupuesto.test.tsx` — 12/12 green. RED/verde cycle: `disabled={ocupado}` removed from "Convertir en venta" → RED confirmed (`Received element is not disabled`) → reverted → 12/12 green. `npx tsc -b` clean |
 | Runtime harness command/scenario and result | Web-only slice — no server boundary (design: "the API still serves the shape", PR 3 already merged). Runtime harness is the full web suite: `npx vitest run` (no filter) — **51 files, 845/845 green**. `npm run build` (`tsc -b && vite build`) clean. `npm run lint` (oxlint) clean, zero new warnings. `dotnet build` of `Ways.Api` + all three test projects (`Ways.Domain.Tests`, `Ways.Application.Tests`, `Ways.IntegrationTests`) — clean, 0 errors, confirming zero backend regression (`git status` shows zero files touched outside `src/Ways.Web/**`) |
 | Mutation evidence | Web-only slice, no server-side clause to mutate. `web-descriptor-tests`/`mutation-proof-tests` rule 7 applied to the async paths: the stale-`/para-venta`-after-unmount test (task 7.10) and the pre-existing `OrdenesDeCompra`/`Presupuestos` generation-guard tests (both list screens share the identical `generacionRef` pattern, both proven with a real stale-response-lands-after-newer-one scenario resolved inside `act`) |
 | Rollback boundary | Isolated to `src/Ways.Web/**`: new files (`api/presupuestos.ts`, `api/presupuestos.test.ts`, `paginas/Presupuestos.tsx`, `paginas/Presupuestos.test.tsx`, `paginas/Presupuesto.tsx`, `paginas/Presupuesto.test.tsx`) plus modified files (`api/tipos.ts`, `api/ventas.ts`, `App.tsx`, `componentes/Layout.tsx`, `paginas/Pos.tsx`, `paginas/Pos.test.tsx`, `paginas/CuentaCorriente.test.tsx`). `git revert` of this slice's commit(s) alone removes the entire entry point; the API already serves `/api/presupuestos*` and `idPresupuestoOrigen` from PR 3, so nothing server-side reverts or breaks |

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1947,6 +1947,24 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
   posted, cart inputs disabled. *(design.md:508)* — `Pos.test.tsx` "conversión de presupuesto"
   describe block: banner + read-only hydration + PV/cliente disabled + zero `/ofertas/resolver`
   calls + POST body asserted to omit both `idCliente` and `lineas`.
+
+  **CORRECCIÓN REGISTRADA (judgment-day slice-7 ronda 1 juez B, WARNING — mutation-proof-tests
+  regla 2/3, apply-time, run for real).** El `if (modoPresupuesto) { …; return }` de
+  `Pos.tsx:595-600` (el "skip the price-resolution effect entirely" citado arriba) es
+  **inalcanzable-en-efecto**: bajo `?idPresupuesto=`, `lineas` queda `[]` durante toda la vida de
+  la instancia (el carrito se hidrata de `presupuesto.items`, jamás de `setLineas`), y el guard
+  preexistente de la línea 611 (`if (lineas.length === 0 || …) { …; return }`) ya corta el
+  efecto ANTES de llegar al fetch por esa sola razón, sin importar `modoPresupuesto`. Mutación
+  real (`--no-incremental`, no razonada): se borró el bloque `if (modoPresupuesto) {...}` entero
+  y se corrió la suite completa de `Pos.test.tsx` — **54/54 verdes**, incluida la aserción de
+  "cero llamadas a `/ofertas/resolver`" de este mismo test; revertido, confirmado verde de nuevo.
+  El bloque de `modoPresupuesto` es **defensivo** (segunda red, redundante con la de línea 611
+  para el estado que este modo puede alcanzar hoy) — la garantía observable que el test 7.7
+  prueba la da el guard de `lineas` vacías, no este bloque. No hay forma de discriminarlo sin
+  forzar `lineas` no-vacío bajo `modoPresupuesto`, un estado que la UI actual no permite alcanzar
+  (mutation-proof-tests regla 3: confound estructural, no producto de un test débil). El bloque
+  se conserva (documenta la intención server-side-price explícitamente y blindea contra un futuro
+  cambio que popule `lineas` bajo este modo) — solo se corrige qué evidencia lo respalda hoy.
 - [x] 7.8 Test: a non-convertible quote renders no "Convertir" action. — `Presupuesto.test.tsx`:
   `Enviado`+`vencido:true`+`convertible:false` and `Convertido` (terminal) both assert the
   button's absence; a third test asserts it renders when `convertible:true`.
@@ -1958,6 +1976,28 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
   rule 7)* — `Pos.test.tsx`: a `/para-venta` fetch left pending, the screen unmounted, then the
   promise resolved inside `act` — asserts zero `console.error` (proves the `vigente` guard, not
   merely that nothing visibly changed).
+
+  **CORRECCIÓN REGISTRADA (judgment-day slice-7 ronda 1 juez B, WARNING — mutation-proof-tests
+  regla 2/3, apply-time, run for real).** La afirmación "proves the `vigente` guard" quedó
+  desactualizada bajo React 19: `setState` post-desmontaje pasó a ser un no-op silencioso, sin el
+  warning de `console.error` que React ≤18 emitía — `expect(errorSpy).not.toHaveBeenCalled()` da
+  verde exista o no el guard. Mutación real (`--no-incremental`, no razonada): se quitó el
+  chequeo de token (`tokenPresupuestoRef.current !== miToken`) de las tres ramas del `.then()` de
+  la carga de `/para-venta`, dejando solo `vigente` — se corrió la suite completa de
+  `Pos.test.tsx` y dio **54/54 verdes**, incluido este mismo test; revertido, confirmado verde de
+  nuevo. Se intentó además la forma discriminante que pide `mutation-proof-tests` regla 2 (dos
+  cargas de `/para-venta` compitiendo con la MISMA instancia montada, la stale resolviendo
+  después de la fresca): estructuralmente inalcanzable — el efecto que usa el token depende solo
+  de `[modoPresupuesto, idPresupuesto]`, y `Pos()` remonta `PantallaPos` entera por
+  `key={idPresupuesto ?? 'libre'}` en cuanto ese id cambia (react-async-state regla 8), así que
+  dentro de la vida de una instancia montada este efecto corre exactamente una vez; el único caso
+  real de doble corrida (el doble-invoke de `StrictMode` en desarrollo) tampoco discrimina, porque
+  la limpieza del primer run es síncrona y ocurre antes de que cualquier promesa tenga oportunidad
+  de resolver — `vigente` ya blindea ese caso por sí solo. Mismo patrón de confound que el
+  `40P01` de la tarea 1.32: confirmado empíricamente, no razonado. El test se conserva sin
+  cambios (sigue probando, honestamente, que un resolve tardío post-desmontaje no revienta el
+  proceso) con su anotación en el archivo corregida para no reclamar cobertura del guard de
+  token.
 - [x] 7.11 Test: `vencido` toggle disabled without `idPuntoVenta`; pager disabled at edges. —
   `Presupuestos.test.tsx`.
 - [x] 7.12 Rule 10: any recovery path added is grepped for and replicated in sibling screens in
@@ -1970,7 +2010,21 @@ slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry poin
   31 pre-existing `render(<Pos />)` call sites mechanically became `renderPos()` (a `MemoryRouter`
   wrapper, since `Pos()` now calls `useSearchParams`) with **zero assertion changed**; full file
   green, see Work Unit Evidence.
-- [ ] 7.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
+- [ ] 7.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
+  juez B REJECT** (1 MAJOR + 2 WARNINGs) → fixes aplicados por el fix-agent: (1) MAJOR — el
+  `key={idPresupuesto ?? 'libre'}` de `Pos()` sin cobertura, sobrevivía 53/53; agregado el test
+  que rutea por `<Pos/>` real hasta `cobrar()` y `nuevaVenta()`, asertando que el ticket
+  desaparece y el input de escaneo vuelve tras el remount — mutante quitando el `key` → RED
+  confirmado → revert → verde (ver 7.13's describe block, nuevo `it` en "conversión de
+  presupuesto"). (2) WARNING — anotación de la tarea 7.7 corregida: el skip de precios de
+  `Pos.tsx:595-600` es defensivo/redundante con el guard de `lineas` vacías de la línea 611,
+  confound estructural confirmado por mutación real (54/54 verdes con el bloque borrado). (3)
+  WARNING — anotación de la tarea 7.10 corregida: `expect(errorSpy).not.toHaveBeenCalled()` no
+  discrimina el guard de token bajo React 19 (setState post-desmontaje es no-op silencioso);
+  intentada la forma discriminante (dos cargas compitiendo con la misma instancia montada) y
+  confirmada estructuralmente inalcanzable por mutación real (54/54 verdes con el chequeo de
+  token quitado) — mismo patrón de confound que el `40P01` de la tarea 1.32. Commit
+  `<pendiente>`. Pendiente: re-judge acotado a este diff.
 - [ ] 7.15 Open PR #7 `feat/stage17-slice7-web-presupuestos`, merge after a clean round.
 
 ### Work Unit Evidence

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -1901,35 +1901,86 @@ could not obtain lock on row in relation "remitos"`, duración de test ~5-6s, pr
 slices 4-6). **Finish**: quote list/detail/draft + the POS conversion entry point.
 **Rollback**: screens/branch disappear, API still serves the shape.
 
-- [ ] 7.1 Create `src/Ways.Web/src/api/presupuestos.ts` — client + pure mappers.
-- [ ] 7.2 Create `Presupuestos.tsx` — list, filters (PV/cliente/estado/`vencido`/desde-hasta),
+- [x] 7.1 Create `src/Ways.Web/src/api/presupuestos.ts` — client + pure mappers.
+- [x] 7.2 Create `Presupuestos.tsx` — list, filters (PV/cliente/estado/`vencido`/desde-hasta),
   `HistoricoDeCajas.tsx` pager pattern, `vencido` toggle disabled without a PV.
   *(design.md:399-403)*
-- [ ] 7.3 Create `Presupuesto.tsx` — draft editor (`CompraEditor.tsx` line grid) + detail +
+- [x] 7.3 Create `Presupuesto.tsx` — draft editor (`CompraEditor.tsx` line grid) + detail +
   expiry state + `enviar` (date input defaulted `hoy + 30` in PV zone) + `anular` +
   *"Convertir en venta"* (rendered only when `Convertible`). *(design.md:404-407)*
-- [ ] 7.4 Modify `Pos.tsx` — read `idPresupuesto` from `useSearchParams`, fetch `/para-venta`,
+  **DEVIATION REGISTERED**: the line grid mirrors `OrdenDeCompra.tsx`'s `SelectorDeArticulo` +
+  quantity-only row (article + cantidad, no cost/IVA/lista-precio columns), not
+  `CompraEditor.tsx`'s richer grid — `LineaDePresupuesto`/`ContratosDePresupuesto.cs` carries
+  **zero price fields** by design (decisión 2: the price is resolved server-side at save time,
+  never client-entered), so `CompraEditor.tsx`'s cost/discount/IVA columns have no destination
+  field to bind to. `OrdenDeCompra.tsx`'s simpler grid — itself the same `SelectorDeArticulo`
+  pattern, article+quantity only — is the structurally correct precedent for a request shape
+  with no money in it.
+- [x] 7.4 Modify `Pos.tsx` — read `idPresupuesto` from `useSearchParams`, fetch `/para-venta`,
   render the frozen-price banner, hydrate the cart **read-only**, **skip the price-resolution
   effect entirely**, disable scan/quantity/removal, post `{ idPuntoVenta,
   codigoTipoComprobante: 'TX', idPresupuestoOrigen, lineas: undefined, pagos }`,
   `key={idPresupuesto ?? 'libre'}`. *(design.md:408-415, react-async-state rule 8)*
-- [ ] 7.5 Modify `App.tsx` — routes `/presupuestos`, `/presupuestos/nuevo`,
-  `/presupuestos/:id`.
-- [ ] 7.6 Descriptor tests for every new pure helper (expiry-badge formatter, filter builder)
-  and every screen's descriptors. *(web-descriptor-tests)*
-- [ ] 7.7 Test: no price-resolution request issued under `?idPresupuesto=`, no `lineas`
-  posted, cart inputs disabled. *(design.md:508)*
-- [ ] 7.8 Test: a non-convertible quote renders no "Convertir" action.
-- [ ] 7.9 Test: double click on `enviar` issues exactly ONE POST (rule 9 re-entrancy + disable).
-  *(design.md:424-425)*
-- [ ] 7.10 Test: stale promise resolved **inside `act`** (rule 7). *(mutation-proof-tests
-  rule 7)*
-- [ ] 7.11 Test: `vencido` toggle disabled without `idPuntoVenta`; pager disabled at edges.
-- [ ] 7.12 Rule 10: any recovery path added is grepped for and replicated in sibling screens in
-  the same commit.
-- [ ] 7.13 [P] Non-regression: existing `Pos.test.tsx` green (only the new branch added).
+  **DEVIATION REGISTERED**: "disable scan/quantity/removal" is implemented by **hiding** those
+  controls entirely under `?idPresupuesto=` (the scan input-group, every `Quitar` button,
+  `Vaciar carrito`) rather than rendering-but-disabling each one — the read-only cart is a
+  structurally separate render branch sourced directly from `PresupuestoParaVenta.items`, never
+  `lineas`/`precios`. Strictly stronger than disabled-but-present (nothing to click at all), same
+  outcome the task asks for.
+  `SolicitudDeVenta.idCliente`/`.lineas` widened to optional in `tipos.ts` (mirrors the already-
+  merged C# `SolicitudDeVenta(int? IdCliente, IReadOnlyList<LineaDeVenta>? Lineas, ...)` from
+  Slice 3) so the conversion POST can omit both, per `dto-contract-honesty` — `idCliente` is
+  never sent on this path (the server derives it from the presupuesto; sending a matching one
+  would be redundant, sending a mismatched one is refused). `ComprobanteEmitido.idPresupuestoOrigen`
+  added as a required round-trip field (`dto-contract-honesty` rule 2), which required two
+  mechanical fixture updates in already-existing test files (`Pos.test.tsx`,
+  `CuentaCorriente.test.tsx`) — zero assertion changed.
+- [x] 7.5 Modify `App.tsx` — routes `/presupuestos`, `/presupuestos/nuevo`,
+  `/presupuestos/:id`. Also modified `Layout.tsx` (nav entry, same `puedeOperarPos` gate as
+  `/pos`/`/compras` — not itself a numbered task, but required for the entry point to be
+  reachable at all).
+- [x] 7.6 Descriptor tests for every new pure helper (expiry-badge formatter, filter builder)
+  and every screen's descriptors. *(web-descriptor-tests)* — `api/presupuestos.test.ts` (43
+  cases: query builder incl. offset/vencido-without-PV guards, badge/label formatters, form
+  mappers, `aSolicitudDeVentaDesdePresupuesto`).
+- [x] 7.7 Test: no price-resolution request issued under `?idPresupuesto=`, no `lineas`
+  posted, cart inputs disabled. *(design.md:508)* — `Pos.test.tsx` "conversión de presupuesto"
+  describe block: banner + read-only hydration + PV/cliente disabled + zero `/ofertas/resolver`
+  calls + POST body asserted to omit both `idCliente` and `lineas`.
+- [x] 7.8 Test: a non-convertible quote renders no "Convertir" action. — `Presupuesto.test.tsx`:
+  `Enviado`+`vencido:true`+`convertible:false` and `Convertido` (terminal) both assert the
+  button's absence; a third test asserts it renders when `convertible:true`.
+- [x] 7.9 Test: double click on `enviar` issues exactly ONE POST (rule 9 re-entrancy + disable).
+  *(design.md:424-425)* — `Presupuesto.test.tsx`, same same-tick-`dispatchEvent`-inside-`act`
+  pattern as `OrdenDeCompra.test.tsx` (jsdom does not no-op a click on a `disabled` element).
+  Also covers `anular`'s same guard.
+- [x] 7.10 Test: stale promise resolved **inside `act`** (rule 7). *(mutation-proof-tests
+  rule 7)* — `Pos.test.tsx`: a `/para-venta` fetch left pending, the screen unmounted, then the
+  promise resolved inside `act` — asserts zero `console.error` (proves the `vigente` guard, not
+  merely that nothing visibly changed).
+- [x] 7.11 Test: `vencido` toggle disabled without `idPuntoVenta`; pager disabled at edges. —
+  `Presupuestos.test.tsx`.
+- [x] 7.12 Rule 10: any recovery path added is grepped for and replicated in sibling screens in
+  the same commit. — No new error-recovery/self-heal path was added this slice (no new SQLSTATE
+  self-heal, no new filtered-save counter); `grep`-checked, nothing to replicate. Grepped for
+  `errorDetalle`/refetch-isolation shape shared with `OrdenDeCompra.tsx` — `Presupuesto.tsx`
+  already carries the same "refetch failure never blanks a stale-but-present detail" pattern
+  verbatim (same code shape, same comment).
+- [x] 7.13 [P] Non-regression: existing `Pos.test.tsx` green (only the new branch added). — all
+  31 pre-existing `render(<Pos />)` call sites mechanically became `renderPos()` (a `MemoryRouter`
+  wrapper, since `Pos()` now calls `useSearchParams`) with **zero assertion changed**; full file
+  green, see Work Unit Evidence.
 - [ ] 7.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
 - [ ] 7.15 Open PR #7 `feat/stage17-slice7-web-presupuestos`, merge after a clean round.
+
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and result | `npx vitest run src/api/presupuestos.test.ts src/paginas/Pos.test.tsx src/paginas/Presupuestos.test.tsx src/paginas/Presupuesto.test.tsx src/paginas/CuentaCorriente.test.tsx` — 5 files, 138/138 green |
+| Runtime harness command/scenario and result | Web-only slice — no server boundary (design: "the API still serves the shape", PR 3 already merged). Runtime harness is the full web suite: `npx vitest run` (no filter) — **51 files, 845/845 green**. `npm run build` (`tsc -b && vite build`) clean. `npm run lint` (oxlint) clean, zero new warnings. `dotnet build` of `Ways.Api` + all three test projects (`Ways.Domain.Tests`, `Ways.Application.Tests`, `Ways.IntegrationTests`) — clean, 0 errors, confirming zero backend regression (`git status` shows zero files touched outside `src/Ways.Web/**`) |
+| Mutation evidence | Web-only slice, no server-side clause to mutate. `web-descriptor-tests`/`mutation-proof-tests` rule 7 applied to the async paths: the stale-`/para-venta`-after-unmount test (task 7.10) and the pre-existing `OrdenesDeCompra`/`Presupuestos` generation-guard tests (both list screens share the identical `generacionRef` pattern, both proven with a real stale-response-lands-after-newer-one scenario resolved inside `act`) |
+| Rollback boundary | Isolated to `src/Ways.Web/**`: new files (`api/presupuestos.ts`, `api/presupuestos.test.ts`, `paginas/Presupuestos.tsx`, `paginas/Presupuestos.test.tsx`, `paginas/Presupuesto.tsx`, `paginas/Presupuesto.test.tsx`) plus modified files (`api/tipos.ts`, `api/ventas.ts`, `App.tsx`, `componentes/Layout.tsx`, `paginas/Pos.tsx`, `paginas/Pos.test.tsx`, `paginas/CuentaCorriente.test.tsx`). `git revert` of this slice's commit(s) alone removes the entire entry point; the API already serves `/api/presupuestos*` and `idPresupuestoOrigen` from PR 3, so nothing server-side reverts or breaks |
 
 ---
 

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -27,6 +27,8 @@ import { OrdenesDeCompra } from './paginas/OrdenesDeCompra'
 import { PaginaCatalogo } from './paginas/PaginaCatalogo'
 import { Parametros } from './paginas/Parametros'
 import { Pos } from './paginas/Pos'
+import { Presupuesto } from './paginas/Presupuesto'
+import { Presupuestos } from './paginas/Presupuestos'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
 import { Reposicion } from './paginas/Reposicion'
@@ -289,6 +291,35 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <OrdenDeCompra />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-17-presupuestos-y-remitos (Slice 7, design: Web composition, decisión 17):
+                mismo gate que /pos (Politicas.OperacionDePos) para lectura Y escritura — un
+                Vendedor puede quotear igual que puede vender, sin la distinción admin-only de
+                /ordenes-compra. */}
+            <Route
+              path="/presupuestos"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Presupuestos />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/presupuestos/nuevo"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Presupuesto />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/presupuestos/:id"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Presupuesto />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/presupuestos.test.ts
+++ b/src/Ways.Web/src/api/presupuestos.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  aLineaDePresupuestoSolicitada,
+  aSolicitudDeEnvio,
+  aSolicitudDePresupuesto,
+  aSolicitudDeVentaDesdePresupuesto,
+  claseDeBadgeDeEstadoPresupuesto,
+  claseDeBadgeDeVencimiento,
+  construirQueryDePresupuestos,
+  encabezadoDePresupuestoVacio,
+  etiquetaDeEstadoPresupuesto,
+  etiquetaDeVencimiento,
+  filtrosDePresupuestosVacios,
+  itemDePresupuestoAFormulario,
+  lineaDePresupuestoCompletaParaEnvio,
+  lineaDePresupuestoVacia,
+  vencimientoSugerido,
+} from './presupuestos'
+import type { EstadoPresupuesto, ItemDePresupuesto } from './tipos'
+
+describe('filtrosDePresupuestosVacios / construirQueryDePresupuestos', () => {
+  it('sin filtros manda solo pagina/tamanio', () => {
+    expect(construirQueryDePresupuestos(filtrosDePresupuestosVacios())).toBe('?pagina=1&tamanio=25')
+  })
+
+  it('idPuntoVenta, idCliente y estado viajan tal cual', () => {
+    const query = construirQueryDePresupuestos({ ...filtrosDePresupuestosVacios(), idPuntoVenta: 7, idCliente: 3, estado: 'Enviado' })
+    expect(query).toContain('idPuntoVenta=7')
+    expect(query).toContain('idCliente=3')
+    expect(query).toContain('estado=Enviado')
+  })
+
+  it('vencido viaja cuando hay idPuntoVenta (regla del guard de la 400 punto_venta_requerido)', () => {
+    const query = construirQueryDePresupuestos({ ...filtrosDePresupuestosVacios(), idPuntoVenta: 7, vencido: true })
+    expect(decodeURIComponent(query)).toContain('vencido=true')
+  })
+
+  it('vencido NUNCA viaja sin idPuntoVenta, aunque el filtro esté seteado (defensa en profundidad de la 400)', () => {
+    const query = construirQueryDePresupuestos({ ...filtrosDePresupuestosVacios(), idPuntoVenta: null, vencido: true })
+    expect(query).not.toContain('vencido')
+  })
+
+  it('desde/hasta expanden a los bordes del día con el offset horario local', () => {
+    const minutos = new Date(2026, 6, 1).getTimezoneOffset()
+    const signo = minutos > 0 ? '-' : '+'
+    const horas = String(Math.floor(Math.abs(minutos) / 60)).padStart(2, '0')
+    const restoMinutos = String(Math.abs(minutos) % 60).padStart(2, '0')
+    const offset = `${signo}${horas}:${restoMinutos}`
+
+    const query = decodeURIComponent(
+      construirQueryDePresupuestos({ ...filtrosDePresupuestosVacios(), desde: '2026-07-01', hasta: '2026-07-31' }),
+    )
+    expect(query).toContain(`desde=2026-07-01T00:00:00${offset}`)
+    expect(query).toContain(`hasta=2026-07-31T23:59:59.999${offset}`)
+  })
+})
+
+describe('construirQueryDePresupuestos — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00, nunca Z (mutation-proof-tests regla 10)', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+    const query = decodeURIComponent(construirQueryDePresupuestos({ ...filtrosDePresupuestosVacios(), desde: '2026-07-01' }))
+    expect(query).toContain('desde=2026-07-01T00:00:00-03:00')
+  })
+})
+
+describe('etiquetaDeEstadoPresupuesto / claseDeBadgeDeEstadoPresupuesto', () => {
+  const estados: EstadoPresupuesto[] = ['Borrador', 'Enviado', 'Convertido', 'Anulado']
+
+  it('cada estado tiene una etiqueta y una clase de badge propias y distintas', () => {
+    const etiquetas = estados.map(etiquetaDeEstadoPresupuesto)
+    const clases = estados.map(claseDeBadgeDeEstadoPresupuesto)
+    expect(new Set(etiquetas).size).toBe(estados.length)
+    expect(new Set(clases).size).toBe(estados.length)
+    expect(etiquetas).toContain('Convertido')
+  })
+})
+
+describe('etiquetaDeVencimiento / claseDeBadgeDeVencimiento', () => {
+  it('sin vencimiento (borrador) renderiza —, nunca una fecha inventada', () => {
+    expect(etiquetaDeVencimiento(null, false)).toBe('—')
+    expect(claseDeBadgeDeVencimiento(null, false)).toBe('text-bg-secondary')
+  })
+
+  it('vencido true antepone "Venció", vencido false antepone "Vence" — mismo dato crudo', () => {
+    expect(etiquetaDeVencimiento('2026-09-30', true)).toBe('Venció 30/9/2026')
+    expect(etiquetaDeVencimiento('2026-09-30', false)).toBe('Vence 30/9/2026')
+  })
+
+  it('la clase de badge distingue vencido de vigente', () => {
+    expect(claseDeBadgeDeVencimiento('2026-09-30', true)).toBe('text-bg-danger')
+    expect(claseDeBadgeDeVencimiento('2026-09-30', false)).toBe('text-bg-success')
+  })
+})
+
+function itemFixture(sobrescribir: Partial<ItemDePresupuesto> = {}): ItemDePresupuesto {
+  return {
+    orden: 1,
+    idArticulo: 10,
+    descripcion: 'Yerba mate 1kg',
+    cantidad: 5,
+    precioUnitario: 1200.5,
+    descuento: 0,
+    total: 6002.5,
+    idListaPrecio: 1,
+    idOferta: null,
+    idAlicuotaIva: 1,
+    porcentajeIva: 21,
+    ...sobrescribir,
+  }
+}
+
+describe('itemDePresupuestoAFormulario / lineaDePresupuestoVacia', () => {
+  it('un item persistido se vuelca tal cual (sin ningún campo de dinero, design decisión 2)', () => {
+    const linea = itemDePresupuestoAFormulario(1, itemFixture())
+    expect(linea).toEqual({ clave: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidad: '5' })
+  })
+
+  it('lineaDePresupuestoVacia arranca sin artículo ni cantidad', () => {
+    expect(lineaDePresupuestoVacia(9)).toEqual({ clave: 9, idArticulo: '', descripcion: '', cantidad: '' })
+  })
+})
+
+describe('lineaDePresupuestoCompletaParaEnvio', () => {
+  it('sin artículo es incompleta', () => {
+    expect(lineaDePresupuestoCompletaParaEnvio(lineaDePresupuestoVacia(1))).toBe(false)
+  })
+
+  it('con artículo pero sin cantidad es incompleta', () => {
+    expect(lineaDePresupuestoCompletaParaEnvio({ ...lineaDePresupuestoVacia(1), idArticulo: 10 })).toBe(false)
+  })
+
+  it('cantidad 0 o negativa es incompleta (CHECK del servidor: cantidad > 0)', () => {
+    expect(lineaDePresupuestoCompletaParaEnvio({ ...lineaDePresupuestoVacia(1), idArticulo: 10, cantidad: '0' })).toBe(false)
+    expect(lineaDePresupuestoCompletaParaEnvio({ ...lineaDePresupuestoVacia(1), idArticulo: 10, cantidad: '-3' })).toBe(false)
+  })
+
+  it('artículo + cantidad positiva es completa', () => {
+    expect(lineaDePresupuestoCompletaParaEnvio({ ...lineaDePresupuestoVacia(1), idArticulo: 10, cantidad: '5' })).toBe(true)
+  })
+})
+
+describe('aLineaDePresupuestoSolicitada', () => {
+  it('mapea cantidad a número', () => {
+    expect(aLineaDePresupuestoSolicitada({ clave: 1, idArticulo: 10, descripcion: 'Yerba', cantidad: '7' })).toEqual({
+      idArticulo: 10,
+      cantidad: 7,
+    })
+  })
+
+  it('cantidad vacía o no numérica mapea a 0 (nunca viaja sola: el filtro de "completa" ya la descartó antes)', () => {
+    expect(aLineaDePresupuestoSolicitada({ clave: 1, idArticulo: 10, descripcion: '', cantidad: '' }).cantidad).toBe(0)
+  })
+})
+
+describe('aSolicitudDePresupuesto', () => {
+  it('idCliente vacío viaja como null (Consumidor Final por defecto)', () => {
+    const solicitud = aSolicitudDePresupuesto({ ...encabezadoDePresupuestoVacio(), idPuntoVenta: 2 }, [])
+    expect(solicitud.idCliente).toBeNull()
+  })
+
+  it('recorta observaciones vacías a null', () => {
+    const solicitud = aSolicitudDePresupuesto({ ...encabezadoDePresupuestoVacio(), idPuntoVenta: 2, observaciones: '  ' }, [])
+    expect(solicitud.observaciones).toBeNull()
+  })
+
+  it('filtra las líneas incompletas — nunca viajan a medio llenar', () => {
+    const solicitud = aSolicitudDePresupuesto({ ...encabezadoDePresupuestoVacio(), idPuntoVenta: 2 }, [
+      { clave: 1, idArticulo: 10, descripcion: 'A', cantidad: '5' },
+      { clave: 2, idArticulo: '', descripcion: '', cantidad: '' },
+    ])
+    expect(solicitud.lineas).toHaveLength(1)
+    expect(solicitud.lineas[0]).toEqual({ idArticulo: 10, cantidad: 5 })
+  })
+})
+
+describe('aSolicitudDeEnvio', () => {
+  it('vencimiento viaja tal cual, sin offset horario (DateOnly)', () => {
+    expect(aSolicitudDeEnvio('2026-09-15')).toEqual({ vencimiento: '2026-09-15' })
+  })
+})
+
+describe('vencimientoSugerido', () => {
+  it('suma 30 días a la fecha dada, formateado YYYY-MM-DD', () => {
+    expect(vencimientoSugerido(new Date(2026, 0, 1))).toBe('2026-01-31')
+  })
+
+  it('cruza el fin de mes correctamente', () => {
+    expect(vencimientoSugerido(new Date(2026, 8, 15))).toBe('2026-10-15')
+  })
+})
+
+describe('aSolicitudDeVentaDesdePresupuesto', () => {
+  it('arma la SolicitudDeVenta de conversión sin idCliente ni lineas (dto-contract-honesty regla 1)', () => {
+    const solicitud = aSolicitudDeVentaDesdePresupuesto(7, 42, [{ idMedioPago: 1, importe: 100, referencia: null, vuelto: 0 }])
+    expect(solicitud).toEqual({
+      idPuntoVenta: 7,
+      codigoTipoComprobante: 'TX',
+      idComprobanteAsociado: null,
+      pagos: [{ idMedioPago: 1, importe: 100, referencia: null, vuelto: 0 }],
+      direccionEntrega: null,
+      observaciones: null,
+      idPresupuestoOrigen: 42,
+    })
+    expect(solicitud).not.toHaveProperty('idCliente')
+    expect(solicitud).not.toHaveProperty('lineas')
+  })
+})

--- a/src/Ways.Web/src/api/presupuestos.ts
+++ b/src/Ways.Web/src/api/presupuestos.ts
@@ -1,0 +1,230 @@
+/**
+ * Cliente HTTP + mappers puros de presupuestos (stage-17-presupuestos-y-remitos, Slice 7):
+ * CRUD de borrador, `enviar`/`anular`/`para-venta`, y el listado paginado — espejo del contrato
+ * de `Ways.Application.Ventas.ContratosDePresupuesto`/`PresupuestosEndpoints`
+ * (design.md: "client + pure mappers; `tipos.ts` mirrors the read/write DTOs").
+ */
+import { api } from './cliente'
+import type {
+  EstadoPresupuesto,
+  ItemDePresupuesto,
+  LineaDePresupuesto,
+  PagoDeVenta,
+  PaginaDePresupuestos,
+  PresupuestoDetalle,
+  PresupuestoParaVenta,
+  SolicitudDeEnvio,
+  SolicitudDePresupuesto,
+  SolicitudDeVenta,
+} from './tipos'
+
+// ---- Offset local para desde/hasta — mismo criterio que ordenesDeCompra.ts/compras.ts: el
+// servidor corre en UTC, `fecha_emision` es `timestamptz` y un `<input type="date">` sin offset
+// se interpretaría como UTC (mutation-proof-tests regla 10). Duplicado a propósito: no hay un
+// módulo compartido de utilidades de fecha en esta web todavía. -----------------------------------
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+export type FiltrosDePresupuestos = {
+  idPuntoVenta: number | null
+  idCliente: number | null
+  estado: EstadoPresupuesto | null
+  vencido: boolean | null
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+export function filtrosDePresupuestosVacios(): FiltrosDePresupuestos {
+  return { idPuntoVenta: null, idCliente: null, estado: null, vencido: null, desde: '', hasta: '', pagina: 1, tamanio: 25 }
+}
+
+/** Arma el query string de `GET /api/presupuestos` — `vencido` requiere `idPuntoVenta` (design
+ * decisión 16, `400 punto_venta_requerido` del lado del servidor si se manda sin uno): esta
+ * función nunca lo manda si no hay punto de venta elegido, la pantalla además deshabilita el
+ * toggle (tarea 7.11) como defensa en profundidad. `desde`/`hasta` con el mismo offset horario
+ * explícito que el resto de la web (mutation-proof-tests regla 10). */
+export function construirQueryDePresupuestos(filtros: FiltrosDePresupuestos): string {
+  const parametros = new URLSearchParams()
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  if (filtros.idCliente !== null) parametros.set('idCliente', String(filtros.idCliente))
+  if (filtros.estado !== null) parametros.set('estado', filtros.estado)
+  if (filtros.vencido !== null && filtros.idPuntoVenta !== null) parametros.set('vencido', String(filtros.vencido))
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+export const clienteDePresupuestos = {
+  listar: (filtros: FiltrosDePresupuestos) => api.get<PaginaDePresupuestos>(`/presupuestos${construirQueryDePresupuestos(filtros)}`),
+  obtener: (id: number) => api.get<PresupuestoDetalle>(`/presupuestos/${id}`),
+  crear: (solicitud: SolicitudDePresupuesto) => api.post<PresupuestoDetalle>('/presupuestos', solicitud),
+  actualizar: (id: number, solicitud: SolicitudDePresupuesto) => api.put<PresupuestoDetalle>(`/presupuestos/${id}`, solicitud),
+  enviar: (id: number, solicitud: SolicitudDeEnvio) => api.post<PresupuestoDetalle>(`/presupuestos/${id}/enviar`, solicitud),
+  anular: (id: number) => api.post<PresupuestoDetalle>(`/presupuestos/${id}/anular`),
+  paraVenta: (id: number) => api.get<PresupuestoParaVenta>(`/presupuestos/${id}/para-venta`),
+}
+
+export function etiquetaDeEstadoPresupuesto(estado: EstadoPresupuesto): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'Borrador'
+    case 'Enviado':
+      return 'Enviado'
+    case 'Convertido':
+      return 'Convertido'
+    case 'Anulado':
+      return 'Anulado'
+  }
+}
+
+export function claseDeBadgeDeEstadoPresupuesto(estado: EstadoPresupuesto): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'text-bg-secondary'
+    case 'Enviado':
+      return 'text-bg-primary'
+    case 'Convertido':
+      return 'text-bg-success'
+    case 'Anulado':
+      return 'text-bg-danger'
+  }
+}
+
+/** Formatter del badge de vencimiento — `null` (todavía borrador, sin `vencimiento`) renderiza
+ * `—`, nunca una fecha inventada; el prefijo distingue "Vence"/"Venció" del mismo dato crudo
+ * (`vencido` es SIEMPRE derivado server-side, `ReglaDePresupuestos` — acá solo se traduce a
+ * texto, nunca se recalcula). */
+export function etiquetaDeVencimiento(vencimiento: string | null, vencido: boolean): string {
+  if (vencimiento === null) return '—'
+  const fecha = new Date(`${vencimiento}T00:00:00`).toLocaleDateString('es-AR')
+  return vencido ? `Venció ${fecha}` : `Vence ${fecha}`
+}
+
+export function claseDeBadgeDeVencimiento(vencimiento: string | null, vencido: boolean): string {
+  if (vencimiento === null) return 'text-bg-secondary'
+  return vencido ? 'text-bg-danger' : 'text-bg-success'
+}
+
+// ---- Formulario del editor de borrador: una línea por fila de la grilla (mismo shape que
+// `LineaDeOrdenFormulario` de `ordenesDeCompra.ts`, sin ningún campo de dinero — el precio lo
+// resuelve el motor al guardar, nunca lo tipea el operador, design decisión 2) -------------------
+
+export type LineaDePresupuestoFormulario = {
+  /** Clave solo de React — el `PUT` es un replace-set completo, ningún `orden` persistido viaja
+   * en el request. */
+  clave: number
+  idArticulo: number | ''
+  descripcion: string
+  cantidad: string
+}
+
+export function lineaDePresupuestoVacia(clave: number): LineaDePresupuestoFormulario {
+  return { clave, idArticulo: '', descripcion: '', cantidad: '' }
+}
+
+/** Un item ya persistido → fila de formulario, para reabrir un borrador existente. */
+export function itemDePresupuestoAFormulario(clave: number, item: ItemDePresupuesto): LineaDePresupuestoFormulario {
+  return { clave, idArticulo: item.idArticulo, descripcion: item.descripcion, cantidad: String(item.cantidad) }
+}
+
+/** Una línea sin artículo o sin cantidad > 0 nunca viaja al servidor — mismo criterio que
+ * `lineaDeOrdenCompletaParaEnvio` de ordenesDeCompra.ts. */
+export function lineaDePresupuestoCompletaParaEnvio(l: LineaDePresupuestoFormulario): boolean {
+  const cantidad = Number(l.cantidad)
+  return l.idArticulo !== '' && l.cantidad.trim() !== '' && Number.isFinite(cantidad) && cantidad > 0
+}
+
+function numeroDeCantidad(valor: string): number {
+  const n = Number(valor)
+  return valor.trim() === '' || !Number.isFinite(n) ? 0 : n
+}
+
+/** Fila de formulario → `LineaDePresupuesto` — solo las líneas completas
+ * (`lineaDePresupuestoCompletaParaEnvio`) viajan; una fila a medio llenar nunca llega al
+ * servidor. */
+export function aLineaDePresupuestoSolicitada(l: LineaDePresupuestoFormulario): LineaDePresupuesto {
+  return { idArticulo: Number(l.idArticulo), cantidad: numeroDeCantidad(l.cantidad) }
+}
+
+export type EncabezadoDePresupuestoFormulario = {
+  idPuntoVenta: number | ''
+  idCliente: number | ''
+  observaciones: string
+}
+
+export function encabezadoDePresupuestoVacio(): EncabezadoDePresupuestoFormulario {
+  return { idPuntoVenta: '', idCliente: '', observaciones: '' }
+}
+
+/** `idCliente` vacío viaja como `null` — Consumidor Final por defecto, mismo criterio que
+ * `SolicitudDeVenta`. */
+export function aSolicitudDePresupuesto(
+  encabezado: EncabezadoDePresupuestoFormulario,
+  lineas: LineaDePresupuestoFormulario[],
+): SolicitudDePresupuesto {
+  return {
+    idPuntoVenta: encabezado.idPuntoVenta === '' ? 0 : encabezado.idPuntoVenta,
+    idCliente: encabezado.idCliente === '' ? null : encabezado.idCliente,
+    observaciones: encabezado.observaciones.trim() === '' ? null : encabezado.observaciones.trim(),
+    lineas: lineas.filter(lineaDePresupuestoCompletaParaEnvio).map(aLineaDePresupuestoSolicitada),
+  }
+}
+
+/** `vencimiento` viaja tal cual el `<input type="date">` la entrega (`DateOnly`, sin offset
+ * horario) — mismo criterio que `fechaEsperada` en ordenesDeCompra.ts. */
+export function aSolicitudDeEnvio(vencimiento: string): SolicitudDeEnvio {
+  return { vencimiento }
+}
+
+/** Sugerencia de `vencimiento` para el input de `enviar` — `hoy + 30` en el reloj LOCAL del
+ * navegador (design.md: "a date input defaulted to `hoy + 30` in the PV zone"): es solo una
+ * sugerencia editable, el servidor valida `vencimiento >= hoy(zona del PV)` con autoridad — un
+ * desvío de zona horaria acá nunca puede rechazar en silencio nada, el operador siempre puede
+ * cambiar la fecha antes de confirmar. */
+export function vencimientoSugerido(ahora: Date): string {
+  const sugerido = new Date(ahora.getTime())
+  sugerido.setDate(sugerido.getDate() + 30)
+  const anio = sugerido.getFullYear()
+  const mes = String(sugerido.getMonth() + 1).padStart(2, '0')
+  const dia = String(sugerido.getDate()).padStart(2, '0')
+  return `${anio}-${mes}-${dia}`
+}
+
+/**
+ * `PresupuestoParaVenta` confirmado → `SolicitudDeVenta` de conversión (design: Web composition
+ * — "post `{ idPuntoVenta, codigoTipoComprobante: 'TX', idPresupuestoOrigen, lineas: undefined,
+ * pagos }`"), invocado por `Pos.tsx` al cobrar bajo `?idPresupuesto=`. Sin `idCliente` a
+ * propósito (`dto-contract-honesty` regla 1 — el servidor lo deriva del presupuesto; mandar uno
+ * acá sería redundante en el mejor caso y un 409 evitable en el peor si alguna vez desincroniza
+ * del cliente hidratado en pantalla) y sin `lineas` (el precio congelado sale de
+ * `items_presupuesto`, jamás de lo que el carrito pudiera mostrar — proposal decisión 4). */
+export function aSolicitudDeVentaDesdePresupuesto(
+  idPuntoVenta: number,
+  idPresupuestoOrigen: number,
+  pagos: PagoDeVenta[],
+): SolicitudDeVenta {
+  return {
+    idPuntoVenta,
+    codigoTipoComprobante: 'TX',
+    idComprobanteAsociado: null,
+    pagos,
+    direccionEntrega: null,
+    observaciones: null,
+    idPresupuestoOrigen,
+  }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -946,15 +946,22 @@ export type MinimosDeStock = {
 export type LineaDeVenta = { idArticulo: number; cantidad: number; codigoBarra: string | null; idLote: number | null }
 export type PagoDeVenta = { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }
 
+/** stage-17-presupuestos-y-remitos, Slice 7 (design: Interfaces/Contracts, decisión 2/tensión
+ * T7): `idCliente`/`lineas` pasan a opcionales — con `idPresupuestoOrigen` presente, `lineas` NO
+ * viaja (`dto-contract-honesty` regla 1: un campo que el servidor ignoraría no se manda) y
+ * `idCliente` se omite para que el servidor lo derive del presupuesto (mandar uno en conflicto se
+ * rechaza en vez de sobreescribirse en silencio — espejo de `SolicitudDeVenta.IdCliente` en
+ * `Ways.Application.Ventas.Contratos`). Una venta común sigue mandando ambos como siempre. */
 export type SolicitudDeVenta = {
   idPuntoVenta: number
-  idCliente: number
+  idCliente?: number
   codigoTipoComprobante: 'TX' | 'NCX'
   idComprobanteAsociado: number | null
-  lineas: LineaDeVenta[]
+  lineas?: LineaDeVenta[]
   pagos: PagoDeVenta[]
   direccionEntrega: string | null
   observaciones: string | null
+  idPresupuestoOrigen?: number | null
 }
 
 export type EstadoComprobante = 'Emitido' | 'Anulado'
@@ -986,7 +993,12 @@ export type ItemEmitido = {
 export type PagoEmitido = { idMedioPago: number; importe: number; referencia: string | null; vuelto: number }
 
 /** Respuesta de `POST /api/ventas` (checkout) y `GET /api/ventas/{id}` (reimpresión) — espejo
- * de `ComprobanteEmitido`. `numeroVisible` ya viene formateado `PPPP-NNNNNNNN`. */
+ * de `ComprobanteEmitido`. `numeroVisible` ya viene formateado `PPPP-NNNNNNNN`.
+ *
+ * stage-17-presupuestos-y-remitos, Slice 7 (design: Interfaces/Contracts, OD9/T7):
+ * `idPresupuestoOrigen` — `null` en el 100% del tráfico que no nace de un presupuesto, el id del
+ * presupuesto convertido en el resto (`dto-contract-honesty` regla 2: round-trip, siempre
+ * presente en la respuesta — nunca una clave ausente). */
 export type ComprobanteEmitido = {
   id: number
   numero: number
@@ -1003,6 +1015,7 @@ export type ComprobanteEmitido = {
   observaciones: string | null
   items: ItemEmitido[]
   pagos: PagoEmitido[]
+  idPresupuestoOrigen: number | null
 }
 
 // --- Cuenta corriente: estado de cuenta y pago a cuenta (stage-7-cuenta-corriente, Slice 5) ---
@@ -1860,3 +1873,109 @@ export type OrdenDeCompraListada = {
 
 /** Página de `GET /api/ordenes-compra` (espejo de `PaginaDeOrdenesDeCompra`). */
 export type PaginaDeOrdenesDeCompra = { items: OrdenDeCompraListada[]; total: number; pagina: number; tamanio: number }
+
+// --- Presupuestos (stage-17-presupuestos-y-remitos, Slice 7) — espejo de
+// `Ways.Application.Ventas.ContratosDePresupuesto` / `Ways.Domain.Ventas.EstadoPresupuesto` -------
+
+/** Espejo de `EstadoPresupuesto` — el orden de los miembros ES el orden de ciclo de vida
+ * (design.md: "Declaration order = lifecycle = C# member order"). */
+export type EstadoPresupuesto = 'Borrador' | 'Enviado' | 'Convertido' | 'Anulado'
+
+/** Una línea del cuerpo de `POST`/`PUT /api/presupuestos` (espejo de `LineaDePresupuesto`). Sin
+ * dinero — el precio lo resuelve el motor al guardar el borrador, igual que el checkout (design
+ * decisión 2). */
+export type LineaDePresupuesto = { idArticulo: number; cantidad: number }
+
+/** Cuerpo de `POST /api/presupuestos` (crea un borrador) y `PUT /api/presupuestos/{id}`
+ * (replace-set completo del header + los items — espejo de `SolicitudDePresupuesto`).
+ * `idCliente` omitido resuelve a Consumidor Final, mismo criterio que `SolicitudDeVenta`. */
+export type SolicitudDePresupuesto = {
+  idPuntoVenta: number
+  idCliente: number | null
+  observaciones: string | null
+  lineas: LineaDePresupuesto[]
+}
+
+/** Cuerpo de `POST /api/presupuestos/{id}/enviar` (espejo de `SolicitudDeEnvio`) —
+ * `vencimiento` es un `DateOnly`/`<input type="date">`, sin offset horario. */
+export type SolicitudDeEnvio = { vencimiento: string }
+
+/** Un item ya persistido — `orden` es el valor server-asignado; el resto es la procedencia de
+ * precio congelada al guardar el borrador (espejo de `ItemDePresupuesto`). */
+export type ItemDePresupuesto = {
+  orden: number
+  idArticulo: number
+  descripcion: string
+  cantidad: number
+  precioUnitario: number
+  descuento: number
+  total: number
+  idListaPrecio: number
+  idOferta: number | null
+  idAlicuotaIva: number
+  porcentajeIva: number
+}
+
+/** Respuesta de `POST/PUT /api/presupuestos`, `POST /{id}/enviar`, `POST /{id}/anular` y
+ * `GET /{id}` — espejo de `PresupuestoDetalle`. `vencido`/`convertible` son DERIVADOS en cada
+ * lectura (`ReglaDePresupuestos`, zona horaria del punto de venta), nunca columnas propias de
+ * este shape. */
+export type PresupuestoDetalle = {
+  id: number
+  idPuntoVenta: number
+  idCliente: number
+  idEmpleado: number
+  numero: number | null
+  numeroFormateado: string | null
+  fechaEmision: string
+  fechaEnvio: string | null
+  vencimiento: string | null
+  vencido: boolean
+  convertible: boolean
+  zonaId: string
+  observaciones: string | null
+  subtotal: number
+  descuentoTotal: number
+  total: number
+  estado: EstadoPresupuesto
+  idComprobanteVenta: number | null
+  items: ItemDePresupuesto[]
+}
+
+/** `GET /{id}/para-venta` — espejo de `PresupuestoParaVenta`. Lectura PARA MOSTRAR, jamás un
+ * `SolicitudDeVenta` pre-armado (`dto-contract-honesty` regla 1): un shape que el POS pudiera
+ * postear tal cual haría creíble al carrito para el dinero, exactamente lo que la congelación de
+ * precio (proposal decisión 4) existe para impedir. */
+export type PresupuestoParaVenta = {
+  idPresupuesto: number
+  numero: number | null
+  idPuntoVenta: number
+  idCliente: number
+  vencimiento: string | null
+  vencido: boolean
+  convertible: boolean
+  subtotal: number
+  descuentoTotal: number
+  total: number
+  items: ItemDePresupuesto[]
+}
+
+/** Fila de `GET /api/presupuestos` — espejo de `PresupuestoListado`. `vencido`/`convertible`
+ * viajan acá también: se resuelve una zona por punto de venta DISTINTO de la página completa
+ * (design decisión 16), no una consulta agregada por fila. */
+export type PresupuestoListado = {
+  id: number
+  idPuntoVenta: number
+  idCliente: number
+  numero: number | null
+  numeroFormateado: string | null
+  fechaEmision: string
+  vencimiento: string | null
+  vencido: boolean
+  convertible: boolean
+  total: number
+  estado: EstadoPresupuesto
+}
+
+/** Página de `GET /api/presupuestos` (espejo de `PaginaDePresupuestos`). */
+export type PaginaDePresupuestos = { items: PresupuestoListado[]; total: number; pagina: number; tamanio: number }

--- a/src/Ways.Web/src/api/ventas.ts
+++ b/src/Ways.Web/src/api/ventas.ts
@@ -109,7 +109,7 @@ export function aSolicitudDeVenta(params: {
   pagos: PagoDeVenta[]
   direccionEntrega: string | null
   observaciones: string | null
-}): SolicitudDeVenta {
+}): SolicitudDeVenta & { idCliente: number; lineas: LineaDeVenta[] } {
   const lineasDeVenta: LineaDeVenta[] = params.lineas.map((l) => ({
     idArticulo: l.idArticulo,
     cantidad: l.cantidad,

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -65,6 +65,15 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-17-presupuestos-y-remitos (Slice 7, design: Web composition): mismo gate
+                    que /pos/-compras (Politicas.OperacionDePos) — nav y ruta comparten política. */}
+                {usuario && puedeOperarPos(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/presupuestos">
+                      Presupuestos
+                    </NavLink>
+                  </li>
+                )}
                 {/* stage-10-agregacion-dashboard (Slice 7, design: Web Composition): nav y ruta
                     comparten Politicas.LecturaDeReportes — Supervisor + Admin, ni Vendedor ni
                     Root. */}

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -163,6 +163,7 @@ function comprobanteFixture(sobrescribir: Partial<ComprobanteEmitido> = {}): Com
     observaciones: null,
     items: [],
     pagos: [{ idMedioPago: 1, importe: 500, referencia: null, vuelto: 0 }],
+    idPresupuestoOrigen: null,
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Pos } from './Pos'
 import { ErrorApi } from '../api/cliente'
@@ -11,9 +12,25 @@ import type {
   MedioPagoListado,
   PaginaDe,
   ParametroResuelto,
+  PresupuestoParaVenta,
   PuntoVentaListado,
   ResultadoDeResolucion,
 } from '../api/tipos'
+
+/** `Pos()` (stage-17-presupuestos-y-remitos, Slice 7) lee `useSearchParams` — necesita un Router
+ * para montar, mismo criterio que `OrdenDeCompra.test.tsx`/`CompraEditor.test.tsx`. `ruta` por
+ * defecto es la libre (`/pos`, sin `?idPresupuesto=`) para que los tests preexistentes no
+ * cambien de comportamiento. */
+function renderPos(ruta = '/pos') {
+  return render(
+    <MemoryRouter initialEntries={[ruta]}>
+      <Routes>
+        <Route path="/pos" element={<Pos />} />
+        <Route path="/presupuestos" element={<div>Presupuestos</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
@@ -138,6 +155,7 @@ function comprobanteEmitidoFixture(sobrescribir: Partial<ComprobanteEmitido> = {
       },
     ],
     pagos: [{ idMedioPago: 1, importe: 100, referencia: null, vuelto: 0 }],
+    idPresupuestoOrigen: null,
     ...sobrescribir,
   }
 }
@@ -220,7 +238,7 @@ beforeEach(() => {
 /** Deja el carrito con una línea de Coca Cola ($100, sin descuento) y el panel de pagos listo:
  * medio Efectivo elegido, importe = total. Punto de partida de los tests de checkout. */
 async function armarVentaLista() {
-  render(<Pos />)
+  renderPos()
   await screen.findByRole('option', { name: /Consumidor Final/ })
 
   await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
@@ -261,7 +279,7 @@ describe('Pos — formato de moneda negativa (regresión, INFO recurrente desde 
 
 describe('Pos — carga inicial', () => {
   it('selecciona el Consumidor Final por defecto y el único punto de venta disponible', async () => {
-    render(<Pos />)
+    renderPos()
 
     expect(await screen.findByRole('option', { name: /Consumidor Final/ })).toBeInTheDocument()
     expect(screen.getByLabelText('Cliente')).toHaveValue(String(consumidorFinal.id))
@@ -271,7 +289,7 @@ describe('Pos — carga inicial', () => {
 
 describe('Pos — escaneo', () => {
   it('escanear un código agrega una línea al carrito', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
@@ -282,7 +300,7 @@ describe('Pos — escaneo', () => {
   })
 
   it('re-escanear el mismo código suma la cantidad en la misma línea, no duplica', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -300,7 +318,7 @@ describe('Pos — escaneo', () => {
   })
 
   it('el input de escaneo se limpia después de un escaneo exitoso', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -324,7 +342,7 @@ describe('Pos — escaneo', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '999')
@@ -337,7 +355,7 @@ describe('Pos — escaneo', () => {
 
 describe('Pos — selector de cliente', () => {
   it('buscar y elegir otro cliente lo deja seleccionado', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
@@ -367,7 +385,7 @@ describe('Pos — regresión: carga inicial de clientes vs. selección del usuar
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
 
     await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
     await userEvent.click(screen.getByRole('button', { name: 'Buscar' }))
@@ -405,7 +423,7 @@ describe('Pos — vista previa de precios', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -436,7 +454,7 @@ describe('Pos — vista previa de precios', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
@@ -469,7 +487,7 @@ describe('Pos — vista previa de precios', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
@@ -515,7 +533,7 @@ describe('Pos — vista previa de precios', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -559,7 +577,7 @@ describe('Pos — vista previa de precios', () => {
       return Promise.resolve(resultados)
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -590,7 +608,7 @@ describe('Pos — vista previa de precios', () => {
 
 describe('Pos — panel de pagos: precondiciones', () => {
   it('Cobrar está deshabilitado con el carrito vacío', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     expect(screen.getByRole('button', { name: /Cobrar/ })).toBeDisabled()
@@ -611,7 +629,7 @@ describe('Pos — panel de pagos: precondiciones', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -631,7 +649,7 @@ describe('Pos — panel de pagos: precondiciones', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -665,7 +683,7 @@ describe('Pos — regresión: "resolviendo" no queda huérfano en `true`', () =>
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -690,7 +708,7 @@ describe('Pos — regresión: "resolviendo" no queda huérfano en `true`', () =>
 
 describe('Pos — panel de pagos: cuenta corriente y vuelto', () => {
   it('cuenta corriente no aparece como opción para el Consumidor Final', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await screen.findByRole('option', { name: medioEfectivo.nombre })
 
@@ -698,7 +716,7 @@ describe('Pos — panel de pagos: cuenta corriente y vuelto', () => {
   })
 
   it('cuenta corriente aparece como opción para un cliente que no es Consumidor Final', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Buscar cliente'), 'perez')
@@ -710,7 +728,7 @@ describe('Pos — panel de pagos: cuenta corriente y vuelto', () => {
   })
 
   it('el input de vuelto está deshabilitado para un medio sin AdmiteVuelto', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await screen.findByRole('option', { name: medioTarjeta.nombre })
 
@@ -720,7 +738,7 @@ describe('Pos — panel de pagos: cuenta corriente y vuelto', () => {
   })
 
   it('el input de vuelto queda habilitado para un medio con AdmiteVuelto', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await screen.findByRole('option', { name: medioEfectivo.nombre })
 
@@ -774,7 +792,7 @@ describe('Pos — checkout', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '999')
@@ -983,7 +1001,7 @@ describe('Pos — gate seam de turno de caja (stage-6-turnos-caja, Slice 7)', ()
 
 describe('Pos — checkout: split de pago con el mismo medio', () => {
   it('dos filas de Efectivo (split de pago) no colapsan: cada una envía su propio importe y vuelto', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
@@ -1045,7 +1063,7 @@ describe('Pos — badge de ofertas apiladas', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -1059,7 +1077,7 @@ describe('Pos — badge de ofertas apiladas', () => {
 
 describe('Pos — edición de cantidad', () => {
   async function agregarLineaCocaCola() {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -1114,7 +1132,7 @@ describe('Pos — edición de cantidad', () => {
 
 describe('Pos — debounce de la resolución de precios', () => {
   it('una edición debounce ~250ms y una segunda edición dentro de la ventana reemplaza a la primera; un escaneo resuelve sin demora', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -1143,7 +1161,7 @@ describe('Pos — debounce de la resolución de precios', () => {
   })
 
   it('un cambio de cliente inmediatamente después de una edición de cantidad no hereda la demora de esa edición', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -1183,7 +1201,7 @@ describe('Pos — debounce de la resolución de precios', () => {
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Pos />)
+    renderPos()
 
     const entrada = screen.getByLabelText('Código escaneado')
     await userEvent.type(entrada, '7790001234567')
@@ -1213,7 +1231,7 @@ describe('Pos — debounce de la resolución de precios', () => {
 
 describe('Pos — limpieza de ediciones en curso', () => {
   it('quitar una línea con una edición pendiente no deja un override fantasma para un artículo agregado de nuevo', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -1237,7 +1255,7 @@ describe('Pos — limpieza de ediciones en curso', () => {
   })
 
   it('vaciar el carrito con una edición pendiente no deja overrides fantasma para las líneas siguientes', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -1261,7 +1279,7 @@ describe('Pos — limpieza de ediciones en curso', () => {
   })
 
   it('un escaneo que suma sobre una línea existente descarta el override de edición pendiente de esa fila', async () => {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
 
     const entrada = screen.getByLabelText('Código escaneado')
@@ -1299,7 +1317,7 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
   /** Deja el carrito con una sola línea de Coca Cola, sin pasar por el panel de pagos — punto de
    * partida de los tests del picker. */
   async function armarCarritoConUnaLinea() {
-    render(<Pos />)
+    renderPos()
     await screen.findByRole('option', { name: /Consumidor Final/ })
     await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
     await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
@@ -1465,5 +1483,125 @@ describe('Pos — ticket: warning de lote vencido (design decisión 12: "Expired
     expect(await screen.findByText('Venta 0007-00000001')).toBeInTheDocument()
     const fila = screen.getByText('Coca Cola 1L').closest('tr') as HTMLElement
     expect(within(fila).queryByText('⚠ Lote vencido')).not.toBeInTheDocument()
+  })
+})
+
+describe('Pos — conversión de presupuesto (stage-17-presupuestos-y-remitos, Slice 7, design: Web composition)', () => {
+  function presupuestoParaVentaFixture(sobrescribir: Partial<PresupuestoParaVenta> = {}): PresupuestoParaVenta {
+    return {
+      idPresupuesto: 1,
+      numero: 1,
+      idPuntoVenta: 7,
+      idCliente: 2,
+      vencimiento: '2026-09-30',
+      vencido: false,
+      convertible: true,
+      subtotal: 200,
+      descuentoTotal: 0,
+      total: 200,
+      items: [
+        {
+          orden: 1,
+          idArticulo: 1,
+          descripcion: 'Coca Cola 1L',
+          cantidad: 2,
+          precioUnitario: 100,
+          descuento: 0,
+          total: 200,
+          idListaPrecio: 1,
+          idOferta: null,
+          idAlicuotaIva: 1,
+          porcentajeIva: 21,
+        },
+      ],
+      ...sobrescribir,
+    }
+  }
+
+  function mockearApiGetPresupuesto(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/presupuestos/1/para-venta') return Promise.resolve(presupuestoParaVentaFixture())
+      if (ruta === '/clientes/2') return Promise.resolve(otroCliente)
+      const propia = sobrescribir?.(ruta) ?? rutaBaseDePos(ruta, [puntoVentaFixture({ id: 7 })])
+      if (propia) return propia
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+  }
+
+  it('renderiza el banner, hidrata el carrito congelado de solo lectura, fija punto de venta/cliente y NUNCA dispara la resolución de precio (tarea 7.7)', async () => {
+    mockearApiGetPresupuesto()
+    renderPos('/pos?idPresupuesto=1')
+
+    expect(await screen.findByText(/Esta venta viene del presupuesto N° 1/)).toBeInTheDocument()
+    expect(screen.getByText(/vence el/)).toBeInTheDocument()
+    expect(await screen.findByText('Coca Cola 1L')).toBeInTheDocument()
+
+    // El input de escaneo y "Quitar" NUNCA se renderizan bajo este modo — el carrito congelado
+    // no admite mutación (design: "disable scan/quantity/removal").
+    expect(screen.queryByLabelText('Código escaneado')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Quitar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Vaciar carrito' })).not.toBeInTheDocument()
+
+    // Punto de venta y cliente quedan fijados por el presupuesto, ambos deshabilitados.
+    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(7)))
+    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
+    await waitFor(() => expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id)))
+    expect(screen.getByLabelText('Cliente')).toBeDisabled()
+
+    // El total mostrado es el del presupuesto congelado, nunca uno recalculado por resolución.
+    expect(screen.getByText('$200,00', { selector: 'strong' })).toBeInTheDocument()
+
+    // Regla central de la tarea: ninguna resolución de precio bajo este modo.
+    expect(apiPostMock).not.toHaveBeenCalledWith('/ofertas/resolver', expect.anything())
+  })
+
+  it('cobrar postea la SolicitudDeVenta con idPresupuestoOrigen, sin idCliente ni lineas (dto-contract-honesty)', async () => {
+    mockearApiGetPresupuesto()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') return Promise.resolve(comprobanteEmitidoFixture({ idPresupuestoOrigen: 1, total: 200, subtotal: 200 }))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderPos('/pos?idPresupuesto=1')
+    await screen.findByText('Coca Cola 1L')
+
+    await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), medioEfectivo.nombre)
+    const importe = await screen.findByLabelText(`Importe de ${medioEfectivo.nombre} (fila 1)`)
+    await userEvent.type(importe, '200')
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Cobrar/ })).toBeEnabled())
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/ventas', expect.objectContaining({ idPresupuestoOrigen: 1 })))
+    const llamada = apiPostMock.mock.calls.find(([ruta]) => ruta === '/ventas') as [string, Record<string, unknown>]
+    expect(llamada[1]).not.toHaveProperty('idCliente')
+    expect(llamada[1]).not.toHaveProperty('lineas')
+  })
+
+  it('una respuesta tardía de /para-venta tras desmontar la pantalla no dispara ningún error (mutation-proof-tests regla 7: resuelta dentro de act)', async () => {
+    let resolverParaVenta: (p: PresupuestoParaVenta) => void = () => {}
+    const pendiente = new Promise<PresupuestoParaVenta>((resolve) => {
+      resolverParaVenta = resolve
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/presupuestos/1/para-venta') return pendiente
+      if (ruta === '/clientes/2') return Promise.resolve(otroCliente)
+      return rutaBaseDePos(ruta, [puntoVentaFixture({ id: 7 })]) ?? Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    const { unmount } = renderPos('/pos?idPresupuesto=1')
+    await screen.findByText('Cargando…')
+
+    unmount()
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await act(async () => {
+      resolverParaVenta(presupuestoParaVentaFixture())
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
   })
 })

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -1578,7 +1578,61 @@ describe('Pos — conversión de presupuesto (stage-17-presupuestos-y-remitos, S
     expect(llamada[1]).not.toHaveProperty('lineas')
   })
 
-  it('una respuesta tardía de /para-venta tras desmontar la pantalla no dispara ningún error (mutation-proof-tests regla 7: resuelta dentro de act)', async () => {
+  it('"Nueva venta" bajo `?idPresupuesto=` navega a `/pos` y remonta la pantalla entera: el ticket de la venta convertida NO queda pegado (judgment-day slice-7 ronda 1 juez B, MAJOR)', async () => {
+    mockearApiGetPresupuesto()
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/ventas') return Promise.resolve(comprobanteEmitidoFixture({ idPresupuestoOrigen: 1, total: 200, subtotal: 200 }))
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderPos('/pos?idPresupuesto=1')
+    await screen.findByText('Coca Cola 1L')
+
+    await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), medioEfectivo.nombre)
+    const importe = await screen.findByLabelText(`Importe de ${medioEfectivo.nombre} (fila 1)`)
+    await userEvent.type(importe, '200')
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Cobrar/ })).toBeEnabled())
+    await userEvent.click(screen.getByRole('button', { name: /Cobrar/ }))
+    expect(await screen.findByText('Venta 0007-00000001')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Nueva venta' }))
+
+    // `nuevaVenta()` bajo `modoPresupuesto` navega a `/pos` en vez de resetear `ventaEmitida`
+    // localmente (react-async-state regla 8): la ruta pierde `?idPresupuesto=`, el `key` de
+    // `Pos()` pasa de `1` a `'libre'` y `PantallaPos` se remonta entera — sin ese remount, el
+    // ticket de la venta ya convertida quedaría pegado en pantalla para siempre.
+    await waitFor(() => expect(screen.queryByText('Venta 0007-00000001')).not.toBeInTheDocument())
+    expect(await screen.findByLabelText('Código escaneado')).toBeInTheDocument()
+  })
+
+  /**
+   * CORRECCIÓN REGISTRADA (judgment-day slice-7 ronda 1 juez B, WARNING — mutation-proof-tests
+   * regla 2/3): este test se documentaba como prueba del guard `tokenPresupuestoRef.current !==
+   * miToken` del `.then()`/`.catch()`/`.finally()` de la carga de `/para-venta` — no lo es.
+   * React 19 volvió a un `setState` post-desmontaje un no-op silencioso (sin el warning de
+   * `console.error` que React ≤18 emitía), así que `expect(errorSpy).not.toHaveBeenCalled()` da
+   * verde exista o no CUALQUIERA de los dos guards (`vigente` o el token) — no discrimina nada
+   * bajo esta versión de React.
+   *
+   * El chequeo de `vigente` sigue siendo necesario y observable en otro sentido (evita el
+   * `setState` en sí, no solo su warning), pero el chequeo de TOKEN específicamente resultó, tras
+   * intentarlo, estructuralmente imposible de discriminar con un test montado: el efecto que lo
+   * usa depende solo de `[modoPresupuesto, idPresupuesto]`, y `Pos()` remonta `PantallaPos`
+   * entera por `key={idPresupuesto ?? 'libre'}` en cuanto ese id cambia (react-async-state regla
+   * 8) — dentro de la vida de UNA instancia montada, `idPresupuesto` nunca cambia, así que este
+   * efecto corre exactamente una vez (la única excepción real, el doble-invoke de `StrictMode` en
+   * desarrollo, tampoco sirve: la limpieza del primer run se ejecuta de forma síncrona, antes de
+   * que CUALQUIER promesa tenga oportunidad de resolver, así que `vigente` ya blinda ese caso por
+   * sí solo). No existe una re-carga real de `/para-venta` con la MISMA instancia montada que
+   * compita contra un token distinto — cualquier "segunda carga" observable en producción es, en
+   * los hechos, una instancia nueva (mismo patrón que el confound del `40P01` en la tarea 1.32:
+   * confirmado empíricamente, no razonado, y registrado como tal en vez de inflar la cobertura
+   * reclamada). El test se conserva sin cambios (prueba real, aunque no discriminante, de que un
+   * resolve tardío post-desmontaje no revienta el proceso) — solo se corrige la afirmación de qué
+   * prueba.
+   */
+  it('una respuesta tardía de /para-venta tras desmontar la pantalla no dispara ningún error (mutation-proof-tests regla 7: resuelta dentro de act — NO discrimina el guard de token, ver comentario arriba)', async () => {
     let resolverParaVenta: (p: PresupuestoParaVenta) => void = () => {}
     const pendiente = new Promise<PresupuestoParaVenta>((resolve) => {
       resolverParaVenta = resolve

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { clienteDeArticulos } from '../api/articulos'
 import { clienteDeCaja } from '../api/caja'
 import { reducirCarrito, type AccionCarrito, type LineaCarrito } from '../api/carrito'
@@ -19,6 +20,7 @@ import {
   validarPagosLocal,
   type FilaPago,
 } from '../api/pagos'
+import { aSolicitudDeVentaDesdePresupuesto, clienteDePresupuestos } from '../api/presupuestos'
 import { clienteDeStock } from '../api/stock'
 import type {
   ClienteListado,
@@ -27,6 +29,7 @@ import type {
   MedioPagoAlta,
   MedioPagoListado,
   ParametroResuelto,
+  PresupuestoParaVenta,
   PuntoVentaListado,
   ResultadoDeResolucion,
 } from '../api/tipos'
@@ -42,6 +45,7 @@ import {
   type LotesSeleccionados,
 } from '../api/ventas'
 import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
 
 const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
 
@@ -311,13 +315,25 @@ function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegid
   )
 }
 
+type PropsPantallaPos = { idPresupuesto: number | null }
+
 /**
  * Pantalla del POS (stage-5-pos-ventas, Slice 7, design: POS Screen Composition) — escaneo +
  * carrito + selección de punto de venta/cliente (Slice 6) + panel de pagos, checkout (`POST
  * /api/ventas`) y ticket (Slice 7, esta entrega). Precedente de forma: `Articulos.tsx`/`Ofertas.tsx`
  * tras sus rondas de judgment-day.
+ *
+ * stage-17-presupuestos-y-remitos (Slice 7, design: Web composition — "the POS banner, the
+ * read-only hydration, the skipped price effect, the key"): con `idPresupuesto` no nulo, la
+ * pantalla entera opera en modo conversión — carrito congelado de solo lectura, sin resolución de
+ * precio, `POST /api/ventas` con `idPresupuestoOrigen`. Remontada íntegra por `key` desde `Pos()`
+ * (react-async-state regla 8) — ningún estado de una venta libre o de otro presupuesto sobrevive
+ * al cambio de `?idPresupuesto=`.
  */
-export function Pos() {
+function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
+  const modoPresupuesto = idPresupuesto !== null
+  const navigate = useNavigate()
+
   const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
   const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
   const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
@@ -376,6 +392,75 @@ export function Pos() {
 
   const [ventaEmitida, setVentaEmitida] = useState<{ comprobante: ComprobanteEmitido; cliente: ClienteListado } | null>(null)
 
+  // stage-17-presupuestos-y-remitos (Slice 7): el presupuesto congelado que gobierna esta venta
+  // bajo `?idPresupuesto=` — `null` en el camino libre. `cargandoPresupuesto`/`errorPresupuesto`
+  // gatean la pantalla ANTES de mostrar el carrito congelado, mismo criterio que `errorDetalle`
+  // en OrdenDeCompra.tsx.
+  const [presupuesto, setPresupuesto] = useState<PresupuestoParaVenta | null>(null)
+  const [cargandoPresupuesto, setCargandoPresupuesto] = useState(modoPresupuesto)
+  const [errorPresupuesto, setErrorPresupuesto] = useState('')
+  const tokenPresupuestoRef = useRef(0)
+
+  useEffect(() => {
+    if (!modoPresupuesto || idPresupuesto === null) return
+    const miToken = (tokenPresupuestoRef.current += 1)
+    let vigente = true
+    setCargandoPresupuesto(true)
+    setErrorPresupuesto('')
+
+    clienteDePresupuestos
+      .paraVenta(idPresupuesto)
+      .then((p) => {
+        if (!vigente || tokenPresupuestoRef.current !== miToken) return
+        setPresupuesto(p)
+      })
+      .catch((e) => {
+        if (!vigente || tokenPresupuestoRef.current !== miToken) return
+        setErrorPresupuesto(e instanceof ErrorApi ? e.message : 'No se pudo cargar el presupuesto.')
+      })
+      .finally(() => {
+        if (!vigente || tokenPresupuestoRef.current !== miToken) return
+        setCargandoPresupuesto(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [modoPresupuesto, idPresupuesto])
+
+  // El punto de venta lo fija el presupuesto — nunca lo elige el cajero bajo este modo (el
+  // servidor recibe `idPuntoVenta` del body igual que siempre, pero acá viaja el del presupuesto,
+  // nunca uno distinto que el operador pudiera tipear).
+  useEffect(() => {
+    if (!presupuesto) return
+    setIdPuntoVenta(presupuesto.idPuntoVenta)
+  }, [presupuesto])
+
+  // El cliente lo trae el presupuesto por id — se hidrata el registro completo (no solo el id)
+  // porque el panel de pagos necesita `esConsumidorFinal`/`saldo`/`limiteCredito`/`creditoIlimitado`
+  // para su validación local, los mismos campos que la selección manual ya provee.
+  const tokenClientePresupuestoRef = useRef(0)
+  useEffect(() => {
+    if (!presupuesto) return
+    const miToken = (tokenClientePresupuestoRef.current += 1)
+    let vigente = true
+
+    clienteDeClientes
+      .obtener(presupuesto.idCliente)
+      .then((c) => {
+        if (!vigente || tokenClientePresupuestoRef.current !== miToken) return
+        setClienteSeleccionado(c)
+      })
+      .catch((e) => {
+        if (!vigente || tokenClientePresupuestoRef.current !== miToken) return
+        setErrorClientes(e instanceof ErrorApi ? e.message : 'No se pudo cargar el cliente del presupuesto.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [presupuesto])
+
   const puntoVentaSeleccionada = puntosVenta?.find((p) => p.id === idPuntoVenta) ?? null
 
   const medioPorId = useMemo(() => {
@@ -397,9 +482,15 @@ export function Pos() {
       .then((lista) => {
         if (!vigente) return
         setPuntosVenta(lista)
-        const guardado = leerPuntoVentaGuardado()
-        const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
-        setIdPuntoVenta(porDefecto ? porDefecto.id : '')
+        // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=` el punto de venta lo
+        // fija el propio presupuesto (efecto dedicado más abajo) — este default NUNCA escribe
+        // acá, o ganaría una carrera contra esa asignación según cuál de las dos respuestas
+        // llegue primero.
+        if (!modoPresupuesto) {
+          const guardado = leerPuntoVentaGuardado()
+          const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
+          setIdPuntoVenta(porDefecto ? porDefecto.id : '')
+        }
       })
       .catch((e) => {
         if (!vigente) return
@@ -416,8 +507,14 @@ export function Pos() {
       .then((pagina) => {
         if (!vigente || generacionClientesRef.current !== generacionClientes) return
         setOpcionesClientes(pagina.items)
-        const consumidorFinal = pagina.items.find((c) => c.esConsumidorFinal) ?? null
-        setClienteSeleccionado(consumidorFinal)
+        // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=` el cliente lo trae el
+        // presupuesto (efecto dedicado más abajo, hidrata el registro completo por id) — el
+        // default de Consumidor Final NUNCA escribe acá bajo este modo, mismo criterio que el
+        // punto de venta.
+        if (!modoPresupuesto) {
+          const consumidorFinal = pagina.items.find((c) => c.esConsumidorFinal) ?? null
+          setClienteSeleccionado(consumidorFinal)
+        }
       })
       .catch((e) => {
         if (!vigente || generacionClientesRef.current !== generacionClientes) return
@@ -439,7 +536,10 @@ export function Pos() {
     return () => {
       vigente = false
     }
-  }, [])
+    // `modoPresupuesto` es estable durante toda la vida de esta instancia (deriva de la prop
+    // `idPresupuesto`, y `PantallaPos` se remonta entera por `key` cuando cambia) — se declara
+    // igual para dejar el efecto exhaustivo, nunca dispara una segunda corrida.
+  }, [modoPresupuesto])
 
   // react-async-state regla 2: cada cambio de punto de venta dispara la resolución de
   // tolerancia_pago/vuelto_maximo (ADR-13: punto de venta > empresa > default) — una respuesta
@@ -486,6 +586,18 @@ export function Pos() {
   // Composition, regla 2 — "generacionResolucionRef gates every /resolver response").
   useEffect(() => {
     const generacion = (generacionResolucionRef.current += 1)
+
+    // stage-17-presupuestos-y-remitos (Slice 7, design: Web composition — "skip the
+    // price-resolution effect entirely"): el precio de una conversión sale congelado de
+    // `items_presupuesto`, jamás de `ServicioDeOfertas.ResolverAsync` — este efecto no dispara
+    // NINGÚN fetch bajo `?idPresupuesto=` (react-async-state regla 3: la generación igual se
+    // bumpea arriba para huerfanar cualquier resolución en vuelo de una corrida anterior).
+    if (modoPresupuesto) {
+      setPrecios({})
+      setAvisoPrecios('')
+      setResolviendo(false)
+      return
+    }
 
     // Una edición de cantidad se debounce (el usuario suele seguir tipeando); un escaneo
     // dispara la resolución de inmediato, es una única mutación discreta. La bandera se
@@ -537,7 +649,7 @@ export function Pos() {
       vigente = false
       clearTimeout(idTimeout)
     }
-  }, [lineas, clienteSeleccionado, puntoVentaSeleccionada, reintentoPrecios])
+  }, [lineas, clienteSeleccionado, puntoVentaSeleccionada, reintentoPrecios, modoPresupuesto])
 
   /** Reintenta la vista previa de precios sin mutar el carrito (bumpea `reintentoPrecios` para
    * que el efecto de arriba vuelva a correr con las mismas líneas/cliente/punto de venta). */
@@ -750,19 +862,31 @@ export function Pos() {
   // código antes de cobrar.
   function nuevaVenta() {
     if (cobrandoRef.current) return
+    // stage-17-presupuestos-y-remitos (Slice 7): el presupuesto que gobernó esta venta ya quedó
+    // `convertido` — "Nueva venta" navega a la ruta libre en vez de reabrir esta misma pantalla
+    // remontada (react-async-state regla 8: el `key` de `Pos()` es el propio `idPresupuesto`, un
+    // reset local acá dejaría el modo presupuesto pegado a una conversión ya consumida).
+    if (modoPresupuesto) {
+      navigate('/pos', { replace: true })
+      return
+    }
     setVentaEmitida(null)
     setErrorCobro('')
     setErrorEscaneo('')
   }
 
   const subtotalPrevia = calcularSubtotalPrevia(lineas, precios)
-  const totalActual = subtotalPrevia ?? 0
+  // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=` el total nunca sale de la
+  // resolución de precios (que ni siquiera corre) — sale del propio presupuesto congelado.
+  const totalActual = modoPresupuesto ? (presupuesto?.total ?? 0) : (subtotalPrevia ?? 0)
 
   // Una vista previa fallida (`avisoPrecios` seteado, sin estar resolviendo) no cuenta como
   // precondición incumplida (decisión de diseño 3: el servidor es la autoridad final del total)
   // — solo la resolución en vuelo bloquea. `subtotalPrevia === null` sin aviso es el estado de
-  // carga inicial (todavía no hay nada que mostrar), ese sí sigue bloqueando.
-  const previaFallida = subtotalPrevia === null && avisoPrecios !== ''
+  // carga inicial (todavía no hay nada que mostrar), ese sí sigue bloqueando. Bajo
+  // `?idPresupuesto=` esta noción no aplica — el total sale ya congelado, nunca de una
+  // resolución que pudo fallar.
+  const previaFallida = !modoPresupuesto && subtotalPrevia === null && avisoPrecios !== ''
 
   // Con vista previa fallida, el total no es confiable — calcular vuelto/falta contra un total
   // sintético de 0 sugeriría como vuelto el importe tendido completo (judgment-day R3, CRITICAL).
@@ -776,7 +900,7 @@ export function Pos() {
   const excedente = previaFallida ? 0 : calcularExcedente(totalActual, pagosConVuelto)
 
   const rechazoLocal =
-    subtotalPrevia === null || !clienteSeleccionado || !parametros
+    (!modoPresupuesto && subtotalPrevia === null) || !clienteSeleccionado || !parametros
       ? null
       : validarPagosLocal({
           total: totalActual,
@@ -790,23 +914,35 @@ export function Pos() {
         })
 
   // react-async-state regla 7: si medios de pago o parámetros no cargaron, "Cobrar" queda
-  // efectivamente deshabilitado — no solo un aviso decorativo.
-  const precondicionesListas =
-    lineas.length > 0 &&
-    clienteSeleccionado !== null &&
-    puntoVentaSeleccionada !== null &&
-    medios !== null &&
-    errorMedios === '' &&
-    parametros !== null &&
-    errorParametros === '' &&
-    !resolviendo &&
-    (subtotalPrevia !== null || previaFallida)
+  // efectivamente deshabilitado — no solo un aviso decorativo. Bajo `?idPresupuesto=` la
+  // precondición de "hay líneas" es "el presupuesto cargó Y es `Convertible`" (la misma fuente de
+  // verdad server-side que oculta el botón "Convertir en venta" en Presupuesto.tsx).
+  const precondicionesListas = modoPresupuesto
+    ? presupuesto !== null &&
+      presupuesto.convertible &&
+      clienteSeleccionado !== null &&
+      puntoVentaSeleccionada !== null &&
+      medios !== null &&
+      errorMedios === '' &&
+      parametros !== null &&
+      errorParametros === ''
+    : lineas.length > 0 &&
+      clienteSeleccionado !== null &&
+      puntoVentaSeleccionada !== null &&
+      medios !== null &&
+      errorMedios === '' &&
+      parametros !== null &&
+      errorParametros === '' &&
+      !resolviendo &&
+      (subtotalPrevia !== null || previaFallida)
 
-  // Con vista previa disponible, se exige la validación local completa (`rechazoLocal`). Con
-  // vista previa fallida, alcanza un chequeo mínimo de sanidad (al menos una fila de pago con
-  // importe > 0): el servidor recalcula el total real y su rechazo se muestra igual de legible.
-  const puedeCobrar =
-    precondicionesListas && !cobrando && (subtotalPrevia !== null ? rechazoLocal === null : pagosConVuelto.length > 0)
+  // Con vista previa disponible (o bajo `?idPresupuesto=`, el total congelado), se exige la
+  // validación local completa (`rechazoLocal`). Con vista previa fallida en el camino libre,
+  // alcanza un chequeo mínimo de sanidad (al menos una fila de pago con importe > 0): el
+  // servidor recalcula el total real y su rechazo se muestra igual de legible.
+  const puedeCobrar = modoPresupuesto
+    ? precondicionesListas && !cobrando && rechazoLocal === null
+    : precondicionesListas && !cobrando && (subtotalPrevia !== null ? rechazoLocal === null : pagosConVuelto.length > 0)
 
   async function cobrar() {
     // react-async-state regla 9: guard de reentrancia de primera línea — un doble click en el
@@ -820,17 +956,25 @@ export function Pos() {
     setErrorCobro('')
 
     try {
-      const solicitud = aSolicitudDeVenta({
-        idPuntoVenta: puntoVentaSeleccionada.id,
-        idCliente: clienteSeleccionado.id,
-        codigoTipoComprobante: 'TX',
-        idComprobanteAsociado: null,
-        lineas,
-        lotesSeleccionados,
-        pagos: aPagosDeVenta(pagosConVuelto),
-        direccionEntrega: null,
-        observaciones: null,
-      })
+      // stage-17-presupuestos-y-remitos (Slice 7, design: Web composition — "post {
+      // idPuntoVenta, codigoTipoComprobante: 'TX', idPresupuestoOrigen, lineas: undefined,
+      // pagos }"): bajo `?idPresupuesto=` NUNCA se manda `lineas` ni `idCliente` — el precio y el
+      // cliente salen congelados server-side del presupuesto, jamás de lo que esta pantalla
+      // pudiera mostrar.
+      const solicitud =
+        modoPresupuesto && idPresupuesto !== null
+          ? aSolicitudDeVentaDesdePresupuesto(puntoVentaSeleccionada.id, idPresupuesto, aPagosDeVenta(pagosConVuelto))
+          : aSolicitudDeVenta({
+              idPuntoVenta: puntoVentaSeleccionada.id,
+              idCliente: clienteSeleccionado.id,
+              codigoTipoComprobante: 'TX',
+              idComprobanteAsociado: null,
+              lineas,
+              lotesSeleccionados,
+              pagos: aPagosDeVenta(pagosConVuelto),
+              direccionEntrega: null,
+              observaciones: null,
+            })
 
       const emitido = await clienteDeVentas.emitir(solicitud)
       if (generacionCobroRef.current !== miGeneracion) return
@@ -858,6 +1002,30 @@ export function Pos() {
         setCobrando(false)
       }
     }
+  }
+
+  // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=`, la pantalla entera espera
+  // el presupuesto congelado antes de mostrar nada operable — mismo criterio de carga/error
+  // bloqueante que `OrdenDeCompra.tsx`.
+  if (modoPresupuesto && cargandoPresupuesto && presupuesto === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Cargando />
+      </div>
+    )
+  }
+
+  if (modoPresupuesto && errorPresupuesto && presupuesto === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Presupuesto" variante="danger">
+          <p className="text-muted">{errorPresupuesto}</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/presupuestos">
+            Volver a presupuestos
+          </Link>
+        </Box>
+      </div>
+    )
   }
 
   if (gateTurno && puntoVentaSeleccionada) {
@@ -960,11 +1128,31 @@ export function Pos() {
 
   return (
     <div className="container-fluid py-4" key="venta-en-curso">
+      {/* stage-17-presupuestos-y-remitos (Slice 7, design: Web composition — "Esta venta viene
+          del presupuesto N° … (vence el …)"): el banner reemplaza cualquier duda sobre por qué
+          el carrito está congelado, en vez de dejar que el operador lo descubra tocando algo
+          deshabilitado. */}
+      {modoPresupuesto && presupuesto && (
+        <div className="row g-3 mb-3">
+          <div className="col-12">
+            <Box titulo="Venta desde presupuesto" variante="warning">
+              <p className="mb-0">
+                Esta venta viene del presupuesto N° {presupuesto.numero ?? presupuesto.idPresupuesto}
+                {presupuesto.vencimiento &&
+                  ` (vence el ${new Date(`${presupuesto.vencimiento}T00:00:00`).toLocaleDateString('es-AR')})`}
+                . El carrito quedó congelado con el precio ofrecido — no se puede escanear, editar cantidades ni quitar
+                líneas.
+              </p>
+            </Box>
+          </div>
+        </div>
+      )}
+
       <div className="row g-3">
         <div className="col-lg-8">
           <Box titulo="Carrito">
-            {errorEscaneo && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEscaneo}</div>}
-            {avisoPrecios && (
+            {errorEscaneo && !modoPresupuesto && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEscaneo}</div>}
+            {avisoPrecios && !modoPresupuesto && (
               <div className="alert alert-warning rounded-0 py-1 px-2 small d-flex justify-content-between align-items-center gap-2">
                 <span>{avisoPrecios}</span>
                 <button
@@ -978,22 +1166,24 @@ export function Pos() {
               </div>
             )}
 
-            <div className="input-group mb-3">
-              <input
-                type="text"
-                className="form-control rounded-0"
-                placeholder="Escanear o tipear un código (ej. 3*7790001234567)"
-                aria-label="Código escaneado"
-                value={entradaEscaneo}
-                disabled={escaneando || cobrando}
-                onChange={(e) => setEntradaEscaneo(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), escanear())}
-                autoFocus
-              />
-              <button type="button" className="btn btn-primary rounded-0" disabled={escaneando || cobrando} onClick={escanear}>
-                {escaneando ? 'Buscando…' : 'Agregar'}
-              </button>
-            </div>
+            {!modoPresupuesto && (
+              <div className="input-group mb-3">
+                <input
+                  type="text"
+                  className="form-control rounded-0"
+                  placeholder="Escanear o tipear un código (ej. 3*7790001234567)"
+                  aria-label="Código escaneado"
+                  value={entradaEscaneo}
+                  disabled={escaneando || cobrando}
+                  onChange={(e) => setEntradaEscaneo(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), escanear())}
+                  autoFocus
+                />
+                <button type="button" className="btn btn-primary rounded-0" disabled={escaneando || cobrando} onClick={escanear}>
+                  {escaneando ? 'Buscando…' : 'Agregar'}
+                </button>
+              </div>
+            )}
 
             <div className="table-responsive">
               <table className="table table-striped table-hover table-bordered align-middle">
@@ -1009,83 +1199,98 @@ export function Pos() {
                   </tr>
                 </thead>
                 <tbody>
-                  {lineas.map((l) => {
-                    const resultado = precios[l.idArticulo]
-                    const previa = previaDeLinea(l, resultado)
-                    const tieneDescuento = previa.descuentoUnitario > 0 && resultado?.precioOriginal != null
-                    return (
-                      <tr key={l.idArticulo}>
-                        <td>{l.codigoBarra ?? l.codigoInterno}</td>
-                        <td>{l.nombre}</td>
-                        <td>
-                          <input
-                            type="number"
-                            step={CANTIDAD_MINIMA}
-                            min={CANTIDAD_MINIMA}
-                            className="form-control form-control-sm rounded-0"
-                            aria-label={`Cantidad de ${l.nombre}`}
-                            value={textoCantidad(l)}
-                            disabled={cobrando}
-                            onChange={(e) => cambiarCantidad(l.idArticulo, e.target.value)}
-                            onBlur={() => confirmarCantidad(l.idArticulo)}
-                          />
-                        </td>
-                        <td>
-                          {puntoVentaSeleccionada && (
-                            <SelectorDeLote
-                              idPuntoVenta={puntoVentaSeleccionada.id}
-                              idArticulo={l.idArticulo}
-                              nombreArticulo={l.nombre}
-                              idLoteElegido={lotesSeleccionados[l.idArticulo] ?? null}
-                              disabled={cobrando}
-                              onElegir={(idLote) => elegirLote(l.idArticulo, idLote)}
-                            />
-                          )}
-                        </td>
-                        <td className="text-end">
-                          {previa.precioUnitario === null ? (
-                            '—'
-                          ) : (
-                            <>
-                              {tieneDescuento && (
-                                <div className="text-decoration-line-through text-muted small">
-                                  {formatearMoneda(resultado.precioOriginal as number)}
-                                </div>
+                  {modoPresupuesto
+                    ? (presupuesto?.items ?? []).map((item) => (
+                        // stage-17-presupuestos-y-remitos (Slice 7): fila 100% de solo lectura,
+                        // sourced del propio presupuesto congelado — sin `precios`/`previaDeLinea`
+                        // (esos dependen de una resolución que este modo nunca dispara).
+                        <tr key={item.orden}>
+                          <td>—</td>
+                          <td>{item.descripcion}</td>
+                          <td>{item.cantidad}</td>
+                          <td>—</td>
+                          <td className="text-end">{formatearMoneda(item.precioUnitario)}</td>
+                          <td className="text-end">{formatearMoneda(item.total)}</td>
+                          <td className="text-end">—</td>
+                        </tr>
+                      ))
+                    : lineas.map((l) => {
+                        const resultado = precios[l.idArticulo]
+                        const previa = previaDeLinea(l, resultado)
+                        const tieneDescuento = previa.descuentoUnitario > 0 && resultado?.precioOriginal != null
+                        return (
+                          <tr key={l.idArticulo}>
+                            <td>{l.codigoBarra ?? l.codigoInterno}</td>
+                            <td>{l.nombre}</td>
+                            <td>
+                              <input
+                                type="number"
+                                step={CANTIDAD_MINIMA}
+                                min={CANTIDAD_MINIMA}
+                                className="form-control form-control-sm rounded-0"
+                                aria-label={`Cantidad de ${l.nombre}`}
+                                value={textoCantidad(l)}
+                                disabled={cobrando}
+                                onChange={(e) => cambiarCantidad(l.idArticulo, e.target.value)}
+                                onBlur={() => confirmarCantidad(l.idArticulo)}
+                              />
+                            </td>
+                            <td>
+                              {puntoVentaSeleccionada && (
+                                <SelectorDeLote
+                                  idPuntoVenta={puntoVentaSeleccionada.id}
+                                  idArticulo={l.idArticulo}
+                                  nombreArticulo={l.nombre}
+                                  idLoteElegido={lotesSeleccionados[l.idArticulo] ?? null}
+                                  disabled={cobrando}
+                                  onElegir={(idLote) => elegirLote(l.idArticulo, idLote)}
+                                />
                               )}
-                              <div>
-                                {formatearMoneda(previa.precioUnitario)}
-                                {tieneDescuento && resultado.aplicadas.length > 0 && (
-                                  <span
-                                    className="badge bg-success ms-1"
-                                    title={resultado.aplicadas.map((a) => a.nombre).join(', ')}
-                                  >
-                                    {resultado.aplicadas.length === 1
-                                      ? resultado.aplicadas[0].nombre
-                                      : `${resultado.aplicadas[0].nombre} +${resultado.aplicadas.length - 1}`}
-                                  </span>
-                                )}
-                              </div>
-                            </>
-                          )}
-                        </td>
-                        <td className="text-end">{previa.total === null ? '—' : formatearMoneda(previa.total)}</td>
-                        <td className="text-end">
-                          <button
-                            type="button"
-                            className="btn btn-sm btn-outline-danger rounded-0"
-                            disabled={cobrando}
-                            onClick={() => mutarCarrito({ tipo: 'quitarLinea', idArticulo: l.idArticulo })}
-                          >
-                            Quitar
-                          </button>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                  {lineas.length === 0 && (
+                            </td>
+                            <td className="text-end">
+                              {previa.precioUnitario === null ? (
+                                '—'
+                              ) : (
+                                <>
+                                  {tieneDescuento && (
+                                    <div className="text-decoration-line-through text-muted small">
+                                      {formatearMoneda(resultado.precioOriginal as number)}
+                                    </div>
+                                  )}
+                                  <div>
+                                    {formatearMoneda(previa.precioUnitario)}
+                                    {tieneDescuento && resultado.aplicadas.length > 0 && (
+                                      <span
+                                        className="badge bg-success ms-1"
+                                        title={resultado.aplicadas.map((a) => a.nombre).join(', ')}
+                                      >
+                                        {resultado.aplicadas.length === 1
+                                          ? resultado.aplicadas[0].nombre
+                                          : `${resultado.aplicadas[0].nombre} +${resultado.aplicadas.length - 1}`}
+                                      </span>
+                                    )}
+                                  </div>
+                                </>
+                              )}
+                            </td>
+                            <td className="text-end">{previa.total === null ? '—' : formatearMoneda(previa.total)}</td>
+                            <td className="text-end">
+                              <button
+                                type="button"
+                                className="btn btn-sm btn-outline-danger rounded-0"
+                                disabled={cobrando}
+                                onClick={() => mutarCarrito({ tipo: 'quitarLinea', idArticulo: l.idArticulo })}
+                              >
+                                Quitar
+                              </button>
+                            </td>
+                          </tr>
+                        )
+                      })}
+                  {(modoPresupuesto ? (presupuesto?.items.length ?? 0) === 0 : lineas.length === 0) && (
                     <tr>
                       <td colSpan={7} className="text-center text-muted py-4">
-                        Escaneá o tipeá un código para empezar la venta.
+                        {modoPresupuesto ? 'Este presupuesto no tiene items.' : 'Escaneá o tipeá un código para empezar la venta.'}
                       </td>
                     </tr>
                   )}
@@ -1093,7 +1298,7 @@ export function Pos() {
               </table>
             </div>
 
-            {lineas.length > 0 && (
+            {!modoPresupuesto && lineas.length > 0 && (
               <button
                 type="button"
                 className="btn btn-outline-secondary btn-sm rounded-0"
@@ -1118,7 +1323,7 @@ export function Pos() {
                 id="pos-punto-venta"
                 className="form-select rounded-0"
                 value={idPuntoVenta}
-                disabled={puntosVenta === null || cobrando}
+                disabled={puntosVenta === null || cobrando || modoPresupuesto}
                 onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
               >
                 {puntosVenta === null && <option value="">Cargando…</option>}
@@ -1141,7 +1346,7 @@ export function Pos() {
                 id="pos-cliente"
                 className="form-select rounded-0"
                 value={clienteSeleccionado?.id ?? ''}
-                disabled={cobrando}
+                disabled={cobrando || modoPresupuesto}
                 onChange={(e) => cambiarCliente(Number(e.target.value))}
               >
                 {fusionarOpcionesCliente(opcionesClientes, clienteSeleccionado).map((c) => (
@@ -1152,33 +1357,43 @@ export function Pos() {
               </select>
             </div>
 
-            <div className="input-group input-group-sm mb-3">
-              <input
-                type="search"
-                className="form-control rounded-0"
-                placeholder="Buscar otro cliente…"
-                aria-label="Buscar cliente"
-                value={terminoCliente}
-                disabled={buscandoClientes || cobrando}
-                onChange={(e) => setTerminoCliente(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), buscarClientes())}
-              />
-              <button
-                type="button"
-                className="btn btn-outline-primary rounded-0"
-                disabled={buscandoClientes || cobrando}
-                onClick={buscarClientes}
-              >
-                {buscandoClientes ? 'Buscando…' : 'Buscar'}
-              </button>
-            </div>
+            {!modoPresupuesto && (
+              <div className="input-group input-group-sm mb-3">
+                <input
+                  type="search"
+                  className="form-control rounded-0"
+                  placeholder="Buscar otro cliente…"
+                  aria-label="Buscar cliente"
+                  value={terminoCliente}
+                  disabled={buscandoClientes || cobrando}
+                  onChange={(e) => setTerminoCliente(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), buscarClientes())}
+                />
+                <button
+                  type="button"
+                  className="btn btn-outline-primary rounded-0"
+                  disabled={buscandoClientes || cobrando}
+                  onClick={buscarClientes}
+                >
+                  {buscandoClientes ? 'Buscando…' : 'Buscar'}
+                </button>
+              </div>
+            )}
 
             <hr />
 
             <div className="d-flex justify-content-between mb-3">
               <strong>Total previo</strong>
               <strong>
-                {resolviendo ? 'Calculando…' : subtotalPrevia === null ? '—' : formatearMoneda(subtotalPrevia)}
+                {modoPresupuesto
+                  ? cargandoPresupuesto
+                    ? 'Cargando…'
+                    : formatearMoneda(totalActual)
+                  : resolviendo
+                    ? 'Calculando…'
+                    : subtotalPrevia === null
+                      ? '—'
+                      : formatearMoneda(subtotalPrevia)}
               </strong>
             </div>
 
@@ -1290,4 +1505,18 @@ export function Pos() {
       </div>
     </div>
   )
+}
+
+/**
+ * `/pos` (stage-17-presupuestos-y-remitos, Slice 7, design: Web composition — `react-async-state`
+ * regla 8): lee `?idPresupuesto=` de la URL y remonta `PantallaPos` entera por `key` cuando
+ * cambia — un `idPresupuesto` inválido o ausente se trata como el camino libre, nunca un error
+ * bloqueante (la ruta sin query sigue siendo el POS de siempre).
+ */
+export function Pos() {
+  const [searchParams] = useSearchParams()
+  const crudo = searchParams.get('idPresupuesto')
+  const idPresupuesto = crudo !== null && Number.isFinite(Number(crudo)) ? Number(crudo) : null
+
+  return <PantallaPos key={idPresupuesto ?? 'libre'} idPresupuesto={idPresupuesto} />
 }

--- a/src/Ways.Web/src/paginas/Presupuesto.test.tsx
+++ b/src/Ways.Web/src/paginas/Presupuesto.test.tsx
@@ -1,0 +1,296 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Presupuesto } from './Presupuesto'
+import type { ClienteListado, PresupuestoDetalle, PuntoVentaListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown?])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 9,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Depósito Norte',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 5,
+    numero: 5,
+    nombre: 'Juan',
+    apellido: 'Pérez',
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: false,
+    ...sobrescribir,
+  }
+}
+
+function detalleFixture(sobrescribir: Partial<PresupuestoDetalle> = {}): PresupuestoDetalle {
+  return {
+    id: 30,
+    idPuntoVenta: 9,
+    idCliente: 5,
+    idEmpleado: 1,
+    numero: 12,
+    numeroFormateado: '0009-00000012',
+    fechaEmision: '2026-08-19T12:00:00Z',
+    fechaEnvio: '2026-08-19T12:00:00Z',
+    vencimiento: '2026-09-30',
+    vencido: false,
+    convertible: true,
+    zonaId: 'America/Argentina/Buenos_Aires',
+    observaciones: null,
+    subtotal: 200,
+    descuentoTotal: 0,
+    total: 200,
+    estado: 'Enviado',
+    idComprobanteVenta: null,
+    items: [
+      {
+        orden: 1,
+        idArticulo: 10,
+        descripcion: 'Yerba mate 1kg',
+        cantidad: 2,
+        precioUnitario: 100,
+        descuento: 0,
+        total: 200,
+        idListaPrecio: 1,
+        idOferta: null,
+        idAlicuotaIva: 1,
+        porcentajeIva: 21,
+      },
+    ],
+    ...sobrescribir,
+  }
+}
+
+function borradorFixture(sobrescribir: Partial<PresupuestoDetalle> = {}): PresupuestoDetalle {
+  return detalleFixture({ estado: 'Borrador', numero: null, numeroFormateado: null, fechaEnvio: null, vencimiento: null, convertible: false, ...sobrescribir })
+}
+
+function mockearReferencia(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/clientes') return Promise.resolve({ items: [clienteFixture()], total: 1, pagina: 1, tamanio: 25 })
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla(id: string | number = 30) {
+  return render(
+    <MemoryRouter initialEntries={[`/presupuestos/${id}`]}>
+      <Routes>
+        <Route path="/presupuestos/:id" element={<Presupuesto />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiPutMock.mockReset()
+})
+
+describe('Presupuesto — detalle (lectura)', () => {
+  it('muestra el estado, el badge de vencimiento y los items con sus valores', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture()) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('Enviado')).toBeInTheDocument()
+    expect(screen.getByText(/Vence/)).toBeInTheDocument()
+    expect(screen.getByText('Yerba mate 1kg')).toBeInTheDocument()
+    expect(screen.getAllByText('$200,00').length).toBeGreaterThan(0)
+  })
+
+  it('un presupuesto vencido muestra el badge "Venció"', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ vencido: true, convertible: false })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText(/Venció/)).toBeInTheDocument()
+  })
+
+  it('convertido en venta muestra el link a la venta', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ estado: 'Convertido', idComprobanteVenta: 77, convertible: false })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('Convertido en venta #77')).toBeInTheDocument()
+  })
+})
+
+describe('Presupuesto — "Convertir en venta" (design decisión 4, tarea 7.8)', () => {
+  it('renderiza SOLO cuando el servidor reporta Convertible: true', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ convertible: true })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByRole('button', { name: 'Convertir en venta' })).toBeInTheDocument()
+  })
+
+  it('un presupuesto Enviado pero NO convertible (p. ej. vencido) no ofrece la acción', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ vencido: true, convertible: false })) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Enviado')
+    expect(screen.queryByRole('button', { name: 'Convertir en venta' })).not.toBeInTheDocument()
+  })
+
+  it('un presupuesto Convertido no ofrece la acción (terminal — decisión 9)', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ estado: 'Convertido', idComprobanteVenta: 77, convertible: false })) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Convertido')
+    expect(screen.queryByRole('button', { name: 'Convertir en venta' })).not.toBeInTheDocument()
+  })
+})
+
+describe('Presupuesto — crear borrador', () => {
+  it('crea el borrador y navega a la ruta real del presupuesto recién creado', async () => {
+    mockearReferencia()
+    apiPostMock.mockResolvedValue(borradorFixture({ id: 99 }))
+
+    render(
+      <MemoryRouter initialEntries={['/presupuestos/nuevo']}>
+        <Routes>
+          <Route path="/presupuestos/nuevo" element={<Presupuesto />} />
+          <Route path="/presupuestos/:id" element={<Presupuesto />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await userEvent.selectOptions(await screen.findByLabelText('Punto de venta'), '9')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear borrador' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/presupuestos', expect.objectContaining({ idPuntoVenta: 9, idCliente: null })))
+  })
+})
+
+describe('Presupuesto — doble click en "Enviar" (react-async-state regla 9, tarea 7.9)', () => {
+  it('dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(borradorFixture()) : undefined))
+
+    let resolverEnviar: (v: PresupuestoDetalle) => void = () => {}
+    const enviarPendiente = new Promise<PresupuestoDetalle>((resolve) => {
+      resolverEnviar = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/presupuestos/30/enviar' ? enviarPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Enviar' })
+
+    // Los dos dispatchEvent viajan DENTRO de un mismo act() — jsdom no no-opea un click sobre un
+    // elemento disabled (lección vigente del programa), así que probar el guard exige dos clicks
+    // reales en el mismo tick, mismo patrón que OrdenDeCompra.test.tsx.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/presupuestos/30/enviar')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Enviando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverEnviar(detalleFixture())
+      await enviarPendiente
+    })
+  })
+
+  it('manda el vencimiento tipeado por el operador', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(borradorFixture()) : undefined))
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/presupuestos/30/enviar' ? Promise.resolve(detalleFixture()) : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const inputVencimiento = await screen.findByLabelText('Vence el')
+    await userEvent.clear(inputVencimiento)
+    await userEvent.type(inputVencimiento, '2026-10-15')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Enviar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/presupuestos/30/enviar', { vencimiento: '2026-10-15' }))
+  })
+})
+
+describe('Presupuesto — doble click en "Anular"', () => {
+  it('dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture()) : undefined))
+
+    let resolverAnular: (v: PresupuestoDetalle) => void = () => {}
+    const anularPendiente = new Promise<PresupuestoDetalle>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/presupuestos/30/anular' ? anularPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Anular' })
+
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/presupuestos/30/anular')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Anulando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverAnular(detalleFixture({ estado: 'Anulado', convertible: false }))
+      await anularPendiente
+    })
+  })
+})
+
+describe('Presupuesto — role gating (mismo gate que /pos: Politicas.OperacionDePos, sin distinción admin-only)', () => {
+  it('la pantalla no oculta ninguna acción de escritura por rol — no hay `puedeEscribir` (design decisión 17)', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture({ convertible: true })) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Enviado')
+    expect(screen.getByRole('button', { name: 'Convertir en venta' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Anular' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Presupuesto.test.tsx
+++ b/src/Ways.Web/src/paginas/Presupuesto.test.tsx
@@ -282,6 +282,31 @@ describe('Presupuesto — doble click en "Anular"', () => {
       await anularPendiente
     })
   })
+
+  it('mientras "Anular" está en vuelo, "Convertir en venta" también queda deshabilitado (misma ventana de ocupado, judgment-day slice-7 ronda 2)', async () => {
+    mockearReferencia((ruta) => (ruta === '/presupuestos/30' ? Promise.resolve(detalleFixture()) : undefined))
+
+    let resolverAnular: (v: PresupuestoDetalle) => void = () => {}
+    const anularPendiente = new Promise<PresupuestoDetalle>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/presupuestos/30/anular' ? anularPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const botonAnular = await screen.findByRole('button', { name: 'Anular' })
+    const botonConvertir = screen.getByRole('button', { name: 'Convertir en venta' })
+    expect(botonConvertir).not.toBeDisabled()
+
+    await userEvent.click(botonAnular)
+
+    expect(screen.getByRole('button', { name: 'Anulando…' })).toBeDisabled()
+    expect(botonConvertir).toBeDisabled()
+
+    await act(async () => {
+      resolverAnular(detalleFixture({ estado: 'Anulado', convertible: false }))
+      await anularPendiente
+    })
+  })
 })
 
 describe('Presupuesto — role gating (mismo gate que /pos: Politicas.OperacionDePos, sin distinción admin-only)', () => {

--- a/src/Ways.Web/src/paginas/Presupuesto.tsx
+++ b/src/Ways.Web/src/paginas/Presupuesto.tsx
@@ -609,7 +609,7 @@ function PantallaPresupuesto({ idPresupuesto }: PropsPantalla) {
 
               <div className="d-flex gap-2 mb-3">
                 {puedeConvertir && (
-                  <button type="button" className="btn btn-primary rounded-0" onClick={convertirEnVenta}>
+                  <button type="button" className="btn btn-primary rounded-0" disabled={ocupado} onClick={convertirEnVenta}>
                     Convertir en venta
                   </button>
                 )}

--- a/src/Ways.Web/src/paginas/Presupuesto.tsx
+++ b/src/Ways.Web/src/paginas/Presupuesto.tsx
@@ -1,0 +1,657 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import { clienteDeArticulos } from '../api/articulos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
+import {
+  aSolicitudDeEnvio,
+  aSolicitudDePresupuesto,
+  claseDeBadgeDeEstadoPresupuesto,
+  claseDeBadgeDeVencimiento,
+  clienteDePresupuestos,
+  encabezadoDePresupuestoVacio,
+  etiquetaDeEstadoPresupuesto,
+  etiquetaDeVencimiento,
+  itemDePresupuestoAFormulario,
+  lineaDePresupuestoCompletaParaEnvio,
+  lineaDePresupuestoVacia,
+  vencimientoSugerido,
+  type EncabezadoDePresupuestoFormulario,
+  type LineaDePresupuestoFormulario,
+} from '../api/presupuestos'
+import type { ArticuloListado, ClienteListado, PresupuestoDetalle, PuntoVentaListado } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+function formatearFechaHora(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleString('es-AR') : '—'
+}
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+// ---- Selector de artículo por búsqueda (search-as-you-type) — mismo shape que el de
+// OrdenDeCompra.tsx/CompraEditor.tsx, propio de cada fila ------------------------------------------
+
+type PropsSelectorDeArticulo = {
+  descripcion: string
+  disabled: boolean
+  onElegir: (articulo: ArticuloListado) => void
+}
+
+function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDeArticulo) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (termino.trim().length < 2) {
+      setResultados([])
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setBuscando(true)
+
+    const temporizador = setTimeout(() => {
+      clienteDeArticulos
+        .listar(termino, false)
+        .then((pagina) => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados(pagina.items)
+        })
+        .catch(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados([])
+        })
+        .finally(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setBuscando(false)
+        })
+    }, 300)
+
+    return () => {
+      vigente = false
+      clearTimeout(temporizador)
+    }
+  }, [termino])
+
+  return (
+    <div className="position-relative">
+      <input
+        type="text"
+        className="form-control form-control-sm rounded-0"
+        placeholder="Buscar artículo…"
+        value={termino}
+        disabled={disabled}
+        onChange={(e) => setTermino(e.target.value)}
+      />
+      {descripcion && <div className="small text-muted">Elegido: {descripcion}</div>}
+      {buscando && <div className="small text-muted">Buscando…</div>}
+      {!buscando && resultados.length > 0 && (
+        <div className="list-group position-absolute w-100" style={{ zIndex: 10 }}>
+          {resultados.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="list-group-item list-group-item-action py-1 px-2 small"
+              onClick={() => {
+                onElegir(a)
+                setTermino('')
+                setResultados([])
+              }}
+            >
+              {a.codigoInterno} — {a.nombre}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Fila editable del grid de items — sin ningún campo de dinero (design decisión 2: el precio
+// lo resuelve el motor al guardar el borrador, nunca lo tipea el operador) -------------------------
+
+type PropsFilaDeItem = {
+  linea: LineaDePresupuestoFormulario
+  disabled: boolean
+  onCambio: (clave: number, cambios: Partial<LineaDePresupuestoFormulario>) => void
+  onQuitar: (clave: number) => void
+}
+
+function FilaDeItem({ linea, disabled, onCambio, onQuitar }: PropsFilaDeItem) {
+  const incompleta = !lineaDePresupuestoCompletaParaEnvio(linea)
+
+  return (
+    <tr className={incompleta ? 'table-warning text-muted' : undefined}>
+      <td style={{ minWidth: 220 }}>
+        <SelectorDeArticulo
+          descripcion={linea.descripcion}
+          disabled={disabled}
+          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre })}
+        />
+        {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
+      </td>
+      <td style={{ width: 120 }}>
+        <input
+          type="number"
+          step="0.001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Cantidad"
+          value={linea.cantidad}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { cantidad: e.target.value })}
+        />
+      </td>
+      <td>
+        <button type="button" className="btn btn-outline-danger btn-sm rounded-0" disabled={disabled} onClick={() => onQuitar(linea.clave)}>
+          Quitar
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+// ---- Pantalla principal -----------------------------------------------------------------------
+
+type PropsPantalla = { idPresupuesto: number | null }
+
+/** Remontada por `key={idPresupuesto ?? 'nuevo'}` (react-async-state regla 8) — ningún estado de
+ * acá (borrador en edición, avisos, paneles) sobrevive a un cambio de presupuesto. */
+function PantallaPresupuesto({ idPresupuesto }: PropsPantalla) {
+  const navigate = useNavigate()
+  const esNuevo = idPresupuesto === null
+
+  // ---- referencia (puntos de venta/clientes) ----------------------------------------------------
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [clientes, setClientes] = useState<ClienteListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => vigente && setPuntosVenta(lista))
+      .catch((e) => {
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((p) => vigente && setClientes(p.items))
+      .catch((e) => {
+        setClientes([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const referenciaOk = puntosVenta !== null && clientes !== null && errorReferencia === ''
+
+  // ---- detalle (lectura, GET /{id} — única fuente de vencido/convertible/estado real) ------------
+  const [detalle, setDetalle] = useState<PresupuestoDetalle | null>(null)
+  const [cargandoDetalle, setCargandoDetalle] = useState(!esNuevo)
+  const [errorDetalle, setErrorDetalle] = useState('')
+  const generacionRef = useRef(0)
+
+  const cargarDetalle = useCallback(() => {
+    if (esNuevo || idPresupuesto === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargandoDetalle(true)
+    setErrorDetalle('')
+
+    clienteDePresupuestos
+      .obtener(idPresupuesto)
+      .then((d) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDetalle(d)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        // regla 6: un refetch posterior a una escritura 2xx nunca vacía la pantalla a un error
+        // total — `detalle` queda como estaba, solo el aviso de arriba se muestra.
+        setErrorDetalle(
+          e instanceof ErrorApi ? e.message : 'No se pudo actualizar el presupuesto — los datos mostrados pueden estar desactualizados.',
+        )
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargandoDetalle(false)
+      })
+  }, [esNuevo, idPresupuesto])
+
+  useEffect(() => {
+    cargarDetalle()
+  }, [cargarDetalle])
+
+  // ---- formulario editable (nuevo o borrador existente) ------------------------------------------
+  const proximaClaveRef = useRef(1)
+  const [encabezado, setEncabezado] = useState<EncabezadoDePresupuestoFormulario>(encabezadoDePresupuestoVacio())
+  const [lineas, setLineas] = useState<LineaDePresupuestoFormulario[]>([])
+
+  useEffect(() => {
+    if (detalle === null) return
+    setEncabezado({
+      idPuntoVenta: detalle.idPuntoVenta,
+      idCliente: detalle.idCliente,
+      observaciones: detalle.observaciones ?? '',
+    })
+    setLineas(detalle.items.map((item) => itemDePresupuestoAFormulario(proximaClaveRef.current++, item)))
+  }, [detalle])
+
+  // ---- escrituras: guardar/enviar/anular — cada una con su propio guard de reentrancia
+  // (react-async-state regla 9) y su propio flag de "en vuelo" (regla 5) ---------------------------
+  const [guardando, setGuardando] = useState(false)
+  const guardandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [aviso, setAviso] = useState('')
+
+  const [vencimientoAEnviar, setVencimientoAEnviar] = useState(() => vencimientoSugerido(new Date()))
+  const [enviando, setEnviando] = useState(false)
+  const enviandoRef = useRef(false)
+  const [errorEnviar, setErrorEnviar] = useState('')
+
+  const [anulando, setAnulando] = useState(false)
+  const anulandoRef = useRef(false)
+  const [errorAnular, setErrorAnular] = useState('')
+
+  const ocupado = guardando || enviando || anulando
+
+  function cambiarLinea(clave: number, cambios: Partial<LineaDePresupuestoFormulario>) {
+    if (ocupado) return
+    // regla 1: updater funcional, nunca lee `lineas` del cierre.
+    setLineas((prev) => prev.map((l) => (l.clave === clave ? { ...l, ...cambios } : l)))
+  }
+
+  function agregarLinea() {
+    if (ocupado) return
+    setLineas((prev) => [...prev, lineaDePresupuestoVacia(proximaClaveRef.current++)])
+  }
+
+  function quitarLinea(clave: number) {
+    if (ocupado) return
+    setLineas((prev) => prev.filter((l) => l.clave !== clave))
+  }
+
+  const encabezadoCompleto = encabezado.idPuntoVenta !== ''
+  const puedeGuardar = referenciaOk && encabezadoCompleto && !ocupado
+
+  async function guardarBorrador() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (guardandoRef.current) return
+    if (!puedeGuardar) return
+
+    guardandoRef.current = true
+    setGuardando(true)
+    setError('')
+    setAviso('')
+    // regla 3: bumpear la generación de carga ANTES de la escritura.
+    generacionRef.current += 1
+
+    try {
+      const solicitud = aSolicitudDePresupuesto(encabezado, lineas)
+      if (esNuevo) {
+        const creado = await clienteDePresupuestos.crear(solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        // Remontaje completo vía cambio de `key` (regla 8): navega a la ruta real del presupuesto
+        // recién creado, nunca reutiliza este estado de "nuevo" para simular la edición.
+        navigate(`/presupuestos/${creado.id}`, { replace: true })
+      } else if (idPresupuesto !== null) {
+        await clienteDePresupuestos.actualizar(idPresupuesto, solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        setAviso('Borrador guardado.')
+        // regla 6: el refetch posterior vive aislado de este try/catch.
+        cargarDetalle()
+      }
+    } catch (e) {
+      guardandoRef.current = false
+      setGuardando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el borrador.')
+    }
+  }
+
+  async function enviar() {
+    if (ocupado) return
+    if (enviandoRef.current || idPresupuesto === null) return
+    if (vencimientoAEnviar.trim() === '') {
+      setErrorEnviar('Elegí una fecha de vencimiento.')
+      return
+    }
+
+    enviandoRef.current = true
+    setEnviando(true)
+    setErrorEnviar('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDePresupuestos.enviar(idPresupuesto, aSolicitudDeEnvio(vencimientoAEnviar))
+      enviandoRef.current = false
+      setEnviando(false)
+      setAviso('Presupuesto enviado.')
+      cargarDetalle()
+    } catch (e) {
+      enviandoRef.current = false
+      setEnviando(false)
+      setErrorEnviar(e instanceof ErrorApi ? e.message : 'No se pudo enviar el presupuesto.')
+    }
+  }
+
+  async function anular() {
+    if (ocupado) return
+    if (anulandoRef.current || idPresupuesto === null) return
+
+    anulandoRef.current = true
+    setAnulando(true)
+    setErrorAnular('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDePresupuestos.anular(idPresupuesto)
+      anulandoRef.current = false
+      setAnulando(false)
+      setAviso('Presupuesto anulado.')
+      cargarDetalle()
+    } catch (e) {
+      anulandoRef.current = false
+      setAnulando(false)
+      setErrorAnular(e instanceof ErrorApi ? e.message : 'No se pudo anular el presupuesto.')
+    }
+  }
+
+  function convertirEnVenta() {
+    if (ocupado || idPresupuesto === null) return
+    navigate(`/pos?idPresupuesto=${idPresupuesto}`)
+  }
+
+  if (!esNuevo && cargandoDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Cargando />
+      </div>
+    )
+  }
+
+  if (!esNuevo && errorDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Presupuesto" variante="danger">
+          <p className="text-muted">{errorDetalle}</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/presupuestos">
+            Volver a presupuestos
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  const esBorrador = esNuevo || detalle?.estado === 'Borrador'
+  const puedeEnviar = !esNuevo && detalle?.estado === 'Borrador'
+  const puedeAnular = detalle?.estado === 'Borrador' || detalle?.estado === 'Enviado'
+  // El botón de conversión SOLO renderiza cuando el servidor reporta `Convertible` — nunca una
+  // condición client-side sobre `estado`/`vencimiento` sola (tarea 7.8: la fuente de verdad de
+  // "convertible" es siempre la lectura del servidor, `ReglaDePresupuestos`, jamás recalculada acá).
+  const puedeConvertir = !esNuevo && detalle?.estado === 'Enviado' && detalle?.convertible === true
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={esNuevo ? 'Nuevo presupuesto' : `Presupuesto ${detalle?.numeroFormateado ?? `#${idPresupuesto}`}`}
+        variante="inverse"
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/presupuestos">
+            Volver a presupuestos
+          </Link>
+        }
+      >
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorReferencia} No se pueden registrar operaciones de presupuesto hasta que esto se resuelva.
+          </div>
+        )}
+        {errorDetalle && detalle && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorDetalle}</div>}
+
+        {!esNuevo && detalle && (
+          <div className="mb-3">
+            <span className={`badge rounded-0 me-2 ${claseDeBadgeDeEstadoPresupuesto(detalle.estado)}`}>
+              {etiquetaDeEstadoPresupuesto(detalle.estado)}
+            </span>
+            {detalle.estado === 'Enviado' && (
+              <span className={`badge rounded-0 me-2 ${claseDeBadgeDeVencimiento(detalle.vencimiento, detalle.vencido)}`}>
+                {etiquetaDeVencimiento(detalle.vencimiento, detalle.vencido)}
+              </span>
+            )}
+            {detalle.fechaEnvio && <span className="small text-muted me-2">Enviado: {formatearFechaHora(detalle.fechaEnvio)}</span>}
+            {detalle.idComprobanteVenta !== null && <span className="small text-muted">Convertido en venta #{detalle.idComprobanteVenta}</span>}
+          </div>
+        )}
+
+        <div className="row g-2 mb-3">
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="pres-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="pres-punto-venta"
+              className="form-select rounded-0"
+              value={encabezado.idPuntoVenta}
+              disabled={!esBorrador || ocupado || !referenciaOk}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idPuntoVenta: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="pres-cliente">
+              Cliente
+            </label>
+            <select
+              id="pres-cliente"
+              className="form-select rounded-0"
+              value={encabezado.idCliente}
+              disabled={!esBorrador || ocupado || !referenciaOk}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idCliente: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Consumidor Final (por defecto)</option>
+              {(clientes ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {etiquetaDeCliente(c)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-12">
+            <label className="form-label" htmlFor="pres-observaciones">
+              Observaciones
+            </label>
+            <input
+              id="pres-observaciones"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.observaciones}
+              disabled={!esBorrador || ocupado}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, observaciones: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        {esBorrador ? (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Artículo</th>
+                    <th>Cantidad</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lineas.map((l) => (
+                    <FilaDeItem key={l.clave} linea={l} disabled={ocupado || !referenciaOk} onCambio={cambiarLinea} onQuitar={quitarLinea} />
+                  ))}
+                  {lineas.length === 0 && (
+                    <tr>
+                      <td colSpan={3} className="text-center text-muted py-3">
+                        Todavía no hay items cargados.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <button type="button" className="btn btn-outline-secondary btn-sm rounded-0 mb-3" disabled={ocupado || !referenciaOk} onClick={agregarLinea}>
+              + Agregar línea
+            </button>
+
+            <div className="d-flex gap-2 align-items-end mb-3 flex-wrap">
+              <button type="button" className="btn btn-primary rounded-0" disabled={!puedeGuardar} onClick={guardarBorrador}>
+                {guardando ? 'Guardando…' : esNuevo ? 'Crear borrador' : 'Guardar borrador'}
+              </button>
+              {puedeEnviar && (
+                <>
+                  <div>
+                    <label className="form-label small mb-0" htmlFor="pres-vencimiento">
+                      Vence el
+                    </label>
+                    <input
+                      id="pres-vencimiento"
+                      type="date"
+                      className="form-control form-control-sm rounded-0"
+                      value={vencimientoAEnviar}
+                      disabled={ocupado}
+                      onChange={(e) => setVencimientoAEnviar(e.target.value)}
+                    />
+                  </div>
+                  <button type="button" className="btn btn-success rounded-0" disabled={ocupado} onClick={enviar}>
+                    {enviando ? 'Enviando…' : 'Enviar'}
+                  </button>
+                </>
+              )}
+              {puedeAnular && (
+                <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                  {anulando ? 'Anulando…' : 'Anular'}
+                </button>
+              )}
+            </div>
+            {errorEnviar && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEnviar}</div>}
+            {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+          </>
+        ) : (
+          detalle && (
+            <>
+              <h6>Items</h6>
+              <div className="table-responsive mb-3">
+                <table className="table table-sm table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Artículo</th>
+                      <th className="text-end">Cantidad</th>
+                      <th className="text-end">Precio unit.</th>
+                      <th className="text-end">Descuento</th>
+                      <th className="text-end">Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detalle.items.map((item) => (
+                      <tr key={item.orden}>
+                        <td>{item.descripcion}</td>
+                        <td className="text-end">{item.cantidad}</td>
+                        <td className="text-end">{formatearMoneda(item.precioUnitario)}</td>
+                        <td className="text-end">{item.descuento > 0 ? formatearMoneda(item.descuento) : '—'}</td>
+                        <td className="text-end">{formatearMoneda(item.total)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="row g-3 my-3">
+                <div className="col-md-4">
+                  <div className="small text-muted">Subtotal</div>
+                  <div>{formatearMoneda(detalle.subtotal)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Descuento</div>
+                  <div>{formatearMoneda(detalle.descuentoTotal)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Total</div>
+                  <div className="fs-5">
+                    <strong>{formatearMoneda(detalle.total)}</strong>
+                  </div>
+                </div>
+              </div>
+
+              <div className="d-flex gap-2 mb-3">
+                {puedeConvertir && (
+                  <button type="button" className="btn btn-primary rounded-0" onClick={convertirEnVenta}>
+                    Convertir en venta
+                  </button>
+                )}
+                {puedeAnular && (
+                  <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                    {anulando ? 'Anulando…' : 'Anular'}
+                  </button>
+                )}
+              </div>
+              {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+            </>
+          )
+        )}
+      </Box>
+    </div>
+  )
+}
+
+/**
+ * Presupuestos — borrador/detalle (stage-17-presupuestos-y-remitos, Slice 7; design: Web
+ * composition): `/presupuestos/nuevo` crea un borrador desde cero, `/presupuestos/:id` lo edita
+ * (borrador), lo envía/anula, o solo lo muestra con la acción de conversión cuando el servidor
+ * reporta `Convertible`. Mismo gate que `/presupuestos` (`RutaProtegida`, App.tsx).
+ */
+export function Presupuesto() {
+  const { id } = useParams<{ id: string }>()
+  const esNuevo = id === undefined || id === 'nuevo'
+  const idNumerico = esNuevo ? null : Number(id)
+  const idValido = esNuevo || Number.isFinite(idNumerico)
+
+  if (!idValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Presupuesto" variante="warning">
+          <p className="text-muted">No se especificó un presupuesto válido.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/presupuestos">
+            Volver a presupuestos
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return <PantallaPresupuesto key={idNumerico ?? 'nuevo'} idPresupuesto={idNumerico} />
+}

--- a/src/Ways.Web/src/paginas/Presupuestos.test.tsx
+++ b/src/Ways.Web/src/paginas/Presupuestos.test.tsx
@@ -1,0 +1,253 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Presupuestos } from './Presupuestos'
+import type { ClienteListado, PaginaDePresupuestos, PresupuestoListado, PuntoVentaListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 1,
+    numero: 1,
+    nombre: 'Consumidor Final',
+    apellido: null,
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: true,
+    ...sobrescribir,
+  }
+}
+
+function presupuestoFixture(sobrescribir: Partial<PresupuestoListado> = {}): PresupuestoListado {
+  return {
+    id: 1,
+    idPuntoVenta: 7,
+    idCliente: 1,
+    numero: 12,
+    numeroFormateado: '0007-00000012',
+    fechaEmision: '2026-08-01T12:00:00Z',
+    vencimiento: '2026-09-30',
+    vencido: false,
+    convertible: true,
+    total: 1500,
+    estado: 'Enviado',
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(sobrescribir: Partial<PaginaDePresupuestos> = {}): PaginaDePresupuestos {
+  return { items: [presupuestoFixture()], total: 1, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/clientes') return Promise.resolve({ items: [clienteFixture()], total: 1, pagina: 1, tamanio: 25 })
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/presupuestos?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla() {
+  return render(<Presupuestos />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+})
+
+describe('Presupuestos — listado', () => {
+  it('muestra la fila con número, cliente, punto de venta, estado y vencimiento', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('0007-00000012')
+    const fila = screen.getByText('0007-00000012').closest('tr')!
+    expect(within(fila).getByText(/Consumidor Final/)).toBeInTheDocument()
+    expect(within(fila).getByText('Local Centro')).toBeInTheDocument()
+    expect(within(fila).getByText('Enviado')).toBeInTheDocument()
+    expect(within(fila).getByText(/Vence/)).toBeInTheDocument()
+  })
+
+  it('un presupuesto sin número muestra #id', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/presupuestos?') ? Promise.resolve(paginaFixture({ items: [presupuestoFixture({ numeroFormateado: null })] })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('#1')).toBeInTheDocument()
+  })
+
+  it('sin resultados muestra el estado vacío', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/presupuestos?') ? Promise.resolve(paginaFixture({ items: [], total: 0 })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('No hay presupuestos que coincidan con los filtros.')).toBeInTheDocument()
+  })
+
+  it('un presupuesto Borrador (sin vencimiento) muestra — en la columna de vencimiento', async () => {
+    mockearRutasBase((ruta) =>
+      ruta.startsWith('/presupuestos?')
+        ? Promise.resolve(paginaFixture({ items: [presupuestoFixture({ estado: 'Borrador', vencimiento: null, numeroFormateado: null })] }))
+        : undefined,
+    )
+    renderPantalla()
+
+    const fila = (await screen.findByText('#1')).closest('tr')!
+    expect(within(fila).getByText('—')).toBeInTheDocument()
+  })
+})
+
+describe('Presupuestos — toggle "Solo vencidos" (design decisión 16, tarea 7.11)', () => {
+  it('queda deshabilitado hasta elegir un punto de venta', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('0007-00000012')
+    expect(screen.getByLabelText('Solo vencidos')).toBeDisabled()
+  })
+
+  it('se habilita al elegir un punto de venta y su query nunca viaja sin idPuntoVenta', async () => {
+    mockearRutasBase()
+    renderPantalla()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Centro')
+    await waitFor(() => expect(screen.getByLabelText('Solo vencidos')).toBeEnabled())
+
+    await userEvent.click(screen.getByLabelText('Solo vencidos'))
+    await waitFor(() => expect(apiGetMock).toHaveBeenCalledWith(expect.stringContaining('vencido=true')))
+
+    // Volver a "Todos" los puntos de venta deshabilita el toggle de nuevo y limpia el filtro —
+    // nunca queda un `vencido` huérfano en el estado (construirQueryDePresupuestos ya lo filtra,
+    // esto además prueba que la UI lo refleja).
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Todos')
+    await waitFor(() => expect(screen.getByLabelText('Solo vencidos')).toBeDisabled())
+    await waitFor(() => expect(screen.getByLabelText('Solo vencidos')).not.toBeChecked())
+  })
+})
+
+describe('Presupuestos — pager (tarea 7.11)', () => {
+  it('está deshabilitado en ambos bordes cuando hay una sola página', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('0007-00000012')
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
+  it('navega entre páginas, con "Anterior"/"Siguiente" habilitados solo del lado correcto', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/presupuestos?')) {
+        const paginaSolicitada = ruta.includes('pagina=2') ? 2 : 1
+        return Promise.resolve(paginaFixture({ total: 50, pagina: paginaSolicitada, tamanio: 25 }))
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderPantalla()
+
+    await screen.findByText(/Página 1 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 2 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+})
+
+describe('Presupuestos — filtros (react-async-state regla 2, mutation-proof-tests regla 7)', () => {
+  it('una respuesta desactualizada nunca pisa la más reciente', async () => {
+    let resolverPrimera: (v: PaginaDePresupuestos) => void = () => {}
+    const primeraPendiente = new Promise<PaginaDePresupuestos>((resolve) => {
+      resolverPrimera = resolve
+    })
+    let llamadas = 0
+
+    mockearRutasBase((ruta) => {
+      if (!ruta.startsWith('/presupuestos?')) return undefined
+      llamadas += 1
+      if (llamadas === 1) return Promise.resolve(paginaFixture())
+      if (llamadas === 2) return primeraPendiente
+      if (llamadas === 3) return Promise.resolve(paginaFixture({ items: [presupuestoFixture({ id: 3, numeroFormateado: '0007-00000999' })] }))
+      return Promise.reject(new Error('llamada inesperada'))
+    })
+
+    renderPantalla()
+    await screen.findByLabelText('Estado')
+
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Enviado')
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Convertido')
+
+    await waitFor(() => expect(screen.getByText('0007-00000999')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverPrimera(paginaFixture({ items: [presupuestoFixture({ id: 2, numeroFormateado: '0007-00000777' })] }))
+      await primeraPendiente
+    })
+    expect(screen.getByText('0007-00000999')).toBeInTheDocument()
+    expect(screen.queryByText('0007-00000777')).not.toBeInTheDocument()
+  })
+})
+
+describe('Presupuestos — "Nuevo presupuesto" (design decisión 17: sin restricción admin-only)', () => {
+  it('el botón siempre está visible — cualquier rol que llega a la pantalla puede quotear', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    expect(await screen.findByRole('button', { name: 'Nuevo presupuesto' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Presupuestos.tsx
+++ b/src/Ways.Web/src/paginas/Presupuestos.tsx
@@ -1,0 +1,333 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import {
+  claseDeBadgeDeEstadoPresupuesto,
+  claseDeBadgeDeVencimiento,
+  clienteDePresupuestos,
+  etiquetaDeEstadoPresupuesto,
+  etiquetaDeVencimiento,
+  filtrosDePresupuestosVacios,
+  type FiltrosDePresupuestos,
+} from '../api/presupuestos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
+import type { ClienteListado, EstadoPresupuesto, PaginaDePresupuestos, PresupuestoListado, PuntoVentaListado } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const OPCIONES_ESTADO: { valor: EstadoPresupuesto | ''; etiqueta: string }[] = [
+  { valor: '', etiqueta: 'Todos' },
+  { valor: 'Borrador', etiqueta: 'Borrador' },
+  { valor: 'Enviado', etiqueta: 'Enviado' },
+  { valor: 'Convertido', etiqueta: 'Convertido' },
+  { valor: 'Anulado', etiqueta: 'Anulado' },
+]
+
+function formatearFecha(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleDateString('es-AR') : '—'
+}
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+/**
+ * Listado de presupuestos (stage-17-presupuestos-y-remitos, Slice 7; design: Web composition):
+ * filtros punto de venta/cliente/estado/`vencido`/desde-hasta + el pager de `HistoricoDeCajas.tsx`/
+ * `OrdenesDeCompra.tsx`. El `vencido` toggle queda deshabilitado hasta elegir un punto de venta
+ * (design decisión 16 hecha visible, nunca un 400 que el usuario tenga que leer). La ruta sigue
+ * `Politicas.OperacionDePos` — Vendedor/Supervisor/Admin leen Y escriben (design decisión 17: "un
+ * Vendedor tiene que poder vender"), sin la distinción admin-only de OrdenesDeCompra.tsx.
+ */
+export function Presupuestos() {
+  const navigate = useNavigate()
+
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [clientes, setClientes] = useState<ClienteListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDePresupuestos>(filtrosDePresupuestosVacios())
+
+  const [pagina, setPagina] = useState<PaginaDePresupuestos | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((p) => {
+        if (!vigente) return
+        setClientes(p.items)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setClientes([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // react-async-state regla 2: cada cambio de filtro/página dispara una nueva consulta — una
+  // respuesta desactualizada nunca puede pisar la más reciente.
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDePresupuestos
+      .listar(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los presupuestos.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const puntoVentaPorId: Record<number, PuntoVentaListado> = {}
+  for (const pv of puntosVenta ?? []) puntoVentaPorId[pv.id] = pv
+
+  const clientePorId: Record<number, ClienteListado> = {}
+  for (const c of clientes ?? []) clientePorId[c.id] = c
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDePresupuestos, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPuntoVenta(idPuntoVenta: number | null) {
+    // Un cambio de punto de venta que deja el filtro sin PV invalida cualquier `vencido` ya
+    // elegido — el toggle queda deshabilitado de nuevo y nunca viaja huérfano al servidor
+    // (construirQueryDePresupuestos ya lo filtra, esto además limpia la UI).
+    setFiltros((prev) => ({ ...prev, idPuntoVenta, vencido: idPuntoVenta === null ? null : prev.vencido, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  const herramientas = (
+    <nav className="p-2 d-flex gap-2">
+      <button type="button" className="btn btn-sm btn-success rounded-0 text-nowrap" onClick={() => navigate('/presupuestos/nuevo')}>
+        Nuevo presupuesto
+      </button>
+    </nav>
+  )
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Presupuestos" variante="inverse" herramientas={herramientas}>
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorReferencia}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="pres-filtro-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="pres-filtro-punto-venta"
+              className="form-select rounded-0"
+              value={filtros.idPuntoVenta ?? ''}
+              onChange={(e) => cambiarPuntoVenta(e.target.value === '' ? null : Number(e.target.value))}
+            >
+              <option value="">Todos</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="pres-filtro-cliente">
+              Cliente
+            </label>
+            <select
+              id="pres-filtro-cliente"
+              className="form-select rounded-0"
+              value={filtros.idCliente ?? ''}
+              onChange={(e) => cambiarFiltro({ idCliente: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(clientes ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {etiquetaDeCliente(c)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="pres-filtro-estado">
+              Estado
+            </label>
+            <select
+              id="pres-filtro-estado"
+              className="form-select rounded-0"
+              value={filtros.estado ?? ''}
+              onChange={(e) => cambiarFiltro({ estado: e.target.value === '' ? null : (e.target.value as EstadoPresupuesto) })}
+            >
+              {OPCIONES_ESTADO.map((o) => (
+                <option key={o.valor} value={o.valor}>
+                  {o.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-auto d-flex align-items-center gap-1">
+            <div className="form-check">
+              <input
+                id="pres-filtro-vencido"
+                type="checkbox"
+                className="form-check-input"
+                checked={filtros.vencido ?? false}
+                disabled={filtros.idPuntoVenta === null}
+                onChange={(e) => cambiarFiltro({ vencido: e.target.checked ? true : null })}
+              />
+              <label className="form-check-label" htmlFor="pres-filtro-vencido">
+                Solo vencidos
+              </label>
+            </div>
+            {filtros.idPuntoVenta === null && <span className="small text-muted">(elegí un punto de venta)</span>}
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="pres-filtro-desde">
+              Desde
+            </label>
+            <input
+              id="pres-filtro-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="pres-filtro-hasta">
+              Hasta
+            </label>
+            <input
+              id="pres-filtro-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+        </div>
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Número</th>
+                    <th>Cliente</th>
+                    <th>Punto de venta</th>
+                    <th>Estado</th>
+                    <th>Vencimiento</th>
+                    <th>Fecha de emisión</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((p: PresupuestoListado) => (
+                    <tr key={p.id}>
+                      <td>
+                        <Link className="link-underline-opacity-0" to={`/presupuestos/${p.id}`}>
+                          {p.numeroFormateado ?? `#${p.id}`}
+                        </Link>
+                      </td>
+                      <td>{clientePorId[p.idCliente] ? etiquetaDeCliente(clientePorId[p.idCliente]) : `Cliente #${p.idCliente}`}</td>
+                      <td>{puntoVentaPorId[p.idPuntoVenta]?.nombre ?? `PV #${p.idPuntoVenta}`}</td>
+                      <td>
+                        <span className={`badge rounded-0 ${claseDeBadgeDeEstadoPresupuesto(p.estado)}`}>{etiquetaDeEstadoPresupuesto(p.estado)}</span>
+                      </td>
+                      <td>
+                        {p.estado === 'Enviado' ? (
+                          <span className={`badge rounded-0 ${claseDeBadgeDeVencimiento(p.vencimiento, p.vencido)}`}>
+                            {etiquetaDeVencimiento(p.vencimiento, p.vencido)}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td>{formatearFecha(p.fechaEmision)}</td>
+                      <td className="text-end">
+                        ${p.total.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="text-center text-muted py-4">
+                        No hay presupuestos que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} presupuesto(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumen

Slice 7 de la etapa 17: toda la superficie web de presupuestos + el punto de entrada de conversión en el POS.

- `api/presupuestos.ts`: client, query builder (guard vencido-exige-PV), mappers puros y `aSolicitudDeVentaDesdePresupuesto` — 43 tests unitarios colocados.
- `Presupuestos.tsx` (lista/filtros/pager) y `Presupuesto.tsx` (borrador/detalle/enviar/anular; "Convertir en venta" gated por el campo `Convertible` DEL SERVER, nunca derivación local).
- Cirugía de `Pos.tsx`: wrapper con `?idPresupuesto=`, `PantallaPos` remontada por `key`, banner de precio congelado, carrito read-only desde `/para-venta`, `cobrar()` bifurcado al body de conversión (sin `idCliente`/`lineas` — el server los rechaza). Los 31 tests preexistentes envueltos en `MemoryRouter` con CERO asserts cambiados (verificado por ambos jueces).
- Espejos TS de los contratos; rutas y nav gated por `puedeOperarPos` (paridad verificada con la policy real del server).

## Judgment-day (2 rondas, limpia al cierre)

- **Juez B (mutador) REJECT ronda 1**: 1 MAJOR con bug real trazado — sin el `key` de remount, "Nueva venta" tras una conversión dejaba el ticket pegado para siempre (53/53 verdes bajo el mutante). Fix `3c7864f`: test que ruta por la navegación REAL. Además 2 WARNINGs de honestidad de evidencia re-documentados con experimentos reales (el skip de precios es defensivo — probado borrándolo de verdad; el test de stale-promise no puede discriminar bajo React 19 — inalcanzabilidad demostrada estructuralmente). **Re-ronda B: APPROVE.**
- **Juez A APPROVE**: 1 WARNING — `disabled={ocupado}` faltante SOLO en "Convertir en venta" (los 8 hermanos del archivo lo tienen). Fix `e384300` con test del disabled en ventana en vuelo. 1 SUGGESTION preexistente → backlog (`tipos.ts:961`, `pagos` más estricto que el C# — dirección benigna). **Pasada acotada de B sobre el delta: APPROVE** (mutante RED exacto, 12/12).

## Suites

- vitest full: 846/846 (51 archivos). `npx tsc -b` limpio, lint limpio, build limpio. Backend intacto (`dotnet build` verde, cero archivos server en el diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)