### PR TITLE
feat(etiquetas): spike de calibracion + descriptores de formato + HojaDeEtiquetas (etapa 18, slice 1)

### DIFF
--- a/openspec/changes/stage-18-etiquetas-y-consulta/spike-alineacion.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/spike-alineacion.md
@@ -1,0 +1,75 @@
+# Spike de alineación — Etapa 18, Slice 1
+
+> Design: `design.md:67-105` (decisiones 1-2, subject `A4-3x8`). Tasks: `tasks.md` slice 1, tareas
+> 1.1-1.5 y Reconciliación 5 (spike partido en **1a autónomo** / **1b bloqueado en el dueño**).
+
+## Qué mide este documento
+
+Dos criterios de salida, ambos binarios y ambos requeridos antes de que el slice 3 pueda abrir
+(verify criterio 4):
+
+- **E1 (geometría física)** — requiere la impresora y la hoja troquelada de referencia del dueño.
+  **Human-in-the-loop por naturaleza** (design.md:101-102): ningún agente de este pipeline puede
+  ejecutarlo. Tarea **1.4**, registrada `[ ]` y **BLOQUEADA EN EL DUEÑO**.
+- **E2 (no-regresión)** — no comparte esa restricción y corre en este entorno. Tarea **1.5**.
+
+## E1 — Corridas físicas (una fila por corrida, a cargo del dueño)
+
+**Instrucciones de medición para el dueño**:
+
+1. Abrir la grilla de calibración (`HojaDeEtiquetas` en `modo="calibracion"`, subject `A4-3x8` —
+   la geometría más ajustada, borde a borde, sin canaletas: si el margen no imprimible del
+   hardware recorta columnas, este es el subject que lo va a mostrar primero).
+2. Configurar impresión según el bloque `d-print-none` en pantalla: **A4, escala 100% (nunca
+   "ajustar a la página"), sin márgenes, gráficos de fondo activados**.
+3. Imprimir sobre la hoja troquelada de referencia (Avery 3422 o equivalente del mercado local).
+4. Medir con precisión ≥ 0.1 mm la desviación del **origen de cada celda** (la cruz de registro de
+   6 mm) respecto de su posición nominal, en al menos: las **4 celdas de esquina**, la **celda
+   central**, y **ambos extremos de la última fila**.
+5. Medir el **cuadrado de escala**: si no mide 100.0 ± 0.3 mm, la corrida es **NULA** (no un FAIL)
+   — algo en la cadena de impresión (driver, escala real aplicada) no está en 100%; corregir y
+   repetir antes de registrar un veredicto.
+6. Calcular la **deriva acumulada de la última fila** (diferencia entre el primer y el último
+   extremo medido en esa fila).
+7. Verificar E1: **todas** las desviaciones de origen dentro de **±1.0 mm** de nominal **y** la
+   deriva acumulada de la última fila dentro de **±1.5 mm** ⇒ **PASS**. Cualquier medición fuera de
+   esos límites ⇒ **FAIL** (ver "Camino de FAIL" abajo).
+8. Guardar evidencia (foto de la hoja medida con regla/calibre visible, o el archivo de medición)
+   y anotar su ruta en la columna `Evidencia`.
+9. Agregar la fila a la tabla de abajo y actualizar `tasks.md` tarea 1.4 a `[x]` **solo** cuando
+   este documento tenga al menos una corrida con veredicto `PASS` en E1.
+
+**Camino de FAIL**: STOP. No se cambia de librería en silencio — la decisión de licencia de
+QuestPDF se escala al dueño como decisión comercial bloqueante (`proposal.md` OD1). El slice 4 es
+independiente y puede avanzar mientras tanto (`design.md:387-389`).
+
+| Fecha | Navegador + versión | SO | Impresora (marca/modelo) | Hoja de referencia | Escala / márgenes configurados | Cuadrado de escala medido (mm) | Desvío celda esquina 1 (mm) | Desvío celda esquina 2 (mm) | Desvío celda esquina 3 (mm) | Desvío celda esquina 4 (mm) | Desvío celda central (mm) | Desvío extremo 1 última fila (mm) | Desvío extremo 2 última fila (mm) | Deriva acumulada última fila (mm) | Veredicto E1 | Veredicto E2 | Evidencia (ruta) |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| _(sin corridas — pendiente del dueño, tarea 1.4)_ | | | | | | | | | | | | | | | | | |
+
+**Estado actual**: **sin corridas registradas.** Tarea 1.4 permanece `[ ]` y bloqueada en el
+dueño. El slice 3 (`Etiquetas.tsx`) **no puede abrir** hasta que esta tabla tenga una fila con
+`Veredicto E1 = PASS` (verify criterio 4, `tasks.md` Reconciliación 5).
+
+## E2 — No-regresión (tarea 1.5, ejecutable en este entorno)
+
+Tres pruebas, las tres corren sin la impresora/papel del dueño (`design.md:93-97`,
+`tasks.md` Reconciliación 5):
+
+| # | Prueba | Cómo se ejecuta | Resultado |
+|---|---|---|---|
+| 1 | `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` limpio | Comando de shell, determinístico | Ver evidencia en el reporte de apply de este slice — `impresion.css` no aparece en el diff del slice (verify criterio 3, mutation target 2) |
+| 2 | `CajaZ.test.tsx` / `CuentaCorriente.test.tsx` verdes y **sin editar** | `npx vitest run` sobre ambos archivos | Ver evidencia en el reporte de apply — ninguno de los dos archivos aparece en el diff del slice; ambas suites corren dentro de la corrida completa de `npx vitest run` |
+| 3 | Comparación "Guardar como PDF" caja-a-caja de cada vista (`main` vs. la rama), mismo navegador/config | Impresión real desde un navegador contra la app corriendo (o un dev/headless print) | **NO completada en este pase de apply.** Ver nota abajo |
+
+**Nota sobre la prueba 3 — gap reconocido, no corner-cut silencioso**: esta comparación requiere
+una sesión de navegador real contra la app completa (API + Postgres + login) para navegar hasta
+`CajaZ`/`CuentaCorriente` con datos reales y comparar el resultado impreso. El repo no tiene infra
+de E2E (Playwright/Puppeteer) y la etapa tiene como dependencia vinculante *"no new web
+dependency"* (`proposal.md:475`) — instalar una para esta única comparación violaría esa
+restricción. Se registra como **pendiente**, a ejecutar manualmente (por el dueño o un desarrollador
+con la app corriendo) antes de cerrar el veredicto E2 con las tres pruebas completas. Las otras dos
+pruebas de E2, que sí son determinísticas y no requieren un navegador real, están **verdes**.
+
+**Veredicto E2 provisional**: 2/3 pruebas verdes y determinísticas; la tercera queda pendiente de
+una sesión manual. No se marca `PASS` completo hasta que las tres corran.

--- a/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
@@ -148,21 +148,21 @@ not trigger here — the strike rule is a single boolean formula, not a guard ch
 tests pass + `judgment-day` clean round + PR merged; 1b remains open until the owner runs it, and
 gates slice 3 only (verify criterion 4), not this PR.
 
-- [ ] 1.1 **(1a, autonomous)** Create `src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx` in
+- [x] 1.1 **(1a, autonomous)** Create `src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx` in
   `modo="calibracion"`: 0.2 mm hairline box per nominal cell, 6 mm registration cross at each
   cell's top-left origin, `f{row}c{col}` label, a 200 mm horizontal / 280 mm vertical 1 mm-tick
   ruler, a 100.0 × 100.0 mm labelled scale square, driven by the **same** descriptor tuple the real
   sheet uses. *(design.md:67-84, mutation target 6)*
-- [ ] 1.2 **(1a, autonomous)** Same file, `d-print-none` print-settings instruction block: A4,
+- [x] 1.2 **(1a, autonomous)** Same file, `d-print-none` print-settings instruction block: A4,
   100% scale, "fit to page" OFF, margins none, background graphics ON. *(design.md:84, mutation
   target 8)*
-- [ ] 1.3 **(1a, autonomous)** Create
+- [x] 1.3 **(1a, autonomous)** Create
   `openspec/changes/stage-18-etiquetas-y-consulta/spike-alineacion.md` — the recording scaffold:
   one row per run (date, browser+version, OS, printer make/model, sheet reference, print
   scale/margin settings, scale-square measurement, per-cell deviation at the 4 corners + centre +
   both last-row ends, last-row cumulative drift, E1 verdict, E2 verdict, evidence path). Empty
   rows, ready for the owner's physical run. *(design.md:98-102)*
-- [ ] 1.4 **(1b, BLOCKED ON OWNER — physical printer + reference die-cut A4 sheet required)** Print
+- [ ] 1.4 **(1b, BLOCKED ON OWNER — physical printer + reference die-cut A4 sheet required, NOT executed by this apply pass)** Print
   the `A4-3x8` calibration grid at 100% scale on the reference sheet, on at least one target
   browser; measure and record **E1**: every cell origin within ±1.0 mm of nominal (4 corners +
   centre + both last-row ends), last-row cumulative drift within ±1.5 mm, scale-square
@@ -170,51 +170,117 @@ gates slice 3 only (verify criterion 4), not this PR.
   **FAIL path**: STOP — no library swap; escalate the QuestPDF licence question to the owner as a
   blocking commercial decision, never resolved inside this phase. *(proposal.md:147-161,
   design.md:86-92, Reconciliación 5)*
-- [ ] 1.5 **(1a, autonomous)** E2 non-regression, three proofs, appended to `spike-alineacion.md`'s
+- [~] 1.5 **(1a, autonomous, PARTIAL — 2/3 proofs, see Deviations)** E2 non-regression, three proofs, appended to `spike-alineacion.md`'s
   E2 row: `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` clean; `CajaZ.test.tsx` /
   `CuentaCorriente.test.tsx` green and **unedited**; a "Guardar como PDF" page-box comparison of
   each view from `main` vs. the branch, same browser/settings. *(design.md:93-97, mutation target
   1 partial, verify criterion 5)*
-- [ ] 1.6 Create `src/Ways.Web/src/etiquetas/formatos.ts` — `CampoDeCelda` union,
+- [x] 1.6 Create `src/Ways.Web/src/etiquetas/formatos.ts` — `CampoDeCelda` union,
   `DescriptorDeFormato` (flat, function-free, frozen record), the four tuples using the
   **sharpened** `A4-2x7` geometry (99.1×38.1 mm, margins 15.15/4.65 mm, gutter 2.5 mm —
   Reconciliación 2), plus `celdasPorHoja`/`contarHojas` as pure derived helpers, never stored
   fields. *(design.md:111-148, mutation targets 3, 4)*
-- [ ] 1.7 [P] `formatos.test.ts` — for each of the four descriptors, assert the emitted mm values
+- [x] 1.7 [P] `formatos.test.ts` — for each of the four descriptors, assert the emitted mm values
   equal the tuple and `columnas × filas` equals the declared per-sheet count (24/14/1/2).
   *(design.md:315, mutation target 3)*
-- [ ] 1.8 [P] `formatos.test.ts` — `celdasPorHoja`/`contarHojas`: 24→1 hoja, 25→2, 0→0; assert no
+- [x] 1.8 [P] `formatos.test.ts` — `celdasPorHoja`/`contarHojas`: 24→1 hoja, 25→2, 0→0; assert no
   stored derived field exists on the type (a mutated tuple must move the derived count too).
   *(mutation targets 4, 5)*
-- [ ] 1.9 Create `src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx` `modo="normal"`: pure props-only
+- [x] 1.9 Create `src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx` `modo="normal"`: pure props-only
   renderer (descriptor + already-expanded `celdas` + `nombreDeLista`), emits geometry as
   `--pagina-ancho`/`--celda-ancho`/`--pitch-x`/`--margen-sup`… custom properties on
   `.hoja-de-etiquetas` (the only projection jsdom can measure); strike rule is
   `celda.ofertas.length > 0`, **never** `precioOriginal !== precioFinal`. *(design.md:162-176,
   mutation target 7)*
-- [ ] 1.10 [P] `HojaDeEtiquetas.test.tsx` — strike rendered **iff** `ofertas.length > 0`: a
+- [x] 1.10 [P] `HojaDeEtiquetas.test.tsx` — strike rendered **iff** `ofertas.length > 0`: a
   constructed DTO with distinct prices + empty `ofertas` (no strike) and its mirror (equal prices +
   non-empty `ofertas`, strike). *(design.md:316, mutation target 7)*
-- [ ] 1.11 [P] `HojaDeEtiquetas.test.tsx` — calibration-mode emits the identical geometry custom
+- [x] 1.11 [P] `HojaDeEtiquetas.test.tsx` — calibration-mode emits the identical geometry custom
   properties as normal-mode for the same descriptor. *(mutation target 6)*
-- [ ] 1.12 [P] `HojaDeEtiquetas.test.tsx` — the `d-print-none` instruction block is present.
+- [x] 1.12 [P] `HojaDeEtiquetas.test.tsx` — the `d-print-none` instruction block is present.
   *(mutation target 8)*
-- [ ] 1.13 Create `src/Ways.Web/src/estilos/etiquetas.css` — `@page etiquetas { size: A4; margin: 0
+- [x] 1.13 Create `src/Ways.Web/src/estilos/etiquetas.css` — `@page etiquetas { size: A4; margin: 0
   }` + `.hoja-de-etiquetas { page: etiquetas }` + the grid rules; `impresion.css` stays untouched.
   *(design.md:52, mutation target 1)*
-- [ ] 1.14 **(S)** Test: the sheet container carries the named-page class/property — assert
+- [x] 1.14 **(S)** Test: the sheet container carries the named-page class/property — assert
   `.hoja-de-etiquetas`'s declared `page: etiquetas` (structural: jsdom does not implement `@page`).
   *(mutation target 1)*
-- [ ] 1.15 **GATE GUARD** — `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` clean
+- [x] 1.15 **GATE GUARD** — `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` clean
   (re-asserted from 1.5 as the slice's own gate task); no file under `src/Ways.Infrastructure/` in
   this slice's diff. *(verify criteria 1, 3)*
-- [ ] 1.16 Mutation evidence recorded in the PR body for targets 1-8 (structural rows 1, 2, 8
+- [x] 1.16 Mutation evidence recorded in the PR body for targets 1-8 (structural rows 1, 2, 8
   record the file/state assertion, not a runtime failure). *(verify criterion 11)*
 - [ ] 1.17 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
 - [ ] 1.18 Open PR #1 `feat/stage18-slice1-spike-y-formatos`, merge to `main` after a clean
   `judgment-day` round. **Note in PR body**: task 1.4 (E1's physical verdict) is open and
   owner-blocked; slice 3 will not start until it is recorded PASS.
+
+### Work Unit Evidence (Slice 1)
+
+| Evidence | Value |
+|---|---|
+| Focused test command and exact result | `npx vitest run` (`src/Ways.Web`) — **57 test files passed, 926 tests passed** (0 failed), including the two new colocated files `formatos.test.ts` (11 tests) and `HojaDeEtiquetas.test.tsx` (6 tests). One pre-existing/unrelated flake observed in `Vencimientos.test.tsx` on the full-suite run (`Not implemented: navigation to another Document`, a known jsdom limitation — confirmed pre-existing: the file is untouched by this slice's diff, and re-running it in isolation is 9/9 green) |
+| Runtime harness command/scenario and exact result | N/A — this slice ships zero fetch/zero backend consumer by design (`HojaDeEtiquetas` is pure props-only, "no consumer exists yet" per the slice's own Finish criterion). `npx tsc -b` clean, `npm run lint` (oxlint) clean (4 pre-existing warnings in untouched files), `dotnet build` clean (confirms zero backend impact — no `.cs` file touched) |
+| Rollback boundary | `git revert` the slice-1 commit(s): `src/Ways.Web/src/etiquetas/**`, `src/Ways.Web/src/estilos/etiquetas.css`, `openspec/changes/stage-18-etiquetas-y-consulta/spike-alineacion.md`, and the one-line `css: true` addition to `src/Ways.Web/vite.config.ts`'s `test` block. `impresion.css` and every `.cs` file are untouched (`git diff --exit-code` clean on both, confirmed). No component imports `HojaDeEtiquetas`/`formatos.ts` yet, so the revert removes zero consumers |
+
+### Mutation Evidence (targets 1-8, verify criterion 11)
+
+| # | Slice | Clause | Mutation applied | Test that failed | Reverted |
+|---|---|---|---|---|---|
+| 1 **S** | 1 | `@page etiquetas` in `etiquetas.css` + `page: etiquetas` on `.hoja-de-etiquetas` | Deleted `page: etiquetas;` from the `.hoja-de-etiquetas` rule | `HojaDeEtiquetas.test.tsx` › "el contenedor lleva la clase `hoja-de-etiquetas` que etiquetas.css usa para declarar `page: etiquetas`" — FAILED (regex on the raw stylesheet text no longer matches) | Yes, reverted, test green again |
+| 2 **S** | 1 | `impresion.css` untouched | N/A — asserted via `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` against `main`, run and confirmed clean (0 diff, file byte-identical); the file was never written by this slice so there is no local edit to mutate/revert | `git diff --exit-code` (shell, not a vitest test) | N/A |
+| 3 | 1 | Each geometry number of each of the four descriptors | Changed `A4_3X8.celdaMm.alto` from `37.0` to `38.0` | `formatos.test.ts` › "A4-3x8: celda 70.0×37.0 mm..." — FAILED (`expected 38 to be 37`) | Yes |
+| 4 | 1 | `celdasPorHoja`/`contarHojas` derived, never stored | Temporarily hardcoded `celdasPorHoja` to always return `24` regardless of input | `formatos.test.ts` › "un descriptor mutado (celdaPorHoja distinto) mueve el conteo derivado" — FAILED (`expected 24 to be 10`) | Yes |
+| 5 | 1 | `contarHojas = ceil(celdas / porHoja)` | Changed `Math.ceil` to `Math.floor` | `formatos.test.ts` › "contarHojas: 25 etiquetas en A4-3x8 ⇒ 2 hojas" — FAILED (`expected 1 to be 2`) | Yes |
+| 6 | 1 | The calibration grid driven by the same descriptor as the real sheet | Passed `{ ...A4_3X8, celdaMm: { ancho: 50, alto: 20 } }` to the calibration branch only, diverging from the normal-mode descriptor | `HojaDeEtiquetas.test.tsx` › "modo=\"calibracion\" emite exactamente los mismos custom properties..." — FAILED (`--celda-ancho: 50mm` ≠ `70mm`) | Yes |
+| 7 | 1 | The strike rule `ofertas.length > 0` | Changed the strike condition to `celda.precioOriginal !== celda.precioFinal` | Both new tests in the "regla de tachado (mutation target 7)" block — FAILED (distinct-price/empty-ofertas case wrongly struck; equal-price/with-oferta case wrongly not struck) | Yes |
+| 8 **S** | 1 | The print-settings block's `d-print-none` | Removed the `d-print-none` class from the instruction block | `HojaDeEtiquetas.test.tsx` › "modo=\"calibracion\" muestra el bloque d-print-none..." — FAILED (`toHaveClass('d-print-none')`) | Yes |
+
+### Deviations from Design
+
+1. **Task 1.5 (E2) is PARTIAL, not complete.** Two of its three proofs are green and deterministic
+   (`git diff --exit-code` on `impresion.css`; `CajaZ.test.tsx`/`CuentaCorriente.test.tsx` green and
+   unedited — both confirmed inside the full `npx vitest run`). The third proof — a "Guardar como
+   PDF" page-box comparison of `main` vs. the branch inside a real browser session — was **not**
+   executed. It needs an authenticated, fully-running app (API + Postgres) to render `CajaZ`/
+   `CuentaCorriente` with real data, and the repo has no E2E harness; installing one (Playwright/
+   Puppeteer) would violate the stage's own binding "no new web dependency" constraint
+   (`proposal.md:475`). Practically, the risk this proof exists to catch is near-zero for slice 1
+   specifically: `HojaDeEtiquetas`/`etiquetas.css` have **zero consumers** in the app yet (verified —
+   `hoja-de-etiquetas` only appears in the three files this slice created), so the new named page
+   never actually coexists with the global `@page` rule inside a running app until slice 3 mounts
+   `Etiquetas.tsx`. Recommendation: re-run this specific proof as part of slice 3's own gate, when
+   `HojaDeEtiquetas` gets its first real consumer. Recorded in `spike-alineacion.md`'s E2 section,
+   not silently dropped.
+2. **`padExternoMm` for `CARTEL-A4`/`CARTEL-A5` is an assumption, not a design-given value.**
+   `design.md:143-148`'s table only publishes `padExternoMm` for the two label formats (`A4-3x8` =
+   5, `A4-2x7` = 3); the two poster formats have no published value. Set to `5` for both (matching
+   the most conservative published value) since posters already carry a generous 10 mm margin that
+   likely absorbs the printer's non-printable edge, but this is a judgment call, not a cited number
+   — flagged for `judgment-day`/owner review.
+3. **`campos`/`escalaDePrecio` per descriptor are not design-given values.** `design.md` defines the
+   `DescriptorDeFormato` shape and cites these fields' *purpose* but never their per-format values.
+   All four descriptors ship the same full `CampoDeCelda` set (`nombre`, `precioFinal`,
+   `precioOriginal`, `codigo`, `unidadVenta`, `nombreDeOferta`); `escalaDePrecio` uses ascending,
+   undocumented placeholder values (1.4/1.6/3.5/3.0). Neither is exercised by a mutation target or a
+   binding test — slice 3 (`Etiquetas.tsx`, the first real consumer) is the natural place to revisit
+   these once actual cell layouts are on screen.
+4. **`FilaDeEtiqueta` and `OfertaAplicada` types**: `FilaDeEtiqueta` is defined locally in
+   `HojaDeEtiquetas.tsx` (exported) rather than in `api/etiquetas.ts`, because that file does not
+   exist yet — it is slice 3's task 3.1 ("DTO mirrors of `SolicitudDeEtiquetas`/`DatosDeEtiquetas`/
+   `FilaDeEtiqueta`/`ArticuloExcluido`"). `OfertaAplicada` is reused **verbatim** from the existing
+   `api/tipos.ts` (design.md:204: "`Ofertas` reuses `OfertaAplicadaDto` verbatim"). Slice 3 should
+   import `FilaDeEtiqueta` from `etiquetas/HojaDeEtiquetas.tsx` instead of redefining it, to avoid two
+   competing shapes.
+5. **`vite.config.ts` gained one line (`css: true` in the `test` block).** Needed so Vitest stops
+   stubbing `.css` imports (including `?raw`) as empty strings — required for task 1.14's structural
+   test to read the real `etiquetas.css` text. Scoped to test config only; does not change any
+   production build output (`build.outDir`/`sourcemap` untouched).
+
+### Issues Found
+
+None beyond the deviations above.
 
 ---
 

--- a/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
@@ -170,7 +170,7 @@ gates slice 3 only (verify criterion 4), not this PR.
   **FAIL path**: STOP — no library swap; escalate the QuestPDF licence question to the owner as a
   blocking commercial decision, never resolved inside this phase. *(proposal.md:147-161,
   design.md:86-92, Reconciliación 5)*
-- [~] 1.5 **(1a, autonomous, PARTIAL — 2/3 proofs, see Deviations)** E2 non-regression, three proofs, appended to `spike-alineacion.md`'s
+- [ ] 1.5 **(1a, autonomous, PARTIAL — 2/3 proofs done, see Deviation 1 below — kept unchecked, not silently marked done)** E2 non-regression, three proofs, appended to `spike-alineacion.md`'s
   E2 row: `git diff --exit-code src/Ways.Web/src/estilos/impresion.css` clean; `CajaZ.test.tsx` /
   `CuentaCorriente.test.tsx` green and **unedited**; a "Guardar como PDF" page-box comparison of
   each view from `main` vs. the branch, same browser/settings. *(design.md:93-97, mutation target

--- a/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
@@ -210,8 +210,15 @@ gates slice 3 only (verify criterion 4), not this PR.
   this slice's diff. *(verify criteria 1, 3)*
 - [x] 1.16 Mutation evidence recorded in the PR body for targets 1-8 (structural rows 1, 2, 8
   record the file/state assertion, not a runtime failure). *(verify criterion 11)*
-- [ ] 1.17 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
+- [x] 1.17 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
+  **DONE by the orchestrator**: ronda 1 juez B REJECT (1 MAJOR: cruz de registro y hairline sin
+  red — mutantes DOM-observables SURVIVED 6/6; 1 MINOR: ticks de 1mm faltantes) → fixes `5bc6a05`
+  → re-ronda B APPROVE. Ronda 2 juez A REJECT (2 CRITICAL por LECTURA: el cuadrado de escala caía
+  en una SEGUNDA hoja física — 380.2mm de flujo en una página de 297 — falseando el veredicto E1;
+  y el gate E2 sin tarea exigible; + 1 WARNING de la tarea 3.1) → fixes `7e86886` (absolute
+  anchors + Start del slice 3 con E1 Y E2 + tarea 3.0) → pasada acotada B APPROVE (razonamiento
+  del layout físico confirmado) + re-ronda A APPROVE (cero hallazgos). Ronda limpia.
 - [ ] 1.18 Open PR #1 `feat/stage18-slice1-spike-y-formatos`, merge to `main` after a clean
   `judgment-day` round. **Note in PR body**: task 1.4 (E1's physical verdict) is open and
   owner-blocked; slice 3 will not start until it is recorded PASS.

--- a/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
@@ -289,6 +289,14 @@ None beyond the deviations above.
 | 1 | MAJOR | El test de la grilla de calibración (`HojaDeEtiquetas.test.tsx`) no asertaba la cruz de registro (`<span className="cruz-registro">`, `HojaDeEtiquetas.tsx:136`) ni la clase `celda-calibracion` (hook del hairline de 0.2mm) — ambos mutantes sobrevivían 6/6, y `design.md:79-80` exige ambos elementos | `data-testid={\`cruz-registro-f\${fila}c\${columna}\`}` agregado a la cruz (mismo patrón que `cuadrado-de-escala`/`regla-horizontal`); test asserta conteo exacto de cruces == columnas×filas (24, regla 12b), presencia por celda, `toHaveClass('celda-calibracion')`, y que el modo NORMAL no renderiza ninguno de los dos (discriminante de modo) | (a) borrado el `<span className="cruz-registro">` → RED (`getAllByTestId` no encontró coincidencias) → revertido → verde. (b) `celda celda-calibracion` → `celda` → RED (`toHaveClass('celda-calibracion')` falló) → revertido → verde |
 | 2 | MINOR | `design.md:82` especifica "1 mm ticks, 10 mm labels"; `ReglaHorizontal`/`ReglaVertical` solo dibujaban marcas cada 10mm | Ticks de 1mm agregados en ambas reglas (201 en la horizontal, 281 en la vertical), diferenciados por clase `regla-tick-mayor`/`regla-tick-menor` (label solo en los mayores, cada 10mm); CSS distingue alto/ancho por clase; test nuevo asserta conteo exacto de ticks totales y por clase | Paso de 1mm mutado a 2mm en la regla horizontal → RED (`toHaveLength(201)` recibió 101) → revertido → verde |
 
+### judgment-day Slice 1, ronda 2 — juez A (2 CRITICAL + 1 WARNING)
+
+| # | Severidad | Hallazgo | Fix | Ciclo mutación |
+|---|---|---|---|---|
+| 1 | CRITICAL | `ReglaHorizontal` + `ReglaVertical` (`position: relative`) + `CuadradoDeEscala` (sin `position`) vivían en FLUJO NORMAL dentro de `.hoja-de-etiquetas` (297mm de alto) — 0.2mm + 280mm + 100mm = 380.2mm, así que el cuadrado de escala caía en una segunda página impresa donde el dueño puede no verlo, arriesgando un veredicto E1 falso (la precondición de nulidad ±0.3mm exige el cuadrado EN LA MISMA hoja) | `etiquetas.css`: las tres reglas pasan a `position: absolute`. `.regla-horizontal`/`.regla-vertical` anclan en `top:0; left:0` (coincide con `design.md:82`: "a horizontal 200mm ruler (top) and a vertical 280mm ruler (left)"). `.cuadrado-de-escala` ancla en `right:0; bottom:0` — desviación registrada: el design no fija su ubicación, así que se eligió la esquina opuesta a las reglas (sin número mágico de mm, funciona para cualquier `paginaMm`); puede superponerse a la grilla porque el hairline de celda y el contorno del cuadrado son distinguibles a ojo y el design solo exige poder medirlo (design.md:83). Test estructural nuevo en `HojaDeEtiquetas.test.tsx` (mismo patrón que el test de named page existente): asserta `position:\s*absolute` en los bloques CSS de `.regla-horizontal`/`.regla-vertical` y `.cuadrado-de-escala` | Borrado `position: absolute` del bloque `.cuadrado-de-escala` → RED (`toMatch(/position:\s*absolute/)` falló) → `git checkout --` → revertido → verde |
+| 2 | CRITICAL | El criterio vinculante 4 exige "PASS on both E1 and E2 before slice 3 opens", pero el **Start** de slice 3 solo nombraba la tarea 1.4 (E1); la tercera prueba de E2 (comparación de page-box "Guardar como PDF" de `CajaZ`/`CuentaCorriente`, diferida en `spike-alineacion.md` §E2) no tenía ninguna tarea dueña en slice 3 | **Start** de slice 3 enmendado para exigir 1.4 (E1) **y** 1.5 (E2 completo, las tres pruebas), citando el criterio vinculante 4. Nueva tarea **3.0** (gate, antes de 3.1): re-correr la tercera prueba de E2 — PDF de `CajaZ`/`CuentaCorriente` antes y después de montar el primer consumidor real de `HojaDeEtiquetas`, comparación de page-box — y registrar el resultado en `spike-alineacion.md` §E2, cerrando la tarea 1.5 | N/A — cambio de documentación (`tasks.md`), no de código ejecutable; el gate en sí se verifica en slice 3 cuando 3.0 corra |
+| 3 | WARNING | La tarea 3.1 seguía diciendo "DTO mirrors of `.../FilaDeEtiqueta/...`", contradiciendo la propia recomendación de la desviación 4 de slice 1 ("Slice 3 should import `FilaDeEtiqueta` from `etiquetas/HojaDeEtiquetas.tsx` instead of redefining it") | Tarea 3.1 enmendada: `FilaDeEtiqueta` se **importa** de `etiquetas/HojaDeEtiquetas.tsx` (re-exportable desde `api/etiquetas.ts` si algún call site lo necesita ahí), nunca se redefine, citando la desviación 4 de slice 1 | N/A — cambio de documentación (`tasks.md`) |
+
 ---
 
 ## Slice 2: `ServicioDeEtiquetas` + endpoint + 3 filtros + tests (PR 2)
@@ -423,8 +431,11 @@ clean round + PR merged.
 ## Slice 3: `Etiquetas.tsx` (PR 3)
 
 **Branch**: `feat/stage18-slice3-web-etiquetas`. **Start**: PR 1 **and** PR 2 merged, **and** task
-1.4 (E1) recorded PASS in `spike-alineacion.md` — this slice is the one binding verify criterion 4
-gates (`design.md:401-414`). **Finish**: filters (búsqueda/área/categoría/marca/con oferta
+1.4 (E1) **and** task 1.5 (E2, all three proofs) recorded PASS in `spike-alineacion.md` — binding
+verify criterion 4 requires "PASS on both E1 and E2 before slice 3 opens" (`design.md:401-414`,
+`tasks.md` binding verify criterion 4), not E1 alone; judgment-day slice 1 ronda 2 juez A flagged
+this Start as under-specified because E2's third proof (the "Guardar como PDF" page-box comparison)
+had no owning task in this slice — task 3.0 below closes that gap. **Finish**: filters (búsqueda/área/categoría/marca/con oferta
 vigente), the `FacturarRemitos.tsx:134,142-144` multi-select reducer with "elegir todos", per-row
 copies 1-99 + "aplicar a todos", format + lista selectors (lista defaulted to the first
 `EsDefault` row), the "N etiquetas = M hojas" preview, the excluded-count notice, the
@@ -440,8 +451,17 @@ enumerated below.
 visible list cannot send a phantom id, `FacturarRemitos.tsx:138-140`). All four MUST have a
 dedicated test; the print button additionally has a re-entrancy conjunct (pending / not pending).
 
+- [ ] 3.0 **GATE** — close E2's third deferred proof (`spike-alineacion.md`, tarea 1.5) before any
+  other slice-3 task starts: print `CajaZ` and `CuentaCorriente` to PDF ANTES of mounting the first
+  real consumer of `HojaDeEtiquetas` (this slice's first commit) and again DESPUÉS (once `Etiquetas.tsx`
+  is mounted on its route), with the owner's or the environment's real browser, and compare the two
+  page-boxes for each view. Record the comparison result in `spike-alineacion.md` §E2, closing task
+  1.5 with all three E2 proofs `PASS`. *(binding verify criterion 4, `design.md:93-97`)*
 - [ ] 3.1 Create `src/Ways.Web/src/api/etiquetas.ts` — client + DTO mirrors of
-  `SolicitudDeEtiquetas`/`DatosDeEtiquetas`/`FilaDeEtiqueta`/`ArticuloExcluido`. *(design.md:296-297)*
+  `SolicitudDeEtiquetas`/`DatosDeEtiquetas`/`ArticuloExcluido`. `FilaDeEtiqueta` is **imported** from
+  `etiquetas/HojaDeEtiquetas.tsx` (re-exported from here if a call site needs it from `api/etiquetas.ts`)
+  — it is **never redefined**, per slice 1's deviation 4: two competing shapes for the same DTO is
+  exactly the drift that deviation warns against. *(design.md:296-297, slice 1 deviation 4)*
 - [ ] 3.2 [P] `etiquetas.ts.test.ts` — mapper/client descriptor tests. *(web-descriptor-tests)*
 - [ ] 3.3 Create `src/Ways.Web/src/etiquetas/expandirCeldas.ts` — pure `expandirCeldas(filas,
   copias)`, `1..99` clamp. *(design.md:55, 169, mutation target 32)*

--- a/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
+++ b/openspec/changes/stage-18-etiquetas-y-consulta/tasks.md
@@ -282,6 +282,13 @@ gates slice 3 only (verify criterion 4), not this PR.
 
 None beyond the deviations above.
 
+### judgment-day Slice 1, ronda 1 — juez B (1 MAJOR + 1 MINOR)
+
+| # | Severidad | Hallazgo | Fix | Ciclo mutación |
+|---|---|---|---|---|
+| 1 | MAJOR | El test de la grilla de calibración (`HojaDeEtiquetas.test.tsx`) no asertaba la cruz de registro (`<span className="cruz-registro">`, `HojaDeEtiquetas.tsx:136`) ni la clase `celda-calibracion` (hook del hairline de 0.2mm) — ambos mutantes sobrevivían 6/6, y `design.md:79-80` exige ambos elementos | `data-testid={\`cruz-registro-f\${fila}c\${columna}\`}` agregado a la cruz (mismo patrón que `cuadrado-de-escala`/`regla-horizontal`); test asserta conteo exacto de cruces == columnas×filas (24, regla 12b), presencia por celda, `toHaveClass('celda-calibracion')`, y que el modo NORMAL no renderiza ninguno de los dos (discriminante de modo) | (a) borrado el `<span className="cruz-registro">` → RED (`getAllByTestId` no encontró coincidencias) → revertido → verde. (b) `celda celda-calibracion` → `celda` → RED (`toHaveClass('celda-calibracion')` falló) → revertido → verde |
+| 2 | MINOR | `design.md:82` especifica "1 mm ticks, 10 mm labels"; `ReglaHorizontal`/`ReglaVertical` solo dibujaban marcas cada 10mm | Ticks de 1mm agregados en ambas reglas (201 en la horizontal, 281 en la vertical), diferenciados por clase `regla-tick-mayor`/`regla-tick-menor` (label solo en los mayores, cada 10mm); CSS distingue alto/ancho por clase; test nuevo asserta conteo exacto de ticks totales y por clase | Paso de 1mm mutado a 2mm en la regla horizontal → RED (`toHaveLength(201)` recibió 101) → revertido → verde |
+
 ---
 
 ## Slice 2: `ServicioDeEtiquetas` + endpoint + 3 filtros + tests (PR 2)

--- a/src/Ways.Web/src/estilos/etiquetas.css
+++ b/src/Ways.Web/src/estilos/etiquetas.css
@@ -83,7 +83,16 @@
 }
 
 .hoja-de-etiquetas .cuadrado-de-escala {
-  /* 100.0×100.0 mm etiquetado — separa "la grilla está mal" de "el navegador imprimió al 96%". */
+  /* 100.0×100.0 mm etiquetado — separa "la grilla está mal" de "el navegador imprimió al 96%".
+     Ancla explícita en la esquina inferior-derecha de la hoja (judgment-day ronda 2, fix 1): las
+     reglas anclan en el borde superior/izquierdo (top:0/left:0 más abajo), así que right:0/bottom:0
+     lo mantiene fuera de esa esquina sin depender de un número mágico de mm — funciona para
+     cualquier `paginaMm` de cualquier descriptor. Puede superponerse a las celdas de la grilla: el
+     hairline de la celda y el contorno del cuadrado son distinguibles a ojo, y el design solo exige
+     poder MEDIRLO (design.md:83), no reservarle una zona libre. */
+  position: absolute;
+  right: 0;
+  bottom: 0;
   width: 100mm;
   height: 100mm;
   border: 0.2mm solid #000;
@@ -92,7 +101,14 @@
 
 .hoja-de-etiquetas .regla-horizontal,
 .hoja-de-etiquetas .regla-vertical {
-  position: relative;
+  /* judgment-day ronda 2, fix 1: estaban en FLUJO NORMAL (position:relative apila verticalmente
+     dentro de `.hoja-de-etiquetas`) — sumadas a `.cuadrado-de-escala`, empujaban la hoja a 380.2mm
+     y el cuadrado caía en una segunda página impresa. `position:absolute` con origen en la esquina
+     superior-izquierda de la hoja coincide con lo que design.md:82 ya fija: "a horizontal 200mm
+     ruler (top) and a vertical 280mm ruler (left)". */
+  position: absolute;
+  top: 0;
+  left: 0;
   background: #000;
 }
 

--- a/src/Ways.Web/src/estilos/etiquetas.css
+++ b/src/Ways.Web/src/estilos/etiquetas.css
@@ -107,6 +107,34 @@
 }
 
 .hoja-de-etiquetas .regla-tick {
+  /* design.md:82: "1 mm ticks, 10 mm labels" — la marca menor (cada 1mm) y la mayor (cada
+     10mm, con el número) comparten posicionamiento; solo el largo del trazo las distingue. */
   position: absolute;
   background: #000;
+}
+
+.hoja-de-etiquetas .regla-horizontal .regla-tick {
+  top: 0;
+  width: 0.2mm;
+}
+
+.hoja-de-etiquetas .regla-horizontal .regla-tick-mayor {
+  height: 3mm;
+}
+
+.hoja-de-etiquetas .regla-horizontal .regla-tick-menor {
+  height: 1.5mm;
+}
+
+.hoja-de-etiquetas .regla-vertical .regla-tick {
+  left: 0;
+  height: 0.2mm;
+}
+
+.hoja-de-etiquetas .regla-vertical .regla-tick-mayor {
+  width: 3mm;
+}
+
+.hoja-de-etiquetas .regla-vertical .regla-tick-menor {
+  width: 1.5mm;
 }

--- a/src/Ways.Web/src/estilos/etiquetas.css
+++ b/src/Ways.Web/src/estilos/etiquetas.css
@@ -1,0 +1,112 @@
+/*
+ * Etapa 18, Slice 1 (design.md:19-22, decisión 1): la hoja de etiquetas/carteles vive en su
+ * PROPIA página nombrada — nunca en `impresion.css`, que sigue byte-idéntica a `main`
+ * (verify criterio 3, mutation target 2). `@page` no admite un selector ordinario; las named
+ * pages de CSS (`@page etiquetas` + la propiedad `page` en el contenedor) son el único mecanismo
+ * que scopea la caja de página sin tocar el stylesheet global (mutation target 1).
+ */
+@page etiquetas {
+  size: A4;
+  margin: 0;
+}
+
+.hoja-de-etiquetas {
+  /* named page: gatea a `@page etiquetas` de arriba, nunca al `@page { margin: 12mm }` global
+     de `impresion.css` (mutation target 1). */
+  page: etiquetas;
+  position: relative;
+  box-sizing: border-box;
+  width: var(--pagina-ancho);
+  height: var(--pagina-alto);
+}
+
+.hoja-de-etiquetas .grilla-de-celdas {
+  position: absolute;
+  top: var(--margen-sup);
+  left: var(--margen-izq);
+  display: grid;
+  grid-template-columns: repeat(var(--columnas), var(--celda-ancho));
+  grid-template-rows: repeat(var(--filas), var(--celda-alto));
+  column-gap: var(--medianil-h, 0mm);
+  row-gap: var(--medianil-v, 0mm);
+}
+
+.hoja-de-etiquetas .celda {
+  box-sizing: border-box;
+  width: var(--celda-ancho);
+  height: var(--celda-alto);
+  padding: var(--pad-externo);
+  overflow: hidden;
+  position: relative;
+}
+
+/* --- Modo calibración (design.md:67-92, spike de alineación) --- */
+
+.hoja-de-etiquetas[data-modo='calibracion'] .celda-calibracion {
+  /* Hairline de 0.2 mm por celda nominal: lo que debería coincidir con el troquel. */
+  border: 0.2mm solid #000;
+}
+
+.hoja-de-etiquetas .cruz-registro {
+  /* Cruz de registro de 6 mm centrada en el origen (esquina superior-izquierda) de la celda —
+     el punto que se mide, no un borde difuso. */
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 6mm;
+  height: 6mm;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.hoja-de-etiquetas .cruz-registro::before,
+.hoja-de-etiquetas .cruz-registro::after {
+  content: '';
+  position: absolute;
+  background: #000;
+}
+
+.hoja-de-etiquetas .cruz-registro::before {
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 0.2mm;
+  transform: translateY(-50%);
+}
+
+.hoja-de-etiquetas .cruz-registro::after {
+  left: 50%;
+  top: 0;
+  height: 100%;
+  width: 0.2mm;
+  transform: translateX(-50%);
+}
+
+.hoja-de-etiquetas .cuadrado-de-escala {
+  /* 100.0×100.0 mm etiquetado — separa "la grilla está mal" de "el navegador imprimió al 96%". */
+  width: 100mm;
+  height: 100mm;
+  border: 0.2mm solid #000;
+  box-sizing: border-box;
+}
+
+.hoja-de-etiquetas .regla-horizontal,
+.hoja-de-etiquetas .regla-vertical {
+  position: relative;
+  background: #000;
+}
+
+.hoja-de-etiquetas .regla-horizontal {
+  width: 200mm;
+  height: 0.2mm;
+}
+
+.hoja-de-etiquetas .regla-vertical {
+  width: 0.2mm;
+  height: 280mm;
+}
+
+.hoja-de-etiquetas .regla-tick {
+  position: absolute;
+  background: #000;
+}

--- a/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
+++ b/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
@@ -168,3 +168,29 @@ describe('HojaDeEtiquetas — named page (mutation target 1, estructural)', () =
     expect(bloque).toMatch(/page:\s*etiquetas/)
   })
 })
+
+// judgment-day s18-slice-1 ronda 2, fix 1 (CRITICAL): la regla horizontal, la regla vertical y el
+// cuadrado de escala vivían en FLUJO NORMAL dentro de `.hoja-de-etiquetas` (297mm de alto) — sumados
+// a la grilla, el total superaba una hoja A4 y el cuadrado caía en una segunda página impresa,
+// invisible para la precondición de nulidad de E1. jsdom no implementa paginación (`@page`) ni layout
+// real, así que el único contrato asertable es estructural: cada selector declara `position:absolute`
+// en la hoja de estilos (mismo patrón que el test de named page de arriba, mutation target 1).
+describe('HojaDeEtiquetas — calibración cabe en una sola hoja (judgment-day ronda 2, fix 1, estructural)', () => {
+  function bloqueDeclaradoPara(selector: string): string {
+    const inicio = cssTexto.indexOf(selector)
+    expect(inicio).toBeGreaterThanOrEqual(0)
+    const finDeAperturaDeLlave = cssTexto.indexOf('{', inicio)
+    const fin = cssTexto.indexOf('\n}', finDeAperturaDeLlave)
+    return cssTexto.slice(finDeAperturaDeLlave, fin)
+  }
+
+  it('`.regla-horizontal` y `.regla-vertical` declaran `position: absolute` — nunca flujo normal', () => {
+    const bloque = bloqueDeclaradoPara('.hoja-de-etiquetas .regla-horizontal,\n.hoja-de-etiquetas .regla-vertical')
+    expect(bloque).toMatch(/position:\s*absolute/)
+  })
+
+  it('`.cuadrado-de-escala` declara `position: absolute` — nunca flujo normal', () => {
+    const bloque = bloqueDeclaradoPara('.hoja-de-etiquetas .cuadrado-de-escala')
+    expect(bloque).toMatch(/position:\s*absolute/)
+  })
+})

--- a/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
+++ b/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
@@ -73,7 +73,8 @@ describe('HojaDeEtiquetas — geometría compartida entre modos (mutation target
     render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />)
 
     const grilla = screen.getByTestId('grilla-de-calibracion')
-    expect(grilla.children).toHaveLength(A4_3X8.columnas * A4_3X8.filas)
+    const totalCeldas = A4_3X8.columnas * A4_3X8.filas // 3×8 = 24 (valor exacto, regla 12b)
+    expect(grilla.children).toHaveLength(totalCeldas)
 
     expect(screen.getByTestId('celda-calibracion-f0c0')).toHaveTextContent('f0c0')
     expect(screen.getByTestId('celda-calibracion-f7c2')).toHaveTextContent('f7c2')
@@ -81,6 +82,53 @@ describe('HojaDeEtiquetas — geometría compartida entre modos (mutation target
     expect(screen.getByTestId('etiqueta-cuadrado-de-escala')).toHaveTextContent('100.0 × 100.0 mm')
     expect(screen.getByTestId('regla-horizontal')).toBeInTheDocument()
     expect(screen.getByTestId('regla-vertical')).toBeInTheDocument()
+
+    // Mutante (a): el <span className="cruz-registro"> desaparece — una cruz por celda, sin excepción.
+    const cruces = screen.getAllByTestId(/^cruz-registro-f\d+c\d+$/)
+    expect(cruces).toHaveLength(totalCeldas)
+    for (let fila = 0; fila < A4_3X8.filas; fila += 1) {
+      for (let columna = 0; columna < A4_3X8.columnas; columna += 1) {
+        expect(screen.getByTestId(`cruz-registro-f${fila}c${columna}`)).toBeInTheDocument()
+      }
+    }
+
+    // Mutante (b): `celda celda-calibracion` → `celda` — el hook del hairline de 0.2mm.
+    expect(screen.getByTestId('celda-calibracion-f0c0')).toHaveClass('celda-calibracion')
+    expect(screen.getByTestId('celda-calibracion-f7c2')).toHaveClass('celda-calibracion')
+
+    // Discriminante de modo: el modo NORMAL no dibuja cruces ni celdas de calibración.
+    const { container: contenedorNormal } = render(
+      <HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="normal" />,
+    )
+    expect(contenedorNormal.querySelector('.cruz-registro')).not.toBeInTheDocument()
+    expect(contenedorNormal.querySelector('.celda-calibracion')).not.toBeInTheDocument()
+  })
+
+  it('las reglas horizontal (200mm) y vertical (280mm) dibujan un tick por milímetro, con label cada 10mm (design.md:82)', () => {
+    render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />)
+
+    const reglaHorizontal = screen.getByTestId('regla-horizontal')
+    const reglaVertical = screen.getByTestId('regla-vertical')
+
+    // Mutante: el paso de 1mm pasa a 2mm (o se quitan los menores) — el conteo exacto lo detecta.
+    expect(reglaHorizontal.children).toHaveLength(201) // 0..200 mm inclusive, cada 1mm
+    expect(reglaVertical.children).toHaveLength(281) // 0..280 mm inclusive, cada 1mm
+
+    const ticksMayoresHorizontal = reglaHorizontal.querySelectorAll('.regla-tick-mayor')
+    const ticksMenoresHorizontal = reglaHorizontal.querySelectorAll('.regla-tick-menor')
+    expect(ticksMayoresHorizontal).toHaveLength(21) // 0,10,...,200
+    expect(ticksMenoresHorizontal).toHaveLength(180) // 201 - 21
+
+    const ticksMayoresVertical = reglaVertical.querySelectorAll('.regla-tick-mayor')
+    const ticksMenoresVertical = reglaVertical.querySelectorAll('.regla-tick-menor')
+    expect(ticksMayoresVertical).toHaveLength(29) // 0,10,...,280
+    expect(ticksMenoresVertical).toHaveLength(252) // 281 - 29
+
+    expect(screen.getByTestId('regla-horizontal-0')).toHaveTextContent('0')
+    expect(screen.getByTestId('regla-horizontal-200')).toHaveTextContent('200')
+    expect(screen.getByTestId('regla-horizontal-137')).toHaveTextContent('')
+    expect(screen.getByTestId('regla-vertical-280')).toHaveTextContent('280')
+    expect(screen.getByTestId('regla-vertical-93')).toHaveTextContent('')
   })
 })
 

--- a/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
+++ b/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { HojaDeEtiquetas } from './HojaDeEtiquetas'
+import type { FilaDeEtiqueta } from './HojaDeEtiquetas'
+import { A4_3X8 } from './formatos'
+// `?raw` (soportado por Vite, `vite/client`): lee el CSS como texto sin tocar `fs`/`path` de
+// Node, que el `tsconfig.app.json` de la app no tipa (evita ensanchar los `types` compartidos
+// solo para un test).
+import cssTexto from '../estilos/etiquetas.css?raw'
+
+function filaFixture(sobrescribir: Partial<FilaDeEtiqueta> = {}): FilaDeEtiqueta {
+  return {
+    idArticulo: 1,
+    codigoInterno: 'ART-001',
+    codigoBarra: null,
+    nombre: 'Artículo de prueba',
+    unidadVenta: 'un',
+    precioOriginal: 100,
+    precioFinal: 100,
+    ofertas: [],
+    ...sobrescribir,
+  }
+}
+
+// mutation target 7: la regla de tachado es `ofertas.length > 0`, NUNCA
+// `precioOriginal !== precioFinal` — producción jamás emite ese par, así que solo un DTO
+// construido a mano prueba la diferencia entre las dos reglas.
+describe('HojaDeEtiquetas — regla de tachado (mutation target 7)', () => {
+  it('precios DISTINTOS + ofertas VACÍAS ⇒ sin tachado (el mutante `precioOriginal !== precioFinal` tacharía esto)', () => {
+    const fila = filaFixture({ precioOriginal: 150, precioFinal: 120, ofertas: [] })
+    render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[fila]} nombreDeLista="Lista general" />)
+
+    expect(screen.queryByTestId(`precio-original-tachado-${fila.idArticulo}-0`)).not.toBeInTheDocument()
+    expect(screen.getByText('$120,00')).toBeInTheDocument()
+  })
+
+  it('precios IGUALES + ofertas NO VACÍAS ⇒ tachado presente (el mutante `precioOriginal !== precioFinal` lo ocultaría)', () => {
+    const fila = filaFixture({
+      precioOriginal: 100,
+      precioFinal: 100,
+      ofertas: [{ idOferta: 9, nombre: '2x1', descuentoUnitario: 0 }],
+    })
+    render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[fila]} nombreDeLista="Lista general" />)
+
+    const tachado = screen.getByTestId(`precio-original-tachado-${fila.idArticulo}-0`)
+    expect(tachado).toBeInTheDocument()
+    expect(tachado).toHaveStyle({ textDecoration: 'line-through' })
+  })
+})
+
+// mutation target 6: el spike usa el MISMO descriptor que la hoja real — una calibración con
+// números propios no prueba nada. La geometría emitida como custom properties debe ser IDÉNTICA
+// en ambos modos para el mismo descriptor.
+describe('HojaDeEtiquetas — geometría compartida entre modos (mutation target 6)', () => {
+  it('modo="calibracion" emite exactamente los mismos custom properties que modo="normal" para el mismo descriptor', () => {
+    const { container: contenedorNormal } = render(
+      <HojaDeEtiquetas descriptor={A4_3X8} celdas={[filaFixture()]} nombreDeLista="Lista general" modo="normal" />,
+    )
+    const hojaNormal = contenedorNormal.querySelector('.hoja-de-etiquetas')
+    const estiloNormal = hojaNormal?.getAttribute('style')
+
+    const { container: contenedorCalibracion } = render(
+      <HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />,
+    )
+    const hojaCalibracion = contenedorCalibracion.querySelector('.hoja-de-etiquetas')
+    const estiloCalibracion = hojaCalibracion?.getAttribute('style')
+
+    expect(estiloNormal).toBeTruthy()
+    expect(estiloCalibracion).toBe(estiloNormal)
+  })
+
+  it('la grilla de calibración dibuja columnas×filas celdas con etiqueta f{row}c{col} y cruz de registro', () => {
+    render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />)
+
+    const grilla = screen.getByTestId('grilla-de-calibracion')
+    expect(grilla.children).toHaveLength(A4_3X8.columnas * A4_3X8.filas)
+
+    expect(screen.getByTestId('celda-calibracion-f0c0')).toHaveTextContent('f0c0')
+    expect(screen.getByTestId('celda-calibracion-f7c2')).toHaveTextContent('f7c2')
+    expect(screen.getByTestId('cuadrado-de-escala')).toBeInTheDocument()
+    expect(screen.getByTestId('etiqueta-cuadrado-de-escala')).toHaveTextContent('100.0 × 100.0 mm')
+    expect(screen.getByTestId('regla-horizontal')).toBeInTheDocument()
+    expect(screen.getByTestId('regla-vertical')).toBeInTheDocument()
+  })
+})
+
+// mutation target 8: el bloque `d-print-none` de instrucciones de impresión.
+describe('HojaDeEtiquetas — bloque de instrucciones de impresión (mutation target 8)', () => {
+  it('modo="calibracion" muestra el bloque d-print-none con A4/100%/sin márgenes/gráficos de fondo', () => {
+    render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />)
+
+    const bloque = screen.getByTestId('instrucciones-de-impresion')
+    expect(bloque).toHaveClass('d-print-none')
+    expect(bloque).toHaveTextContent(/A4/)
+    expect(bloque).toHaveTextContent(/100%/)
+    expect(bloque).toHaveTextContent(/ajustar a la página/)
+    expect(bloque).toHaveTextContent(/ninguno/)
+    expect(bloque).toHaveTextContent(/gráficos de fondo: activados/i)
+  })
+})
+
+// mutation target 1 (S — estructural): jsdom no implementa `@page`, así que la prueba es sobre el
+// archivo/estado, no sobre un comportamiento en tiempo de ejecución (honest-limits, design.md:327).
+// Combina el componente (lleva la clase que la regla de CSS usa como selector) con el contrato del
+// propio stylesheet (declara `page: etiquetas` bajo esa clase, dentro de la named page).
+describe('HojaDeEtiquetas — named page (mutation target 1, estructural)', () => {
+  it('el contenedor lleva la clase `hoja-de-etiquetas` que etiquetas.css usa para declarar `page: etiquetas`', () => {
+    const { container } = render(<HojaDeEtiquetas descriptor={A4_3X8} celdas={[]} nombreDeLista="Lista general" modo="calibracion" />)
+    expect(container.querySelector('.hoja-de-etiquetas')).toBeInTheDocument()
+
+    expect(cssTexto).toMatch(/@page\s+etiquetas\s*\{[^}]*margin:\s*0/)
+
+    // El bloque `.hoja-de-etiquetas { ... }` declara `page: etiquetas` — buscado por posición en
+    // vez de un `[^}]*` acotado por la próxima `}`, porque el comentario que documenta la regla
+    // contiene un ejemplo con llaves (`@page { margin: 12mm }`) que rompería esa clase de regex.
+    const inicioDelBloque = cssTexto.indexOf('.hoja-de-etiquetas {')
+    expect(inicioDelBloque).toBeGreaterThanOrEqual(0)
+    const finDelBloque = cssTexto.indexOf('\n}', inicioDelBloque)
+    const bloque = cssTexto.slice(inicioDelBloque, finDelBloque)
+    expect(bloque).toMatch(/page:\s*etiquetas/)
+  })
+})

--- a/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx
+++ b/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx
@@ -86,33 +86,47 @@ function CuadradoDeEscala() {
   )
 }
 
+/** design.md:82: "1 mm ticks, 10 mm labels" — una marca menor por milímetro, una marca mayor
+ * (con el número) cada 10 mm. La distinción visual entre menor/mayor es la clase, no el texto:
+ * ambas comparten `regla-tick`, solo la mayor suma `regla-tick-mayor` y el label. */
 function ReglaHorizontal() {
-  const marcas = Array.from({ length: 21 }, (_, i) => i * 10) // 0..200 mm, cada 10 mm
+  const marcas = Array.from({ length: 201 }, (_, i) => i) // 0..200 mm, cada 1 mm
   return (
     <div className="regla-horizontal" data-testid="regla-horizontal">
-      {marcas.map((mm) => (
-        <span
-          key={mm}
-          className="regla-tick"
-          data-testid={`regla-horizontal-${mm}`}
-          style={{ left: `${mm}mm` } as CSSProperties}
-        >
-          {mm}
-        </span>
-      ))}
+      {marcas.map((mm) => {
+        const esMayor = mm % 10 === 0
+        return (
+          <span
+            key={mm}
+            className={esMayor ? 'regla-tick regla-tick-mayor' : 'regla-tick regla-tick-menor'}
+            data-testid={`regla-horizontal-${mm}`}
+            style={{ left: `${mm}mm` } as CSSProperties}
+          >
+            {esMayor ? mm : null}
+          </span>
+        )
+      })}
     </div>
   )
 }
 
 function ReglaVertical() {
-  const marcas = Array.from({ length: 29 }, (_, i) => i * 10) // 0..280 mm, cada 10 mm
+  const marcas = Array.from({ length: 281 }, (_, i) => i) // 0..280 mm, cada 1 mm
   return (
     <div className="regla-vertical" data-testid="regla-vertical">
-      {marcas.map((mm) => (
-        <span key={mm} className="regla-tick" data-testid={`regla-vertical-${mm}`} style={{ top: `${mm}mm` } as CSSProperties}>
-          {mm}
-        </span>
-      ))}
+      {marcas.map((mm) => {
+        const esMayor = mm % 10 === 0
+        return (
+          <span
+            key={mm}
+            className={esMayor ? 'regla-tick regla-tick-mayor' : 'regla-tick regla-tick-menor'}
+            data-testid={`regla-vertical-${mm}`}
+            style={{ top: `${mm}mm` } as CSSProperties}
+          >
+            {esMayor ? mm : null}
+          </span>
+        )
+      })}
     </div>
   )
 }
@@ -133,7 +147,7 @@ function GrillaDeCalibracion({ descriptor }: { descriptor: DescriptorDeFormato }
         {filas.map((fila) =>
           columnas.map((columna) => (
             <div key={`f${fila}c${columna}`} className="celda celda-calibracion" data-testid={`celda-calibracion-f${fila}c${columna}`}>
-              <span className="cruz-registro" aria-hidden="true" />
+              <span className="cruz-registro" aria-hidden="true" data-testid={`cruz-registro-f${fila}c${columna}`} />
               <span>{`f${fila}c${columna}`}</span>
             </div>
           )),

--- a/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx
+++ b/src/Ways.Web/src/etiquetas/HojaDeEtiquetas.tsx
@@ -1,0 +1,201 @@
+import type { CSSProperties } from 'react'
+import type { OfertaAplicada } from '../api/tipos'
+import type { DescriptorDeFormato } from './formatos'
+import '../estilos/etiquetas.css'
+
+/**
+ * Espejo de `Ways.Application.Etiquetas.Contratos.FilaDeEtiqueta` (design.md:193-195). No existe
+ * consumidor de API todavía en este slice (slice 3 crea `api/etiquetas.ts` con el mirror completo
+ * de `SolicitudDeEtiquetas`/`DatosDeEtiquetas`); este tipo es el contrato mínimo que el renderer
+ * PURO necesita y queda disponible para que slice 3 lo reutilice en vez de duplicarlo.
+ */
+export type FilaDeEtiqueta = {
+  readonly idArticulo: number
+  readonly codigoInterno: string
+  readonly codigoBarra: string | null
+  readonly nombre: string
+  readonly unidadVenta: string
+  readonly precioOriginal: number
+  readonly precioFinal: number
+  readonly ofertas: readonly OfertaAplicada[]
+}
+
+type Props = {
+  descriptor: DescriptorDeFormato
+  /** Ya multiplicadas por copias (decisión 4, `expandirCeldas` en slice 3) — este componente no
+   * conoce el concepto de "copias". */
+  celdas: readonly FilaDeEtiqueta[]
+  /** Decisión 11: el nombre de la lista SIEMPRE viene del servidor, nunca del selector en pantalla. */
+  nombreDeLista: string
+  /** El spike usa el MISMO componente que la hoja real — una grilla dibujada con otros números
+   * no prueba nada (design.md:73-75, mutation target 6). */
+  modo?: 'normal' | 'calibracion'
+}
+
+function formatearMoneda(valor: number): string {
+  return `$${valor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+/** Geometría emitida como custom properties en mm sobre `.hoja-de-etiquetas` — la única
+ * proyección que jsdom PUEDE medir (design.md:172-176). Compartida por ambos modos: mutation
+ * target 6 exige que la calibración emita EXACTAMENTE la misma geometría que el modo normal para
+ * el mismo descriptor. */
+function estiloDeGeometria(descriptor: DescriptorDeFormato): CSSProperties {
+  const pitchX = descriptor.celdaMm.ancho + descriptor.medianilHorizontalMm
+  const pitchY = descriptor.celdaMm.alto + descriptor.medianilVerticalMm
+
+  return {
+    '--pagina-ancho': `${descriptor.paginaMm.ancho}mm`,
+    '--pagina-alto': `${descriptor.paginaMm.alto}mm`,
+    '--margen-sup': `${descriptor.margenSuperiorMm}mm`,
+    '--margen-izq': `${descriptor.margenIzquierdoMm}mm`,
+    '--celda-ancho': `${descriptor.celdaMm.ancho}mm`,
+    '--celda-alto': `${descriptor.celdaMm.alto}mm`,
+    '--pitch-x': `${pitchX}mm`,
+    '--pitch-y': `${pitchY}mm`,
+    '--medianil-h': `${descriptor.medianilHorizontalMm}mm`,
+    '--medianil-v': `${descriptor.medianilVerticalMm}mm`,
+    '--columnas': descriptor.columnas,
+    '--filas': descriptor.filas,
+    '--pad-externo': `${descriptor.padExternoMm}mm`,
+  } as CSSProperties
+}
+
+/** Bloque de instrucciones de impresión (design.md:84, mutation target 8): A4, 100% de escala,
+ * "ajustar a la página" apagado, sin márgenes, gráficos de fondo activados. Solo aparece en modo
+ * calibración — es el spike quien lo necesita en pantalla para guiar la corrida física. */
+function InstruccionesDeImpresion() {
+  return (
+    <div className="d-print-none alert alert-warning rounded-0" data-testid="instrucciones-de-impresion">
+      <strong>Configuración de impresión requerida:</strong>
+      <ul className="mb-0">
+        <li>Tamaño de papel: A4</li>
+        <li>Escala: 100% (nunca "ajustar a la página")</li>
+        <li>Márgenes: ninguno</li>
+        <li>Gráficos de fondo: activados</li>
+      </ul>
+    </div>
+  )
+}
+
+function CuadradoDeEscala() {
+  return (
+    <div className="cuadrado-de-escala" data-testid="cuadrado-de-escala">
+      <span data-testid="etiqueta-cuadrado-de-escala">100.0 × 100.0 mm</span>
+    </div>
+  )
+}
+
+function ReglaHorizontal() {
+  const marcas = Array.from({ length: 21 }, (_, i) => i * 10) // 0..200 mm, cada 10 mm
+  return (
+    <div className="regla-horizontal" data-testid="regla-horizontal">
+      {marcas.map((mm) => (
+        <span
+          key={mm}
+          className="regla-tick"
+          data-testid={`regla-horizontal-${mm}`}
+          style={{ left: `${mm}mm` } as CSSProperties}
+        >
+          {mm}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function ReglaVertical() {
+  const marcas = Array.from({ length: 29 }, (_, i) => i * 10) // 0..280 mm, cada 10 mm
+  return (
+    <div className="regla-vertical" data-testid="regla-vertical">
+      {marcas.map((mm) => (
+        <span key={mm} className="regla-tick" data-testid={`regla-vertical-${mm}`} style={{ top: `${mm}mm` } as CSSProperties}>
+          {mm}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** Grilla de calibración (design.md:67-85, task 1.1): un hairline de 0.2 mm por celda nominal, una
+ * cruz de registro de 6 mm en el origen (esquina superior-izquierda) de cada celda, la etiqueta
+ * `f{row}c{col}` centrada, más las reglas y el cuadrado de escala — todo dibujado con el MISMO
+ * descriptor que la hoja real usa. */
+function GrillaDeCalibracion({ descriptor }: { descriptor: DescriptorDeFormato }) {
+  const filas = Array.from({ length: descriptor.filas }, (_, i) => i)
+  const columnas = Array.from({ length: descriptor.columnas }, (_, i) => i)
+
+  return (
+    <>
+      <ReglaHorizontal />
+      <ReglaVertical />
+      <div className="grilla-de-celdas" data-testid="grilla-de-calibracion">
+        {filas.map((fila) =>
+          columnas.map((columna) => (
+            <div key={`f${fila}c${columna}`} className="celda celda-calibracion" data-testid={`celda-calibracion-f${fila}c${columna}`}>
+              <span className="cruz-registro" aria-hidden="true" />
+              <span>{`f${fila}c${columna}`}</span>
+            </div>
+          )),
+        )}
+      </div>
+      <CuadradoDeEscala />
+      <InstruccionesDeImpresion />
+    </>
+  )
+}
+
+/** Hoja de producción (design.md:162-176, task 1.9): renderer puro props-only — sin fetch, sin
+ * estado, sin reloj. La regla de tachado es `ofertas.length > 0`, NUNCA
+ * `precioOriginal !== precioFinal` (mutation target 7): producción jamás emite ese par porque el
+ * servidor ya resuelve el precio final, así que solo un DTO construido a mano puede probar la
+ * diferencia. */
+function GrillaDeProduccion({
+  descriptor,
+  celdas,
+  nombreDeLista,
+}: {
+  descriptor: DescriptorDeFormato
+  celdas: readonly FilaDeEtiqueta[]
+  nombreDeLista: string
+}) {
+  return (
+    <div className="grilla-de-celdas" data-testid="grilla-de-produccion" data-lista={nombreDeLista}>
+      {celdas.map((celda, indice) => {
+        const conOferta = celda.ofertas.length > 0
+        return (
+          <div key={`${celda.idArticulo}-${indice}`} className="celda" data-testid={`celda-${celda.idArticulo}-${indice}`}>
+            {descriptor.campos.includes('nombre') && <div className="celda-nombre">{celda.nombre}</div>}
+            {conOferta && descriptor.campos.includes('precioOriginal') && (
+              <div className="celda-precio-original" data-testid={`precio-original-tachado-${celda.idArticulo}-${indice}`} style={{ textDecoration: 'line-through' }}>
+                {formatearMoneda(celda.precioOriginal)}
+              </div>
+            )}
+            {descriptor.campos.includes('precioFinal') && (
+              <div className="celda-precio-final" style={{ fontSize: `${descriptor.escalaDePrecio}em` }}>
+                {formatearMoneda(celda.precioFinal)}
+              </div>
+            )}
+            {descriptor.campos.includes('codigo') && <div className="celda-codigo">{celda.codigoBarra ?? celda.codigoInterno}</div>}
+            {descriptor.campos.includes('unidadVenta') && <div className="celda-unidad">{celda.unidadVenta}</div>}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Componente de impresión PURO (design.md:162-176): props = descriptor + filas ya expandidas por
+ * copias. Sin fetch, sin estado, sin reloj — el spike (modo="calibracion") y la pantalla de
+ * producción (slice 3, modo="normal") comparten este MISMO componente y el MISMO tuple. */
+export function HojaDeEtiquetas({ descriptor, celdas, nombreDeLista, modo = 'normal' }: Props) {
+  return (
+    <div className="hoja-de-etiquetas" data-modo={modo} style={estiloDeGeometria(descriptor)}>
+      {modo === 'calibracion' ? (
+        <GrillaDeCalibracion descriptor={descriptor} />
+      ) : (
+        <GrillaDeProduccion descriptor={descriptor} celdas={celdas} nombreDeLista={nombreDeLista} />
+      )}
+    </div>
+  )
+}

--- a/src/Ways.Web/src/etiquetas/formatos.test.ts
+++ b/src/Ways.Web/src/etiquetas/formatos.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { A4_2X7, A4_3X8, CARTEL_A4, CARTEL_A5, FORMATOS, celdasPorHoja, contarHojas } from './formatos'
+import type { DescriptorDeFormato } from './formatos'
+
+// mutation target 3: cada número de geometría de cada uno de los cuatro descriptores — el mm
+// emitido y el conteo por hoja declarado deben coincidir con la tupla (design.md:143-148).
+describe('formatos — geometría de los cuatro descriptores (mutation target 3)', () => {
+  const casos: Array<{ descriptor: DescriptorDeFormato; porHoja: number }> = [
+    { descriptor: A4_3X8, porHoja: 24 },
+    { descriptor: A4_2X7, porHoja: 14 },
+    { descriptor: CARTEL_A4, porHoja: 1 },
+    { descriptor: CARTEL_A5, porHoja: 2 },
+  ]
+
+  it.each(casos)('$descriptor.id: columnas × filas == el conteo declarado por hoja', ({ descriptor, porHoja }) => {
+    expect(descriptor.columnas * descriptor.filas).toBe(porHoja)
+    expect(celdasPorHoja(descriptor)).toBe(porHoja)
+  })
+
+  it('A4-3x8: celda 70.0×37.0 mm, offset 0.5/0, sin medianiles, cierra la página A4', () => {
+    expect(A4_3X8.celdaMm).toEqual({ ancho: 70.0, alto: 37.0 })
+    expect(A4_3X8.margenSuperiorMm).toBe(0.5)
+    expect(A4_3X8.margenIzquierdoMm).toBe(0)
+    expect(A4_3X8.medianilHorizontalMm).toBe(0)
+    expect(A4_3X8.medianilVerticalMm).toBe(0)
+    expect(A4_3X8.padExternoMm).toBe(5)
+    expect(A4_3X8.columnas * A4_3X8.celdaMm.ancho + 2 * A4_3X8.margenIzquierdoMm).toBe(210)
+    expect(A4_3X8.filas * A4_3X8.celdaMm.alto + 2 * A4_3X8.margenSuperiorMm).toBe(297)
+  })
+
+  it('A4-2x7: celda 99.1×38.1 mm sharpeada (Reconciliación T2), offset 15.15/4.65, gutter 2.5, cierra exacto', () => {
+    expect(A4_2X7.celdaMm).toEqual({ ancho: 99.1, alto: 38.1 })
+    expect(A4_2X7.margenSuperiorMm).toBeCloseTo(15.15)
+    expect(A4_2X7.margenIzquierdoMm).toBeCloseTo(4.65)
+    expect(A4_2X7.medianilHorizontalMm).toBe(2.5)
+    expect(A4_2X7.medianilVerticalMm).toBe(0)
+    expect(A4_2X7.padExternoMm).toBe(3)
+    expect(A4_2X7.columnas * A4_2X7.celdaMm.ancho + 2 * A4_2X7.margenIzquierdoMm + A4_2X7.medianilHorizontalMm).toBeCloseTo(210)
+    expect(A4_2X7.filas * A4_2X7.celdaMm.alto + 2 * A4_2X7.margenSuperiorMm).toBeCloseTo(297)
+  })
+
+  it('CARTEL-A4: hoja completa 190×277 mm, margen 10/10, 1×1', () => {
+    expect(CARTEL_A4.celdaMm).toEqual({ ancho: 190.0, alto: 277.0 })
+    expect(CARTEL_A4.margenSuperiorMm).toBe(10.0)
+    expect(CARTEL_A4.margenIzquierdoMm).toBe(10.0)
+    expect(CARTEL_A4.columnas).toBe(1)
+    expect(CARTEL_A4.filas).toBe(1)
+    expect(CARTEL_A4.celdaMm.ancho + 2 * CARTEL_A4.margenIzquierdoMm).toBe(210)
+    expect(CARTEL_A4.celdaMm.alto + 2 * CARTEL_A4.margenSuperiorMm).toBe(297)
+  })
+
+  it('CARTEL-A5: media hoja 190×133.5 mm, 1×2, gutter vertical 10', () => {
+    expect(CARTEL_A5.celdaMm).toEqual({ ancho: 190.0, alto: 133.5 })
+    expect(CARTEL_A5.columnas).toBe(1)
+    expect(CARTEL_A5.filas).toBe(2)
+    expect(CARTEL_A5.medianilVerticalMm).toBe(10.0)
+    expect(CARTEL_A5.filas * CARTEL_A5.celdaMm.alto + 2 * CARTEL_A5.margenSuperiorMm + CARTEL_A5.medianilVerticalMm).toBe(297)
+  })
+
+  it('FORMATOS contiene exactamente los cuatro descriptores, ningún literal-id atajo', () => {
+    expect(FORMATOS).toHaveLength(4)
+    expect(FORMATOS.map((d) => d.id)).toEqual(['A4-3x8', 'A4-2x7', 'CARTEL-A4', 'CARTEL-A5'])
+  })
+})
+
+// mutation targets 4/5: celdasPorHoja/contarHojas SIEMPRE derivados — nunca un campo
+// almacenado — y contarHojas redondea hacia ARRIBA (ceil), nunca floor/división entera.
+describe('formatos — celdasPorHoja / contarHojas derivados (mutation targets 4, 5)', () => {
+  it('celdasPorHoja: 24 en A4-3x8 (3×8), 14 en A4-2x7 (2×7)', () => {
+    expect(celdasPorHoja(A4_3X8)).toBe(24)
+    expect(celdasPorHoja(A4_2X7)).toBe(14)
+  })
+
+  it('contarHojas: 24 etiquetas en A4-3x8 ⇒ 1 hoja exacta (límite inferior)', () => {
+    expect(contarHojas(24, A4_3X8)).toBe(1)
+  })
+
+  it('contarHojas: 25 etiquetas en A4-3x8 ⇒ 2 hojas (ceil, nunca floor/división entera)', () => {
+    expect(contarHojas(25, A4_3X8)).toBe(2)
+  })
+
+  it('contarHojas: 0 etiquetas ⇒ 0 hojas', () => {
+    expect(contarHojas(0, A4_3X8)).toBe(0)
+  })
+
+  it('un descriptor mutado (celdaPorHoja distinto) mueve el conteo derivado — no hay un campo propio que se quede atrás', () => {
+    // Prueba anti-regresión de la regla "nunca almacenado": si celdasPorHoja se leyera de un
+    // campo cacheado en vez de columnas*filas, este descriptor con geometría alterada seguiría
+    // reportando el valor viejo. Construye un descriptor con la MISMA forma pero otra grilla y
+    // confirma que el derivado sigue la tupla, no una copia.
+    const otraGrilla: DescriptorDeFormato = { ...A4_3X8, columnas: 2, filas: 5 }
+    expect(celdasPorHoja(otraGrilla)).toBe(10)
+    expect(contarHojas(11, otraGrilla)).toBe(2)
+  })
+})

--- a/src/Ways.Web/src/etiquetas/formatos.ts
+++ b/src/Ways.Web/src/etiquetas/formatos.ts
@@ -1,0 +1,121 @@
+// Etapa 18, Slice 1 (design.md:109-160, decisión 3): la ÚNICA fuente de milímetros de la etapa.
+// Registro plano, sin funciones ni derivados almacenados: una fila de un futuro
+// `formatos_etiqueta` (C1, OD3) mapea 1:1 sobre estos campos y el renderer no cambia.
+// Ningún componente importa un descriptor por id literal — todos reciben
+// `descriptores: readonly DescriptorDeFormato[]` como dato (la puerta a C1 se mantiene abierta).
+
+export type CampoDeCelda = 'nombre' | 'codigo' | 'precioFinal' | 'precioOriginal' | 'unidadVenta' | 'nombreDeOferta'
+
+export type DescriptorDeFormato = {
+  readonly id: string
+  readonly nombre: string
+  readonly familia: 'etiqueta' | 'cartel'
+  readonly paginaMm: { readonly ancho: number; readonly alto: number }
+  readonly margenSuperiorMm: number
+  readonly margenIzquierdoMm: number
+  readonly columnas: number
+  readonly filas: number
+  readonly celdaMm: { readonly ancho: number; readonly alto: number }
+  readonly medianilHorizontalMm: number
+  readonly medianilVerticalMm: number
+  /** Padding interior de la celda: la defensa contra el margen no imprimible del hardware,
+   * nunca mueve la grilla (design.md:130-131). */
+  readonly padExternoMm: number
+  readonly campos: readonly CampoDeCelda[]
+  /** Tamaño relativo del precio final dentro de la celda. */
+  readonly escalaDePrecio: number
+  /** La hoja real de la que salió la geometría. */
+  readonly referencia: string
+}
+
+const CAMPOS_COMPLETOS: readonly CampoDeCelda[] = ['nombre', 'precioFinal', 'precioOriginal', 'codigo', 'unidadVenta', 'nombreDeOferta']
+
+// Reconciliación T2 (tasks.md): la geometría sharpeada de `design.md:143-148` es la verdad de
+// implementación — la etiqueta redondeada del proposal/spec queda como label de UI, nunca como
+// una segunda tupla.
+export const A4_3X8: DescriptorDeFormato = {
+  id: 'A4-3x8',
+  nombre: 'A4 · 3×8 (24 etiquetas, 70×37 mm)',
+  familia: 'etiqueta',
+  paginaMm: { ancho: 210, alto: 297 },
+  margenSuperiorMm: 0.5,
+  margenIzquierdoMm: 0,
+  columnas: 3,
+  filas: 8,
+  celdaMm: { ancho: 70.0, alto: 37.0 },
+  medianilHorizontalMm: 0,
+  medianilVerticalMm: 0,
+  padExternoMm: 5,
+  campos: CAMPOS_COMPLETOS,
+  escalaDePrecio: 1.4,
+  referencia:
+    'Hoja A4 autoadhesiva 24 et. 70×37 (Avery 3422 y equivalentes del mercado local). ' +
+    'Tesela borde a borde: 3×70 = 210, 8×37 = 296 (+0.5 arriba y abajo).',
+}
+
+export const A4_2X7: DescriptorDeFormato = {
+  id: 'A4-2x7',
+  nombre: 'A4 · 2×7 (14 etiquetas, 99.1×38.1 mm)',
+  familia: 'etiqueta',
+  paginaMm: { ancho: 210, alto: 297 },
+  margenSuperiorMm: 15.15,
+  margenIzquierdoMm: 4.65,
+  columnas: 2,
+  filas: 7,
+  celdaMm: { ancho: 99.1, alto: 38.1 },
+  medianilHorizontalMm: 2.5,
+  medianilVerticalMm: 0,
+  padExternoMm: 3,
+  campos: CAMPOS_COMPLETOS,
+  escalaDePrecio: 1.6,
+  referencia:
+    'Hoja A4 autoadhesiva 14 et. 99.1×38.1 (Avery L7163 y equivalentes). ' +
+    'Cierra exacto: 2×99.1 + 2×4.65 + 2.5 = 210, 7×38.1 + 2×15.15 = 297.',
+}
+
+export const CARTEL_A4: DescriptorDeFormato = {
+  id: 'CARTEL-A4',
+  nombre: 'Cartel A4 (hoja completa)',
+  familia: 'cartel',
+  paginaMm: { ancho: 210, alto: 297 },
+  margenSuperiorMm: 10.0,
+  margenIzquierdoMm: 10.0,
+  columnas: 1,
+  filas: 1,
+  celdaMm: { ancho: 190.0, alto: 277.0 },
+  medianilHorizontalMm: 0,
+  medianilVerticalMm: 0,
+  // Sin valor publicado por el design para carteles; el margen de 10 mm ya cubre el margen no
+  // imprimible típico del hardware, así que no se suma un pad adicional (asunción documentada,
+  // ver reporte de apply del slice 1).
+  padExternoMm: 5,
+  campos: CAMPOS_COMPLETOS,
+  escalaDePrecio: 3.5,
+  referencia: 'Hoja entera, margen 10 mm.',
+}
+
+export const CARTEL_A5: DescriptorDeFormato = {
+  id: 'CARTEL-A5',
+  nombre: 'Cartel A5 (media hoja, 2 por A4)',
+  familia: 'cartel',
+  paginaMm: { ancho: 210, alto: 297 },
+  margenSuperiorMm: 10.0,
+  margenIzquierdoMm: 10.0,
+  columnas: 1,
+  filas: 2,
+  celdaMm: { ancho: 190.0, alto: 133.5 },
+  medianilHorizontalMm: 0,
+  medianilVerticalMm: 10.0,
+  padExternoMm: 5,
+  campos: CAMPOS_COMPLETOS,
+  escalaDePrecio: 3.0,
+  referencia: 'Media hoja: 2×133.5 + 10 + 2×10 = 297.',
+}
+
+/** Los cuatro descriptores fijos de la etapa (OD3: C3, plantillas fijas en código). Todo
+ * consumidor recibe este arreglo como dato — nunca importa un descriptor por id literal. */
+export const FORMATOS: readonly DescriptorDeFormato[] = [A4_3X8, A4_2X7, CARTEL_A4, CARTEL_A5]
+
+// Derivados: SIEMPRE calculados, JAMÁS almacenados (decisión 3, mutation targets 4/5).
+export const celdasPorHoja = (d: DescriptorDeFormato): number => d.columnas * d.filas
+export const contarHojas = (celdas: number, d: DescriptorDeFormato): number => Math.ceil(celdas / celdasPorHoja(d))

--- a/src/Ways.Web/vite.config.ts
+++ b/src/Ways.Web/vite.config.ts
@@ -22,5 +22,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    // `css: true` (etapa 18, slice 1): sin esto Vitest reemplaza cualquier import de `.css` —
+    // incluido `?raw` — por un string vacío, y el test estructural de la named page
+    // (`etiquetas.css`, mutation target 1) necesita el texto real del stylesheet.
+    css: true,
   },
 })


### PR DESCRIPTION
## Resumen

Slice 1 de la etapa 18 (etiquetas, carteles y consulta de precios): la base de impresión.

- `DescriptorDeFormato` (record plano, la puerta a formatos configurables) + 4 tuples con geometría de hojas publicadas que CIERRA el A4 exacto (A4-3x8 70.0×37.0 · A4-2x7 99.1×38.1 con offsets 15.15/4.65 · carteles A4/A5) — verificada por aritmética independiente de ambos jueces.
- `HojaDeEtiquetas.tsx`: renderer de impresión PURO con modos normal/calibración (el MISMO tuple alimenta ambos — mutation target).
- **Named page** `@page etiquetas { margin: 0 }` en `etiquetas.css` — `impresion.css` BYTE-IDÉNTICA (criterio vinculante verificado por `git diff --exit-code`): cero riesgo de regresión sobre la impresión de CajaZ/CuentaCorriente.
- **La grilla de calibración del spike** (tarea 1a, autónoma): cruz de registro por celda, reglas con ticks de 1mm, cuadrado de escala de 100.0mm, instrucciones de impresión — TODO en una sola hoja física. `spike-alineacion.md` queda listo para la medición E1 del dueño (tarea 1b, BLOQUEADA-EN-DUEÑO — solo gatea el slice 3). E2 parcial 2/3 documentado con la tarea 3.0 como dueña del re-chequeo.

## Judgment-day (2 rondas, limpia al cierre)

- **Ronda 1 — juez B (mutador) REJECT**: la cruz de registro y el hairline sin red (mutantes DOM-observables sobrevivían 6/6 — honest-limits NO aplicaba) + ticks de 1mm faltantes vs design. Fixes `5bc6a05` con conteos exactos (regla 12b). Re-ronda B APPROVE. Los 8 mutation targets del slice con evidencia RED/verde; geometría re-verificada por aritmética propia.
- **Ronda 2 — juez A (read-only) REJECT con el hallazgo del slice**: por pura lectura de CSS detectó que el flujo normal sumaba 380.2mm en una página de 297 — el cuadrado de escala caía en una SEGUNDA hoja física, falseando la precondición de nulidad del veredicto E1. Más el gate E2 sin tarea exigible. Fixes `7e86886`: anclas absolute (reglas en sus anchors del design; cuadrado en right:0/bottom:0, desviación documentada), Start del slice 3 exigiendo E1 Y E2, tarea 3.0 nueva. Pasada acotada B APPROVE (layout físico razonado: una sola hoja, mismo sistema de coordenadas, medibilidad preservada) + re-ronda A APPROVE con cero hallazgos.

## Suites

- vitest: 23/23 dirigidos (etiquetas/), full 926/926 en el apply. `tsc -b` limpio, lint limpio, `dotnet build` limpio (cero backend). `vite.config.ts` con `test.css: true` (necesario para el test estructural del CSS real; suite completa verificada sin regresión).

🤖 Generated with [Claude Code](https://claude.com/claude-code)