### PR TITLE
test(presupuestos): seeds de precios inmunes al calendario en los helpers con reloj pineado

### DIFF
--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -37,6 +37,11 @@ namespace Ways.IntegrationTests;
 [Collection("Ways.IntegrationTests secuencial")]
 public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
+    // Literal fijo del pasado, jamas derivado del reloj real: los tests que pinean el reloj en
+    // instantes historicos necesitan un precio ya vigente bajo AMBOS relojes, hoy y siempre —
+    // un seed relativo a UtcNow se vuelve una bomba de calendario apenas la fecha real avanza.
+    private static readonly DateTimeOffset InicioDeVigenciaFijo = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
 
@@ -150,7 +155,7 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         db.Precios.Add(new Precio
         {
             IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
-            VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
         });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -150,7 +150,7 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         db.Precios.Add(new Precio
         {
             IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
-            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
         });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
@@ -34,6 +34,11 @@ namespace Ways.IntegrationTests;
 [Collection("Ways.IntegrationTests secuencial")]
 public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
+    // Literal fijo del pasado, jamas derivado del reloj real: los tests que pinean el reloj en
+    // instantes historicos necesitan un precio ya vigente bajo AMBOS relojes, hoy y siempre —
+    // un seed relativo a UtcNow se vuelve una bomba de calendario apenas la fecha real avanza.
+    private static readonly DateTimeOffset InicioDeVigenciaFijo = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
     private const string PasswordVendedor = "vendedor-password-larga";
@@ -120,20 +125,16 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
         db.Articulos.AddRange(articulo1, articulo2);
         await db.SaveChangesAsync();
 
-        // VigenteDesde va un año atrás, no un día: varios tests de este archivo pinean el reloj
-        // en instantes fijos del pasado (2026-08-19, 2026-09-30) y un seed relativo al reloj REAL
-        // deja de regir en el instante pineado apenas el calendario avanza — el precio tiene que
-        // ser vigente bajo ambos relojes.
         db.Precios.AddRange(
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo1.Id, IdListaPrecio = lista.Id, Monto = 100m,
-                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             },
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo2.Id, IdListaPrecio = lista.Id, Monto = 250m,
-                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDePresupuestosTests.cs
@@ -120,16 +120,20 @@ public class ServicioDePresupuestosTests(WaysApiFixture fixture) : IClassFixture
         db.Articulos.AddRange(articulo1, articulo2);
         await db.SaveChangesAsync();
 
+        // VigenteDesde va un año atrás, no un día: varios tests de este archivo pinean el reloj
+        // en instantes fijos del pasado (2026-08-19, 2026-09-30) y un seed relativo al reloj REAL
+        // deja de regir en el instante pineado apenas el calendario avanza — el precio tiene que
+        // ser vigente bajo ambos relojes.
         db.Precios.AddRange(
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo1.Id, IdListaPrecio = lista.Id, Monto = 100m,
-                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             },
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo2.Id, IdListaPrecio = lista.Id, Monto = 250m,
-                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -151,7 +151,7 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         db.Precios.Add(new Precio
         {
             IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
-            VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
         });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -34,6 +34,11 @@ namespace Ways.IntegrationTests;
 [Collection("Ways.IntegrationTests secuencial")]
 public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
+    // Literal fijo del pasado, jamas derivado del reloj real: los tests que pinean el reloj en
+    // instantes historicos necesitan un precio ya vigente bajo AMBOS relojes, hoy y siempre —
+    // un seed relativo a UtcNow se vuelve una bomba de calendario apenas la fecha real avanza.
+    private static readonly DateTimeOffset InicioDeVigenciaFijo = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
 
@@ -151,7 +156,7 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
         db.Precios.Add(new Precio
         {
             IdTenant = ctx.IdTenant, IdArticulo = articulo.Id, IdListaPrecio = ctx.IdListaPrecio, Monto = precio,
-            VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+            VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
         });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
@@ -42,6 +42,11 @@ namespace Ways.IntegrationTests;
 [Collection("Ways.IntegrationTests secuencial")]
 public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
 {
+    // Literal fijo del pasado, jamas derivado del reloj real: los tests que pinean el reloj en
+    // instantes historicos necesitan un precio ya vigente bajo AMBOS relojes, hoy y siempre —
+    // un seed relativo a UtcNow se vuelve una bomba de calendario apenas la fecha real avanza.
+    private static readonly DateTimeOffset InicioDeVigenciaFijo = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
 
@@ -134,12 +139,12 @@ public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFix
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo1.Id, IdListaPrecio = lista.Id, Monto = 100m,
-                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             },
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo2.Id, IdListaPrecio = lista.Id, Monto = 250m,
-                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = InicioDeVigenciaFijo, VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             });
         await db.SaveChangesAsync();
 

--- a/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
@@ -134,12 +134,12 @@ public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFix
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo1.Id, IdListaPrecio = lista.Id, Monto = 100m,
-                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             },
             new Precio
             {
                 IdTenant = resultado.IdTenant, IdArticulo = articulo2.Id, IdListaPrecio = lista.Id, Monto = 250m,
-                VigenteDesde = ahora.AddDays(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
+                VigenteDesde = ahora.AddYears(-1), VigenteHasta = null, CreatedAt = ahora, UpdatedAt = ahora
             });
         await db.SaveChangesAsync();
 


### PR DESCRIPTION
## Resumen

`UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina` fallaba de forma DETERMINÍSTICA desde el 2026-08-20 (detectado en la full suite del slice 8): el test pinea el reloj en 2026-08-19 pero el helper compartido sembraba los precios con `VigenteDesde = UtcNow real − 1 día` — apenas el calendario avanzó, el precio dejó de regir bajo el reloj pineado (`articulo_sin_precio_vigente`). TODOS los tests con reloj pineado del archivo eran bombas de calendario (los de 2026-09-30 explotaban el 1 de octubre).

## Cambios

| Archivo | Cambio |
|---|---|
| `ServicioDePresupuestosTests.cs` (+3 helpers hermanos) | `VigenteDesde` pasa al literal fijo `InicioDeVigenciaFijo = 2020-01-01` — jamás derivado del reloj real, vigente bajo AMBOS relojes para siempre — con el racional comentado en los 4 archivos |

La replicación a los hermanos (Conversion/Remitos/FacturacionDeRemitos) es preventiva: siembran idéntico y eran la misma bomba latente (regla 10 ampliada del programa). Barrido del resto de la suite: ningún otro archivo combina reloj-pineado-histórico + seed relativo (verificado por el juez A).

## Judgment-day (ronda limpia)

- **Juez A APPROVE** — 2 SUGGESTIONs (el AddYears inicial solo pateaba la bomba un año; comentario sin replicar) APLICADAS antes del veredicto de B.
- **Juez B APPROVE** — mutante 1 (seed relativo restaurado) → RED HOY con `articulo_sin_precio_vigente`; mutante 2 (literal futuro 2030) → RED masivo 14/20 — el seed gatea de verdad; hermano spot-checkeado 26/26; cero asserts tocados en el diff completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)