### PR TITLE
feat(remitos): web de remitos + consolidacion + cierre de la etapa 17 (slice 8)

### DIFF
--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -474,8 +474,8 @@ items_presupuesto (
 );
 ```
 
-**Estado (Etapa 17, slice 1 — schema + backstops, DB CHANGE GATE ejercido y aprobado):
-implementada — schema y los dos nets del PRE latente.** Creadas por la migración
+**Estado (Etapa 17, DB CHANGE GATE ejercido y aprobado en slice 1):
+implementada — etapa completa (PRs #1-#8).** Creadas por la migración
 `PresupuestosEtapa17`, junto con el ALTER de `comprobantes_venta` (§4) y el data statement 1
 del cierre del PRE (§1). `EntidadBase`: **SÍ** en las dos tablas — un presupuesto es mutable
 durante `borrador` (replace-set completo bajo `SELECT … FOR UPDATE`) y se edita de nuevo en
@@ -494,7 +494,10 @@ slice). `ReglaDePresupuestos` (`Ways.Domain.Ventas`, sin base de datos) es la ú
 de `EstaVencido`/`EsConvertible` — `vencimiento < hoy` (nunca `<=`), resuelto siempre en la
 zona horaria del punto de venta. `ServicioDePresupuestos` (draft CRUD, `enviar` con la serie
 `'PRES'`, `anular`, la lectura con `vencido` derivado) es slice 2; la conversión dentro de la
-transacción de venta (`EscriturasDePresupuesto`, el guard en `ServicioDeVentas`) es slice 3.
+transacción de venta (`EscriturasDePresupuesto`, el guard en `ServicioDeVentas`) es slice 3;
+`Presupuestos.tsx`/`Presupuesto.tsx` + la entrada de conversión en `Pos.tsx` son slice 7 —
+mergeados, la etapa cierra en slice 8 (regla 19 del programa: este header nunca queda claiming
+"implementada" mientras un write path siga sin mergear).
 
 ### Remitos (Etapa 17)
 
@@ -541,8 +544,8 @@ items_remito (
 );
 ```
 
-**Estado (Etapa 17, slice 4 — schema + backstops, DB CHANGE GATE ejercido y aprobado):
-implementada — schema.** Creadas por la migración `RemitosEtapa17`, junto con el `ALTER TYPE
+**Estado (Etapa 17, DB CHANGE GATE ejercido y aprobado en slice 4):
+implementada — etapa completa (PRs #1-#8).** Creadas por la migración `RemitosEtapa17`, junto con el `ALTER TYPE
 motivo_stock ADD VALUE 'remito'` (§6, **el único artefacto IRREVERSIBLE de la etapa**, aceptado y
 registrado) y el ALTER de `movimientos_stock` (§6, `id_remito`). `EntidadBase`: **SÍ** en las dos
 tablas, mismo criterio que `presupuestos`. `ux_remitos_numero` es **UNIQUE PARCIAL** `WHERE
@@ -555,7 +558,9 @@ también con `HasPostgresEnum`. `ManejadorDeErrores.cs` gana 7 ramas exactas: 2 
 (`ux_remitos_numero` → `numero_de_remito_duplicado`, **quinta ocurrencia** del ordering trap;
 `ux_items_remito_orden` → `orden_de_item_duplicado`) + 5 `23514` (las cinco CHECKs de este
 slice). `ServicioDeRemitos` (draft CRUD, `emitir` — el cuarto write site — con la serie `'REM'`,
-`anular`) es slice 5; la consolidación (`ServicioDeFacturacionDeRemitos`) es slice 6.
+`anular`) es slice 5; la consolidación (`ServicioDeFacturacionDeRemitos`) es slice 6;
+`Remitos.tsx`/`Remito.tsx`/`FacturarRemitos.tsx` son slice 8 — mergeados, la etapa cierra acá
+(regla 19 del programa).
 
 ## 5. Comprobantes de compra
 
@@ -828,8 +833,10 @@ stock_lotes (                  -- [operativa] (Etapa 12)
 > selección FEFO particionada no-vencidos-primero (`ReglaDeLotes.ElegirFefo`); vencido =
 > `fecha_vencimiento < hoy` estricto, con "hoy" en la zona horaria del punto de venta.
 >
-> **Estado (Etapa 17, slice 4 — schema + backstops, DB CHANGE GATE ejercido y aprobado):
-> `movimientos_stock.id_remito` implementada — sin escritor todavía (abre en slice 5).**
+> **Estado (Etapa 17, DB CHANGE GATE ejercido y aprobado en slice 4):
+> `movimientos_stock.id_remito` implementada — etapa completa (PRs #1-#8); el cuarto write
+> site (`ServicioDeRemitos.EmitirAsync`, slice 5) ya escribe esta columna — este header quedó
+> abierto entre las slices 4 y 5 y se cierra recién acá, siguiendo la regla 19 del programa.**
 > `ALTER TABLE movimientos_stock ADD COLUMN id_remito integer NULL` + `fk_movimientos_stock_remito`
 > compuesta MATCH SIMPLE + `ix_movimientos_stock_remito` — mismo shape exacto que
 > `fk_movimientos_stock_comprobante_venta`/`..._comprobante_compra`. Metadata-only en PG 11+

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -2181,6 +2181,40 @@ serves the shape.
   — **30/30 verde** (10 + 8 + 12). `npx tsc -b` — limpio. Commit
   `fix(remitos): judgment-day slice-8 ronda 1 juez B — dos TXRs, ids exactos del POST y redes
   de stale`. Pendiente: re-judge acotado a este diff (orquestador).
+
+  **judgment-day Slice 8, ronda 2 — juez A (APPROVE, 1 WARNING + 2 SUGGESTIONs) — fixed 1
+  WARNING + 1 SUGGESTION, 1 SUGGESTION → backlog.**
+
+  1. **WARNING — query incondicional nueva en TODO `GET /api/ventas/{id}`.**
+     `ServicioDeVentas.ObtenerAsync` (:410-433, post ronda-1) consultaba `db.TiposComprobante`
+     SIEMPRE, aunque el camino ordinario solo usa el tipo para bifurcar a un `TXR` — misma clase
+     del MAJOR "query desperdiciada 16→15" de slice 3 (juez A). Fix: la consulta del tipo queda
+     GATEADA detrás de `items.Count == 0` — un comprobante ordinario SIEMPRE tiene items
+     (`ExigirLineasValidas` lo exige en `EmitirAsync`; un TXR nace itemless por construcción,
+     precedente `RC`), así que solo el caso raro (`items.Count == 0`) paga la query nueva. Nuevo
+     test `ElDetalleOrdinarioNuncaConsultaTiposComprobante` (`VentasCheckoutTests.cs`) — mide
+     con `ContadorDeConsultasSobreTabla("tipos_comprobante")` que un GET ordinario dispara CERO
+     consultas contra esa tabla. Ciclo: quitado el gate (vuelta a la consulta incondicional) →
+     **RED** (`Expected: 0, Actual: 1`) → revertido (edit manual, no `git checkout --` para no
+     perder el fix ni el de FIX 2 en el mismo archivo) → **verde**. Focused tests:
+     `dotnet test --filter
+     "FullyQualifiedName~VentasCheckoutTests|FullyQualifiedName~ServicioDeFacturacionDeRemitos"`
+     — **50/50 verde** (28 + 22).
+  2. **SUGGESTION — tail de proyección duplicado.** Las dos sobrecargas de `Proyectar` (:1651+)
+     duplicaban verbatim los 9 campos del header y el mapping de pagos. Extraído a
+     `ProyectarConItems(ComprobanteVenta, IReadOnlyList<ItemEmitido>, IReadOnlyList<PagoComprobante>)`
+     — ambas sobrecargas delegan; un campo futuro se agrega en un solo lugar. Cero cambio de
+     comportamiento (misma evidencia: 50/50 verde arriba, sin tocar ningún assert existente).
+  3. **SUGGESTION (backlog, NO fixeada) — asimetría latente de un TXR anulado.** Un `TXR`
+     anulado des-liga sus remitos (`EjecutarAnulacionAsync`), así que su `GET` devuelve
+     `items: []` — hoy inalcanzable desde la web porque `Remito.tsx` solo consulta con
+     `idComprobanteVenta != null`. Registrado como backlog del veredicto de juez A; referencia:
+     `openspec/changes/stage-17-presupuestos-y-remitos/design.md` (T11 / spec de anulación de
+     TXR).
+
+  Commit `fix(remitos): judgment-day slice-8 ronda 2 juez A — gate del tipo por items vacios y
+  tail de proyeccion unico`. Ronda 2 era la ÚLTIMA del presupuesto nativo — cierra `judgment-day`
+  para esta slice.
 - [ ] 8.15 Open PR #8 `feat/stage17-slice8-web-remitos`, merge after a clean round — **stage
   close**.
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -2126,7 +2126,16 @@ serves the shape.
   `npm run build` clean, `npm run lint` clean. Numbers in Work Unit Evidence below.
 - [x] 8.13 **STAGE CLOSE** — re-verify design.md's binding verify criteria 1-9 against the
   merged stack. *(design.md:628-654)* See Work Unit Evidence below.
-- [ ] 8.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
+- [x] 8.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
+  **DONE by the orchestrator**: juez B REJECT ronda 1 (3 MAJOR test-only: el join de OD10 sin
+  fixture de dos TXRs — la clase 12c del slice 6 otra vez —, el POST de consolidación sin probar
+  los ids EXACTOS tildados, y las redes de stale sin replicar; + 1 MINOR del assert que no
+  discriminaba null) → fixes `25ea8f3` (las 3 pantallas tenían camino real de doble carga — cero
+  inalcanzabilidades) → re-ronda B APPROVE. Juez A APPROVE (1 WARNING: query nueva incondicional
+  en todo GET de detalle — la clase del 16→15 del slice 3; + 1 SUGGESTION de tail duplicado; + 1
+  SUGGESTION latente → backlog) → fixes `0912eb2` (gate items.Count == 0 estructuralmente probado
+  + ProyectarConItems único + test de conteo nuevo con RED/verde) → pasada acotada B APPROVE con
+  la verificación de los 3 caminos (emisión, anulación, conversión vía presupuesto_sin_items).
   juez B REJECT** (3 MAJOR + 1 MINOR, all test-only gaps over correct code) → fixes aplicados
   por el fix-agent:
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -2067,40 +2067,79 @@ remito/consolidación circuit has a UI; doc-10's "Estado (Etapa 17)" headers clo
 (one remito at a time) if this slice overflows. **Rollback**: screens disappear, API still
 serves the shape.
 
-- [ ] 8.1 Create `src/Ways.Web/src/api/remitos.ts` — client + mappers.
-- [ ] 8.2 Create `Remitos.tsx` — list + filters (mirrors 7.2).
-- [ ] 8.3 Create `Remito.tsx` — draft/detail + `emitir` (`SelectorDeLote` reuse) + `anular`;
-  `facturado` renders its invoice link and no actions. *(design.md:416-418)*
-- [ ] 8.4 Create `FacturarRemitos.tsx` — cliente + PV picker, `emitido` unlinked list,
+- [x] 8.1 Create `src/Ways.Web/src/api/remitos.ts` — client + mappers.
+- [x] 8.2 Create `Remitos.tsx` — list + filters (mirrors 7.2).
+- [x] 8.3 Create `Remito.tsx` — draft/detail + `emitir` (`SelectorDeLote` reuse) + `anular`;
+  `facturado` renders its invoice link and no actions. *(design.md:416-418)* **Deviation
+  registered**: `SelectorDeLote` was a local, unexported component inside `Pos.tsx` — extracted
+  to `src/Ways.Web/src/componentes/SelectorDeLote.tsx` (both `Pos.tsx` and `Remito.tsx` now
+  import the same module; `Pos.test.tsx` unaffected, no direct import of the component). No
+  `/ventas/:id` detail page exists in this app; "the invoice link" renders as the TXR's own
+  `numeroVisible`/`total` (live via `GET /api/ventas/{id}`, the OD10 read model), not a
+  navigable `<Link>` to a route that doesn't exist — creating that page was out of the assigned
+  8.1-8.13 scope.
+- [x] 8.4 Create `FacturarRemitos.tsx` — cliente + PV picker, `emitido` unlinked list,
   multi-select, summed total, POS payment rows, post the consolidation. *(design.md:419-421)*
-- [ ] 8.5 Modify `App.tsx` — routes `/remitos`, `/remitos/nuevo`, `/remitos/:id`,
-  `/remitos/facturacion`.
-- [ ] 8.6 **[EXPLICIT, new programme rule]** Modify `docs/10-modelo-de-datos.md` — refresh the
+  Full multi-select shipped (no degradation needed).
+- [x] 8.5 Modify `App.tsx` — routes `/remitos`, `/remitos/nuevo`, `/remitos/:id`,
+  `/remitos/facturacion`; nav entry added to `Layout.tsx` (same gate as `/presupuestos`).
+- [x] 8.6 **[EXPLICIT, new programme rule]** Modify `docs/10-modelo-de-datos.md` — refresh the
   "Estado (Etapa 17)" headers opened at tasks 1.20/4.21 to *"implementada — etapa completa
   (PRs #1-#8)"* — this is the **last** slice; the header must never claim *"implementada"*
   while a write path is still unmerged. *(design.md:465, 600-603 — the stage-16 W1 verify
-  remediation, codified forward as a mandatory task instead of a carryover risk)*
-- [ ] 8.7 Descriptor tests for every new screen + pure helper (consolidation total reducer).
-- [ ] 8.8 Multi-select reducer test.
-- [ ] 8.9 Disabled-action matrix by `estado` (`borrador`/`emitido`/`facturado`/`anulado`).
-- [ ] 8.10 Test: double click on `emitir`/`anular`/`facturar` issues exactly one POST each.
-- [ ] 8.10b **[OD10, judgment slice 6 juez A]** The TXR read model sources its detail from
+  remediation, codified forward as a mandatory task instead of a carryover risk)* **Deviation
+  registered (W1 drift caught, not skipped)**: found FOUR "Estado (Etapa 17...)" annotations,
+  not two — the Presupuestos section header (line 477) and the Remitos section header (line
+  547) match tasks 1.20/4.21 exactly and are now closed to the exact mandated text; a third,
+  `movimientos_stock.id_remito`'s inline annotation (originally "sin escritor todavía (abre en
+  slice 5)"), was ALSO stale — slice 5 shipped its writer stages ago and the note was never
+  closed, the literal W1-class drift the task warns not to skip — closed too, registered as an
+  extra fix beyond the strict two-header instruction. The fourth (`comprobantes_venta`'s
+  `id_presupuesto_origen` annotation, line 418) makes no forward-looking "opens in slice N"
+  claim and needed no change.
+- [x] 8.7 Descriptor tests for every new screen + pure helper (consolidation total reducer:
+  `totalDeRemitosElegidos`, `remitos.test.ts`).
+- [x] 8.8 Multi-select reducer test (`reducirSeleccionDeRemitos`, `remitos.test.ts` — 7 cases
+  including no-mutation-of-previous-state).
+- [x] 8.9 Disabled-action matrix by `estado` (`borrador`/`emitido`/`facturado`/`anulado`) —
+  `Remito.test.tsx`, `describe.each` over the four estados.
+- [x] 8.10 Test: double click on `emitir`/`anular`/`facturar` issues exactly one POST each —
+  `Remito.test.tsx` (emitir, anular), `FacturarRemitos.test.tsx` (facturar).
+- [x] 8.10b **[OD10, judgment slice 6 juez A]** The TXR read model sources its detail from
   `items_remito`: `GET /api/ventas/{id}` (or the shape the web consumes for a TXR) joins the
   linked remitos' frozen lines instead of returning `items: []` — the spec scenario
   (comprobantes-venta: *"shows all 5 lines, sourced from items_remito, not from
   items_comprobante_venta"*) and design T11 both mandate it; no prior task implemented it.
   Ships with: the API test of the spec scenario, an N=1 consolidation test NAMED as the
   deliberate boundary, and a TXR-annulment-with-closed-turno test (the two SUGGESTIONs of the
-  same verdict). Mutation evidence per mutation-proof-tests v1.1.
-- [ ] 8.11 **STAGE CLOSE** — full solution test suite run once end-to-end
-  (`dotnet test`, no filter) — confirms non-regression across the whole tree.
-- [ ] 8.12 **STAGE CLOSE** — full web suite end-to-end (`npx vitest run`, no filter),
-  `npm run build` clean, `npm run lint` clean.
-- [ ] 8.13 **STAGE CLOSE** — re-verify design.md's binding verify criteria 1-9 against the
-  merged stack. *(design.md:628-654)*
+  same verdict). Mutation evidence per mutation-proof-tests v1.1 — see Work Unit Evidence table
+  below (`tipo.Codigo == "TXR"` clause: applied → 5 expected/0 actual failure → reverted →
+  green). Implemented in `ServicioDeVentas.ObtenerAsync` + private `ObtenerItemsDeTxrAsync` +
+  a `Proyectar(ComprobanteVenta, IReadOnlyList<ItemEmitido>, ...)` overload; three new tests in
+  `ServicioDeFacturacionDeRemitosTests.cs`.
+- [x] 8.11 **STAGE CLOSE** — full solution test suite run once end-to-end
+  (`dotnet test`, no filter) — confirms non-regression across the whole tree. **Deviation
+  registered**: the repo has THREE test projects, not four (`Ways.Domain.Tests`,
+  `Ways.Application.Tests`, `Ways.IntegrationTests` — no fourth project exists in `Ways.slnx`).
+  Numbers in Work Unit Evidence below.
+- [x] 8.12 **STAGE CLOSE** — full web suite end-to-end (`npx vitest run`, no filter),
+  `npm run build` clean, `npm run lint` clean. Numbers in Work Unit Evidence below.
+- [x] 8.13 **STAGE CLOSE** — re-verify design.md's binding verify criteria 1-9 against the
+  merged stack. *(design.md:628-654)* See Work Unit Evidence below.
 - [ ] 8.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
 - [ ] 8.15 Open PR #8 `feat/stage17-slice8-web-remitos`, merge after a clean round — **stage
   close**.
+
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and result | `npx vitest run src/api/remitos.test.ts src/paginas/Remitos.test.tsx src/paginas/Remito.test.tsx src/paginas/FacturarRemitos.test.tsx src/paginas/Pos.test.tsx` — 5 files, 109/109 green (30 + 7 + 11 + 8 + 53). `dotnet test --filter "FullyQualifiedName~ServicioDeFacturacionDeRemitosTests"` (the three new OD10 tests) — 3/3 green |
+| Mutation evidence (OD10, task 8.10b) | Clause named: `if (tipo.Codigo == "TXR")` in `ServicioDeVentas.ObtenerAsync` — the read-model branch that sources a TXR's detail from `items_remito`. Applied: mutated to `"MUTADO_NUNCA_VERDADERO"` → ran `ElDetalleDeUnTxrQueLigaDosRemitosMuestraLasCincoLineasCombinadasSourceadasDeItemsRemito` → **RED** (`Expected: 5, Actual: 0`) → reverted → **green** (mutation-proof-tests v1.1 rule 2, applied → failing test → reverted → green) |
+| **STAGE CLOSE** — full solution test suite (task 8.11) | `dotnet build` (whole solution) — 0 errors. `dotnet test tests/Ways.Domain.Tests` — **540/540 green**. `dotnet test tests/Ways.Application.Tests` — **297/297 green**. `dotnet test tests/Ways.IntegrationTests` (no filter) — **1580/1581**, ONE failure: `ServicioDePresupuestosTests.UnPresupuestoConVencimientoPasadoSeReportaVencidoYElFiltroLoDiscrimina`. Regla 17 (flakiness) protocol followed: isolated re-run + trx (`slice8-rerun-flaky.trx`) — failed AGAIN, deterministically, not intermittent noise. Root-caused: the test hardcodes `RelojFijo` at `2026-08-19T12:00:00Z` while its own `PrepararConFactoryAsync` seeds `Precio.VigenteDesde = DateTimeOffset.UtcNow.AddDays(-1)` (REAL wall clock) — with today's real date past 2026-08-19, the seeded price's `VigenteDesde` now lands AFTER the hardcoded fixed clock, so the price resolves as not-yet-vigente. Confirmed **pre-existing and unrelated**: last touched in slice 2 (`git log` — commits `8c752e0`/`00b2505`, months before this branch), never touched by this slice's diff (`git status` shows zero changes to `ServicioDePresupuestosTests.cs` or anything under `src/Ways.Application/Ventas/ServicioDePresupuestos*`). A permanent calendar-drift defect (will fail every day from now on, not just today) — reported as a risk, **not fixed** here: out of the assigned 8.1-8.13 scope, filing a test-only fix for an unrelated file was not authorized |
+| **STAGE CLOSE** — full web suite (task 8.12) | `npx vitest run` (no filter) — **55 files, 902/902 green**. `npm run build` (`tsc -b && vite build`) — clean, 0 errors. `npm run lint` (oxlint) — clean, only 4 PRE-EXISTING warnings in files this slice never touched (`AuthContext.tsx`, `ResumenSaldoDeProveedor.tsx`, `PanelDeCambio.tsx`, `Auditoria.tsx`) |
+| **STAGE CLOSE** — binding verify criteria 1-9 re-check (task 8.13) | 1/2/4/5/6 unaffected — no DDL, no `ServicioDeVentas` transactional-path edits, `Politicas.cs`/`AsignadorDeNumeroComprobante.cs` untouched, nothing under `Compras/`/`Stock/`. **3 — registered deviation, OD10-authorized**: `ServicioDeVentas.cs` gains `ObtenerAsync`'s TXR branch + `ObtenerItemsDeTxrAsync` + a `Proyectar` overload — outside criterion 3's slice-3-era enumeration, but this is the READ path (`GET /api/ventas/{id}`), never `EjecutarTransaccionAsync`/`EjecutarAnulacionAsync`; the pinned statement order and both write loops stay byte-identical (untouched, confirmed by diff) — state.yaml's OD10 pre-authorized exactly this as "the ONLY backend exception of the slice". 7 — mutation evidence recorded for the new OD10 clause (row above); rows 59-60 (web layer, slices 7-8) remain covered by their own slices' tests, unaffected. 8 — Domain/Application/vitest all green; Integration green except the one pre-existing unrelated failure (row above) — colocated tests exist for every new pure helper (`remitos.ts` → `remitos.test.ts`) and every new screen (`Remitos.tsx`/`Remito.tsx`/`FacturarRemitos.tsx` → their own `.test.tsx`). 9 — doc-10 carries the closed "Estado (Etapa 17)" annotations (task 8.6 above) |
+| Rollback boundary | Isolated to: `src/Ways.Web/src/api/remitos.ts(.test.ts)`, `src/Ways.Web/src/paginas/{Remitos,Remito,FacturarRemitos}.tsx(.test.tsx)`, `src/Ways.Web/src/componentes/SelectorDeLote.tsx` (new, extracted), `src/Ways.Web/src/paginas/Pos.tsx` (import-only change, behavior-preserving), `src/Ways.Web/src/api/{tipos,ventas}.ts` (additive types + one new `clienteDeVentas.obtener`), `src/Ways.Web/src/App.tsx`/`componentes/Layout.tsx` (additive routes/nav), `docs/10-modelo-de-datos.md` (three status headers closed, no schema/prose change beyond that), and the single backend file `src/Ways.Application/Ventas/ServicioDeVentas.cs` (`git diff --stat`: +93/-3 — the 3 deletions are `ObtenerAsync`'s own 3-line body, replaced by the TXR-branching version; `EjecutarTransaccionAsync`/`EjecutarAnulacionAsync` and every other existing method are untouched) + `tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs` (three new tests appended). `git revert` of this slice's commit(s) alone removes the entire remitos web surface and the OD10 read-model branch; every route/service the web calls already exists from PRs #4-#6 |
 
 ---
 

--- a/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
+++ b/openspec/changes/stage-17-presupuestos-y-remitos/tasks.md
@@ -2126,7 +2126,61 @@ serves the shape.
   `npm run build` clean, `npm run lint` clean. Numbers in Work Unit Evidence below.
 - [x] 8.13 **STAGE CLOSE** — re-verify design.md's binding verify criteria 1-9 against the
   merged stack. *(design.md:628-654)* See Work Unit Evidence below.
-- [ ] 8.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round.
+- [ ] 8.14 `judgment-day` round, fix confirmed findings, re-judge to a clean round. — **ronda 1
+  juez B REJECT** (3 MAJOR + 1 MINOR, all test-only gaps over correct code) → fixes aplicados
+  por el fix-agent:
+
+  **judgment-day Slice 8, ronda 1 — juez B (3 MAJOR + 1 MINOR, todos test-only).**
+
+  1. **MAJOR — el join de OD10 sin discriminar por comprobante (misma clase que slice 6).**
+     `ServicioDeVentas.ObtenerItemsDeTxrAsync` (:447) filtra
+     `Where(r => r.IdComprobanteVenta == idComprobante)`, pero cada test previo crea UN solo TXR
+     por tenant — un mutante ensanchado a `!= null` sobrevivía 3/3. Fix: nuevo test
+     `DosConsolidacionesIndependientesDelMismoTenantCadaTxrMuestraSoloSusPropiasLineas` en
+     `ServicioDeFacturacionDeRemitosTests.cs` — dos TXRs independientes del mismo tenant, cada
+     uno con artículos/cantidades discriminantes; assert de conteo (2, no 4) Y de identidad
+     (artículo/cantidad) por cada lado. Ciclo: mutado `== idComprobante` → `!= null` (`dotnet
+     build --no-incremental`) → **RED** (`Expected: 2, Actual: 4`) → revertido (`git checkout
+     --`) → suite completa del archivo **22/22 verde**.
+  2. **MAJOR — el POST de consolidación no probaba los ids exactos.** En
+     `FacturarRemitos.test.tsx`, un mutante que mandara TODOS los remitos listados en vez de los
+     seleccionados sobrevivía 8/8. Fix: nuevo test "el POST lleva idsRemito EXACTAMENTE igual al
+     subconjunto elegido, nunca todos los listados" — fixture con 3 remitos listados, se tildan
+     2 (subconjunto propio), `toEqual`/`objectContaining({ idsRemito: [1, 3] })`. Ciclo: mutado
+     `FacturarRemitos.tsx:256` (`seleccionados` → `(remitos ?? []).map(r => r.id)`) → **RED**
+     (timeout esperando el `toHaveBeenCalledWith` exacto) → revertido → **verde**.
+  3. **MAJOR — guards de stale sin red propia en las 3 pantallas.** El patrón de
+     promesa-stale (`Pos.test.tsx`, `SelectorDeLote`) nunca se replicó en `Remitos.tsx`,
+     `Remito.tsx` ni `FacturarRemitos.tsx`. Se intentó de verdad un camino real de recarga sobre
+     la MISMA instancia montada en las tres — las tres SÍ tienen un camino alcanzable (ninguna
+     inalcanzabilidad que registrar):
+     - `Remitos.tsx`: cambio de filtro `estado` dispara `cargar()` dos veces en secuencia;
+       resuelta la respuesta VIEJA (`estado=Facturado`) DESPUÉS de la NUEVA
+       (`estado=Anulado`), dentro de `act`. Ciclo: quitado el guard de generación del `.then()`
+       de `cargar` → **RED** (`Unable to find element with text: 0007-00000099`) → revertido →
+       **verde**.
+     - `Remito.tsx`: dos escrituras en secuencia sobre la misma instancia (Emitir → su propio
+       refetch queda en vuelo; Anular → su propio refetch, más nuevo) — resuelto el refetch de
+       Emitir DESPUÉS del de Anular, dentro de `act`; assert de estado (`Anulado`) Y de
+       `Observaciones` (discriminante). Ciclo: quitado el guard de generación del `.then()` de
+       `cargarDetalle` → **RED** (quedó en `Borrador`, el estado stale) → revertido → **verde**.
+     - `FacturarRemitos.tsx`: cambio de cliente dispara `cargarRemitos()` dos veces en
+       secuencia; resuelta la lista del cliente A DESPUÉS de la del cliente B, dentro de `act`.
+       Ciclo: quitado el guard de generación del `.then()` de `cargarRemitos` → **RED**
+       (`Unable to find element with text: 0007-00000099`) → revertido → **verde**.
+  4. **MINOR — assert que no discrimina `null`.** `FacturarRemitos.test.tsx:309` usaba
+     `expect.not.objectContaining({ idCliente: expect.anything() })`, que no matchea un valor
+     `null` explícito. Fix: assert fuerte — `Object.keys(body)).not.toContain('idCliente')`.
+     Ciclo: mutado el mapper `aSolicitudDeFacturacionDeRemitos` agregando `idCliente: null` al
+     objeto devuelto → **RED** (`expected [...] to not include 'idCliente'`) → revertido →
+     **verde**.
+
+  Focused tests tras los 4 fixes: `dotnet test --filter
+  "FullyQualifiedName~ServicioDeFacturacionDeRemitosTests"` — **22/22 verde**. `npx vitest run
+  src/paginas/FacturarRemitos.test.tsx src/paginas/Remitos.test.tsx src/paginas/Remito.test.tsx`
+  — **30/30 verde** (10 + 8 + 12). `npx tsc -b` — limpio. Commit
+  `fix(remitos): judgment-day slice-8 ronda 1 juez B — dos TXRs, ids exactos del POST y redes
+  de stale`. Pendiente: re-judge acotado a este diff (orquestador).
 - [ ] 8.15 Open PR #8 `feat/stage17-slice8-web-remitos`, merge after a clean round — **stage
   close**.
 

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -415,19 +415,28 @@ public class ServicioDeVentas(
             .Where(p => p.IdComprobanteVenta == id)
             .ToListAsync(ct);
 
-        var tipo = await db.TiposComprobante.AsNoTracking()
-            .FirstAsync(t => t.Id == comprobante.IdTipoComprobante, ct);
-
-        if (tipo.Codigo == "TXR")
-        {
-            var itemsTxr = await ObtenerItemsDeTxrAsync(id, ct);
-            return Proyectar(comprobante, itemsTxr, pagos);
-        }
-
         var items = await db.ItemsComprobanteVenta
             .Where(i => i.IdComprobanteVenta == id)
             .OrderBy(i => i.Orden)
             .ToListAsync(ct);
+
+        // judgment-day slice-8 ronda 2 (juez A, WARNING): la consulta de TiposComprobante queda
+        // GATEADA detrás de items.Count == 0 — un comprobante ordinario SIEMPRE tiene items
+        // (ExigirLineasValidas lo exige en EmitirAsync), un TXR nace itemless por construcción
+        // (precedente RC), así que items.Count == 0 es el gate natural: solo ese caso raro paga la
+        // query nueva, el camino ordinario (16→15 en slice 3, mismo criterio del MAJOR de juez A)
+        // no suma ningún round trip.
+        if (items.Count == 0)
+        {
+            var tipo = await db.TiposComprobante.AsNoTracking()
+                .FirstAsync(t => t.Id == comprobante.IdTipoComprobante, ct);
+
+            if (tipo.Codigo == "TXR")
+            {
+                var itemsTxr = await ObtenerItemsDeTxrAsync(id, ct);
+                return Proyectar(comprobante, itemsTxr, pagos);
+            }
+        }
 
         return Proyectar(comprobante, items, pagos);
     }
@@ -1641,13 +1650,9 @@ public class ServicioDeVentas(
     /// el fallback queda solo por si algún día <paramref name="planItems"/> falta.</summary>
     private static ComprobanteEmitido Proyectar(
         ComprobanteVenta comprobante, IReadOnlyList<ItemComprobanteVenta> items, IReadOnlyList<PagoComprobante> pagos,
-        IReadOnlyList<LineaDelPlan>? planItems = null) => new(
-        comprobante.Id, comprobante.Numero,
-        NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
-        comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
-        comprobante.IdComprobanteAsociado, comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.Total,
-        comprobante.DireccionEntrega, comprobante.Observaciones,
-        items
+        IReadOnlyList<LineaDelPlan>? planItems = null)
+    {
+        var itemsEmitidos = items
             .OrderBy(i => i.Orden)
             .Select(i =>
             {
@@ -1657,17 +1662,23 @@ public class ServicioDeVentas(
                     i.IdAlicuotaIva, i.PorcentajeIva, i.Cantidad, i.PrecioUnitario, i.Descuento, i.Total,
                     planItem?.IdLote ?? i.IdLote, planItem?.CodigoLote, planItem?.LoteVencido ?? false);
             })
-            .ToList(),
-        pagos
-            .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
-            .ToList(),
-        comprobante.IdPresupuestoOrigen);
+            .ToList();
+
+        return ProyectarConItems(comprobante, itemsEmitidos, pagos);
+    }
 
     /// <summary>OD10: overload para el detalle de un <c>TXR</c>, que ya llega proyectado a
     /// <see cref="ItemEmitido"/> (join de <c>items_remito</c>, <see cref="ObtenerItemsDeTxrAsync"/>)
     /// en vez de a partir de <see cref="ItemComprobanteVenta"/> — mismo tail de proyección del
     /// header/pagos, distinto origen de items.</summary>
     private static ComprobanteEmitido Proyectar(
+        ComprobanteVenta comprobante, IReadOnlyList<ItemEmitido> items, IReadOnlyList<PagoComprobante> pagos) =>
+        ProyectarConItems(comprobante, items, pagos);
+
+    /// <summary>judgment-day slice-8 ronda 2 (juez A, SUGGESTION): tail común de las dos
+    /// sobrecargas de <see cref="Proyectar"/> — los 9 campos del header y el mapping de pagos eran
+    /// duplicados verbatim entre ambas; un campo futuro ahora se agrega en UN solo lugar.</summary>
+    private static ComprobanteEmitido ProyectarConItems(
         ComprobanteVenta comprobante, IReadOnlyList<ItemEmitido> items, IReadOnlyList<PagoComprobante> pagos) => new(
         comprobante.Id, comprobante.Numero,
         NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),

--- a/src/Ways.Application/Ventas/ServicioDeVentas.cs
+++ b/src/Ways.Application/Ventas/ServicioDeVentas.cs
@@ -399,20 +399,93 @@ public class ServicioDeVentas(
         return Proyectar(comprobante, items, pagos);
     }
 
+    /// <summary>
+    /// stage-17-presupuestos-y-remitos, Slice 8 (OD10 — judgment slice 6, juez A; design T11;
+    /// comprobantes-venta/spec.md: "shows all N lines, sourced from items_remito, not from
+    /// items_comprobante_venta"). Un <c>TXR</c> nace itemless por construcción (precedente
+    /// <c>RC</c>) — <c>items_comprobante_venta</c> siempre devolvería 0 filas para él, así que su
+    /// detalle leído/impreso viene de las líneas CONGELADAS de <c>items_remito</c> de los remitos
+    /// que consolida (<c>Remito.IdComprobanteVenta == id</c>), nunca de la tabla de items del
+    /// comprobante. Cualquier otro tipo sigue el camino de siempre.</summary>
     public async Task<ComprobanteEmitido> ObtenerAsync(int id, CancellationToken ct = default)
     {
         var comprobante = await BuscarComprobanteAsync(id, ct);
+
+        var pagos = await db.PagosComprobante
+            .Where(p => p.IdComprobanteVenta == id)
+            .ToListAsync(ct);
+
+        var tipo = await db.TiposComprobante.AsNoTracking()
+            .FirstAsync(t => t.Id == comprobante.IdTipoComprobante, ct);
+
+        if (tipo.Codigo == "TXR")
+        {
+            var itemsTxr = await ObtenerItemsDeTxrAsync(id, ct);
+            return Proyectar(comprobante, itemsTxr, pagos);
+        }
 
         var items = await db.ItemsComprobanteVenta
             .Where(i => i.IdComprobanteVenta == id)
             .OrderBy(i => i.Orden)
             .ToListAsync(ct);
 
-        var pagos = await db.PagosComprobante
-            .Where(p => p.IdComprobanteVenta == id)
+        return Proyectar(comprobante, items, pagos);
+    }
+
+    /// <summary>OD10: junta <c>items_remito</c> de TODOS los remitos ligados a este <c>TXR</c>,
+    /// ordenados por remito (número visible, <c>Id</c> como desempate estable) y, dentro de cada
+    /// uno, por su propio <c>Orden</c> — renumerado 1..N de forma CONTINUA para el detalle
+    /// combinado (<c>ItemEmitido.Orden</c> es la posición mostrada, nunca la del remito de
+    /// origen). <c>IdArea</c> se resuelve del artículo VIGENTE hoy — <c>items_remito</c> no lo
+    /// congela, es un campo de agrupación visual/no monetario, a diferencia de precio/descuento/
+    /// IVA que sí vienen congelados de la línea. <c>CodigoBarra</c> y los campos de lote quedan
+    /// sin snapshot de escaneo (un remito nunca capturó un código de barras), salvo
+    /// <c>IdLote</c>, que items_remito sí congela.</summary>
+    private async Task<IReadOnlyList<ItemEmitido>> ObtenerItemsDeTxrAsync(int idComprobante, CancellationToken ct)
+    {
+        var remitos = await db.Remitos.AsNoTracking()
+            .Where(r => r.IdComprobanteVenta == idComprobante)
+            .OrderBy(r => r.Numero)
+            .ThenBy(r => r.Id)
             .ToListAsync(ct);
 
-        return Proyectar(comprobante, items, pagos);
+        if (remitos.Count == 0)
+        {
+            return [];
+        }
+
+        var idsRemito = remitos.Select(r => r.Id).ToList();
+        var ordenPorRemito = remitos
+            .Select((r, indice) => (r.Id, indice))
+            .ToDictionary(x => x.Id, x => x.indice);
+
+        var items = await db.ItemsRemito.AsNoTracking()
+            .Where(i => idsRemito.Contains(i.IdRemito))
+            .ToListAsync(ct);
+
+        var idsArticulo = items.Select(i => i.IdArticulo).Distinct().ToList();
+        var articuloPorId = await db.Articulos.AsNoTracking()
+            .Where(a => idsArticulo.Contains(a.Id))
+            .ToDictionaryAsync(a => a.Id, ct);
+
+        var ordenados = items
+            .OrderBy(i => ordenPorRemito[i.IdRemito])
+            .ThenBy(i => i.Orden)
+            .ToList();
+
+        var resultado = new List<ItemEmitido>(ordenados.Count);
+        for (var indice = 0; indice < ordenados.Count; indice++)
+        {
+            var item = ordenados[indice];
+            var idArea = articuloPorId.TryGetValue(item.IdArticulo, out var articulo) ? articulo.IdArea : 0;
+
+            resultado.Add(new ItemEmitido(
+                indice + 1, item.IdArticulo, item.Descripcion, CodigoBarra: null, idArea, item.IdListaPrecio,
+                item.IdOferta, item.IdAlicuotaIva, item.PorcentajeIva, item.Cantidad, item.PrecioUnitario,
+                item.Descuento, item.Total, item.IdLote));
+        }
+
+        return resultado;
     }
 
     public async Task<PaginaDeVentas> ListarAsync(
@@ -1585,6 +1658,23 @@ public class ServicioDeVentas(
                     planItem?.IdLote ?? i.IdLote, planItem?.CodigoLote, planItem?.LoteVencido ?? false);
             })
             .ToList(),
+        pagos
+            .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
+            .ToList(),
+        comprobante.IdPresupuestoOrigen);
+
+    /// <summary>OD10: overload para el detalle de un <c>TXR</c>, que ya llega proyectado a
+    /// <see cref="ItemEmitido"/> (join de <c>items_remito</c>, <see cref="ObtenerItemsDeTxrAsync"/>)
+    /// en vez de a partir de <see cref="ItemComprobanteVenta"/> — mismo tail de proyección del
+    /// header/pagos, distinto origen de items.</summary>
+    private static ComprobanteEmitido Proyectar(
+        ComprobanteVenta comprobante, IReadOnlyList<ItemEmitido> items, IReadOnlyList<PagoComprobante> pagos) => new(
+        comprobante.Id, comprobante.Numero,
+        NumeroDeComprobante.Formatear(comprobante.IdPuntoVenta, comprobante.Numero),
+        comprobante.Estado, comprobante.Fecha, comprobante.IdPuntoVenta, comprobante.IdCliente,
+        comprobante.IdComprobanteAsociado, comprobante.Subtotal, comprobante.DescuentoTotal, comprobante.Total,
+        comprobante.DireccionEntrega, comprobante.Observaciones,
+        items,
         pagos
             .Select(p => new PagoEmitido(p.IdMedioPago, p.Importe, p.Referencia, p.Vuelto))
             .ToList(),

--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -31,6 +31,9 @@ import { Presupuesto } from './paginas/Presupuesto'
 import { Presupuestos } from './paginas/Presupuestos'
 import { Proveedores } from './paginas/Proveedores'
 import { PuntosVenta } from './paginas/PuntosVenta'
+import { FacturarRemitos } from './paginas/FacturarRemitos'
+import { Remito } from './paginas/Remito'
+import { Remitos } from './paginas/Remitos'
 import { Reposicion } from './paginas/Reposicion'
 import { RutaCatalogo } from './paginas/RutaCatalogo'
 import { Tablero } from './paginas/Tablero'
@@ -320,6 +323,44 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <Presupuesto />
+                </RutaProtegida>
+              }
+            />
+
+            {/* stage-17-presupuestos-y-remitos (Slice 8, design: Web composition, decisión 17):
+                mismo gate que /presupuestos (Politicas.OperacionDePos) — un Vendedor despacha
+                remitos igual que quotea. `/remitos/facturacion` va ANTES de `/remitos/:id` — un
+                literal más específico gana sobre el parámetro en react-router, pero declararlo
+                primero es el mismo criterio defensivo que el resto de las rutas con hijos. */}
+            <Route
+              path="/remitos"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Remitos />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/remitos/facturacion"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <FacturarRemitos />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/remitos/nuevo"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Remito />
+                </RutaProtegida>
+              }
+            />
+            <Route
+              path="/remitos/:id"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <Remito />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/api/remitos.test.ts
+++ b/src/Ways.Web/src/api/remitos.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  aLineaDeRemitoSolicitada,
+  aSolicitudDeFacturacionDeRemitos,
+  aSolicitudDeRemito,
+  claseDeBadgeDeEstadoRemito,
+  construirQueryDeRemitos,
+  encabezadoDeRemitoVacio,
+  etiquetaDeEstadoRemito,
+  filtrosDeRemitosVacios,
+  itemDeRemitoAFormulario,
+  lineaDeRemitoCompletaParaEnvio,
+  lineaDeRemitoVacia,
+  reducirSeleccionDeRemitos,
+  totalDeRemitosElegidos,
+} from './remitos'
+import type { EstadoRemito, ItemDeRemito } from './tipos'
+
+describe('filtrosDeRemitosVacios / construirQueryDeRemitos', () => {
+  it('sin filtros manda solo pagina/tamanio', () => {
+    expect(construirQueryDeRemitos(filtrosDeRemitosVacios())).toBe('?pagina=1&tamanio=25')
+  })
+
+  it('idPuntoVenta, idCliente y estado viajan tal cual', () => {
+    const query = construirQueryDeRemitos({ ...filtrosDeRemitosVacios(), idPuntoVenta: 7, idCliente: 3, estado: 'Emitido' })
+    expect(query).toContain('idPuntoVenta=7')
+    expect(query).toContain('idCliente=3')
+    expect(query).toContain('estado=Emitido')
+  })
+
+  it('desde/hasta expanden a los bordes del día con el offset horario local', () => {
+    const minutos = new Date(2026, 6, 1).getTimezoneOffset()
+    const signo = minutos > 0 ? '-' : '+'
+    const horas = String(Math.floor(Math.abs(minutos) / 60)).padStart(2, '0')
+    const restoMinutos = String(Math.abs(minutos) % 60).padStart(2, '0')
+    const offset = `${signo}${horas}:${restoMinutos}`
+
+    const query = decodeURIComponent(
+      construirQueryDeRemitos({ ...filtrosDeRemitosVacios(), desde: '2026-07-01', hasta: '2026-07-31' }),
+    )
+    expect(query).toContain(`desde=2026-07-01T00:00:00${offset}`)
+    expect(query).toContain(`hasta=2026-07-31T23:59:59.999${offset}`)
+  })
+})
+
+describe('construirQueryDeRemitos — offset fijo (sin espejar la fórmula de la implementación)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minutos=180 (UTC-3) produce el literal -03:00, nunca Z (mutation-proof-tests regla 10)', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180)
+    const query = decodeURIComponent(construirQueryDeRemitos({ ...filtrosDeRemitosVacios(), desde: '2026-07-01' }))
+    expect(query).toContain('desde=2026-07-01T00:00:00-03:00')
+  })
+})
+
+describe('etiquetaDeEstadoRemito / claseDeBadgeDeEstadoRemito', () => {
+  const estados: EstadoRemito[] = ['Borrador', 'Emitido', 'Facturado', 'Anulado']
+
+  it('cada estado tiene una etiqueta y una clase de badge propias y distintas', () => {
+    const etiquetas = estados.map(etiquetaDeEstadoRemito)
+    const clases = estados.map(claseDeBadgeDeEstadoRemito)
+    expect(new Set(etiquetas).size).toBe(estados.length)
+    expect(new Set(clases).size).toBe(estados.length)
+    expect(etiquetas).toContain('Facturado')
+  })
+})
+
+function itemFixture(sobrescribir: Partial<ItemDeRemito> = {}): ItemDeRemito {
+  return {
+    orden: 1,
+    idArticulo: 10,
+    descripcion: 'Yerba mate 1kg',
+    cantidad: 5,
+    precioUnitario: 1200.5,
+    descuento: 0,
+    total: 6002.5,
+    idListaPrecio: 1,
+    idOferta: null,
+    idAlicuotaIva: 1,
+    porcentajeIva: 21,
+    costoUnitario: null,
+    costoEsEstimado: false,
+    idLote: null,
+    ...sobrescribir,
+  }
+}
+
+describe('itemDeRemitoAFormulario / lineaDeRemitoVacia', () => {
+  it('un item persistido se vuelca tal cual, incluido el idLote congelado', () => {
+    const linea = itemDeRemitoAFormulario(1, itemFixture({ idLote: 55 }))
+    expect(linea).toEqual({ clave: 1, idArticulo: 10, descripcion: 'Yerba mate 1kg', cantidad: '5', idLote: 55 })
+  })
+
+  it('lineaDeRemitoVacia arranca sin artículo, cantidad ni lote', () => {
+    expect(lineaDeRemitoVacia(9)).toEqual({ clave: 9, idArticulo: '', descripcion: '', cantidad: '', idLote: null })
+  })
+})
+
+describe('lineaDeRemitoCompletaParaEnvio', () => {
+  it('sin artículo es incompleta', () => {
+    expect(lineaDeRemitoCompletaParaEnvio(lineaDeRemitoVacia(1))).toBe(false)
+  })
+
+  it('con artículo pero sin cantidad es incompleta', () => {
+    expect(lineaDeRemitoCompletaParaEnvio({ ...lineaDeRemitoVacia(1), idArticulo: 10 })).toBe(false)
+  })
+
+  it('cantidad 0 o negativa es incompleta (CHECK del servidor: cantidad > 0)', () => {
+    expect(lineaDeRemitoCompletaParaEnvio({ ...lineaDeRemitoVacia(1), idArticulo: 10, cantidad: '0' })).toBe(false)
+    expect(lineaDeRemitoCompletaParaEnvio({ ...lineaDeRemitoVacia(1), idArticulo: 10, cantidad: '-3' })).toBe(false)
+  })
+
+  it('artículo + cantidad positiva es completa, sin importar si hay lote elegido', () => {
+    expect(lineaDeRemitoCompletaParaEnvio({ ...lineaDeRemitoVacia(1), idArticulo: 10, cantidad: '5' })).toBe(true)
+    expect(lineaDeRemitoCompletaParaEnvio({ ...lineaDeRemitoVacia(1), idArticulo: 10, cantidad: '5', idLote: 3 })).toBe(true)
+  })
+})
+
+describe('aLineaDeRemitoSolicitada', () => {
+  it('mapea cantidad a número y propaga el idLote elegido', () => {
+    expect(aLineaDeRemitoSolicitada({ clave: 1, idArticulo: 10, descripcion: 'Yerba', cantidad: '7', idLote: 3 })).toEqual({
+      idArticulo: 10,
+      cantidad: 7,
+      idLote: 3,
+    })
+  })
+
+  it('sin lote elegido viaja null (camino feliz de FEFO automático)', () => {
+    expect(aLineaDeRemitoSolicitada({ clave: 1, idArticulo: 10, descripcion: '', cantidad: '2', idLote: null }).idLote).toBeNull()
+  })
+
+  it('cantidad vacía o no numérica mapea a 0 (nunca viaja sola: el filtro de "completa" ya la descartó antes)', () => {
+    expect(aLineaDeRemitoSolicitada({ clave: 1, idArticulo: 10, descripcion: '', cantidad: '', idLote: null }).cantidad).toBe(0)
+  })
+})
+
+describe('aSolicitudDeRemito', () => {
+  it('idCliente vacío viaja como null (Consumidor Final por defecto)', () => {
+    const solicitud = aSolicitudDeRemito({ ...encabezadoDeRemitoVacio(), idPuntoVenta: 2 }, [])
+    expect(solicitud.idCliente).toBeNull()
+  })
+
+  it('recorta direccionEntrega y observaciones vacías a null', () => {
+    const solicitud = aSolicitudDeRemito(
+      { ...encabezadoDeRemitoVacio(), idPuntoVenta: 2, direccionEntrega: '  ', observaciones: '  ' },
+      [],
+    )
+    expect(solicitud.direccionEntrega).toBeNull()
+    expect(solicitud.observaciones).toBeNull()
+  })
+
+  it('filtra las líneas incompletas — nunca viajan a medio llenar', () => {
+    const solicitud = aSolicitudDeRemito({ ...encabezadoDeRemitoVacio(), idPuntoVenta: 2 }, [
+      { clave: 1, idArticulo: 10, descripcion: 'A', cantidad: '5', idLote: null },
+      { clave: 2, idArticulo: '', descripcion: '', cantidad: '', idLote: null },
+    ])
+    expect(solicitud.lineas).toHaveLength(1)
+    expect(solicitud.lineas[0]).toEqual({ idArticulo: 10, cantidad: 5, idLote: null })
+  })
+})
+
+describe('aSolicitudDeFacturacionDeRemitos (consolidación)', () => {
+  it('arma la solicitud sin idCliente — el servidor lo deriva de los remitos (dto-contract-honesty regla 1)', () => {
+    const solicitud = aSolicitudDeFacturacionDeRemitos(7, [1, 2], [{ idMedioPago: 1, importe: 500, referencia: null, vuelto: 0 }], '')
+    expect(solicitud).toEqual({
+      idPuntoVenta: 7,
+      idsRemito: [1, 2],
+      pagos: [{ idMedioPago: 1, importe: 500, referencia: null, vuelto: 0 }],
+      observaciones: null,
+    })
+    expect(solicitud).not.toHaveProperty('idCliente')
+  })
+
+  it('recorta observaciones vacías a null', () => {
+    const solicitud = aSolicitudDeFacturacionDeRemitos(7, [1], [], '   ')
+    expect(solicitud.observaciones).toBeNull()
+  })
+
+  it('conserva observaciones con contenido', () => {
+    const solicitud = aSolicitudDeFacturacionDeRemitos(7, [1], [], ' entrega urgente ')
+    expect(solicitud.observaciones).toBe('entrega urgente')
+  })
+})
+
+describe('totalDeRemitosElegidos', () => {
+  it('suma los totales de los remitos elegidos', () => {
+    expect(totalDeRemitosElegidos([{ total: 100 }, { total: 250.5 }, { total: 10 }])).toBe(360.5)
+  })
+
+  it('sin remitos elegidos da 0', () => {
+    expect(totalDeRemitosElegidos([])).toBe(0)
+  })
+})
+
+describe('reducirSeleccionDeRemitos (task 8.8, multi-select reducer)', () => {
+  it('alternar agrega un id ausente', () => {
+    expect(reducirSeleccionDeRemitos([1, 2], { tipo: 'alternar', id: 3 })).toEqual([1, 2, 3])
+  })
+
+  it('alternar quita un id presente', () => {
+    expect(reducirSeleccionDeRemitos([1, 2, 3], { tipo: 'alternar', id: 2 })).toEqual([1, 3])
+  })
+
+  it('alternar sobre una selección vacía agrega el único id', () => {
+    expect(reducirSeleccionDeRemitos([], { tipo: 'alternar', id: 5 })).toEqual([5])
+  })
+
+  it('elegirTodos reemplaza la selección completa con los ids provistos por el caller', () => {
+    expect(reducirSeleccionDeRemitos([1], { tipo: 'elegirTodos', ids: [4, 5, 6] })).toEqual([4, 5, 6])
+  })
+
+  it('elegirTodos con lista vacía deselecciona todo (mismo efecto que limpiar)', () => {
+    expect(reducirSeleccionDeRemitos([1, 2], { tipo: 'elegirTodos', ids: [] })).toEqual([])
+  })
+
+  it('limpiar vacía la selección sin importar el estado previo', () => {
+    expect(reducirSeleccionDeRemitos([1, 2, 3], { tipo: 'limpiar' })).toEqual([])
+  })
+
+  it('el estado previo nunca se muta — cada acción retorna un array nuevo', () => {
+    const previo = [1, 2]
+    const siguiente = reducirSeleccionDeRemitos(previo, { tipo: 'alternar', id: 3 })
+    expect(siguiente).not.toBe(previo)
+    expect(previo).toEqual([1, 2])
+  })
+})

--- a/src/Ways.Web/src/api/remitos.ts
+++ b/src/Ways.Web/src/api/remitos.ts
@@ -1,0 +1,215 @@
+/**
+ * Cliente HTTP + mappers puros de remitos (stage-17-presupuestos-y-remitos, Slice 8):
+ * CRUD de borrador, `emitir`/`anular`/listado, y la consolidación (`facturacion`) — espejo del
+ * contrato de `Ways.Application.Ventas.ContratosDeRemito`/`RemitosEndpoints`
+ * (design.md: "client + pure mappers; `tipos.ts` mirrors the read/write DTOs").
+ */
+import { api } from './cliente'
+import type {
+  ComprobanteEmitido,
+  EstadoRemito,
+  ItemDeRemito,
+  LineaDeRemito,
+  PaginaDeRemitos,
+  PagoDeVenta,
+  RemitoDetalle,
+  SolicitudDeFacturacionDeRemitos,
+  SolicitudDeRemito,
+} from './tipos'
+
+// ---- Offset local para desde/hasta — mismo criterio que presupuestos.ts/compras.ts/
+// cuentaCorriente.ts: el servidor corre en UTC, `fecha_emision` es `timestamptz` y un
+// `<input type="date">` sin offset se interpretaría como UTC (mutation-proof-tests regla 10).
+// Duplicado a propósito: no hay un módulo compartido de utilidades de fecha en esta web todavía. --
+function desplazamientoUtcLocal(anio: number, mes: number, dia: number): string {
+  const minutos = new Date(anio, mes - 1, dia).getTimezoneOffset()
+  const signo = minutos > 0 ? '-' : '+'
+  const minutosAbsolutos = Math.abs(minutos)
+  const horas = String(Math.floor(minutosAbsolutos / 60)).padStart(2, '0')
+  const restoMinutos = String(minutosAbsolutos % 60).padStart(2, '0')
+  return `${signo}${horas}:${restoMinutos}`
+}
+
+function fechaIsoConOffset(fechaIso: string, horaLimite: string): string {
+  const [anio, mes, dia] = fechaIso.split('-').map(Number)
+  return `${fechaIso}T${horaLimite}${desplazamientoUtcLocal(anio, mes, dia)}`
+}
+
+export type FiltrosDeRemitos = {
+  idPuntoVenta: number | null
+  idCliente: number | null
+  estado: EstadoRemito | null
+  desde: string
+  hasta: string
+  pagina: number
+  tamanio: number
+}
+
+export function filtrosDeRemitosVacios(): FiltrosDeRemitos {
+  return { idPuntoVenta: null, idCliente: null, estado: null, desde: '', hasta: '', pagina: 1, tamanio: 25 }
+}
+
+/** Arma el query string de `GET /api/remitos` — `desde`/`hasta` con el mismo offset horario
+ * explícito que el resto de la web (mutation-proof-tests regla 10). */
+export function construirQueryDeRemitos(filtros: FiltrosDeRemitos): string {
+  const parametros = new URLSearchParams()
+  if (filtros.idPuntoVenta !== null) parametros.set('idPuntoVenta', String(filtros.idPuntoVenta))
+  if (filtros.idCliente !== null) parametros.set('idCliente', String(filtros.idCliente))
+  if (filtros.estado !== null) parametros.set('estado', filtros.estado)
+  if (filtros.desde) parametros.set('desde', fechaIsoConOffset(filtros.desde, '00:00:00'))
+  if (filtros.hasta) parametros.set('hasta', fechaIsoConOffset(filtros.hasta, '23:59:59.999'))
+  parametros.set('pagina', String(filtros.pagina))
+  parametros.set('tamanio', String(filtros.tamanio))
+  return `?${parametros.toString()}`
+}
+
+export const clienteDeRemitos = {
+  listar: (filtros: FiltrosDeRemitos) => api.get<PaginaDeRemitos>(`/remitos${construirQueryDeRemitos(filtros)}`),
+  obtener: (id: number) => api.get<RemitoDetalle>(`/remitos/${id}`),
+  crear: (solicitud: SolicitudDeRemito) => api.post<RemitoDetalle>('/remitos', solicitud),
+  actualizar: (id: number, solicitud: SolicitudDeRemito) => api.put<RemitoDetalle>(`/remitos/${id}`, solicitud),
+  emitir: (id: number) => api.post<RemitoDetalle>(`/remitos/${id}/emitir`),
+  anular: (id: number) => api.post<RemitoDetalle>(`/remitos/${id}/anular`),
+  facturar: (solicitud: SolicitudDeFacturacionDeRemitos) => api.post<ComprobanteEmitido>('/remitos/facturacion', solicitud),
+}
+
+export function etiquetaDeEstadoRemito(estado: EstadoRemito): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'Borrador'
+    case 'Emitido':
+      return 'Emitido'
+    case 'Facturado':
+      return 'Facturado'
+    case 'Anulado':
+      return 'Anulado'
+  }
+}
+
+export function claseDeBadgeDeEstadoRemito(estado: EstadoRemito): string {
+  switch (estado) {
+    case 'Borrador':
+      return 'text-bg-secondary'
+    case 'Emitido':
+      return 'text-bg-primary'
+    case 'Facturado':
+      return 'text-bg-success'
+    case 'Anulado':
+      return 'text-bg-danger'
+  }
+}
+
+// ---- Formulario del editor de borrador: una línea por fila de la grilla (mismo shape que
+// `LineaDePresupuestoFormulario`, con `idLote` opcional — el pick explícito que `emitir` honra,
+// SelectorDeLote.tsx/design.md: "lot picker reusing SelectorDeLote") ------------------------------
+
+export type LineaDeRemitoFormulario = {
+  /** Clave solo de React — el `PUT` es un replace-set completo, ningún `orden` persistido viaja
+   * en el request. */
+  clave: number
+  idArticulo: number | ''
+  descripcion: string
+  cantidad: string
+  idLote: number | null
+}
+
+export function lineaDeRemitoVacia(clave: number): LineaDeRemitoFormulario {
+  return { clave, idArticulo: '', descripcion: '', cantidad: '', idLote: null }
+}
+
+/** Un item ya persistido → fila de formulario, para reabrir un borrador existente. */
+export function itemDeRemitoAFormulario(clave: number, item: ItemDeRemito): LineaDeRemitoFormulario {
+  return { clave, idArticulo: item.idArticulo, descripcion: item.descripcion, cantidad: String(item.cantidad), idLote: item.idLote }
+}
+
+/** Una línea sin artículo o sin cantidad > 0 nunca viaja al servidor — mismo criterio que
+ * `lineaDePresupuestoCompletaParaEnvio`. */
+export function lineaDeRemitoCompletaParaEnvio(l: LineaDeRemitoFormulario): boolean {
+  const cantidad = Number(l.cantidad)
+  return l.idArticulo !== '' && l.cantidad.trim() !== '' && Number.isFinite(cantidad) && cantidad > 0
+}
+
+function numeroDeCantidad(valor: string): number {
+  const n = Number(valor)
+  return valor.trim() === '' || !Number.isFinite(n) ? 0 : n
+}
+
+/** Fila de formulario → `LineaDeRemito` — solo las líneas completas
+ * (`lineaDeRemitoCompletaParaEnvio`) viajan; una fila a medio llenar nunca llega al servidor. */
+export function aLineaDeRemitoSolicitada(l: LineaDeRemitoFormulario): LineaDeRemito {
+  return { idArticulo: Number(l.idArticulo), cantidad: numeroDeCantidad(l.cantidad), idLote: l.idLote }
+}
+
+export type EncabezadoDeRemitoFormulario = {
+  idPuntoVenta: number | ''
+  idCliente: number | ''
+  direccionEntrega: string
+  observaciones: string
+}
+
+export function encabezadoDeRemitoVacio(): EncabezadoDeRemitoFormulario {
+  return { idPuntoVenta: '', idCliente: '', direccionEntrega: '', observaciones: '' }
+}
+
+/** `idCliente` vacío viaja como `null` — Consumidor Final por defecto, mismo criterio que
+ * `SolicitudDePresupuesto`. */
+export function aSolicitudDeRemito(
+  encabezado: EncabezadoDeRemitoFormulario,
+  lineas: LineaDeRemitoFormulario[],
+): SolicitudDeRemito {
+  return {
+    idPuntoVenta: encabezado.idPuntoVenta === '' ? 0 : encabezado.idPuntoVenta,
+    idCliente: encabezado.idCliente === '' ? null : encabezado.idCliente,
+    direccionEntrega: encabezado.direccionEntrega.trim() === '' ? null : encabezado.direccionEntrega.trim(),
+    observaciones: encabezado.observaciones.trim() === '' ? null : encabezado.observaciones.trim(),
+    lineas: lineas.filter(lineaDeRemitoCompletaParaEnvio).map(aLineaDeRemitoSolicitada),
+  }
+}
+
+/**
+ * `RemitoListado[]` elegidos + pagos → `SolicitudDeFacturacionDeRemitos` de la consolidación
+ * (design.md: "pick a cliente + punto de venta, list its emitido unlinked remitos, multi-select,
+ * show the summed total, take payments with the POS payment rows, post the consolidation"). Sin
+ * `idCliente` (`dto-contract-honesty` regla 1: el servidor lo deriva de los remitos mismos).
+ */
+export function aSolicitudDeFacturacionDeRemitos(
+  idPuntoVenta: number,
+  idsRemito: number[],
+  pagos: PagoDeVenta[],
+  observaciones: string,
+): SolicitudDeFacturacionDeRemitos {
+  return {
+    idPuntoVenta,
+    idsRemito,
+    pagos,
+    observaciones: observaciones.trim() === '' ? null : observaciones.trim(),
+  }
+}
+
+/** `Σ total` de los remitos elegidos para facturar — reducer puro usado tanto por el cálculo del
+ * panel de pagos como por el total mostrado en pantalla (web-descriptor-tests: cubierto con
+ * fixtures de valores pairwise-distintos). */
+export function totalDeRemitosElegidos(remitos: { total: number }[]): number {
+  return remitos.reduce((acumulado, r) => acumulado + r.total, 0)
+}
+
+// ---- Multi-select de `FacturarRemitos.tsx` (task 8.8: reducer puro con su propio test) -----------
+
+export type AccionDeSeleccionDeRemitos =
+  | { tipo: 'alternar'; id: number }
+  | { tipo: 'elegirTodos'; ids: number[] }
+  | { tipo: 'limpiar' }
+
+/** Reducer puro del multi-select — `ids` viaja completo en `elegirTodos` (nunca se calcula acá
+ * cuáles son "todos", eso lo decide el caller con la lista filtrada vigente). `alternar` no
+ * duplica un id ya presente ni dos veces (idempotente sobre el mismo id repetido). */
+export function reducirSeleccionDeRemitos(seleccionados: number[], accion: AccionDeSeleccionDeRemitos): number[] {
+  switch (accion.tipo) {
+    case 'alternar':
+      return seleccionados.includes(accion.id) ? seleccionados.filter((id) => id !== accion.id) : [...seleccionados, accion.id]
+    case 'elegirTodos':
+      return accion.ids
+    case 'limpiar':
+      return []
+  }
+}

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -1979,3 +1979,93 @@ export type PresupuestoListado = {
 
 /** Página de `GET /api/presupuestos` (espejo de `PaginaDePresupuestos`). */
 export type PaginaDePresupuestos = { items: PresupuestoListado[]; total: number; pagina: number; tamanio: number }
+
+// --- Remitos (stage-17-presupuestos-y-remitos, Slice 8) — espejo de
+// `Ways.Application.Ventas.ContratosDeRemito` / `Ways.Domain.Ventas.EstadoRemito` -----------------
+
+/** Espejo de `EstadoRemito` — el orden de los miembros ES el orden de ciclo de vida (mismo
+ * criterio que `EstadoPresupuesto`). */
+export type EstadoRemito = 'Borrador' | 'Emitido' | 'Facturado' | 'Anulado'
+
+/** Una línea del cuerpo de `POST`/`PUT /api/remitos` (espejo de `LineaDeRemito`). `idLote` es la
+ * elección EXPLÍCITA del cliente antes de `emitir` (a diferencia de `LineaDePresupuesto`) — `null`
+ * es el camino feliz de cero tecleo, el servidor corre FEFO solo. */
+export type LineaDeRemito = { idArticulo: number; cantidad: number; idLote: number | null }
+
+/** Cuerpo de `POST /api/remitos` (crea un borrador) y `PUT /api/remitos/{id}` (replace-set
+ * completo del header + los items — espejo de `SolicitudDeRemito`). `idCliente` omitido resuelve a
+ * Consumidor Final, mismo criterio que `SolicitudDePresupuesto`. */
+export type SolicitudDeRemito = {
+  idPuntoVenta: number
+  idCliente: number | null
+  direccionEntrega: string | null
+  observaciones: string | null
+  lineas: LineaDeRemito[]
+}
+
+/** Un item ya persistido — espejo de `ItemDeRemito`. `costoUnitario`/`costoEsEstimado`/`idLote`
+ * quedan `null`/`false` mientras el remito está en `borrador` (salvo `idLote`, que el cliente
+ * puede fijar de antemano) y recién se congelan al `emitir`. */
+export type ItemDeRemito = {
+  orden: number
+  idArticulo: number
+  descripcion: string
+  cantidad: number
+  precioUnitario: number
+  descuento: number
+  total: number
+  idListaPrecio: number
+  idOferta: number | null
+  idAlicuotaIva: number
+  porcentajeIva: number
+  costoUnitario: number | null
+  costoEsEstimado: boolean
+  idLote: number | null
+}
+
+/** Respuesta de `POST/PUT /api/remitos`, `POST /{id}/emitir`, `POST /{id}/anular` y `GET /{id}` —
+ * espejo de `RemitoDetalle`. Sin `vencido`/`convertible`: un remito no expira. */
+export type RemitoDetalle = {
+  id: number
+  idPuntoVenta: number
+  idCliente: number
+  idEmpleado: number
+  numero: number | null
+  numeroFormateado: string | null
+  fechaEmision: string
+  fechaSalida: string | null
+  direccionEntrega: string | null
+  observaciones: string | null
+  subtotal: number
+  descuentoTotal: number
+  total: number
+  estado: EstadoRemito
+  idComprobanteVenta: number | null
+  items: ItemDeRemito[]
+}
+
+/** Fila de `GET /api/remitos` — espejo de `RemitoListado`. */
+export type RemitoListado = {
+  id: number
+  idPuntoVenta: number
+  idCliente: number
+  numero: number | null
+  numeroFormateado: string | null
+  fechaEmision: string
+  total: number
+  estado: EstadoRemito
+  idComprobanteVenta: number | null
+}
+
+/** Página de `GET /api/remitos` (espejo de `PaginaDeRemitos`). */
+export type PaginaDeRemitos = { items: RemitoListado[]; total: number; pagina: number; tamanio: number }
+
+/** Cuerpo de `POST /api/remitos/facturacion` (espejo de `SolicitudDeFacturacionDeRemitos`). Sin
+ * `idCliente` (`dto-contract-honesty` regla 1): el cliente se DERIVA de los remitos mismos — un
+ * valor en conflicto no tendría destino real. `pagos` mismo shape que el checkout. */
+export type SolicitudDeFacturacionDeRemitos = {
+  idPuntoVenta: number
+  idsRemito: number[]
+  pagos: PagoDeVenta[]
+  observaciones: string | null
+}

--- a/src/Ways.Web/src/api/ventas.ts
+++ b/src/Ways.Web/src/api/ventas.ts
@@ -22,6 +22,10 @@ export const clienteDeVentas = {
   /** `POST /api/ventas` (design: API Surface): checkout — 201 + body = comprobante emitido, sin
    * ningún campo de dinero re-derivable en el cliente (el servidor vuelve a resolver todo). */
   emitir: (solicitud: SolicitudDeVenta) => api.post<ComprobanteEmitido>('/ventas', solicitud),
+  /** `GET /api/ventas/{id}` (stage-17-presupuestos-y-remitos, Slice 8, OD10): reimpresión/lectura
+   * de un comprobante ya emitido — `Remito.tsx` lo usa para mostrar el link a la factura de un
+   * remito `facturado` (un `TXR`, cuyo detalle sale de `items_remito` del lado del servidor). */
+  obtener: (id: number) => api.get<ComprobanteEmitido>(`/ventas/${id}`),
 }
 
 /** Respuesta de `GET /api/articulos/escaneo` → acción `escanear` de `carrito.ts` (spec:

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -74,6 +74,15 @@ export function Layout() {
                     </NavLink>
                   </li>
                 )}
+                {/* stage-17-presupuestos-y-remitos (Slice 8, design: Web composition): mismo gate
+                    que /presupuestos (Politicas.OperacionDePos) — nav y ruta comparten política. */}
+                {usuario && puedeOperarPos(usuario.rolId) && (
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/remitos">
+                      Remitos
+                    </NavLink>
+                  </li>
+                )}
                 {/* stage-10-agregacion-dashboard (Slice 7, design: Web Composition): nav y ruta
                     comparten Politicas.LecturaDeReportes — Supervisor + Admin, ni Vendedor ni
                     Root. */}

--- a/src/Ways.Web/src/componentes/SelectorDeLote.tsx
+++ b/src/Ways.Web/src/componentes/SelectorDeLote.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react'
+import { clienteDeStock } from '../api/stock'
+import { ErrorApi } from '../api/cliente'
+import { opcionDeLote } from '../api/ventas'
+import type { LoteListado } from '../api/tipos'
+
+export type PropsSelectorDeLote = {
+  idPuntoVenta: number
+  idArticulo: number
+  nombreArticulo: string
+  idLoteElegido: number | null
+  disabled: boolean
+  onElegir: (idLote: number | null) => void
+}
+
+/**
+ * Picker de lote de una línea (stage-12-lotes-vencimientos, Slice 14, design decisión 19): se
+ * pide bajo demanda (click en "Elegir lote") — el camino feliz de cero tecleo (omitir `idLote`,
+ * el servidor resuelve FEFO solo) nunca dispara este fetch. `sugerido` llega ya resuelto del
+ * servidor (`ReglaDeLotes.ElegirFefo`); acá solo se resalta, nunca se recalcula.
+ *
+ * stage-17-presupuestos-y-remitos (Slice 8, design.md:416-418): extraído de `Pos.tsx` (nació ahí
+ * en Slice 14) a este módulo compartido — `Remito.tsx` lo reusa tal cual para el pick de lote del
+ * borrador, mismo criterio literal de "lot picker reusing SelectorDeLote" del design. Ambos call
+ * sites importan de acá; ninguno mantiene una copia local.
+ */
+export function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegido, disabled, onElegir }: PropsSelectorDeLote) {
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState('')
+  const [lotes, setLotes] = useState<LoteListado[] | null>(null)
+  const tokenRef = useRef(0)
+
+  // react-async-state regla 3: los saldos de lote son por punto de venta — un cambio de PV
+  // invalida cualquier fetch en vuelo y cualquier lote ya cargado, nunca puede sobrevivir a la
+  // selección anterior (mutation-proof-tests regla 7: probado resolviendo la promesa vieja
+  // DESPUÉS del cambio de PV, dentro de `act`).
+  useEffect(() => {
+    tokenRef.current += 1
+    setCargando(false)
+    setError('')
+    setLotes(null)
+  }, [idPuntoVenta, idArticulo])
+
+  async function cargar() {
+    // El guard de reentrancia de primera línea es el `disabled` nativo del botón (más abajo):
+    // JSDOM y los navegadores no despachan `click` sobre un elemento disabled, así que un
+    // `cargandoRef` extra acá era inalcanzable — verificado por mutación en judgment-day
+    // (slice 14, MAJOR 2b). `lotes !== null` sigue evitando un refetch tras una carga exitosa.
+    if (lotes !== null) return
+
+    const miToken = (tokenRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    try {
+      const resultado = await clienteDeStock.listarLotes(idPuntoVenta, idArticulo)
+      if (tokenRef.current !== miToken) return
+      setLotes(resultado)
+    } catch (e) {
+      if (tokenRef.current !== miToken) return
+      setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
+    } finally {
+      if (tokenRef.current === miToken) {
+        setCargando(false)
+      }
+    }
+  }
+
+  if (lotes === null) {
+    return (
+      <div>
+        <button type="button" className="btn btn-sm btn-outline-secondary rounded-0" disabled={disabled || cargando} onClick={cargar}>
+          {cargando ? 'Cargando…' : 'Elegir lote'}
+        </button>
+        {error && <div className="small text-danger">{error}</div>}
+      </div>
+    )
+  }
+
+  if (lotes.length === 0) {
+    return <span className="small text-muted">Sin lotes registrados — FEFO automático.</span>
+  }
+
+  const sugerido = lotes.find((l) => l.sugerido) ?? null
+  const valorActual = idLoteElegido !== null ? String(idLoteElegido) : sugerido ? String(sugerido.idLote) : ''
+
+  return (
+    <select
+      className="form-select form-select-sm rounded-0"
+      aria-label={`Lote de ${nombreArticulo}`}
+      value={valorActual}
+      disabled={disabled}
+      onChange={(e) => onElegir(e.target.value === '' ? null : Number(e.target.value))}
+    >
+      <option value="">FEFO automático (recomendado)</option>
+      {lotes.map((l) => {
+        const opcion = opcionDeLote(l)
+        return (
+          <option key={l.idLote} value={opcion.valor}>
+            {opcion.etiqueta}
+          </option>
+        )
+      })}
+    </select>
+  )
+}

--- a/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
+++ b/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
@@ -1,0 +1,311 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FacturarRemitos } from './FacturarRemitos'
+import type { ClienteListado, ComprobanteEmitido, MedioPagoListado, PaginaDeRemitos, ParametroResuelto, PuntoVentaListado, RemitoListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 1,
+    numero: 1,
+    nombre: 'Consumidor Final',
+    apellido: null,
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: true,
+    ...sobrescribir,
+  }
+}
+
+function medioFixture(sobrescribir: Partial<MedioPagoListado> = {}): MedioPagoListado {
+  return {
+    id: 1,
+    nombre: 'Efectivo',
+    comportamiento: 'Efectivo',
+    admiteVuelto: true,
+    requiereReferencia: false,
+    activo: true,
+    orden: 1,
+    idEmpresa: null,
+    recargoPorcentaje: null,
+    ...sobrescribir,
+  }
+}
+
+function remitoFixture(sobrescribir: Partial<RemitoListado> = {}): RemitoListado {
+  return {
+    id: 1,
+    idPuntoVenta: 7,
+    idCliente: 1,
+    numero: 12,
+    numeroFormateado: '0007-00000012',
+    fechaEmision: '2026-08-01T12:00:00Z',
+    total: 500,
+    estado: 'Emitido',
+    idComprobanteVenta: null,
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(sobrescribir: Partial<PaginaDeRemitos> = {}): PaginaDeRemitos {
+  return { items: [remitoFixture()], total: 1, pagina: 1, tamanio: 200, ...sobrescribir }
+}
+
+function comprobanteFixture(sobrescribir: Partial<ComprobanteEmitido> = {}): ComprobanteEmitido {
+  return {
+    id: 90,
+    numero: 5,
+    numeroVisible: '0007-00000005',
+    estado: 'Emitido',
+    fecha: '2026-08-20T12:00:00Z',
+    idPuntoVenta: 7,
+    idCliente: 1,
+    idComprobanteAsociado: null,
+    subtotal: 500,
+    descuentoTotal: 0,
+    total: 500,
+    direccionEntrega: null,
+    observaciones: null,
+    items: [],
+    pagos: [],
+    idPresupuestoOrigen: null,
+    ...sobrescribir,
+  }
+}
+
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/clientes') return Promise.resolve({ items: [clienteFixture()], total: 1, pagina: 1, tamanio: 25 })
+    if (ruta === '/catalogos/medios-pago') return Promise.resolve([medioFixture()])
+    if (ruta.startsWith('/parametros/tolerancia_pago')) return Promise.resolve({ clave: 'tolerancia_pago', valor: '0' } satisfies ParametroResuelto)
+    if (ruta.startsWith('/parametros/vuelto_maximo')) return Promise.resolve({ clave: 'vuelto_maximo', valor: '0' } satisfies ParametroResuelto)
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/remitos?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla() {
+  return render(<FacturarRemitos />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+async function elegirClientePuntoVenta() {
+  await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Centro')
+  await userEvent.selectOptions(screen.getByLabelText('Cliente'), '#1 — Consumidor Final')
+}
+
+/** "Falta" y "Total a facturar" pueden mostrar el mismo monto formateado a la vez — se espera
+ * al menos una aparición en vez de una única coincidencia (evita el falso "multiple elements"
+ * de `findByText` cuando dos textos legítimos comparten el mismo valor). */
+async function esperarMonto(texto: string) {
+  await waitFor(() => expect(screen.getAllByText(texto).length).toBeGreaterThan(0))
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+})
+
+describe('FacturarRemitos — picker cliente + punto de venta', () => {
+  it('sin elegir ambos, muestra el mensaje guía y no lista remitos', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    expect(await screen.findByText(/Elegí un punto de venta y un cliente/)).toBeInTheDocument()
+    expect(apiGetMock.mock.calls.some((c) => String(c[0]).startsWith('/remitos?'))).toBe(false)
+  })
+
+  it('al elegir ambos, lista los remitos emitido sin ligar de ese par', async () => {
+    mockearRutasBase()
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+
+    await elegirClientePuntoVenta()
+
+    expect(await screen.findByText('0007-00000012')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(apiGetMock).toHaveBeenCalledWith(expect.stringMatching(/^\/remitos\?.*idPuntoVenta=7.*idCliente=1.*estado=Emitido|^\/remitos\?.*idCliente=1.*idPuntoVenta=7.*estado=Emitido/)),
+    )
+  })
+
+  it('sin remitos emitidos sin ligar, muestra el estado vacío', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/remitos?') ? Promise.resolve(paginaFixture({ items: [], total: 0 })) : undefined))
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+
+    await elegirClientePuntoVenta()
+
+    expect(await screen.findByText(/no tiene remitos emitidos sin facturar/)).toBeInTheDocument()
+  })
+})
+
+describe('FacturarRemitos — multi-select (task 8.8)', () => {
+  it('elegir un remito suma su total al total a facturar', async () => {
+    mockearRutasBase((ruta) =>
+      ruta.startsWith('/remitos?')
+        ? Promise.resolve(paginaFixture({ items: [remitoFixture({ id: 1, total: 500 }), remitoFixture({ id: 2, numeroFormateado: '0007-00000013', total: 300 })] }))
+        : undefined,
+    )
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000012'))
+    await esperarMonto('$500,00')
+
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000013'))
+    await esperarMonto('$800,00')
+  })
+
+  it('"Elegir todos" selecciona/deselecciona el conjunto completo', async () => {
+    mockearRutasBase((ruta) =>
+      ruta.startsWith('/remitos?')
+        ? Promise.resolve(paginaFixture({ items: [remitoFixture({ id: 1, total: 500 }), remitoFixture({ id: 2, numeroFormateado: '0007-00000013', total: 300 })] }))
+        : undefined,
+    )
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.click(screen.getByLabelText('Elegir todos'))
+    await esperarMonto('$800,00')
+    expect(screen.getByLabelText('Elegir remito 0007-00000012')).toBeChecked()
+    expect(screen.getByLabelText('Elegir remito 0007-00000013')).toBeChecked()
+
+    await userEvent.click(screen.getByLabelText('Elegir todos'))
+    expect(screen.getByLabelText('Elegir remito 0007-00000012')).not.toBeChecked()
+    expect(screen.getByLabelText('Elegir remito 0007-00000013')).not.toBeChecked()
+  })
+
+  it('cambiar el cliente/punto de venta limpia la selección previa', async () => {
+    mockearRutasBase()
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000012'))
+    expect(await screen.findByText('Total a facturar (1 remito(s))')).toBeInTheDocument()
+
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), '')
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Centro')
+
+    // El checkbox de la fila vuelve a aparecer sin marcar — el conteo del resumen cae a 0, no
+    // arrastra la selección del par cliente/PV anterior.
+    await screen.findByText('0007-00000012')
+    expect(screen.getByText('Total a facturar (0 remito(s))')).toBeInTheDocument()
+    expect(screen.getByLabelText('Elegir remito 0007-00000012')).not.toBeChecked()
+  })
+})
+
+describe('FacturarRemitos — doble click en "Facturar" (react-async-state regla 9, tarea 8.10)', () => {
+  it('dispara exactamente un POST', async () => {
+    mockearRutasBase()
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000012'))
+
+    await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), 'Efectivo')
+    await userEvent.type(screen.getByLabelText(/Importe de Efectivo/), '500')
+
+    let resolverFacturar: (v: ComprobanteEmitido) => void = () => {}
+    const facturarPendiente = new Promise<ComprobanteEmitido>((resolve) => {
+      resolverFacturar = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/facturacion' ? facturarPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    const boton = await screen.findByRole('button', { name: 'Facturar' })
+    expect(boton).toBeEnabled()
+
+    // Los dos dispatchEvent viajan DENTRO de un mismo act() — jsdom no no-opea un click sobre un
+    // elemento disabled, mismo patrón que Presupuesto.test.tsx/Remito.test.tsx.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/remitos/facturacion')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Facturando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverFacturar(comprobanteFixture())
+      await facturarPendiente
+    })
+
+    expect(await screen.findByText(/Comprobante/)).toBeInTheDocument()
+  })
+
+  it('el POST nunca manda idCliente (dto-contract-honesty regla 1: el servidor lo deriva de los remitos)', async () => {
+    mockearRutasBase()
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/facturacion' ? Promise.resolve(comprobanteFixture()) : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000012'))
+    await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), 'Efectivo')
+    await userEvent.type(screen.getByLabelText(/Importe de Efectivo/), '500')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Facturar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/remitos/facturacion', expect.not.objectContaining({ idCliente: expect.anything() })))
+  })
+})

--- a/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
+++ b/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
@@ -254,6 +254,51 @@ describe('FacturarRemitos — multi-select (task 8.8)', () => {
   })
 })
 
+describe('FacturarRemitos — guard de stale en cargarRemitos (mutation-proof-tests regla 7)', () => {
+  it('una respuesta stale del cliente anterior no pisa la del cliente más nuevo, sobre la misma instancia montada', async () => {
+    let resolverListaClienteA: (v: PaginaDeRemitos) => void = () => {}
+    let promesaListaClienteA: Promise<PaginaDeRemitos> = Promise.resolve(paginaFixture())
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+      if (ruta === '/clientes')
+        return Promise.resolve({ items: [clienteFixture(), clienteFixture({ id: 2, numero: 2, nombre: 'Cliente B' })], total: 2, pagina: 1, tamanio: 25 })
+      if (ruta === '/catalogos/medios-pago') return Promise.resolve([medioFixture()])
+      if (ruta.startsWith('/parametros/tolerancia_pago')) return Promise.resolve({ clave: 'tolerancia_pago', valor: '0' } satisfies ParametroResuelto)
+      if (ruta.startsWith('/parametros/vuelto_maximo')) return Promise.resolve({ clave: 'vuelto_maximo', valor: '0' } satisfies ParametroResuelto)
+      // Cliente A (id 1): el fetch de sus remitos queda en vuelo — se resuelve MÁS TARDE, DESPUÉS
+      // de que el cambio a Cliente B ya haya recargado.
+      if (ruta.startsWith('/remitos?') && ruta.includes('idCliente=1')) {
+        promesaListaClienteA = new Promise((resolve) => (resolverListaClienteA = resolve))
+        return promesaListaClienteA
+      }
+      if (ruta.startsWith('/remitos?') && ruta.includes('idCliente=2')) {
+        return Promise.resolve(paginaFixture({ items: [remitoFixture({ id: 9, idCliente: 2, numeroFormateado: '0007-00000099' })] }))
+      }
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Centro')
+    await userEvent.selectOptions(screen.getByLabelText('Cliente'), '#1 — Consumidor Final')
+    // El fetch de remitos del Cliente A queda en vuelo — `resolverListaClienteA` todavía no se llamó.
+
+    await userEvent.selectOptions(screen.getByLabelText('Cliente'), '#2 — Cliente B')
+    await screen.findByText('0007-00000099')
+
+    // regla 7: el flush del microtask stale va DENTRO de act — resolver DESPUÉS de que el
+    // cliente más nuevo ya aterrizó no puede pisar la lista mostrada.
+    await act(async () => {
+      resolverListaClienteA(paginaFixture({ items: [remitoFixture({ id: 1, numeroFormateado: '0007-00000012' })] }))
+      await promesaListaClienteA
+    })
+
+    expect(screen.getByText('0007-00000099')).toBeInTheDocument()
+    expect(screen.queryByText('0007-00000012')).not.toBeInTheDocument()
+  })
+})
+
 describe('FacturarRemitos — doble click en "Facturar" (react-async-state regla 9, tarea 8.10)', () => {
   it('dispara exactamente un POST', async () => {
     mockearRutasBase()
@@ -306,6 +351,44 @@ describe('FacturarRemitos — doble click en "Facturar" (react-async-state regla
 
     await userEvent.click(screen.getByRole('button', { name: 'Facturar' }))
 
-    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/remitos/facturacion', expect.not.objectContaining({ idCliente: expect.anything() })))
+    // judgment-day Slice 8, ronda 1, juez B — MINOR: `expect.not.objectContaining` con
+    // `expect.anything()` NO matchea un valor `null` explícito (el matcher de Jest/Vitest solo
+    // discrimina "está ausente", no "es null") — assert fuerte: la KEY `idCliente` no existe en
+    // absoluto en el body posteado.
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalled())
+    const [, bodyIdCliente] = apiPostMock.mock.calls.find((c) => c[0] === '/remitos/facturacion')!
+    expect(Object.keys(bodyIdCliente as object)).not.toContain('idCliente')
+  })
+
+  it('el POST lleva idsRemito EXACTAMENTE igual al subconjunto elegido, nunca todos los listados', async () => {
+    mockearRutasBase((ruta) =>
+      ruta.startsWith('/remitos?')
+        ? Promise.resolve(
+            paginaFixture({
+              items: [
+                remitoFixture({ id: 1, total: 500 }),
+                remitoFixture({ id: 2, numeroFormateado: '0007-00000013', total: 300 }),
+                remitoFixture({ id: 3, numeroFormateado: '0007-00000014', total: 200 }),
+              ],
+            }),
+          )
+        : undefined,
+    )
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/facturacion' ? Promise.resolve(comprobanteFixture()) : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+    renderPantalla()
+    await screen.findByLabelText('Punto de venta')
+    await elegirClientePuntoVenta()
+    await screen.findByText('0007-00000012')
+
+    // Subconjunto propio: remitos 1 y 3, NUNCA el 2 (listado pero sin tildar) — mutation target:
+    // un mapper que mandara TODOS los remitos listados en vez de los tildados lo delataría acá.
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000012'))
+    await userEvent.click(screen.getByLabelText('Elegir remito 0007-00000014'))
+    await userEvent.selectOptions(screen.getByLabelText('Medio de pago'), 'Efectivo')
+    await userEvent.type(screen.getByLabelText(/Importe de Efectivo/), '700')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Facturar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/remitos/facturacion', expect.objectContaining({ idsRemito: [1, 3] })))
   })
 })

--- a/src/Ways.Web/src/paginas/FacturarRemitos.tsx
+++ b/src/Ways.Web/src/paginas/FacturarRemitos.tsx
@@ -1,0 +1,532 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { Link } from 'react-router'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeCatalogo } from '../api/catalogos'
+import { clienteDeClientes } from '../api/clientes'
+import {
+  aPagosDeVenta,
+  calcularExcedente,
+  calcularFaltante,
+  filaPagoVacia,
+  filasAPagosConVuelto,
+  medioDisponibleParaCliente,
+  validarPagosLocal,
+  type FilaPago,
+} from '../api/pagos'
+import { aSolicitudDeFacturacionDeRemitos, clienteDeRemitos, filtrosDeRemitosVacios, reducirSeleccionDeRemitos, totalDeRemitosElegidos } from '../api/remitos'
+import type { ClienteListado, MedioPagoAlta, MedioPagoListado, ParametroResuelto, PuntoVentaListado, RemitoListado } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function etiquetaDeCampoFila(prefijo: string, medioDeFila: MedioPagoListado | null, idFila: number): string {
+  return `${prefijo} de ${medioDeFila?.nombre ?? 'medio de pago'} (fila ${idFila})`
+}
+
+/**
+ * Consolidación de remitos (stage-17-presupuestos-y-remitos, Slice 8; design.md:419-421): elegí
+ * cliente + punto de venta, listá sus remitos `emitido` sin ligar, multi-selección con el total
+ * sumado, tomá pago(s) con las mismas filas del POS, y postea `POST /api/remitos/facturacion`.
+ *
+ * **Degradación pre-aprobada** (design.md, "Slices 7/8 overflow"): si este slice desborda, el
+ * multi-select cae a de-a-uno — la API ya admite un array de un solo id, así que esta pantalla no
+ * necesitaría ningún cambio de contrato para degradar, solo perdería el checkbox "elegir todos".
+ * Registrado acá para que la próxima persona que la toque sepa que el corte ya está pre-aprobado y
+ * no es una regresión si algún día se aplica.
+ */
+export function FacturarRemitos() {
+  // ---- referencia (puntos de venta/clientes/medios) -----------------------------------------------
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [clientes, setClientes] = useState<ClienteListado[] | null>(null)
+  const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => vigente && setPuntosVenta(lista))
+      .catch((e) => {
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((p) => vigente && setClientes(p.items))
+      .catch((e) => {
+        setClientes([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.'))
+      })
+
+    clienteMediosPago
+      .listar(false)
+      .then((lista) => vigente && setMedios(lista))
+      .catch((e) => {
+        setMedios([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los medios de pago.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const referenciaOk = puntosVenta !== null && clientes !== null && medios !== null && errorReferencia === ''
+  const medioPorId: Record<number, MedioPagoListado> = {}
+  for (const m of medios ?? []) medioPorId[m.id] = m
+
+  // ---- picker cliente + punto de venta ------------------------------------------------------------
+  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
+  const [idCliente, setIdCliente] = useState<number | ''>('')
+  const clienteElegido = clientes?.find((c) => c.id === idCliente) ?? null
+  const puntoVentaElegido = puntosVenta?.find((pv) => pv.id === idPuntoVenta) ?? null
+
+  // ---- listado de remitos `emitido` sin ligar del par cliente/PV elegido ---------------------------
+  const [remitos, setRemitos] = useState<RemitoListado[] | null>(null)
+  const [cargandoRemitos, setCargandoRemitos] = useState(false)
+  const [errorRemitos, setErrorRemitos] = useState('')
+  const generacionRemitosRef = useRef(0)
+
+  const cargarRemitos = useCallback(() => {
+    if (idPuntoVenta === '' || idCliente === '') {
+      setRemitos(null)
+      return
+    }
+
+    const miGeneracion = (generacionRemitosRef.current += 1)
+    setCargandoRemitos(true)
+    setErrorRemitos('')
+
+    clienteDeRemitos
+      .listar({ ...filtrosDeRemitosVacios(), idPuntoVenta, idCliente, estado: 'Emitido', tamanio: 200 })
+      .then((pagina) => {
+        if (generacionRemitosRef.current !== miGeneracion) return
+        setRemitos(pagina.items)
+      })
+      .catch((e) => {
+        if (generacionRemitosRef.current !== miGeneracion) return
+        setRemitos(null)
+        setErrorRemitos(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los remitos.')
+      })
+      .finally(() => {
+        if (generacionRemitosRef.current !== miGeneracion) return
+        setCargandoRemitos(false)
+      })
+  }, [idPuntoVenta, idCliente])
+
+  useEffect(() => {
+    cargarRemitos()
+  }, [cargarRemitos])
+
+  // ---- multi-select (task 8.8: reducer puro, `reducirSeleccionDeRemitos`) --------------------------
+  const [seleccionados, dispatchSeleccion] = useReducer(reducirSeleccionDeRemitos, [] as number[])
+
+  // Un cambio de cliente/PV invalida cualquier selección previa — un remito de OTRO par ya no
+  // aparece en la lista, así que dejarlo "elegido" mandaría un id fantasma al servidor.
+  useEffect(() => {
+    dispatchSeleccion({ tipo: 'limpiar' })
+  }, [idPuntoVenta, idCliente])
+
+  const remitosElegidos = (remitos ?? []).filter((r) => seleccionados.includes(r.id))
+  const total = totalDeRemitosElegidos(remitosElegidos)
+  const todosElegidos = (remitos ?? []).length > 0 && seleccionados.length === (remitos ?? []).length
+
+  // ---- parámetros de pago (tolerancia/vuelto), por punto de venta — mismo criterio que Pos.tsx ----
+  const [parametros, setParametros] = useState<{ toleranciaPago: number; vueltoMaximo: number } | null>(null)
+  const [errorParametros, setErrorParametros] = useState('')
+  const generacionParametrosRef = useRef(0)
+
+  useEffect(() => {
+    if (!puntoVentaElegido) {
+      setParametros(null)
+      setErrorParametros('')
+      return
+    }
+
+    const generacion = (generacionParametrosRef.current += 1)
+    let vigente = true
+
+    Promise.all([
+      api.get<ParametroResuelto>(`/parametros/tolerancia_pago?idEmpresa=${puntoVentaElegido.idEmpresa}&idPuntoVenta=${puntoVentaElegido.id}`),
+      api.get<ParametroResuelto>(`/parametros/vuelto_maximo?idEmpresa=${puntoVentaElegido.idEmpresa}&idPuntoVenta=${puntoVentaElegido.id}`),
+    ])
+      .then(([tolerancia, vuelto]) => {
+        if (!vigente || generacionParametrosRef.current !== generacion) return
+        setParametros({ toleranciaPago: Number(tolerancia.valor), vueltoMaximo: Number(vuelto.valor) })
+        setErrorParametros('')
+      })
+      .catch((e) => {
+        if (!vigente || generacionParametrosRef.current !== generacion) return
+        setParametros(null)
+        setErrorParametros(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los parámetros de pago. No se puede facturar.')
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [puntoVentaElegido])
+
+  // ---- panel de pagos — mismas filas/mappers puros del POS ------------------------------------------
+  const proximaFilaPagoIdRef = useRef(1)
+  const [filasPago, setFilasPago] = useState<FilaPago[]>(() => [filaPagoVacia(proximaFilaPagoIdRef.current++)])
+  const [observaciones, setObservaciones] = useState('')
+
+  const [facturando, setFacturando] = useState(false)
+  const facturandoRef = useRef(false)
+  const [errorFacturar, setErrorFacturar] = useState('')
+  const [facturado, setFacturado] = useState<{ numeroVisible: string; total: number } | null>(null)
+
+  const ocupado = facturando
+
+  function agregarFilaPago() {
+    if (ocupado) return
+    const id = proximaFilaPagoIdRef.current++
+    setFilasPago((prev) => [...prev, filaPagoVacia(id)])
+  }
+
+  function quitarFilaPago(id: number) {
+    if (ocupado) return
+    setFilasPago((prev) => prev.filter((f) => f.id !== id))
+  }
+
+  function cambiarMedioDeFila(id: number, idMedioPago: number | '') {
+    if (ocupado) return
+    setFilasPago((prev) => prev.map((f) => (f.id === id ? { ...f, idMedioPago, vueltoManual: '' } : f)))
+  }
+
+  function cambiarImporteDeFila(id: number, importe: string) {
+    if (ocupado) return
+    setFilasPago((prev) => prev.map((f) => (f.id === id ? { ...f, importe } : f)))
+  }
+
+  function cambiarReferenciaDeFila(id: number, referencia: string) {
+    if (ocupado) return
+    setFilasPago((prev) => prev.map((f) => (f.id === id ? { ...f, referencia } : f)))
+  }
+
+  function cambiarVueltoDeFila(id: number, vueltoManual: string) {
+    if (ocupado) return
+    setFilasPago((prev) => prev.map((f) => (f.id === id ? { ...f, vueltoManual } : f)))
+  }
+
+  const pagosConVuelto = filasAPagosConVuelto(filasPago, medioPorId, total)
+  const faltante = calcularFaltante(total, pagosConVuelto)
+  const excedente = calcularExcedente(total, pagosConVuelto)
+
+  const rechazoLocal =
+    seleccionados.length === 0 || !clienteElegido || !puntoVentaElegido || !parametros
+      ? null
+      : validarPagosLocal({
+          total,
+          pagos: pagosConVuelto,
+          toleranciaPago: parametros.toleranciaPago,
+          vueltoMaximo: parametros.vueltoMaximo,
+          esConsumidorFinal: clienteElegido.esConsumidorFinal,
+          saldoCliente: clienteElegido.saldo,
+          limiteCredito: clienteElegido.limiteCredito,
+          creditoIlimitado: clienteElegido.creditoIlimitado,
+        })
+
+  const puedeFacturar =
+    referenciaOk && seleccionados.length > 0 && !!clienteElegido && !!puntoVentaElegido && !!parametros && rechazoLocal === null && !ocupado
+
+  async function facturar() {
+    // react-async-state regla 9: guard de reentrancia de primera línea + bloqueo de ventana
+    // completa (regla 5) — un doble click no puede emitir dos TXR ni mover CC dos veces.
+    if (facturandoRef.current) return
+    if (!puedeFacturar || idPuntoVenta === '') return
+
+    facturandoRef.current = true
+    setFacturando(true)
+    setErrorFacturar('')
+
+    try {
+      const solicitud = aSolicitudDeFacturacionDeRemitos(idPuntoVenta, seleccionados, aPagosDeVenta(pagosConVuelto), observaciones)
+      const comprobante = await clienteDeRemitos.facturar(solicitud)
+      facturandoRef.current = false
+      setFacturando(false)
+      setFacturado({ numeroVisible: comprobante.numeroVisible, total: comprobante.total })
+      dispatchSeleccion({ tipo: 'limpiar' })
+      // regla 6: el refetch posterior vive aislado de este try/catch — un 201 confirmado nunca se
+      // reporta como fallo aunque el refresco de la lista falle.
+      cargarRemitos()
+    } catch (e) {
+      facturandoRef.current = false
+      setFacturando(false)
+      setErrorFacturar(e instanceof ErrorApi ? e.message : 'No se pudo facturar los remitos seleccionados.')
+    }
+  }
+
+  function nuevaConsolidacion() {
+    if (ocupado) return
+    setFacturado(null)
+    setFilasPago([filaPagoVacia(proximaFilaPagoIdRef.current++)])
+    setObservaciones('')
+  }
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo="Facturar remitos"
+        variante="inverse"
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/remitos">
+            Volver a remitos
+          </Link>
+        }
+      >
+        {errorReferencia && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorReferencia}</div>}
+
+        {facturado ? (
+          <div className="alert alert-success rounded-0">
+            <p className="mb-2">
+              Comprobante <strong>{facturado.numeroVisible}</strong> emitido por {formatearMoneda(facturado.total)}.
+            </p>
+            <button type="button" className="btn btn-primary btn-sm rounded-0" onClick={nuevaConsolidacion}>
+              Facturar otro grupo
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="row g-2 mb-3">
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="facturar-punto-venta">
+                  Punto de venta
+                </label>
+                <select
+                  id="facturar-punto-venta"
+                  className="form-select rounded-0"
+                  value={idPuntoVenta}
+                  disabled={!referenciaOk || ocupado}
+                  onChange={(e) => setIdPuntoVenta(e.target.value === '' ? '' : Number(e.target.value))}
+                >
+                  <option value="">Elegir…</option>
+                  {(puntosVenta ?? []).map((pv) => (
+                    <option key={pv.id} value={pv.id}>
+                      {pv.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="facturar-cliente">
+                  Cliente
+                </label>
+                <select
+                  id="facturar-cliente"
+                  className="form-select rounded-0"
+                  value={idCliente}
+                  disabled={!referenciaOk || ocupado}
+                  onChange={(e) => setIdCliente(e.target.value === '' ? '' : Number(e.target.value))}
+                >
+                  <option value="">Elegir…</option>
+                  {(clientes ?? []).map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {etiquetaDeCliente(c)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {idPuntoVenta === '' || idCliente === '' ? (
+              <p className="text-muted">Elegí un punto de venta y un cliente para ver sus remitos emitidos sin facturar.</p>
+            ) : (
+              <>
+                {cargandoRemitos && <Cargando />}
+                {errorRemitos && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorRemitos}</div>}
+
+                {!cargandoRemitos && remitos && (
+                  <>
+                    <div className="table-responsive mb-3">
+                      <table className="table table-sm table-bordered align-middle">
+                        <thead>
+                          <tr>
+                            <th style={{ width: 40 }}>
+                              <input
+                                type="checkbox"
+                                aria-label="Elegir todos"
+                                checked={todosElegidos}
+                                disabled={ocupado || remitos.length === 0}
+                                onChange={(e) =>
+                                  dispatchSeleccion(
+                                    e.target.checked ? { tipo: 'elegirTodos', ids: remitos.map((r) => r.id) } : { tipo: 'limpiar' },
+                                  )
+                                }
+                              />
+                            </th>
+                            <th>Número</th>
+                            <th>Fecha de emisión</th>
+                            <th className="text-end">Total</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {remitos.map((r) => (
+                            <tr key={r.id}>
+                              <td>
+                                <input
+                                  type="checkbox"
+                                  aria-label={`Elegir remito ${r.numeroFormateado ?? `#${r.id}`}`}
+                                  checked={seleccionados.includes(r.id)}
+                                  disabled={ocupado}
+                                  onChange={() => dispatchSeleccion({ tipo: 'alternar', id: r.id })}
+                                />
+                              </td>
+                              <td>{r.numeroFormateado ?? `#${r.id}`}</td>
+                              <td>{new Date(r.fechaEmision).toLocaleDateString('es-AR')}</td>
+                              <td className="text-end">{formatearMoneda(r.total)}</td>
+                            </tr>
+                          ))}
+                          {remitos.length === 0 && (
+                            <tr>
+                              <td colSpan={4} className="text-center text-muted py-3">
+                                Este cliente no tiene remitos emitidos sin facturar en este punto de venta.
+                              </td>
+                            </tr>
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {remitos.length > 0 && (
+                      <>
+                        <div className="d-flex justify-content-between mb-3">
+                          <strong>Total a facturar ({seleccionados.length} remito(s))</strong>
+                          <strong>{formatearMoneda(total)}</strong>
+                        </div>
+
+                        <div className="mb-3">
+                          <label className="form-label" htmlFor="facturar-observaciones">
+                            Observaciones
+                          </label>
+                          <input
+                            id="facturar-observaciones"
+                            type="text"
+                            className="form-control rounded-0"
+                            value={observaciones}
+                            disabled={ocupado}
+                            onChange={(e) => setObservaciones(e.target.value)}
+                          />
+                        </div>
+
+                        {errorParametros && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorParametros}</div>}
+                        {errorFacturar && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorFacturar}</div>}
+
+                        <h6>Pagos</h6>
+                        {filasPago.map((fila) => {
+                          const medioDeFila = fila.idMedioPago === '' ? null : (medioPorId[fila.idMedioPago] ?? null)
+                          const pagoDeFila = pagosConVuelto.find((p) => p.idFila === fila.id) ?? null
+                          const vueltoMostrado = fila.vueltoManual !== '' ? fila.vueltoManual : String(pagoDeFila?.vuelto ?? 0)
+
+                          return (
+                            <div className="row g-2 mb-2 align-items-center" key={fila.id}>
+                              <div className="col-4">
+                                <select
+                                  className="form-select form-select-sm rounded-0"
+                                  aria-label="Medio de pago"
+                                  value={fila.idMedioPago}
+                                  disabled={ocupado || medios === null}
+                                  onChange={(e) => cambiarMedioDeFila(fila.id, e.target.value === '' ? '' : Number(e.target.value))}
+                                >
+                                  <option value="">Elegir medio…</option>
+                                  {(medios ?? [])
+                                    .filter((m) => medioDisponibleParaCliente(m, clienteElegido?.esConsumidorFinal ?? false))
+                                    .map((m) => (
+                                      <option key={m.id} value={m.id}>
+                                        {m.nombre}
+                                      </option>
+                                    ))}
+                                </select>
+                              </div>
+                              <div className="col-3">
+                                <input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  className="form-control form-control-sm rounded-0"
+                                  aria-label={etiquetaDeCampoFila('Importe', medioDeFila, fila.id)}
+                                  value={fila.importe}
+                                  disabled={ocupado}
+                                  onChange={(e) => cambiarImporteDeFila(fila.id, e.target.value)}
+                                />
+                              </div>
+                              <div className="col-3">
+                                <input
+                                  type="text"
+                                  className="form-control form-control-sm rounded-0"
+                                  aria-label={etiquetaDeCampoFila('Referencia', medioDeFila, fila.id)}
+                                  placeholder={medioDeFila?.requiereReferencia ? 'Referencia (requerida)' : 'Referencia'}
+                                  value={fila.referencia}
+                                  disabled={ocupado || !medioDeFila?.requiereReferencia}
+                                  onChange={(e) => cambiarReferenciaDeFila(fila.id, e.target.value)}
+                                />
+                              </div>
+                              <div className="col-2 d-flex align-items-center gap-1">
+                                <input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  className="form-control form-control-sm rounded-0"
+                                  aria-label={etiquetaDeCampoFila('Vuelto', medioDeFila, fila.id)}
+                                  value={vueltoMostrado}
+                                  disabled={ocupado || !medioDeFila?.admiteVuelto}
+                                  onChange={(e) => cambiarVueltoDeFila(fila.id, e.target.value)}
+                                />
+                                {filasPago.length > 1 && (
+                                  <button
+                                    type="button"
+                                    className="btn btn-sm btn-outline-danger rounded-0"
+                                    disabled={ocupado}
+                                    aria-label="Quitar medio de pago"
+                                    onClick={() => quitarFilaPago(fila.id)}
+                                  >
+                                    ×
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                          )
+                        })}
+
+                        <button type="button" className="btn btn-outline-secondary btn-sm rounded-0 mb-3" disabled={ocupado} onClick={agregarFilaPago}>
+                          + Agregar medio de pago
+                        </button>
+
+                        <div className="d-flex justify-content-between small">
+                          <span>Falta</span>
+                          <span>{formatearMoneda(faltante)}</span>
+                        </div>
+                        <div className="d-flex justify-content-between small mb-2">
+                          <span>Vuelto</span>
+                          <span>{formatearMoneda(excedente)}</span>
+                        </div>
+
+                        {rechazoLocal && <div className="alert alert-warning rounded-0 py-1 px-2 small">{rechazoLocal.mensaje}</div>}
+
+                        <button type="button" className="btn btn-primary rounded-0" disabled={!puedeFacturar} onClick={facturar}>
+                          {facturando ? 'Facturando…' : 'Facturar'}
+                        </button>
+                      </>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -21,11 +21,9 @@ import {
   type FilaPago,
 } from '../api/pagos'
 import { aSolicitudDeVentaDesdePresupuesto, clienteDePresupuestos } from '../api/presupuestos'
-import { clienteDeStock } from '../api/stock'
 import type {
   ClienteListado,
   ComprobanteEmitido,
-  LoteListado,
   MedioPagoAlta,
   MedioPagoListado,
   ParametroResuelto,
@@ -40,12 +38,12 @@ import {
   calcularSubtotalPrevia,
   clienteDeVentas,
   indexarResolucionPorArticulo,
-  opcionDeLote,
   previaDeLinea,
   type LotesSeleccionados,
 } from '../api/ventas'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { SelectorDeLote } from '../componentes/SelectorDeLote'
 
 const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
 
@@ -211,107 +209,6 @@ function PanelGateTurno({ idPuntoVenta, onAbierto }: PropsPanelGateTurno) {
         </div>
       </div>
     </div>
-  )
-}
-
-type PropsSelectorDeLote = {
-  idPuntoVenta: number
-  idArticulo: number
-  nombreArticulo: string
-  idLoteElegido: number | null
-  disabled: boolean
-  onElegir: (idLote: number | null) => void
-}
-
-/**
- * Picker de lote de una línea del carrito (stage-12-lotes-vencimientos, Slice 14, design decisión
- * 19): se pide bajo demanda (click en "Elegir lote") — el camino feliz de cero tecleo (omitir
- * `idLote`, el servidor resuelve FEFO solo) nunca dispara este fetch. `sugerido` llega ya resuelto
- * del servidor (`ReglaDeLotes.ElegirFefo`); acá solo se resalta, nunca se recalcula.
- */
-function SelectorDeLote({ idPuntoVenta, idArticulo, nombreArticulo, idLoteElegido, disabled, onElegir }: PropsSelectorDeLote) {
-  const [cargando, setCargando] = useState(false)
-  const [error, setError] = useState('')
-  const [lotes, setLotes] = useState<LoteListado[] | null>(null)
-  const tokenRef = useRef(0)
-
-  // react-async-state regla 3: los saldos de lote son por punto de venta — un cambio de PV
-  // invalida cualquier fetch en vuelo y cualquier lote ya cargado, nunca puede sobrevivir a la
-  // selección anterior (mutation-proof-tests regla 7: probado en Pos.test.tsx resolviendo la
-  // promesa vieja DESPUÉS del cambio de PV, dentro de `act`).
-  useEffect(() => {
-    tokenRef.current += 1
-    setCargando(false)
-    setError('')
-    setLotes(null)
-  }, [idPuntoVenta, idArticulo])
-
-  async function cargar() {
-    // El guard de reentrancia de primera línea es el `disabled` nativo del botón (más abajo):
-    // JSDOM y los navegadores no despachan `click` sobre un elemento disabled, así que un
-    // `cargandoRef` extra acá era inalcanzable — verificado por mutación en judgment-day
-    // (slice 14, MAJOR 2b). `lotes !== null` sigue evitando un refetch tras una carga exitosa.
-    if (lotes !== null) return
-
-    const miToken = (tokenRef.current += 1)
-    setCargando(true)
-    setError('')
-
-    try {
-      const resultado = await clienteDeStock.listarLotes(idPuntoVenta, idArticulo)
-      if (tokenRef.current !== miToken) return
-      setLotes(resultado)
-    } catch (e) {
-      if (tokenRef.current !== miToken) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los lotes.')
-    } finally {
-      if (tokenRef.current === miToken) {
-        setCargando(false)
-      }
-    }
-  }
-
-  if (lotes === null) {
-    return (
-      <div>
-        <button
-          type="button"
-          className="btn btn-sm btn-outline-secondary rounded-0"
-          disabled={disabled || cargando}
-          onClick={cargar}
-        >
-          {cargando ? 'Cargando…' : 'Elegir lote'}
-        </button>
-        {error && <div className="small text-danger">{error}</div>}
-      </div>
-    )
-  }
-
-  if (lotes.length === 0) {
-    return <span className="small text-muted">Sin lotes registrados — FEFO automático.</span>
-  }
-
-  const sugerido = lotes.find((l) => l.sugerido) ?? null
-  const valorActual = idLoteElegido !== null ? String(idLoteElegido) : sugerido ? String(sugerido.idLote) : ''
-
-  return (
-    <select
-      className="form-select form-select-sm rounded-0"
-      aria-label={`Lote de ${nombreArticulo}`}
-      value={valorActual}
-      disabled={disabled}
-      onChange={(e) => onElegir(e.target.value === '' ? null : Number(e.target.value))}
-    >
-      <option value="">FEFO automático (recomendado)</option>
-      {lotes.map((l) => {
-        const opcion = opcionDeLote(l)
-        return (
-          <option key={l.idLote} value={opcion.valor}>
-            {opcion.etiqueta}
-          </option>
-        )
-      })}
-    </select>
   )
 }
 

--- a/src/Ways.Web/src/paginas/Remito.test.tsx
+++ b/src/Ways.Web/src/paginas/Remito.test.tsx
@@ -1,0 +1,339 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Remito } from './Remito'
+import type { ClienteListado, ComprobanteEmitido, EstadoRemito, PuntoVentaListado, RemitoDetalle } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown?])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown?])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 9,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Depósito Norte',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 5,
+    numero: 5,
+    nombre: 'Juan',
+    apellido: 'Pérez',
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: false,
+    ...sobrescribir,
+  }
+}
+
+function detalleFixture(sobrescribir: Partial<RemitoDetalle> = {}): RemitoDetalle {
+  return {
+    id: 30,
+    idPuntoVenta: 9,
+    idCliente: 5,
+    idEmpleado: 1,
+    numero: 12,
+    numeroFormateado: '0009-00000012',
+    fechaEmision: '2026-08-19T12:00:00Z',
+    fechaSalida: '2026-08-19T12:00:00Z',
+    direccionEntrega: null,
+    observaciones: null,
+    subtotal: 200,
+    descuentoTotal: 0,
+    total: 200,
+    estado: 'Emitido',
+    idComprobanteVenta: null,
+    items: [
+      {
+        orden: 1,
+        idArticulo: 10,
+        descripcion: 'Yerba mate 1kg',
+        cantidad: 2,
+        precioUnitario: 100,
+        descuento: 0,
+        total: 200,
+        idListaPrecio: 1,
+        idOferta: null,
+        idAlicuotaIva: 1,
+        porcentajeIva: 21,
+        costoUnitario: 50,
+        costoEsEstimado: false,
+        idLote: null,
+      },
+    ],
+    ...sobrescribir,
+  }
+}
+
+function borradorFixture(sobrescribir: Partial<RemitoDetalle> = {}): RemitoDetalle {
+  return detalleFixture({ estado: 'Borrador', numero: null, numeroFormateado: null, fechaSalida: null, ...sobrescribir })
+}
+
+function facturaFixture(sobrescribir: Partial<ComprobanteEmitido> = {}): ComprobanteEmitido {
+  return {
+    id: 77,
+    numero: 3,
+    numeroVisible: '0009-00000003',
+    estado: 'Emitido',
+    fecha: '2026-08-20T12:00:00Z',
+    idPuntoVenta: 9,
+    idCliente: 5,
+    idComprobanteAsociado: null,
+    subtotal: 200,
+    descuentoTotal: 0,
+    total: 200,
+    direccionEntrega: null,
+    observaciones: null,
+    items: [],
+    pagos: [],
+    idPresupuestoOrigen: null,
+    ...sobrescribir,
+  }
+}
+
+function mockearReferencia(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/clientes') return Promise.resolve({ items: [clienteFixture()], total: 1, pagina: 1, tamanio: 25 })
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla(id: string | number = 30) {
+  return render(
+    <MemoryRouter initialEntries={[`/remitos/${id}`]}>
+      <Routes>
+        <Route path="/remitos/:id" element={<Remito />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiPutMock.mockReset()
+})
+
+describe('Remito — detalle (lectura)', () => {
+  it('muestra el estado y los items con sus valores', async () => {
+    mockearReferencia((ruta) => (ruta === '/remitos/30' ? Promise.resolve(detalleFixture()) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('Emitido')).toBeInTheDocument()
+    expect(screen.getByText('Yerba mate 1kg')).toBeInTheDocument()
+    expect(screen.getAllByText('$200,00').length).toBeGreaterThan(0)
+  })
+})
+
+describe('Remito — facturado muestra el link a su factura y CERO acciones (tarea 8.3)', () => {
+  it('renderiza el número visible y el total de la factura, sin ningún botón de acción', async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/remitos/30') return Promise.resolve(detalleFixture({ estado: 'Facturado', idComprobanteVenta: 77 }))
+      if (ruta === '/ventas/77') return Promise.resolve(facturaFixture())
+      return undefined
+    })
+    renderPantalla()
+
+    await screen.findByText('Facturado')
+    expect(await screen.findByText('0009-00000003')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Anular/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Emitir/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Guardar borrador' })).not.toBeInTheDocument()
+  })
+})
+
+describe.each<{ estado: EstadoRemito; emitir: boolean; anular: boolean }>([
+  { estado: 'Borrador', emitir: true, anular: true },
+  { estado: 'Emitido', emitir: false, anular: true },
+  { estado: 'Facturado', emitir: false, anular: false },
+  { estado: 'Anulado', emitir: false, anular: false },
+])('Remito — matriz de acciones deshabilitadas por estado (tarea 8.9): $estado', ({ estado, emitir, anular }) => {
+  it(`Emitir ${emitir ? 'SÍ' : 'NO'} se ofrece / Anular ${anular ? 'SÍ' : 'NO'} se ofrece`, async () => {
+    mockearReferencia((ruta) => {
+      if (ruta === '/remitos/30') {
+        const fixture = estado === 'Borrador' ? borradorFixture() : detalleFixture({ estado, idComprobanteVenta: estado === 'Facturado' ? 77 : null })
+        return Promise.resolve(fixture)
+      }
+      if (ruta === '/ventas/77') return Promise.resolve(facturaFixture())
+      return undefined
+    })
+    renderPantalla()
+
+    await screen.findByText(estado)
+
+    if (emitir) {
+      expect(screen.getByRole('button', { name: 'Emitir' })).toBeInTheDocument()
+    } else {
+      expect(screen.queryByRole('button', { name: 'Emitir' })).not.toBeInTheDocument()
+    }
+
+    if (anular) {
+      expect(screen.getByRole('button', { name: 'Anular' })).toBeInTheDocument()
+    } else {
+      expect(screen.queryByRole('button', { name: 'Anular' })).not.toBeInTheDocument()
+    }
+  })
+})
+
+describe('Remito — doble click en "Emitir" (react-async-state regla 9, tarea 8.10)', () => {
+  it('dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/remitos/30' ? Promise.resolve(borradorFixture()) : undefined))
+
+    let resolverEmitir: (v: RemitoDetalle) => void = () => {}
+    const emitirPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverEmitir = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/30/emitir' ? emitirPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Emitir' })
+
+    // Los dos dispatchEvent viajan DENTRO de un mismo act() — jsdom no no-opea un click sobre un
+    // elemento disabled (lección vigente del programa), así que probar el guard exige dos clicks
+    // reales en el mismo tick, mismo patrón que Presupuesto.test.tsx.
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/remitos/30/emitir')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Emitiendo…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverEmitir(detalleFixture())
+      await emitirPendiente
+    })
+  })
+})
+
+describe('Remito — doble click en "Anular"', () => {
+  it('dispara exactamente un POST', async () => {
+    mockearReferencia((ruta) => (ruta === '/remitos/30' ? Promise.resolve(detalleFixture()) : undefined))
+
+    let resolverAnular: (v: RemitoDetalle) => void = () => {}
+    const anularPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/30/anular' ? anularPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const boton = await screen.findByRole('button', { name: 'Anular' })
+
+    act(() => {
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      boton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    expect(apiPostMock.mock.calls.filter((c) => c[0] === '/remitos/30/anular')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Anulando…' })).toBeDisabled()
+
+    await act(async () => {
+      resolverAnular(detalleFixture({ estado: 'Anulado' }))
+      await anularPendiente
+    })
+  })
+
+  it('mientras "Anular" está en vuelo, "Emitir" también queda deshabilitado (misma ventana de ocupado, react-async-state regla 5)', async () => {
+    mockearReferencia((ruta) => (ruta === '/remitos/30' ? Promise.resolve(borradorFixture()) : undefined))
+
+    let resolverAnular: (v: RemitoDetalle) => void = () => {}
+    const anularPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => (ruta === '/remitos/30/anular' ? anularPendiente : Promise.reject(new Error(`ruta no mockeada: ${ruta}`))))
+
+    renderPantalla()
+    const botonAnular = await screen.findByRole('button', { name: 'Anular' })
+    const botonEmitir = screen.getByRole('button', { name: 'Emitir' })
+    expect(botonEmitir).not.toBeDisabled()
+
+    await userEvent.click(botonAnular)
+
+    expect(screen.getByRole('button', { name: 'Anulando…' })).toBeDisabled()
+    expect(botonEmitir).toBeDisabled()
+
+    await act(async () => {
+      resolverAnular(detalleFixture({ estado: 'Anulado' }))
+      await anularPendiente
+    })
+  })
+})
+
+describe('Remito — crear borrador', () => {
+  it('crea el borrador y navega a la ruta real del remito recién creado', async () => {
+    mockearReferencia()
+    apiPostMock.mockResolvedValue(borradorFixture({ id: 99 }))
+
+    render(
+      <MemoryRouter initialEntries={['/remitos/nuevo']}>
+        <Routes>
+          <Route path="/remitos/nuevo" element={<Remito />} />
+          <Route path="/remitos/:id" element={<Remito />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await userEvent.selectOptions(await screen.findByLabelText('Punto de venta'), '9')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear borrador' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/remitos', expect.objectContaining({ idPuntoVenta: 9, idCliente: null })))
+  })
+})
+
+describe('Remito — role gating (mismo gate que /presupuestos: Politicas.OperacionDePos, sin distinción admin-only)', () => {
+  it('la pantalla no oculta ninguna acción de escritura por rol — no hay `puedeEscribir`', async () => {
+    mockearReferencia((ruta) => (ruta === '/remitos/30' ? Promise.resolve(borradorFixture()) : undefined))
+    renderPantalla()
+
+    await screen.findByText('Borrador')
+    expect(screen.getByRole('button', { name: 'Emitir' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Anular' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Remito.test.tsx
+++ b/src/Ways.Web/src/paginas/Remito.test.tsx
@@ -306,6 +306,83 @@ describe('Remito — doble click en "Anular"', () => {
   })
 })
 
+describe('Remito — guard de stale en cargarDetalle tras dos escrituras en secuencia (mutation-proof-tests regla 7)', () => {
+  it('el refetch stale disparado por Emitir, resuelto DESPUÉS del disparado por Anular, no pisa el estado más nuevo', async () => {
+    let resolverGetStaleTrasEmitir: (v: RemitoDetalle) => void = () => {}
+    const getStaleTrasEmitirPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverGetStaleTrasEmitir = resolve
+    })
+    let resolverGetNuevoTrasAnular: (v: RemitoDetalle) => void = () => {}
+    const getNuevoTrasAnularPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverGetNuevoTrasAnular = resolve
+    })
+
+    let llamadasGetRemito = 0
+    mockearReferencia((ruta) => {
+      if (ruta === '/remitos/30') {
+        llamadasGetRemito += 1
+        if (llamadasGetRemito === 1) return Promise.resolve(borradorFixture())
+        if (llamadasGetRemito === 2) return getStaleTrasEmitirPendiente
+        if (llamadasGetRemito === 3) return getNuevoTrasAnularPendiente
+        return Promise.reject(new Error('GET /remitos/30 llamado más veces de las esperadas'))
+      }
+      return undefined
+    })
+
+    let resolverEmitir: (v: RemitoDetalle) => void = () => {}
+    const emitirPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverEmitir = resolve
+    })
+    let resolverAnular: (v: RemitoDetalle) => void = () => {}
+    const anularPendiente = new Promise<RemitoDetalle>((resolve) => {
+      resolverAnular = resolve
+    })
+    apiPostMock.mockImplementation((ruta: string) => {
+      if (ruta === '/remitos/30/emitir') return emitirPendiente
+      if (ruta === '/remitos/30/anular') return anularPendiente
+      return Promise.reject(new Error(`ruta no mockeada: ${ruta}`))
+    })
+
+    renderPantalla()
+    await screen.findByRole('button', { name: 'Emitir' })
+
+    // Primera escritura: Emitir. Al resolver, dispara SU propio cargarDetalle (GET #2, queda en
+    // vuelo — `resolverGetStaleTrasEmitir` todavía no se llamó).
+    await userEvent.click(screen.getByRole('button', { name: 'Emitir' }))
+    await act(async () => {
+      resolverEmitir(borradorFixture())
+      await emitirPendiente
+    })
+    await waitFor(() => expect(llamadasGetRemito).toBe(2))
+
+    // Segunda escritura: Anular, sobre la MISMA instancia montada (todavía Borrador según el
+    // `detalle` vigente — el GET #2 stale ni siquiera aterrizó). Al resolver, dispara SU propio
+    // cargarDetalle (GET #3, discriminante: `observaciones` distinto del de arriba).
+    await userEvent.click(screen.getByRole('button', { name: 'Anular' }))
+    await act(async () => {
+      resolverAnular(detalleFixture({ estado: 'Anulado', observaciones: 'nuevo-anular' }))
+      await anularPendiente
+    })
+    await waitFor(() => expect(llamadasGetRemito).toBe(3))
+
+    // regla 7: la respuesta MÁS NUEVA (GET #3) aterriza primero, y la MÁS VIEJA (GET #2, stale)
+    // se resuelve DESPUÉS — dentro de act, para no dejar el microtask stale sin flushear.
+    await act(async () => {
+      resolverGetNuevoTrasAnular(detalleFixture({ estado: 'Anulado', observaciones: 'nuevo-anular' }))
+      await getNuevoTrasAnularPendiente
+    })
+    await act(async () => {
+      resolverGetStaleTrasEmitir(borradorFixture({ observaciones: 'stale-post-emitir' }))
+      await getStaleTrasEmitirPendiente
+    })
+
+    // THEN el estado final es el de la respuesta MÁS NUEVA — estado Y observaciones (regla 12c),
+    // nunca el de la stale que aterrizó después.
+    expect(screen.getByText('Anulado')).toBeInTheDocument()
+    expect(screen.getByLabelText('Observaciones')).toHaveValue('nuevo-anular')
+  })
+})
+
 describe('Remito — crear borrador', () => {
   it('crea el borrador y navega a la ruta real del remito recién creado', async () => {
     mockearReferencia()

--- a/src/Ways.Web/src/paginas/Remito.tsx
+++ b/src/Ways.Web/src/paginas/Remito.tsx
@@ -1,0 +1,713 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import { clienteDeArticulos } from '../api/articulos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
+import {
+  aSolicitudDeRemito,
+  claseDeBadgeDeEstadoRemito,
+  clienteDeRemitos,
+  encabezadoDeRemitoVacio,
+  etiquetaDeEstadoRemito,
+  itemDeRemitoAFormulario,
+  lineaDeRemitoCompletaParaEnvio,
+  lineaDeRemitoVacia,
+  type EncabezadoDeRemitoFormulario,
+  type LineaDeRemitoFormulario,
+} from '../api/remitos'
+import type { ArticuloListado, ClienteListado, ComprobanteEmitido, RemitoDetalle, PuntoVentaListado } from '../api/tipos'
+import { clienteDeVentas } from '../api/ventas'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+import { SelectorDeLote } from '../componentes/SelectorDeLote'
+
+function formatearFechaHora(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleString('es-AR') : '—'
+}
+
+function formatearMoneda(valor: number): string {
+  const signo = valor < 0 ? '-' : ''
+  return `${signo}$${Math.abs(valor).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+// ---- Selector de artículo por búsqueda (search-as-you-type) — mismo shape que el de
+// Presupuesto.tsx/OrdenDeCompra.tsx/CompraEditor.tsx, propio de cada fila ---------------------------
+
+type PropsSelectorDeArticulo = {
+  descripcion: string
+  disabled: boolean
+  onElegir: (articulo: ArticuloListado) => void
+}
+
+function SelectorDeArticulo({ descripcion, disabled, onElegir }: PropsSelectorDeArticulo) {
+  const [termino, setTermino] = useState('')
+  const [resultados, setResultados] = useState<ArticuloListado[]>([])
+  const [buscando, setBuscando] = useState(false)
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    if (termino.trim().length < 2) {
+      setResultados([])
+      return
+    }
+
+    let vigente = true
+    const miGeneracion = (generacionRef.current += 1)
+    setBuscando(true)
+
+    const temporizador = setTimeout(() => {
+      clienteDeArticulos
+        .listar(termino, false)
+        .then((pagina) => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados(pagina.items)
+        })
+        .catch(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setResultados([])
+        })
+        .finally(() => {
+          if (!vigente || generacionRef.current !== miGeneracion) return
+          setBuscando(false)
+        })
+    }, 300)
+
+    return () => {
+      vigente = false
+      clearTimeout(temporizador)
+    }
+  }, [termino])
+
+  return (
+    <div className="position-relative">
+      <input
+        type="text"
+        className="form-control form-control-sm rounded-0"
+        placeholder="Buscar artículo…"
+        value={termino}
+        disabled={disabled}
+        onChange={(e) => setTermino(e.target.value)}
+      />
+      {descripcion && <div className="small text-muted">Elegido: {descripcion}</div>}
+      {buscando && <div className="small text-muted">Buscando…</div>}
+      {!buscando && resultados.length > 0 && (
+        <div className="list-group position-absolute w-100" style={{ zIndex: 10 }}>
+          {resultados.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="list-group-item list-group-item-action py-1 px-2 small"
+              onClick={() => {
+                onElegir(a)
+                setTermino('')
+                setResultados([])
+              }}
+            >
+              {a.codigoInterno} — {a.nombre}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Fila editable del grid de items — con el pick de lote (design.md: "lot picker reusing
+// SelectorDeLote") sobre el mismo `idPuntoVenta` del encabezado ------------------------------------
+
+type PropsFilaDeItem = {
+  linea: LineaDeRemitoFormulario
+  idPuntoVenta: number | ''
+  disabled: boolean
+  onCambio: (clave: number, cambios: Partial<LineaDeRemitoFormulario>) => void
+  onQuitar: (clave: number) => void
+}
+
+function FilaDeItem({ linea, idPuntoVenta, disabled, onCambio, onQuitar }: PropsFilaDeItem) {
+  const incompleta = !lineaDeRemitoCompletaParaEnvio(linea)
+
+  return (
+    <tr className={incompleta ? 'table-warning text-muted' : undefined}>
+      <td style={{ minWidth: 220 }}>
+        <SelectorDeArticulo
+          descripcion={linea.descripcion}
+          disabled={disabled}
+          onElegir={(a) => onCambio(linea.clave, { idArticulo: a.id, descripcion: a.nombre, idLote: null })}
+        />
+        {incompleta && <div className="small text-warning-emphasis">Línea incompleta — no se va a guardar.</div>}
+      </td>
+      <td style={{ width: 120 }}>
+        <input
+          type="number"
+          step="0.001"
+          min="0"
+          className="form-control form-control-sm rounded-0"
+          aria-label="Cantidad"
+          value={linea.cantidad}
+          disabled={disabled}
+          onChange={(e) => onCambio(linea.clave, { cantidad: e.target.value })}
+        />
+      </td>
+      <td style={{ minWidth: 160 }}>
+        {linea.idArticulo !== '' && idPuntoVenta !== '' ? (
+          <SelectorDeLote
+            idPuntoVenta={idPuntoVenta}
+            idArticulo={linea.idArticulo}
+            nombreArticulo={linea.descripcion || `Artículo #${linea.idArticulo}`}
+            idLoteElegido={linea.idLote}
+            disabled={disabled}
+            onElegir={(idLote) => onCambio(linea.clave, { idLote })}
+          />
+        ) : (
+          <span className="small text-muted">—</span>
+        )}
+      </td>
+      <td>
+        <button type="button" className="btn btn-outline-danger btn-sm rounded-0" disabled={disabled} onClick={() => onQuitar(linea.clave)}>
+          Quitar
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+// ---- Pantalla principal -----------------------------------------------------------------------
+
+type PropsPantalla = { idRemito: number | null }
+
+/** Remontada por `key={idRemito ?? 'nuevo'}` (react-async-state regla 8) — ningún estado de acá
+ * (borrador en edición, avisos, paneles) sobrevive a un cambio de remito. */
+function PantallaRemito({ idRemito }: PropsPantalla) {
+  const navigate = useNavigate()
+  const esNuevo = idRemito === null
+
+  // ---- referencia (puntos de venta/clientes) ----------------------------------------------------
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [clientes, setClientes] = useState<ClienteListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => vigente && setPuntosVenta(lista))
+      .catch((e) => {
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((p) => vigente && setClientes(p.items))
+      .catch((e) => {
+        setClientes([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  const referenciaOk = puntosVenta !== null && clientes !== null && errorReferencia === ''
+
+  // ---- detalle (lectura, GET /{id} — única fuente de estado real) --------------------------------
+  const [detalle, setDetalle] = useState<RemitoDetalle | null>(null)
+  const [cargandoDetalle, setCargandoDetalle] = useState(!esNuevo)
+  const [errorDetalle, setErrorDetalle] = useState('')
+  const generacionRef = useRef(0)
+
+  const cargarDetalle = useCallback(() => {
+    if (esNuevo || idRemito === null) return
+    const miGeneracion = (generacionRef.current += 1)
+    setCargandoDetalle(true)
+    setErrorDetalle('')
+
+    clienteDeRemitos
+      .obtener(idRemito)
+      .then((d) => {
+        if (generacionRef.current !== miGeneracion) return
+        setDetalle(d)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        // regla 6: un refetch posterior a una escritura 2xx nunca vacía la pantalla a un error
+        // total — `detalle` queda como estaba, solo el aviso de arriba se muestra.
+        setErrorDetalle(
+          e instanceof ErrorApi ? e.message : 'No se pudo actualizar el remito — los datos mostrados pueden estar desactualizados.',
+        )
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargandoDetalle(false)
+      })
+  }, [esNuevo, idRemito])
+
+  useEffect(() => {
+    cargarDetalle()
+  }, [cargarDetalle])
+
+  // ---- factura del remito facturado (OD10: GET /api/ventas/{id}, el read model del TXR) ---------
+  const [factura, setFactura] = useState<ComprobanteEmitido | null>(null)
+  const [cargandoFactura, setCargandoFactura] = useState(false)
+  const [errorFactura, setErrorFactura] = useState('')
+  const facturaGeneracionRef = useRef(0)
+  const idComprobanteVenta = detalle?.idComprobanteVenta ?? null
+
+  useEffect(() => {
+    setFactura(null)
+    setErrorFactura('')
+    if (idComprobanteVenta === null) return
+
+    let vigente = true
+    const miGeneracion = (facturaGeneracionRef.current += 1)
+    setCargandoFactura(true)
+
+    clienteDeVentas
+      .obtener(idComprobanteVenta)
+      .then((c) => {
+        if (!vigente || facturaGeneracionRef.current !== miGeneracion) return
+        setFactura(c)
+      })
+      .catch((e) => {
+        if (!vigente || facturaGeneracionRef.current !== miGeneracion) return
+        setErrorFactura(e instanceof ErrorApi ? e.message : 'No se pudo cargar la factura.')
+      })
+      .finally(() => {
+        if (!vigente || facturaGeneracionRef.current !== miGeneracion) return
+        setCargandoFactura(false)
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [idComprobanteVenta])
+
+  // ---- formulario editable (nuevo o borrador existente) ------------------------------------------
+  const proximaClaveRef = useRef(1)
+  const [encabezado, setEncabezado] = useState<EncabezadoDeRemitoFormulario>(encabezadoDeRemitoVacio())
+  const [lineas, setLineas] = useState<LineaDeRemitoFormulario[]>([])
+
+  useEffect(() => {
+    if (detalle === null) return
+    setEncabezado({
+      idPuntoVenta: detalle.idPuntoVenta,
+      idCliente: detalle.idCliente,
+      direccionEntrega: detalle.direccionEntrega ?? '',
+      observaciones: detalle.observaciones ?? '',
+    })
+    setLineas(detalle.items.map((item) => itemDeRemitoAFormulario(proximaClaveRef.current++, item)))
+  }, [detalle])
+
+  // ---- escrituras: guardar/emitir/anular — cada una con su propio guard de reentrancia
+  // (react-async-state regla 9) y su propio flag de "en vuelo" (regla 5) ---------------------------
+  const [guardando, setGuardando] = useState(false)
+  const guardandoRef = useRef(false)
+  const [error, setError] = useState('')
+  const [aviso, setAviso] = useState('')
+
+  const [emitiendo, setEmitiendo] = useState(false)
+  const emitiendoRef = useRef(false)
+  const [errorEmitir, setErrorEmitir] = useState('')
+
+  const [anulando, setAnulando] = useState(false)
+  const anulandoRef = useRef(false)
+  const [errorAnular, setErrorAnular] = useState('')
+
+  const ocupado = guardando || emitiendo || anulando
+
+  function cambiarLinea(clave: number, cambios: Partial<LineaDeRemitoFormulario>) {
+    if (ocupado) return
+    // regla 1: updater funcional, nunca lee `lineas` del cierre.
+    setLineas((prev) => prev.map((l) => (l.clave === clave ? { ...l, ...cambios } : l)))
+  }
+
+  function agregarLinea() {
+    if (ocupado) return
+    setLineas((prev) => [...prev, lineaDeRemitoVacia(proximaClaveRef.current++)])
+  }
+
+  function quitarLinea(clave: number) {
+    if (ocupado) return
+    setLineas((prev) => prev.filter((l) => l.clave !== clave))
+  }
+
+  const encabezadoCompleto = encabezado.idPuntoVenta !== ''
+  const puedeGuardar = referenciaOk && encabezadoCompleto && !ocupado
+
+  async function guardarBorrador() {
+    // regla 9: guard de reentrancia de primera línea.
+    if (guardandoRef.current) return
+    if (!puedeGuardar) return
+
+    guardandoRef.current = true
+    setGuardando(true)
+    setError('')
+    setAviso('')
+    // regla 3: bumpear la generación de carga ANTES de la escritura.
+    generacionRef.current += 1
+
+    try {
+      const solicitud = aSolicitudDeRemito(encabezado, lineas)
+      if (esNuevo) {
+        const creado = await clienteDeRemitos.crear(solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        // Remontaje completo vía cambio de `key` (regla 8): navega a la ruta real del remito
+        // recién creado, nunca reutiliza este estado de "nuevo" para simular la edición.
+        navigate(`/remitos/${creado.id}`, { replace: true })
+      } else if (idRemito !== null) {
+        await clienteDeRemitos.actualizar(idRemito, solicitud)
+        guardandoRef.current = false
+        setGuardando(false)
+        setAviso('Borrador guardado.')
+        // regla 6: el refetch posterior vive aislado de este try/catch.
+        cargarDetalle()
+      }
+    } catch (e) {
+      guardandoRef.current = false
+      setGuardando(false)
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar el borrador.')
+    }
+  }
+
+  async function emitir() {
+    if (ocupado) return
+    if (emitiendoRef.current || idRemito === null) return
+
+    emitiendoRef.current = true
+    setEmitiendo(true)
+    setErrorEmitir('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDeRemitos.emitir(idRemito)
+      emitiendoRef.current = false
+      setEmitiendo(false)
+      setAviso('Remito emitido — stock actualizado.')
+      cargarDetalle()
+    } catch (e) {
+      emitiendoRef.current = false
+      setEmitiendo(false)
+      setErrorEmitir(e instanceof ErrorApi ? e.message : 'No se pudo emitir el remito.')
+    }
+  }
+
+  async function anular() {
+    if (ocupado) return
+    if (anulandoRef.current || idRemito === null) return
+
+    anulandoRef.current = true
+    setAnulando(true)
+    setErrorAnular('')
+    generacionRef.current += 1
+
+    try {
+      await clienteDeRemitos.anular(idRemito)
+      anulandoRef.current = false
+      setAnulando(false)
+      setAviso('Remito anulado.')
+      cargarDetalle()
+    } catch (e) {
+      anulandoRef.current = false
+      setAnulando(false)
+      setErrorAnular(e instanceof ErrorApi ? e.message : 'No se pudo anular el remito.')
+    }
+  }
+
+  if (!esNuevo && cargandoDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Cargando />
+      </div>
+    )
+  }
+
+  if (!esNuevo && errorDetalle && detalle === null) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Remito" variante="danger">
+          <p className="text-muted">{errorDetalle}</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/remitos">
+            Volver a remitos
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  const esBorrador = esNuevo || detalle?.estado === 'Borrador'
+  const esFacturado = !esNuevo && detalle?.estado === 'Facturado'
+  const puedeEmitir = !esNuevo && detalle?.estado === 'Borrador'
+  const puedeAnular = detalle?.estado === 'Borrador' || detalle?.estado === 'Emitido'
+
+  return (
+    <div className="container-fluid py-4">
+      <Box
+        titulo={esNuevo ? 'Nuevo remito' : `Remito ${detalle?.numeroFormateado ?? `#${idRemito}`}`}
+        variante="inverse"
+        herramientas={
+          <Link className="btn btn-sm btn-outline-light rounded-0" to="/remitos">
+            Volver a remitos
+          </Link>
+        }
+      >
+        {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && (
+          <div className="alert alert-warning rounded-0 py-1 px-2 small">
+            {errorReferencia} No se pueden registrar operaciones de remito hasta que esto se resuelva.
+          </div>
+        )}
+        {errorDetalle && detalle && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorDetalle}</div>}
+
+        {!esNuevo && detalle && (
+          <div className="mb-3">
+            <span className={`badge rounded-0 me-2 ${claseDeBadgeDeEstadoRemito(detalle.estado)}`}>{etiquetaDeEstadoRemito(detalle.estado)}</span>
+            {detalle.fechaSalida && <span className="small text-muted me-2">Salió: {formatearFechaHora(detalle.fechaSalida)}</span>}
+          </div>
+        )}
+
+        {/* facturado: link a la factura (OD10, GET /api/ventas/{id}) + CERO acciones — el design
+            lo pide explícito ("facturado renders its invoice link and no actions"). */}
+        {esFacturado && (
+          <div className="mb-3 p-2 border rounded-0 bg-light-subtle">
+            {cargandoFactura && <span className="small text-muted">Cargando factura…</span>}
+            {errorFactura && <span className="small text-danger">{errorFactura}</span>}
+            {factura && (
+              // Sin una pantalla de detalle de venta en esta web todavía (fuera del alcance de
+              // este slice — ver Deviations del apply), el "link a la factura" que design.md pide
+              // se muestra como la referencia identificatoria de la factura (número visible +
+              // total), sourceada en vivo del read model de OD10 (`GET /api/ventas/{id}`), nunca
+              // un `<Link>` a una ruta que no existe.
+              <span className="small">
+                Facturado en el comprobante <strong>{factura.numeroVisible}</strong> — {formatearMoneda(factura.total)}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="row g-2 mb-3">
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="rem-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="rem-punto-venta"
+              className="form-select rounded-0"
+              value={encabezado.idPuntoVenta}
+              disabled={!esBorrador || ocupado || !referenciaOk}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idPuntoVenta: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Elegir…</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="rem-cliente">
+              Cliente
+            </label>
+            <select
+              id="rem-cliente"
+              className="form-select rounded-0"
+              value={encabezado.idCliente}
+              disabled={!esBorrador || ocupado || !referenciaOk}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, idCliente: e.target.value === '' ? '' : Number(e.target.value) }))}
+            >
+              <option value="">Consumidor Final (por defecto)</option>
+              {(clientes ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {etiquetaDeCliente(c)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label" htmlFor="rem-direccion-entrega">
+              Dirección de entrega
+            </label>
+            <input
+              id="rem-direccion-entrega"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.direccionEntrega}
+              disabled={!esBorrador || ocupado}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, direccionEntrega: e.target.value }))}
+            />
+          </div>
+          <div className="col-12">
+            <label className="form-label" htmlFor="rem-observaciones">
+              Observaciones
+            </label>
+            <input
+              id="rem-observaciones"
+              type="text"
+              className="form-control rounded-0"
+              value={encabezado.observaciones}
+              disabled={!esBorrador || ocupado}
+              onChange={(e) => setEncabezado((prev) => ({ ...prev, observaciones: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        {esBorrador ? (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Artículo</th>
+                    <th>Cantidad</th>
+                    <th>Lote</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lineas.map((l) => (
+                    <FilaDeItem
+                      key={l.clave}
+                      linea={l}
+                      idPuntoVenta={encabezado.idPuntoVenta}
+                      disabled={ocupado || !referenciaOk}
+                      onCambio={cambiarLinea}
+                      onQuitar={quitarLinea}
+                    />
+                  ))}
+                  {lineas.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="text-center text-muted py-3">
+                        Todavía no hay items cargados.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <button type="button" className="btn btn-outline-secondary btn-sm rounded-0 mb-3" disabled={ocupado || !referenciaOk} onClick={agregarLinea}>
+              + Agregar línea
+            </button>
+
+            <div className="d-flex gap-2 align-items-end mb-3 flex-wrap">
+              <button type="button" className="btn btn-primary rounded-0" disabled={!puedeGuardar} onClick={guardarBorrador}>
+                {guardando ? 'Guardando…' : esNuevo ? 'Crear borrador' : 'Guardar borrador'}
+              </button>
+              {puedeEmitir && (
+                <button type="button" className="btn btn-success rounded-0" disabled={ocupado} onClick={emitir}>
+                  {emitiendo ? 'Emitiendo…' : 'Emitir'}
+                </button>
+              )}
+              {puedeAnular && (
+                <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                  {anulando ? 'Anulando…' : 'Anular'}
+                </button>
+              )}
+            </div>
+            {errorEmitir && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorEmitir}</div>}
+            {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+          </>
+        ) : (
+          detalle && (
+            <>
+              <h6>Items</h6>
+              <div className="table-responsive mb-3">
+                <table className="table table-sm table-bordered align-middle">
+                  <thead>
+                    <tr>
+                      <th>Artículo</th>
+                      <th className="text-end">Cantidad</th>
+                      <th className="text-end">Precio unit.</th>
+                      <th className="text-end">Descuento</th>
+                      <th className="text-end">Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detalle.items.map((item) => (
+                      <tr key={item.orden}>
+                        <td>{item.descripcion}</td>
+                        <td className="text-end">{item.cantidad}</td>
+                        <td className="text-end">{formatearMoneda(item.precioUnitario)}</td>
+                        <td className="text-end">{item.descuento > 0 ? formatearMoneda(item.descuento) : '—'}</td>
+                        <td className="text-end">{formatearMoneda(item.total)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="row g-3 my-3">
+                <div className="col-md-4">
+                  <div className="small text-muted">Subtotal</div>
+                  <div>{formatearMoneda(detalle.subtotal)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Descuento</div>
+                  <div>{formatearMoneda(detalle.descuentoTotal)}</div>
+                </div>
+                <div className="col-md-4">
+                  <div className="small text-muted">Total</div>
+                  <div className="fs-5">
+                    <strong>{formatearMoneda(detalle.total)}</strong>
+                  </div>
+                </div>
+              </div>
+
+              {/* Un remito emitido (no facturado) sigue pudiendo anularse — un facturado no
+                  renderiza ninguna acción (esFacturado ya cubrió su propio bloque arriba). */}
+              {!esFacturado && (
+                <>
+                  <div className="d-flex gap-2 mb-3">
+                    {puedeAnular && (
+                      <button type="button" className="btn btn-danger rounded-0" disabled={ocupado} onClick={anular}>
+                        {anulando ? 'Anulando…' : 'Anular'}
+                      </button>
+                    )}
+                  </div>
+                  {errorAnular && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorAnular}</div>}
+                </>
+              )}
+            </>
+          )
+        )}
+      </Box>
+    </div>
+  )
+}
+
+/**
+ * Remitos — borrador/detalle (stage-17-presupuestos-y-remitos, Slice 8; design: Web composition):
+ * `/remitos/nuevo` crea un borrador desde cero, `/remitos/:id` lo edita (borrador), lo emite/anula
+ * (reusando `SelectorDeLote` para el pick de lote per-línea antes de emitir), o solo lo muestra —
+ * un remito `facturado` renderiza el link a su factura y CERO acciones. Mismo gate que
+ * `/presupuestos` (`RutaProtegida`, App.tsx).
+ */
+export function Remito() {
+  const { id } = useParams<{ id: string }>()
+  const esNuevo = id === undefined || id === 'nuevo'
+  const idNumerico = esNuevo ? null : Number(id)
+  const idValido = esNuevo || Number.isFinite(idNumerico)
+
+  if (!idValido) {
+    return (
+      <div className="container-fluid py-4">
+        <Box titulo="Remito" variante="warning">
+          <p className="text-muted">No se especificó un remito válido.</p>
+          <Link className="btn btn-outline-secondary rounded-0" to="/remitos">
+            Volver a remitos
+          </Link>
+        </Box>
+      </div>
+    )
+  }
+
+  return <PantallaRemito key={idNumerico ?? 'nuevo'} idRemito={idNumerico} />
+}

--- a/src/Ways.Web/src/paginas/Remitos.test.tsx
+++ b/src/Ways.Web/src/paginas/Remitos.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -141,6 +141,39 @@ describe('Remitos — filtro por estado', () => {
 
     await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Facturado')
     await waitFor(() => expect(apiGetMock).toHaveBeenCalledWith(expect.stringContaining('estado=Facturado')))
+  })
+
+  it('una respuesta stale de un filtro anterior no pisa la del filtro más nuevo (mutation-proof-tests regla 7)', async () => {
+    let resolverFacturado: (v: PaginaDeRemitos) => void = () => {}
+    let promesaFacturado: Promise<PaginaDeRemitos> = Promise.resolve(paginaFixture())
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/remitos?') && ruta.includes('estado=Facturado')) {
+        promesaFacturado = new Promise((resolve) => (resolverFacturado = resolve))
+        return promesaFacturado
+      }
+      if (ruta.startsWith('/remitos?') && ruta.includes('estado=Anulado')) {
+        return Promise.resolve(paginaFixture({ items: [remitoFixture({ id: 2, numeroFormateado: '0007-00000099' })] }))
+      }
+      return undefined
+    })
+    renderPantalla()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Facturado')
+    // el fetch de "Facturado" queda en vuelo — `resolverFacturado` todavía no se llamó.
+
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Anulado')
+    await screen.findByText('0007-00000099')
+
+    // regla 7: el flush del microtask stale va DENTRO de act — un `waitFor` pasaría en su primer
+    // tick, antes de que el `.then` stale aterrice, y saldría verde sin probar nada.
+    await act(async () => {
+      resolverFacturado(paginaFixture({ items: [remitoFixture({ id: 3, numeroFormateado: '0007-00000199' })] }))
+      await promesaFacturado
+    })
+
+    expect(screen.getByText('0007-00000099')).toBeInTheDocument()
+    expect(screen.queryByText('0007-00000199')).not.toBeInTheDocument()
   })
 })
 

--- a/src/Ways.Web/src/paginas/Remitos.test.tsx
+++ b/src/Ways.Web/src/paginas/Remitos.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Remitos } from './Remitos'
+import type { ClienteListado, PaginaDeRemitos, PuntoVentaListado, RemitoListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 7,
+    idTenant: 1,
+    idEmpresa: 1,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    ...sobrescribir,
+  }
+}
+
+function clienteFixture(sobrescribir: Partial<ClienteListado> = {}): ClienteListado {
+  return {
+    id: 1,
+    numero: 1,
+    nombre: 'Consumidor Final',
+    apellido: null,
+    razonSocial: null,
+    tipoDocumento: null,
+    numeroDocumento: null,
+    idCondicionFiscal: 1,
+    nacimiento: null,
+    domicilio: null,
+    telefono: null,
+    celular: null,
+    email: null,
+    observaciones: null,
+    idListaPrecio: 1,
+    limiteCredito: 0,
+    creditoIlimitado: true,
+    saldo: 0,
+    activo: true,
+    idEmpresa: null,
+    esConsumidorFinal: true,
+    ...sobrescribir,
+  }
+}
+
+function remitoFixture(sobrescribir: Partial<RemitoListado> = {}): RemitoListado {
+  return {
+    id: 1,
+    idPuntoVenta: 7,
+    idCliente: 1,
+    numero: 12,
+    numeroFormateado: '0007-00000012',
+    fechaEmision: '2026-08-01T12:00:00Z',
+    total: 1500,
+    estado: 'Emitido',
+    idComprobanteVenta: null,
+    ...sobrescribir,
+  }
+}
+
+function paginaFixture(sobrescribir: Partial<PaginaDeRemitos> = {}): PaginaDeRemitos {
+  return { items: [remitoFixture()], total: 1, pagina: 1, tamanio: 25, ...sobrescribir }
+}
+
+function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve([puntoVentaFixture()])
+    if (ruta === '/clientes') return Promise.resolve({ items: [clienteFixture()], total: 1, pagina: 1, tamanio: 25 })
+    const propia = sobrescribirGet?.(ruta)
+    if (propia) return propia
+    if (ruta.startsWith('/remitos?')) return Promise.resolve(paginaFixture())
+    return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+  })
+}
+
+function renderPantalla() {
+  return render(<Remitos />, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter> })
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+})
+
+describe('Remitos — listado', () => {
+  it('muestra la fila con número, cliente, punto de venta y estado', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('0007-00000012')
+    const fila = screen.getByText('0007-00000012').closest('tr')!
+    expect(within(fila).getByText(/Consumidor Final/)).toBeInTheDocument()
+    expect(within(fila).getByText('Local Centro')).toBeInTheDocument()
+    expect(within(fila).getByText('Emitido')).toBeInTheDocument()
+  })
+
+  it('un remito sin número muestra #id', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/remitos?') ? Promise.resolve(paginaFixture({ items: [remitoFixture({ numeroFormateado: null })] })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('#1')).toBeInTheDocument()
+  })
+
+  it('sin resultados muestra el estado vacío', async () => {
+    mockearRutasBase((ruta) => (ruta.startsWith('/remitos?') ? Promise.resolve(paginaFixture({ items: [], total: 0 })) : undefined))
+    renderPantalla()
+
+    expect(await screen.findByText('No hay remitos que coincidan con los filtros.')).toBeInTheDocument()
+  })
+})
+
+describe('Remitos — filtro por estado', () => {
+  it('cambiar el estado dispara una nueva consulta con el filtro aplicado', async () => {
+    mockearRutasBase()
+    renderPantalla()
+    await screen.findByText('0007-00000012')
+
+    await userEvent.selectOptions(screen.getByLabelText('Estado'), 'Facturado')
+    await waitFor(() => expect(apiGetMock).toHaveBeenCalledWith(expect.stringContaining('estado=Facturado')))
+  })
+})
+
+describe('Remitos — pager', () => {
+  it('está deshabilitado en ambos bordes cuando hay una sola página', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    await screen.findByText('0007-00000012')
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+
+  it('navega entre páginas, con "Anterior"/"Siguiente" habilitados solo del lado correcto', async () => {
+    mockearRutasBase((ruta) => {
+      if (ruta.startsWith('/remitos?')) {
+        const paginaSolicitada = ruta.includes('pagina=2') ? 2 : 1
+        return Promise.resolve(paginaFixture({ total: 50, pagina: paginaSolicitada, tamanio: 25 }))
+      }
+      return undefined
+    })
+    const usuario = userEvent.setup()
+    renderPantalla()
+
+    await screen.findByText(/Página 1 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeEnabled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Siguiente' }))
+    await screen.findByText(/Página 2 de 2/)
+    expect(screen.getByRole('button', { name: 'Anterior' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Siguiente' })).toBeDisabled()
+  })
+})
+
+describe('Remitos — herramientas ("Nuevo remito" / "Facturar remitos")', () => {
+  it('ambos botones siempre están visibles — cualquier rol que llega a la pantalla puede despachar/facturar', async () => {
+    mockearRutasBase()
+    renderPantalla()
+
+    expect(await screen.findByRole('button', { name: 'Nuevo remito' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Facturar remitos' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Remitos.tsx
+++ b/src/Ways.Web/src/paginas/Remitos.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import {
+  claseDeBadgeDeEstadoRemito,
+  clienteDeRemitos,
+  etiquetaDeEstadoRemito,
+  filtrosDeRemitosVacios,
+  type FiltrosDeRemitos,
+} from '../api/remitos'
+import { api, ErrorApi } from '../api/cliente'
+import { clienteDeClientes } from '../api/clientes'
+import type { ClienteListado, EstadoRemito, PaginaDeRemitos, PuntoVentaListado, RemitoListado } from '../api/tipos'
+import { Box } from '../componentes/Box'
+import { Cargando } from '../componentes/Cargando'
+
+const OPCIONES_ESTADO: { valor: EstadoRemito | ''; etiqueta: string }[] = [
+  { valor: '', etiqueta: 'Todos' },
+  { valor: 'Borrador', etiqueta: 'Borrador' },
+  { valor: 'Emitido', etiqueta: 'Emitido' },
+  { valor: 'Facturado', etiqueta: 'Facturado' },
+  { valor: 'Anulado', etiqueta: 'Anulado' },
+]
+
+function formatearFecha(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleDateString('es-AR') : '—'
+}
+
+function etiquetaDeCliente(c: ClienteListado): string {
+  const nombreCompleto = c.razonSocial ?? [c.nombre, c.apellido].filter(Boolean).join(' ')
+  return `#${c.numero} — ${nombreCompleto}`
+}
+
+/**
+ * Listado de remitos (stage-17-presupuestos-y-remitos, Slice 8; design: Web composition — mirrors
+ * `Presupuestos.tsx`, 7.2): filtros punto de venta/cliente/estado/desde-hasta + el pager de
+ * `HistoricoDeCajas.tsx`/`Presupuestos.tsx`. La ruta sigue `Politicas.OperacionDePos` — Vendedor/
+ * Supervisor/Admin leen Y escriben, mismo criterio que /presupuestos.
+ */
+export function Remitos() {
+  const navigate = useNavigate()
+
+  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
+  const [clientes, setClientes] = useState<ClienteListado[] | null>(null)
+  const [errorReferencia, setErrorReferencia] = useState('')
+
+  const [filtros, setFiltros] = useState<FiltrosDeRemitos>(filtrosDeRemitosVacios())
+
+  const [pagina, setPagina] = useState<PaginaDeRemitos | null>(null)
+  const [cargando, setCargando] = useState(true)
+  const [error, setError] = useState('')
+  const generacionRef = useRef(0)
+
+  useEffect(() => {
+    let vigente = true
+    api
+      .get<PuntoVentaListado[]>('/puntos-venta')
+      .then((lista) => {
+        if (!vigente) return
+        setPuntosVenta(lista)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setPuntosVenta([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.'))
+      })
+
+    clienteDeClientes
+      .listar('', false)
+      .then((p) => {
+        if (!vigente) return
+        setClientes(p.items)
+      })
+      .catch((e) => {
+        if (!vigente) return
+        setClientes([])
+        setErrorReferencia((prev) => (prev ? prev : e instanceof ErrorApi ? e.message : 'No se pudieron cargar los clientes.'))
+      })
+
+    return () => {
+      vigente = false
+    }
+  }, [])
+
+  // react-async-state regla 2: cada cambio de filtro/página dispara una nueva consulta — una
+  // respuesta desactualizada nunca puede pisar la más reciente.
+  const cargar = useCallback(() => {
+    const miGeneracion = (generacionRef.current += 1)
+    setCargando(true)
+    setError('')
+
+    clienteDeRemitos
+      .listar(filtros)
+      .then((datos) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(datos)
+      })
+      .catch((e) => {
+        if (generacionRef.current !== miGeneracion) return
+        setPagina(null)
+        setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los remitos.')
+      })
+      .finally(() => {
+        if (generacionRef.current !== miGeneracion) return
+        setCargando(false)
+      })
+  }, [filtros])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const puntoVentaPorId: Record<number, PuntoVentaListado> = {}
+  for (const pv of puntosVenta ?? []) puntoVentaPorId[pv.id] = pv
+
+  const clientePorId: Record<number, ClienteListado> = {}
+  for (const c of clientes ?? []) clientePorId[c.id] = c
+
+  function cambiarFiltro(cambios: Partial<Omit<FiltrosDeRemitos, 'pagina' | 'tamanio'>>) {
+    setFiltros((prev) => ({ ...prev, ...cambios, pagina: 1 }))
+  }
+
+  function cambiarPagina(delta: number) {
+    setFiltros((prev) => ({ ...prev, pagina: Math.max(1, prev.pagina + delta) }))
+  }
+
+  const totalPaginas = pagina ? Math.max(1, Math.ceil(pagina.total / pagina.tamanio)) : 1
+
+  const herramientas = (
+    <nav className="p-2 d-flex gap-2">
+      <button type="button" className="btn btn-sm btn-outline-light rounded-0 text-nowrap" onClick={() => navigate('/remitos/facturacion')}>
+        Facturar remitos
+      </button>
+      <button type="button" className="btn btn-sm btn-success rounded-0 text-nowrap" onClick={() => navigate('/remitos/nuevo')}>
+        Nuevo remito
+      </button>
+    </nav>
+  )
+
+  return (
+    <div className="container-fluid py-4">
+      <Box titulo="Remitos" variante="inverse" herramientas={herramientas}>
+        {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {errorReferencia && <div className="alert alert-warning rounded-0 py-1 px-2 small">{errorReferencia}</div>}
+
+        <div className="row g-2 align-items-end mb-3">
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="rem-filtro-punto-venta">
+              Punto de venta
+            </label>
+            <select
+              id="rem-filtro-punto-venta"
+              className="form-select rounded-0"
+              value={filtros.idPuntoVenta ?? ''}
+              onChange={(e) => cambiarFiltro({ idPuntoVenta: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(puntosVenta ?? []).map((pv) => (
+                <option key={pv.id} value={pv.id}>
+                  {pv.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-3">
+            <label className="form-label" htmlFor="rem-filtro-cliente">
+              Cliente
+            </label>
+            <select
+              id="rem-filtro-cliente"
+              className="form-select rounded-0"
+              value={filtros.idCliente ?? ''}
+              onChange={(e) => cambiarFiltro({ idCliente: e.target.value === '' ? null : Number(e.target.value) })}
+            >
+              <option value="">Todos</option>
+              {(clientes ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {etiquetaDeCliente(c)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="rem-filtro-estado">
+              Estado
+            </label>
+            <select
+              id="rem-filtro-estado"
+              className="form-select rounded-0"
+              value={filtros.estado ?? ''}
+              onChange={(e) => cambiarFiltro({ estado: e.target.value === '' ? null : (e.target.value as EstadoRemito) })}
+            >
+              {OPCIONES_ESTADO.map((o) => (
+                <option key={o.valor} value={o.valor}>
+                  {o.etiqueta}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="rem-filtro-desde">
+              Desde
+            </label>
+            <input
+              id="rem-filtro-desde"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.desde}
+              onChange={(e) => cambiarFiltro({ desde: e.target.value })}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label" htmlFor="rem-filtro-hasta">
+              Hasta
+            </label>
+            <input
+              id="rem-filtro-hasta"
+              type="date"
+              className="form-control rounded-0"
+              value={filtros.hasta}
+              onChange={(e) => cambiarFiltro({ hasta: e.target.value })}
+            />
+          </div>
+        </div>
+
+        {cargando && !pagina && <Cargando />}
+
+        {pagina && (
+          <>
+            <div className="table-responsive">
+              <table className="table table-sm table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th>Número</th>
+                    <th>Cliente</th>
+                    <th>Punto de venta</th>
+                    <th>Estado</th>
+                    <th>Fecha de emisión</th>
+                    <th className="text-end">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagina.items.map((r: RemitoListado) => (
+                    <tr key={r.id}>
+                      <td>
+                        <Link className="link-underline-opacity-0" to={`/remitos/${r.id}`}>
+                          {r.numeroFormateado ?? `#${r.id}`}
+                        </Link>
+                      </td>
+                      <td>{clientePorId[r.idCliente] ? etiquetaDeCliente(clientePorId[r.idCliente]) : `Cliente #${r.idCliente}`}</td>
+                      <td>{puntoVentaPorId[r.idPuntoVenta]?.nombre ?? `PV #${r.idPuntoVenta}`}</td>
+                      <td>
+                        <span className={`badge rounded-0 ${claseDeBadgeDeEstadoRemito(r.estado)}`}>{etiquetaDeEstadoRemito(r.estado)}</span>
+                      </td>
+                      <td>{formatearFecha(r.fechaEmision)}</td>
+                      <td className="text-end">
+                        ${r.total.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </td>
+                    </tr>
+                  ))}
+                  {pagina.items.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="text-center text-muted py-4">
+                        No hay remitos que coincidan con los filtros.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center">
+              <span className="small text-muted">
+                Página {pagina.pagina} de {totalPaginas} — {pagina.total} remito(s)
+              </span>
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina <= 1 || cargando}
+                  onClick={() => cambiarPagina(-1)}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary rounded-0"
+                  disabled={pagina.pagina >= totalPaginas || cargando}
+                  onClick={() => cambiarPagina(1)}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -1221,6 +1221,167 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
     }
 
     // =============================================================================================
+    // stage-17-presupuestos-y-remitos, Slice 8, task 8.10b [OD10 — judgment slice 6, juez A]:
+    // GET /api/ventas/{id} de un TXR arma su detalle a partir de items_remito (mismo criterio que
+    // el design T11/comprobantes-venta spec: "shows all N lines, sourced from items_remito, not
+    // from items_comprobante_venta"), un test de N=1 NOMBRADO como el borde deliberado (una
+    // consolidación de un solo remito no es un caso degenerado — el spec/design nunca hablan de un
+    // mínimo de 2), y un test de anulación de TXR con turno cerrado independiente del guard
+    // genérico de ventas (VentasTurnoWiringTests solo lo probó para un TX con items reales).
+    // =============================================================================================
+
+    [Fact]
+    public async Task ElDetalleDeUnTxrQueLigaDosRemitosMuestraLasCincoLineasCombinadasSourceadasDeItemsRemito()
+    {
+        var ctx = await PrepararAsync(nameof(ElDetalleDeUnTxrQueLigaDosRemitosMuestraLasCincoLineasCombinadasSourceadasDeItemsRemito));
+        var idArticulo1 = await SembrarArticuloAsync(ctx, "Txr Detalle Art 1", 100m);
+        var idArticulo2 = await SembrarArticuloAsync(ctx, "Txr Detalle Art 2", 200m);
+        var idArticulo3 = await SembrarArticuloAsync(ctx, "Txr Detalle Art 3", 300m);
+        var idArticulo4 = await SembrarArticuloAsync(ctx, "Txr Detalle Art 4", 400m);
+        var idArticulo5 = await SembrarArticuloAsync(ctx, "Txr Detalle Art 5", 500m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo2, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo3, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo4, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo5, 10m);
+
+        // GIVEN un TXR que liga dos remitos, con 2 y 3 líneas respectivamente (spec: "linking two
+        // remitos with 2 and 3 lines respectively").
+        var remitoDosLineas = await CrearYEmitirRemitoAsync(
+            ctx.Admin,
+            new SolicitudDeRemito(ctx.IdPuntoVenta, ctx.IdCliente, null, null,
+                [new LineaDeRemito(idArticulo1, 1m, null), new LineaDeRemito(idArticulo2, 2m, null)]));
+        var remitoTresLineas = await CrearYEmitirRemitoAsync(
+            ctx.Admin,
+            new SolicitudDeRemito(ctx.IdPuntoVenta, ctx.IdCliente, null, null,
+                [
+                    new LineaDeRemito(idArticulo3, 1m, null), new LineaDeRemito(idArticulo4, 2m, null),
+                    new LineaDeRemito(idArticulo5, 3m, null),
+                ]));
+
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion",
+            SolicitudFacturacion(ctx, [remitoDosLineas.Id, remitoTresLineas.Id], remitoDosLineas.Total + remitoTresLineas.Total));
+        var cuerpoFacturado = await facturado.Content.ReadAsStringAsync();
+        Assert.True(facturado.StatusCode == HttpStatusCode.Created, cuerpoFacturado);
+        var txr = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoFacturado, OpcionesJson)!;
+
+        // Mutation target (OD10): items_comprobante_venta sigue vacío — el requirement "carries
+        // zero items_comprobante_venta rows" no se rompe por esta lectura.
+        await using var dbCero = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await dbCero.ItemsComprobanteVenta.CountAsync(i => i.IdComprobanteVenta == txr.Id));
+
+        // WHEN se lee su detalle impreso (GET /api/ventas/{id}).
+        var respuestaDetalle = await ctx.Admin.GetAsync($"/api/ventas/{txr.Id}");
+        var cuerpoDetalle = await respuestaDetalle.Content.ReadAsStringAsync();
+        Assert.True(respuestaDetalle.StatusCode == HttpStatusCode.OK, cuerpoDetalle);
+        var detalle = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoDetalle, OpcionesJson)!;
+
+        // THEN muestra las 5 líneas combinadas, sourceadas de items_remito — no items_comprobante_venta.
+        Assert.Equal(5, detalle.Items.Count);
+        var descripciones = detalle.Items.Select(i => i.Descripcion).ToList();
+        Assert.Equal(
+            new[] { "Txr Detalle Art 1", "Txr Detalle Art 2", "Txr Detalle Art 3", "Txr Detalle Art 4", "Txr Detalle Art 5" },
+            descripciones);
+        // Orden renumerado 1..N de forma continua sobre el detalle combinado (rule 12b: cada
+        // posición leída con su propia identidad, no solo el conteo).
+        Assert.Equal([1, 2, 3, 4, 5], detalle.Items.Select(i => i.Orden).ToArray());
+        Assert.Equal([1m, 2m, 1m, 2m, 3m], detalle.Items.Select(i => i.Cantidad).ToArray());
+        Assert.Equal([100m, 200m, 300m, 400m, 500m], detalle.Items.Select(i => i.PrecioUnitario).ToArray());
+
+        // Mutation target (OD10, mitad "no from items_comprobante_venta"): un mutante que volviera
+        // a leer items_comprobante_venta para un TXR vería 0 líneas acá — este assert lo mata.
+        Assert.NotEmpty(detalle.Items);
+    }
+
+    /// <summary>[borde deliberado N=1] El spec/design nunca imponen un mínimo de 2 remitos para
+    /// consolidar — un `TXR` de un solo remito tiene que comportarse igual que uno de N: itemless
+    /// en `items_comprobante_venta`, su detalle leído con la única línea del remito, cero
+    /// movimientos de stock.</summary>
+    [Fact]
+    public async Task LaConsolidacionDeUnSoloRemitoEsElBordeDeliberadoNIgualAUnoNoUnCasoDegenerado()
+    {
+        var ctx = await PrepararAsync(nameof(LaConsolidacionDeUnSoloRemitoEsElBordeDeliberadoNIgualAUnoNoUnCasoDegenerado));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Borde N Uno", 75m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 2m));
+
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        var cuerpoFacturado = await facturado.Content.ReadAsStringAsync();
+        Assert.True(facturado.StatusCode == HttpStatusCode.Created, cuerpoFacturado);
+        var txr = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoFacturado, OpcionesJson)!;
+        Assert.Empty(txr.Items); // el POST ya proyecta itemless, N=1 igual que N>1.
+
+        var respuestaDetalle = await ctx.Admin.GetAsync($"/api/ventas/{txr.Id}");
+        var cuerpoDetalle = await respuestaDetalle.Content.ReadAsStringAsync();
+        Assert.True(respuestaDetalle.StatusCode == HttpStatusCode.OK, cuerpoDetalle);
+        var detalle = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoDetalle, OpcionesJson)!;
+
+        var unicoItem = Assert.Single(detalle.Items);
+        Assert.Equal(1, unicoItem.Orden);
+        Assert.Equal("Txr Borde N Uno", unicoItem.Descripcion);
+        Assert.Equal(2m, unicoItem.Cantidad);
+        Assert.Equal(75m, unicoItem.PrecioUnitario);
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        Assert.Equal(0, await db.ItemsComprobanteVenta.CountAsync(i => i.IdComprobanteVenta == txr.Id));
+        Assert.Equal(0, await db.MovimientosStock.CountAsync(m => m.IdComprobanteVenta == txr.Id));
+    }
+
+    /// <summary>[SUGGESTION del mismo veredicto OD10] `EjecutarAnulacionAsync`'s guard de turno
+    /// cerrado (`ExigirTurnoAbiertoAsync`/`turno_cerrado`, ver `VentasTurnoWiringTests`) nunca se
+    /// probó específicamente contra un `TXR` — la composición (loop de items VACÍO + el un-link
+    /// guardado en 1.6) podría, en teoría, tomar un camino que sortee el guard genérico. Prueba
+    /// discriminante: cierra el turno DESPUÉS de facturar (el TXR nació bajo turno abierto), y
+    /// confirma que el guard sigue disparando ANTES de mover cualquier remito o stock.</summary>
+    [Fact]
+    public async Task AnularUnTxrConSuTurnoYaCerradoEsRechazado409TurnoCerradoSinDesligarNiTocarStock()
+    {
+        var ctx = await PrepararAsync(nameof(AnularUnTxrConSuTurnoYaCerradoEsRechazado409TurnoCerradoSinDesligarNiTocarStock));
+        var idArticulo = await SembrarArticuloAsync(ctx, "Txr Turno Cerrado Anular", 60m);
+        await SembrarStockAgregadoAsync(ctx, idArticulo, 10m);
+        var remito = await CrearYEmitirRemitoAsync(ctx.Admin, SolicitudRemitoSimple(ctx, idArticulo, 1m));
+
+        var facturado = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remito.Id], remito.Total));
+        var cuerpoFacturado = await facturado.Content.ReadAsStringAsync();
+        Assert.True(facturado.StatusCode == HttpStatusCode.Created, cuerpoFacturado);
+        var txr = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoFacturado, OpcionesJson)!;
+
+        await using var dbTurno = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var turno = await dbTurno.TurnosCaja
+            .Where(t => t.IdPuntoVenta == ctx.IdPuntoVenta && t.Estado == EstadoTurno.Abierto)
+            .SingleAsync();
+
+        var solicitudDeCierre = new Ways.Application.Caja.SolicitudDeCierre(
+            [new Ways.Application.Caja.ConteoDeclarado(ctx.IdMedioEfectivo, txr.Total)], null);
+        var respuestaCierre = await ctx.Admin.PostAsJsonAsync($"/api/caja/turnos/{turno.Id}/cierre", solicitudDeCierre);
+        var cuerpoCierre = await respuestaCierre.Content.ReadAsStringAsync();
+        Assert.True(respuestaCierre.StatusCode == HttpStatusCode.OK, cuerpoCierre);
+
+        await using var dbAntes = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        var movimientosAntes = await dbAntes.MovimientosStock.CountAsync();
+
+        var respuestaAnular = await ctx.Admin.PostAsync($"/api/ventas/{txr.Id}/anulacion", null);
+        var cuerpoAnular = await respuestaAnular.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Conflict, respuestaAnular.StatusCode);
+        var problema = JsonSerializer.Deserialize<JsonElement>(cuerpoAnular, OpcionesJson);
+        Assert.Equal("turno_cerrado", problema.GetProperty("codigo").GetString());
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant));
+        // El guard disparó ANTES del un-link (posición 1.6) y antes de cualquier reversa de stock
+        // — el remito sigue facturado/ligado, cero movimientos nuevos.
+        var r = await db.Remitos.AsNoTracking().FirstAsync(x => x.Id == remito.Id);
+        Assert.Equal(EstadoRemito.Facturado, r.Estado);
+        Assert.Equal(txr.Id, r.IdComprobanteVenta);
+        Assert.Equal(movimientosAntes, await db.MovimientosStock.CountAsync());
+        Assert.Equal(EstadoComprobante.Emitido, (await db.ComprobantesVenta.AsNoTracking().FirstAsync(c => c.Id == txr.Id)).Estado);
+    }
+
+    // =============================================================================================
     // judgment-day Slice 6, ronda 1, juez B — SUGGESTION (fidelidad de totales, :100-107 de
     // ServicioDeFacturacionDeRemitos): desincronizamos `remitos.total` por escritura cruda ANTES
     // de facturar (sentinel distinto de la suma de items_remito congelados) y probamos el

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -1294,6 +1294,76 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
         Assert.NotEmpty(detalle.Items);
     }
 
+    /// <summary>[judgment-day Slice 8, ronda 1, juez B — MAJOR] El filtro por comprobante de
+    /// <c>ObtenerItemsDeTxrAsync</c> (<c>r.IdComprobanteVenta == idComprobante</c>) nunca quedó
+    /// puesto a prueba con DOS TXRs independientes del MISMO tenant: cada test anterior crea un
+    /// solo TXR por tenant, así que un mutante que ensanche el filtro a
+    /// <c>r.IdComprobanteVenta != null</c> (trayendo remitos de CUALQUIER TXR del tenant) sigue
+    /// viendo el join correcto por casualidad — no hay un segundo TXR cuyas líneas puedan
+    /// filtrarse de más. Below-the-confound: dos consolidaciones separadas, cada una arma SU
+    /// propio detalle con SUS propias líneas — conteo Y identidad (artículo/cantidad,
+    /// discriminantes entre A y B, regla 12c) por cada lado.</summary>
+    [Fact]
+    public async Task DosConsolidacionesIndependientesDelMismoTenantCadaTxrMuestraSoloSusPropiasLineas()
+    {
+        var ctx = await PrepararAsync(nameof(DosConsolidacionesIndependientesDelMismoTenantCadaTxrMuestraSoloSusPropiasLineas));
+        var idArticuloA1 = await SembrarArticuloAsync(ctx, "Txr Discrim A1", 110m);
+        var idArticuloA2 = await SembrarArticuloAsync(ctx, "Txr Discrim A2", 220m);
+        var idArticuloB1 = await SembrarArticuloAsync(ctx, "Txr Discrim B1", 330m);
+        var idArticuloB2 = await SembrarArticuloAsync(ctx, "Txr Discrim B2", 440m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloA1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloA2, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloB1, 10m);
+        await SembrarStockAgregadoAsync(ctx, idArticuloB2, 10m);
+
+        // GIVEN dos TXRs INDEPENDIENTES del mismo tenant — A consolida un remito con
+        // artículos/cantidades DISTINTAS de B (discriminante entre ambos lados).
+        var remitoA = await CrearYEmitirRemitoAsync(
+            ctx.Admin,
+            new SolicitudDeRemito(ctx.IdPuntoVenta, ctx.IdCliente, null, null,
+                [new LineaDeRemito(idArticuloA1, 1m, null), new LineaDeRemito(idArticuloA2, 2m, null)]));
+        var remitoB = await CrearYEmitirRemitoAsync(
+            ctx.Admin,
+            new SolicitudDeRemito(ctx.IdPuntoVenta, ctx.IdCliente, null, null,
+                [new LineaDeRemito(idArticuloB1, 3m, null), new LineaDeRemito(idArticuloB2, 4m, null)]));
+
+        var facturadoA = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remitoA.Id], remitoA.Total));
+        var cuerpoA = await facturadoA.Content.ReadAsStringAsync();
+        Assert.True(facturadoA.StatusCode == HttpStatusCode.Created, cuerpoA);
+        var txrA = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoA, OpcionesJson)!;
+
+        var facturadoB = await ctx.Admin.PostAsJsonAsync(
+            "/api/remitos/facturacion", SolicitudFacturacion(ctx, [remitoB.Id], remitoB.Total));
+        var cuerpoB = await facturadoB.Content.ReadAsStringAsync();
+        Assert.True(facturadoB.StatusCode == HttpStatusCode.Created, cuerpoB);
+        var txrB = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoB, OpcionesJson)!;
+
+        // WHEN se lee el detalle de CADA TXR por separado.
+        var respuestaA = await ctx.Admin.GetAsync($"/api/ventas/{txrA.Id}");
+        var cuerpoDetalleA = await respuestaA.Content.ReadAsStringAsync();
+        Assert.True(respuestaA.StatusCode == HttpStatusCode.OK, cuerpoDetalleA);
+        var detalleA = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoDetalleA, OpcionesJson)!;
+
+        var respuestaB = await ctx.Admin.GetAsync($"/api/ventas/{txrB.Id}");
+        var cuerpoDetalleB = await respuestaB.Content.ReadAsStringAsync();
+        Assert.True(respuestaB.StatusCode == HttpStatusCode.OK, cuerpoDetalleB);
+        var detalleB = JsonSerializer.Deserialize<ComprobanteEmitido>(cuerpoDetalleB, OpcionesJson)!;
+
+        // THEN cada detalle trae EXACTAMENTE sus propias líneas — mutation target: un filtro
+        // ensanchado a `!= null` traería las 4 líneas (de AMBOS TXRs) a cada lado; conteo (2, no
+        // 4) Y identidad (artículo/cantidad discriminantes) matan esa mutación.
+        Assert.Equal(2, detalleA.Items.Count);
+        Assert.Equal(
+            new[] { "Txr Discrim A1", "Txr Discrim A2" }, detalleA.Items.Select(i => i.Descripcion).ToArray());
+        Assert.Equal([1m, 2m], detalleA.Items.Select(i => i.Cantidad).ToArray());
+
+        Assert.Equal(2, detalleB.Items.Count);
+        Assert.Equal(
+            new[] { "Txr Discrim B1", "Txr Discrim B2" }, detalleB.Items.Select(i => i.Descripcion).ToArray());
+        Assert.Equal([3m, 4m], detalleB.Items.Select(i => i.Cantidad).ToArray());
+    }
+
     /// <summary>[borde deliberado N=1] El spec/design nunca imponen un mínimo de 2 remitos para
     /// consolidar — un `TXR` de un solo remito tiene que comportarse igual que uno de N: itemless
     /// en `items_comprobante_venta`, su detalle leído con la única línea del remito, cero

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -849,6 +849,72 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         Assert.Equal(150m, reimpreso.Items[0].PrecioUnitario);
     }
 
+    /// <summary>judgment-day slice-8 ronda 2, juez A (WARNING): <c>ObtenerAsync</c> consultaba
+    /// <c>TiposComprobante</c> INCONDICIONALMENTE en TODO GET /api/ventas/{id}, aunque el camino
+    /// ordinario solo la necesita para bifurcar a un <c>TXR</c> — misma clase del MAJOR "query
+    /// desperdiciada 16→15" de slice 3. Fix: gatear esa consulta detrás de <c>items.Count == 0</c>
+    /// (un comprobante ordinario SIEMPRE tiene items, <c>ExigirLineasValidas</c> lo exige en
+    /// <c>EmitirAsync</c>; un TXR nace itemless por construcción). Mutation target: quitar el gate
+    /// (volver la consulta incondicional) hace este assert caer RED.</summary>
+    [Fact]
+    public async Task ElDetalleOrdinarioNuncaConsultaTiposComprobante()
+    {
+        var ctx = await PrepararAsync(nameof(ElDetalleOrdinarioNuncaConsultaTiposComprobante));
+        var idArticulo = await SembrarArticuloConPrecioAsync(ctx, "articulo-gate-tipo", 50m);
+        var (idCliente, _) = await SembrarClienteAsync(ctx, "Cliente Gate Tipo");
+
+        var solicitud = new SolicitudDeVenta(
+            ctx.IdPuntoVenta, idCliente, "TX", null,
+            [new LineaDeVenta(idArticulo, 1m, null)],
+            [new PagoDeVenta(ctx.IdMedioEfectivo, 50m, null, 0m)],
+            null, null);
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/ventas", solicitud);
+        var emitido = (await respuesta.Content.ReadFromJsonAsync<ComprobanteEmitido>(OpcionesJson))!;
+
+        var consultasSobreTipos = await ObtenerYContarConsultasSobreTablaAsync(ctx, emitido.Id, "tipos_comprobante");
+
+        Assert.Equal(0, consultasSobreTipos);
+    }
+
+    private async Task<int> ObtenerYContarConsultasSobreTablaAsync(Contexto ctx, int idComprobante, string tabla)
+    {
+        var contador = new ContadorDeConsultasSobreTabla(tabla);
+        var tenantActual = new TenantActualFijo(ModoDeAcceso.Tenant, ctx.IdTenant);
+
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
+            .Options;
+
+        await using var db = new WaysDbContext(opciones, tenantActual);
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contexto = new ContextoFijo(ctx.IdTenant, usuarioId: 1);
+        var servicioDePrecios = new Ways.Application.Precios.ServicioDePrecios(db, reloj, contexto);
+        var servicioDeOfertas = new ServicioDeOfertas(db, reloj, contexto, servicioDePrecios);
+        var lectorDeMovimientos = new Ways.Application.Caja.LectorDeMovimientosDelTurno(db);
+        var servicioDeTurnos = new Ways.Application.Caja.ServicioDeTurnos(db, reloj, contexto, lectorDeMovimientos);
+        var servicioDeLotes = new Ways.Application.Stock.ServicioDeLotes(db, reloj, contexto);
+        var servicioDeVentas = new ServicioDeVentas(db, reloj, contexto, servicioDeOfertas, servicioDeTurnos, servicioDeLotes);
+
+        await servicioDeVentas.ObtenerAsync(idComprobante);
+
+        return contador.Consultas;
+    }
+
     // ---- task 4.12: guard de presupuesto de consultas --------------------------------------------
 
     /// <summary>Cuenta cada comando que dispara <c>ReaderExecuting</c> — misma técnica que


### PR DESCRIPTION
## Resumen

Slice 8 — el ÚLTIMO de la etapa 17: el circuito completo de remitos/consolidación tiene UI, y la etapa cierra.

- `api/remitos.ts` (client + mappers + reducers de multi-select), `Remitos.tsx`, `Remito.tsx` (emitir con `SelectorDeLote` extraído de Pos + anular; `facturado` muestra su factura y CERO acciones), `FacturarRemitos.tsx` (multi-select completo, total sumado, pagos POS, POST de consolidación — sin necesidad de la degradación pre-autorizada).
- **OD10** (la única excepción backend, pre-autorizada): el detalle de un `TXR` se lee de `items_remito` (`ObtenerItemsDeTxrAsync` con renumeración de `Orden`), cerrando el requirement-sin-task que destapó el juez A del slice 6 — con el escenario del spec, el borde N=1 nombrado y la anulación con turno cerrado.
- Los 3 headers "Estado (Etapa 17)" de doc-10 cerrados (más un tercero vencido que el barrido cazó — la clase W1 de las etapas 13/14/15).

## Judgment-day (2 rondas, limpia al cierre)

- **Juez B REJECT ronda 1**: 3 MAJOR test-only — el join de OD10 sin fixture de DOS TXRs (la clase 12c del slice 6 reincidente), el POST de consolidación que no probaba los ids EXACTOS tildados (el mutante que factura todo lo listado sobrevivía 8/8 — bug de negocio serio sin red), y las redes de stale sin replicar en las 3 pantallas. Fixes `25ea8f3` con ciclo RED/verde por mutante y cero inalcanzabilidades. **Re-ronda B: APPROVE.**
- **Juez A APPROVE**: 1 WARNING — query nueva incondicional en TODO `GET /api/ventas/{id}` (la clase del "16→15" del slice 3). Fix `0912eb2`: gate `items.Count == 0` (estructuralmente imposible para un ordinario: `ExigirLineasValidas` + la anulación nunca borra items + `presupuesto_sin_items` cierra la conversión) + test de conteo nuevo + `ProyectarConItems` único. Backlog registrado: asimetría latente del TXR anulado (hoy inalcanzable desde la web). **Pasada acotada de B: APPROVE** con la verificación adversarial de los tres caminos.

## Suites (cierre de etapa, corridas en el apply)

- Domain **540/540** · Application **297/297** · Integration **1580/1581** (la única falla era la bomba de calendario preexistente, ya cerrada aparte en #154) · vitest **55 archivos, 902/902**. Build y lint limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)