### PR TITLE
feat(fiscal): schema fiscal completo de la etapa 19a — migracion, entidades y backstops (slice 1)

### DIFF
--- a/docs/09-multi-tenancy.md
+++ b/docs/09-multi-tenancy.md
@@ -59,7 +59,7 @@ empresas (
     razon_social  citext NOT NULL,
     nombre_fantasia citext NULL,
     cuit          varchar(13) NULL,
-    -- condición IVA, domicilio fiscal, etc. cuando toque facturación electrónica
+    id_condicion_fiscal integer NULL REFERENCES condiciones_fiscales,  -- Etapa 19a, FK simple
     UNIQUE (id_empresa, id_tenant)          -- habilita FKs compuestas (ver Aislamiento)
 );
 
@@ -69,10 +69,26 @@ puntos_venta (
     id_empresa     integer NOT NULL,
     nombre         citext NOT NULL,
     domicilio, horario, whatsapp, instagram, facebook, web, ...,   -- lo que ya define el doc 03
+    numero_fiscal  integer NULL,             -- Etapa 19a: PtoVta ARCA, UNIQUE por empresa (1..99999)
     FOREIGN KEY (id_empresa, id_tenant) REFERENCES empresas (id_empresa, id_tenant),
     UNIQUE (id_punto_venta, id_tenant)
 );
 ```
+
+> **Estado (Etapa 19a, slice 1 — schema fiscal, apply en curso):** `empresas.id_condicion_fiscal`
+> y `puntos_venta.numero_fiscal` implementadas por la migración `FiscalArcaEtapa19a` — ambas
+> `NULL` a propósito, sin default honesto (`openspec/changes/stage-19-fiscal-arca/proposal.md`
+> §B/§C). `numero_fiscal` es `UNIQUE (id_tenant, id_empresa, numero_fiscal)` PARCIAL — vuelve
+> inyectivo el mapa de la serie de ARCA `(PtoVta, CbteTipo)` a `(id_punto_venta, codigo_afip)`.
+>
+> Esta etapa también agrega `certificados_fiscales`, una **DESVIACIÓN DOCUMENTADA** de la forma
+> de catálogo de esta sección: mientras un catálogo de tenant lleva `id_empresa NULL` = *"vale
+> para todas las empresas del tenant"* (ver la regla de scoping más abajo), `certificados_fiscales`
+> lleva **`id_empresa NOT NULL`** — un certificado X.509 pertenece a UN CUIT (una empresa) y
+> nunca se comparte entre empresas del mismo tenant, misma forma exacta que `puntos_venta`
+> (scoping operativa: `id_tenant` + `id_empresa`/`id_punto_venta` no-nulos). `numeraciones_fiscales`
+> es scoping **operativa** estándar (`id_tenant` + `id_punto_venta`), sin desvío — mismo criterio
+> que `numeraciones_comprobante`.
 
 ## Regla de scoping por tipo de tabla
 

--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -92,6 +92,19 @@ tipos_comprobante (           -- [global]
 )
 ```
 
+> **Estado (Etapa 19a, slice 1 — schema fiscal, apply en curso):** `codigo_afip` de los tres
+> catálogos de arriba deja de ser `NULL` a propósito y se puebla vía tres data statements
+> idempotentes de la migración `FiscalArcaEtapa19a` (`WHERE codigo_afip IS NULL`) + sus tres
+> seed nets gemelos en `InicializadorDeBaseDeDatos` (doble red, cada net probado
+> independientemente). `tipos_comprobante`: `FA`→1, `NDA`→2, `NCA`→3, `FB`→6, `NCB`→8, `FC`→11,
+> `NCC`→13. `condiciones_fiscales` (RG 5616 `CondicionIVAReceptorId`): `RI`→1, `EXENTO`→4,
+> `CF`→5, `MONOTRIBUTO`→6, `NO_RESP`→15 (mapeo a la condición más cercana, la ÚNICA
+> incertidumbre flaggeada — se confirma contra `FEParamGetCondicionIvaReceptor` en 19b; hasta
+> entonces un receptor `NO_RESP` se rechaza por su código, no por este valor). `alicuotas_iva`
+> (`FEParamGetTiposIva`): `0%`→3, `10.5%`→4, `21%`→5, `27%`→6 — `Exento`/`No gravado` quedan
+> `codigo_afip NULL` **por regla**: no son alícuotas, sus importes van a `ImpOpEx`/`ImpTotConc`
+> y jamás al array `Iva[]` de ARCA.
+
 **`PRE` — desactivado desde la etapa 17 (el cierre del PRE latente).** `PRE` era un tipo
 `activo`, `afecta_stock = false`, sin ningún camino de escritura propio — una venta fantasma
 podía colarse por `POST /api/ventas` con `codigoTipoComprobante = "PRE"`, decrementar stock y
@@ -355,7 +368,12 @@ comprobantes_venta (          -- [operativa]
     neto_gravado NULL, iva_total NULL,       -- solo si discrimina_iva
     -- entrega
     direccion_entrega text NULL, observaciones text NULL,
-    estado  estado_comprobante NOT NULL      -- enum: emitido | anulado
+    estado  estado_comprobante NOT NULL,     -- enum: emitido | anulado
+    -- Etapa 19a: aditivas, las cuatro NULL ⇒ "no es un comprobante fiscal" (TX/NCX/TXR/RC)
+    cae                    varchar(14) NULL,
+    cae_vencimiento        date        NULL,
+    resultado_fiscal       resultado_fiscal NULL,  -- enum: pendiente|aprobado|aprobado_con_observaciones|rechazado
+    observaciones_fiscales jsonb       NULL         -- [{ "codigo": int, "mensaje": string }]
 );
 -- UNIQUE (id_punto_venta, id_tipo_comprobante, numero)
 
@@ -430,6 +448,84 @@ movimientos, y los movimientos no se editan.
 > "Presupuestos" más abajo). `ComprobanteEmitido` gana `IdPresupuestoOrigen` en el
 > round-trip (`dto-contract-honesty` regla 2).
 >
+> **Estado (Etapa 19a, slice 1 — schema fiscal, apply en curso — header ABIERTO, cierra en
+> slice 5, regla 19):** `comprobantes_venta` gana las cuatro columnas de arriba (migración
+> `FiscalArcaEtapa19a`), aditivas puras — CERO statement extra en una venta no fiscal.
+> `ck_comprobantes_venta_fiscal_coherente` (4 conjuntos): o las cuatro son `NULL`, o
+> `resultado_fiscal` está seteado con `cae`/`cae_vencimiento` llegando juntos y presentes SII
+> `resultado_fiscal` es una de las dos aprobaciones (`aprobado`/`aprobado_con_observaciones` —
+> una aprobación CON observaciones **es** una factura válida, I3 de la máquina CAE la trata
+> como terminal). `ck_comprobantes_venta_cae_digitos` exige 14 dígitos. Índice PARCIAL
+> `ix_comprobantes_venta_fiscal_pendientes` `WHERE resultado_fiscal = 'pendiente'` — su
+> consumidor (resolución de pendientes/reintento, invariante I2) llega en slice 5. Sin columna
+> nueva para el número fiscal: `numero` ya lo lleva, alimentado por la serie fiscal
+> (`numeraciones_fiscales`, ver "Fiscal ARCA" más abajo) en vez de la interna — disjuntas por
+> tipo de comprobante. `observaciones_fiscales` sigue el precedente `jsonb` de `Auditoria` —
+> nunca la respuesta cruda de ARCA (persistiría `Token`/`Sign`, una credencial portadora, sin
+> cifrado). El camino de escritura fiscal (`ServicioDeFacturacionFiscal`) llega en slice 5; esta
+> slice no tiene ningún caller.
+
+### Fiscal ARCA (Etapa 19a)
+
+El núcleo fiscal buildable sin credenciales (`openspec/changes/stage-19-fiscal-arca/`, slice 1
+— schema): el certificado activo es el gate estructural, no un feature flag — sin uno, el
+camino fiscal devuelve 409 y realiza **cero** llamadas de red (invariante I4). `resultado_fiscal`
+y `ambiente_fiscal` son enums nativos nuevos, **enteramente creados por `CREATE TYPE`** — CERO
+`ALTER TYPE … ADD VALUE`, así que esta sub-etapa no deja ningún artefacto irreversible tras un
+`Down()` (a diferencia de las etapas 12/17).
+
+```sql
+certificados_fiscales (         -- [id_tenant + id_empresa NOT NULL] — DESVIACIÓN del catálogo,
+                                 -- ver doc 09: un certificado es de UN CUIT, nunca compartido
+    id_certificado, id_tenant, id_empresa,
+    ambiente               ambiente_fiscal NOT NULL,  -- enum: homologacion | produccion
+    alias                  varchar(60)  NOT NULL,     -- etiqueta humana ("Homo 2026")
+    cuit_titular            varchar(11) NOT NULL,      -- CUIT al que ARCA emitió el certificado
+    certificado_pem         text        NOT NULL,      -- parte PÚBLICA: no es secreto
+    clave_privada_cifrada   bytea       NOT NULL,      -- AES-256-GCM
+    nonce                   bytea       NOT NULL,      -- 12 bytes
+    tag_autenticacion       bytea       NOT NULL,      -- 16 bytes
+    id_clave_maestra        varchar(30) NOT NULL,      -- versión de la clave maestra (rotación)
+    huella_sha256           varchar(64) NOT NULL,      -- fingerprint: trazar sin descifrar
+    vigencia_desde, vigencia_hasta timestamptz NOT NULL,  -- del propio X.509
+    activo                  boolean     NOT NULL
+    -- EntidadBase completa (created_at/updated_at/deleted_at) — la rotación da de baja lógica
+    -- la fila superada
+);
+-- UNIQUE (id_tenant, id_empresa, ambiente) WHERE activo AND deleted_at IS NULL
+--   ⇒ a lo sumo UN certificado activo por empresa+ambiente
+
+numeraciones_fiscales (         -- [operativa] id_tenant + id_punto_venta, PK-only sin auditoría
+                                 -- (mismo criterio que numeraciones_comprobante, doc 09)
+    id_punto_venta integer  NOT NULL,   -- el interno; su numero_fiscal es UNIQUE (ver arriba)
+    codigo_afip    smallint NOT NULL,   -- CbteTipo de ARCA (1, 3, 6, 8, 11, 13, …)
+    id_tenant      integer  NOT NULL,
+    proximo_numero bigint   NOT NULL DEFAULT 1,
+    ultimo_autorizado_arca bigint      NULL,   -- de FECompUltimoAutorizado; 0 = serie sin usar
+    sincronizado_en         timestamptz NULL   -- par del anterior (IRelojDelSistema)
+    -- PK (id_punto_venta, codigo_afip)
+);
+```
+
+**Estado (Etapa 19a, slice 1 — schema fiscal, DB CHANGE GATE ratificado por el orquestador —
+apply en curso).** Creadas por la migración `FiscalArcaEtapa19a`, junto con los tres ALTERs
+aditivos de arriba (`empresas`, `puntos_venta`, `comprobantes_venta`) y las dos nuevas `CREATE
+TYPE`. RLS estándar (`ENABLE` + `FORCE`) en ambas tablas. `certificados_fiscales`: `EntidadBase`
+**SÍ** — key material que se rota, nunca se edita in place. `numeraciones_fiscales`:
+`EntidadBase` **NO** — mismo criterio exacto que `numeraciones_comprobante` (doc 09), necesita
+filtro de tenant escrito a mano (`WaysDbContext.AplicarFiltroDeTenantEnNumeracionFiscal`) y un
+guard de rechazo de escritura por `SaveChangesAsync` — su único escritor legítimo es
+`AsignadorDeNumeroFiscal` (slice 4), con SQL crudo, **disciplina OPUESTA** a
+`AsignadorDeNumeroComprobante`: toma el número DENTRO de la transacción de emisión (nunca en una
+transacción propia previa) porque en una serie de ARCA un número quemado no abre un hueco
+legítimo — **detiene la serie** (error 10016 de ARCA). El `codigo_afip` de los tres catálogos
+(`tipos_comprobante`, `condiciones_fiscales`, `alicuotas_iva`) queda poblado por esta misma
+migración vía tres data statements idempotentes + sus tres seed nets gemelos en
+`InicializadorDeBaseDeDatos` (doble red de la etapa 17) — sin ningún `ALTER`, las tres tablas ya
+tenían `codigo_afip smallint NULL` desde la etapa 1. Ningún camino de escritura de negocio existe
+todavía en esta slice: `ServicioDeFacturacionFiscal` (la emisión, slices 4-5),
+`AsignadorDeNumeroFiscal` y `ServicioDeCertificados` llegan en slices posteriores — esta slice es
+schema puro.
 
 ### Presupuestos (Etapa 17)
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -272,8 +272,15 @@ green + `judgment-day` clean round + PR merged.
 - [x] 1.50 Mutation evidence recorded in the PR body for targets 1-23 (**S** rows 2, 3, 21, 22, 23
   record the file/state/definition assertion, not a runtime failure). See "Work Unit Evidence"
   table below.
-- [ ] 1.51 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
+- [x] 1.51 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
+  **DONE by the orchestrator**: juez B APPROVE (5 spot-checks reproducen + el mutante extra del
+  orden de ManejadorDeErrores RED en ambos caminos; 1 MINOR de etiquetado — target 1 re-clasificado
+  [S] por equivalencia de runtime — + 1 SUGGESTION de honestidad del doble guard + 1 WARNING
+  diferido como nota vinculante del slice 5; fixes documentales `1df54ac`). Juez A APPROVE con
+  CERO hallazgos (contrato del gate verificado columna por columna; NO_RESP=15 consistente en los
+  3 lugares; ServicioDeVentas.cs ausente del patch — guard del POS byte-idéntico; los 2 fixtures
+  raw-SQL preservan semántica). Ronda limpia.
 - [ ] 1.52 [ ] Open PR #1 `feat/stage19a-slice1-schema-fiscal`, merge to `main` after a clean
   `judgment-day` round.
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -133,129 +133,164 @@ guarded-`UPDATE` conjunct set in this slice — U1-U4 belong to slices 4-5), `db
 (the full **10** new branches: 2 × `23505` + 8 × `23514`), `work-unit-commits`. **Done** = tests
 green + `judgment-day` clean round + PR merged.
 
-- [ ] 1.1 Migration `FiscalArcaEtapa19a`, statement 01: `AlterDatabase()` emitting `CREATE TYPE
+- [x] 1.1 Migration `FiscalArcaEtapa19a`, statement 01: `AlterDatabase()` emitting `CREATE TYPE
   ambiente_fiscal ('homologacion','produccion')` and `CREATE TYPE resultado_fiscal
   ('pendiente','aprobado','aprobado_con_observaciones','rechazado')`, lifecycle order hand-corrected
   (EF serializes alphabetically), **zero** `ALTER TYPE … ADD VALUE`. *(design.md:84-93,
   proposal.md:490-501)*
-- [ ] 1.2 Same migration §B: `AddColumn empresas.id_condicion_fiscal integer NULL` + FK1
+- [x] 1.2 Same migration §B: `AddColumn empresas.id_condicion_fiscal integer NULL` + FK1
   `fk_empresas_condicion_fiscal` (simple, RESTRICT) + Index 1 `ix_empresas_condicion_fiscal`
   (simple, **not** `id_tenant`-led — the stage-14 amendment trap). *(design.md:94-96,
   proposal.md:503-521)*
-- [ ] 1.3 Same migration §C: `AddColumn puntos_venta.numero_fiscal integer NULL` + CHECK 1
+- [x] 1.3 Same migration §C: `AddColumn puntos_venta.numero_fiscal integer NULL` + CHECK 1
   `ck_puntos_venta_numero_fiscal_rango` (1..99999) + Index 2 `ux_puntos_venta_numero_fiscal`
   UNIQUE PARTIAL `WHERE numero_fiscal IS NOT NULL`. *(design.md:97-99, proposal.md:522-533)*
-- [ ] 1.4 Same migration §D: `AddColumn ×4` on `comprobantes_venta` (`cae`, `cae_vencimiento`,
+- [x] 1.4 Same migration §D: `AddColumn ×4` on `comprobantes_venta` (`cae`, `cae_vencimiento`,
   `resultado_fiscal`, `observaciones_fiscales`) + CHECK 2 `ck_comprobantes_venta_fiscal_coherente`
   (4 conjuncts) + CHECK 3 `ck_comprobantes_venta_cae_digitos` + Index 3
   `ix_comprobantes_venta_fiscal_pendientes` PARTIAL `WHERE resultado_fiscal = 'pendiente'`.
   *(design.md:100-103, proposal.md:535-557)*
-- [ ] 1.5 Same migration §E: `CreateTable certificados_fiscales` — 18 columns, PK, FK2 (tenant
+- [x] 1.5 Same migration §E: `CreateTable certificados_fiscales` — 18 columns, PK, FK2 (tenant
   simple), FK3 (empresa composite against `puntos_venta`'s AK), CHECK 4 `…vigencia`, CHECK 5
   `…cuit`, CHECK 6 GCM sizes (3 conjuncts) inline. *(design.md:104, proposal.md:559-606)*
-- [ ] 1.6 Same migration: `CreateIndex ×3` on `certificados_fiscales` — `ix_…_tenant`,
+- [x] 1.6 Same migration: `CreateIndex ×3` on `certificados_fiscales` — `ix_…_tenant`,
   `ix_…_empresa`, `ux_certificados_fiscales_activo` UNIQUE PARTIAL (2 filter conjuncts: `activo AND
   deleted_at IS NULL`). *(design.md:105, proposal.md:599-601)*
-- [ ] 1.7 Same migration §F: `CreateTable numeraciones_fiscales` — 6 columns, PK
+- [x] 1.7 Same migration §F: `CreateTable numeraciones_fiscales` — 6 columns, PK
   `(id_punto_venta, codigo_afip)`, FK4 (tenant), FK5 (punto_venta composite, **mirrored from**
   `NumeracionComprobanteConfiguration`), CHECK 7 `…rango` (0 legal for "serie sin usar"), CHECK 8
   `…sincronizacion` inline. *(design.md:106, proposal.md:607-641, fact 2:22-27)*
-- [ ] 1.8 Same migration: `CreateIndex ×2` on `numeraciones_fiscales` — `ix_…_tenant`,
+- [x] 1.8 Same migration: `CreateIndex ×2` on `numeraciones_fiscales` — `ix_…_tenant`,
   `ix_…_punto_venta` (not covered by the PK, whose second column is `codigo_afip`).
   *(design.md:107)*
-- [ ] 1.9 Same migration §G: `Sql` DS1 `tipos_comprobante` (7 rows, `WHERE codigo_afip IS NULL`),
+- [x] 1.9 Same migration §G: `Sql` DS1 `tipos_comprobante` (7 rows, `WHERE codigo_afip IS NULL`),
   DS2 `condiciones_fiscales` (5 rows), DS3 `alicuotas_iva` (4 rows) — all idempotent, **zero** rows
   inserted/activated/deactivated. *(design.md:108-110, proposal.md:649-670)*
-- [ ] 1.10 Same migration: `HabilitarRlsDeTenant` on `certificados_fiscales` and
+- [x] 1.10 Same migration: `HabilitarRlsDeTenant` on `certificados_fiscales` and
   `numeraciones_fiscales`, **LAST** in `Up()`. *(design.md:111-112)*
-- [ ] 1.11 Write `Down()` — exact inverse in reverse order: 3 doubly-guarded `UPDATE` reverts
+- [x] 1.11 Write `Down()` — exact inverse in reverse order: 3 doubly-guarded `UPDATE` reverts
   (DS3/DS2/DS1), `DropTable ×2`, `DropIndex`/`DropCheck`/`DropColumn ×4` on `comprobantes_venta`
   (**before** the `DROP TYPE`), same on `puntos_venta` and `empresas`, `AlterDatabase()` swap ⇒
   `DROP TYPE ×2`. *(design.md:122-145)*
-- [ ] 1.12 Create `src/Ways.Domain/Fiscal/{ResultadoFiscal,AmbienteFiscal}.cs` — member order =
+- [x] 1.12 Create `src/Ways.Domain/Fiscal/{ResultadoFiscal,AmbienteFiscal}.cs` — member order =
   lifecycle = `CREATE TYPE` order. *(design.md:363)*
-- [ ] 1.13 Create `src/Ways.Domain/Fiscal/{CertificadoFiscal,NumeracionFiscal}.cs` — `EntidadBase`
+- [x] 1.13 Create `src/Ways.Domain/Fiscal/{CertificadoFiscal,NumeracionFiscal}.cs` — `EntidadBase`
   **yes**/**no** respectively. *(design.md:364, proposal.md §E/§F)*
-- [ ] 1.14 Create `Configuraciones/CertificadoFiscalConfiguration.cs` — 18 columns, PK, 2 FKs, 3
+- [x] 1.14 Create `Configuraciones/CertificadoFiscalConfiguration.cs` — 18 columns, PK, 2 FKs, 3
   CHECKs, 3 indexes, explicit snake_case names. *(design.md:170)*
-- [ ] 1.15 Create `Configuraciones/NumeracionFiscalConfiguration.cs` — line-for-line mirror of
+- [x] 1.15 Create `Configuraciones/NumeracionFiscalConfiguration.cs` — line-for-line mirror of
   `NumeracionComprobanteConfiguration`: PK, `IdTenant` non-key, `ProximoNumero`
   `HasDefaultValue(1L)`, both index names hand-written, composite FK mirrored from the sibling.
   *(design.md:171, fact 2:22-27)*
-- [ ] 1.16 Modify `Configuraciones/EmpresaConfiguration.cs` — `id_condicion_fiscal` property +
+- [x] 1.16 Modify `Configuraciones/EmpresaConfiguration.cs` — `id_condicion_fiscal` property +
   simple `HasOne` + named index. *(design.md:167)*
-- [ ] 1.17 Modify `Configuraciones/PuntoVentaConfiguration.cs` — `numero_fiscal` + CHECK + named
+- [x] 1.17 Modify `Configuraciones/PuntoVentaConfiguration.cs` — `numero_fiscal` + CHECK + named
   filtered unique index. *(design.md:168)*
-- [ ] 1.18 Modify `Configuraciones/ComprobanteVentaConfiguration.cs` — 4 properties (`jsonb`
+- [x] 1.18 Modify `Configuraciones/ComprobanteVentaConfiguration.cs` — 4 properties (`jsonb`
   converter for `observaciones_fiscales`, the `Auditoria` precedent), 2 CHECKs, the partial index.
   *(design.md:169)*
-- [ ] 1.19 Modify `WaysDbContext.cs` — `DbSet<CertificadoFiscal>` (exposed in `IWaysDbContext`),
+- [x] 1.19 Modify `WaysDbContext.cs` — `DbSet<CertificadoFiscal>` (exposed in `IWaysDbContext`),
   `DbSet<NumeracionFiscal>` **not** exposed (sibling criterion), `AplicarFiltroDeTenantEnNumeracionFiscal`,
-  `RechazarEscriturasDeNumeracionFiscal`, two `HasPostgresEnum` registrations. *(design.md:172)*
-- [ ] 1.20 Modify `WaysDbContextFactory.cs` and `DependencyInjection.cs` —
-  `MapEnum<ResultadoFiscal>`/`MapEnum<AmbienteFiscal>` in both builders.
-- [ ] 1.21 Modify `InicializadorDeBaseDeDatos.cs` — three seed nets: `CodigoAfip` field on
+  `RechazarEscriturasDeNumeracionFiscal`. **DEVIATION (registered, not silent)**: the two enum
+  registrations use `npgsql.MapEnum<T>()` in `WaysDbContextFactory.cs`/`DependencyInjection.cs`
+  (task 1.20), never `HasPostgresEnum` in `OnModelCreating` — `WaysDbContext.cs:210-213`'s own
+  comment states this is the project's established convention for every prior enum
+  (`estado_usuario`/`estado_tenant`/…): declaring an enum in both places would generate the type
+  twice in the migration. `design.md:172`'s "two HasPostgresEnum registrations" line does not
+  match the codebase's actual mechanism. *(design.md:172)*
+- [x] 1.20 Modify `WaysDbContextFactory.cs` and `DependencyInjection.cs` —
+  `MapEnum<ResultadoFiscal>`/`MapEnum<AmbienteFiscal>` in both builders. Also added to the test
+  fixture's own three `MapEnum` blocks (`WaysApiFixture.cs`) — not listed in design.md's file
+  table but required for the shared test host to boot against the new schema (same convention
+  every prior stage's migration followed).
+- [x] 1.21 Modify `InicializadorDeBaseDeDatos.cs` — three seed nets: `CodigoAfip` field on
   `TiposComprobanteBase`/`CondicionesFiscalesBase`/`AlicuotasIvaBase`, each net tested
   **independently**. *(proposal.md:672-676)*
-- [ ] 1.22 Modify `src/Ways.Api/Seguridad/ManejadorDeErrores.cs` — 2 exact-name `23505` branches
+- [x] 1.22 Modify `src/Ways.Api/Seguridad/ManejadorDeErrores.cs` — 2 exact-name `23505` branches
   (`ux_puntos_venta_numero_fiscal`, `ux_certificados_fiscales_activo`) + 8 exact-name `23514`
   branches (CHECKs 1-8), each its own named domain error. *(proposal.md:680-682)*
-- [ ] 1.23 Modify `docs/09-multi-tenancy.md` — `certificados_fiscales`'s documented scoping
+- [x] 1.23 Modify `docs/09-multi-tenancy.md` — `certificados_fiscales`'s documented scoping
   deviation (`id_empresa NOT NULL`) vs. the catálogo shape. *(proposal.md decision 5)*
-- [ ] 1.24 Modify `docs/10-modelo-de-datos.md` — scoping table, §4-adjacent subsections, "Estado
+- [x] 1.24 Modify `docs/10-modelo-de-datos.md` — scoping table, §4-adjacent subsections, "Estado
   (Etapa 19a)" header **OPENED** (closes at slice 5, regla 19).
-- [ ] 1.25 [P] Domain unit: enum-order test — C# member index ↔ `pg_enum.enumsortorder`, both
+- [x] 1.25 [P] Domain unit: enum-order test — C# member index ↔ `pg_enum.enumsortorder`, both
   enums. *(target 1)*
-- [ ] 1.26 **[S]** Migration-source scan: zero `ALTER TYPE … ADD VALUE` in the file. *(target 2)*
-- [ ] 1.27 [P] `pg_indexes` by-definition comparison — all 8 new index definitions (8
+- [x] 1.26 **[S]** Migration-source scan: zero `ALTER TYPE … ADD VALUE` in the file. *(target 2)*
+- [x] 1.27 [P] `pg_indexes` by-definition comparison — all 8 new index definitions (8
   sub-mutations, count = 8). *(target 3, design.md:147-161)*
-- [ ] 1.28 [P] Raw-insert CHECK 1 boundary — `numero_fiscal = 0` and `= 100000` ⇒ `23514`.
+- [x] 1.28 [P] Raw-insert CHECK 1 boundary — `numero_fiscal = 0` and `= 100000` ⇒ `23514`.
   *(target 4)*
-- [ ] 1.29 [P] Raw-insert CHECK 2 — four conjunct-killing writes: CAE without expiry; `rechazado`
+- [x] 1.29 [P] Raw-insert CHECK 2 — four conjunct-killing writes: CAE without expiry; `rechazado`
   with a CAE; `aprobado` without a CAE; `cae` set with `resultado_fiscal` NULL. *(target 5)*
-- [ ] 1.30 [P] Raw-insert CHECK 3 — a 13-digit and an alphanumeric CAE. *(target 6)*
-- [ ] 1.31 [P] Raw-insert CHECK 4 — equal `vigencia_hasta`/`vigencia_desde`. *(target 7)*
-- [ ] 1.32 [P] Raw-insert CHECK 5 — a 10-digit CUIT. *(target 8)*
-- [ ] 1.33 [P] Raw-insert CHECK 6 — three conjunct-killing writes: 11-byte nonce, 15-byte tag,
+- [x] 1.30 [P] Raw-insert CHECK 3 — a 13-digit and an alphanumeric CAE. *(target 6)*
+- [x] 1.31 [P] Raw-insert CHECK 4 — equal `vigencia_hasta`/`vigencia_desde`. *(target 7)*
+- [x] 1.32 [P] Raw-insert CHECK 5 — a 10-digit CUIT. *(target 8)*
+- [x] 1.33 [P] Raw-insert CHECK 6 — three conjunct-killing writes: 11-byte nonce, 15-byte tag,
   empty ciphertext. *(target 9)*
-- [ ] 1.34 [P] Raw-insert CHECK 7 — `proximo_numero = 0` must succeed, `100000000` must fail.
-  *(target 10)*
-- [ ] 1.35 [P] Raw-insert CHECK 8 — either half (`ultimo_autorizado_arca`/`sincronizado_en`)
+- [x] 1.34 [P] Raw-insert CHECK 7 — `proximo_numero = 0` must succeed, `100000000` must fail.
+  *(target 10)* **CORRECTION (registered, mutation-proof-tests rule 2 "run it, don't reason it")**:
+  the CHECK itself is `proximo_numero BETWEEN 1 AND 99999999 AND (ultimo_autorizado_arca IS NULL
+  OR ultimo_autorizado_arca BETWEEN 0 AND 99999999)` — `proximo_numero = 0` cannot succeed under
+  that range (1 is the floor); "0 is legal" is exclusively true of `ultimo_autorizado_arca`
+  ("serie sin usar", design.md's own row 10 wording). Tested both real behaviors:
+  `UnUltimoAutorizadoArcaEnCeroEsLegalYNoViolaLaCheckDeRango` (succeeds) and
+  `UnProximoNumeroEnCeroVIOLALaCheckDeRango` (fails, the literal wording's contradiction with the
+  CHECK, confirmed by running it) plus the `100000000` over-range kill.
+- [x] 1.35 [P] Raw-insert CHECK 8 — either half (`ultimo_autorizado_arca`/`sincronizado_en`)
   written alone. *(target 11)*
-- [ ] 1.36 [P] Duplicate-write test on `ux_puntos_venta_numero_fiscal` ⇒ `23505`; two `NULL`
+- [x] 1.36 [P] Duplicate-write test on `ux_puntos_venta_numero_fiscal` ⇒ `23505`; two `NULL`
   fiscal numbers still accepted (the filter's own kill). *(target 12)*
-- [ ] 1.37 [P] Duplicate-write test on `ux_certificados_fiscales_activo` ⇒ `23505`; a
+- [x] 1.37 [P] Duplicate-write test on `ux_certificados_fiscales_activo` ⇒ `23505`; a
   soft-deleted twin and an inactive twin must both be accepted. *(target 13)*
-- [ ] 1.38 [P] RLS cross-tenant read+write pair on `certificados_fiscales` via `ways_app`.
+- [x] 1.38 [P] RLS cross-tenant read+write pair on `certificados_fiscales` via `ways_app`.
   *(target 14)*
-- [ ] 1.39 [P] RLS cross-tenant read+write pair on `numeraciones_fiscales` via `ways_app`.
+- [x] 1.39 [P] RLS cross-tenant read+write pair on `numeraciones_fiscales` via `ways_app`.
   *(target 15)*
-- [ ] 1.40 [P] Delete `AplicarFiltroDeTenantEnNumeracionFiscal`, confirm a tenant-B context reads
+- [x] 1.40 [P] Delete `AplicarFiltroDeTenantEnNumeracionFiscal`, confirm a tenant-B context reads
   tenant A's counter through EF (mutation applied, red, reverted, green). *(target 16)*
-- [ ] 1.41 [P] Delete `RechazarEscriturasDeNumeracionFiscal`, confirm `SaveChangesAsync` over a
+- [x] 1.41 [P] Delete `RechazarEscriturasDeNumeracionFiscal`, confirm `SaveChangesAsync` over a
   tracked `NumeracionFiscal` throws. *(target 17)*
-- [ ] 1.42 [P] Each migration data statement (DS1/DS2/DS3) tested independently on an
+- [x] 1.42 [P] Each migration data statement (DS1/DS2/DS3) tested independently on an
   already-migrated DB — deleting one alone fails only its own test. *(target 18)*
-- [ ] 1.43 [P] Each seed net tested independently on a fresh DB — deleting one field alone fails
+- [x] 1.43 [P] Each seed net tested independently on a fresh DB — deleting one field alone fails
   only its own test. *(target 19)*
-- [ ] 1.44 [P] Assert `Exento`/`No gravado` remain `codigo_afip NULL` after DS3. *(target 20)*
-- [ ] 1.45 **[S]** `ix_empresas_condicion_fiscal` definition test — simple, not `(id_tenant,
+- [x] 1.44 [P] Assert `Exento`/`No gravado` remain `codigo_afip NULL` after DS3. *(target 20)*
+- [x] 1.45 **[S]** `ix_empresas_condicion_fiscal` definition test — simple, not `(id_tenant,
   id_condicion_fiscal)`. *(target 21)*
-- [ ] 1.46 **[S]** `Up → Down → Up` clean, `has-pending-model-changes` clean at each leg,
+- [x] 1.46 **[S]** `Up → Down → Up` clean, `has-pending-model-changes` clean at each leg,
   pre-state comparison of the three catalogues' `codigo_afip`. *(target 22)*
-- [ ] 1.47 **[S]** `NumeracionFiscalConfiguration`'s explicit `HasDatabaseName` definition test on
+- [x] 1.47 **[S]** `NumeracionFiscalConfiguration`'s explicit `HasDatabaseName` definition test on
   both indexes. *(target 23)*
-- [ ] 1.48 Non-regression: full domain/application/integration suite green;
+- [x] 1.48 Non-regression: full domain/application/integration suite green;
   `src/Ways.Application/Ventas/ServicioDeVentas.cs` untouched this slice (reasserted at slice 5).
-- [ ] 1.49 GATE GUARD — exactly one migration file `FiscalArcaEtapa19a`; `has-pending-model-changes`
+- [x] 1.49 GATE GUARD — exactly one migration file `FiscalArcaEtapa19a`; `has-pending-model-changes`
   clean; zero `ALTER TYPE ADD VALUE`; index count = 8; CHECK count = 8 — all **by definition**.
   *(proposal.md §I criteria 1-4; Binding Verify Criteria 1-4)*
-- [ ] 1.50 Mutation evidence recorded in the PR body for targets 1-23 (**S** rows 2, 3, 21, 22, 23
-  record the file/state/definition assertion, not a runtime failure).
+- [x] 1.50 Mutation evidence recorded in the PR body for targets 1-23 (**S** rows 2, 3, 21, 22, 23
+  record the file/state/definition assertion, not a runtime failure). See "Work Unit Evidence"
+  table below.
 - [ ] 1.51 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
 - [ ] 1.52 [ ] Open PR #1 `feat/stage19a-slice1-schema-fiscal`, merge to `main` after a clean
   `judgment-day` round.
+
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Mode | Standard (no `strict_tdd` config found; `mutation-proof-tests` v1.1 discipline followed instead — see per-target evidence below) |
+| Focused test command | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~FiscalSchemaTests\|FullyQualifiedName~ManejadorDeErroresFiscalTests"` → **63/63 passed** (0 failed), against a real Postgres 17 Testcontainer (Docker confirmed available in this environment) |
+| Runtime harness | Testcontainers Postgres 17 via `WaysApiFixture`, `ways_app` role (RLS-scoped, non-superuser connection) for every cross-tenant/CHECK/UNIQUE test; three ad-hoc throwaway databases created/dropped via raw `CREATE DATABASE`/`DROP DATABASE ... WITH (FORCE)` for the data-statement (target 18), seed-net (target 19), and Up→Down→Up (target 22) tests — real migrations applied via `IMigrator`, not simulated |
+| `dotnet build --no-incremental` | `src/Ways.Api`, `src/Ways.Infrastructure`, `tests/Ways.IntegrationTests`, `tests/Ways.Application.Tests` all built clean (0 warnings, 0 errors) after every production edit in this slice |
+| `dotnet ef migrations has-pending-model-changes` | Clean — confirmed via CLI (`No changes have been made to the model since the last migration.`) after the hand-edited migration, and re-confirmed at runtime via `Database.HasPendingModelChanges()` in target 22's Up/Up-after-Down legs |
+| Full suite (non-regression, task 1.48) | `Ways.Application.Tests`: **297/297 passed**. `Ways.IntegrationTests` (full suite, all pre-existing + new fiscal tests): **1674/1674 passed**, 0 failed, 11 m 46 s — real Postgres 17 Testcontainer. First run surfaced 16 real failures (`PendingModelChangesWarning` in 7 files whose own throwaway-DB `MapEnum` lists predate this slice's two new enums; a `42804` type mismatch in 14 more files with the same gap touching `comprobantes_venta`; a `42703 column "id_condicion_fiscal" does not exist` in `CostoCongeladoTests`/`CuentaCorrienteProveedorBackfillTests`, whose pre-Etapa-19a throwaway databases now diverge from the EF model's `empresas`/`puntos_venta` shape — the FIRST such divergence since Etapa 1). All fixed (21 test files touched: `MapEnum<ResultadoFiscal>`/`MapEnum<AmbienteFiscal>` added to every hand-curated builder; `empresas`/`puntos_venta` writes switched to raw SQL in the two pre-migration seeding helpers, mirroring the file's own established `comprobantes_venta`/`articulos` pattern for the exact same reason). Re-run clean per rule 17 (isolated re-run with the fix applied) |
+| Rollback boundary | `dotnet ef migrations remove` / `Down()` — both `CREATE TYPE`s (`ambiente_fiscal`, `resultado_fiscal`) drop cleanly (zero `ALTER TYPE ADD VALUE` anywhere in the file, confirmed by target 2's source scan); no operational row is modified except the three catalogues' `codigo_afip`, reverted by the exact value `Up()` set (doubly-guarded `WHERE codigo = … AND codigo_afip = …`); confirmed empirically by target 22's Up→Down→Up test against a real throwaway database |
+
+**Deviations registered (not silent):**
+1. Task 1.19's `design.md:172` line "two `HasPostgresEnum` registrations" does not match the codebase's actual, uniform convention (`WaysDbContext.cs:210-213`'s own comment): every enum in this project is registered exclusively via `npgsql.MapEnum<T>()` in `WaysDbContextFactory.cs`/`DependencyInjection.cs` (task 1.20), never via `HasPostgresEnum` in `OnModelCreating` — declaring it in both places would emit the `CREATE TYPE` twice. Followed the established convention instead of the design line.
+2. Target 10 / task 1.34's literal wording ("`proximo_numero = 0` must succeed") contradicts CHECK 7's own range (`proximo_numero BETWEEN 1 AND 99999999`) — confirmed by actually running the mutation (mutation-proof-tests rule 2: "run it, don't reason it"). The "0 is legal" clause applies exclusively to `ultimo_autorizado_arca` ("serie sin usar"). Both real behaviors are tested; see the task 1.34 note above.
+3. `NO_RESP`'s `codigo_afip` mapping (proposal.md decision 11 flags this as "the one uncertainty" but never states the numeric value): mapped to **15** (RG 5616 "IVA No Alcanzado", the closest real ARCA condition to an unregistered/non-categorized receptor). This value is never read by any runtime emission decision in this slice — the slice-5 rejection of a `NO_RESP` receptor checks `condiciones_fiscales.Codigo`, not `CodigoAfip` — and is explicitly flagged in both `InicializadorDeBaseDeDatos.cs` and `docs/10-modelo-de-datos.md` for confirmation against `FEParamGetCondicionIvaReceptor` in 19b.
+4. `WaysApiFixture.cs`'s three `MapEnum` blocks (test host DI) needed the two new enum registrations too — not listed in design.md's file table (which only names production `WaysDbContextFactory.cs`/`DependencyInjection.cs`) but required for the shared integration-test host to boot against the new schema, same convention every prior stage's slice-1 migration followed for this fixture.
 
 ---
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -213,8 +213,11 @@ green + `judgment-day` clean round + PR merged.
   deviation (`id_empresa NOT NULL`) vs. the catálogo shape. *(proposal.md decision 5)*
 - [x] 1.24 Modify `docs/10-modelo-de-datos.md` — scoping table, §4-adjacent subsections, "Estado
   (Etapa 19a)" header **OPENED** (closes at slice 5, regla 19).
-- [x] 1.25 [P] Domain unit: enum-order test — C# member index ↔ `pg_enum.enumsortorder`, both
-  enums. *(target 1)*
+- [x] 1.25 [P] **[S]** Domain unit: enum-order test — C# member index ↔ `pg_enum.enumsortorder`,
+  both enums. *(target 1)* **RE-CLASIFICADO [S] (judgment ronda 1, juez B)**: `Npgsql.MapEnum`
+  resuelve por NOMBRE y ningún código de este slice ordena/compara los enums, así que el mutante
+  de orden es equivalente en runtime — el test es una aserción estructural de catálogo (misma
+  clase que targets 3/21/23), nunca un runtime kill.
 - [x] 1.26 **[S]** Migration-source scan: zero `ALTER TYPE … ADD VALUE` in the file. *(target 2)*
 - [x] 1.27 [P] `pg_indexes` by-definition comparison — all 8 new index definitions (8
   sub-mutations, count = 8). *(target 3, design.md:147-161)*
@@ -284,7 +287,7 @@ green + `judgment-day` clean round + PR merged.
 | `dotnet build --no-incremental` | `src/Ways.Api`, `src/Ways.Infrastructure`, `tests/Ways.IntegrationTests`, `tests/Ways.Application.Tests` all built clean (0 warnings, 0 errors) after every production edit in this slice |
 | `dotnet ef migrations has-pending-model-changes` | Clean — confirmed via CLI (`No changes have been made to the model since the last migration.`) after the hand-edited migration, and re-confirmed at runtime via `Database.HasPendingModelChanges()` in target 22's Up/Up-after-Down legs |
 | Full suite (non-regression, task 1.48) | `Ways.Application.Tests`: **297/297 passed**. `Ways.IntegrationTests` (full suite, all pre-existing + new fiscal tests): **1674/1674 passed**, 0 failed, 11 m 46 s — real Postgres 17 Testcontainer. First run surfaced 16 real failures (`PendingModelChangesWarning` in 7 files whose own throwaway-DB `MapEnum` lists predate this slice's two new enums; a `42804` type mismatch in 14 more files with the same gap touching `comprobantes_venta`; a `42703 column "id_condicion_fiscal" does not exist` in `CostoCongeladoTests`/`CuentaCorrienteProveedorBackfillTests`, whose pre-Etapa-19a throwaway databases now diverge from the EF model's `empresas`/`puntos_venta` shape — the FIRST such divergence since Etapa 1). All fixed (21 test files touched: `MapEnum<ResultadoFiscal>`/`MapEnum<AmbienteFiscal>` added to every hand-curated builder; `empresas`/`puntos_venta` writes switched to raw SQL in the two pre-migration seeding helpers, mirroring the file's own established `comprobantes_venta`/`articulos` pattern for the exact same reason). Re-run clean per rule 17 (isolated re-run with the fix applied) |
-| Rollback boundary | `dotnet ef migrations remove` / `Down()` — both `CREATE TYPE`s (`ambiente_fiscal`, `resultado_fiscal`) drop cleanly (zero `ALTER TYPE ADD VALUE` anywhere in the file, confirmed by target 2's source scan); no operational row is modified except the three catalogues' `codigo_afip`, reverted by the exact value `Up()` set (doubly-guarded `WHERE codigo = … AND codigo_afip = …`); confirmed empirically by target 22's Up→Down→Up test against a real throwaway database |
+| Rollback boundary | `dotnet ef migrations remove` / `Down()` — both `CREATE TYPE`s (`ambiente_fiscal`, `resultado_fiscal`) drop cleanly (zero `ALTER TYPE ADD VALUE` anywhere in the file, confirmed by target 2's source scan); no operational row is modified except the three catalogues' `codigo_afip`, reverted by the exact value `Up()` set (doubly-guarded `WHERE codigo = … AND codigo_afip = …`); the Up→Down→Up cycle of target 22 confirms Down() reverts what Up() set on a fresh database; the second guard half (`AND codigo_afip = …`) is NOT independently discriminated by any test (no fixture carries a pre-existing divergent codigo_afip — imposible hoy, barato de garantizar para siempre, honestidad registrada en judgment ronda 1) |
 
 **Deviations registered (not silent):**
 1. Task 1.19's `design.md:172` line "two `HasPostgresEnum` registrations" does not match the codebase's actual, uniform convention (`WaysDbContext.cs:210-213`'s own comment): every enum in this project is registered exclusively via `npgsql.MapEnum<T>()` in `WaysDbContextFactory.cs`/`DependencyInjection.cs` (task 1.20), never via `HasPostgresEnum` in `OnModelCreating` — declaring it in both places would emit the `CREATE TYPE` twice. Followed the established convention instead of the design line.
@@ -293,6 +296,14 @@ green + `judgment-day` clean round + PR merged.
 4. `WaysApiFixture.cs`'s three `MapEnum` blocks (test host DI) needed the two new enum registrations too — not listed in design.md's file table (which only names production `WaysDbContextFactory.cs`/`DependencyInjection.cs`) but required for the shared integration-test host to boot against the new schema, same convention every prior stage's slice-1 migration followed for this fixture.
 
 ---
+
+### Nota vinculante para el Slice 5 (judgment Slice 1 ronda 1, juez B — WARNING)
+
+El residual de la desviación 2 (NO_RESP → codigo_afip 15): `ServicioDeCatalogosFiscales`
+(preexistente) expone hoy ese 15 en el listado de catálogo — inerte porque no existe camino de
+emisión todavía. **El slice 5 DEBE confirmar que su guard de rechazo de NO_RESP decide por
+`Codigo`, jamás por `CodigoAfip`** (el 15 es provisional hasta la verificación de 19b contra
+`FEParamGetCondicionIvaReceptor`).
 
 ## Slice 2: SobreSoap + TRA/CMS + ClienteWsaa + caché TA + certificado de prueba + fixtures WSAA (PR 2)
 

--- a/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
+++ b/src/Ways.Api/Seguridad/ManejadorDeErrores.cs
@@ -253,6 +253,28 @@ public class ManejadorDeErrores(
                 when string.Equals(uxItemRemito, "ux_items_remito_orden", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "Ya existe un ítem con ese orden en este remito.", "orden_de_item_duplicado"),
 
+            // stage-19a-slice1 (task 1.22, db-error-backstops, proposal.md §H): ux_puntos_venta_numero_fiscal
+            // tiene que resolverse por nombre EXACTO, ANTES de ClasificarUnicidad — su nombre
+            // contiene "_numero", así que la rama genérica de esa substring (la familia de
+            // ux_clientes_numero) lo atraparía primero y lo clasificaría mal. SEXTA ocurrencia
+            // del ordering trap, mismo tratamiento exacto que ux_remitos_numero/
+            // ux_presupuestos_numero/ux_ordenes_compra_numero/ux_comprobantes_compra_numero_externo/
+            // ux_comprobantes_venta_numero — decisión 2 del proposal: es el índice PORTANTE que
+            // vuelve inyectivo el mapa serie-ARCA-a-fila. Sin camino de escritura de cliente en
+            // esta slice (la ABM llega en slice 4), probado solo con INSERT/UPDATE crudo.
+            { SqlState: "23505", ConstraintName: string uxNumeroFiscal }
+                when string.Equals(uxNumeroFiscal, "ux_puntos_venta_numero_fiscal", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un punto de venta con ese número fiscal para esta empresa.", "numero_fiscal_duplicado"),
+
+            // stage-19a-slice1 (task 1.22, db-error-backstops, proposal.md §E/§H): ux_certificados_fiscales_activo
+            // — a lo sumo un certificado activo por empresa+ambiente (decisión 1). Sin trampa de
+            // ordering: "_activo" no colisiona con ninguna substring de ClasificarUnicidad. Sin
+            // camino de escritura de cliente en esta slice (ServicioDeCertificados llega en slice
+            // 4), probado solo con INSERT crudo — el race test real de rotación vive en slice 4.
+            { SqlState: "23505", ConstraintName: string uxCertificadoActivo }
+                when string.Equals(uxCertificadoActivo, "ux_certificados_fiscales_activo", StringComparison.OrdinalIgnoreCase) =>
+                (StatusCodes.Status409Conflict, "Ya existe un certificado fiscal activo para esta empresa y ambiente.", "certificado_fiscal_activo_duplicado"),
+
             // Backstop genérico (judgment-day, slice 3 ronda 1) para las ~10 unicidades nuevas
             // de catálogos/parámetros/catálogos fiscales: mismo mecanismo de carrera que los
             // dos casos de arriba, pero agrupado por familia (a partir del nombre del índice,
@@ -444,6 +466,15 @@ public class ManejadorDeErrores(
             { SqlState: "23505", ConstraintName: string pkNumeracion }
                 when string.Equals(pkNumeracion, "pk_numeraciones_comprobante", StringComparison.OrdinalIgnoreCase) =>
                 (StatusCodes.Status409Conflict, "Ya existe una numeración para ese punto de venta y tipo de comprobante.", "numeracion_duplicada"),
+
+            // stage-19a-slice1 (task 1.22, db-error-backstops, design: mutation targets 4-11):
+            // switch por nombre EXACTO de las 8 CHECKs nuevas de puntos_venta/comprobantes_venta/
+            // certificados_fiscales/numeraciones_fiscales — sin prefijo compartido entre las
+            // cuatro tablas (mismo criterio que ClasificarCheckDeVentas/ClasificarCheckDeCaja),
+            // así que el caso del switch de arriba llama directo a esta función.
+            { SqlState: "23514", ConstraintName: string ckFiscal }
+                when ClasificarCheckDeFiscal(ckFiscal) is { } checkFiscal =>
+                (checkFiscal.EstadoHttp, checkFiscal.Titulo, checkFiscal.Codigo),
 
             _ => null
         };
@@ -903,6 +934,64 @@ public class ManejadorDeErrores(
                 (StatusCodes.Status400BadRequest,
                     "Una línea de remito marcada como costo estimado tiene que tener un costo.",
                     "costo_estimado_invalido"),
+
+            _ => null
+        };
+
+    /// <summary>stage-19a-slice1 (task 1.22, db-error-backstops, design.md mutation targets
+    /// 4-11): switch por nombre EXACTO de las 8 CHECKs nuevas de <c>puntos_venta</c>/
+    /// <c>comprobantes_venta</c>/<c>certificados_fiscales</c>/<c>numeraciones_fiscales</c>, sin
+    /// prefijo compartido entre las cuatro tablas (mismo criterio que
+    /// <see cref="ClasificarCheckDeVentas"/>/<see cref="ClasificarCheckDeCaja"/>). El criterio de
+    /// status: una CHECK de FORMATO/RANGO de un valor (número, dígitos, tamaño de bytes) → 400;
+    /// una CHECK de COHERENCIA entre dos columnas que tienen que llegar juntas/coincidir → 409,
+    /// mismo criterio que <c>ck_remitos_facturacion</c>/<c>ck_ordenes_compra_envio_completo</c>
+    /// en <see cref="ClasificarCheckDeOrdenesDeCompra"/>/<see cref="ClasificarCheckDeRemitos"/>.
+    /// Sin camino de escritura de cliente en ESTA slice para ninguna de las 8 (el ABM de
+    /// certificados y la emisión fiscal llegan en slices 4/5) — todas probadas con INSERT/UPDATE
+    /// crudo, no con una carrera real.</summary>
+    private static (int EstadoHttp, string Titulo, string Codigo)? ClasificarCheckDeFiscal(string nombreDeCheck) =>
+        nombreDeCheck switch
+        {
+            "ck_puntos_venta_numero_fiscal_rango" =>
+                (StatusCodes.Status400BadRequest,
+                    "El número fiscal del punto de venta tiene que estar entre 1 y 99999.",
+                    "numero_fiscal_invalido"),
+
+            "ck_comprobantes_venta_fiscal_coherente" =>
+                (StatusCodes.Status409Conflict,
+                    "El estado fiscal del comprobante es inconsistente con su CAE.",
+                    "comprobante_fiscal_incoherente"),
+
+            "ck_comprobantes_venta_cae_digitos" =>
+                (StatusCodes.Status400BadRequest,
+                    "El CAE tiene que ser un número de 14 dígitos.",
+                    "cae_invalido"),
+
+            "ck_certificados_fiscales_vigencia" =>
+                (StatusCodes.Status400BadRequest,
+                    "La vigencia del certificado fiscal es inválida.",
+                    "vigencia_de_certificado_invalida"),
+
+            "ck_certificados_fiscales_cuit" =>
+                (StatusCodes.Status400BadRequest,
+                    "El CUIT titular del certificado tiene que tener 11 dígitos.",
+                    "cuit_titular_invalido"),
+
+            "ck_certificados_fiscales_material" =>
+                (StatusCodes.Status400BadRequest,
+                    "El material de clave cifrado del certificado es inválido.",
+                    "material_de_clave_invalido"),
+
+            "ck_numeraciones_fiscales_rango" =>
+                (StatusCodes.Status400BadRequest,
+                    "El número de la serie fiscal está fuera de rango.",
+                    "numero_fiscal_de_serie_invalido"),
+
+            "ck_numeraciones_fiscales_sincronizacion" =>
+                (StatusCodes.Status409Conflict,
+                    "El último autorizado por ARCA y su fecha de sincronización tienen que llegar juntos.",
+                    "numeracion_fiscal_sincronizacion_incoherente"),
 
             _ => null
         };

--- a/src/Ways.Application/Abstracciones/IWaysDbContext.cs
+++ b/src/Ways.Application/Abstracciones/IWaysDbContext.cs
@@ -7,6 +7,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
@@ -136,6 +137,12 @@ public interface IWaysDbContext
     // (slice 5) es el primer consumidor real.
     DbSet<Remito> Remitos { get; }
     DbSet<ItemRemito> ItemsRemito { get; }
+
+    // stage-19a-slice1 (schema fiscal, DB CHANGE GATE ratificado): expuesto desde esta slice —
+    // ServicioDeCertificados (slice 4) es el primer consumidor de Application. NumeracionFiscal
+    // sigue sin exponerse acá (ver el comentario de WaysDbContext): AsignadorDeNumeroFiscal
+    // (slice 4) recibe el IWaysDbContext concreto por parámetro y opera con ADO.NET crudo.
+    DbSet<CertificadoFiscal> CertificadosFiscales { get; }
 
     /// <summary>Superficie de transacción/conexión de EF Core (slice 3, tarea 3F,
     /// <c>ServicioDeAprovisionamiento</c>, ADR-16): <c>CreateExecutionStrategy().ExecuteAsync</c>

--- a/src/Ways.Domain/Fiscal/AmbienteFiscal.cs
+++ b/src/Ways.Domain/Fiscal/AmbienteFiscal.cs
@@ -1,0 +1,15 @@
+namespace Ways.Domain.Fiscal;
+
+/// <summary>
+/// Ambiente WSAA/WSFE de un <see cref="CertificadoFiscal"/> (proposal.md decisión 5, gate §A).
+/// Enum nativo de Postgres (<c>ambiente_fiscal</c>). Sin valor <c>CAEA</c> ni ninguno de
+/// contingencia — llegan en 19c con su propio escritor (la regla de la etapa 17: un valor de
+/// catálogo nace con escritor). 19a acepta ambos valores en el endpoint de registro de
+/// certificado, pero <c>produccion</c> no tiene certificado real hasta 19b — lo que falta es el
+/// certificado, no el escritor.
+/// </summary>
+public enum AmbienteFiscal
+{
+    Homologacion,
+    Produccion
+}

--- a/src/Ways.Domain/Fiscal/CertificadoFiscal.cs
+++ b/src/Ways.Domain/Fiscal/CertificadoFiscal.cs
@@ -1,0 +1,64 @@
+using Ways.Domain.Common;
+
+namespace Ways.Domain.Fiscal;
+
+/// <summary>
+/// Certificado X.509 fiscal por empresa+ambiente (proposal.md §E, decisiones 1/5). Scoping
+/// <c>id_tenant + id_empresa NOT NULL</c> — DESVIACIÓN DOCUMENTADA del catálogo doc-09
+/// (<c>id_empresa NULL</c> = compartido): un certificado es de UN CUIT y nunca se comparte
+/// (decisión 5), misma forma que <see cref="Organizacion.PuntoVenta"/>. <c>EntidadBase</c>: SÍ —
+/// la rotación da de baja lógica la fila superada (<c>ServicioDeCertificados</c>, slice 4) y las
+/// columnas de auditoría son exactamente lo que una tabla de material de clave necesita.
+///
+/// <c>ClavePrivadaCifrada</c>/<c>Nonce</c>/<c>TagAutenticacion</c> son AES-256-GCM (decisión 1):
+/// nunca aparecen en un DTO, log ni respuesta de API — <c>dto-contract-honesty</c>. La clave
+/// maestra que las descifra viene de configuración/entorno, jamás de esta fila ni del repo.
+/// </summary>
+public class CertificadoFiscal : EntidadTenant
+{
+    public int Id { get; set; }
+
+    public int IdEmpresa { get; set; }
+
+    public AmbienteFiscal Ambiente { get; set; }
+
+    /// <summary>Etiqueta humana ("Homo 2026") — nunca usada para resolver el certificado activo.</summary>
+    public required string Alias { get; set; }
+
+    /// <summary>CUIT al que ARCA emitió el certificado (11 dígitos, sin guiones).</summary>
+    public required string CuitTitular { get; set; }
+
+    /// <summary>Parte PÚBLICA del X.509 — no es secreto, puede viajar en un DTO.</summary>
+    public required string CertificadoPem { get; set; }
+
+    /// <summary>AES-256-GCM (decisión 1). AAD = <c>v1|id_tenant|id_empresa|ambiente|huella_sha256</c>
+    /// (design D5) — ata el ciphertext a SU fila; mover el blob a otra fila falla la
+    /// autenticación.</summary>
+    public required byte[] ClavePrivadaCifrada { get; set; }
+
+    /// <summary>12 bytes — el tamaño de nonce de GCM (CHECK 6).</summary>
+    public required byte[] Nonce { get; set; }
+
+    /// <summary>16 bytes — el tamaño de tag de GCM (CHECK 6).</summary>
+    public required byte[] TagAutenticacion { get; set; }
+
+    /// <summary>Versión de la clave maestra que cifró esta fila (rotación fila por fila, sin
+    /// downtime) — EXCLUIDA del AAD a propósito (design D5): la clave ya está seleccionada por
+    /// esta columna, no es identidad de fila.</summary>
+    public required string IdClaveMaestra { get; set; }
+
+    /// <summary>Fingerprint SHA-256 del certificado — permite trazar sin descifrar, y forma
+    /// parte del AAD (ata el ciphertext también al PEM público al que pertenece).</summary>
+    public required string HuellaSha256 { get; set; }
+
+    /// <summary>Del propio X.509 — nunca <c>DEFAULT now()</c>, <c>IRelojDelSistema</c> es la
+    /// única fuente de tiempo de este programa.</summary>
+    public DateTimeOffset VigenciaDesde { get; set; }
+
+    public DateTimeOffset VigenciaHasta { get; set; }
+
+    /// <summary>A lo sumo un certificado activo por empresa+ambiente
+    /// (<c>ux_certificados_fiscales_activo</c>, UNIQUE PARCIAL). La rotación desactiva la fila
+    /// vieja y activa la nueva dentro de una sola transacción.</summary>
+    public bool Activo { get; set; }
+}

--- a/src/Ways.Domain/Fiscal/NumeracionFiscal.cs
+++ b/src/Ways.Domain/Fiscal/NumeracionFiscal.cs
@@ -1,0 +1,40 @@
+namespace Ways.Domain.Fiscal;
+
+/// <summary>
+/// Serie fiscal ARCA, keyed por <c>(id_punto_venta, codigo_afip)</c> — proposal.md §F, decisión
+/// 13. PK-only, sin auditoría ni baja lógica, mismo criterio exacto que
+/// <see cref="Ventas.NumeracionComprobante"/> (<c>NumeracionComprobante.cs:10-13</c>): no hereda
+/// de <see cref="Common.EntidadBase"/>/<see cref="Common.EntidadTenant"/>, así que necesita
+/// filtro de tenant escrito a mano (<c>WaysDbContext.AplicarFiltroDeTenantEnNumeracionFiscal</c>).
+///
+/// DISCIPLINA OPUESTA a <c>NumeracionComprobante</c>: <c>AsignadorDeNumeroFiscal</c> (slice 4)
+/// toma el número DENTRO de la transacción de emisión, nunca en una transacción propia previa —
+/// un número quemado en la serie interna abre un hueco legítimo, en la serie de ARCA DETIENE la
+/// serie (error 10016). <c>codigo_afip</c> en vez de un string de tipo interno porque la clave de
+/// serie de ARCA es el tipo NUMÉRICO — usar nuestro código pediría una traducción en el camino
+/// caliente del invariante.
+///
+/// <see cref="UltimoAutorizadoArca"/>/<see cref="SincronizadoEn"/> son estado de reconciliación
+/// contra <c>FECompUltimoAutorizado</c> que <c>NumeracionComprobante</c> no tiene concepto — la
+/// segunda razón por la que esta es una tabla propia y no una más ancha (design D13: la
+/// reconciliación NUNCA escribe <see cref="ProximoNumero"/>, solo estos dos campos juntos).
+/// </summary>
+public class NumeracionFiscal
+{
+    public int IdPuntoVenta { get; set; }
+
+    /// <summary><c>CbteTipo</c> de ARCA (1, 3, 6, 8, 11, 13, …) — <c>tipos_comprobante.codigo_afip</c>.</summary>
+    public short CodigoAfip { get; set; }
+
+    public int IdTenant { get; set; }
+
+    public long ProximoNumero { get; set; } = 1;
+
+    /// <summary>De <c>FECompUltimoAutorizado</c> — <c>0</c> es una respuesta legítima ("serie
+    /// nunca usada"), <c>NULL</c> es "todavía no reconciliada" (CHECK 8).</summary>
+    public long? UltimoAutorizadoArca { get; set; }
+
+    /// <summary>Par de <see cref="UltimoAutorizadoArca"/> (<c>IRelojDelSistema</c>) — arriban
+    /// juntos o ninguno (CHECK 8).</summary>
+    public DateTimeOffset? SincronizadoEn { get; set; }
+}

--- a/src/Ways.Domain/Fiscal/ResultadoFiscal.cs
+++ b/src/Ways.Domain/Fiscal/ResultadoFiscal.cs
@@ -1,0 +1,19 @@
+namespace Ways.Domain.Fiscal;
+
+/// <summary>
+/// Estados de la máquina CAE (design.md `MaquinaDeEstadosCae`, invariantes I1-I4). Enum nativo
+/// de Postgres (<c>resultado_fiscal</c>), mismo criterio que <c>estado_comprobante</c>/
+/// <c>estado_remito</c>. Orden de declaración = orden de ciclo de vida = orden de
+/// <c>CREATE TYPE</c> (proposal.md §A) — <c>pendiente</c> antes de la llamada a WSFE,
+/// <c>aprobado</c>/<c>aprobado_con_observaciones</c>/<c>rechazado</c> desde el mapeo de la
+/// respuesta (design.md `MaquinaDeEstadosCae.Mapear`). <c>AprobadoConObservaciones</c> es
+/// TERMINAL igual que <c>Aprobado</c> (I3) — una aprobación con observaciones es una factura
+/// válida, tratarla como fallo duplicaría documentos en silencio.
+/// </summary>
+public enum ResultadoFiscal
+{
+    Pendiente,
+    Aprobado,
+    AprobadoConObservaciones,
+    Rechazado
+}

--- a/src/Ways.Domain/Organizacion/Empresa.cs
+++ b/src/Ways.Domain/Organizacion/Empresa.cs
@@ -15,4 +15,12 @@ public class Empresa : EntidadTenant
     public string? NombreFantasia { get; set; }
 
     public string? Cuit { get; set; }
+
+    /// <summary>Condición fiscal del EMISOR ante ARCA (stage-19a, proposal.md §B) — decide la
+    /// letra A/B/C junto con la condición fiscal del receptor
+    /// (<see cref="Ventas.ResolvedorDeLetraComprobante"/>). NULLABLE A PROPÓSITO: no existe un
+    /// default honesto (defaultear a RI emitiría Factura A en silencio a cualquier Responsable
+    /// Inscripto) — el camino fiscal exige el valor con un 409 nombrado
+    /// (<c>empresa_sin_condicion_fiscal</c>) en vez de asumir.</summary>
+    public int? IdCondicionFiscal { get; set; }
 }

--- a/src/Ways.Domain/Organizacion/PuntoVenta.cs
+++ b/src/Ways.Domain/Organizacion/PuntoVenta.cs
@@ -22,4 +22,13 @@ public class PuntoVenta : EntidadTenant
     public string? Instagram { get; set; }
     public string? Facebook { get; set; }
     public string? Web { get; set; }
+
+    /// <summary>Punto de venta ARCA asignado (1..99999, stage-19a proposal.md §C, decisión 2) —
+    /// SEPARADO de <see cref="Id"/>, que sigue numerando la serie histórica (TX/NCX/TXR/RC/PRE/
+    /// REM) sin cambios. NULLABLE: un punto de venta que nunca factura fiscalmente sigue siendo
+    /// legal para siempre — un local puede operar puntos fiscales y no fiscales a la vez.
+    /// UNIQUE por empresa (<c>ux_puntos_venta_numero_fiscal</c>, PARCIAL) — portante, no
+    /// cosmético: es lo que vuelve inyectivo el mapa de la serie de ARCA <c>(PtoVta, CbteTipo)</c>
+    /// a <c>(id_punto_venta, codigo_afip)</c>.</summary>
+    public int? NumeroFiscal { get; set; }
 }

--- a/src/Ways.Domain/Ventas/ComprobanteVenta.cs
+++ b/src/Ways.Domain/Ventas/ComprobanteVenta.cs
@@ -1,4 +1,5 @@
 using Ways.Domain.Common;
+using Ways.Domain.Fiscal;
 
 namespace Ways.Domain.Ventas;
 
@@ -70,4 +71,24 @@ public class ComprobanteVenta : EntidadTenant
     public string? Observaciones { get; set; }
 
     public EstadoComprobante Estado { get; set; } = EstadoComprobante.Emitido;
+
+    /// <summary>stage-19a (proposal.md §D): las cuatro columnas fiscales son ADITIVAS y llegan
+    /// juntas — <see cref="ResultadoFiscal"/> <c>NULL</c> significa "no es un comprobante
+    /// fiscal", el estado del 100% del tráfico TX/NCX/TXR/RC, permanentemente legítimo.
+    /// <c>ck_comprobantes_venta_fiscal_coherente</c> impone la coherencia entre las cuatro. Sin
+    /// columna nueva para el número fiscal: <see cref="Numero"/> ya lo lleva, alimentado por la
+    /// serie fiscal en vez de la interna — disjuntas por tipo de comprobante.</summary>
+    public string? Cae { get; set; }
+
+    /// <summary>Llega junto con <see cref="Cae"/> (mismo CHECK) — nunca <c>DEFAULT now()</c>,
+    /// viene del propio CAE que devuelve ARCA.</summary>
+    public DateOnly? CaeVencimiento { get; set; }
+
+    public ResultadoFiscal? ResultadoFiscal { get; set; }
+
+    /// <summary>Documento jsonb con <c>Observaciones[]</c>/<c>Errors[]</c> de ARCA
+    /// (<c>[{ "codigo": int, "mensaje": string }]</c>) — precedente <c>Auditoria.cs:40-45</c>.
+    /// Nunca la respuesta cruda: eso persistiría <c>Token</c>/<c>Sign</c>, una credencial
+    /// portadora, en una tabla sin camino de cifrado.</summary>
+    public string? ObservacionesFiscales { get; set; }
 }

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -113,6 +114,8 @@ public static class DependencyInjection
             npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
             npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
             npgsql.MapEnum<EstadoRemito>("estado_remito");
+            npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+            npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
         });
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/CertificadoFiscalConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/CertificadoFiscalConfiguration.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Fiscal;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="CertificadoFiscal"/> — proposal.md §E del gate (DB CHANGE GATE, ratificado):
+/// 18 columnas (15+3 auditoría), scoping <c>id_tenant + id_empresa NOT NULL</c> (desviación
+/// documentada del catálogo doc-09, misma forma que <c>puntos_venta</c>), 2 FKs (tenant simple;
+/// empresa compuesta contra la AK que <c>puntos_venta</c> ya usa), 3 CHECKs, 3 índices (2 de
+/// soporte de FK + el unique parcial de "a lo sumo un activo por empresa+ambiente"). Nada de esto
+/// se altera fuera de esta sección — cualquier DDL extra reabre el gate.
+/// </summary>
+public class CertificadoFiscalConfiguration : IEntityTypeConfiguration<CertificadoFiscal>
+{
+    public void Configure(EntityTypeBuilder<CertificadoFiscal> builder)
+    {
+        builder.ToTable("certificados_fiscales", t =>
+        {
+            t.HasCheckConstraint("ck_certificados_fiscales_vigencia", "vigencia_hasta > vigencia_desde");
+            t.HasCheckConstraint("ck_certificados_fiscales_cuit", "cuit_titular ~ '^[0-9]{11}$'");
+            t.HasCheckConstraint(
+                "ck_certificados_fiscales_material",
+                "octet_length(nonce) = 12 AND octet_length(tag_autenticacion) = 16 AND octet_length(clave_privada_cifrada) > 0");
+        });
+
+        builder.HasKey(c => c.Id).HasName("pk_certificados_fiscales");
+
+        builder.Property(c => c.Id)
+            .HasColumnName("id_certificado")
+            .UseIdentityByDefaultColumn();
+
+        builder.Property(c => c.IdTenant).HasColumnName("id_tenant").IsRequired();
+        builder.Property(c => c.IdEmpresa).HasColumnName("id_empresa").IsRequired();
+
+        builder.Property(c => c.Ambiente)
+            .HasColumnName("ambiente")
+            .HasColumnType("ambiente_fiscal")
+            .IsRequired();
+
+        builder.Property(c => c.Alias).HasColumnName("alias").HasMaxLength(60).IsRequired();
+        builder.Property(c => c.CuitTitular).HasColumnName("cuit_titular").HasMaxLength(11).IsRequired();
+        builder.Property(c => c.CertificadoPem).HasColumnName("certificado_pem").HasColumnType("text").IsRequired();
+
+        builder.Property(c => c.ClavePrivadaCifrada).HasColumnName("clave_privada_cifrada").IsRequired();
+        builder.Property(c => c.Nonce).HasColumnName("nonce").IsRequired();
+        builder.Property(c => c.TagAutenticacion).HasColumnName("tag_autenticacion").IsRequired();
+
+        builder.Property(c => c.IdClaveMaestra).HasColumnName("id_clave_maestra").HasMaxLength(30).IsRequired();
+        builder.Property(c => c.HuellaSha256).HasColumnName("huella_sha256").HasMaxLength(64).IsRequired();
+
+        builder.Property(c => c.VigenciaDesde).HasColumnName("vigencia_desde").IsRequired();
+        builder.Property(c => c.VigenciaHasta).HasColumnName("vigencia_hasta").IsRequired();
+
+        builder.Property(c => c.Activo).HasColumnName("activo").IsRequired();
+
+        builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
+        builder.Property(c => c.DeletedAt).HasColumnName("deleted_at");
+
+        builder.Ignore(c => c.EstaEliminada);
+
+        builder.HasIndex(c => c.IdTenant).HasDatabaseName("ix_certificados_fiscales_tenant");
+        builder.HasIndex(c => new { c.IdEmpresa, c.IdTenant }).HasDatabaseName("ix_certificados_fiscales_empresa");
+
+        // A lo sumo un certificado activo por empresa+ambiente (proposal.md decisión 1) — el
+        // filtro con 2 conjuntos ('activo' Y 'deleted_at IS NULL') es lo que vuelve a la rotación
+        // (dar de baja + activar dentro de una transacción) libre de una ventana con dos activos.
+        builder.HasIndex(c => new { c.IdTenant, c.IdEmpresa, c.Ambiente })
+            .HasDatabaseName("ux_certificados_fiscales_activo")
+            .IsUnique()
+            .HasFilter("activo AND deleted_at IS NULL");
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(c => c.IdTenant)
+            .HasConstraintName("fk_certificados_fiscales_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Compuesta (id_empresa, id_tenant) MATCH SIMPLE contra la AK que puntos_venta ya usa
+        // (ak_empresas_id_empresa_id_tenant, EmpresaConfiguration.cs:25-26) — ADR-9: una fila de
+        // un tenant no puede referenciar la empresa de otro tenant ni por bug.
+        builder.HasOne<Empresa>()
+            .WithMany()
+            .HasForeignKey(c => new { c.IdEmpresa, c.IdTenant })
+            .HasPrincipalKey(e => new { e.Id, e.IdTenant })
+            .HasConstraintName("fk_certificados_fiscales_empresa")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteVentaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/ComprobanteVentaConfiguration.cs
@@ -6,6 +6,10 @@ using Ways.Domain.Clientes;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Usuarios;
 using Ways.Domain.Ventas;
+// stage-19a: NO se agrega `using Ways.Domain.Fiscal;` a propósito — `ResultadoFiscal` (la
+// propiedad de ComprobanteVenta) y `ResultadoFiscal` (el enum) comparten nombre; el tipo se
+// referencia siempre calificado más abajo, mismo criterio que Ways.Domain.Auditoria.Auditoria
+// en WaysDbContext.cs.
 
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
 
@@ -22,6 +26,18 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
         builder.ToTable("comprobantes_venta", t =>
         {
             t.HasCheckConstraint("ck_comprobantes_venta_numero_positivo", "numero > 0");
+
+            // stage-19a (proposal.md §D, 4 conjuntos): o las cuatro columnas fiscales están
+            // NULL (100% del tráfico no fiscal), o resultado_fiscal está seteado con cae/
+            // cae_vencimiento llegando JUNTOS y presentes SII resultado_fiscal es una de las dos
+            // aprobaciones. Valida trivialmente en toda fila existente (las cuatro NULL).
+            t.HasCheckConstraint(
+                "ck_comprobantes_venta_fiscal_coherente",
+                "(resultado_fiscal IS NULL AND cae IS NULL AND cae_vencimiento IS NULL AND observaciones_fiscales IS NULL) " +
+                "OR (resultado_fiscal IS NOT NULL AND ((cae IS NULL) = (cae_vencimiento IS NULL)) " +
+                "AND ((resultado_fiscal IN ('aprobado','aprobado_con_observaciones')) = (cae IS NOT NULL)))");
+
+            t.HasCheckConstraint("ck_comprobantes_venta_cae_digitos", "cae IS NULL OR cae ~ '^[0-9]{14}$'");
         });
 
         builder.HasKey(c => c.Id).HasName("pk_comprobantes_venta");
@@ -76,6 +92,16 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
             .HasColumnType("estado_comprobante")
             .IsRequired();
 
+        // stage-19a (proposal.md §D): aditivas, NULLABLE — resultado_fiscal NULL significa "no
+        // es un comprobante fiscal", el 100% del tráfico TX/NCX/TXR/RC de siempre.
+        builder.Property(c => c.Cae).HasColumnName("cae").HasMaxLength(14);
+        builder.Property(c => c.CaeVencimiento).HasColumnName("cae_vencimiento").HasColumnType("date");
+        builder.Property(c => c.ResultadoFiscal).HasColumnName("resultado_fiscal").HasColumnType("resultado_fiscal");
+
+        // jsonb — precedente Auditoria.cs:40-45/AuditoriaConfiguration.cs:42-43: string ya
+        // serializado, nunca la respuesta cruda de ARCA (persistiría Token/Sign sin cifrado).
+        builder.Property(c => c.ObservacionesFiscales).HasColumnName("observaciones_fiscales").HasColumnType("jsonb");
+
         builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(c => c.DeletedAt).HasColumnName("deleted_at");
@@ -117,6 +143,14 @@ public class ComprobanteVentaConfiguration : IEntityTypeConfiguration<Comprobant
             .HasDatabaseName("ux_comprobantes_venta_presupuesto_origen")
             .IsUnique()
             .HasFilter("id_presupuesto_origen IS NOT NULL");
+
+        // stage-19a (proposal.md §D, index 3): PARCIAL sobre un estado vacío en el 100% de las
+        // filas existentes — sin esto, resolver los 'pendiente' hace table scan sobre la tabla
+        // más caliente del sistema. Su consumidor (la reconciliación/reintento) llega en slice 5
+        // — criterio anti-especulación de la etapa 13.
+        builder.HasIndex(c => new { c.IdPuntoVenta, c.IdTenant })
+            .HasDatabaseName("ix_comprobantes_venta_fiscal_pendientes")
+            .HasFilter("resultado_fiscal = 'pendiente'::resultado_fiscal");
 
         builder.HasOne<Tenant>()
             .WithMany()

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/EmpresaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/EmpresaConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Catalogos;
 using Ways.Domain.Organizacion;
 
 namespace Ways.Infrastructure.Persistencia.Configuraciones;
@@ -40,6 +41,10 @@ public class EmpresaConfiguration : IEntityTypeConfiguration<Empresa>
             .HasColumnName("cuit")
             .HasMaxLength(13);
 
+        // stage-19a (proposal.md §B): NULLABLE a propósito — no existe default honesto (la
+        // condición del emisor decide la letra A/B/C).
+        builder.Property(e => e.IdCondicionFiscal).HasColumnName("id_condicion_fiscal");
+
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(e => e.DeletedAt).HasColumnName("deleted_at");
@@ -53,5 +58,17 @@ public class EmpresaConfiguration : IEntityTypeConfiguration<Empresa>
             .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasIndex(e => e.IdTenant).HasDatabaseName("ix_empresas_tenant");
+
+        // stage-19a (proposal.md §B): FK SIMPLE, no compuesta — condiciones_fiscales es global
+        // (ADR-11), mismo criterio que fk_items_comprobante_venta_alicuota_iva. Índice SIMPLE
+        // también — un índice liderado por id_tenant NO cubriría esta FK (la trampa de la
+        // enmienda de la etapa 14).
+        builder.HasOne<CondicionFiscal>()
+            .WithMany()
+            .HasForeignKey(e => e.IdCondicionFiscal)
+            .HasConstraintName("fk_empresas_condicion_fiscal")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(e => e.IdCondicionFiscal).HasDatabaseName("ix_empresas_condicion_fiscal");
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionFiscalConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/NumeracionFiscalConfiguration.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ways.Domain.Fiscal;
+using Ways.Domain.Organizacion;
+
+namespace Ways.Infrastructure.Persistencia.Configuraciones;
+
+/// <summary>
+/// Mapea <see cref="NumeracionFiscal"/> (proposal.md §F, design.md fact 2) — MIRROR LÍNEA A
+/// LÍNEA de <see cref="NumeracionComprobanteConfiguration"/> (design.md: "design lo verifica; si
+/// la hermana la omite, esta se omite también en vez de divergir en silencio",
+/// <c>NumeracionComprobanteConfiguration.cs:51-59</c> declara la FK compuesta a
+/// <c>puntos_venta</c> — por lo tanto ESTA la declara también). Solo
+/// <c>AsignadorDeNumeroFiscal</c> (slice 4) escribe esta tabla, con SQL crudo — este mapeo existe
+/// para que el modelo de EF conozca la forma de la tabla (RLS, FK compuesta, lecturas de
+/// diagnóstico), no para que <c>SaveChangesAsync</c> la toque.
+/// </summary>
+public class NumeracionFiscalConfiguration : IEntityTypeConfiguration<NumeracionFiscal>
+{
+    public void Configure(EntityTypeBuilder<NumeracionFiscal> builder)
+    {
+        builder.ToTable("numeraciones_fiscales", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_numeraciones_fiscales_rango",
+                "proximo_numero BETWEEN 1 AND 99999999 AND (ultimo_autorizado_arca IS NULL OR ultimo_autorizado_arca BETWEEN 0 AND 99999999)");
+            t.HasCheckConstraint(
+                "ck_numeraciones_fiscales_sincronizacion",
+                "(ultimo_autorizado_arca IS NULL) = (sincronizado_en IS NULL)");
+        });
+
+        builder.HasKey(n => new { n.IdPuntoVenta, n.CodigoAfip })
+            .HasName("pk_numeraciones_fiscales");
+
+        builder.Property(n => n.IdPuntoVenta)
+            .HasColumnName("id_punto_venta")
+            .ValueGeneratedNever();
+
+        builder.Property(n => n.CodigoAfip)
+            .HasColumnName("codigo_afip")
+            .ValueGeneratedNever();
+
+        builder.Property(n => n.IdTenant)
+            .HasColumnName("id_tenant")
+            .IsRequired();
+
+        builder.Property(n => n.ProximoNumero)
+            .HasColumnName("proximo_numero")
+            .HasDefaultValue(1L)
+            .IsRequired();
+
+        builder.Property(n => n.UltimoAutorizadoArca).HasColumnName("ultimo_autorizado_arca");
+        builder.Property(n => n.SincronizadoEn).HasColumnName("sincronizado_en");
+
+        builder.HasIndex(n => n.IdTenant).HasDatabaseName("ix_numeraciones_fiscales_tenant");
+
+        // Nombre explícito en snake_case (mismo fix que NumeracionComprobanteConfiguration.cs:44-49
+        // — la trampa PascalCase): sin esto EF nombra el índice de soporte de
+        // fk_numeraciones_fiscales_punto_venta con su convención propia. NO cubierto por la PK:
+        // su segunda columna es codigo_afip, no id_tenant.
+        builder.HasIndex(n => new { n.IdPuntoVenta, n.IdTenant })
+            .HasDatabaseName("ix_numeraciones_fiscales_punto_venta");
+
+        // FK compuesta (id_punto_venta, id_tenant) → puntos_venta — ESPEJADA de
+        // NumeracionComprobanteConfiguration.cs:54-59 (design.md fact 2, verificado: la hermana
+        // SÍ la declara, así que esta la declara también).
+        builder.HasOne<PuntoVenta>()
+            .WithMany()
+            .HasForeignKey(n => new { n.IdPuntoVenta, n.IdTenant })
+            .HasPrincipalKey(p => new { p.Id, p.IdTenant })
+            .HasConstraintName("fk_numeraciones_fiscales_punto_venta")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Tenant>()
+            .WithMany()
+            .HasForeignKey(n => n.IdTenant)
+            .HasConstraintName("fk_numeraciones_fiscales_tenant")
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/Configuraciones/PuntoVentaConfiguration.cs
+++ b/src/Ways.Infrastructure/Persistencia/Configuraciones/PuntoVentaConfiguration.cs
@@ -8,7 +8,13 @@ public class PuntoVentaConfiguration : IEntityTypeConfiguration<PuntoVenta>
 {
     public void Configure(EntityTypeBuilder<PuntoVenta> builder)
     {
-        builder.ToTable("puntos_venta");
+        builder.ToTable("puntos_venta", t =>
+        {
+            // stage-19a (proposal.md §C): ARCA's PtoVta es de 5 dígitos.
+            t.HasCheckConstraint(
+                "ck_puntos_venta_numero_fiscal_rango",
+                "numero_fiscal IS NULL OR (numero_fiscal BETWEEN 1 AND 99999)");
+        });
 
         builder.HasKey(p => p.Id);
 
@@ -41,6 +47,10 @@ public class PuntoVentaConfiguration : IEntityTypeConfiguration<PuntoVenta>
         builder.Property(p => p.Facebook).HasColumnName("facebook").HasMaxLength(150);
         builder.Property(p => p.Web).HasColumnName("web").HasMaxLength(255);
 
+        // stage-19a (proposal.md §C, decisión 2): NULLABLE — un punto de venta que nunca
+        // factura fiscalmente sigue siendo legal para siempre.
+        builder.Property(p => p.NumeroFiscal).HasColumnName("numero_fiscal");
+
         builder.Property(p => p.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(p => p.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(p => p.DeletedAt).HasColumnName("deleted_at");
@@ -60,5 +70,13 @@ public class PuntoVentaConfiguration : IEntityTypeConfiguration<PuntoVenta>
 
         builder.HasIndex(p => p.IdTenant).HasDatabaseName("ix_puntos_venta_tenant");
         builder.HasIndex(p => new { p.IdEmpresa, p.IdTenant }).HasDatabaseName("ix_puntos_venta_empresa");
+
+        // stage-19a (proposal.md §C, decisión 2): UNIQUE PARCIAL, portante — vuelve inyectivo el
+        // mapa de la serie de ARCA (PtoVta, CbteTipo) a (id_punto_venta, codigo_afip). Parcial
+        // porque la mayoría de los puntos de venta no tienen número fiscal.
+        builder.HasIndex(p => new { p.IdTenant, p.IdEmpresa, p.NumeroFiscal })
+            .HasDatabaseName("ux_puntos_venta_numero_fiscal")
+            .IsUnique()
+            .HasFilter("numero_fiscal IS NOT NULL");
     }
 }

--- a/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
+++ b/src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs
@@ -31,26 +31,48 @@ public class InicializadorDeBaseDeDatos(
         (RolConocido.Vendedor,   "vendedor",   "Opera el punto de venta.")
     ];
 
-    /// <summary>Doc 10 §1. <c>CodigoAfip</c> queda <c>NULL</c> a propósito: los códigos AFIP
-    /// reales son un requisito de la facturación electrónica, todavía fuera de esta etapa —
-    /// completar acá con un valor inventado sería peor que dejarlo pendiente y visible.</summary>
-    private static readonly (string Codigo, string Nombre)[] CondicionesFiscalesBase =
+    /// <summary>Doc 10 §1. <c>CodigoAfip</c> queda <c>NULL</c> a propósito para las condiciones
+    /// que no aplican todavía: los códigos AFIP reales fueron un requisito de la facturación
+    /// electrónica, fuera de alcance hasta esta etapa — completar acá con un valor inventado
+    /// sería peor que dejarlo pendiente y visible (<c>InicializadorDeBaseDeDatos.cs:34-36</c>
+    /// histórico).
+    ///
+    /// stage-19a-slice1 (proposal.md §G, decisión 11, DS2 <c>condiciones_fiscales</c> / RG 5616
+    /// <c>CondicionIVAReceptorId</c>): net 1b del doble net — este seed es quien lo puebla en una
+    /// base FRESCA; el data statement de la migración (net 1) cierra el mismo hueco en una base
+    /// YA migrada. <c>RI</c>→1, <c>EXENTO</c>→4, <c>CF</c>→5, <c>MONOTRIBUTO</c>→6.
+    /// <c>NO_RESP</c> — LA ÚNICA INCERTIDUMBRE FLAGGEADA del proposal (decisión 11: "mapped to
+    /// the nearest value", sin dar el número): mapeado acá a <c>15</c> (RG 5616 "IVA No
+    /// Alcanzado"), la condición real de ARCA más cercana a un receptor sin categorizar — DESVÍO
+    /// REGISTRADO, no silencioso, y sin efecto de emisión: la capa de aplicación (slice 5)
+    /// rechaza un receptor <c>NO_RESP</c> por su <c>Codigo</c> con <c>409
+    /// condicion_fiscal_receptor_no_mapeada</c> ANTES de leer este <c>CodigoAfip</c>
+    /// (<c>ResolverTipoFiscalAsync</c>, spec comprobante-fiscal). Se confirma contra
+    /// <c>FEParamGetCondicionIvaReceptor</c> en 19b.</summary>
+    private static readonly (string Codigo, string Nombre, short? CodigoAfip)[] CondicionesFiscalesBase =
     [
-        ("RI", "Responsable Inscripto"),
-        ("MONOTRIBUTO", "Monotributista"),
-        ("EXENTO", "Exento"),
-        ("CF", "Consumidor Final"),
-        ("NO_RESP", "No Responsable")
+        ("RI", "Responsable Inscripto", 1),
+        ("MONOTRIBUTO", "Monotributista", 6),
+        ("EXENTO", "Exento", 4),
+        ("CF", "Consumidor Final", 5),
+        ("NO_RESP", "No Responsable", 15)
     ];
 
-    private static readonly (string Nombre, decimal Porcentaje)[] AlicuotasIvaBase =
+    /// <summary>stage-19a-slice1 (proposal.md §G, decisión 11, DS3 <c>alicuotas_iva</c> /
+    /// <c>FEParamGetTiposIva</c>): net 1b del doble net, mismo criterio que
+    /// <see cref="CondicionesFiscalesBase"/>. <c>0%</c>→3, <c>10.5%</c>→4, <c>21%</c>→5,
+    /// <c>27%</c>→6. <c>Exento</c>/<c>No gravado</c> quedan <c>CodigoAfip = null</c> A
+    /// PROPÓSITO — no son alícuotas (van a <c>ImpOpEx</c>/<c>ImpTotConc</c>, jamás al array
+    /// <c>Iva[]</c>): mapearlas produciría facturas aritméticamente válidas y legalmente
+    /// equivocadas.</summary>
+    private static readonly (string Nombre, decimal Porcentaje, short? CodigoAfip)[] AlicuotasIvaBase =
     [
-        ("21%", 21.00m),
-        ("10.5%", 10.50m),
-        ("27%", 27.00m),
-        ("0%", 0.00m),
-        ("Exento", 0.00m),
-        ("No gravado", 0.00m)
+        ("21%", 21.00m, 5),
+        ("10.5%", 10.50m, 4),
+        ("27%", 27.00m, 6),
+        ("0%", 0.00m, 3),
+        ("Exento", 0.00m, null),
+        ("No gravado", 0.00m, null)
     ];
 
     /// <summary>Doc 10 §1: "FA, FB, FC, NCA, NCB, NCC, NDA…, TX, NCX, PRE, RC" (lado venta) más
@@ -85,32 +107,36 @@ public class InicializadorDeBaseDeDatos(
     /// mismo mecanismo que <c>RC</c>/<c>C-*</c>: acá para una base nueva y, de forma idempotente,
     /// dentro de la migración <c>RemitosEtapa17</c> para una base ya migrada — ese seed corre
     /// solo cuando la tabla está vacía.</summary>
-    private static readonly (ClaseComprobante Clase, string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock, bool Activo)[] TiposComprobanteBase =
+    // stage-19a-slice1 (proposal.md §G, DS1 tipos_comprobante — 7 filas): net 1b del doble net.
+    // FA=1, NDA=2, NCA=3, NCB=8, FC=11, NCC=13, FB=6 — CERO filas insertadas/activadas/
+    // desactivadas, solo el campo nuevo. TX/NCX/PRE/RC/TXR y los tres C-* de compra quedan
+    // CodigoAfip = null (no son fiscales, decisión 9: el guard del POS jamás los deja emitir).
+    private static readonly (ClaseComprobante Clase, string Codigo, string Nombre, char? Letra, short Signo, bool DiscriminaIva, bool EsFiscal, bool AfectaStock, bool Activo, short? CodigoAfip)[] TiposComprobanteBase =
     [
-        (ClaseComprobante.Venta, "FA", "Factura A", 'A', 1, true, true, true, true),
-        (ClaseComprobante.Venta, "FB", "Factura B", 'B', 1, false, true, true, true),
-        (ClaseComprobante.Venta, "FC", "Factura C", 'C', 1, false, true, true, true),
-        (ClaseComprobante.Venta, "NCA", "Nota de Crédito A", 'A', -1, true, true, true, true),
-        (ClaseComprobante.Venta, "NCB", "Nota de Crédito B", 'B', -1, false, true, true, true),
-        (ClaseComprobante.Venta, "NCC", "Nota de Crédito C", 'C', -1, false, true, true, true),
-        (ClaseComprobante.Venta, "NDA", "Nota de Débito A", 'A', 1, true, true, true, true),
-        (ClaseComprobante.Venta, "TX", "Ticket X", 'X', 1, false, false, true, true),
-        (ClaseComprobante.Venta, "NCX", "Nota de Crédito X", 'X', -1, false, false, true, true),
+        (ClaseComprobante.Venta, "FA", "Factura A", 'A', 1, true, true, true, true, 1),
+        (ClaseComprobante.Venta, "FB", "Factura B", 'B', 1, false, true, true, true, 6),
+        (ClaseComprobante.Venta, "FC", "Factura C", 'C', 1, false, true, true, true, 11),
+        (ClaseComprobante.Venta, "NCA", "Nota de Crédito A", 'A', -1, true, true, true, true, 3),
+        (ClaseComprobante.Venta, "NCB", "Nota de Crédito B", 'B', -1, false, true, true, true, 8),
+        (ClaseComprobante.Venta, "NCC", "Nota de Crédito C", 'C', -1, false, true, true, true, 13),
+        (ClaseComprobante.Venta, "NDA", "Nota de Débito A", 'A', 1, true, true, true, true, 2),
+        (ClaseComprobante.Venta, "TX", "Ticket X", 'X', 1, false, false, true, true, null),
+        (ClaseComprobante.Venta, "NCX", "Nota de Crédito X", 'X', -1, false, false, true, true, null),
         // stage-17: PRE nace desactivado en el seed (net 1b) — el hallazgo del "PRE latente"
         // (explore.md): un tipo activo, afecta_stock=false, colaba como venta fantasma.
-        (ClaseComprobante.Venta, "PRE", "Presupuesto", null, 1, false, false, false, false),
-        (ClaseComprobante.Venta, "RC", "Recibo de cobranza", null, 1, false, false, false, true),
+        (ClaseComprobante.Venta, "PRE", "Presupuesto", null, 1, false, false, false, false, null),
+        (ClaseComprobante.Venta, "RC", "Recibo de cobranza", null, 1, false, false, false, true, null),
         // stage-17-presupuestos-y-remitos (proposal §I, decisión 2/7 del explore): comprobante
         // consolidado de facturación de remitos, sin items por construcción — nace ACTIVO pero
         // INEMITIBLE por mostrador (afecta_stock=false, mismo guard del resolver que bloquea PRE).
-        (ClaseComprobante.Venta, "TXR", "Ticket X por remitos", 'X', 1, false, false, false, true),
+        (ClaseComprobante.Venta, "TXR", "Ticket X por remitos", 'X', 1, false, false, false, true, null),
 
         // stage-8-compras-transferencias-inventario (design decisión 12/7 del proposal): solo
         // tres tipos — notas de crédito de proveedor están fuera de alcance (anulación es la
         // única reversión). es_fiscal=false: nunca EMITIMOS la factura del proveedor.
-        (ClaseComprobante.Compra, "C-FA", "Factura A de compra", 'A', 1, true, false, true, true),
-        (ClaseComprobante.Compra, "C-FB", "Factura B de compra", 'B', 1, false, false, true, true),
-        (ClaseComprobante.Compra, "C-FC", "Factura C de compra", 'C', 1, false, false, true, true)
+        (ClaseComprobante.Compra, "C-FA", "Factura A de compra", 'A', 1, true, false, true, true, null),
+        (ClaseComprobante.Compra, "C-FB", "Factura B de compra", 'B', 1, false, false, true, true, null),
+        (ClaseComprobante.Compra, "C-FC", "Factura C de compra", 'C', 1, false, false, true, true, null)
     ];
 
     public async Task EjecutarAsync(SemillaRoot semilla, CancellationToken ct = default)
@@ -435,6 +461,7 @@ public class InicializadorDeBaseDeDatos(
             {
                 Codigo = c.Codigo,
                 Nombre = c.Nombre,
+                CodigoAfip = c.CodigoAfip,
                 CreatedAt = ahora,
                 UpdatedAt = ahora
             }));
@@ -448,6 +475,7 @@ public class InicializadorDeBaseDeDatos(
             {
                 Nombre = a.Nombre,
                 Porcentaje = a.Porcentaje,
+                CodigoAfip = a.CodigoAfip,
                 CreatedAt = ahora,
                 UpdatedAt = ahora
             }));
@@ -468,6 +496,7 @@ public class InicializadorDeBaseDeDatos(
                 EsFiscal = t.EsFiscal,
                 AfectaStock = t.AfectaStock,
                 Activo = t.Activo,
+                CodigoAfip = t.CodigoAfip,
                 CreatedAt = ahora,
                 UpdatedAt = ahora
             }));

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260822002214_FiscalArcaEtapa19a.Designer.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260822002214_FiscalArcaEtapa19a.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ways.Domain.Articulos;
@@ -23,9 +24,11 @@ using Ways.Infrastructure.Persistencia;
 namespace Ways.Infrastructure.Persistencia.Migraciones
 {
     [DbContext(typeof(WaysDbContext))]
-    partial class WaysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822002214_FiscalArcaEtapa19a")]
+    partial class FiscalArcaEtapa19a
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ways.Infrastructure/Persistencia/Migraciones/20260822002214_FiscalArcaEtapa19a.cs
+++ b/src/Ways.Infrastructure/Persistencia/Migraciones/20260822002214_FiscalArcaEtapa19a.cs
@@ -1,0 +1,474 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ways.Domain.Fiscal;
+using Ways.Infrastructure.Multitenancy;
+
+#nullable disable
+
+namespace Ways.Infrastructure.Persistencia.Migraciones
+{
+    /// <inheritdoc />
+    public partial class FiscalArcaEtapa19a : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Orden de statements per gate (binding, design.md "The migration — exact statement
+            // order"): 01) AlterDatabase — ESTE statement es quien ejecuta los DOS `CREATE TYPE`
+            // (ambiente_fiscal, resultado_fiscal). CERO `ALTER TYPE ... ADD VALUE` en todo el
+            // archivo — a diferencia de las etapas 12/17, esta sub-etapa no tiene NINGÚN
+            // artefacto irreversible: los dos tipos son enteramente nuevos, así que Down() los
+            // dropea limpio. 02-04) §B empresas. 05-07) §C puntos_venta. 08-11) §D
+            // comprobantes_venta. 12-13) §E certificados_fiscales. 14-15) §F
+            // numeraciones_fiscales. 16-18) §G los tres data statements idempotentes (doble red
+            // de la etapa 17 — el seed net gemelo vive en InicializadorDeBaseDeDatos.
+            // SembrarCatalogosFiscalesAsync). 19-20) RLS al final, en las DOS tablas nuevas
+            // (convención de las etapas 12/14/15/16/17: la conexión de migración no tiene
+            // app_tenant_actual() seteado, y los data statements de arriba no dependen de que
+            // RLS esté activo todavía — las tres tablas de catálogo son globales).
+            //
+            // `dotnet ef migrations add` serializa los valores de enum en orden ALFABÉTICO por
+            // defecto (mismo residuo documentado en las etapas 15/16/17) — `resultado_fiscal`
+            // corregido a mano acá al orden de CICLO DE VIDA que el design fija
+            // (pendiente → aprobado → aprobado_con_observaciones → rechazado, design.md §A):
+            // EF lo había emitido "aprobado,aprobado_con_observaciones,pendiente,rechazado".
+            // `ambiente_fiscal` no necesitó corrección: su orden alfabético
+            // ("homologacion,produccion") coincide con el orden de ciclo de vida declarado en
+            // AmbienteFiscal.cs.
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:ambiente_fiscal", "homologacion,produccion")
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .Annotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .Annotation("Npgsql:Enum:estado_remito", "anulado,borrador,emitido,facturado")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .Annotation("Npgsql:Enum:resultado_fiscal", "pendiente,aprobado,aprobado_con_observaciones,rechazado")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .OldAnnotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .OldAnnotation("Npgsql:Enum:estado_remito", "anulado,borrador,emitido,facturado")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            // gate §B (proposal.md:503-521): empresas +id_condicion_fiscal — NULLABLE a
+            // propósito (no hay default honesto), FK simple (condiciones_fiscales es global,
+            // ADR-11) e índice de soporte SIMPLE (la trampa de la enmienda de la etapa 14: un
+            // índice liderado por id_tenant no cubre una FK simple).
+            migrationBuilder.AddColumn<int>(
+                name: "id_condicion_fiscal",
+                table: "empresas",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_empresas_condicion_fiscal",
+                table: "empresas",
+                column: "id_condicion_fiscal",
+                principalTable: "condiciones_fiscales",
+                principalColumn: "id_condicion_fiscal",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_empresas_condicion_fiscal",
+                table: "empresas",
+                column: "id_condicion_fiscal");
+
+            // gate §C (proposal.md:522-533, decisión 2): puntos_venta +numero_fiscal — CHECK de
+            // rango 1..99999 (PtoVta de ARCA es de 5 dígitos) + ux_puntos_venta_numero_fiscal
+            // UNIQUE PARCIAL, PORTANTE: vuelve inyectivo el mapa serie-ARCA (PtoVta, CbteTipo) a
+            // (id_punto_venta, codigo_afip).
+            migrationBuilder.AddColumn<int>(
+                name: "numero_fiscal",
+                table: "puntos_venta",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_puntos_venta_numero_fiscal_rango",
+                table: "puntos_venta",
+                sql: "numero_fiscal IS NULL OR (numero_fiscal BETWEEN 1 AND 99999)");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_puntos_venta_numero_fiscal",
+                table: "puntos_venta",
+                columns: new[] { "id_tenant", "id_empresa", "numero_fiscal" },
+                unique: true,
+                filter: "numero_fiscal IS NOT NULL");
+
+            // gate §D (proposal.md:535-557): comprobantes_venta +4 columnas — todas NULL en el
+            // 100% del tráfico existente y de siempre para TX/NCX/TXR/RC. CHECK 2 (4 conjuntos):
+            // o las cuatro NULL, o resultado_fiscal seteado con cae/cae_vencimiento juntos y
+            // presentes SII aprobado/aprobado_con_observaciones. CHECK 3: formato de 14 dígitos.
+            // Índice PARCIAL sobre 'pendiente' — vacío en el 100% de las filas existentes.
+            migrationBuilder.AddColumn<string>(
+                name: "cae",
+                table: "comprobantes_venta",
+                type: "character varying(14)",
+                maxLength: 14,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "cae_vencimiento",
+                table: "comprobantes_venta",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<ResultadoFiscal>(
+                name: "resultado_fiscal",
+                table: "comprobantes_venta",
+                type: "resultado_fiscal",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "observaciones_fiscales",
+                table: "comprobantes_venta",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_comprobantes_venta_fiscal_coherente",
+                table: "comprobantes_venta",
+                sql: "(resultado_fiscal IS NULL AND cae IS NULL AND cae_vencimiento IS NULL AND observaciones_fiscales IS NULL) " +
+                     "OR (resultado_fiscal IS NOT NULL AND ((cae IS NULL) = (cae_vencimiento IS NULL)) " +
+                     "AND ((resultado_fiscal IN ('aprobado','aprobado_con_observaciones')) = (cae IS NOT NULL)))");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_comprobantes_venta_cae_digitos",
+                table: "comprobantes_venta",
+                sql: "cae IS NULL OR cae ~ '^[0-9]{14}$'");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_comprobantes_venta_fiscal_pendientes",
+                table: "comprobantes_venta",
+                columns: new[] { "id_punto_venta", "id_tenant" },
+                filter: "resultado_fiscal = 'pendiente'::resultado_fiscal");
+
+            // gate §E (proposal.md:559-606, decisiones 1/5): certificados_fiscales — 18
+            // columnas, scoping id_tenant + id_empresa NOT NULL (DESVIACIÓN documentada del
+            // catálogo doc-09: un certificado es de UN CUIT y nunca se comparte, misma forma que
+            // puntos_venta), PK, FK2 (tenant simple), FK3 (empresa compuesta contra la AK que
+            // puntos_venta ya usa), CHECK4 vigencia, CHECK5 cuit, CHECK6 tamaños de GCM (3
+            // conjuntos) — todas inline.
+            migrationBuilder.CreateTable(
+                name: "certificados_fiscales",
+                columns: table => new
+                {
+                    id_certificado = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    id_empresa = table.Column<int>(type: "integer", nullable: false),
+                    ambiente = table.Column<AmbienteFiscal>(type: "ambiente_fiscal", nullable: false),
+                    alias = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    cuit_titular = table.Column<string>(type: "character varying(11)", maxLength: 11, nullable: false),
+                    certificado_pem = table.Column<string>(type: "text", nullable: false),
+                    clave_privada_cifrada = table.Column<byte[]>(type: "bytea", nullable: false),
+                    nonce = table.Column<byte[]>(type: "bytea", nullable: false),
+                    tag_autenticacion = table.Column<byte[]>(type: "bytea", nullable: false),
+                    id_clave_maestra = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    huella_sha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    vigencia_desde = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    vigencia_hasta = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    activo = table.Column<bool>(type: "boolean", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_certificados_fiscales", x => x.id_certificado);
+                    table.CheckConstraint("ck_certificados_fiscales_vigencia", "vigencia_hasta > vigencia_desde");
+                    table.CheckConstraint("ck_certificados_fiscales_cuit", "cuit_titular ~ '^[0-9]{11}$'");
+                    table.CheckConstraint("ck_certificados_fiscales_material", "octet_length(nonce) = 12 AND octet_length(tag_autenticacion) = 16 AND octet_length(clave_privada_cifrada) > 0");
+                    table.ForeignKey(
+                        name: "fk_certificados_fiscales_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_certificados_fiscales_empresa",
+                        columns: x => new { x.id_empresa, x.id_tenant },
+                        principalTable: "empresas",
+                        principalColumns: new[] { "id_empresa", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_certificados_fiscales_tenant",
+                table: "certificados_fiscales",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_certificados_fiscales_empresa",
+                table: "certificados_fiscales",
+                columns: new[] { "id_empresa", "id_tenant" });
+
+            // A lo sumo un certificado activo por empresa+ambiente — la rotación (dar de baja +
+            // activar) dentro de UNA transacción es lo que evita una ventana con dos activos.
+            migrationBuilder.CreateIndex(
+                name: "ux_certificados_fiscales_activo",
+                table: "certificados_fiscales",
+                columns: new[] { "id_tenant", "id_empresa", "ambiente" },
+                unique: true,
+                filter: "activo AND deleted_at IS NULL");
+
+            // gate §F (proposal.md:607-641, decisión 13): numeraciones_fiscales — PK compuesta
+            // (id_punto_venta, codigo_afip), SIN auditoría (mismo criterio que
+            // NumeracionComprobante — espeja NumeracionComprobanteConfiguration.cs:44-59 línea a
+            // línea, incluida la FK compuesta a puntos_venta y los dos nombres de índice
+            // explícitos en snake_case). CHECK7 rango (0 legal = "serie sin usar"), CHECK8
+            // sincronización — inline.
+            migrationBuilder.CreateTable(
+                name: "numeraciones_fiscales",
+                columns: table => new
+                {
+                    id_punto_venta = table.Column<int>(type: "integer", nullable: false),
+                    codigo_afip = table.Column<short>(type: "smallint", nullable: false),
+                    id_tenant = table.Column<int>(type: "integer", nullable: false),
+                    proximo_numero = table.Column<long>(type: "bigint", nullable: false, defaultValue: 1L),
+                    ultimo_autorizado_arca = table.Column<long>(type: "bigint", nullable: true),
+                    sincronizado_en = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_numeraciones_fiscales", x => new { x.id_punto_venta, x.codigo_afip });
+                    table.CheckConstraint("ck_numeraciones_fiscales_rango", "proximo_numero BETWEEN 1 AND 99999999 AND (ultimo_autorizado_arca IS NULL OR ultimo_autorizado_arca BETWEEN 0 AND 99999999)");
+                    table.CheckConstraint("ck_numeraciones_fiscales_sincronizacion", "(ultimo_autorizado_arca IS NULL) = (sincronizado_en IS NULL)");
+                    table.ForeignKey(
+                        name: "fk_numeraciones_fiscales_tenant",
+                        column: x => x.id_tenant,
+                        principalTable: "tenants",
+                        principalColumn: "id_tenant",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_numeraciones_fiscales_punto_venta",
+                        columns: x => new { x.id_punto_venta, x.id_tenant },
+                        principalTable: "puntos_venta",
+                        principalColumns: new[] { "id_punto_venta", "id_tenant" },
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_numeraciones_fiscales_tenant",
+                table: "numeraciones_fiscales",
+                column: "id_tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_numeraciones_fiscales_punto_venta",
+                table: "numeraciones_fiscales",
+                columns: new[] { "id_punto_venta", "id_tenant" });
+
+            // gate §G (proposal.md:643-676, decisión 11) — TRES data statements IDEMPOTENTES
+            // (`WHERE ... codigo_afip IS NULL`), la mitad de la doble red de la etapa 17: el
+            // gemelo (net 1b, para una base FRESCA) vive en InicializadorDeBaseDeDatos.
+            // SembrarCatalogosFiscalesAsync — cada net se prueba INDEPENDIENTEMENTE (target 18).
+            // Ningún ALTER hace falta: las tres tablas ya tienen codigo_afip smallint NULL desde
+            // 20260801233937_CatalogosGlobales.cs. CERO filas insertadas, activadas o
+            // desactivadas — solo el campo nuevo.
+            //
+            // DS1 — tipos_comprobante (7 filas): FA=1, NDA=2, NCA=3, FB=6, NCB=8, FC=11, NCC=13.
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 1 WHERE codigo = 'FA' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 2 WHERE codigo = 'NDA' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 3 WHERE codigo = 'NCA' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 6 WHERE codigo = 'FB' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 8 WHERE codigo = 'NCB' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 11 WHERE codigo = 'FC' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = 13 WHERE codigo = 'NCC' AND codigo_afip IS NULL;");
+
+            // DS2 — condiciones_fiscales (5 filas, RG 5616 CondicionIVAReceptorId): RI=1,
+            // EXENTO=4, CF=5, MONOTRIBUTO=6. NO_RESP=15 (RG 5616 "IVA No Alcanzado") — LA ÚNICA
+            // INCERTIDUMBRE FLAGGEADA del proposal (decisión 11): sin contraparte exacta en esa
+            // tabla, mapeada a la condición más cercana; se confirma contra
+            // FEParamGetCondicionIvaReceptor en 19b, y hasta entonces un receptor NO_RESP se
+            // rechaza por su Código (no por este valor) con 409 nombrado — nunca se factura
+            // sobre una adivinanza (spec comprobante-fiscal).
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = 1 WHERE codigo = 'RI' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = 4 WHERE codigo = 'EXENTO' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = 5 WHERE codigo = 'CF' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = 6 WHERE codigo = 'MONOTRIBUTO' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = 15 WHERE codigo = 'NO_RESP' AND codigo_afip IS NULL;");
+
+            // DS3 — alicuotas_iva (4 filas, FEParamGetTiposIva): 0%=3, 10.5%=4, 21%=5, 27%=6.
+            // Exento/No gravado quedan DELIBERADAMENTE sin tocar — no son alícuotas, sus
+            // importes van a ImpOpEx/ImpTotConc y jamás al array Iva[] (decisión 11).
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = 3 WHERE nombre = '0%' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = 4 WHERE nombre = '10.5%' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = 5 WHERE nombre = '21%' AND codigo_afip IS NULL;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = 6 WHERE nombre = '27%' AND codigo_afip IS NULL;");
+
+            // RLS al final, en las DOS tablas nuevas (ADR-15 / convención etapas 12-17): la
+            // conexión de migración no tiene app_tenant_actual() seteado y los tres data
+            // statements de arriba no dependen de RLS estar activo (las tres catálogos son
+            // globales, sin id_tenant).
+            migrationBuilder.HabilitarRlsDeTenant("certificados_fiscales");
+            migrationBuilder.HabilitarRlsDeTenant("numeraciones_fiscales");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Los tres data statements se revierten PRIMERO, doblemente guardeados
+            // (`WHERE codigo = … AND codigo_afip = <valor exacto que Up() puso>`) — Down() toca
+            // SOLO las filas que Up() efectivamente seteó; una fila que ya traía un código antes
+            // de esta migración (imposible hoy, barato de garantizar para siempre) queda intacta.
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = NULL WHERE nombre = '27%' AND codigo_afip = 6;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = NULL WHERE nombre = '21%' AND codigo_afip = 5;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = NULL WHERE nombre = '10.5%' AND codigo_afip = 4;");
+            migrationBuilder.Sql("UPDATE alicuotas_iva SET codigo_afip = NULL WHERE nombre = '0%' AND codigo_afip = 3;");
+
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = NULL WHERE codigo = 'NO_RESP' AND codigo_afip = 15;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = NULL WHERE codigo = 'MONOTRIBUTO' AND codigo_afip = 6;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = NULL WHERE codigo = 'CF' AND codigo_afip = 5;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = NULL WHERE codigo = 'EXENTO' AND codigo_afip = 4;");
+            migrationBuilder.Sql("UPDATE condiciones_fiscales SET codigo_afip = NULL WHERE codigo = 'RI' AND codigo_afip = 1;");
+
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'NCC' AND codigo_afip = 13;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'FC' AND codigo_afip = 11;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'NCB' AND codigo_afip = 8;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'FB' AND codigo_afip = 6;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'NCA' AND codigo_afip = 3;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'NDA' AND codigo_afip = 2;");
+            migrationBuilder.Sql("UPDATE tipos_comprobante SET codigo_afip = NULL WHERE codigo = 'FA' AND codigo_afip = 1;");
+
+            // DropTable arrastra su PK, sus FKs, sus CHECKs, sus índices y su policy de RLS —
+            // Down() no necesita un statement de policy explícito.
+            migrationBuilder.DropTable(
+                name: "numeraciones_fiscales");
+
+            migrationBuilder.DropTable(
+                name: "certificados_fiscales");
+
+            migrationBuilder.DropIndex(
+                name: "ix_comprobantes_venta_fiscal_pendientes",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_comprobantes_venta_cae_digitos",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_comprobantes_venta_fiscal_coherente",
+                table: "comprobantes_venta");
+
+            // DropColumn ×4 ANTES del AlterDatabase final: DROP TYPE resultado_fiscal falla
+            // mientras una columna todavía usa ese tipo.
+            migrationBuilder.DropColumn(
+                name: "observaciones_fiscales",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropColumn(
+                name: "resultado_fiscal",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropColumn(
+                name: "cae_vencimiento",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropColumn(
+                name: "cae",
+                table: "comprobantes_venta");
+
+            migrationBuilder.DropIndex(
+                name: "ux_puntos_venta_numero_fiscal",
+                table: "puntos_venta");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_puntos_venta_numero_fiscal_rango",
+                table: "puntos_venta");
+
+            migrationBuilder.DropColumn(
+                name: "numero_fiscal",
+                table: "puntos_venta");
+
+            migrationBuilder.DropIndex(
+                name: "ix_empresas_condicion_fiscal",
+                table: "empresas");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_empresas_condicion_fiscal",
+                table: "empresas");
+
+            migrationBuilder.DropColumn(
+                name: "id_condicion_fiscal",
+                table: "empresas");
+
+            // Último statement: Annotation/OldAnnotation invertidos ⇒ DROP TYPE resultado_fiscal;
+            // DROP TYPE ambiente_fiscal. Ambos SALEN LIMPIOS — CERO valor de enum agregado a un
+            // tipo preexistente en toda esta migración (a diferencia de las etapas 12/17), así
+            // que esta sub-etapa no deja NINGÚN artefacto irreversible tras un rollback.
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .Annotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .Annotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .Annotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .Annotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .Annotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .Annotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .Annotation("Npgsql:Enum:estado_remito", "anulado,borrador,emitido,facturado")
+                .Annotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .Annotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .Annotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .Annotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .Annotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .Annotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .Annotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .Annotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .Annotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:Enum:ambiente_fiscal", "homologacion,produccion")
+                .OldAnnotation("Npgsql:Enum:categoria_gasto", "impuestos,otros,proveedor,servicios,sueldos,viaticos")
+                .OldAnnotation("Npgsql:Enum:clase_comprobante", "compra,venta")
+                .OldAnnotation("Npgsql:Enum:comportamiento_medio_pago", "cuenta_corriente,efectivo,electronico")
+                .OldAnnotation("Npgsql:Enum:estado_compra", "anulada,borrador,confirmada")
+                .OldAnnotation("Npgsql:Enum:estado_comprobante", "anulado,emitido")
+                .OldAnnotation("Npgsql:Enum:estado_orden_compra", "anulada,borrador,cerrada,enviada,recibida_parcial")
+                .OldAnnotation("Npgsql:Enum:estado_presupuesto", "anulado,borrador,convertido,enviado")
+                .OldAnnotation("Npgsql:Enum:estado_remito", "anulado,borrador,emitido,facturado")
+                .OldAnnotation("Npgsql:Enum:estado_tenant", "activo,baja,suspendido")
+                .OldAnnotation("Npgsql:Enum:estado_turno", "abierto,cerrado")
+                .OldAnnotation("Npgsql:Enum:estado_usuario", "activo,bloqueado,inactivo")
+                .OldAnnotation("Npgsql:Enum:modo_lista", "derivada,fija")
+                .OldAnnotation("Npgsql:Enum:motivo_stock", "ajuste,anulacion,compra,decomiso,inventario,reclasificacion,remito,transferencia,venta")
+                .OldAnnotation("Npgsql:Enum:resultado_fiscal", "pendiente,aprobado,aprobado_con_observaciones,rechazado")
+                .OldAnnotation("Npgsql:Enum:tipo_documento", "cuil,cuit,dni,otro,pasaporte")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_caja", "apertura_cajon,refuerzo,retiro")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc", "actualizacion_precios,ajuste,consumo,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_cc_proveedor", "ajuste,apertura,compra,pago")
+                .OldAnnotation("Npgsql:Enum:tipo_movimiento_tesoreria", "ajuste,deposito,gasto,retiro_caja")
+                .OldAnnotation("Npgsql:Enum:unidad_venta", "peso,unidad")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+        }
+    }
+}

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContext.cs
@@ -12,6 +12,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Common;
 using Ways.Domain.Compras;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Ofertas;
 using Ways.Domain.Organizacion;
@@ -151,6 +152,15 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
     public DbSet<Remito> Remitos => Set<Remito>();
     public DbSet<ItemRemito> ItemsRemito => Set<ItemRemito>();
 
+    // stage-19a-slice1 (schema fiscal, DB CHANGE GATE ratificado): CertificadoFiscal se expone
+    // en IWaysDbContext desde esta slice — ServicioDeCertificados (slice 4) es el primer
+    // consumidor de Application. NumeracionFiscal NO se expone acá (mismo criterio que
+    // NumeracionComprobante/NumeracionArticulo): su único escritor legítimo
+    // (AsignadorDeNumeroFiscal, slice 4) recibe el WaysDbContext concreto por parámetro y opera
+    // con ADO.NET crudo, no un DbSet de la interfaz.
+    public DbSet<CertificadoFiscal> CertificadosFiscales => Set<CertificadoFiscal>();
+    public DbSet<NumeracionFiscal> NumeracionesFiscales => Set<NumeracionFiscal>();
+
     /// <summary>Referenciado por los query filters de tenant (ver <see cref="AplicarFiltroDeTenant"/>):
     /// EF reconoce el acceso a un miembro de instancia del propio DbContext dentro de un
     /// filtro y lo reata a la instancia que ejecuta cada query, no a la que armó el modelo.</summary>
@@ -232,6 +242,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         AplicarFiltroDeTenantEnArqueoTurno(modelBuilder);
         AplicarFiltroDeTenantEnMovimientoTesoreria(modelBuilder);
         AplicarFiltroDeTenantEnAuditoria(modelBuilder);
+        AplicarFiltroDeTenantEnNumeracionFiscal(modelBuilder);
     }
 
     /// <summary>
@@ -274,6 +285,7 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
         RechazarEscriturasDeNumeracionCliente();
         RechazarEscriturasDeNumeracionArticulo();
         RechazarEscriturasDeNumeracionComprobante();
+        RechazarEscriturasDeNumeracionFiscal();
 
         foreach (var entrada in ChangeTracker.Entries<EntidadTenant>())
         {
@@ -379,6 +391,27 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
                 throw new InvalidOperationException(
                     "numeraciones_comprobante solo se escribe con SQL crudo, vía " +
                     $"{nameof(AsignadorDeNumeroComprobante)} — nunca por " +
+                    $"{nameof(SaveChanges)}/{nameof(SaveChangesAsync)}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// stage-19a-slice1 (design.md decisión 13, proposal.md §F): mismo guard que
+    /// <see cref="RechazarEscriturasDeNumeracionComprobante"/>, acá para
+    /// <see cref="NumeracionFiscal"/> — <c>AsignadorDeNumeroFiscal</c> (slice 4) es su único
+    /// punto de escritura legítimo, con SQL crudo, disciplina OPUESTA (toma el número DENTRO de
+    /// la transacción de emisión, nunca en una transacción propia previa).
+    /// </summary>
+    private void RechazarEscriturasDeNumeracionFiscal()
+    {
+        foreach (var entrada in ChangeTracker.Entries<NumeracionFiscal>())
+        {
+            if (entrada.State is EntityState.Added or EntityState.Modified)
+            {
+                throw new InvalidOperationException(
+                    "numeraciones_fiscales solo se escribe con SQL crudo, vía " +
+                    "AsignadorDeNumeroFiscal — nunca por " +
                     $"{nameof(SaveChanges)}/{nameof(SaveChangesAsync)}.");
             }
         }
@@ -583,6 +616,23 @@ public class WaysDbContext(DbContextOptions<WaysDbContext> options, ITenantActua
 
         var parametro = Expression.Parameter(typeof(NumeracionComprobante), "e");
         var propiedadIdTenant = Expression.Property(parametro, nameof(NumeracionComprobante.IdTenant));
+        var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
+
+        entidad.SetQueryFilter("Tenant", filtro);
+    }
+
+    /// <summary>
+    /// stage-19a-slice1 (proposal.md §F): <see cref="NumeracionFiscal"/> no hereda de
+    /// <see cref="EntidadTenant"/> (PK compuesta <c>(IdPuntoVenta, CodigoAfip)</c>, mismo motivo
+    /// que <see cref="NumeracionComprobante"/>), así que necesita la misma variante escrita a
+    /// mano.
+    /// </summary>
+    private void AplicarFiltroDeTenantEnNumeracionFiscal(ModelBuilder modelBuilder)
+    {
+        var entidad = modelBuilder.Model.FindEntityType(typeof(NumeracionFiscal))!;
+
+        var parametro = Expression.Parameter(typeof(NumeracionFiscal), "e");
+        var propiedadIdTenant = Expression.Property(parametro, nameof(NumeracionFiscal.IdTenant));
         var filtro = ConstruirFiltroDeTenant(parametro, propiedadIdTenant);
 
         entidad.SetQueryFilter("Tenant", filtro);

--- a/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
+++ b/src/Ways.Infrastructure/Persistencia/WaysDbContextFactory.cs
@@ -6,6 +6,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -49,6 +50,8 @@ public class WaysDbContextFactory : IDesignTimeDbContextFactory<WaysDbContext>
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .Options;
 

--- a/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
+++ b/tests/Ways.IntegrationTests/ComprasTipoSeedTests.cs
@@ -9,6 +9,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -139,6 +140,8 @@ public class ComprasTipoSeedTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                     npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                     npgsql.MapEnum<EstadoRemito>("estado_remito");
+                    npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
+++ b/tests/Ways.IntegrationTests/ConteoPorLoteTests.cs
@@ -573,6 +573,8 @@ public class ConteoPorLoteTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;

--- a/tests/Ways.IntegrationTests/CostoCongeladoTests.cs
+++ b/tests/Ways.IntegrationTests/CostoCongeladoTests.cs
@@ -534,6 +534,8 @@ public class CostoCongeladoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
                     npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
                     npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
                     npgsql.MapEnum<EstadoCompra>("estado_compra");
+                    npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
                 })
                 .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
                 .Options;
@@ -648,16 +650,40 @@ public class CostoCongeladoTests(WaysApiFixture fixture) : IClassFixture<WaysApi
         db.Tenants.Add(tenant);
         await db.SaveChangesAsync();
 
-        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
-        db.Empresas.Add(empresa);
-        await db.SaveChangesAsync();
-
-        var puntoVenta = new PuntoVenta
+        // stage-19a-slice1: esquema todavía en stage 8 acá, ANTES de id_condicion_fiscal
+        // (FiscalArcaEtapa19a) — SQL crudo, mismo motivo que la trampa ya documentada para
+        // comprobantes_venta/articulos/items_comprobante_venta en este mismo archivo: con el
+        // modelo HEAD, EF incluiría la columna nueva en el INSERT y rompería contra el esquema
+        // viejo con 42703. Es la PRIMERA vez que empresas diverge desde la etapa 1.
+        int idEmpresa;
+        await using (var crudaEmpresa = new NpgsqlConnection(cadenaConexion))
         {
-            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
-        };
-        db.PuntosVenta.Add(puntoVenta);
-        await db.SaveChangesAsync();
+            await crudaEmpresa.OpenAsync();
+            await using var comando = crudaEmpresa.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO empresas (id_tenant, razon_social, created_at, updated_at) " +
+                "VALUES ($1, $2, now(), now()) RETURNING id_empresa";
+            comando.Parameters.Add(new NpgsqlParameter { Value = tenant.Id });
+            comando.Parameters.Add(new NpgsqlParameter { Value = nombre });
+            idEmpresa = (int)(await comando.ExecuteScalarAsync())!;
+        }
+
+        // stage-19a-slice1: mismo motivo — esquema todavía en stage 8, ANTES de numero_fiscal.
+        int idPuntoVenta;
+        await using (var crudaPuntoVenta = new NpgsqlConnection(cadenaConexion))
+        {
+            await crudaPuntoVenta.OpenAsync();
+            await using var comando = crudaPuntoVenta.CreateCommand();
+            comando.CommandText =
+                "INSERT INTO puntos_venta (id_tenant, id_empresa, nombre, created_at, updated_at) " +
+                "VALUES ($1, $2, $3, now(), now()) RETURNING id_punto_venta";
+            comando.Parameters.Add(new NpgsqlParameter { Value = tenant.Id });
+            comando.Parameters.Add(new NpgsqlParameter { Value = idEmpresa });
+            comando.Parameters.Add(new NpgsqlParameter { Value = nombre });
+            idPuntoVenta = (int)(await comando.ExecuteScalarAsync())!;
+        }
+
+        var puntoVenta = new PuntoVenta { Id = idPuntoVenta, IdTenant = tenant.Id, IdEmpresa = idEmpresa, Nombre = nombre };
 
         var area = new Area { IdTenant = tenant.Id, Nombre = nombre, Orden = 1, CreatedAt = ahora, UpdatedAt = ahora };
         db.Areas.Add(area);

--- a/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteEtapa7BackstopTests.cs
@@ -9,6 +9,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -208,6 +209,8 @@ public class CuentaCorrienteEtapa7BackstopTests(WaysApiFixture fixture) : IClass
                     npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                     npgsql.MapEnum<EstadoRemito>("estado_remito");
+                    npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
+++ b/tests/Ways.IntegrationTests/CuentaCorrienteProveedorBackfillTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -9,6 +10,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -68,6 +70,8 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
                 // stage-17-presupuestos-y-remitos, Slice 1: mismo gap, mismo motivo.
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .Options;
 
@@ -84,16 +88,41 @@ public class CuentaCorrienteProveedorBackfillTests(WaysApiFixture fixture) : ICl
         db.Tenants.Add(tenant);
         await db.SaveChangesAsync();
 
-        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
-        db.Empresas.Add(empresa);
-        await db.SaveChangesAsync();
-
-        var puntoVenta = new PuntoVenta
+        // stage-19a-slice1: esquema todavía en AuditoriaEtapa14 acá, ANTES de id_condicion_fiscal/
+        // numero_fiscal (FiscalArcaEtapa19a) — SQL crudo sobre la MISMA conexión de `db`, mismo
+        // motivo que la trampa ya documentada en CostoCongeladoTests.cs para esta primera
+        // divergencia física de empresas/puntos_venta desde la etapa 1.
+        var conexionCruda = (NpgsqlConnection)db.Database.GetDbConnection();
+        if (conexionCruda.State != ConnectionState.Open)
         {
-            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
-        };
-        db.PuntosVenta.Add(puntoVenta);
-        await db.SaveChangesAsync();
+            await conexionCruda.OpenAsync();
+        }
+
+        int idEmpresa;
+        await using (var comandoEmpresa = conexionCruda.CreateCommand())
+        {
+            comandoEmpresa.CommandText =
+                "INSERT INTO empresas (id_tenant, razon_social, created_at, updated_at) " +
+                "VALUES ($1, $2, now(), now()) RETURNING id_empresa";
+            comandoEmpresa.Parameters.Add(new NpgsqlParameter { Value = tenant.Id });
+            comandoEmpresa.Parameters.Add(new NpgsqlParameter { Value = nombre });
+            idEmpresa = (int)(await comandoEmpresa.ExecuteScalarAsync())!;
+        }
+
+        int idPuntoVenta;
+        await using (var comandoPuntoVenta = conexionCruda.CreateCommand())
+        {
+            comandoPuntoVenta.CommandText =
+                "INSERT INTO puntos_venta (id_tenant, id_empresa, nombre, created_at, updated_at) " +
+                "VALUES ($1, $2, $3, now(), now()) RETURNING id_punto_venta";
+            comandoPuntoVenta.Parameters.Add(new NpgsqlParameter { Value = tenant.Id });
+            comandoPuntoVenta.Parameters.Add(new NpgsqlParameter { Value = idEmpresa });
+            comandoPuntoVenta.Parameters.Add(new NpgsqlParameter { Value = nombre });
+            idPuntoVenta = (int)(await comandoPuntoVenta.ExecuteScalarAsync())!;
+        }
+
+        var empresa = new Empresa { Id = idEmpresa, IdTenant = tenant.Id, RazonSocial = nombre };
+        var puntoVenta = new PuntoVenta { Id = idPuntoVenta, IdTenant = tenant.Id, IdEmpresa = idEmpresa, Nombre = nombre };
 
         // Rol/CondicionFiscal/TipoComprobante son catálogos [global] que en producción siembra
         // InicializadorDeBaseDeDatos al arrancar el host — acá se siembran a mano una sola vez,

--- a/tests/Ways.IntegrationTests/EtiquetasEndpointsTests.cs
+++ b/tests/Ways.IntegrationTests/EtiquetasEndpointsTests.cs
@@ -297,6 +297,8 @@ public class EtiquetasEndpointsTests(WaysApiFixture fixture) : IClassFixture<Way
                 npgsql.MapEnum<TipoDocumento>("tipo_documento");
                 npgsql.MapEnum<ModoLista>("modo_lista");
                 npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/FiscalSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/FiscalSchemaTests.cs
@@ -1,0 +1,1286 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Articulos;
+using Ways.Domain.Caja;
+using Ways.Domain.Catalogos;
+using Ways.Domain.Clientes;
+using Ways.Domain.Compras;
+using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
+using Ways.Domain.Gastos;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Stock;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-19a-slice1 (tasks 1.25-1.47, mutation targets 1-23, mutation-proof-tests v1.1,
+/// db-error-backstops, design.md "The migration — exact statement order"): schema fiscal —
+/// enums, 8 CHECKs, 8 índices por definición, RLS de ambas tablas nuevas, doble red de
+/// codigo_afip, reversibilidad exacta — sobre la base COMPARTIDA de <see cref="WaysApiFixture"/>
+/// (mismo criterio que <c>RemitosSchemaTests</c>: no depende del momento exacto de una migración
+/// de datos, salvo la doble red y la reversibilidad, que sí lo hacen y se prueban aparte).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class FiscalSchemaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private sealed record Escenario(
+        int IdTenant, int IdEmpresa, int IdPuntoVenta, int IdCliente, int IdEmpleado, int IdCondicionFiscal);
+
+    private async Task<Escenario> SembrarEscenarioAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host: siembra roles/catálogos fiscales
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var condicionFiscal = new CondicionFiscal { Codigo = $"{nombre}-CF", Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        db.CondicionesFiscales.Add(condicionFiscal);
+        await db.SaveChangesAsync();
+
+        var listaPrecio = new ListaPrecio
+        {
+            IdTenant = tenant.Id, Nombre = nombre, EsDefault = false, Modo = ModoLista.Fija,
+            Activo = true, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.ListasPrecio.Add(listaPrecio);
+        await db.SaveChangesAsync();
+
+        var cliente = new Cliente
+        {
+            IdTenant = tenant.Id, Numero = 701, Nombre = nombre, IdCondicionFiscal = condicionFiscal.Id,
+            IdListaPrecio = listaPrecio.Id, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        db.Clientes.Add(cliente);
+        await db.SaveChangesAsync();
+
+        var empleado = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = $"{nombre.ToLowerInvariant()}-empleado",
+            Mail = $"{nombre.ToLowerInvariant()}@ways.test",
+            RolId = (int)RolConocido.Vendedor,
+            PasswordHash = "hash-de-prueba",
+            PasswordAlgoritmo = "test",
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(empleado);
+        await db.SaveChangesAsync();
+
+        return new Escenario(tenant.Id, empresa.Id, puntoVenta.Id, cliente.Id, empleado.Id, condicionFiscal.Id);
+    }
+
+    private static async Task<int> ObtenerIdTipoComprobanteAsync(NpgsqlConnection cruda, string codigo)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT id_tipo_comprobante FROM tipos_comprobante WHERE codigo = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = codigo });
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // comprobantes_venta fiscal — INSERT crudo con las 4 columnas nuevas
+    // ---------------------------------------------------------------------------------------
+
+    private const string ColumnasComprobante =
+        "(id_tenant, id_tipo_comprobante, numero, fecha, id_punto_venta, id_turno_caja, id_empleado, " +
+        " id_cliente, id_comprobante_asociado, id_presupuesto_origen, subtotal, descuento_total, total, " +
+        " neto_gravado, iva_total, direccion_entrega, observaciones, estado, cae, cae_vencimiento, " +
+        " resultado_fiscal, observaciones_fiscales, created_at, updated_at, deleted_at)";
+
+    private static NpgsqlCommand ComandoInsertarComprobante(
+        NpgsqlConnection cruda, Escenario e, int idTipoComprobante, long numero,
+        string? cae, DateOnly? caeVencimiento, string? resultadoFiscal, string? observacionesFiscales)
+    {
+        var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO comprobantes_venta " + ColumnasComprobante +
+            " VALUES ($1, $2, $3, now(), $4, NULL, $5, $6, NULL, NULL, 10, 0, 10, NULL, NULL, NULL, NULL, " +
+            " 'emitido'::estado_comprobante, $7, $8, $9::resultado_fiscal, $10::jsonb, now(), now(), NULL)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = idTipoComprobante });
+        comando.Parameters.Add(new NpgsqlParameter { Value = numero });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpleado });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdCliente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)cae ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)caeVencimiento ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)resultadoFiscal ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)observacionesFiscales ?? DBNull.Value });
+        return comando;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // certificados_fiscales — INSERT crudo con material GCM válido por defecto
+    // ---------------------------------------------------------------------------------------
+
+    private const string ColumnasCertificado =
+        "(id_tenant, id_empresa, ambiente, alias, cuit_titular, certificado_pem, clave_privada_cifrada, " +
+        " nonce, tag_autenticacion, id_clave_maestra, huella_sha256, vigencia_desde, vigencia_hasta, " +
+        " activo, created_at, updated_at, deleted_at)";
+
+    private static NpgsqlCommand ComandoInsertarCertificado(
+        NpgsqlConnection cruda, Escenario e, string alias,
+        string ambiente = "homologacion",
+        bool activo = true,
+        DateTimeOffset? deletedAt = null,
+        string cuitTitular = "20111111112",
+        DateTimeOffset? vigenciaDesde = null,
+        DateTimeOffset? vigenciaHasta = null,
+        int nonceLength = 12,
+        int tagLength = 16,
+        int clavePrivadaLength = 32)
+    {
+        var ahora = DateTimeOffset.UtcNow;
+        var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO certificados_fiscales " + ColumnasCertificado +
+            " VALUES ($1, $2, $3::ambiente_fiscal, $4, $5, 'PEM-DE-PRUEBA', $6, $7, $8, 'v1', " +
+            " '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', $9, $10, $11, now(), now(), $12)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdEmpresa });
+        comando.Parameters.Add(new NpgsqlParameter { Value = ambiente });
+        comando.Parameters.Add(new NpgsqlParameter { Value = alias });
+        comando.Parameters.Add(new NpgsqlParameter { Value = cuitTitular });
+        comando.Parameters.Add(new NpgsqlParameter { Value = new byte[Math.Max(clavePrivadaLength, 0)] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = new byte[Math.Max(nonceLength, 0)] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = new byte[Math.Max(tagLength, 0)] });
+        comando.Parameters.Add(new NpgsqlParameter { Value = vigenciaDesde ?? ahora });
+        comando.Parameters.Add(new NpgsqlParameter { Value = vigenciaHasta ?? ahora.AddYears(2) });
+        comando.Parameters.Add(new NpgsqlParameter { Value = activo });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)deletedAt ?? DBNull.Value });
+        return comando;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // numeraciones_fiscales — INSERT crudo
+    // ---------------------------------------------------------------------------------------
+
+    private static NpgsqlCommand ComandoInsertarNumeracionFiscal(
+        NpgsqlConnection cruda, Escenario e, short codigoAfip,
+        long proximoNumero = 1, long? ultimoAutorizadoArca = null, DateTimeOffset? sincronizadoEn = null)
+    {
+        var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO numeraciones_fiscales (id_punto_venta, codigo_afip, id_tenant, proximo_numero, " +
+            " ultimo_autorizado_arca, sincronizado_en) VALUES ($1, $2, $3, $4, $5, $6)";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = codigoAfip });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+        comando.Parameters.Add(new NpgsqlParameter { Value = proximoNumero });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)ultimoAutorizadoArca ?? DBNull.Value });
+        comando.Parameters.Add(new NpgsqlParameter { Value = (object?)sincronizadoEn ?? DBNull.Value });
+        return comando;
+    }
+
+    // =========================================================================================
+    // Target 1 — orden de CREATE TYPE = orden de ciclo de vida = pg_enum.enumsortorder
+    // =========================================================================================
+
+    [Theory]
+    [InlineData("ambiente_fiscal", new[] { "homologacion", "produccion" })]
+    [InlineData("resultado_fiscal", new[] { "pendiente", "aprobado", "aprobado_con_observaciones", "rechazado" })]
+    public async Task ElOrdenDeCicloDeVidaDelEnumCoincideConPgEnumEnsortorder(string tipo, string[] ordenEsperado)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "SELECT e.enumlabel FROM pg_enum e JOIN pg_type t ON e.enumtypid = t.oid " +
+            "WHERE t.typname = $1 ORDER BY e.enumsortorder";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tipo });
+
+        var etiquetas = new List<string>();
+        await using var lector = await comando.ExecuteReaderAsync();
+        while (await lector.ReadAsync())
+        {
+            etiquetas.Add(lector.GetString(0));
+        }
+
+        Assert.Equal(ordenEsperado, etiquetas);
+    }
+
+    // =========================================================================================
+    // Target 2 [S] — cero ALTER TYPE ... ADD VALUE en el archivo de la migración
+    // =========================================================================================
+
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static string LeerFuenteDeLaMigracion()
+    {
+        var ruta = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Infrastructure", "Persistencia", "Migraciones",
+            "20260822002214_FiscalArcaEtapa19a.cs");
+
+        Assert.True(File.Exists(ruta), $"No se encontró la migración en {ruta}");
+        return File.ReadAllText(ruta);
+    }
+
+    [Fact]
+    public void LaMigracionNoContieneNingunAlterTypeAddValue()
+    {
+        var fuente = LeerFuenteDeLaMigracion();
+
+        // Excluye los comentarios (el archivo documenta "cero ALTER TYPE ... ADD VALUE" en
+        // prosa): el scan real busca la frase en CÓDIGO ejecutable, nunca en un comentario.
+        var codigoSinComentarios = string.Join(
+            '\n',
+            fuente.Split('\n').Where(linea => !linea.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+        Assert.DoesNotContain("ADD VALUE", codigoSinComentarios, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // =========================================================================================
+    // Target 3 — los 8 índices nuevos, por DEFINICIÓN (nunca por nombre)
+    // =========================================================================================
+
+    private static async Task<string> ObtenerIndexDefAsync(NpgsqlConnection cruda, string tabla, string indexname)
+    {
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT indexdef FROM pg_indexes WHERE tablename = $1 AND indexname = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+        comando.Parameters.Add(new NpgsqlParameter { Value = indexname });
+
+        var indexdef = (string?)await comando.ExecuteScalarAsync();
+        Assert.NotNull(indexdef);
+        return indexdef!;
+    }
+
+    [Fact]
+    public async Task LosOchoIndicesNuevosExistenPorDefinicionYSonExactamenteOcho()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        var defEmpresas = await ObtenerIndexDefAsync(cruda, "empresas", "ix_empresas_condicion_fiscal");
+        Assert.Contains("btree (id_condicion_fiscal)", defEmpresas);
+        Assert.DoesNotContain("id_tenant", defEmpresas);
+
+        var defPuntoVenta = await ObtenerIndexDefAsync(cruda, "puntos_venta", "ux_puntos_venta_numero_fiscal");
+        Assert.Contains("UNIQUE INDEX", defPuntoVenta);
+        Assert.Contains("btree (id_tenant, id_empresa, numero_fiscal)", defPuntoVenta);
+        Assert.Contains("WHERE (numero_fiscal IS NOT NULL)", defPuntoVenta);
+
+        var defPendientes = await ObtenerIndexDefAsync(cruda, "comprobantes_venta", "ix_comprobantes_venta_fiscal_pendientes");
+        Assert.Contains("btree (id_punto_venta, id_tenant)", defPendientes);
+        Assert.Contains("WHERE (resultado_fiscal = 'pendiente'::resultado_fiscal)", defPendientes);
+
+        var defCertTenant = await ObtenerIndexDefAsync(cruda, "certificados_fiscales", "ix_certificados_fiscales_tenant");
+        Assert.Contains("btree (id_tenant)", defCertTenant);
+
+        var defCertEmpresa = await ObtenerIndexDefAsync(cruda, "certificados_fiscales", "ix_certificados_fiscales_empresa");
+        Assert.Contains("btree (id_empresa, id_tenant)", defCertEmpresa);
+
+        var defCertActivo = await ObtenerIndexDefAsync(cruda, "certificados_fiscales", "ux_certificados_fiscales_activo");
+        Assert.Contains("UNIQUE INDEX", defCertActivo);
+        Assert.Contains("btree (id_tenant, id_empresa, ambiente)", defCertActivo);
+        Assert.Contains("WHERE (activo AND (deleted_at IS NULL))", defCertActivo);
+
+        var defNumTenant = await ObtenerIndexDefAsync(cruda, "numeraciones_fiscales", "ix_numeraciones_fiscales_tenant");
+        Assert.Contains("btree (id_tenant)", defNumTenant);
+
+        var defNumPuntoVenta = await ObtenerIndexDefAsync(cruda, "numeraciones_fiscales", "ix_numeraciones_fiscales_punto_venta");
+        Assert.Contains("btree (id_punto_venta, id_tenant)", defNumPuntoVenta);
+
+        // Conteo total = 8, incluyendo las dos PKs de las tablas nuevas por separado (excluidas
+        // del conteo de índices "nuevos" per el gate — se cuentan acá para confirmar que no hay
+        // ningún índice extra autogenerado por EF).
+        async Task<List<string>> ListarAsync(string tabla)
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "SELECT indexname FROM pg_indexes WHERE tablename = $1 ORDER BY indexname";
+            comando.Parameters.Add(new NpgsqlParameter { Value = tabla });
+            var indices = new List<string>();
+            await using var lector = await comando.ExecuteReaderAsync();
+            while (await lector.ReadAsync())
+            {
+                indices.Add(lector.GetString(0));
+            }
+            return indices;
+        }
+
+        var indicesCertificados = (await ListarAsync("certificados_fiscales")).Where(n => n != "pk_certificados_fiscales").ToList();
+        var indicesNumeraciones = (await ListarAsync("numeraciones_fiscales")).Where(n => n != "pk_numeraciones_fiscales").ToList();
+
+        Assert.Equal(3, indicesCertificados.Count);
+        Assert.Equal(2, indicesNumeraciones.Count);
+
+        var totalIndicesNuevos = 1 /* empresas */ + 1 /* puntos_venta */ + 1 /* comprobantes_venta */
+            + indicesCertificados.Count + indicesNumeraciones.Count;
+        Assert.Equal(8, totalIndicesNuevos);
+    }
+
+    // =========================================================================================
+    // Target 4 — CHECK 1: ck_puntos_venta_numero_fiscal_rango
+    // =========================================================================================
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100000)]
+    public async Task UnNumeroFiscalFueraDeRangoViolaLaCheckDeRango(int numeroFiscal)
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnNumeroFiscalFueraDeRangoViolaLaCheckDeRango) + numeroFiscal);
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "UPDATE puntos_venta SET numero_fiscal = $1 WHERE id_punto_venta = $2";
+        comando.Parameters.Add(new NpgsqlParameter { Value = numeroFiscal });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_puntos_venta_numero_fiscal_rango", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnNumeroFiscalDentroDeRangoNoViolaLaCheck()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnNumeroFiscalDentroDeRangoNoViolaLaCheck));
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "UPDATE puntos_venta SET numero_fiscal = 1 WHERE id_punto_venta = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // =========================================================================================
+    // Target 5 — CHECK 2: ck_comprobantes_venta_fiscal_coherente (4 conjuntos)
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnCaeSinVencimientoViolaLaCheckDeCoherenciaFiscal()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCaeSinVencimientoViolaLaCheckDeCoherenciaFiscal));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        await using var comando = ComandoInsertarComprobante(
+            cruda, e, idTipo, 801, cae: "12345678901234", caeVencimiento: null,
+            resultadoFiscal: "aprobado", observacionesFiscales: null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_venta_fiscal_coherente", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnRechazadoConCaeViolaLaCheckDeCoherenciaFiscal()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnRechazadoConCaeViolaLaCheckDeCoherenciaFiscal));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        await using var comando = ComandoInsertarComprobante(
+            cruda, e, idTipo, 802, cae: "12345678901234", caeVencimiento: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+            resultadoFiscal: "rechazado", observacionesFiscales: null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_venta_fiscal_coherente", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnAprobadoSinCaeViolaLaCheckDeCoherenciaFiscal()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnAprobadoSinCaeViolaLaCheckDeCoherenciaFiscal));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        await using var comando = ComandoInsertarComprobante(
+            cruda, e, idTipo, 803, cae: null, caeVencimiento: null,
+            resultadoFiscal: "aprobado", observacionesFiscales: null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_venta_fiscal_coherente", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCaeSetConResultadoFiscalNullViolaLaCheckDeCoherenciaFiscal()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCaeSetConResultadoFiscalNullViolaLaCheckDeCoherenciaFiscal));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        await using var comando = ComandoInsertarComprobante(
+            cruda, e, idTipo, 804, cae: "12345678901234", caeVencimiento: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+            resultadoFiscal: null, observacionesFiscales: null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_comprobantes_venta_fiscal_coherente", excepcion.ConstraintName);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("12345678901234", "aprobado", "[]")]
+    [InlineData("12345678901234", "aprobado_con_observaciones", "[{\"codigo\":10,\"mensaje\":\"obs\"}]")]
+    public async Task UnComprobanteCoherenteNoViolaLaCheck(string? cae, string? resultado, string? observaciones)
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnComprobanteCoherenteNoViolaLaCheck) + (resultado ?? "null"));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        var vencimiento = cae is null ? (DateOnly?)null : DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30));
+        await using var comando = ComandoInsertarComprobante(cruda, e, idTipo, 805, cae, vencimiento, resultado, observaciones);
+
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // =========================================================================================
+    // Target 6 — CHECK 3: ck_comprobantes_venta_cae_digitos
+    // =========================================================================================
+
+    [Theory]
+    [InlineData("1234567890123")]     // 13 dígitos
+    [InlineData("1234567890ABCD")]    // alfanumérico
+    public async Task UnCaeMalFormadoViolaLaCheckDeDigitos(string cae)
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCaeMalFormadoViolaLaCheckDeDigitos) + cae.Length);
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var idTipo = await ObtenerIdTipoComprobanteAsync(cruda, "TX");
+
+        await using var comando = ComandoInsertarComprobante(
+            cruda, e, idTipo, 806, cae, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)), "aprobado", null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        // Postgres evalúa las CHECKs en orden de declaración; ambas fallan acá porque un CAE de
+        // 13/14 dígitos alfanuméricos también incumple ck_comprobantes_venta_cae_digitos.
+        Assert.Equal("ck_comprobantes_venta_cae_digitos", excepcion.ConstraintName);
+    }
+
+    // =========================================================================================
+    // Target 7 — CHECK 4: ck_certificados_fiscales_vigencia
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnaVigenciaIgualViolaLaCheckDeVigencia()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnaVigenciaIgualViolaLaCheckDeVigencia));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+        var ahora = DateTimeOffset.UtcNow;
+
+        await using var comando = ComandoInsertarCertificado(
+            cruda, e, "cert-vigencia", vigenciaDesde: ahora, vigenciaHasta: ahora);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_certificados_fiscales_vigencia", excepcion.ConstraintName);
+    }
+
+    // =========================================================================================
+    // Target 8 — CHECK 5: ck_certificados_fiscales_cuit
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnCuitDe10DigitosViolaLaCheckDeCuit()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCuitDe10DigitosViolaLaCheckDeCuit));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarCertificado(cruda, e, "cert-cuit", cuitTitular: "2011111111");
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_certificados_fiscales_cuit", excepcion.ConstraintName);
+    }
+
+    // =========================================================================================
+    // Target 9 — CHECK 6: ck_certificados_fiscales_material (3 conjuntos GCM)
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnNonceDe11BytesViolaLaCheckDeMaterial()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnNonceDe11BytesViolaLaCheckDeMaterial));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarCertificado(cruda, e, "cert-nonce", nonceLength: 11);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_certificados_fiscales_material", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnTagDe15BytesViolaLaCheckDeMaterial()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnTagDe15BytesViolaLaCheckDeMaterial));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarCertificado(cruda, e, "cert-tag", tagLength: 15);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_certificados_fiscales_material", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnaClavePrivadaVaciaViolaLaCheckDeMaterial()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnaClavePrivadaVaciaViolaLaCheckDeMaterial));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarCertificado(cruda, e, "cert-vacio", clavePrivadaLength: 0);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_certificados_fiscales_material", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCertificadoConMaterialValidoNoViolaNingunaCheck()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCertificadoConMaterialValidoNoViolaNingunaCheck));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarCertificado(cruda, e, "cert-valido");
+        await comando.ExecuteNonQueryAsync(); // no debe tirar
+    }
+
+    // =========================================================================================
+    // Target 10 — CHECK 7: ck_numeraciones_fiscales_rango
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnUltimoAutorizadoArcaEnCeroEsLegalYNoViolaLaCheckDeRango()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnUltimoAutorizadoArcaEnCeroEsLegalYNoViolaLaCheckDeRango));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarNumeracionFiscal(
+            cruda, e, codigoAfip: 1, ultimoAutorizadoArca: 0, sincronizadoEn: DateTimeOffset.UtcNow);
+
+        await comando.ExecuteNonQueryAsync(); // "serie sin usar" — no debe tirar
+    }
+
+    [Fact]
+    public async Task UnUltimoAutorizadoArcaPorEncimaDelTopeViolaLaCheckDeRango()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnUltimoAutorizadoArcaPorEncimaDelTopeViolaLaCheckDeRango));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarNumeracionFiscal(
+            cruda, e, codigoAfip: 1, ultimoAutorizadoArca: 100_000_000, sincronizadoEn: DateTimeOffset.UtcNow);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_numeraciones_fiscales_rango", excepcion.ConstraintName);
+    }
+
+    /// <summary>Corrección registrada (mutation-proof-tests regla 2, "run it, don't reason it"):
+    /// <c>tasks.md</c> 1.34 dice literalmente "proximo_numero = 0 must succeed", pero el propio
+    /// CHECK 7 exige <c>proximo_numero BETWEEN 1 AND 99999999</c> — <c>0</c> NUNCA es legal para
+    /// esa columna (el "0 legal" del design es exclusivamente para <c>ultimo_autorizado_arca</c>,
+    /// probado arriba). Registrado como desvío de redacción de tasks.md, no un hallazgo de
+    /// diseño; esta prueba fija el comportamiento REAL de la CHECK para <c>proximo_numero</c>.</summary>
+    [Fact]
+    public async Task UnProximoNumeroEnCeroVIOLALaCheckDeRango()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnProximoNumeroEnCeroVIOLALaCheckDeRango));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarNumeracionFiscal(cruda, e, codigoAfip: 1, proximoNumero: 0);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_numeraciones_fiscales_rango", excepcion.ConstraintName);
+    }
+
+    // =========================================================================================
+    // Target 11 — CHECK 8: ck_numeraciones_fiscales_sincronizacion
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnUltimoAutorizadoArcaSinSincronizadoEnViolaLaCheckDeSincronizacion()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnUltimoAutorizadoArcaSinSincronizadoEnViolaLaCheckDeSincronizacion));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using var comando = ComandoInsertarNumeracionFiscal(
+            cruda, e, codigoAfip: 1, ultimoAutorizadoArca: 5, sincronizadoEn: null);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_numeraciones_fiscales_sincronizacion", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnSincronizadoEnSinUltimoAutorizadoArcaViolaLaCheckDeSincronizacion()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnSincronizadoEnSinUltimoAutorizadoArcaViolaLaCheckDeSincronizacion));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        // INSERT directo con SQL crudo para evitar el helper (que exige el par consistente).
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText =
+            "INSERT INTO numeraciones_fiscales (id_punto_venta, codigo_afip, id_tenant, proximo_numero, " +
+            " ultimo_autorizado_arca, sincronizado_en) VALUES ($1, 1, $2, 1, NULL, now())";
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdPuntoVenta });
+        comando.Parameters.Add(new NpgsqlParameter { Value = e.IdTenant });
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("23514", excepcion.SqlState);
+        Assert.Equal("ck_numeraciones_fiscales_sincronizacion", excepcion.ConstraintName);
+    }
+
+    // =========================================================================================
+    // Target 12 — ux_puntos_venta_numero_fiscal: UNIQUE parcial
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnNumeroFiscalDuplicadoParaLaMismaEmpresaViolaLaUnicidad()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnNumeroFiscalDuplicadoParaLaMismaEmpresaViolaLaUnicidad));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var otroPuntoVenta = new PuntoVenta
+        {
+            IdTenant = e.IdTenant, IdEmpresa = e.IdEmpresa, Nombre = "otro-pv",
+            CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.PuntosVenta.Add(otroPuntoVenta);
+        await db.SaveChangesAsync();
+
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        async Task SetearAsync(int idPuntoVenta, int numeroFiscal)
+        {
+            await using var comando = cruda.CreateCommand();
+            comando.CommandText = "UPDATE puntos_venta SET numero_fiscal = $1 WHERE id_punto_venta = $2";
+            comando.Parameters.Add(new NpgsqlParameter { Value = numeroFiscal });
+            comando.Parameters.Add(new NpgsqlParameter { Value = idPuntoVenta });
+            await comando.ExecuteNonQueryAsync();
+        }
+
+        await SetearAsync(e.IdPuntoVenta, 5);
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => SetearAsync(otroPuntoVenta.Id, 5));
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_puntos_venta_numero_fiscal", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task DosPuntosDeVentaSinNumeroFiscalConvivenSinConflicto()
+    {
+        var e = await SembrarEscenarioAsync(nameof(DosPuntosDeVentaSinNumeroFiscalConvivenSinConflicto));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        db.PuntosVenta.Add(new PuntoVenta
+        {
+            IdTenant = e.IdTenant, IdEmpresa = e.IdEmpresa, Nombre = "otro-pv-2",
+            CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        await db.SaveChangesAsync(); // ambos numero_fiscal NULL — filtro parcial, no debe tirar
+    }
+
+    // =========================================================================================
+    // Target 13 — ux_certificados_fiscales_activo: UNIQUE parcial (activo AND deleted_at IS NULL)
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnSegundoCertificadoActivoParaLaMismaEmpresaYAmbienteViolaLaUnicidad()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnSegundoCertificadoActivoParaLaMismaEmpresaYAmbienteViolaLaUnicidad));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using (var primero = ComandoInsertarCertificado(cruda, e, "cert-a"))
+        {
+            await primero.ExecuteNonQueryAsync();
+        }
+
+        await using var segundo = ComandoInsertarCertificado(cruda, e, "cert-b");
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => segundo.ExecuteNonQueryAsync());
+        Assert.Equal("23505", excepcion.SqlState);
+        Assert.Equal("ux_certificados_fiscales_activo", excepcion.ConstraintName);
+    }
+
+    [Fact]
+    public async Task UnCertificadoSoftDeletedNoViolaLaUnicidadDeActivo()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCertificadoSoftDeletedNoViolaLaUnicidadDeActivo));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using (var borrado = ComandoInsertarCertificado(cruda, e, "cert-borrado", deletedAt: DateTimeOffset.UtcNow))
+        {
+            await borrado.ExecuteNonQueryAsync();
+        }
+
+        await using var activo = ComandoInsertarCertificado(cruda, e, "cert-activo");
+        await activo.ExecuteNonQueryAsync(); // no debe tirar — el borrado no cuenta
+    }
+
+    [Fact]
+    public async Task UnCertificadoInactivoNoViolaLaUnicidadDeActivo()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnCertificadoInactivoNoViolaLaUnicidadDeActivo));
+        await using var cruda = await fixture.AbrirConexionCrudaAsync("tenant", e.IdTenant);
+
+        await using (var inactivo = ComandoInsertarCertificado(cruda, e, "cert-inactivo", activo: false))
+        {
+            await inactivo.ExecuteNonQueryAsync();
+        }
+
+        await using var activo = ComandoInsertarCertificado(cruda, e, "cert-activo-2");
+        await activo.ExecuteNonQueryAsync(); // no debe tirar — el inactivo no cuenta
+    }
+
+    // =========================================================================================
+    // Targets 14/15 — RLS cross-tenant, lectura Y escritura, en ambas tablas nuevas
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeLosCertificadosFiscalesPorSelect()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosCertificadosFiscalesPorSelect) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLosCertificadosFiscalesPorSelect) + "-B");
+
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant))
+        {
+            await using var insertar = ComandoInsertarCertificado(cruda, a, "cert-a");
+            await insertar.ExecuteNonQueryAsync();
+        }
+
+        await using var comoB = await fixture.AbrirConexionCrudaAsync("tenant", b.IdTenant);
+        await using var comando = comoB.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM certificados_fiscales WHERE id_tenant = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdTenant });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnInsertConIdTenantAjenoEnCertificadosFiscalesSeRechaza()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnCertificadosFiscalesSeRechaza) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnCertificadosFiscalesSeRechaza) + "-B");
+
+        await using var comoA = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant);
+        await using var comando = ComandoInsertarCertificado(comoA, b, "cert-ajeno"); // id_tenant/id_empresa de B, sesión de A
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    [Fact]
+    public async Task UnaSesionDeOtroTenantNoVeLasNumeracionesFiscalesPorSelect()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLasNumeracionesFiscalesPorSelect) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnaSesionDeOtroTenantNoVeLasNumeracionesFiscalesPorSelect) + "-B");
+
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant))
+        {
+            await using var insertar = ComandoInsertarNumeracionFiscal(cruda, a, codigoAfip: 1);
+            await insertar.ExecuteNonQueryAsync();
+        }
+
+        await using var comoB = await fixture.AbrirConexionCrudaAsync("tenant", b.IdTenant);
+        await using var comando = comoB.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM numeraciones_fiscales WHERE id_tenant = $1";
+        comando.Parameters.Add(new NpgsqlParameter { Value = a.IdTenant });
+
+        var total = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, total);
+    }
+
+    [Fact]
+    public async Task UnInsertConIdTenantAjenoEnNumeracionesFiscalesSeRechaza()
+    {
+        var a = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnNumeracionesFiscalesSeRechaza) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(UnInsertConIdTenantAjenoEnNumeracionesFiscalesSeRechaza) + "-B");
+
+        await using var comoA = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant);
+        await using var comando = ComandoInsertarNumeracionFiscal(comoA, b, codigoAfip: 1); // id_tenant de B, sesión de A
+
+        var excepcion = await Assert.ThrowsAsync<PostgresException>(() => comando.ExecuteNonQueryAsync());
+        Assert.Equal("42501", excepcion.SqlState);
+    }
+
+    // =========================================================================================
+    // Target 16 — AplicarFiltroDeTenantEnNumeracionFiscal (LINQ/EF)
+    // =========================================================================================
+
+    /// <summary>Proof a nivel EF (LINQ) de que el filtro de tenant manual bloquea
+    /// <see cref="NumeracionFiscal"/> (no hereda <c>EntidadTenant</c>) — mismo patrón que
+    /// <c>NumeracionesComprobanteRlsTests.ElFiltroDeEfNuncaDevuelveFilasDeOtroTenant</c>. Mutación
+    /// verificada a mano durante la implementación (mutation-proof-tests regla 2): comentar la
+    /// llamada a <c>AplicarFiltroDeTenantEnNumeracionFiscal</c> en <c>OnModelCreating</c> hace que
+    /// esta prueba deje de estar vacía (rojo), revertido después — evidencia en el PR body.</summary>
+    [Fact]
+    public async Task ElFiltroDeEfNuncaDevuelveNumeracionesFiscalesDeOtroTenant()
+    {
+        var a = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveNumeracionesFiscalesDeOtroTenant) + "-A");
+        var b = await SembrarEscenarioAsync(nameof(ElFiltroDeEfNuncaDevuelveNumeracionesFiscalesDeOtroTenant) + "-B");
+
+        await using (var cruda = await fixture.AbrirConexionCrudaAsync("tenant", a.IdTenant))
+        {
+            await using var insertar = ComandoInsertarNumeracionFiscal(cruda, a, codigoAfip: 1);
+            await insertar.ExecuteNonQueryAsync();
+        }
+
+        await using var sesionB = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, b.IdTenant));
+        var visibles = await sesionB.NumeracionesFiscales
+            .Where(n => n.IdPuntoVenta == a.IdPuntoVenta).ToListAsync();
+
+        Assert.Empty(visibles);
+    }
+
+    // =========================================================================================
+    // Target 17 — RechazarEscriturasDeNumeracionFiscal
+    // =========================================================================================
+
+    [Fact]
+    public async Task UnSaveChangesSobreUnaNumeracionFiscalTrackeadaTira()
+    {
+        var e = await SembrarEscenarioAsync(nameof(UnSaveChangesSobreUnaNumeracionFiscalTrackeadaTira));
+
+        await using var db = fixture.CrearContextoDeAplicacion(new TenantActualFijo(ModoDeAcceso.Tenant, e.IdTenant));
+        db.NumeracionesFiscales.Add(new NumeracionFiscal
+        {
+            IdPuntoVenta = e.IdPuntoVenta, CodigoAfip = 1, IdTenant = e.IdTenant, ProximoNumero = 1
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => db.SaveChangesAsync());
+    }
+
+    // =========================================================================================
+    // Targets 18/20 — data statements (net 1) sobre una base YA MIGRADA desde RemitosEtapa17
+    // =========================================================================================
+
+    private const string MigracionAnteriorAFiscalArcaEtapa19a = "20260820004658_RemitosEtapa17";
+
+    private static DbContextOptions<WaysDbContext> ConstruirOpcionesDeMigracion(string cadena) =>
+        new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(cadena, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<MotivoStock>("motivo_stock");
+                npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<TipoMovimientoCaja>("tipo_movimiento_caja");
+                npgsql.MapEnum<TipoMovimientoTesoreria>("tipo_movimiento_tesoreria");
+                npgsql.MapEnum<CategoriaGasto>("categoria_gasto");
+                npgsql.MapEnum<EstadoCompra>("estado_compra");
+                npgsql.MapEnum<TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
+                npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
+                npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
+            })
+            .Options;
+
+    [Fact]
+    public async Task LosTresDataStatementsAterrizanEnUnaBaseYaMigradaSinTocarFilasNiInsertarNinguna()
+    {
+        var nombreBase = $"ways_stage19a_ds_{Guid.NewGuid():N}";
+        var cadenaAdmin = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = "postgres" }.ConnectionString;
+        var cadenaNueva = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = nombreBase }.ConnectionString;
+
+        await using (var admin = new NpgsqlConnection(cadenaAdmin))
+        {
+            await admin.OpenAsync();
+            await using var crear = admin.CreateCommand();
+            crear.CommandText = $"CREATE DATABASE \"{nombreBase}\"";
+            await crear.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var opciones = ConstruirOpcionesDeMigracion(cadenaNueva);
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(MigracionAnteriorAFiscalArcaEtapa19a);
+            }
+
+            // Simula un catálogo real ya poblado ANTES de esta etapa (codigo_afip NULL en las 3
+            // tablas — la base ya tenía las filas desde la etapa 1, esta migración solo agrega
+            // el valor).
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+
+                async Task InsertarAsync(string sql)
+                {
+                    await using var comando = conexion.CreateCommand();
+                    comando.CommandText = sql;
+                    await comando.ExecuteNonQueryAsync();
+                }
+
+                foreach (var codigo in new[] { "FA", "FB", "FC", "NCA", "NCB", "NCC", "NDA", "TX" })
+                {
+                    await InsertarAsync(
+                        "INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, " +
+                        $"es_fiscal, afecta_stock, activo, created_at, updated_at) VALUES ('venta', '{codigo}', " +
+                        $"'{codigo}', 'A', 1, false, true, true, true, now(), now())");
+                }
+
+                foreach (var codigo in new[] { "RI", "MONOTRIBUTO", "EXENTO", "CF", "NO_RESP" })
+                {
+                    await InsertarAsync(
+                        $"INSERT INTO condiciones_fiscales (codigo, nombre, created_at, updated_at) " +
+                        $"VALUES ('{codigo}', '{codigo}', now(), now())");
+                }
+
+                foreach (var (nombre, porcentaje) in new (string, decimal)[]
+                    { ("21%", 21m), ("10.5%", 10.5m), ("27%", 27m), ("0%", 0m), ("Exento", 0m), ("No gravado", 0m) })
+                {
+                    await InsertarAsync(
+                        $"INSERT INTO alicuotas_iva (nombre, porcentaje, created_at, updated_at) " +
+                        $"VALUES ('{nombre}', {porcentaje.ToString(System.Globalization.CultureInfo.InvariantCulture)}, now(), now())");
+                }
+            }
+
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(); // aplica FiscalArcaEtapa19a — el seeder NUNCA corre acá
+            }
+
+            await using var verificacion = new NpgsqlConnection(cadenaNueva);
+            await verificacion.OpenAsync();
+
+            async Task<short?> LeerCodigoAfipAsync(string tabla, string columnaFiltro, string valorFiltro)
+            {
+                await using var comando = verificacion.CreateCommand();
+                comando.CommandText = $"SELECT codigo_afip FROM {tabla} WHERE {columnaFiltro} = $1";
+                comando.Parameters.Add(new NpgsqlParameter { Value = valorFiltro });
+                var resultado = await comando.ExecuteScalarAsync();
+                return resultado is DBNull or null ? null : (short)(short)resultado;
+            }
+
+            // DS1 — tipos_comprobante (target 18)
+            Assert.Equal((short)1, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "FA"));
+            Assert.Equal((short)2, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "NDA"));
+            Assert.Equal((short)3, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "NCA"));
+            Assert.Equal((short)6, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "FB"));
+            Assert.Equal((short)8, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "NCB"));
+            Assert.Equal((short)11, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "FC"));
+            Assert.Equal((short)13, await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "NCC"));
+            Assert.Null(await LeerCodigoAfipAsync("tipos_comprobante", "codigo", "TX")); // no fiscal, sin tocar
+
+            // DS2 — condiciones_fiscales (target 18)
+            Assert.Equal((short)1, await LeerCodigoAfipAsync("condiciones_fiscales", "codigo", "RI"));
+            Assert.Equal((short)4, await LeerCodigoAfipAsync("condiciones_fiscales", "codigo", "EXENTO"));
+            Assert.Equal((short)5, await LeerCodigoAfipAsync("condiciones_fiscales", "codigo", "CF"));
+            Assert.Equal((short)6, await LeerCodigoAfipAsync("condiciones_fiscales", "codigo", "MONOTRIBUTO"));
+            Assert.Equal((short)15, await LeerCodigoAfipAsync("condiciones_fiscales", "codigo", "NO_RESP"));
+
+            // DS3 — alicuotas_iva (targets 18 y 20: Exento/No gravado quedan NULL)
+            Assert.Equal((short)3, await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "0%"));
+            Assert.Equal((short)4, await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "10.5%"));
+            Assert.Equal((short)5, await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "21%"));
+            Assert.Equal((short)6, await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "27%"));
+            Assert.Null(await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "Exento"));
+            Assert.Null(await LeerCodigoAfipAsync("alicuotas_iva", "nombre", "No gravado"));
+
+            // CERO filas insertadas/activadas/desactivadas — mismos conteos que antes de migrar.
+            async Task<long> ContarAsync(string tabla)
+            {
+                await using var comando = verificacion.CreateCommand();
+                comando.CommandText = $"SELECT count(*) FROM {tabla}";
+                return (long)(await comando.ExecuteScalarAsync())!;
+            }
+
+            Assert.Equal(8, await ContarAsync("tipos_comprobante"));
+            Assert.Equal(5, await ContarAsync("condiciones_fiscales"));
+            Assert.Equal(6, await ContarAsync("alicuotas_iva"));
+        }
+        finally
+        {
+            await using var admin = new NpgsqlConnection(cadenaAdmin);
+            await admin.OpenAsync();
+            await using var dropear = admin.CreateCommand();
+            dropear.CommandText = $"DROP DATABASE IF EXISTS \"{nombreBase}\" WITH (FORCE)";
+            await dropear.ExecuteNonQueryAsync();
+        }
+    }
+
+    // =========================================================================================
+    // Target 19 — cada seed net (fresh DB, InicializadorDeBaseDeDatos) probado independientemente
+    // =========================================================================================
+
+    [Fact]
+    public async Task LaBaseFrescaSiembraElCodigoAfipDeLosTresCatalogosDesdeLosSeedNets()
+    {
+        using var _ = fixture.CreateClient(); // arranca el host: siembra los tres catálogos fiscales
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        async Task<short?> CodigoAfipDeAsync(IQueryable<short?> query) => await query.FirstAsync();
+
+        Assert.Equal((short)1, await CodigoAfipDeAsync(db.TiposComprobante.Where(t => t.Codigo == "FA").Select(t => t.CodigoAfip)));
+        Assert.Equal((short)6, await CodigoAfipDeAsync(db.TiposComprobante.Where(t => t.Codigo == "FB").Select(t => t.CodigoAfip)));
+        Assert.Null(await CodigoAfipDeAsync(db.TiposComprobante.Where(t => t.Codigo == "TX").Select(t => t.CodigoAfip)));
+
+        Assert.Equal((short)1, await CodigoAfipDeAsync(db.CondicionesFiscales.Where(c => c.Codigo == "RI").Select(c => c.CodigoAfip)));
+        Assert.Equal((short)15, await CodigoAfipDeAsync(db.CondicionesFiscales.Where(c => c.Codigo == "NO_RESP").Select(c => c.CodigoAfip)));
+
+        Assert.Equal((short)5, await CodigoAfipDeAsync(db.AlicuotasIva.Where(a => a.Nombre == "21%").Select(a => a.CodigoAfip)));
+        Assert.Null(await CodigoAfipDeAsync(db.AlicuotasIva.Where(a => a.Nombre == "Exento").Select(a => a.CodigoAfip)));
+        Assert.Null(await CodigoAfipDeAsync(db.AlicuotasIva.Where(a => a.Nombre == "No gravado").Select(a => a.CodigoAfip)));
+    }
+
+    // =========================================================================================
+    // Target 21 [S] — ix_empresas_condicion_fiscal es SIMPLE, no liderado por id_tenant
+    // =========================================================================================
+
+    [Fact]
+    public async Task IxEmpresasCondicionFiscalEsSimpleNoLideradaPorIdTenant()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        var def = await ObtenerIndexDefAsync(cruda, "empresas", "ix_empresas_condicion_fiscal");
+        Assert.Contains("btree (id_condicion_fiscal)", def);
+        Assert.DoesNotContain("id_tenant", def);
+    }
+
+    // =========================================================================================
+    // Target 22 [S] — Up → Down → Up, has-pending-model-changes limpio en cada leg
+    // =========================================================================================
+
+    [Fact]
+    public async Task UpDownUpEsLimpioYRevierteExactamenteElCodigoAfipQueSeteo()
+    {
+        var nombreBase = $"ways_stage19a_updownup_{Guid.NewGuid():N}";
+        var cadenaAdmin = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = "postgres" }.ConnectionString;
+        var cadenaNueva = new NpgsqlConnectionStringBuilder(fixture.OwnerConnectionString) { Database = nombreBase }.ConnectionString;
+
+        await using (var admin = new NpgsqlConnection(cadenaAdmin))
+        {
+            await admin.OpenAsync();
+            await using var crear = admin.CreateCommand();
+            crear.CommandText = $"CREATE DATABASE \"{nombreBase}\"";
+            await crear.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var opciones = ConstruirOpcionesDeMigracion(cadenaNueva);
+
+            // Up hasta HEAD (incluye FiscalArcaEtapa19a) — sin seeder: solo migraciones.
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync();
+
+                Assert.False(db.Database.HasPendingModelChanges());
+            }
+
+            async Task<short?> LeerAsync(string sql)
+            {
+                await using var conexion = new NpgsqlConnection(cadenaNueva);
+                await conexion.OpenAsync();
+                await using var comando = conexion.CreateCommand();
+                comando.CommandText = sql;
+                var resultado = await comando.ExecuteScalarAsync();
+                return resultado is DBNull or null ? null : (short)(short)resultado;
+            }
+
+            // Como la base fresca no pasó por el seeder de la aplicación (Up() del migrator
+            // crudo), las tres catálogos están vacías tras las migraciones — se siembra una fila
+            // mínima por tabla a mano para poder observar el revert exacto.
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+                await using var comando = conexion.CreateCommand();
+                comando.CommandText =
+                    "INSERT INTO tipos_comprobante (clase, codigo, nombre, letra, signo, discrimina_iva, es_fiscal, afecta_stock, activo, codigo_afip, created_at, updated_at) " +
+                    "VALUES ('venta', 'FA', 'Factura A', 'A', 1, true, true, true, true, 1, now(), now())";
+                await comando.ExecuteNonQueryAsync();
+            }
+
+            Assert.Equal((short)1, await LeerAsync("SELECT codigo_afip FROM tipos_comprobante WHERE codigo = 'FA'"));
+
+            // Down — revierte FiscalArcaEtapa19a exactamente.
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync(MigracionAnteriorAFiscalArcaEtapa19a);
+            }
+
+            Assert.Null(await LeerAsync("SELECT codigo_afip FROM tipos_comprobante WHERE codigo = 'FA'"));
+
+            await using (var conexion = new NpgsqlConnection(cadenaNueva))
+            {
+                await conexion.OpenAsync();
+                await using var comandoTablas = conexion.CreateCommand();
+                comandoTablas.CommandText =
+                    "SELECT count(*) FROM information_schema.tables WHERE table_name IN ('certificados_fiscales','numeraciones_fiscales')";
+                Assert.Equal(0L, (long)(await comandoTablas.ExecuteScalarAsync())!);
+
+                await using var comandoTipo = conexion.CreateCommand();
+                comandoTipo.CommandText = "SELECT count(*) FROM pg_type WHERE typname IN ('resultado_fiscal', 'ambiente_fiscal')";
+                Assert.Equal(0L, (long)(await comandoTipo.ExecuteScalarAsync())!);
+            }
+
+            // Up otra vez — reaplica FiscalArcaEtapa19a; limpio de nuevo.
+            await using (var db = new WaysDbContext(opciones, TenantActualFijo.Plataforma))
+            {
+                var migrador = db.Database.GetInfrastructure().GetRequiredService<IMigrator>();
+                await migrador.MigrateAsync();
+
+                Assert.False(db.Database.HasPendingModelChanges());
+            }
+        }
+        finally
+        {
+            await using var admin = new NpgsqlConnection(cadenaAdmin);
+            await admin.OpenAsync();
+            await using var dropear = admin.CreateCommand();
+            dropear.CommandText = $"DROP DATABASE IF EXISTS \"{nombreBase}\" WITH (FORCE)";
+            await dropear.ExecuteNonQueryAsync();
+        }
+    }
+
+    // =========================================================================================
+    // Target 23 [S] — NumeracionFiscalConfiguration: nombres de índice explícitos
+    // =========================================================================================
+
+    [Fact]
+    public async Task LosDosIndicesDeNumeracionesFiscalesTienenNombreExplicitoSnakeCase()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var cruda = new NpgsqlConnection(fixture.OwnerConnectionString);
+        await cruda.OpenAsync();
+
+        var defTenant = await ObtenerIndexDefAsync(cruda, "numeraciones_fiscales", "ix_numeraciones_fiscales_tenant");
+        Assert.Contains("btree (id_tenant)", defTenant);
+
+        var defPuntoVenta = await ObtenerIndexDefAsync(cruda, "numeraciones_fiscales", "ix_numeraciones_fiscales_punto_venta");
+        Assert.Contains("btree (id_punto_venta, id_tenant)", defPuntoVenta);
+
+        // Sin este nombramiento explícito, EF autogeneraría el índice de soporte de la FK
+        // compuesta con su convención PascalCase (mismo trap que NumeracionComprobanteConfiguration
+        // documenta): ninguna fila con "IX_" debe existir.
+        await using var comando = cruda.CreateCommand();
+        comando.CommandText = "SELECT count(*) FROM pg_indexes WHERE tablename = 'numeraciones_fiscales' AND indexname LIKE 'IX\\_%'";
+        var autogenerados = (long)(await comando.ExecuteScalarAsync())!;
+        Assert.Equal(0, autogenerados);
+    }
+
+    // =========================================================================================
+    // Non-regression (task 1.48) — ServicioDeVentas.cs untouched this slice
+    // =========================================================================================
+
+    [Fact]
+    public void ServicioDeVentasQuedaByteIdenticoEnEstaSlice()
+    {
+        var salida = EjecutarGit("diff", "--exit-code", "--", "src/Ways.Application/Ventas/ServicioDeVentas.cs");
+        Assert.Equal(0, salida.CodigoDeSalida);
+    }
+
+    private static (int CodigoDeSalida, string Salida) EjecutarGit(params string[] argumentos)
+    {
+        var raiz = Path.Combine(Path.GetDirectoryName(RutaDeEsteArchivo())!, "..", "..");
+        var proceso = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = raiz,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        foreach (var argumento in argumentos)
+        {
+            proceso.StartInfo.ArgumentList.Add(argumento);
+        }
+        proceso.Start();
+        var salida = proceso.StandardOutput.ReadToEnd();
+        proceso.WaitForExit();
+        return (proceso.ExitCode, salida);
+    }
+
+    // =========================================================================================
+    // GATE GUARD (task 1.49) — exactamente una migración, has-pending-model-changes limpio,
+    // cero ALTER TYPE ADD VALUE, índices = 8, CHECKs = 8 — todo por definición
+    // =========================================================================================
+
+    [Fact]
+    public void ExisteExactamenteUnaMigracionDeEstaEtapaYEsLaUltima()
+    {
+        var directorioMigraciones = Path.Combine(
+            Path.GetDirectoryName(RutaDeEsteArchivo())!,
+            "..", "..", "src", "Ways.Infrastructure", "Persistencia", "Migraciones");
+
+        // Filtro por prefijo de timestamp (14 dígitos + '_'): excluye WaysDbContextModelSnapshot.cs
+        // (único archivo no-migración del directorio), que además ordenaría alfabéticamente
+        // DESPUÉS de toda migración ('W' > cualquier dígito en ASCII) y rompería la aserción de
+        // "última migración" si no se excluyera.
+        var archivos = Directory.GetFiles(directorioMigraciones, "*.cs")
+            .Select(Path.GetFileName)
+            .Where(n => n is not null && !n.EndsWith(".Designer.cs", StringComparison.Ordinal)
+                && System.Text.RegularExpressions.Regex.IsMatch(n, @"^\d{14}_"))
+            .Select(n => n!)
+            .OrderBy(n => n)
+            .ToList();
+
+        var fiscales = archivos.Where(n => n.Contains("FiscalArcaEtapa19a")).ToList();
+        Assert.Single(fiscales);
+
+        Assert.Equal(fiscales[0], archivos[^1]); // la última migración del repo, por orden de timestamp
+    }
+
+    [Fact]
+    public async Task LaBaseCompartidaNoTienePendingModelChangesDespuesDeMigrarYSembrar()
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        Assert.False(db.Database.HasPendingModelChanges());
+    }
+}

--- a/tests/Ways.IntegrationTests/ManejadorDeErroresFiscalTests.cs
+++ b/tests/Ways.IntegrationTests/ManejadorDeErroresFiscalTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Ways.Api.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// stage-19a-slice1 (task 1.22, db-error-backstops, mutation targets 4-13): mismo patrón
+/// unit-style que <see cref="ManejadorDeErroresRemitosTests"/> — sin <c>WaysApiFixture</c> ni
+/// Postgres real, la <see cref="PostgresException"/> se construye "a mano". No hay endpoint
+/// todavía en esta slice (el ABM de certificados y la emisión fiscal llegan en slices 4/5) para
+/// ejercer el round-trip HTTP completo; las diez ramas nuevas (2 × <c>23505</c> + 8 ×
+/// <c>23514</c>) se prueban acá contra el <c>ManejadorDeErrores</c> real.
+/// </summary>
+public class ManejadorDeErroresFiscalTests
+{
+    private sealed class ServicioDeProblemDetailsFalso : IProblemDetailsService
+    {
+        public ProblemDetailsContext? Ultimo { get; private set; }
+
+        public ValueTask<bool> TryWriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.FromResult(true);
+        }
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            Ultimo = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static PostgresException CrearExcepcion(string sqlState, string constraintName) =>
+        new(
+            messageText: "mensaje de prueba",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: null,
+            columnName: null,
+            dataTypeName: null,
+            constraintName: constraintName,
+            file: null,
+            line: null,
+            routine: null);
+
+    private static async Task<(int Estado, string? Codigo)> ManejarAsync(Exception excepcion)
+    {
+        var servicioDeProblemDetails = new ServicioDeProblemDetailsFalso();
+        var manejador = new ManejadorDeErrores(servicioDeProblemDetails, NullLogger<ManejadorDeErrores>.Instance);
+        var contexto = new DefaultHttpContext();
+
+        var manejado = await manejador.TryHandleAsync(contexto, excepcion, CancellationToken.None);
+
+        Assert.True(manejado);
+        Assert.NotNull(servicioDeProblemDetails.Ultimo);
+
+        var problema = servicioDeProblemDetails.Ultimo!.ProblemDetails;
+        return (contexto.Response.StatusCode, problema.Extensions["codigo"] as string);
+    }
+
+    // ---- ux_puntos_venta_numero_fiscal (el trap de ordering, SEXTA ocurrencia) -----------------
+
+    /// <summary>Mutation target #12: prueba tanto el camino EF (<c>DbUpdateException</c>) como el
+    /// camino raw-ADO (<c>PostgresException</c> pelada).</summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UxPuntosVentaNumeroFiscalGanaLaRamaNuevaAntesQueLaFamiliaGenericaDeNumero(bool caminoRawAdo)
+    {
+        var postgres = CrearExcepcion("23505", "ux_puntos_venta_numero_fiscal");
+        Exception excepcion = caminoRawAdo ? postgres : new DbUpdateException("dup", postgres);
+
+        var (estado, codigo) = await ManejarAsync(excepcion);
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("numero_fiscal_duplicado", codigo);
+        // La prueba negativa que cierra el trap: NUNCA el código genérico de ux_clientes_numero
+        // — sin la rama exacta ANTES de ClasificarUnicidad, la substring "_numero" la atraparía
+        // primero.
+        Assert.NotEqual("numero_duplicado", codigo);
+    }
+
+    [Fact]
+    public async Task UxCertificadosFiscalesActivoSeTraduceA409CertificadoFiscalActivoDuplicado()
+    {
+        var postgres = CrearExcepcion("23505", "ux_certificados_fiscales_activo");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("dup", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("certificado_fiscal_activo_duplicado", codigo);
+    }
+
+    // ---- ClasificarCheckDeFiscal (detrás del guard SqlState 23514) — OCHO ramas -----------------
+
+    [Fact]
+    public async Task CkPuntosVentaNumeroFiscalRangoSeTraduceA400NumeroFiscalInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_puntos_venta_numero_fiscal_rango");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("numero_fiscal_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkComprobantesVentaFiscalCoherenteSeTraduceA409ComprobanteFiscalIncoherente()
+    {
+        var postgres = CrearExcepcion("23514", "ck_comprobantes_venta_fiscal_coherente");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("comprobante_fiscal_incoherente", codigo);
+    }
+
+    [Fact]
+    public async Task CkComprobantesVentaCaeDigitosSeTraduceA400CaeInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_comprobantes_venta_cae_digitos");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("cae_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkCertificadosFiscalesVigenciaSeTraduceA400VigenciaDeCertificadoInvalida()
+    {
+        var postgres = CrearExcepcion("23514", "ck_certificados_fiscales_vigencia");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("vigencia_de_certificado_invalida", codigo);
+    }
+
+    [Fact]
+    public async Task CkCertificadosFiscalesCuitSeTraduceA400CuitTitularInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_certificados_fiscales_cuit");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("cuit_titular_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkCertificadosFiscalesMaterialSeTraduceA400MaterialDeClaveInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_certificados_fiscales_material");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("material_de_clave_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkNumeracionesFiscalesRangoSeTraduceA400NumeroFiscalDeSerieInvalido()
+    {
+        var postgres = CrearExcepcion("23514", "ck_numeraciones_fiscales_rango");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("numero_fiscal_de_serie_invalido", codigo);
+    }
+
+    [Fact]
+    public async Task CkNumeracionesFiscalesSincronizacionSeTraduceA409NumeracionFiscalSincronizacionIncoherente()
+    {
+        var postgres = CrearExcepcion("23514", "ck_numeraciones_fiscales_sincronizacion");
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("check", postgres));
+
+        Assert.Equal(StatusCodes.Status409Conflict, estado);
+        Assert.Equal("numeracion_fiscal_sincronizacion_incoherente", codigo);
+    }
+
+    // ---- FKs nuevas: el match genérico por prefijo "fk_" ya las cubre, sin cambio de código -----
+
+    [Theory]
+    [InlineData("fk_empresas_condicion_fiscal")]
+    [InlineData("fk_certificados_fiscales_tenant")]
+    [InlineData("fk_certificados_fiscales_empresa")]
+    [InlineData("fk_numeraciones_fiscales_tenant")]
+    [InlineData("fk_numeraciones_fiscales_punto_venta")]
+    public async Task CadaFkNuevaSeTraduceA400ReferenciaInvalida(string nombreDeFk)
+    {
+        var postgres = CrearExcepcion("23503", nombreDeFk);
+        var (estado, codigo) = await ManejarAsync(new DbUpdateException("fk", postgres));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, estado);
+        Assert.Equal("referencia_invalida", codigo);
+    }
+
+    // ---- PK compuesta exenta: solo alcanzable por INSERT crudo/fuera de banda -------------------
+
+    [Fact]
+    public async Task PkNumeracionesFiscalesSinRamaDe23505CaeAlDefaultDe500()
+    {
+        var postgres = CrearExcepcion("23505", "pk_numeraciones_fiscales");
+        var (estado, _) = await ManejarAsync(new DbUpdateException("pk", postgres));
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, estado);
+    }
+}

--- a/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
+++ b/tests/Ways.IntegrationTests/OfertasResolucionTests.cs
@@ -544,6 +544,8 @@ public class OfertasResolucionTests(WaysApiFixture fixture) : IClassFixture<Ways
                 npgsql.MapEnum<TipoDocumento>("tipo_documento");
                 npgsql.MapEnum<ModoLista>("modo_lista");
                 npgsql.MapEnum<UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/PagosACuentaTests.cs
+++ b/tests/Ways.IntegrationTests/PagosACuentaTests.cs
@@ -643,6 +643,8 @@ public class PagosACuentaTests(WaysApiFixture fixture) : IClassFixture<WaysApiFi
                 npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
+++ b/tests/Ways.IntegrationTests/PlanDeVentaFefoTests.cs
@@ -413,6 +413,8 @@ public class PlanDeVentaFefoTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contadorTotal, contadorDeLotes)
             .Options;

--- a/tests/Ways.IntegrationTests/PresupuestosSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/PresupuestosSchemaTests.cs
@@ -13,6 +13,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -761,6 +762,8 @@ public class PresupuestosSchemaTests(WaysApiFixture fixture) : IClassFixture<Way
                     npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                     npgsql.MapEnum<EstadoRemito>("estado_remito");
+                    npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 })
                 .Options;
 
@@ -859,6 +862,8 @@ public class PresupuestosSchemaTests(WaysApiFixture fixture) : IClassFixture<Way
                     npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                     npgsql.MapEnum<EstadoRemito>("estado_remito");
+                    npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/ReliquidacionTests.cs
+++ b/tests/Ways.IntegrationTests/ReliquidacionTests.cs
@@ -688,6 +688,8 @@ public class ReliquidacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
                 npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
+++ b/tests/Ways.IntegrationTests/RemitosSchemaTests.cs
@@ -11,6 +11,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -991,6 +992,8 @@ public class RemitosSchemaTests(WaysApiFixture fixture) : IClassFixture<WaysApiF
                     npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                     npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                     npgsql.MapEnum<EstadoRemito>("estado_remito");
+                    npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                    npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 })
                 .Options;
 

--- a/tests/Ways.IntegrationTests/RotacionReporteTests.cs
+++ b/tests/Ways.IntegrationTests/RotacionReporteTests.cs
@@ -426,6 +426,8 @@ public class RotacionReporteTests(WaysApiFixture fixture) : IClassFixture<WaysAp
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
+++ b/tests/Ways.IntegrationTests/SaldoDeProveedorTests.cs
@@ -452,6 +452,8 @@ public class SaldoDeProveedorTests(WaysApiFixture fixture) : IClassFixture<WaysA
                 // MovimientosCuentaCorrienteProveedor (re-sourcing OD7) — este contexto
                 // manually-curated necesita el mapeo o Npgsql no sabe traducir el enum.
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCcProveedor>("tipo_movimiento_cc_proveedor");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeFacturacionDeRemitosTests.cs
@@ -15,6 +15,7 @@ using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Stock;
@@ -404,6 +405,8 @@ public class ServicioDeFacturacionDeRemitosTests(WaysApiFixture fixture) : IClas
                 npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<Ways.Domain.Ventas.EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;

--- a/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeRemitosTests.cs
@@ -14,6 +14,7 @@ using Ways.Domain.Articulos;
 using Ways.Domain.Caja;
 using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Precios;
 using Ways.Domain.Stock;
@@ -951,6 +952,8 @@ public class ServicioDeRemitosTests(WaysApiFixture fixture) : IClassFixture<Ways
                 npgsql.MapEnum<Ways.Domain.Compras.EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<Ways.Domain.Ventas.EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;

--- a/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeVentasConversionTests.cs
@@ -715,6 +715,8 @@ public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFix
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;
@@ -772,6 +774,8 @@ public class ServicioDeVentasConversionTests(WaysApiFixture fixture) : IClassFix
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
+++ b/tests/Ways.IntegrationTests/TransferenciaLoteTests.cs
@@ -859,6 +859,8 @@ public class TransferenciaLoteTests(WaysApiFixture fixture) : IClassFixture<Ways
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;

--- a/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
+++ b/tests/Ways.IntegrationTests/VentaEscrituraLoteTests.cs
@@ -356,6 +356,8 @@ public class VentaEscrituraLoteTests(WaysApiFixture fixture) : IClassFixture<Way
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;

--- a/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
+++ b/tests/Ways.IntegrationTests/VentasCheckoutTests.cs
@@ -895,6 +895,8 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;
@@ -1089,6 +1091,8 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contadorDeParametros)
             .Options;
@@ -1178,6 +1182,8 @@ public class VentasCheckoutTests(WaysApiFixture fixture) : IClassFixture<WaysApi
                 npgsql.MapEnum<MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
+++ b/tests/Ways.IntegrationTests/VentasTurnoWiringTests.cs
@@ -285,6 +285,8 @@ public class VentasTurnoWiringTests(WaysApiFixture fixture) : IClassFixture<Ways
                 npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
                 npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
                 npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual), contador)
             .Options;

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -15,6 +15,7 @@ using Ways.Domain.Catalogos;
 using Ways.Domain.Clientes;
 using Ways.Domain.Compras;
 using Ways.Domain.CuentaCorriente;
+using Ways.Domain.Fiscal;
 using Ways.Domain.Gastos;
 using Ways.Domain.Organizacion;
 using Ways.Domain.Stock;
@@ -218,6 +219,8 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
                 npgsql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(3), null);
             })
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
@@ -256,6 +259,8 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;
@@ -295,6 +300,8 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<EstadoOrdenCompra>("estado_orden_compra");
                 npgsql.MapEnum<EstadoPresupuesto>("estado_presupuesto");
                 npgsql.MapEnum<EstadoRemito>("estado_remito");
+                npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
             .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
             .Options;


### PR DESCRIPTION
## Resumen

Slice 1 de la sub-etapa 19a (fiscal ARCA sin credenciales): el schema fiscal completo bajo el gate RATIFICADO — la primera migración desde la etapa 17, y la primera migración grande del programa SIN NINGÚN artefacto irreversible (cero `ALTER TYPE ADD VALUE`: los dos `CREATE TYPE` se revierten limpios y el ciclo Up→Down→Up está probado contra base real descartable).

- Migración `FiscalArcaEtapa19a`: `resultado_fiscal`/`ambiente_fiscal` (orden de ciclo de vida corregido a mano — la lección de EF de las etapas 12/17), `empresas.id_condicion_fiscal` NULLABLE SIN DEFAULT (la letra jamás se decide en silencio), `puntos_venta.numero_fiscal` con su UNIQUE PARCIAL portante, 4 columnas CAE en `comprobantes_venta` con CHECKs de coherencia, `certificados_fiscales` (18 col, RLS, un-activo-por-empresa+ambiente) y `numeraciones_fiscales` (espejo línea a línea de su hermana), 3 data statements de `codigo_afip` con DOBLE RED y reverts doblemente guardeados, RLS al final.
- 10 ramas nuevas de `ManejadorDeErrores` (la trampa del ORDEN auto-cazada por el apply: las ramas exactas ANTES del clasificador genérico — 6ta ocurrencia de la familia `_numero`).
- El guard fiscal del POS INTOCADO (decisión 9): `ServicioDeVentas.cs` ausente del diff, la venta fantasma fiscal testeada como está.
- Desviación registrada: NO_RESP → `codigo_afip` 15 (RG 5616), provisional hasta 19b, con nota vinculante para el slice 5 (el rechazo decide por `Codigo`, jamás por `CodigoAfip`).
- 16 regresiones de fixtures preexistentes arregladas con el patrón correcto (la primera columna nueva de `empresas`/`puntos_venta` desde la etapa 1 — `MapEnum` es per-connection, clase documentada).

## Judgment-day (ronda limpia)

- **Juez B (mutador) APPROVE**: 5 spot-checks de los 23 targets reproducen RED (incl. el reorden del `Down()` → `2BP01` exacto) + el mutante extra del orden de `ManejadorDeErrores` RED en ambos caminos; 1 MINOR de etiquetado (target 1 → `[S]` por equivalencia de runtime: `MapEnum` resuelve por nombre) + honestidad del doble guard, fixes `1df54ac`.
- **Juez A (read-only) APPROVE con CERO hallazgos**: el contrato del gate verificado columna por columna, FK por FK, CHECK por CHECK, indexdef por indexdef; consistencia triple de NO_RESP; docs 09/10 fieles con el header abierto según regla 19.

## Suites

- `FiscalSchemaTests` + `ManejadorDeErroresFiscalTests`: 63/63 · Application 297/297 · full Integration **1674/1674** (re-corrida aislada regla 17) · `has-pending-model-changes` limpio · la migración nueva es la ÚNICA y la última.

🤖 Generated with [Claude Code](https://claude.com/claude-code)