### PR TITLE
feat(fiscal): numeracion fiscal, cifrado de certificados y la policy AdministracionFiscal (19a, slice 4)

### DIFF
--- a/openspec/changes/stage-19-fiscal-arca/specs/certificados-fiscales/spec.md
+++ b/openspec/changes/stage-19-fiscal-arca/specs/certificados-fiscales/spec.md
@@ -27,8 +27,10 @@ policy, admitting only `RolConocido.Admin`.
 
 `clave_privada_cifrada` MUST be encrypted with `System.Security.Cryptography.AesGcm` using an AAD
 composed of `id_tenant | id_empresa | ambiente | huella_sha256`, so the ciphertext is authenticated
-against its own row identity. The master key MUST come from configuration/environment
-(`Ways:Fiscal:ClaveMaestra`) and MUST NEVER be stored in the database or the repository.
+against its own row identity. The master key MUST come from configuration/environment, versioned
+(`Ways:Fiscal:ClaveMaestraActual` names the active key id; `Ways:Fiscal:ClavesMaestras:<id>` holds
+the 32-byte base64 key for that id — design D6) and MUST NEVER be stored in the database or the
+repository.
 
 #### Scenario: A certificate's private key round-trips through AES-GCM
 - GIVEN a certificate registered with its private key encrypted under its row's AAD
@@ -42,7 +44,8 @@ against its own row identity. The master key MUST come from configuration/enviro
 - THEN `AesGcm` decryption fails — the AAD no longer matches the row identity
 
 #### Scenario: A missing master key makes the fiscal path inert, never a plaintext fallback
-- GIVEN `Ways:Fiscal:ClaveMaestra` is unset or unreadable
+- GIVEN `Ways:Fiscal:ClaveMaestraActual` (or its resolved `Ways:Fiscal:ClavesMaestras:<id>`) is
+  unset, too short, or otherwise unreadable
 - WHEN any fiscal signing operation is attempted
 - THEN it fails loudly (409/503) — the system never decrypts to, or falls back to, plaintext
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -901,7 +901,7 @@ the same rows.
 - [x] 4.23 Mutation evidence recorded in the PR body for targets 52-63 (**S** rows 55, 60 record
   the assertion, not a runtime failure). See "Work Unit Evidence" table below for the full
   per-target log.
-- [ ] 4.24 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
+- [x] 4.24 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
   **judgment-day Slice 4 (19a), ronda 1 — juez B (3 MAJOR test-only; la 3ra ocurrencia de la clase
   GET-authz cierra con guard estructural), fixes aplicados por el jd-fix-agent** (checkbox sin
@@ -935,6 +935,16 @@ the same rows.
     desapercibido — la metadata de `IAuthorizeData` del grupo sigue presente, es el middleware el
     que la ignora en runtime). Ciclo: mutante del juez (`.AllowAnonymous()` en el `MapGet` de
     `FiscalEndpoints.cs`) → RED por el guard nuevo Y por los cuatro tests de rol → revert → verde.
+  **CERRADO POR EL ORQUESTADOR**: ronda 1 juez B REJECT (3 MAJOR test-only: D13 sin test — el
+  auto-heal sobrevivía; la carrera que serializaba por suerte — resuelta con el rendezvous REAL
+  de interceptor; el GET sin authz — 3ra ocurrencia de la clase, cerrada con el TERCER guard
+  estructural de superficies) → fixes `48a4ed8` → re-ronda B APPROVE. Ronda 2 juez A REJECT
+  (1 CRITICAL: la CryptographicException PELADA ante ciphertext corrupto contra el contrato del
+  propio doc-comment → certificado_fiscal_ilegible 409 opaco; + Created, PFX zeroeado, spec
+  versionado, borde de segmento) → fixes `fb70eec` + COMPLECIÓN `2dddb53` (arbitraje del
+  orquestador: el finally no cubría el camino de CargarPfx — cazado por la pasada acotada de B,
+  el try movido antes de la carga, probado byte a byte) → confirmación B APPROVE + re-ronda A
+  APPROVE (cero hallazgos). Ronda limpia.
 
   **judgment-day Slice 4 (19a), ronda 2 — juez A (1 CRITICAL + 3 WARNINGs + 1 SUGGESTION), fixes
   aplicados por el jd-fix-agent** (checkbox sin marcar hasta que el re-judge confirme ronda limpia,

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -66,6 +66,16 @@ no-key-material scan (design.md:576-578).
    `IAlmacenDeClavesFiscales`/`CertificadoFiscalDto` → Slice 4 — each later slice **extending** the
    same `Contratos.cs` file rather than redefining it. Registered per the stage-17 process-rule
    precedent (every deviation registered, never left to verify-phase archaeology).
+7. **`specs/certificados-fiscales/spec.md` master-key config name — drift corrected, per the
+   stage-15 parallel-phase-drift precedent (every drift registered, never silently patched).**
+   `proposal.md`/`design.md:70` (D6) and the shipped `CifradoDeClavesFiscales` implementation both
+   use the **versioned** shape `Ways:Fiscal:ClaveMaestraActual` (an id) +
+   `Ways:Fiscal:ClavesMaestras:<id>` (the 32-byte base64 key for that id) — the spec's Requirement
+   "The Private Key Is Encrypted With AES-256-GCM Bound To Its Own Row" instead named a single
+   unversioned `Ways:Fiscal:ClaveMaestra`, an earlier (pre-D6) shape that never shipped. Found by
+   judgment-day 19a-slice-4 ronda 2 juez A (WARNING). The spec is amended in place to the shipped
+   versioned shape — this is the active change's own artifact, not a downstream document, so the
+   correction lands directly rather than through a follow-up change.
 
 ## Binding Verify Criteria (all slices)
 
@@ -925,6 +935,50 @@ the same rows.
     desapercibido — la metadata de `IAuthorizeData` del grupo sigue presente, es el middleware el
     que la ignora en runtime). Ciclo: mutante del juez (`.AllowAnonymous()` en el `MapGet` de
     `FiscalEndpoints.cs`) → RED por el guard nuevo Y por los cuatro tests de rol → revert → verde.
+
+  **judgment-day Slice 4 (19a), ronda 2 — juez A (1 CRITICAL + 3 WARNINGs + 1 SUGGESTION), fixes
+  aplicados por el jd-fix-agent** (checkbox sin marcar hasta que el re-judge confirme ronda limpia,
+  regla 18):
+  - **CRITICAL** (`CryptographicException` pelada — `UsarCertificadoAsync` sin `catch`; una clave
+    maestra RESOLUBLE contra un ciphertext corrupto/manipulado propagaba la excepción cruda de
+    `AesGcm`, contradiciendo el contrato de `IAlmacenDeClavesFiscales:42-43`): `catch
+    (CryptographicException)` alrededor de la llamada a `Descifrar` en
+    `CifradoDeClavesFiscales.UsarCertificadoAsync`, traducido a un código NOMBRADO nuevo y opaco —
+    `409 certificado_fiscal_ilegible` — con mensaje neutro que NO distingue clave-equivocada de
+    fila-manipulada (esa distinción sería una fuga de información útil para un atacante sondeando
+    filas). Doc-comment del contrato (`IAlmacenDeClavesFiscales.cs`) actualizado para nombrar AMBOS
+    códigos honestos: `certificado_fiscal_ausente` (ausente) y `certificado_fiscal_ilegible`
+    (ilegible). Test nuevo
+    `UsarCertificadoAsyncConCiphertextCorruptoTraduceLaExcepcionDeCryptoAlErrorNombrado`
+    (`CifradoDeClavesFiscalesTests.cs`) — clave maestra resoluble, fila sembrada con un byte del
+    ciphertext flipeado. Ciclo: quitar el `catch` → RED (`AuthenticationTagMismatchException` cruda,
+    no `ErrorDominio`) → revert → verde.
+  - **WARNING** (POST 200 en vez de la convención `Results.Created` del resto del repo — 12 archivos
+    citados por el juez): `FiscalEndpoints.cs`'s `MapPost("/")` ahora devuelve
+    `Results.Created($"/api/fiscal/certificados/{creado.Id}", creado)`. Los cinco asserts de
+    `ServicioDeCertificadosTests.cs` que esperaban `HttpStatusCode.OK` tras un alta exitosa pasan a
+    `HttpStatusCode.Created`. Ciclo: revertir a la lambda síncrona (200) → RED
+    (`UnAdminEsAceptadoAlRegistrarUnCertificadoFiscal`: `Expected: Created, Actual: OK`) → re-aplicar
+    → verde.
+  - **WARNING** (el PFX sin zeroear — `ServicioDeCertificados.RegistrarAsync` solo limpiaba
+    `clavePrivada`, nunca `datos.Pfx`, igual de sensible): `CryptographicOperations.ZeroMemory(datos.Pfx)`
+    agregado al mismo `finally`. El password (`string` inmutable de .NET) documentado como límite
+    honesto en el doc-comment de `RegistroDeCertificadoFiscal` — no se puede zerear de forma
+    confiable, y no se finge una garantía que no existe. Test estructural nuevo
+    `RegistrarAsyncLimpiaLaClavePrivadaYElPfxEnUnFinally` (`CifradoDeClavesFiscalesTests.cs` —
+    ningún test estructural cubría este archivo todavía, se agrega siguiendo el mismo patrón
+    source-read + `Contains` discriminante del test de `UsarCertificadoAsync`). Ciclo: quitar la
+    línea `ZeroMemory(datos.Pfx)` → RED (`Contains` no encuentra el string) → revert → verde.
+  - **WARNING** (drift preexistente pero del artefacto activo — `spec.md` nombraba
+    `Ways:Fiscal:ClaveMaestra` sin versionar, contra D6/implementación real
+    `Ways:Fiscal:ClaveMaestraActual` + `Ways:Fiscal:ClavesMaestras:<id>`): `spec.md` enmendado in
+    place al shape versionado real (Requirement body + su scenario). Enmienda registrada como
+    Reconciliación 7 de este mismo archivo, per el precedente de stage-15 (todo drift se registra,
+    nunca se parchea en silencio).
+  - **SUGGESTION** (el borde de segmento en `SuperficieDeAutorizacionTests.cs:341-346` — `StartsWith`
+    crudo dejaría que un futuro `/api/fiscalizacion` cayera bajo el prefijo `/api/fiscal` solo por
+    compartir caracteres; fallaba cerrado pero era una trampa): matcheo por segmento —
+    `patron.Equals(prefijo, ...) || patron.StartsWith(prefijo + "/", ...)`.
 - [ ] 4.25 [ ] Open PR #4 `feat/stage19a-slice4-numeracion-y-certificados`, merge to `main` after a
   clean `judgment-day` round.
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -893,6 +893,38 @@ the same rows.
   per-target log.
 - [ ] 4.24 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
+  **judgment-day Slice 4 (19a), ronda 1 — juez B (3 MAJOR test-only; la 3ra ocurrencia de la clase
+  GET-authz cierra con guard estructural), fixes aplicados por el jd-fix-agent** (checkbox sin
+  marcar hasta que el re-judge confirme ronda limpia, regla 18):
+  - **MAJOR** (D13 sin test — el auto-heal de `proximo_numero` en `ReconciliarAsync` sobrevivía
+    9/9): nuevo test dedicado `ReconciliarUnaSerieConDeudaPreviaNoTocaElProximoNumero`
+    (`AsignadorDeNumeroFiscalTests.cs`), con deuda previa NO trivial (regla 11: `proximo_numero`
+    arranca en 4 — tres asignaciones ya comiteadas —, `ultimoAutorizadoArca = 2`, ninguno es 1 ni
+    coincide con lo que produciría el auto-heal). Ciclo: mutante del juez
+    (`proximo_numero = $1 + 1` agregado al `UPDATE` de `ReconciliarAsync`) → RED (`Expected: 4,
+    Actual: 3`) → revert → verde.
+  - **MAJOR** (la carrera que serializaba por suerte — `Task.WhenAll` desnudo sin rendezvous real):
+    `DosAsignacionesConcurrentesDeLaMismaSerieDanNumerosDistintosYConsecutivos` reescrito con
+    `InterceptorDeRendezvousEnAmbasTransacciones` (mismo patrón que
+    `InterceptorDeRendezvousEnLaSegundaTransaccion` de `ServicioDeVentasConversionTests.cs:437`,
+    adaptado: acá hay UNA sola transacción por contexto, no dos, así que el barrier retiene la
+    PRIMERA `TransactionStartedAsync` hasta que la SEGUNDA también arrancó). El entrelazado SÍ fue
+    forzable por interceptor para este camino — no hizo falta el precedente del 40P01. Ciclo:
+    mutante lost-update del juez (`SELECT proximo_numero` sin lock + `UPDATE` separado, en vez del
+    `UPDATE ... RETURNING` atómico) → RED bajo el rendezvous (`Assert.NotEqual` — ambas tareas
+    devolvieron 1, la carrera real de lost-update) → revert → verde.
+  - **MAJOR** (el GET sin authz test — 3ra ocurrencia de la clase, después de
+    `/api/catalogos-fiscales` y `/api/presupuestos`): (a) matriz de roles agregada a
+    `ServicioDeCertificadosTests.cs` para `GET /api/fiscal/certificados` (Admin 200; Supervisor/
+    Vendedor/Root 403; anónimo 401). (b) TERCER guard estructural en
+    `SuperficieDeAutorizacionTests.cs` —
+    `TodoEndpointGetBajoSuperficiesMasEstrictasQueOperacionDePosApilaSuPolicyExigida` — con un
+    registro de prefijos `(Prefijo, PolicyExigida)` (`/api/fiscal` → `AdministracionFiscal`) y un
+    walker que exige tanto la policy exacta como la AUSENCIA de `IAllowAnonymous` (sin ese segundo
+    chequeo, `.AllowAnonymous()` sobre un endpoint que ya heredaba la policy del grupo pasaría
+    desapercibido — la metadata de `IAuthorizeData` del grupo sigue presente, es el middleware el
+    que la ignora en runtime). Ciclo: mutante del juez (`.AllowAnonymous()` en el `MapGet` de
+    `FiscalEndpoints.cs`) → RED por el guard nuevo Y por los cuatro tests de rol → revert → verde.
 - [ ] 4.25 [ ] Open PR #4 `feat/stage19a-slice4-numeracion-y-certificados`, merge to `main` after a
   clean `judgment-day` round.
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -808,67 +808,138 @@ the same rows.
   **producción** rotates; (d) an already-inactive row untouched (affected-row count, not final
   state); (e) a soft-deleted twin neither resurrected nor counted.
 
-- [ ] 4.1 Create `src/Ways.Application/Fiscal/AsignadorDeNumeroFiscal.cs` — `AsegurarContadorAsync`
+- [x] 4.1 Create `src/Ways.Application/Fiscal/AsignadorDeNumeroFiscal.cs` — `AsegurarContadorAsync`
   (`INSERT … ON CONFLICT DO NOTHING`) + `AsignarSiguienteAsync` (`UPDATE … RETURNING`), raw ADO on
   the caller's connection, discipline **opposite** to `AsignadorDeNumeroComprobante` (D1, proposal
   decision 13). *(design.md:284-307, 372)* — implements U1
-- [ ] 4.2 Same file: reconciliation against `FECompUltimoAutorizado` — writes **only**
+- [x] 4.2 Same file: reconciliation against `FECompUltimoAutorizado` — writes **only**
   `ultimo_autorizado_arca` + `sincronizado_en`, divergence raises `409
   numeracion_fiscal_desincronizada`, **never** auto-heals `proximo_numero` (D13).
   *(design.md D13:77)* — implements U3
-- [ ] 4.3 Create `src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs` — AES-256-GCM, AAD =
+- [x] 4.3 Create `src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs` — AES-256-GCM, AAD =
   `UTF8("v1|"+idTenant+"|"+idEmpresa+"|"+ambiente+"|"+huellaSha256)` **excluding**
   `id_clave_maestra` (D5), key versioning via `id_clave_maestra`, `ZeroMemory` in a `finally`.
-  *(design.md D5:69, 379)*
-- [ ] 4.4 Same file: master-key lookup — `Ways:Fiscal:ClaveMaestraActual` +
+  *(design.md D5:69, 379)* **RESUME FIX (this apply, mutation-proof-tests rule 2 "run it, don't
+  reason it")**: the interrupted apply's own mutation cycle for target 60 surfaced a real gap —
+  `UsarCertificadoAsync`'s `finally` zeroed only `claveMaestra` (the key that OPENS the row), never
+  `clavePrivadaPlana` (the decrypted RSA private key itself, the actually sensitive buffer the
+  method exists to protect). A stray marker comment (`// MUTANTE TEMPORAL (target 60): NO
+  commitear.`) was the only trace left in the source, with no accompanying code mutation — the
+  gap was real, not a leftover test artifact. Fixed: `finally` now zeroes both buffers
+  (`clavePrivadaPlana` guarded by a null check, since a `Descifrar` failure leaves it unset).
+  Target 60's structural test strengthened to assert both variable names discriminately (see task
+  4.17). Live cycle: reverted the fix → `UsarCertificadoAsyncLimpiaElBufferDescifradoEnUnFinally`
+  RED (`Not found: "ZeroMemory(clavePrivadaPlana)"`) → restored → green (71/71 Fiscal namespace).
+- [x] 4.4 Same file: master-key lookup — `Ways:Fiscal:ClaveMaestraActual` +
   `Ways:Fiscal:ClavesMaestras:<id>`; missing/short/absent ⇒ `503 clave_maestra_ausente` on the ABM /
   `409 certificado_fiscal_ausente` on emission, **never** a plaintext fallback or generated-on-boot
   key (D6). *(design.md D6:70)*
-- [ ] 4.5 Create `src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs`. Modify `Contratos.cs` —
+- [x] 4.5 Create `src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs`. Modify `Contratos.cs` —
   `CertificadoFiscalDto` with **no** key-material property. *(design.md:262-267, 371)*
-- [ ] 4.6 Create `src/Ways.Application/Fiscal/ServicioDeCertificados.cs` — register/list (never
+- [x] 4.6 Create `src/Ways.Application/Fiscal/ServicioDeCertificados.cs` — register/list (never
   returning key material)/deactivate; rotation = deactivate+activate inside one transaction.
-  *(proposal.md §707, design.md file changes)* — implements U4
-- [ ] 4.7 Create `src/Ways.Api/Endpoints/FiscalEndpoints.cs` (certificate ABM routes only this
+  *(proposal.md §707, design.md file changes)* — implements U4. **DEVIATION (registered)**: the
+  U4 `UPDATE` itself lives in a sibling static class, `DesactivadorDeCertificadoFiscal` (same
+  precedent as `AsignadorDeNumeroFiscal`/`SobreSoap` — no `InternalsVisibleTo` in the repo, so a
+  `public static` method is what lets the five U4 kills be tested directly from
+  `Ways.IntegrationTests` without going through the full PFX+encryption flow of `RegistrarAsync`
+  for every conjunct). `id_tenant` travels explicit in that `WHERE` (unlike U1/U3, which rely
+  entirely on RLS) — defense in depth for the table holding key material, documented in the
+  class's own doc-comment.
+- [x] 4.7 Create `src/Ways.Api/Endpoints/FiscalEndpoints.cs` (certificate ABM routes only this
   slice) — `POST`/`GET`/`DELETE /api/fiscal/certificados`, `PUT
   /api/fiscal/empresas/{id}/condicion-fiscal`, `PUT
   /api/fiscal/puntos-venta/{id}/numero-fiscal`, all under `AdministracionFiscal`. *(proposal.md
   API surface 705-710)*
-- [ ] 4.8 Modify `src/Ways.Api/Seguridad/Politicas.cs` — **+1** exact policy `AdministracionFiscal`
+- [x] 4.8 Modify `src/Ways.Api/Seguridad/Politicas.cs` — **+1** exact policy `AdministracionFiscal`
   (Admin only). 11 → **12**. *(proposal.md §684, design.md fact 7:54-56, Binding Verify Criterion
-  11)*
-- [ ] 4.9 [P] U1 conjunct (a) `id_punto_venta` — sibling-PV test (rule 12c). *(target 52)*
-- [ ] 4.10 [P] U1 conjunct (b) `codigo_afip` — sibling-type test on the same PV. *(target 53)*
-- [ ] 4.11 [P] I1 test — a `rechazado` emission does **not** advance the series: number stays
+  11)* Confirmed by count: `grep -c "public const string"` → **12**.
+- [x] 4.9 [P] U1 conjunct (a) `id_punto_venta` — sibling-PV test (rule 12c). *(target 52)*
+- [x] 4.10 [P] U1 conjunct (b) `codigo_afip` — sibling-type test on the same PV. *(target 53)*
+- [x] 4.11 [P] I1 test — a `rechazado` emission does **not** advance the series: number stays
   bound, `proximo_numero` consistent, no hole. *(target 54)*
-- [ ] 4.12 **[S]** D1 lock proof — `pg_locks` polled from a second connection: `numeraciones_fiscales`
+- [x] 4.12 **[S]** D1 lock proof — `pg_locks` polled from a second connection: `numeraciones_fiscales`
   is the **first and only** existing-row lock of the fiscal transaction (both halves asserted, rule
   13). *(target 55)*
-- [ ] 4.13 [P] U3 conjuncts (a)(b) — sibling pair, the neighbour's `ultimo_autorizado_arca` stays
+- [x] 4.13 [P] U3 conjuncts (a)(b) — sibling pair, the neighbour's `ultimo_autorizado_arca` stays
   `NULL`. *(target 56)*
-- [ ] 4.14 [P] AAD four-component tamper test — one per component (tenant, empresa, ambiente,
+- [x] 4.14 [P] AAD four-component tamper test — one per component (tenant, empresa, ambiente,
   huella), each failing authentication. *(target 57)*
-- [ ] 4.15 [P] AAD **excludes** `id_clave_maestra` — rotation test: a re-encrypted row must still
+- [x] 4.15 [P] AAD **excludes** `id_clave_maestra` — rotation test: a re-encrypted row must still
   decrypt. *(target 58)*
-- [ ] 4.16 [P] No-plaintext-fallback test — missing/short master key ⇒ the named error, **nothing**
+- [x] 4.16 [P] No-plaintext-fallback test — missing/short master key ⇒ the named error, **nothing**
   written. *(target 59)*
-- [ ] 4.17 **[S]** `CryptographicOperations.ZeroMemory` structural assertion — `UsarCertificadoAsync`
-  clears its buffer in a `finally`. *(target 60)*
-- [ ] 4.18 [P] U4 conjuncts (a)-(e) — five kills: cross-tenant `ways_app`; sibling empresa; sibling
+- [x] 4.17 **[S]** `CryptographicOperations.ZeroMemory` structural assertion — `UsarCertificadoAsync`
+  clears its buffer in a `finally`. *(target 60)* **STRENGTHENED (this apply)**: the original
+  assertion only checked that the substring `"CryptographicOperations.ZeroMemory"` appeared
+  somewhere in the `finally` block — true even with the real gap in place (only `claveMaestra`
+  zeroed). Now asserts both `ZeroMemory(claveMaestra)` and `ZeroMemory(clavePrivadaPlana)` appear,
+  discriminately. See task 4.3's note for the live mutation cycle that proves the kill.
+- [x] 4.18 [P] U4 conjuncts (a)-(e) — five kills: cross-tenant `ways_app`; sibling empresa; sibling
   ambiente; already-inactive row (affected-row count); soft-deleted twin. *(target 61)*
-- [ ] 4.19 [P] Certificate DTO exposure clause — recursive property-**name** assertion, no
+- [x] 4.19 [P] Certificate DTO exposure clause — recursive property-**name** assertion, no
   `ClavePrivadaCifrada`/`Nonce`/`TagAutenticacion`/`CertificadoPem`/`ClaveMaestra` property anywhere
   in the serialized response. *(target 62)*
-- [ ] 4.20 [P] `AdministracionFiscal` role matrix — Admin 200, Supervisor/Vendedor/Root 403;
+- [x] 4.20 [P] `AdministracionFiscal` role matrix — Admin 200, Supervisor/Vendedor/Root 403;
   `Politicas.cs` count 11 → 12. *(target 63)*
-- [ ] 4.21 Non-regression: full suite green, `ServicioDeVentas.cs` untouched.
-- [ ] 4.22 GATE GUARD — zero new migrations this slice; `has-pending-model-changes` clean.
-- [ ] 4.23 Mutation evidence recorded in the PR body for targets 52-63 (**S** rows 55, 60 record
-  the assertion, not a runtime failure).
+- [x] 4.21 Non-regression: full suite green, `ServicioDeVentas.cs` untouched. `git diff --exit-code
+  src/Ways.Application/Ventas/ServicioDeVentas.cs` clean (file absent from this slice's diff
+  entirely). See Work Unit Evidence below for the full-suite counts.
+- [x] 4.22 GATE GUARD — zero new migrations this slice; `has-pending-model-changes` clean. Confirmed:
+  `git status` under `Migraciones/` empty; `dotnet ef migrations has-pending-model-changes` → "No
+  changes have been made to the model since the last migration."
+- [x] 4.23 Mutation evidence recorded in the PR body for targets 52-63 (**S** rows 55, 60 record
+  the assertion, not a runtime failure). See "Work Unit Evidence" table below for the full
+  per-target log.
 - [ ] 4.24 [ ] `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a
   clean round.
 - [ ] 4.25 [ ] Open PR #4 `feat/stage19a-slice4-numeracion-y-certificados`, merge to `main` after a
   clean `judgment-day` round.
+
+### Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Mode | Standard (no `strict_tdd` config found; `mutation-proof-tests` v1.1 discipline followed — see per-target mutation log below) |
+| Focused test command | `dotnet test tests/Ways.Application.Tests --filter "FullyQualifiedName~Fiscal"` → **71/71 passed** (56 pre-existing from slices 2-3 + 15 new for `CifradoDeClavesFiscalesTests`); `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~AsignadorDeNumeroFiscalTests\|FullyQualifiedName~ServicioDeCertificadosTests"` → **24/24 passed**, real Postgres 17 Testcontainer |
+| Runtime harness | Testcontainers Postgres 17 via `WaysApiFixture`, `ways_app` role for the RLS/lock-order/conjunct tests; a second raw `NpgsqlConnection` polling `pg_locks` for target 55 (D1's two-sided proof); an in-memory `IConfiguration` for the pure-crypto and no-master-key tests (no DB needed) |
+| `dotnet build --no-incremental` | Full solution (`Ways.slnx`, all 7 projects) built clean — 0 errors, 2 pre-existing unrelated `NU1903` warnings (SSH.NET, not touched by this slice) |
+| `dotnet ef migrations has-pending-model-changes` | Clean — "No changes have been made to the model since the last migration." Zero files under `Migraciones/` touched (`git status` confirmed) |
+| Full suite (non-regression, task 4.21) | `Ways.Domain.Tests`: **545/545** (identical to slice 3's baseline — zero domain changes this slice). `Ways.Application.Tests`: **364/364** (353 baseline + 11 net new). `Ways.IntegrationTests` (full run, Docker Testcontainers, real Postgres 17, per rule 17 — this slice edits production DI wiring in both `Ways.Application/DependencyInjection.cs` and `Ways.Infrastructure/DependencyInjection.cs` plus `Program.cs`/`Politicas.cs`): first run **1687/1698**, 11 failed with a `Docker.DotNet`/`ChunkedReadStream` HTTP-stream stack trace (Testcontainers daemon-connectivity flakiness, not application logic — no test name in the failure output pointed at a fiscal/application assertion); isolated re-run per rule 17 (`--logger trx`, single run, no concurrent suite against the same Docker daemon): **1698/1698 passed**, 0 failed, 12 m 44 s — identical total count to slice 3's baseline (1674) + this slice's 24 new integration tests = 1698, confirming zero regression |
+| Rollback boundary | `git revert` — `numeraciones_fiscales` is empty in production (nothing has been emitted yet, slice 5 is the first caller), `certificados_fiscales` has no row until an owner uploads one via the new ABM, `Politicas.cs`'s addition is one `public const` + one `AddPolicy` block; reverting removes `src/Ways.Api/Endpoints/FiscalEndpoints.cs`, `src/Ways.Application/Fiscal/{AsignadorDeNumeroFiscal,DesactivadorDeCertificadoFiscal,IAlmacenDeClavesFiscales,ServicioDeCertificados}.cs`, `src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs`, the `Contratos.cs`/`Politicas.cs`/both `DependencyInjection.cs`/`Program.cs` additions, and `tests/**/Fiscal/{CifradoDeClavesFiscalesTests,AsignadorDeNumeroFiscalTests,ServicioDeCertificadosTests}.cs` — nothing outside those paths |
+
+**Resumption note (this apply)**: this work unit resumes an interrupted `sdd-apply` — the previous
+agent had written the full implementation and was mid-cycle proving target 60's mutation when it
+was stopped. Audit on resume found **one real production gap** (task 4.3/4.17: `clavePrivadaPlana`
+never zeroed in `UsarCertificadoAsync`'s `finally`, only `claveMaestra` was) plus a stray marker
+comment with no accompanying code mutation — the working tree was **not** left in a mutated state
+otherwise; every other file matched its own doc-comments/tests on inspection and by running the
+full non-regression suites clean. No other checkbox, file, or test needed rework.
+
+#### Mutation evidence log (targets 52-63)
+
+Every non-**S** target below is proven by a real Postgres/crypto assertion whose passing is
+impossible without the guarded conjunct in place — sibling/neighbour rows are seeded, and the test
+reads them back over the real connection (by construction, mutation-proof-tests rule 4: dropping
+any one conjunct from the `WHERE`/AAD would let the sibling assertion fail). Target 60 was proven
+by an actual live mutation cycle during this resumed apply (see task 4.3's note) because it is the
+one target where the interrupted agent's own evidence trail showed a real gap, not a hypothetical
+one.
+
+| Target | Kill proven by | Reverted, confirmed green |
+|---|---|---|
+| 52 **S1 conjunct (a)** | `AsignarSobreUnPuntoDeVentaNoTocaElProximoNumeroDeUnPuntoDeVentaHermano` — PV-B's `proximo_numero` stays 1 while PV-A advances to 2; removing the `id_punto_venta` conjunct from the `UPDATE` would advance both | By construction |
+| 53 **U1 conjunct (b)** | `AsignarSobreUnCodigoAfipNoTocaElProximoNumeroDeOtroCodigoAfipDelMismoPuntoDeVenta` — `FB`'s counter stays 1 while `FA` advances; removing the `codigo_afip` conjunct would advance both | By construction |
+| 54 | `UnNumeroComiteadoPorUnaEmisionQueTerminaRechazadaNoSeLiberaYElSiguienteEsConsecutivo` — two committed assignments are strictly consecutive regardless of the first's fiscal outcome; `UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco` proves the ONLY release path is an uncommitted rollback | By construction |
+| 55 **S** | `LaTransaccionDeAsignacionSostieneSoloElLockDeNumeracionesFiscales` — real `pg_locks` poll from a second connection while the first is held open: `numeraciones_fiscales` present, `turnos_caja`/`stock`/`stock_lotes`/`clientes` absent, both halves in one assertion set (rule 13) | Structural — the poll itself is the assertion, run against real Postgres |
+| 56 **U3 conjuncts (a)(b)** | `ReconciliarUnaSerieNoTocaElUltimoAutorizadoDeUnPuntoDeVentaHermano` + `...DeUnCodigoAfipHermano` — the neighbour's `ultimo_autorizado_arca` stays `NULL` after reconciling the other row | By construction |
+| 57 | Four independent `MoverElCiphertext…FallaLaAutenticacion` tests — moving the ciphertext to another tenant/empresa/ambiente/huella each throws `AuthenticationTagMismatchException` from real `AesGcm.Decrypt` | By construction (AES-GCM's own authentication, not a mocked check) |
+| 58 | `UnaFilaCifradaConUnaVersionDeClaveMaestraSigueDescifrandoTrasRotarLaClaveActual` — a row encrypted under `v1` while `v1` was "current" still decrypts after `v2` becomes "current", proving the AAD (and the lookup) key off the row's own `id_clave_maestra`, never the system's "current" pointer | By construction |
+| 59 | `CifrarAsyncSinClaveMaestraConfiguradaTira…` (absent) + `…ConUnaClaveMaestraDeMenosDe32BytesTira…` (short) + `UsarCertificadoAsyncSinCertificadoActivoTira…` + `RegistrarSinClaveMaestraConfiguradaNoEscribeNingunaFila` (ABM-level reassertion: zero rows written) — all four assert the named error, never a bare `CryptographicException`/plaintext write | By construction |
+| 60 **S** | `UsarCertificadoAsyncLimpiaElBufferDescifradoEnUnFinally`, **strengthened this apply** — **live-run**: reverted the `clavePrivadaPlana` zeroing → RED (`Not found: "ZeroMemory(clavePrivadaPlana)"`) → restored → green | Yes — live mutation, not by construction (see task 4.3) |
+| 61 **U4 conjuncts (a)-(e)** | `ConjuncoIdTenant_UnTenantAjenoNoPuedeDesactivarLaFilaDeOtroTenant` (a, via RLS under a tenant-B EF context — 0 rows affected); `ConjuntoIdEmpresa_UnaEmpresaHermanaMantieneSuCertificadoActivo` (b); `ConjuntoAmbiente_ElCertificadoDeProduccionSigueActivoMientrasHomologacionRota` (c); `ConjuntoActivo_UnCertificadoYaInactivoNoSeCuentaComoAfectado` (d, asserted on the affected-row count per rule 4, not final state); `ConjuntoDeletedAt_UnGemeloDadoDeBajaNiSeResucitaNiSeCuenta` (e) | By construction, five independent seeded siblings |
+| 62 | `ListarCertificadosNuncaExponeMaterialDeClave` — recursive property-name walk over the live JSON response after a real registration; none of `clavePrivadaCifrada`/`nonce`/`tagAutenticacion`/`certificadoPem`/`claveMaestra` appear anywhere, case-insensitive | By construction (the DTO record has no such property to leak in the first place — `Contratos.cs`) |
+| 63 | `UnAdminEsAceptadoAlRegistrarUnCertificadoFiscal` (200) + `UnSupervisorOVendedorEsRechazadoAlRegistrarUnCertificadoFiscal` (Theory, 403×2) + `UnRootEsRechazadoAlRegistrarUnCertificadoFiscal` (403) + the condición-fiscal Admin/Vendedor pair + `Politicas.cs`'s `public const string` count confirmed **12** by `grep -c` | By construction + direct count |
 
 ---
 

--- a/openspec/changes/stage-19-fiscal-arca/tasks.md
+++ b/openspec/changes/stage-19-fiscal-arca/tasks.md
@@ -969,6 +969,22 @@ the same rows.
     ningún test estructural cubría este archivo todavía, se agrega siguiendo el mismo patrón
     source-read + `Contains` discriminante del test de `UsarCertificadoAsync`). Ciclo: quitar la
     línea `ZeroMemory(datos.Pfx)` → RED (`Contains` no encuentra el string) → revert → verde.
+    **COMPLECIÓN del fix 3 (arbitraje del orquestador — el `finally` no cubría el camino de
+    `CargarPfx`; confirmado por la pasada acotada de B)**: el `try` que agregó el `ZeroMemory(datos.Pfx)`
+    arrancaba DESPUÉS de `CargarPfx(datos.Pfx, datos.PasswordPfx)` y del `GetRSAPrivateKey() ?? throw`
+    — el camino de fallo más probable del ABM (password incorrecta → `pfx_invalido`) y el de PFX sin
+    clave RSA quedaban AMBOS fuera del `finally`. Movido el `try` para que arranque antes de
+    `CargarPfx` (`clavePrivada` declarada `byte[]?` fuera del `try`, zeroeada solo si fue asignada —
+    `CryptographicOperations.ZeroMemory` acepta `null` como span vacío, no hace falta el null-check
+    explícito en el `finally`). Doc-comment de `Contratos.cs:120-134` corregido para nombrar
+    explícitamente que el zeroing cubre TODOS los caminos de salida, incluidos ambos fallos
+    tempranos. Test nuevo `RegistrarConPasswordIncorrectaLimpiaElBufferPfxAunqueFalleLaCarga`
+    (`ServicioDeCertificadosTests.cs`, integración): password incorrecta → `pfx_invalido` Y el
+    array `datos.Pfx` (misma referencia que conserva el caller) queda todo-cero tras la llamada.
+    Ciclo: mutante restaurando el `try` tardío → RED (`Assert.Equal(0, b)` falla, el buffer conserva
+    bytes ≠0 tras el fallo de password) → revert → verde. `CifradoDeClavesFiscalesTests` (12/12) y
+    `ServicioDeCertificadosTests` (21/21) completos, verdes; `dotnet build --no-incremental` limpio
+    (0 errores).
   - **WARNING** (drift preexistente pero del artefacto activo — `spec.md` nombraba
     `Ways:Fiscal:ClaveMaestra` sin versionar, contra D6/implementación real
     `Ways:Fiscal:ClaveMaestraActual` + `Ways:Fiscal:ClavesMaestras:<id>`): `spec.md` enmendado in

--- a/src/Ways.Api/Endpoints/FiscalEndpoints.cs
+++ b/src/Ways.Api/Endpoints/FiscalEndpoints.cs
@@ -19,9 +19,12 @@ public static class FiscalEndpoints
             .WithTags("Fiscal")
             .RequireAuthorization(Politicas.AdministracionFiscal);
 
-        certificados.MapPost("/", (
+        certificados.MapPost("/", async (
             ServicioDeCertificados servicio, RegistroDeCertificadoFiscal datos, CancellationToken ct) =>
-            servicio.RegistrarAsync(datos, ct))
+        {
+            var creado = await servicio.RegistrarAsync(datos, ct);
+            return Results.Created($"/api/fiscal/certificados/{creado.Id}", creado);
+        })
         .WithSummary("Registra (o rota, si ya hay uno activo) un certificado fiscal.");
 
         certificados.MapGet("/", (ServicioDeCertificados servicio, CancellationToken ct) =>

--- a/src/Ways.Api/Endpoints/FiscalEndpoints.cs
+++ b/src/Ways.Api/Endpoints/FiscalEndpoints.cs
@@ -1,0 +1,61 @@
+using Ways.Api.Seguridad;
+using Ways.Application.Fiscal;
+
+namespace Ways.Api.Endpoints;
+
+/// <summary>
+/// El ABM de certificados fiscales + la carga de condición fiscal de empresa / número fiscal de
+/// punto de venta (stage-19a, Slice 4; proposal.md API surface 705-710) — las TRES rutas van bajo
+/// <see cref="Politicas.AdministracionFiscal"/> (solo Admin, target 63). La emisión fiscal en sí
+/// (<c>POST /api/fiscal/comprobantes</c>, <c>.../reintentar</c>) llega en Slice 5, bajo
+/// <see cref="Politicas.OperacionDePos"/> — un grupo de ruta distinto, esta clase solo mapea la
+/// mitad de configuración de esta slice.
+/// </summary>
+public static class FiscalEndpoints
+{
+    public static IEndpointRouteBuilder MapearFiscal(this IEndpointRouteBuilder app)
+    {
+        var certificados = app.MapGroup("/api/fiscal/certificados")
+            .WithTags("Fiscal")
+            .RequireAuthorization(Politicas.AdministracionFiscal);
+
+        certificados.MapPost("/", (
+            ServicioDeCertificados servicio, RegistroDeCertificadoFiscal datos, CancellationToken ct) =>
+            servicio.RegistrarAsync(datos, ct))
+        .WithSummary("Registra (o rota, si ya hay uno activo) un certificado fiscal.");
+
+        certificados.MapGet("/", (ServicioDeCertificados servicio, CancellationToken ct) =>
+            servicio.ListarAsync(ct))
+        .WithSummary("Lista los certificados fiscales — nunca expone material de clave.");
+
+        certificados.MapDelete("/{id:int}", async (
+            ServicioDeCertificados servicio, int id, CancellationToken ct) =>
+        {
+            await servicio.DesactivarAsync(id, ct);
+            return Results.NoContent();
+        })
+        .WithSummary("Desactiva un certificado fiscal.");
+
+        var fiscal = app.MapGroup("/api/fiscal")
+            .WithTags("Fiscal")
+            .RequireAuthorization(Politicas.AdministracionFiscal);
+
+        fiscal.MapPut("/empresas/{id:int}/condicion-fiscal", async (
+            ServicioDeCertificados servicio, int id, CondicionFiscalDeEmpresaEdicion datos, CancellationToken ct) =>
+        {
+            await servicio.ActualizarCondicionFiscalDeEmpresaAsync(id, datos.IdCondicionFiscal, ct);
+            return Results.NoContent();
+        })
+        .WithSummary("Carga la condición fiscal (ARCA) del emisor sobre una empresa.");
+
+        fiscal.MapPut("/puntos-venta/{id:int}/numero-fiscal", async (
+            ServicioDeCertificados servicio, int id, NumeroFiscalDePuntoVentaEdicion datos, CancellationToken ct) =>
+        {
+            await servicio.ActualizarNumeroFiscalDePuntoVentaAsync(id, datos.NumeroFiscal, ct);
+            return Results.NoContent();
+        })
+        .WithSummary("Carga el punto de venta ARCA de un punto de venta interno.");
+
+        return app;
+    }
+}

--- a/src/Ways.Api/Program.cs
+++ b/src/Ways.Api/Program.cs
@@ -187,6 +187,9 @@ app.MapearPresupuestos();
 app.MapearRemitos();
 app.MapearReportes();
 app.MapearAuditoria();
+// stage-19a-slice4: ABM de certificados fiscales + condición fiscal de empresa / número fiscal de
+// PV, bajo Politicas.AdministracionFiscal. La emisión fiscal en sí llega en Slice 5.
+app.MapearFiscal();
 
 // Cualquier ruta que no sea /api la resuelve el router de React.
 // Una /api/... inexistente tiene que dar 404, no devolver el index.html.

--- a/src/Ways.Api/Seguridad/Politicas.cs
+++ b/src/Ways.Api/Seguridad/Politicas.cs
@@ -91,6 +91,16 @@ public static class Politicas
     /// sube el gate.</summary>
     public const string SupervisionDeCuentaDeProveedor = "supervision_cuenta_proveedor";
 
+    /// <summary>Solo admin — la puerta del ABM de certificados fiscales y de la carga de
+    /// condición fiscal de empresa / número fiscal de punto de venta (stage-19a, Slice 4;
+    /// design.md fact 7, proposal.md §H). Riesgo genuinamente nuevo: material de clave
+    /// privada cifrado más la identidad legal del emisor ante ARCA — mismo criterio de la
+    /// etapa 15 que separó <see cref="LecturaDeAuditoria"/> de <see cref="LecturaDeRentabilidad"/>
+    /// en vez de reusar <see cref="GestionDeCatalogo"/>. Root queda afuera (root administra
+    /// tenants, no opera ninguno); la EMISIÓN fiscal en sí (slice 5) va bajo
+    /// <see cref="OperacionDePos"/> — esta policy es solo la puerta de configuración/ABM.</summary>
+    public const string AdministracionFiscal = "administracion_fiscal";
+
     public static AuthorizationBuilder AgregarPoliticasWays(this AuthorizationBuilder builder)
     {
         return builder
@@ -150,6 +160,9 @@ public static class Politicas
                         .RequireClaim(
                             ClaimsWays.RolId,
                             ((int)RolConocido.Supervisor).ToString(),
-                            ((int)RolConocido.Admin).ToString()));
+                            ((int)RolConocido.Admin).ToString()))
+            .AddPolicy(AdministracionFiscal, politica =>
+                politica.RequireAuthenticatedUser()
+                        .RequireClaim(ClaimsWays.RolId, ((int)RolConocido.Admin).ToString()));
     }
 }

--- a/src/Ways.Application/DependencyInjection.cs
+++ b/src/Ways.Application/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Ways.Application.Clientes;
 using Ways.Application.Compras;
 using Ways.Application.CuentaCorriente;
 using Ways.Application.Etiquetas;
+using Ways.Application.Fiscal;
 using Ways.Application.Gastos;
 using Ways.Application.Ofertas;
 using Ways.Application.Organizacion;
@@ -146,6 +147,11 @@ public static class DependencyInjection
         // stage-11-exportacion-reportes, Slice 9 (proposal decisión 10, droppable a Etapa 13):
         // existencias — LINQ puro sobre stock ⋈ articulos, sin dependencia de LectorDeSerieTemporal.
         services.AddScoped<ServicioDeReportesDeStock>();
+
+        // stage-19a-slice4: el ABM de certificados fiscales bajo Politicas.AdministracionFiscal —
+        // IAlmacenDeClavesFiscales se registra del lado de Infrastructure (DependencyInjection.cs),
+        // que es donde vive la implementación concreta del cifrado (CifradoDeClavesFiscales).
+        services.AddScoped<ServicioDeCertificados>();
 
         return services;
     }

--- a/src/Ways.Application/Fiscal/AsignadorDeNumeroFiscal.cs
+++ b/src/Ways.Application/Fiscal/AsignadorDeNumeroFiscal.cs
@@ -1,0 +1,121 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+
+namespace Ways.Application.Fiscal;
+
+/// <summary>
+/// Asigna <c>numeraciones_fiscales.proximo_numero</c> por serie ARCA — <c>(id_punto_venta,
+/// codigo_afip)</c> — con la disciplina OPUESTA de <see cref="Ventas.AsignadorDeNumeroComprobante"/>
+/// (design D1, proposal decisión 13): ESE asignador abre y comitea su PROPIA transacción chica,
+/// ANTES de la del llamador, a propósito, para que "el número se consume aunque falle el resto" —
+/// un hueco en la serie interna es legítimo. Acá, para una serie de ARCA, ese mismo hueco DETIENE
+/// la serie completa (error 10016): <see cref="AsignarSiguienteAsync"/> corre DENTRO de la
+/// transacción del llamador (la emisión fiscal, slice 5), nunca abre ni comitea la suya — el row
+/// lock del <c>UPDATE … RETURNING</c> se sostiene hasta el <c>COMMIT</c> de esa transacción,
+/// incluido el round trip a WSFE (D1: <c>numeraciones_fiscales</c> es el ÚNICO lock existente que
+/// esa transacción toma, en la posición 0 del orden total).
+///
+/// Mismo raw ADO sobre la conexión/transacción activa de <paramref name="db"/> que el asignador
+/// hermano (<c>Database.SqlQuery&lt;T&gt;()</c>/<c>FromSqlRaw&lt;T&gt;()</c> prohibidos, hallazgo
+/// stage-1-slice-2) — <c>WaysDbContext.RechazarEscriturasDeNumeracionFiscal</c> es el guard que
+/// hace que <c>SaveChangesAsync</c> nunca pueda escribir esta tabla por accidente.
+///
+/// Implementa las guarded-UPDATEs U1 (<see cref="AsignarSiguienteAsync"/>) y U3
+/// (<see cref="ReconciliarAsync"/>) enumeradas en tasks.md Slice 4 (mutation-proof-tests regla 3
+/// v1.1) — U1 conjuncts (a) <c>id_punto_venta</c> (b) <c>codigo_afip</c>; U3 mismos dos conjuncts.
+/// </summary>
+public static class AsignadorDeNumeroFiscal
+{
+    public static async Task AsegurarContadorAsync(
+        IWaysDbContext db, int idTenant, int idPuntoVenta, short codigoAfip, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "INSERT INTO numeraciones_fiscales (id_punto_venta, codigo_afip, id_tenant, proximo_numero) " +
+            "VALUES ($1, $2, $3, 1) " +
+            "ON CONFLICT (id_punto_venta, codigo_afip) DO NOTHING";
+
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, codigoAfip);
+        ParametrosDeComando.Agregar(comando, idTenant);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>U1: <c>UPDATE numeraciones_fiscales SET proximo_numero = proximo_numero + 1 WHERE
+    /// id_punto_venta = $1 AND codigo_afip = $2</c>. El row lock que este <c>UPDATE</c> toma es el
+    /// que D1 fija en la posición 0 del orden total de locks — la emisión fiscal (slice 5) lo
+    /// sostiene hasta su <c>COMMIT</c>, round trip a WSFE incluido.</summary>
+    public static async Task<long> AsignarSiguienteAsync(
+        IWaysDbContext db, int idPuntoVenta, short codigoAfip, CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "UPDATE numeraciones_fiscales SET proximo_numero = proximo_numero + 1 " +
+            "WHERE id_punto_venta = $1 AND codigo_afip = $2 RETURNING proximo_numero - 1";
+
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, codigoAfip);
+
+        var resultado = await comando.ExecuteScalarAsync(ct)
+            ?? throw new InvalidOperationException(
+                $"No existe serie fiscal para el punto de venta {idPuntoVenta}, código AFIP " +
+                $"{codigoAfip}: llamá a {nameof(AsegurarContadorAsync)} antes de asignar.");
+
+        return Convert.ToInt64(resultado);
+    }
+
+    /// <summary>U3: <c>UPDATE numeraciones_fiscales SET ultimo_autorizado_arca = $, sincronizado_en
+    /// = $ WHERE id_punto_venta = $ AND codigo_afip = $</c> — escribe SOLO estos dos campos,
+    /// SIEMPRE juntos (CHECK 8 los exige juntos o ninguno), y NUNCA <c>proximo_numero</c> (D13):
+    /// auto-sanar la serie sería un programa decidiendo, desatendido, si un documento legal existe
+    /// o no. Si ARCA está adelante, un comprobante local está sin CAE y lo encuentra I2
+    /// (<c>FECompConsultar</c>); si nosotros estamos adelante, un número quedó quemado y solo un
+    /// operador lo libera (I1, 19c). El 409 <c>numeracion_fiscal_desincronizada</c> ante un 10016
+    /// de WSFE ya se lanza en <c>ClienteWsfe</c> (slice 3, antes de llegar hasta acá) — este método
+    /// es la escritura de reconciliación en sí, no el punto que decide si hay divergencia.</summary>
+    public static async Task ReconciliarAsync(
+        IWaysDbContext db,
+        int idPuntoVenta,
+        short codigoAfip,
+        long ultimoAutorizadoArca,
+        IRelojDelSistema reloj,
+        CancellationToken ct = default)
+    {
+        var conexion = await ObtenerConexionAbiertaAsync(db, ct);
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "UPDATE numeraciones_fiscales SET ultimo_autorizado_arca = $1, sincronizado_en = $2 " +
+            "WHERE id_punto_venta = $3 AND codigo_afip = $4";
+
+        ParametrosDeComando.Agregar(comando, ultimoAutorizadoArca);
+        ParametrosDeComando.Agregar(comando, reloj.Ahora);
+        ParametrosDeComando.Agregar(comando, idPuntoVenta);
+        ParametrosDeComando.Agregar(comando, codigoAfip);
+
+        await comando.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task<DbConnection> ObtenerConexionAbiertaAsync(IWaysDbContext db, CancellationToken ct)
+    {
+        var conexion = db.Database.GetDbConnection();
+
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        return conexion;
+    }
+}

--- a/src/Ways.Application/Fiscal/Contratos.cs
+++ b/src/Ways.Application/Fiscal/Contratos.cs
@@ -124,10 +124,13 @@ public sealed record ParametroArca(string Id, string Descripcion);
 /// que cifra antes de persistir (<c>IAlmacenDeClavesFiscales.CifrarAsync</c>, D5). <see cref="Pfx"/>/
 /// <see cref="PasswordPfx"/> viven SOLO durante este request — no hay columna que los guarde tal
 /// cual (dto-contract-honesty: nada especulativo, ningún campo de acá aparece en
-/// <see cref="CertificadoFiscalDto"/>). LÍMITE HONESTO (judgment-day 19a-slice-4 ronda 2 juez A):
-/// <see cref="ServicioDeCertificados.RegistrarAsync"/> limpia <see cref="Pfx"/> con
-/// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> en su
-/// <c>finally</c> — es un <c>byte[]</c>, se puede. <see cref="PasswordPfx"/> NO: es un
+/// <see cref="CertificadoFiscalDto"/>). LÍMITE HONESTO (judgment-day 19a-slice-4 ronda 2 juez A,
+/// completado en la misma ronda tras la pasada acotada del juez B): el <c>try/finally</c> de
+/// <see cref="ServicioDeCertificados.RegistrarAsync"/> arranca ANTES de cargar el PFX, así que
+/// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> limpia
+/// <see cref="Pfx"/> en TODOS los caminos de salida — incluido el más probable del ABM, contraseña
+/// incorrecta (PFX inválido), y el PFX sin clave RSA — no solo el camino feliz. Es un <c>byte[]</c>,
+/// se puede. <see cref="PasswordPfx"/> NO: es un
 /// <see cref="string"/> inmutable de .NET, nunca se puede zerear de forma confiable (queda en el
 /// heap gestionado hasta que el GC lo recolecte, potencialmente duplicado por interning o por
 /// promoción de generación) — no hay API que lo garantice, y fingir que sí sería una garantía

--- a/src/Ways.Application/Fiscal/Contratos.cs
+++ b/src/Ways.Application/Fiscal/Contratos.cs
@@ -116,3 +116,45 @@ public sealed record ConsultaDeComprobante(
 /// Sin consumidor en 19a (los mapeos ya están en la migración, decisión 11); confirmarlos contra
 /// esto es tarea de 19b.</summary>
 public sealed record ParametroArca(string Id, string Descripcion);
+
+/// <summary>
+/// Alta de un certificado fiscal (slice 4, <c>ServicioDeCertificados</c>) — el operador sube el
+/// PFX exportado desde ARCA con su contraseña; el servicio extrae la parte pública (PEM), la
+/// huella SHA-256, la vigencia (del propio X.509, nunca <c>DEFAULT now()</c>) y la clave privada,
+/// que cifra antes de persistir (<c>IAlmacenDeClavesFiscales.CifrarAsync</c>, D5). <see cref="Pfx"/>/
+/// <see cref="PasswordPfx"/> viven SOLO durante este request — no hay columna que los guarde tal
+/// cual (dto-contract-honesty: nada especulativo, ningún campo de acá aparece en
+/// <see cref="CertificadoFiscalDto"/>).</summary>
+public sealed record RegistroDeCertificadoFiscal(
+    int IdEmpresa,
+    AmbienteFiscal Ambiente,
+    string Alias,
+    string CuitTitular,
+    byte[] Pfx,
+    string PasswordPfx);
+
+/// <summary>
+/// Lectura de un certificado fiscal — <c>dto-contract-honesty</c> rule 1 (design T5): SIN
+/// <c>CertificadoPem</c> (público, pero sin consumidor hasta la pantalla de 19c) y, sobre todo,
+/// SIN <see cref="Domain.Fiscal.CertificadoFiscal.ClavePrivadaCifrada"/>/<c>Nonce</c>/
+/// <c>TagAutenticacion</c>/<c>IdClaveMaestra</c> — ninguno de los cuatro tiene una propiedad acá,
+/// ni con otro nombre (spec certificados-fiscales: "Key Material Never Appears In Any DTO, Log,
+/// Or API Response").</summary>
+public sealed record CertificadoFiscalDto(
+    int Id,
+    int IdEmpresa,
+    AmbienteFiscal Ambiente,
+    string Alias,
+    string CuitTitular,
+    DateTimeOffset VigenciaDesde,
+    DateTimeOffset VigenciaHasta,
+    bool Activo);
+
+/// <summary>Body de <c>PUT /api/fiscal/empresas/{id}/condicion-fiscal</c> — proposal.md §B: sin
+/// default honesto, el camino fiscal exige el valor explícito.</summary>
+public sealed record CondicionFiscalDeEmpresaEdicion(int IdCondicionFiscal);
+
+/// <summary>Body de <c>PUT /api/fiscal/puntos-venta/{id}/numero-fiscal</c> — proposal.md §C
+/// decisión 2: el punto de venta ARCA (1..99999, <c>ck_puntos_venta_numero_fiscal_rango</c>),
+/// separado de <c>PuntoVenta.Id</c>.</summary>
+public sealed record NumeroFiscalDePuntoVentaEdicion(int NumeroFiscal);

--- a/src/Ways.Application/Fiscal/Contratos.cs
+++ b/src/Ways.Application/Fiscal/Contratos.cs
@@ -124,7 +124,14 @@ public sealed record ParametroArca(string Id, string Descripcion);
 /// que cifra antes de persistir (<c>IAlmacenDeClavesFiscales.CifrarAsync</c>, D5). <see cref="Pfx"/>/
 /// <see cref="PasswordPfx"/> viven SOLO durante este request — no hay columna que los guarde tal
 /// cual (dto-contract-honesty: nada especulativo, ningún campo de acá aparece en
-/// <see cref="CertificadoFiscalDto"/>).</summary>
+/// <see cref="CertificadoFiscalDto"/>). LÍMITE HONESTO (judgment-day 19a-slice-4 ronda 2 juez A):
+/// <see cref="ServicioDeCertificados.RegistrarAsync"/> limpia <see cref="Pfx"/> con
+/// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> en su
+/// <c>finally</c> — es un <c>byte[]</c>, se puede. <see cref="PasswordPfx"/> NO: es un
+/// <see cref="string"/> inmutable de .NET, nunca se puede zerear de forma confiable (queda en el
+/// heap gestionado hasta que el GC lo recolecte, potencialmente duplicado por interning o por
+/// promoción de generación) — no hay API que lo garantice, y fingir que sí sería una garantía
+/// falsa.</summary>
 public sealed record RegistroDeCertificadoFiscal(
     int IdEmpresa,
     AmbienteFiscal Ambiente,

--- a/src/Ways.Application/Fiscal/DesactivadorDeCertificadoFiscal.cs
+++ b/src/Ways.Application/Fiscal/DesactivadorDeCertificadoFiscal.cs
@@ -1,0 +1,60 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Fiscal;
+
+namespace Ways.Application.Fiscal;
+
+/// <summary>
+/// Implementa U4 (tasks.md Slice 4, mutation-proof-tests regla 3 v1.1): <c>UPDATE
+/// certificados_fiscales SET activo = false … WHERE id_tenant = $1 AND id_empresa = $2 AND
+/// ambiente = $3 AND activo AND deleted_at IS NULL</c> — la mitad "desactivar" de una rotación
+/// (design.md: "rotation = deactivate+activate inside one transaction",
+/// <see cref="ServicioDeCertificados.RegistrarAsync"/> la corre SIEMPRE antes del alta, dentro de
+/// la MISMA transacción; un no-op si no había fila activa). Clase estática propia, no un método
+/// privado de <see cref="ServicioDeCertificados"/> — mismo criterio que
+/// <see cref="AsignadorDeNumeroFiscal"/>: el repo no tiene <c>InternalsVisibleTo</c> en ningún
+/// lado (precedente <c>SobreSoap</c>, slice 2), así que un método <c>public static</c> propio es
+/// lo que deja a los cinco kills de U4 (a-e) testeables DIRECTO desde
+/// <c>Ways.IntegrationTests</c>, sin pasar por el flujo completo de PFX+cifrado de
+/// <see cref="ServicioDeCertificados.RegistrarAsync"/> para cada conjunto.
+///
+/// <c>id_tenant</c> viaja EXPLÍCITO en el <c>WHERE</c> (a diferencia de U1/U3, que confían
+/// enteramente en RLS) — defensa en profundidad deliberada para la tabla que guarda material de
+/// clave: aun si algún día un caller pasara el <c>id_tenant</c> equivocado, RLS sigue sin dejar
+/// pasar una fila de otro tenant (conjunct (a), probado bajo <c>ways_app</c>).
+/// </summary>
+public static class DesactivadorDeCertificadoFiscal
+{
+    /// <summary>Devuelve la cantidad de filas afectadas — el conjunct (d) ("un certificado ya
+    /// inactivo no se toca") se prueba sobre este número, no sobre el estado final (que ya era
+    /// <c>false</c> de todos modos, mutation-proof-tests regla 4).</summary>
+    public static async Task<int> DesactivarActivoAsync(
+        IWaysDbContext db,
+        int idTenant,
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        DateTimeOffset ahora,
+        CancellationToken ct = default)
+    {
+        var conexion = db.Database.GetDbConnection();
+        if (conexion.State != ConnectionState.Open)
+        {
+            await db.Database.OpenConnectionAsync(ct);
+        }
+
+        await using var comando = conexion.CreateCommand();
+        comando.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+        comando.CommandText =
+            "UPDATE certificados_fiscales SET activo = false, updated_at = $1 " +
+            "WHERE id_tenant = $2 AND id_empresa = $3 AND ambiente = $4 AND activo AND deleted_at IS NULL";
+
+        ParametrosDeComando.Agregar(comando, ahora);
+        ParametrosDeComando.Agregar(comando, idTenant);
+        ParametrosDeComando.Agregar(comando, idEmpresa);
+        ParametrosDeComando.Agregar(comando, ambiente);
+
+        return await comando.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs
+++ b/src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography.X509Certificates;
+using Ways.Domain.Fiscal;
+
+namespace Ways.Application.Fiscal;
+
+/// <summary>
+/// Puerto del cifrado/descifrado de material de clave fiscal (design.md: Ports and the CAE
+/// machine; decisión 1/D5/D6). La implementación concreta (<c>CifradoDeClavesFiscales</c>, AES-256-GCM
+/// vía la BCL) vive en Infrastructure.
+///
+/// <see cref="CifrarAsync"/> es la ampliación de esta slice sobre el snippet de <c>design.md</c>
+/// (que solo nombra <see cref="UsarCertificadoAsync{T}"/> literalmente): sin ella,
+/// <c>ServicioDeCertificados</c> (Application) tendría que llamar <c>AesGcm</c> directo, cruzando
+/// el límite hexagonal que el resto del proyecto respeta (Clean/Hexagonal Architecture) — acá el
+/// ABM cifra material NUEVO antes de guardarlo, la contraparte simétrica de
+/// <see cref="UsarCertificadoAsync{T}"/> que descifra una fila existente para firmar.
+/// DEVIACIÓN REGISTRADA, no silenciosa.
+/// </summary>
+public interface IAlmacenDeClavesFiscales
+{
+    /// <summary>Cifra <paramref name="clavePrivada"/> con la clave maestra ACTUAL
+    /// (<c>Ways:Fiscal:ClaveMaestraActual</c>, D6) y devuelve el ciphertext/nonce/tag junto con el
+    /// <c>id_clave_maestra</c> que la cifró (versionado, para poder rotar la clave maestra sin
+    /// invalidar filas ya cifradas con una anterior). Clave maestra ausente/corta ⇒
+    /// <c>503 clave_maestra_ausente</c> — el alta/rotación de certificados queda inhabilitada,
+    /// JAMÁS un fallback a texto plano (D6).</summary>
+    Task<(byte[] Ciphertext, byte[] Nonce, byte[] Tag, string IdClaveMaestra)> CifrarAsync(
+        byte[] clavePrivada,
+        int idTenant,
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        string huellaSha256,
+        CancellationToken ct);
+
+    /// <summary>Resuelve el certificado ACTIVO de <paramref name="idEmpresa"/>+<paramref name="ambiente"/>,
+    /// lo descifra (por la versión de clave maestra de SU fila, <c>id_clave_maestra</c> — no
+    /// necesariamente la "actual"), reconstruye un <see cref="X509Certificate2"/> con la clave
+    /// privada adjunta y lo entrega a <paramref name="uso"/>. El material descifrado vive SOLO
+    /// dentro de este callback; el buffer se limpia con
+    /// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> en un
+    /// <c>finally</c>, pase lo que pase. Sin certificado activo, o sin la clave maestra que lo
+    /// descifra ⇒ <c>409 certificado_fiscal_ausente</c> — el camino fiscal queda INERTE (I4),
+    /// JAMÁS una excepción de crypto pelada.</summary>
+    Task<T> UsarCertificadoAsync<T>(
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        Func<X509Certificate2, Task<T>> uso,
+        CancellationToken ct);
+}

--- a/src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs
+++ b/src/Ways.Application/Fiscal/IAlmacenDeClavesFiscales.cs
@@ -38,9 +38,12 @@ public interface IAlmacenDeClavesFiscales
     /// privada adjunta y lo entrega a <paramref name="uso"/>. El material descifrado vive SOLO
     /// dentro de este callback; el buffer se limpia con
     /// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> en un
-    /// <c>finally</c>, pase lo que pase. Sin certificado activo, o sin la clave maestra que lo
-    /// descifra ⇒ <c>409 certificado_fiscal_ausente</c> — el camino fiscal queda INERTE (I4),
-    /// JAMÁS una excepción de crypto pelada.</summary>
+    /// <c>finally</c>, pase lo que pase. Dos códigos nombrados, nunca una excepción de crypto
+    /// pelada: sin certificado activo, o sin la clave maestra que lo descifra ⇒ <c>409
+    /// certificado_fiscal_ausente</c>; con la clave maestra resuelta pero el descifrado autenticado
+    /// igual falla (clave equivocada para esta fila, o fila corrupta/manipulada — a propósito
+    /// indistinguibles en el mensaje, para no filtrar cuál de las dos pasó) ⇒ <c>409
+    /// certificado_fiscal_ilegible</c>. En ambos casos el camino fiscal queda INERTE (I4).</summary>
     Task<T> UsarCertificadoAsync<T>(
         int idEmpresa,
         AmbienteFiscal ambiente,

--- a/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
+++ b/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
@@ -1,0 +1,196 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.EntityFrameworkCore;
+using Ways.Application.Abstracciones;
+using Ways.Domain.Common;
+using Ways.Domain.Fiscal;
+
+namespace Ways.Application.Fiscal;
+
+/// <summary>
+/// El ABM de certificados fiscales bajo <c>Politicas.AdministracionFiscal</c> (solo Admin,
+/// tasks.md Slice 4, target 63) — más la carga de <c>empresas.id_condicion_fiscal</c> /
+/// <c>puntos_venta.numero_fiscal</c> que <c>FiscalEndpoints</c> agrupa bajo la misma policy
+/// (proposal.md API surface 705-710). DEVIACIÓN REGISTRADA: <c>design.md</c>'s File changes table
+/// solo nombra este servicio para "register/list/deactivate" del certificado — las dos rutas de
+/// carga de empresa/PV no tienen dueño explícito en el diseño, y quedan acá por ser el único
+/// servicio de aplicación bajo esta policy en esta slice.
+///
+/// <see cref="RegistrarAsync"/> implementa U4 (<c>UPDATE certificados_fiscales SET activo = false
+/// … WHERE id_tenant = $ AND id_empresa = $ AND ambiente = $ AND activo AND deleted_at IS NULL</c>)
+/// como la mitad "desactivar" de la rotación atómica (design.md: "rotation = deactivate+activate
+/// inside one transaction") — SIEMPRE corre antes del alta, sea o no una rotación real: si no hay
+/// fila activa, es un no-op; si la hay, la desactiva dentro de la MISMA transacción que inserta la
+/// nueva fila activa, así que nunca hay una ventana con dos certificados activos a la vez (spec:
+/// "Rotation Is Atomic — No Window With Two Active Certificates"). El backstop de esquema del
+/// <c>23505</c> de <c>ux_certificados_fiscales_activo</c> (el "race backstop" de U4, ya existente
+/// desde slice 1 en <c>ManejadorDeErrores</c>) es lo que traduce una carrera genuina entre dos
+/// altas concurrentes — este método no lo reemplaza, lo ejercita.
+/// </summary>
+public class ServicioDeCertificados(IWaysDbContext db, IRelojDelSistema reloj, IAlmacenDeClavesFiscales almacen)
+{
+    // --- Certificados ---
+
+    public async Task<CertificadoFiscalDto> RegistrarAsync(
+        RegistroDeCertificadoFiscal datos, CancellationToken ct = default)
+    {
+        var alias = Normalizar(datos.Alias, "alias_de_certificado", "alias", 60);
+        var cuitTitular = Normalizar(datos.CuitTitular, "cuit_titular", "CUIT titular", 11);
+
+        var empresa = await db.Empresas.FirstOrDefaultAsync(e => e.Id == datos.IdEmpresa, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {datos.IdEmpresa}.");
+
+        using var certificado = CargarPfx(datos.Pfx, datos.PasswordPfx);
+
+        var certificadoPem = certificado.ExportCertificatePem();
+        var huellaSha256 = Convert.ToHexStringLower(SHA256.HashData(certificado.RawData));
+
+        using var rsa = certificado.GetRSAPrivateKey()
+            ?? throw new ErrorDominio(
+                "certificado_sin_clave_rsa",
+                "El PFX no contiene una clave privada RSA — solo RSA está soportado en 19a.", 400);
+
+        var clavePrivada = rsa.ExportPkcs8PrivateKey();
+
+        try
+        {
+            // EnableRetryOnFailure exige que BeginTransactionAsync viva DENTRO de la lambda del
+            // execution strategy (mismo criterio que ServicioDePrecios.EstablecerPrecioAsync) —
+            // sin esto, EF tira InvalidOperationException al primer BeginTransactionAsync manual.
+            var estrategia = db.Database.CreateExecutionStrategy();
+
+            var nuevo = await estrategia.ExecuteAsync(async () =>
+            {
+                await using var transaccion = await db.Database.BeginTransactionAsync(ct);
+
+                // U4: desactiva lo que esté activo hoy para esta empresa+ambiente ANTES del alta
+                // — no-op si no hay nada activo (primer alta), la mitad "desactivar" de una
+                // rotación si lo hay. Misma transacción que el INSERT de más abajo (spec:
+                // rotación atómica).
+                await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+                    db, empresa.IdTenant, empresa.Id, datos.Ambiente, reloj.Ahora, ct);
+
+                var (ciphertext, nonce, tag, idClaveMaestra) = await almacen.CifrarAsync(
+                    clavePrivada, empresa.IdTenant, empresa.Id, datos.Ambiente, huellaSha256, ct);
+
+                var fila = new CertificadoFiscal
+                {
+                    IdTenant = empresa.IdTenant,
+                    IdEmpresa = empresa.Id,
+                    Ambiente = datos.Ambiente,
+                    Alias = alias,
+                    CuitTitular = cuitTitular,
+                    CertificadoPem = certificadoPem,
+                    ClavePrivadaCifrada = ciphertext,
+                    Nonce = nonce,
+                    TagAutenticacion = tag,
+                    IdClaveMaestra = idClaveMaestra,
+                    HuellaSha256 = huellaSha256,
+                    VigenciaDesde = new DateTimeOffset(certificado.NotBefore.ToUniversalTime()),
+                    VigenciaHasta = new DateTimeOffset(certificado.NotAfter.ToUniversalTime()),
+                    Activo = true,
+                    CreatedAt = reloj.Ahora,
+                    UpdatedAt = reloj.Ahora
+                };
+
+                db.CertificadosFiscales.Add(fila);
+                await db.SaveChangesAsync(ct);
+
+                await transaccion.CommitAsync(ct);
+
+                return fila;
+            });
+
+            return Proyectar(nuevo);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(clavePrivada);
+        }
+    }
+
+    public async Task<IReadOnlyList<CertificadoFiscalDto>> ListarAsync(CancellationToken ct = default) =>
+        await db.CertificadosFiscales
+            .OrderByDescending(c => c.CreatedAt)
+            .Select(c => new CertificadoFiscalDto(
+                c.Id, c.IdEmpresa, c.Ambiente, c.Alias, c.CuitTitular, c.VigenciaDesde, c.VigenciaHasta, c.Activo))
+            .ToListAsync(ct);
+
+    /// <summary>Idempotente a propósito (mismo criterio que
+    /// <c>ServicioDeOrganizacion.CambiarEstadoTenantAsync</c>): desactivar un certificado ya
+    /// inactivo no es un error.</summary>
+    public async Task DesactivarAsync(int id, CancellationToken ct = default)
+    {
+        var certificado = await db.CertificadosFiscales.FirstOrDefaultAsync(c => c.Id == id, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el certificado fiscal {id}.");
+
+        if (certificado.Activo)
+        {
+            certificado.Activo = false;
+            certificado.UpdatedAt = reloj.Ahora;
+            await db.SaveChangesAsync(ct);
+        }
+    }
+
+    // --- Condición fiscal de empresa / número fiscal de punto de venta ---
+
+    public async Task ActualizarCondicionFiscalDeEmpresaAsync(
+        int idEmpresa, int idCondicionFiscal, CancellationToken ct = default)
+    {
+        var empresa = await db.Empresas.FirstOrDefaultAsync(e => e.Id == idEmpresa, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {idEmpresa}.");
+
+        empresa.IdCondicionFiscal = idCondicionFiscal;
+        empresa.UpdatedAt = reloj.Ahora;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task ActualizarNumeroFiscalDePuntoVentaAsync(
+        int idPuntoVenta, int numeroFiscal, CancellationToken ct = default)
+    {
+        var puntoVenta = await db.PuntosVenta.FirstOrDefaultAsync(p => p.Id == idPuntoVenta, ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {idPuntoVenta}.");
+
+        puntoVenta.NumeroFiscal = numeroFiscal;
+        puntoVenta.UpdatedAt = reloj.Ahora;
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    // --- Común ---
+
+    private static X509Certificate2 CargarPfx(byte[] pfx, string password)
+    {
+        try
+        {
+            return X509CertificateLoader.LoadPkcs12(pfx, password, X509KeyStorageFlags.Exportable);
+        }
+        catch (CryptographicException)
+        {
+            throw new ErrorDominio(
+                "pfx_invalido", "El archivo PFX o la contraseña son inválidos.", 400);
+        }
+    }
+
+    private static CertificadoFiscalDto Proyectar(CertificadoFiscal c) => new(
+        c.Id, c.IdEmpresa, c.Ambiente, c.Alias, c.CuitTitular, c.VigenciaDesde, c.VigenciaHasta, c.Activo);
+
+    private static string Normalizar(string? valor, string codigo, string campo, int largoMaximo)
+    {
+        var limpio = valor?.Trim() ?? string.Empty;
+
+        if (limpio.Length == 0)
+        {
+            throw new ErrorDominio($"{codigo}_requerido", $"El campo {campo} es obligatorio.", 400);
+        }
+
+        if (limpio.Length > largoMaximo)
+        {
+            throw new ErrorDominio(
+                $"{codigo}_muy_largo", $"El campo {campo} no puede superar los {largoMaximo} caracteres.", 400);
+        }
+
+        return limpio;
+    }
+}

--- a/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
+++ b/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
@@ -40,20 +40,22 @@ public class ServicioDeCertificados(IWaysDbContext db, IRelojDelSistema reloj, I
         var empresa = await db.Empresas.FirstOrDefaultAsync(e => e.Id == datos.IdEmpresa, ct)
             ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {datos.IdEmpresa}.");
 
-        using var certificado = CargarPfx(datos.Pfx, datos.PasswordPfx);
-
-        var certificadoPem = certificado.ExportCertificatePem();
-        var huellaSha256 = Convert.ToHexStringLower(SHA256.HashData(certificado.RawData));
-
-        using var rsa = certificado.GetRSAPrivateKey()
-            ?? throw new ErrorDominio(
-                "certificado_sin_clave_rsa",
-                "El PFX no contiene una clave privada RSA — solo RSA está soportado en 19a.", 400);
-
-        var clavePrivada = rsa.ExportPkcs8PrivateKey();
+        byte[]? clavePrivada = null;
 
         try
         {
+            using var certificado = CargarPfx(datos.Pfx, datos.PasswordPfx);
+
+            var certificadoPem = certificado.ExportCertificatePem();
+            var huellaSha256 = Convert.ToHexStringLower(SHA256.HashData(certificado.RawData));
+
+            using var rsa = certificado.GetRSAPrivateKey()
+                ?? throw new ErrorDominio(
+                    "certificado_sin_clave_rsa",
+                    "El PFX no contiene una clave privada RSA — solo RSA está soportado en 19a.", 400);
+
+            clavePrivada = rsa.ExportPkcs8PrivateKey();
+
             // EnableRetryOnFailure exige que BeginTransactionAsync viva DENTRO de la lambda del
             // execution strategy (mismo criterio que ServicioDePrecios.EstablecerPrecioAsync) —
             // sin esto, EF tira InvalidOperationException al primer BeginTransactionAsync manual.

--- a/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
+++ b/src/Ways.Application/Fiscal/ServicioDeCertificados.cs
@@ -106,6 +106,7 @@ public class ServicioDeCertificados(IWaysDbContext db, IRelojDelSistema reloj, I
         finally
         {
             CryptographicOperations.ZeroMemory(clavePrivada);
+            CryptographicOperations.ZeroMemory(datos.Pfx);
         }
     }
 

--- a/src/Ways.Infrastructure/DependencyInjection.cs
+++ b/src/Ways.Infrastructure/DependencyInjection.cs
@@ -110,6 +110,12 @@ public static class DependencyInjection
         services.AddSingleton<IRepositorioDeTicketDeAcceso>(
             sp => sp.GetRequiredService<RepositorioEnMemoriaDeTicketDeAcceso>());
 
+        // stage-19a-slice4 (design D5/D6): AES-256-GCM, clave maestra desde configuración/entorno
+        // — Ways:Fiscal:ClaveMaestraActual + Ways:Fiscal:ClavesMaestras:<id>, JAMÁS en appsettings
+        // commiteado (verify criterion 8 lo cubre para el hostname de ARCA; la clave maestra en sí
+        // no tiene default alguno acá, así que ausente es el estado de base honesto en 19a).
+        services.AddScoped<IAlmacenDeClavesFiscales, CifradoDeClavesFiscales>();
+
         return services;
     }
 

--- a/src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs
+++ b/src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs
@@ -28,7 +28,12 @@ namespace Ways.Infrastructure.Fiscal;
 /// (<c>Ways:Fiscal:ClaveMaestraActual</c> + <c>Ways:Fiscal:ClavesMaestras:&lt;id&gt;</c>, 32 bytes
 /// base64) para cifrar material NUEVO; <see cref="UsarCertificadoAsync{T}"/> resuelve la clave por
 /// la versión guardada en la fila (<c>id_clave_maestra</c>) para descifrar una existente. Ausente/
-/// corta ⇒ el error nombrado de D6, nunca una excepción de crypto pelada ni texto plano.
+/// corta ⇒ el error nombrado de D6, nunca una excepción de crypto pelada ni texto plano. Y si la
+/// clave maestra SÍ resuelve pero <see cref="Descifrar"/> igual falla (clave equivocada para esta
+/// fila, o fila corrupta/manipulada — <see cref="AesGcm"/> no distingue las dos, judgment-day
+/// 19a-slice-4 ronda 2 juez A), <see cref="UsarCertificadoAsync{T}"/> traduce la
+/// <see cref="CryptographicException"/> pelada al mismo tipo de error nombrado (<c>409
+/// certificado_fiscal_ilegible</c>), nunca la deja propagar cruda.
 /// </summary>
 public sealed class CifradoDeClavesFiscales(IWaysDbContext db, IConfiguration configuration)
     : IAlmacenDeClavesFiscales
@@ -83,15 +88,26 @@ public sealed class CifradoDeClavesFiscales(IWaysDbContext db, IConfiguration co
         byte[]? clavePrivadaPlana = null;
         try
         {
-            clavePrivadaPlana = Descifrar(
-                claveMaestra,
-                certificado.ClavePrivadaCifrada,
-                certificado.Nonce,
-                certificado.TagAutenticacion,
-                certificado.IdTenant,
-                certificado.IdEmpresa,
-                certificado.Ambiente,
-                certificado.HuellaSha256);
+            try
+            {
+                clavePrivadaPlana = Descifrar(
+                    claveMaestra,
+                    certificado.ClavePrivadaCifrada,
+                    certificado.Nonce,
+                    certificado.TagAutenticacion,
+                    certificado.IdTenant,
+                    certificado.IdEmpresa,
+                    certificado.Ambiente,
+                    certificado.HuellaSha256);
+            }
+            catch (CryptographicException)
+            {
+                // No distinguir en el mensaje si falló por clave-incorrecta o por fila-manipulada
+                // (judgment-day 19a-slice-4 ronda 2 juez A): un mensaje que lo revelara sería una
+                // fuga de información sobre CUÁL de las dos cosas está mal, útil para un atacante
+                // que sondea filas — un único código opaco, siempre el mismo, para ambos casos.
+                throw CertificadoIlegible();
+            }
 
             using var publico = X509Certificate2.CreateFromPem(certificado.CertificadoPem);
             using var rsa = RSA.Create();
@@ -115,6 +131,18 @@ public sealed class CifradoDeClavesFiscales(IWaysDbContext db, IConfiguration co
             "certificado_fiscal_ausente",
             "No hay certificado fiscal activo (o su clave maestra no está disponible) para esta " +
             "empresa y ambiente.",
+            409);
+
+    /// <summary>La clave maestra resolvió, pero el descifrado autenticado (<see cref="AesGcm"/>)
+    /// falló igual — clave equivocada para esta fila y fila corrupta/manipulada producen la MISMA
+    /// excepción de la BCL (<see cref="CryptographicException"/>/<see cref="AuthenticationTagMismatchException"/>)
+    /// y este código no las distingue a propósito (judgment-day 19a-slice-4 ronda 2 juez A: el
+    /// mensaje jamás debe filtrar cuál de las dos pasó).</summary>
+    private static ErrorDominio CertificadoIlegible() =>
+        new(
+            "certificado_fiscal_ilegible",
+            "El certificado fiscal activo no pudo leerse para esta empresa y ambiente — el camino " +
+            "fiscal queda inerte.",
             409);
 
     // --- Crypto puro (targets 57-59): sin IConfiguration ni IWaysDbContext, testeable directo. ---

--- a/src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs
+++ b/src/Ways.Infrastructure/Fiscal/CifradoDeClavesFiscales.cs
@@ -1,0 +1,209 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Ways.Application.Abstracciones;
+using Ways.Application.Fiscal;
+using Ways.Domain.Common;
+using Ways.Domain.Fiscal;
+
+namespace Ways.Infrastructure.Fiscal;
+
+/// <summary>
+/// Implementación de <see cref="IAlmacenDeClavesFiscales"/> — AES-256-GCM vía
+/// <see cref="AesGcm"/> (BCL, cero dependencia de terceros, proposal.md decisión 1). Dos mitades:
+///
+/// (1) Crypto PURA y ESTÁTICA (<see cref="Cifrar"/>/<see cref="Descifrar"/>/<see cref="ConstruirAad"/>)
+/// — testeable sin base de datos ni configuración (targets 57-59): AAD = <c>"v1|" + idTenant + "|"
+/// + idEmpresa + "|" + ambiente + "|" + huellaSha256</c> (design D5), que ata el ciphertext a SU
+/// FILA — mover el blob a otra fila (otro tenant, otra empresa, otro ambiente, otro certificado)
+/// falla la autenticación de <see cref="AesGcm"/>. <c>id_clave_maestra</c> queda EXCLUIDO a
+/// propósito: es la versión de clave que lo abre, no identidad de fila — incluirla haría que una
+/// rotación legítima cambiara el AAD (target 58).
+///
+/// (2) Los dos métodos de instancia del puerto (D6: la clave maestra viene de
+/// configuración/entorno, JAMÁS de la base ni del repo, JAMÁS un fallback a texto plano ni una
+/// generada en boot): <see cref="CifrarAsync"/> resuelve la clave maestra ACTUAL
+/// (<c>Ways:Fiscal:ClaveMaestraActual</c> + <c>Ways:Fiscal:ClavesMaestras:&lt;id&gt;</c>, 32 bytes
+/// base64) para cifrar material NUEVO; <see cref="UsarCertificadoAsync{T}"/> resuelve la clave por
+/// la versión guardada en la fila (<c>id_clave_maestra</c>) para descifrar una existente. Ausente/
+/// corta ⇒ el error nombrado de D6, nunca una excepción de crypto pelada ni texto plano.
+/// </summary>
+public sealed class CifradoDeClavesFiscales(IWaysDbContext db, IConfiguration configuration)
+    : IAlmacenDeClavesFiscales
+{
+    public const int TamanioNonce = 12;
+    public const int TamanioTag = 16;
+    private const int TamanioClaveEnBytes = 32;
+
+    public async Task<(byte[] Ciphertext, byte[] Nonce, byte[] Tag, string IdClaveMaestra)> CifrarAsync(
+        byte[] clavePrivada,
+        int idTenant,
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        string huellaSha256,
+        CancellationToken ct)
+    {
+        if (!TryResolverActual(out var idClaveMaestra, out var claveMaestra))
+        {
+            throw new ErrorDominio(
+                "clave_maestra_ausente",
+                "No hay clave maestra de cifrado fiscal configurada — el alta o la rotación de " +
+                "certificados está inhabilitada.",
+                503);
+        }
+
+        try
+        {
+            var (ciphertext, nonce, tag) = Cifrar(claveMaestra, clavePrivada, idTenant, idEmpresa, ambiente, huellaSha256);
+            return await Task.FromResult((ciphertext, nonce, tag, idClaveMaestra));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(claveMaestra);
+        }
+    }
+
+    public async Task<T> UsarCertificadoAsync<T>(
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        Func<X509Certificate2, Task<T>> uso,
+        CancellationToken ct)
+    {
+        var certificado = await db.CertificadosFiscales
+            .FirstOrDefaultAsync(c => c.IdEmpresa == idEmpresa && c.Ambiente == ambiente && c.Activo, ct)
+            ?? throw CertificadoAusente();
+
+        if (!TryResolverPorId(certificado.IdClaveMaestra, out _, out var claveMaestra))
+        {
+            throw CertificadoAusente();
+        }
+
+        byte[]? clavePrivadaPlana = null;
+        try
+        {
+            clavePrivadaPlana = Descifrar(
+                claveMaestra,
+                certificado.ClavePrivadaCifrada,
+                certificado.Nonce,
+                certificado.TagAutenticacion,
+                certificado.IdTenant,
+                certificado.IdEmpresa,
+                certificado.Ambiente,
+                certificado.HuellaSha256);
+
+            using var publico = X509Certificate2.CreateFromPem(certificado.CertificadoPem);
+            using var rsa = RSA.Create();
+            rsa.ImportPkcs8PrivateKey(clavePrivadaPlana, out _);
+            using var conClavePrivada = publico.CopyWithPrivateKey(rsa);
+
+            return await uso(conClavePrivada);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(claveMaestra);
+            if (clavePrivadaPlana is not null)
+            {
+                CryptographicOperations.ZeroMemory(clavePrivadaPlana);
+            }
+        }
+    }
+
+    private static ErrorDominio CertificadoAusente() =>
+        new(
+            "certificado_fiscal_ausente",
+            "No hay certificado fiscal activo (o su clave maestra no está disponible) para esta " +
+            "empresa y ambiente.",
+            409);
+
+    // --- Crypto puro (targets 57-59): sin IConfiguration ni IWaysDbContext, testeable directo. ---
+
+    public static (byte[] Ciphertext, byte[] Nonce, byte[] Tag) Cifrar(
+        byte[] claveMaestra,
+        byte[] plaintext,
+        int idTenant,
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        string huellaSha256)
+    {
+        var nonce = RandomNumberGenerator.GetBytes(TamanioNonce);
+        var tag = new byte[TamanioTag];
+        var ciphertext = new byte[plaintext.Length];
+        var aad = ConstruirAad(idTenant, idEmpresa, ambiente, huellaSha256);
+
+        using var aesGcm = new AesGcm(claveMaestra, TamanioTag);
+        aesGcm.Encrypt(nonce, plaintext, ciphertext, tag, aad);
+
+        return (ciphertext, nonce, tag);
+    }
+
+    /// <summary>Lanza <see cref="CryptographicException"/> si <paramref name="tag"/> no valida —
+    /// tanto por una clave equivocada como por un AAD que no coincide con la fila (target 57: el
+    /// tamper de cualquiera de sus cuatro componentes tiene que fallar acá).</summary>
+    public static byte[] Descifrar(
+        byte[] claveMaestra,
+        byte[] ciphertext,
+        byte[] nonce,
+        byte[] tag,
+        int idTenant,
+        int idEmpresa,
+        AmbienteFiscal ambiente,
+        string huellaSha256)
+    {
+        var aad = ConstruirAad(idTenant, idEmpresa, ambiente, huellaSha256);
+        var plaintext = new byte[ciphertext.Length];
+
+        using var aesGcm = new AesGcm(claveMaestra, TamanioTag);
+        aesGcm.Decrypt(nonce, ciphertext, tag, plaintext, aad);
+
+        return plaintext;
+    }
+
+    /// <summary><c>"v1|" + idTenant + "|" + idEmpresa + "|" + ambiente + "|" + huellaSha256</c>
+    /// (design D5) — <c>ambiente</c> se escribe en minúscula (<c>"homologacion"</c>/<c>"produccion"</c>),
+    /// la misma forma que su etiqueta de <c>CREATE TYPE</c> en la base, no el nombre del miembro de
+    /// C# (<c>Homologacion</c>/<c>Produccion</c>): ata el AAD a la representación que la fila
+    /// realmente persiste, no a un detalle de nombrado del enum de este lenguaje.</summary>
+    public static byte[] ConstruirAad(int idTenant, int idEmpresa, AmbienteFiscal ambiente, string huellaSha256) =>
+        Encoding.UTF8.GetBytes(
+            $"v1|{idTenant}|{idEmpresa}|{ambiente.ToString().ToLowerInvariant()}|{huellaSha256}");
+
+    private bool TryResolverActual(out string idClaveMaestra, out byte[] clave) =>
+        TryResolverPorId(configuration["Ways:Fiscal:ClaveMaestraActual"], out idClaveMaestra, out clave);
+
+    private bool TryResolverPorId(string? id, out string idClaveMaestra, out byte[] clave)
+    {
+        idClaveMaestra = id ?? string.Empty;
+        clave = [];
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        var valor = configuration[$"Ways:Fiscal:ClavesMaestras:{id}"];
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return false;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(valor);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        if (bytes.Length != TamanioClaveEnBytes)
+        {
+            return false;
+        }
+
+        clave = bytes;
+        return true;
+    }
+}

--- a/tests/Ways.Application.Tests/Fiscal/CifradoDeClavesFiscalesTests.cs
+++ b/tests/Ways.Application.Tests/Fiscal/CifradoDeClavesFiscalesTests.cs
@@ -201,6 +201,56 @@ public class CifradoDeClavesFiscalesTests
         Assert.True(idCertificado > 0);
     }
 
+    // --- judgment-day 19a-slice-4 ronda 2 juez A (CRITICAL): clave maestra RESOLUBLE pero
+    // ciphertext corrupto/manipulado — la excepción de crypto pelada de AesGcm NUNCA debe cruzar
+    // el puerto, tiene que traducirse al error nombrado. ---
+
+    [Fact]
+    public async Task UsarCertificadoAsyncConCiphertextCorruptoTraduceLaExcepcionDeCryptoAlErrorNombrado()
+    {
+        var nombreDeBase = nameof(UsarCertificadoAsyncConCiphertextCorruptoTraduceLaExcepcionDeCryptoAlErrorNombrado);
+        var configuracion = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ways:Fiscal:ClaveMaestraActual"] = "v1",
+                ["Ways:Fiscal:ClavesMaestras:v1"] = Convert.ToBase64String(ClaveMaestra)
+            })
+            .Build();
+
+        using var certificadoDePrueba = GenerarCertificadoDePrueba();
+        var certificadoPem = certificadoDePrueba.ExportCertificatePem();
+        using var rsaPrivada = certificadoDePrueba.GetRSAPrivateKey()!;
+        var clavePrivadaPkcs8 = rsaPrivada.ExportPkcs8PrivateKey();
+
+        byte[] ciphertext, nonce, tag;
+        await using (var db = CrearContexto(nombreDeBase))
+        {
+            var almacen = new CifradoDeClavesFiscales(db, configuracion);
+            string idClaveMaestra;
+            (ciphertext, nonce, tag, idClaveMaestra) = await almacen.CifrarAsync(
+                clavePrivadaPkcs8, IdTenant, IdEmpresa, Ambiente, Huella, CancellationToken.None);
+
+            // Un solo byte del ciphertext, flipeado — misma clase de tamper que un tag/nonce
+            // corrupto (target 57 ya cubre mover la fila entera; esto es la fila QUEDÁNDOSE en su
+            // lugar pero con el blob dañado, la clave sigue resolviendo igual).
+            ciphertext[0] ^= 0xFF;
+
+            var certificado = CrearCertificadoDePrueba(certificadoPem, ciphertext, nonce, tag, idClaveMaestra);
+            db.CertificadosFiscales.Add(certificado);
+            await db.SaveChangesAsync();
+        }
+
+        await using var dbLectura = CrearContexto(nombreDeBase);
+        var almacenLectura = new CifradoDeClavesFiscales(dbLectura, configuracion);
+
+        var error = await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() =>
+            almacenLectura.UsarCertificadoAsync(
+                IdEmpresa, Ambiente, _ => Task.FromResult(true), CancellationToken.None));
+
+        Assert.Equal("certificado_fiscal_ilegible", error.Codigo);
+        Assert.Equal(409, error.EstadoHttp);
+    }
+
     // --- Target 60 [S]: UsarCertificadoAsync limpia su buffer descifrado en un finally. ---
 
     [Fact]
@@ -231,6 +281,39 @@ public class CifradoDeClavesFiscalesTests
         // del método, es lo que hace la aserción estructural discriminante.
         Assert.Contains("ZeroMemory(claveMaestra)", cuerpoFinally, StringComparison.Ordinal);
         Assert.Contains("ZeroMemory(clavePrivadaPlana)", cuerpoFinally, StringComparison.Ordinal);
+    }
+
+    // --- WARNING (judgment-day 19a-slice-4 ronda 2 juez A): ServicioDeCertificados.RegistrarAsync
+    // recibe el PFX crudo (datos.Pfx) — igual de sensible que la clave privada que sale de él —
+    // pero solo limpiaba clavePrivada, nunca el Pfx en sí. Mismo criterio estructural que el test
+    // de arriba (source-read + Contains discriminante por nombre de variable, no un mock que un
+    // mutante podría esquivar), aplicado al archivo correcto (Application, no Infrastructure). No
+    // existía un test estructural previo para este método — se agrega, no se "extiende" uno viejo,
+    // porque ninguno cubría este archivo.
+
+    [Fact]
+    public void RegistrarAsyncLimpiaLaClavePrivadaYElPfxEnUnFinally()
+    {
+        var directorioDeEsteArchivo = Path.GetDirectoryName(RutaDeEsteArchivo())!;
+        var ruta = Path.GetFullPath(Path.Combine(
+            directorioDeEsteArchivo, "..", "..", "..", "src", "Ways.Application", "Fiscal", "ServicioDeCertificados.cs"));
+        var fuente = File.ReadAllText(ruta);
+
+        var inicio = fuente.IndexOf(
+            "public async Task<CertificadoFiscalDto> RegistrarAsync(", StringComparison.Ordinal);
+        Assert.True(inicio >= 0, "No se encontró el método RegistrarAsync en el archivo fuente.");
+
+        // El método completo (incluye la transacción + el finally que le sigue) — un rango generoso
+        // en vez de parsear C#, mismo criterio que el test de CifradoDeClavesFiscales.
+        var bloque = fuente.Substring(inicio, Math.Min(4000, fuente.Length - inicio));
+
+        Assert.Contains("finally", bloque, StringComparison.Ordinal);
+
+        var indiceFinally = bloque.IndexOf("finally", StringComparison.Ordinal);
+        var cuerpoFinally = bloque[indiceFinally..];
+
+        Assert.Contains("ZeroMemory(clavePrivada)", cuerpoFinally, StringComparison.Ordinal);
+        Assert.Contains("ZeroMemory(datos.Pfx)", cuerpoFinally, StringComparison.Ordinal);
     }
 
     private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;

--- a/tests/Ways.Application.Tests/Fiscal/CifradoDeClavesFiscalesTests.cs
+++ b/tests/Ways.Application.Tests/Fiscal/CifradoDeClavesFiscalesTests.cs
@@ -1,0 +1,285 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Ways.Domain.Fiscal;
+using Ways.Infrastructure.Fiscal;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+
+namespace Ways.Application.Tests.Fiscal;
+
+/// <summary>
+/// <see cref="CifradoDeClavesFiscales"/> — tasks.md Slice 4, targets 57-60 (D5's AAD, D6's
+/// versionado y ausencia de fallback, la limpieza de <see cref="CryptographicOperations.ZeroMemory"/>).
+/// Los targets 57/59 corren sobre el crypto PURO (<see cref="CifradoDeClavesFiscales.Cifrar"/>/
+/// <see cref="CifradoDeClavesFiscales.Descifrar"/>, sin base de datos ni configuración); 58/60
+/// necesitan la instancia completa (EF InMemory como <c>IWaysDbContext</c>, <c>IConfiguration</c>
+/// en memoria) porque son propiedades del PUERTO (versionado de clave, limpieza del buffer), no
+/// del algoritmo aislado.
+/// </summary>
+public class CifradoDeClavesFiscalesTests
+{
+    private static readonly byte[] ClaveMaestra = RandomNumberGenerator.GetBytes(32);
+    private static readonly byte[] Plaintext = Encoding.UTF8.GetBytes("material-de-clave-de-prueba-19a");
+    private const int IdTenant = 1;
+    private const int IdEmpresa = 10;
+    private const AmbienteFiscal Ambiente = AmbienteFiscal.Homologacion;
+    private const string Huella = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd";
+
+    private static (byte[] Ciphertext, byte[] Nonce, byte[] Tag) CifrarDeReferencia() =>
+        CifradoDeClavesFiscales.Cifrar(ClaveMaestra, Plaintext, IdTenant, IdEmpresa, Ambiente, Huella);
+
+    [Fact]
+    public void CifrarYDescifrarConLosMismosComponentesDeFilaDevuelveElPlaintextOriginal()
+    {
+        var (ciphertext, nonce, tag) = CifrarDeReferencia();
+
+        var descifrado = CifradoDeClavesFiscales.Descifrar(
+            ClaveMaestra, ciphertext, nonce, tag, IdTenant, IdEmpresa, Ambiente, Huella);
+
+        Assert.Equal(Plaintext, descifrado);
+    }
+
+    // --- Target 57: el AAD ata el ciphertext a su fila — tamperear CUALQUIERA de sus cuatro
+    // componentes tiene que fallar la autenticación de AesGcm, uno por uno. ---
+
+    [Fact]
+    public void MoverElCiphertextAOtroIdTenantFallaLaAutenticacion()
+    {
+        var (ciphertext, nonce, tag) = CifrarDeReferencia();
+
+        Assert.Throws<AuthenticationTagMismatchException>(() =>
+            CifradoDeClavesFiscales.Descifrar(
+                ClaveMaestra, ciphertext, nonce, tag, IdTenant + 1, IdEmpresa, Ambiente, Huella));
+    }
+
+    [Fact]
+    public void MoverElCiphertextAOtraEmpresaFallaLaAutenticacion()
+    {
+        var (ciphertext, nonce, tag) = CifrarDeReferencia();
+
+        Assert.Throws<AuthenticationTagMismatchException>(() =>
+            CifradoDeClavesFiscales.Descifrar(
+                ClaveMaestra, ciphertext, nonce, tag, IdTenant, IdEmpresa + 1, Ambiente, Huella));
+    }
+
+    [Fact]
+    public void MoverElCiphertextAOtroAmbienteFallaLaAutenticacion()
+    {
+        var (ciphertext, nonce, tag) = CifrarDeReferencia();
+
+        Assert.Throws<AuthenticationTagMismatchException>(() =>
+            CifradoDeClavesFiscales.Descifrar(
+                ClaveMaestra, ciphertext, nonce, tag, IdTenant, IdEmpresa, AmbienteFiscal.Produccion, Huella));
+    }
+
+    [Fact]
+    public void MoverElCiphertextAOtraHuellaFallaLaAutenticacion()
+    {
+        var (ciphertext, nonce, tag) = CifrarDeReferencia();
+        var huellaDistinta = new string('f', Huella.Length);
+
+        Assert.Throws<AuthenticationTagMismatchException>(() =>
+            CifradoDeClavesFiscales.Descifrar(
+                ClaveMaestra, ciphertext, nonce, tag, IdTenant, IdEmpresa, Ambiente, huellaDistinta));
+    }
+
+    // --- Target 59: sin clave maestra (ausente/corta), nada se escribe — el error nombrado, jamás
+    // texto plano ni una excepción de crypto pelada. ---
+
+    [Fact]
+    public async Task CifrarAsyncSinClaveMaestraConfiguradaTiraElErrorNombradoYNoLlegaADevolverNada()
+    {
+        var db = CrearContexto(nameof(CifrarAsyncSinClaveMaestraConfiguradaTiraElErrorNombradoYNoLlegaADevolverNada));
+        var configuracion = ConfiguracionSinClaves();
+        var almacen = new CifradoDeClavesFiscales(db, configuracion);
+
+        var error = await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() =>
+            almacen.CifrarAsync(Plaintext, IdTenant, IdEmpresa, Ambiente, Huella, CancellationToken.None));
+
+        Assert.Equal("clave_maestra_ausente", error.Codigo);
+        Assert.Equal(503, error.EstadoHttp);
+    }
+
+    [Fact]
+    public async Task CifrarAsyncConUnaClaveMaestraDeMenosDe32BytesTiraElErrorNombrado()
+    {
+        var db = CrearContexto(nameof(CifrarAsyncConUnaClaveMaestraDeMenosDe32BytesTiraElErrorNombrado));
+        var configuracion = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ways:Fiscal:ClaveMaestraActual"] = "v1",
+                ["Ways:Fiscal:ClavesMaestras:v1"] = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16))
+            })
+            .Build();
+        var almacen = new CifradoDeClavesFiscales(db, configuracion);
+
+        var error = await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() =>
+            almacen.CifrarAsync(Plaintext, IdTenant, IdEmpresa, Ambiente, Huella, CancellationToken.None));
+
+        Assert.Equal("clave_maestra_ausente", error.Codigo);
+    }
+
+    [Fact]
+    public async Task UsarCertificadoAsyncSinCertificadoActivoTiraCertificadoFiscalAusente()
+    {
+        var db = CrearContexto(nameof(UsarCertificadoAsyncSinCertificadoActivoTiraCertificadoFiscalAusente));
+        var almacen = new CifradoDeClavesFiscales(db, ConfiguracionSinClaves());
+
+        var error = await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() =>
+            almacen.UsarCertificadoAsync(IdEmpresa, Ambiente, _ => Task.FromResult(true), CancellationToken.None));
+
+        Assert.Equal("certificado_fiscal_ausente", error.Codigo);
+        Assert.Equal(409, error.EstadoHttp);
+    }
+
+    // --- Target 58: el AAD EXCLUYE id_clave_maestra — una fila cifrada bajo una versión de clave
+    // maestra sigue descifrando cuando la clave "actual" del sistema ya rotó a otra versión (el
+    // puerto resuelve por el id_clave_maestra de LA FILA, nunca por la actual). ---
+
+    [Fact]
+    public async Task UnaFilaCifradaConUnaVersionDeClaveMaestraSigueDescifrandoTrasRotarLaClaveActual()
+    {
+        var nombreDeBase = nameof(UnaFilaCifradaConUnaVersionDeClaveMaestraSigueDescifrandoTrasRotarLaClaveActual);
+        var claveV1 = RandomNumberGenerator.GetBytes(32);
+        var claveV2 = RandomNumberGenerator.GetBytes(32);
+
+        // La clave privada cifrada tiene que ser un PKCS#8 real que empareje con el PEM público
+        // guardado en la fila — UsarCertificadoAsync la reconstruye de verdad
+        // (X509Certificate2.CopyWithPrivateKey), no un blob opaco cualquiera.
+        using var certificadoDePrueba = GenerarCertificadoDePrueba();
+        var certificadoPem = certificadoDePrueba.ExportCertificatePem();
+        using var rsaPrivada = certificadoDePrueba.GetRSAPrivateKey()!;
+        var clavePrivadaPkcs8 = rsaPrivada.ExportPkcs8PrivateKey();
+
+        // Estado ANTES de la rotación: "actual" = v1.
+        var configuracionAntesDeRotar = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ways:Fiscal:ClaveMaestraActual"] = "v1",
+                ["Ways:Fiscal:ClavesMaestras:v1"] = Convert.ToBase64String(claveV1)
+            })
+            .Build();
+
+        int idCertificado;
+        await using (var db = CrearContexto(nombreDeBase))
+        {
+            var almacen = new CifradoDeClavesFiscales(db, configuracionAntesDeRotar);
+            var (ciphertext, nonce, tag, idClaveMaestra) = await almacen.CifrarAsync(
+                clavePrivadaPkcs8, IdTenant, IdEmpresa, Ambiente, Huella, CancellationToken.None);
+
+            Assert.Equal("v1", idClaveMaestra);
+
+            var certificado = CrearCertificadoDePrueba(certificadoPem, ciphertext, nonce, tag, idClaveMaestra);
+            db.CertificadosFiscales.Add(certificado);
+            await db.SaveChangesAsync();
+            idCertificado = certificado.Id;
+        }
+
+        // Estado DESPUÉS de la rotación: "actual" pasa a v2 — v1 sigue configurada (no se puede
+        // apagar hasta que TODAS las filas viejas se re-cifren), pero ya no es la que cifra
+        // material nuevo. La fila de arriba NUNCA se re-cifra en este test — sigue con
+        // id_clave_maestra = "v1" en la base.
+        var configuracionDespuesDeRotar = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ways:Fiscal:ClaveMaestraActual"] = "v2",
+                ["Ways:Fiscal:ClavesMaestras:v1"] = Convert.ToBase64String(claveV1),
+                ["Ways:Fiscal:ClavesMaestras:v2"] = Convert.ToBase64String(claveV2)
+            })
+            .Build();
+
+        await using var dbDespues = CrearContexto(nombreDeBase);
+        var almacenDespues = new CifradoDeClavesFiscales(dbDespues, configuracionDespuesDeRotar);
+
+        var descifradoOk = await almacenDespues.UsarCertificadoAsync(
+            IdEmpresa, Ambiente, cert => Task.FromResult(cert is not null), CancellationToken.None);
+
+        Assert.True(descifradoOk);
+        Assert.True(idCertificado > 0);
+    }
+
+    // --- Target 60 [S]: UsarCertificadoAsync limpia su buffer descifrado en un finally. ---
+
+    [Fact]
+    public void UsarCertificadoAsyncLimpiaElBufferDescifradoEnUnFinally()
+    {
+        var directorioDeEsteArchivo = Path.GetDirectoryName(RutaDeEsteArchivo())!;
+        var ruta = Path.GetFullPath(Path.Combine(
+            directorioDeEsteArchivo, "..", "..", "..", "src", "Ways.Infrastructure", "Fiscal", "CifradoDeClavesFiscales.cs"));
+        var fuente = File.ReadAllText(ruta);
+
+        var inicio = fuente.IndexOf("public async Task<T> UsarCertificadoAsync<T>(", StringComparison.Ordinal);
+        Assert.True(inicio >= 0, "No se encontró el método UsarCertificadoAsync en el archivo fuente.");
+
+        // El método completo es el próximo bloque hasta el cierre del `finally` que sigue al
+        // `try` — recorta un rango generoso (2500 caracteres alcanza sobra) en vez de parsear C#.
+        var bloque = fuente.Substring(inicio, Math.Min(2500, fuente.Length - inicio));
+
+        Assert.Contains("finally", bloque, StringComparison.Ordinal);
+
+        var indiceFinally = bloque.IndexOf("finally", StringComparison.Ordinal);
+        var cuerpoFinally = bloque[indiceFinally..];
+
+        // El gap real que este test dejaba pasar (mutation-proof-tests regla 2, corregido en el
+        // resume de este apply): un ÚNICO "Contains" no discrimina QUÉ buffer se limpia — un
+        // finally que solo zerea `claveMaestra` (la clave que ABRE la fila) y JAMÁS
+        // `clavePrivadaPlana` (el material descifrado en sí, lo verdaderamente sensible que sale
+        // del `Descifrar`) pasaba este assert igual. Ambos nombres de variable, no solo el nombre
+        // del método, es lo que hace la aserción estructural discriminante.
+        Assert.Contains("ZeroMemory(claveMaestra)", cuerpoFinally, StringComparison.Ordinal);
+        Assert.Contains("ZeroMemory(clavePrivadaPlana)", cuerpoFinally, StringComparison.Ordinal);
+    }
+
+    private static string RutaDeEsteArchivo([System.Runtime.CompilerServices.CallerFilePath] string ruta = "") => ruta;
+
+    private static IConfiguration ConfiguracionSinClaves() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+
+    private static WaysDbContext CrearContexto(string nombreDeBase) =>
+        new(new DbContextOptionsBuilder<WaysDbContext>().UseInMemoryDatabase(nombreDeBase).Options,
+            TenantActualFijo.Plataforma);
+
+    private static CertificadoFiscal CrearCertificadoDePrueba(
+        string certificadoPem, byte[] ciphertext, byte[] nonce, byte[] tag, string idClaveMaestra)
+    {
+        var ahora = DateTimeOffset.UtcNow;
+        return new CertificadoFiscal
+        {
+            IdTenant = IdTenant,
+            IdEmpresa = IdEmpresa,
+            Ambiente = Ambiente,
+            Alias = "Homo de prueba",
+            CuitTitular = "20111111112",
+            CertificadoPem = certificadoPem,
+            ClavePrivadaCifrada = ciphertext,
+            Nonce = nonce,
+            TagAutenticacion = tag,
+            IdClaveMaestra = idClaveMaestra,
+            HuellaSha256 = Huella,
+            VigenciaDesde = ahora.AddDays(-1),
+            VigenciaHasta = ahora.AddYears(1),
+            Activo = true,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+    }
+
+    /// <summary>Generado en runtime (D7/decisión 12, mismo criterio que
+    /// <c>CertificadoDePrueba</c>): CERO material de clave se escribe a disco ni se commitea.
+    /// Exportable a propósito — el test necesita <c>GetRSAPrivateKey()</c>.</summary>
+    private static X509Certificate2 GenerarCertificadoDePrueba()
+    {
+        using var rsa = RSA.Create(2048);
+        var solicitud = new CertificateRequest(
+            "CN=Ways Test Rotacion", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var ahora = DateTimeOffset.UtcNow;
+        using var efimero = solicitud.CreateSelfSigned(ahora.AddDays(-1), ahora.AddYears(1));
+
+        var contrasenaEfimera = Guid.NewGuid().ToString("N");
+        var pfx = efimero.Export(X509ContentType.Pkcs12, contrasenaEfimera);
+        return X509CertificateLoader.LoadPkcs12(pfx, contrasenaEfimera, X509KeyStorageFlags.Exportable);
+    }
+}

--- a/tests/Ways.IntegrationTests/AsignadorDeNumeroFiscalTests.cs
+++ b/tests/Ways.IntegrationTests/AsignadorDeNumeroFiscalTests.cs
@@ -1,10 +1,16 @@
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql;
 using Ways.Application.Abstracciones;
 using Ways.Application.Fiscal;
+using Ways.Domain.Catalogos;
 using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Domain.Ventas;
 using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
 
 namespace Ways.IntegrationTests;
 
@@ -329,7 +335,105 @@ public class AsignadorDeNumeroFiscalTests(WaysApiFixture fixture) : IClassFixtur
         Assert.Equal(0L, await LeerUltimoAutorizadoAsync(idPuntoVenta, CodigoAfipFa));
     }
 
+    // --- D13: ReconciliarAsync nunca auto-sana proximo_numero (judgment-day 19a-slice-4, ronda 1,
+    // juez B) ---
+
+    /// <summary>D13 (design.md, doc-comment de <see cref="AsignadorDeNumeroFiscal.ReconciliarAsync"/>):
+    /// reconciliar escribe SOLO <c>ultimo_autorizado_arca</c>/<c>sincronizado_en</c>, nunca
+    /// <c>proximo_numero</c> — ni siquiera ante una divergencia real y no trivial entre ambos
+    /// contadores (nosotros adelante de ARCA, el caso legítimo que dispara el 409
+    /// <c>numeracion_fiscal_desincronizada</c>). Semilla deliberada (regla 11): <c>proximo_numero</c>
+    /// arranca en 4 (≠1, tres asignaciones ya comiteadas) y <c>ultimoAutorizadoArca</c> es 2 (≠1 y
+    /// ≠ proximo_numero) — así un mutante de auto-heal (<c>proximo_numero = ultimoAutorizadoArca +
+    /// 1 = 3</c>) produce un valor DISTINTO del vigente (4), detectable, no uno que coincida por
+    /// casualidad con el ya persistido.</summary>
+    [Fact]
+    public async Task ReconciliarUnaSerieConDeudaPreviaNoTocaElProximoNumero()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(ReconciliarUnaSerieConDeudaPreviaNoTocaElProximoNumero));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa); // consume 1
+        await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa); // consume 2
+        await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa); // consume 3
+        Assert.Equal(4L, await LeerProximoNumeroAsync(idPuntoVenta, CodigoAfipFa));
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroFiscal.ReconciliarAsync(
+            db, idPuntoVenta, CodigoAfipFa, ultimoAutorizadoArca: 2, new RelojFijo(DateTimeOffset.UtcNow));
+
+        Assert.Equal(4L, await LeerProximoNumeroAsync(idPuntoVenta, CodigoAfipFa));
+        Assert.Equal(2L, await LeerUltimoAutorizadoAsync(idPuntoVenta, CodigoAfipFa));
+    }
+
     // --- spec: concurrencia serializada (Requirement: Concurrent Emissions Are Serialized) ---
+
+    /// <summary>Rendezvous forzado (design.md:450, judgment-day 19a-slice-4 ronda 1 juez B): un
+    /// <c>Task.WhenAll</c> desnudo no garantiza que las dos transacciones lleguen a pelear por el
+    /// mismo row lock — el scheduler puede correrlas de punta a punta sin solaparse nunca, y ahí un
+    /// mutante lost-update (<c>SELECT</c> sin lock + <c>UPDATE</c> separado) sobrevive por pura
+    /// suerte. Este interceptor retiene la PRIMERA transacción que arranca hasta que la SEGUNDA
+    /// también arrancó la suya — recién ahí libera a ambas, así los dos <c>UPDATE ... RETURNING</c>
+    /// (o, bajo el mutante, los dos <c>SELECT</c>) corren genuinamente solapados.</summary>
+    private sealed class InterceptorDeRendezvousEnAmbasTransacciones : DbTransactionInterceptor
+    {
+        private readonly TaskCompletionSource _primeraLlego = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _segundaLlego = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_primeraLlego.TrySetResult())
+            {
+                _segundaLlego.TrySetResult();
+            }
+            else
+            {
+                await _segundaLlego.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            }
+
+            return await base.TransactionStartedAsync(connection, eventData, transaction, cancellationToken);
+        }
+    }
+
+    private WaysDbContext CrearContextoConInterceptor(DbTransactionInterceptor interceptor)
+    {
+        var opciones = new DbContextOptionsBuilder<WaysDbContext>()
+            .UseNpgsql(fixture.AppConnectionString, npgsql =>
+            {
+                npgsql.MapEnum<EstadoUsuario>("estado_usuario");
+                npgsql.MapEnum<EstadoTenant>("estado_tenant");
+                npgsql.MapEnum<ComportamientoMedioPago>("comportamiento_medio_pago");
+                npgsql.MapEnum<ClaseComprobante>("clase_comprobante");
+                npgsql.MapEnum<Ways.Domain.Clientes.TipoDocumento>("tipo_documento");
+                npgsql.MapEnum<ModoLista>("modo_lista");
+                npgsql.MapEnum<Ways.Domain.Articulos.UnidadVenta>("unidad_venta");
+                npgsql.MapEnum<EstadoComprobante>("estado_comprobante");
+                npgsql.MapEnum<Ways.Domain.Stock.MotivoStock>("motivo_stock");
+                npgsql.MapEnum<Ways.Domain.CuentaCorriente.TipoMovimientoCc>("tipo_movimiento_cc");
+                npgsql.MapEnum<Ways.Domain.Caja.EstadoTurno>("estado_turno");
+                npgsql.MapEnum<Ways.Domain.Fiscal.ResultadoFiscal>("resultado_fiscal");
+                npgsql.MapEnum<Ways.Domain.Fiscal.AmbienteFiscal>("ambiente_fiscal");
+            })
+            .AddInterceptors(new InterceptorDeContextoDeTenant(TenantActualFijo.Plataforma), interceptor)
+            .Options;
+
+        return new WaysDbContext(opciones, TenantActualFijo.Plataforma);
+    }
+
+    private async Task<long> AsignarComiteadoConInterceptorAsync(
+        int idPuntoVenta, short codigoAfip, DbTransactionInterceptor interceptor)
+    {
+        await using var db = CrearContextoConInterceptor(interceptor);
+        await using var transaccion = await db.Database.BeginTransactionAsync();
+
+        var numero = await AsignadorDeNumeroFiscal.AsignarSiguienteAsync(db, idPuntoVenta, codigoAfip);
+
+        await transaccion.CommitAsync();
+        return numero;
+    }
 
     [Fact]
     public async Task DosAsignacionesConcurrentesDeLaMismaSerieDanNumerosDistintosYConsecutivos()
@@ -338,8 +442,9 @@ public class AsignadorDeNumeroFiscalTests(WaysApiFixture fixture) : IClassFixtur
             nameof(DosAsignacionesConcurrentesDeLaMismaSerieDanNumerosDistintosYConsecutivos));
         await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
 
-        var tareaA = AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
-        var tareaB = AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+        var interceptor = new InterceptorDeRendezvousEnAmbasTransacciones();
+        var tareaA = AsignarComiteadoConInterceptorAsync(idPuntoVenta, CodigoAfipFa, interceptor);
+        var tareaB = AsignarComiteadoConInterceptorAsync(idPuntoVenta, CodigoAfipFa, interceptor);
 
         var numeros = await Task.WhenAll(tareaA, tareaB);
 

--- a/tests/Ways.IntegrationTests/AsignadorDeNumeroFiscalTests.cs
+++ b/tests/Ways.IntegrationTests/AsignadorDeNumeroFiscalTests.cs
@@ -1,0 +1,349 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Fiscal;
+using Ways.Domain.Organizacion;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// <see cref="AsignadorDeNumeroFiscal"/> — tasks.md Slice 4, targets 52-56 (U1/U3 conjuncts, I1,
+/// D1's lock proof) más los dos escenarios propios de <c>specs/numeracion-fiscal/spec.md</c>
+/// (rollback no consume, concurrencia N/N+1 — el mismo patrón exacto de
+/// <c>AsignadorDeNumeroComprobanteConcurrenciaTests</c>, con la disciplina invertida: ACÁ no hay
+/// <c>AsignarComprometidoAsync</c> que abra su propia transacción — el llamador es siempre quien la
+/// abre y la comitea, design D1).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class AsignadorDeNumeroFiscalTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const short CodigoAfipFa = 1;
+    private const short CodigoAfipFb = 6;
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    private async Task<(int IdTenant, int IdPuntoVenta)> SembrarPuntoVentaAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Tenants.Add(tenant);
+        await siembra.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Empresas.Add(empresa);
+        await siembra.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = nombre, CreatedAt = ahora, UpdatedAt = ahora
+        };
+        siembra.PuntosVenta.Add(puntoVenta);
+        await siembra.SaveChangesAsync();
+
+        return (tenant.Id, puntoVenta.Id);
+    }
+
+    /// <summary>Dos puntos de venta bajo el MISMO tenant — a diferencia de
+    /// <see cref="SembrarPuntoVentaAsync"/> (que arma un tenant nuevo por llamada), los tests de
+    /// U1/U3 conjunct (a) necesitan que ambos PV compartan tenant, así la FK compuesta
+    /// <c>fk_numeraciones_fiscales_punto_venta (id_punto_venta, id_tenant)</c> los acepta a los
+    /// dos.</summary>
+    private async Task<(int IdTenant, int IdPuntoVentaA, int IdPuntoVentaB)> SembrarDosPuntosDeVentaAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Tenants.Add(tenant);
+        await siembra.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Empresas.Add(empresa);
+        await siembra.SaveChangesAsync();
+
+        var puntoVentaA = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = $"{nombre}-A", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        var puntoVentaB = new PuntoVenta
+        {
+            IdTenant = tenant.Id, IdEmpresa = empresa.Id, Nombre = $"{nombre}-B", CreatedAt = ahora, UpdatedAt = ahora
+        };
+        siembra.PuntosVenta.AddRange(puntoVentaA, puntoVentaB);
+        await siembra.SaveChangesAsync();
+
+        return (tenant.Id, puntoVentaA.Id, puntoVentaB.Id);
+    }
+
+    private async Task AsegurarAsync(int idTenant, int idPuntoVenta, short codigoAfip)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroFiscal.AsegurarContadorAsync(db, idTenant, idPuntoVenta, codigoAfip);
+    }
+
+    private async Task<long> AsignarComiteadoAsync(int idPuntoVenta, short codigoAfip)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccion = await db.Database.BeginTransactionAsync();
+
+        var numero = await AsignadorDeNumeroFiscal.AsignarSiguienteAsync(db, idPuntoVenta, codigoAfip);
+
+        await transaccion.CommitAsync();
+        return numero;
+    }
+
+    /// <summary>Conexión cruda en modo <c>plataforma</c> (bypassea RLS, misma convención que
+    /// <c>SembrarPuntoVentaAsync</c>) — SIN esto, una lectura raw contra una tabla <c>FORCE</c>
+    /// RLS con <c>app.tenant_id</c> sin setear ve CERO filas y <c>ExecuteScalarAsync</c> devuelve
+    /// <c>null</c> en silencio, no una excepción (el bug real detrás del primer intento de este
+    /// archivo: "Expected 5, Actual null" no era la producción fallando, era el lector de la
+    /// prueba leyendo sin contexto de tenant).</summary>
+    private async Task<NpgsqlConnection> AbrirConexionPlataformaAsync()
+    {
+        var conexion = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexion.OpenAsync();
+        await using var guc = new NpgsqlCommand("SELECT set_config('app.acceso', 'plataforma', false)", conexion);
+        await guc.ExecuteNonQueryAsync();
+        return conexion;
+    }
+
+    private async Task<long?> LeerProximoNumeroAsync(int idPuntoVenta, short codigoAfip)
+    {
+        await using var conexion = await AbrirConexionPlataformaAsync();
+        await using var comando = new NpgsqlCommand(
+            "SELECT proximo_numero FROM numeraciones_fiscales WHERE id_punto_venta = $1 AND codigo_afip = $2",
+            conexion);
+        comando.Parameters.AddWithValue(idPuntoVenta);
+        comando.Parameters.AddWithValue(codigoAfip);
+
+        var resultado = await comando.ExecuteScalarAsync();
+        return resultado is null ? null : Convert.ToInt64(resultado);
+    }
+
+    private async Task<long?> LeerUltimoAutorizadoAsync(int idPuntoVenta, short codigoAfip)
+    {
+        await using var conexion = await AbrirConexionPlataformaAsync();
+        await using var comando = new NpgsqlCommand(
+            "SELECT ultimo_autorizado_arca FROM numeraciones_fiscales WHERE id_punto_venta = $1 AND codigo_afip = $2",
+            conexion);
+        comando.Parameters.AddWithValue(idPuntoVenta);
+        comando.Parameters.AddWithValue(codigoAfip);
+
+        var resultado = await comando.ExecuteScalarAsync();
+        return resultado is null or DBNull ? null : Convert.ToInt64(resultado);
+    }
+
+    // --- Target 52: U1 conjunct (a) id_punto_venta ---
+
+    [Fact]
+    public async Task AsignarSobreUnPuntoDeVentaNoTocaElProximoNumeroDeUnPuntoDeVentaHermano()
+    {
+        var (idTenant, idPuntoVentaA, idPuntoVentaB) = await SembrarDosPuntosDeVentaAsync(
+            nameof(AsignarSobreUnPuntoDeVentaNoTocaElProximoNumeroDeUnPuntoDeVentaHermano));
+
+        await AsegurarAsync(idTenant, idPuntoVentaA, CodigoAfipFa);
+        await AsegurarAsync(idTenant, idPuntoVentaB, CodigoAfipFa);
+
+        await AsignarComiteadoAsync(idPuntoVentaA, CodigoAfipFa);
+
+        Assert.Equal(2L, await LeerProximoNumeroAsync(idPuntoVentaA, CodigoAfipFa));
+        Assert.Equal(1L, await LeerProximoNumeroAsync(idPuntoVentaB, CodigoAfipFa));
+    }
+
+    // --- Target 53: U1 conjunct (b) codigo_afip ---
+
+    [Fact]
+    public async Task AsignarSobreUnCodigoAfipNoTocaElProximoNumeroDeOtroCodigoAfipDelMismoPuntoDeVenta()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(AsignarSobreUnCodigoAfipNoTocaElProximoNumeroDeOtroCodigoAfipDelMismoPuntoDeVenta));
+
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFb);
+
+        await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+
+        Assert.Equal(2L, await LeerProximoNumeroAsync(idPuntoVenta, CodigoAfipFa));
+        Assert.Equal(1L, await LeerProximoNumeroAsync(idPuntoVenta, CodigoAfipFb));
+    }
+
+    // --- Target 54: I1 — un rechazo no libera el número ---
+
+    /// <summary>I1: un número asignado y COMITEADO (aunque el comprobante que lo usó termine
+    /// <c>rechazado</c>) no se libera — el release explícito del operador es 19c (T2). El único
+    /// caso en el que un número no se consume es un ROLLBACK antes de comitear (spec: "A Rolled-Back
+    /// Emission Does Not Consume The Fiscal Number", cubierto aparte, más abajo).</summary>
+    [Fact]
+    public async Task UnNumeroComiteadoPorUnaEmisionQueTerminaRechazadaNoSeLiberaYElSiguienteEsConsecutivo()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(UnNumeroComiteadoPorUnaEmisionQueTerminaRechazadaNoSeLiberaYElSiguienteEsConsecutivo));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        // Simula el número que quedó atado a un comprobante 'rechazado' — la transacción COMITEA
+        // igual (el número se consume aunque el resultado de ARCA termine siendo un rechazo; solo
+        // un rollback ANTES de comitear reusa el número, ver el test de más abajo).
+        var numeroDelRechazo = await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+        var numeroSiguiente = await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+
+        Assert.Equal(numeroDelRechazo + 1, numeroSiguiente);
+    }
+
+    /// <summary>spec numeracion-fiscal: "A Rolled-Back Emission Does Not Consume The Fiscal
+    /// Number" — un rollback ANTES de comitear (p. ej. la transacción entera de la emisión falla
+    /// antes del `COMMIT`) no deja un hueco: el número queda disponible para el siguiente intento.</summary>
+    [Fact]
+    public async Task UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(UnaAsignacionConRollbackAntesDeComitearReusaElNumeroEnVezDeDejarUnHueco));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        await using var dbRollback = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccionRollback = await dbRollback.Database.BeginTransactionAsync();
+        var numeroDescartado = await AsignadorDeNumeroFiscal.AsignarSiguienteAsync(dbRollback, idPuntoVenta, CodigoAfipFa);
+        await transaccionRollback.RollbackAsync();
+
+        var numeroSiguiente = await AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+
+        Assert.Equal(numeroDescartado, numeroSiguiente);
+    }
+
+    // --- Target 55 [S]: D1's lock proof, ambos lados ---
+
+    /// <summary>D1 (design.md, Lock order — arbitrated): mientras la transacción que asignó el
+    /// número sigue abierta (sin comitear), <c>numeraciones_fiscales</c> tiene que aparecer entre
+    /// los locks de relación de esa conexión (posición 0, prefijo singleton) y NINGUNA de las
+    /// tablas de la serie contendida (<c>turnos_caja</c>, <c>stock</c>, <c>stock_lotes</c>,
+    /// <c>clientes</c>) puede aparecer — la prueba obligatoria es de DOS lados (rule 13), no basta
+    /// con confirmar que el lock esperado está.</summary>
+    [Fact]
+    public async Task LaTransaccionDeAsignacionSostieneSoloElLockDeNumeracionesFiscales()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(LaTransaccionDeAsignacionSostieneSoloElLockDeNumeracionesFiscales));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await using var transaccion = await db.Database.BeginTransactionAsync();
+
+        await AsignadorDeNumeroFiscal.AsignarSiguienteAsync(db, idPuntoVenta, CodigoAfipFa);
+
+        var conexionBackend = db.Database.GetDbConnection();
+        int pid;
+        await using (var comandoPid = conexionBackend.CreateCommand())
+        {
+            comandoPid.CommandText = "SELECT pg_backend_pid()";
+            comandoPid.Transaction = db.Database.CurrentTransaction?.GetDbTransaction();
+            pid = (int)(await comandoPid.ExecuteScalarAsync())!;
+        }
+
+        await using var conexionPoll = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexionPoll.OpenAsync();
+        await using var comandoPoll = new NpgsqlCommand(
+            "SELECT c.relname FROM pg_locks l JOIN pg_class c ON c.oid = l.relation " +
+            "WHERE l.pid = $1 AND l.locktype = 'relation' AND c.relkind = 'r'",
+            conexionPoll);
+        comandoPoll.Parameters.AddWithValue(pid);
+
+        var relacionesBloqueadas = new List<string>();
+        await using (var lector = await comandoPoll.ExecuteReaderAsync())
+        {
+            while (await lector.ReadAsync())
+            {
+                relacionesBloqueadas.Add(lector.GetString(0));
+            }
+        }
+
+        await transaccion.RollbackAsync();
+
+        Assert.Contains("numeraciones_fiscales", relacionesBloqueadas);
+        Assert.DoesNotContain("turnos_caja", relacionesBloqueadas);
+        Assert.DoesNotContain("stock", relacionesBloqueadas);
+        Assert.DoesNotContain("stock_lotes", relacionesBloqueadas);
+        Assert.DoesNotContain("clientes", relacionesBloqueadas);
+    }
+
+    // --- Target 56: U3 conjuncts (a)(b) ---
+
+    [Fact]
+    public async Task ReconciliarUnaSerieNoTocaElUltimoAutorizadoDeUnPuntoDeVentaHermano()
+    {
+        var (idTenant, idPuntoVentaA, idPuntoVentaB) = await SembrarDosPuntosDeVentaAsync(
+            nameof(ReconciliarUnaSerieNoTocaElUltimoAutorizadoDeUnPuntoDeVentaHermano));
+
+        await AsegurarAsync(idTenant, idPuntoVentaA, CodigoAfipFa);
+        await AsegurarAsync(idTenant, idPuntoVentaB, CodigoAfipFa);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroFiscal.ReconciliarAsync(
+            db, idPuntoVentaA, CodigoAfipFa, 5, new RelojFijo(DateTimeOffset.UtcNow));
+
+        Assert.Equal(5L, await LeerUltimoAutorizadoAsync(idPuntoVentaA, CodigoAfipFa));
+        Assert.Null(await LeerUltimoAutorizadoAsync(idPuntoVentaB, CodigoAfipFa));
+    }
+
+    [Fact]
+    public async Task ReconciliarUnaSerieNoTocaElUltimoAutorizadoDeUnCodigoAfipHermano()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(ReconciliarUnaSerieNoTocaElUltimoAutorizadoDeUnCodigoAfipHermano));
+
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFb);
+
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroFiscal.ReconciliarAsync(
+            db, idPuntoVenta, CodigoAfipFa, 5, new RelojFijo(DateTimeOffset.UtcNow));
+
+        Assert.Equal(5L, await LeerUltimoAutorizadoAsync(idPuntoVenta, CodigoAfipFa));
+        Assert.Null(await LeerUltimoAutorizadoAsync(idPuntoVenta, CodigoAfipFb));
+    }
+
+    /// <summary>spec numeracion-fiscal: "Reconciling An Empty Series Records 0, Not NULL" — un
+    /// <c>FECompUltimoAutorizado</c> de serie nunca usada responde <c>CbteNro = 0</c>, y eso es un
+    /// valor LEGÍTIMO (CHECK 7 lo permite explícitamente para esta columna) — no hay que
+    /// confundirlo con "todavía no reconciliada" (<c>NULL</c>).</summary>
+    [Fact]
+    public async Task ReconciliarUnaSerieNuncaUsadaRegistraCeroNoNull()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(ReconciliarUnaSerieNuncaUsadaRegistraCeroNoNull));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        var ahora = new DateTimeOffset(2026, 8, 21, 10, 0, 0, TimeSpan.Zero);
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        await AsignadorDeNumeroFiscal.ReconciliarAsync(db, idPuntoVenta, CodigoAfipFa, 0, new RelojFijo(ahora));
+
+        Assert.Equal(0L, await LeerUltimoAutorizadoAsync(idPuntoVenta, CodigoAfipFa));
+    }
+
+    // --- spec: concurrencia serializada (Requirement: Concurrent Emissions Are Serialized) ---
+
+    [Fact]
+    public async Task DosAsignacionesConcurrentesDeLaMismaSerieDanNumerosDistintosYConsecutivos()
+    {
+        var (idTenant, idPuntoVenta) = await SembrarPuntoVentaAsync(
+            nameof(DosAsignacionesConcurrentesDeLaMismaSerieDanNumerosDistintosYConsecutivos));
+        await AsegurarAsync(idTenant, idPuntoVenta, CodigoAfipFa);
+
+        var tareaA = AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+        var tareaB = AsignarComiteadoAsync(idPuntoVenta, CodigoAfipFa);
+
+        var numeros = await Task.WhenAll(tareaA, tareaB);
+
+        Assert.NotEqual(numeros[0], numeros[1]);
+        Assert.Equal([1L, 2L], numeros.OrderBy(n => n));
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
@@ -1,0 +1,505 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using Ways.Application.Abstracciones;
+using Ways.Application.Fiscal;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Fiscal;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Fiscal;
+using Ways.Infrastructure.Multitenancy;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// <see cref="ServicioDeCertificados"/>/<see cref="DesactivadorDeCertificadoFiscal"/> — tasks.md
+/// Slice 4, targets 61-63: U4 (los cinco kills, (a) vía RLS bajo <c>ways_app</c>, (b)-(e) directo
+/// contra el mismo método de producción), la cláusula de exposición del DTO (target 62), y la
+/// matriz de roles de <see cref="Politicas.AdministracionFiscal"/> (target 63).
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+    private const string PasswordOtroRol = "otro-rol-password-larga";
+    private static readonly DateTimeOffset Ahora = new(2026, 8, 21, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>D6/verify criterion 8: <c>Ways.Api/Program.cs</c> lee <c>builder.Configuration</c>
+    /// SÍNCRONO, antes de que <c>WebApplicationFactory.ConfigureAppConfiguration</c> tenga chance
+    /// de inyectar nada (mismo hallazgo documentado en <c>WaysApiFixture.ConfigureWebHost</c> para
+    /// la cadena de conexión) — la única vía que Program.Main sí lee es una variable de ENTORNO,
+    /// seteada acá en el constructor estático (garantizado por el runtime "antes del primer uso
+    /// del tipo", así que corre antes de que cualquier test de esta clase llegue a su primer
+    /// <c>fixture.CreateClient()</c>). Nunca commiteada a <c>appsettings*.json</c> — coherente con
+    /// D6 y el verify criterion 8 (ningún hostname/secreto real como default).</summary>
+    static ServicioDeCertificadosTests()
+    {
+        Environment.SetEnvironmentVariable("Ways__Fiscal__ClaveMaestraActual", "v1");
+        Environment.SetEnvironmentVariable(
+            "Ways__Fiscal__ClavesMaestras__v1", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
+    }
+
+    /// <summary>El servidor serializa enums como texto (Program.cs, <c>JsonStringEnumConverter</c>)
+    /// — el <see cref="HttpClient"/> de prueba no hereda esa configuración (mismo hallazgo que
+    /// <c>OrganizacionTests.OpcionesJson</c>): hay que repetirla para <see cref="CertificadoFiscalDto.Ambiente"/>.</summary>
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private sealed record Contexto(
+        int IdTenant, int IdEmpresa, HttpClient Admin, HttpClient Supervisor, HttpClient Vendedor, HttpClient Root);
+
+    private async Task<Contexto> PrepararAsync(string nombre)
+    {
+        var root = fixture.CreateClient();
+        var loginRoot = await root.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, loginRoot.StatusCode);
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var solicitud = new SolicitudDeAprovisionamiento(nombre, $"{nombre} SA", "Local 1", mailAdmin);
+        var respuesta = await root.PostAsJsonAsync("/api/plataforma/tenants", solicitud);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
+        var resultado = (await respuesta.Content.ReadFromJsonAsync<ResultadoAprovisionamiento>())!;
+
+        var admin = fixture.CreateClient();
+        var loginAdmin = await admin.PostAsJsonAsync(
+            "/api/auth/login", new SolicitudDeLogin(mailAdmin, resultado.PasswordTemporal));
+        Assert.Equal(HttpStatusCode.OK, loginAdmin.StatusCode);
+
+        var supervisor = await CrearYLoguearAsync(admin, nombre, "supervisor", RolConocido.Supervisor);
+        var vendedor = await CrearYLoguearAsync(admin, nombre, "vendedor", RolConocido.Vendedor);
+
+        return new Contexto(resultado.IdTenant, resultado.IdEmpresa, admin, supervisor, vendedor, root);
+    }
+
+    private async Task<HttpClient> CrearYLoguearAsync(HttpClient admin, string nombre, string sufijo, RolConocido rol)
+    {
+        var corto = Guid.NewGuid().ToString("N")[..8];
+        var mail = $"{nombre.ToLowerInvariant()}-{sufijo}@ways.test";
+        var alta = await admin.PostAsJsonAsync(
+            "/api/usuarios", new CrearUsuario($"{sufijo}-{corto}", mail, (int)rol, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
+
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mail, PasswordOtroRol));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private static (byte[] Pfx, string Password) GenerarPfx(string cn)
+    {
+        using var rsa = RSA.Create(2048);
+        var solicitud = new CertificateRequest(cn, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var ahora = DateTimeOffset.UtcNow;
+        using var certificado = solicitud.CreateSelfSigned(ahora.AddDays(-1), ahora.AddYears(1));
+
+        var password = Guid.NewGuid().ToString("N");
+        return (certificado.Export(X509ContentType.Pkcs12, password), password);
+    }
+
+    private static IConfiguration ConfiguracionConClaveMaestra() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ways:Fiscal:ClaveMaestraActual"] = "v1",
+                ["Ways:Fiscal:ClavesMaestras:v1"] = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            })
+            .Build();
+
+    // --- Target 63: matriz de roles de AdministracionFiscal ---
+
+    [Fact]
+    public async Task UnAdminEsAceptadoAlRegistrarUnCertificadoFiscal()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoAlRegistrarUnCertificadoFiscal));
+        var (pfx, password) = GenerarPfx("CN=Ways Test Admin");
+
+        var respuesta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20111111112", pfx, password));
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(nameof(RolConocido.Supervisor))]
+    [InlineData(nameof(RolConocido.Vendedor))]
+    public async Task UnSupervisorOVendedorEsRechazadoAlRegistrarUnCertificadoFiscal(string rol)
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorOVendedorEsRechazadoAlRegistrarUnCertificadoFiscal) + rol);
+        var cliente = rol == nameof(RolConocido.Supervisor) ? ctx.Supervisor : ctx.Vendedor;
+        var (pfx, password) = GenerarPfx($"CN=Ways Test {rol}");
+
+        var respuesta = await cliente.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20111111112", pfx, password));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazadoAlRegistrarUnCertificadoFiscal()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoAlRegistrarUnCertificadoFiscal));
+        var (pfx, password) = GenerarPfx("CN=Ways Test Root");
+
+        var respuesta = await ctx.Root.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20111111112", pfx, password));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminEsAceptadoAlCargarLaCondicionFiscalDeUnaEmpresa()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoAlCargarLaCondicionFiscalDeUnaEmpresa));
+
+        var respuesta = await ctx.Admin.PutAsJsonAsync(
+            $"/api/fiscal/empresas/{ctx.IdEmpresa}/condicion-fiscal", new CondicionFiscalDeEmpresaEdicion(1));
+
+        Assert.Equal(HttpStatusCode.NoContent, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAdminEsAceptadoAlDesactivarUnCertificadoFiscal()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoAlDesactivarUnCertificadoFiscal));
+        var (pfx, password) = GenerarPfx("CN=Ways Test Desactivar");
+
+        var alta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo a desactivar", "20111111112", pfx, password));
+        Assert.Equal(HttpStatusCode.OK, alta.StatusCode);
+        var creado = await alta.Content.ReadFromJsonAsync<CertificadoFiscalDto>(OpcionesJson);
+
+        var respuesta = await ctx.Admin.DeleteAsync($"/api/fiscal/certificados/{creado!.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnVendedorEsRechazadoAlCargarLaCondicionFiscalDeUnaEmpresa()
+    {
+        var ctx = await PrepararAsync(nameof(UnVendedorEsRechazadoAlCargarLaCondicionFiscalDeUnaEmpresa));
+
+        var respuesta = await ctx.Vendedor.PutAsJsonAsync(
+            $"/api/fiscal/empresas/{ctx.IdEmpresa}/condicion-fiscal", new CondicionFiscalDeEmpresaEdicion(1));
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    // --- Target 62: la cláusula de exposición — ninguna respuesta serializada del ABM puede
+    // llevar una propiedad de material de clave, matcheada por NOMBRE, recursiva. ---
+
+    private static readonly string[] PropiedadesDeMaterialDeClave =
+        ["clavePrivadaCifrada", "nonce", "tagAutenticacion", "certificadoPem", "claveMaestra"];
+
+    [Fact]
+    public async Task ListarCertificadosNuncaExponeMaterialDeClave()
+    {
+        var ctx = await PrepararAsync(nameof(ListarCertificadosNuncaExponeMaterialDeClave));
+        var (pfx, password) = GenerarPfx("CN=Ways Test Exposicion");
+
+        var alta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20222222223", pfx, password));
+        Assert.Equal(HttpStatusCode.OK, alta.StatusCode);
+
+        var listado = await ctx.Admin.GetAsync("/api/fiscal/certificados");
+        Assert.Equal(HttpStatusCode.OK, listado.StatusCode);
+
+        var cuerpo = await listado.Content.ReadAsStringAsync();
+        using var documento = JsonDocument.Parse(cuerpo);
+
+        var encontradas = new List<string>();
+        RecorrerNombresDePropiedad(documento.RootElement, encontradas);
+
+        foreach (var prohibida in PropiedadesDeMaterialDeClave)
+        {
+            Assert.DoesNotContain(
+                encontradas, nombre => string.Equals(nombre, prohibida, StringComparison.OrdinalIgnoreCase));
+        }
+
+        Assert.Contains(cuerpo, c => true); // el body no está vacío (guard trivial, evita un JSON [] falso-positivo)
+        Assert.Contains("alias", encontradas.Select(n => n.ToLowerInvariant()));
+    }
+
+    private static void RecorrerNombresDePropiedad(JsonElement elemento, List<string> acumulado)
+    {
+        switch (elemento.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var propiedad in elemento.EnumerateObject())
+                {
+                    acumulado.Add(propiedad.Name);
+                    RecorrerNombresDePropiedad(propiedad.Value, acumulado);
+                }
+
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in elemento.EnumerateArray())
+                {
+                    RecorrerNombresDePropiedad(item, acumulado);
+                }
+
+                break;
+        }
+    }
+
+    // --- Target 61: U4 — los cinco kills de la UPDATE de desactivación ---
+
+    private async Task<int> SembrarTenantConEmpresaAsync(string nombre)
+    {
+        using var _ = fixture.CreateClient();
+
+        await using var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Tenants.Add(tenant);
+        await siembra.SaveChangesAsync();
+
+        var empresa = new Empresa { IdTenant = tenant.Id, RazonSocial = nombre, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Empresas.Add(empresa);
+        await siembra.SaveChangesAsync();
+
+        return empresa.Id;
+    }
+
+    private async Task<int> SembrarCertificadoRawAsync(
+        int idTenant, int idEmpresa, AmbienteFiscal ambiente, bool activo, bool eliminado)
+    {
+        await using var conexion = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexion.OpenAsync();
+        await using (var guc = new NpgsqlCommand("SELECT set_config('app.acceso', 'plataforma', false)", conexion))
+        {
+            await guc.ExecuteNonQueryAsync();
+        }
+
+        await using var comando = new NpgsqlCommand(
+            """
+            INSERT INTO certificados_fiscales
+                (id_tenant, id_empresa, ambiente, alias, cuit_titular, certificado_pem,
+                 clave_privada_cifrada, nonce, tag_autenticacion, id_clave_maestra, huella_sha256,
+                 vigencia_desde, vigencia_hasta, activo, created_at, updated_at, deleted_at)
+            VALUES
+                ($1, $2, $3::ambiente_fiscal, 'Certificado de prueba', '20111111112', '-----BEGIN CERTIFICATE-----test-----END CERTIFICATE-----',
+                 $4, $5, $6, 'v1', $7, $8, $9, $10, $8, $8, $11)
+            RETURNING id_certificado
+            """,
+            conexion);
+        comando.Parameters.AddWithValue(idTenant);
+        comando.Parameters.AddWithValue(idEmpresa);
+        // Conexión cruda SIN MapEnum<AmbienteFiscal> registrado (a diferencia de
+        // db.Database.GetDbConnection(), armada vía UseNpgsql con el enum mapeado) — el enum viaja
+        // como texto y el cast explícito ($3::ambiente_fiscal) de la SQL hace el resto.
+        comando.Parameters.AddWithValue(ambiente.ToString().ToLowerInvariant());
+        comando.Parameters.AddWithValue(new byte[] { 1, 2, 3, 4 });
+        comando.Parameters.AddWithValue(new byte[12]);
+        comando.Parameters.AddWithValue(new byte[16]);
+        comando.Parameters.AddWithValue($"huella-{Guid.NewGuid():N}");
+        comando.Parameters.AddWithValue(Ahora);
+        comando.Parameters.AddWithValue(Ahora.AddYears(1));
+        comando.Parameters.AddWithValue(activo);
+        comando.Parameters.AddWithValue((object?)(eliminado ? Ahora : null) ?? DBNull.Value);
+
+        return (int)(await comando.ExecuteScalarAsync())!;
+    }
+
+    private async Task<(bool Activo, DateTimeOffset UpdatedAt)> LeerEstadoAsync(int idCertificado)
+    {
+        await using var conexion = new NpgsqlConnection(fixture.AppConnectionString);
+        await conexion.OpenAsync();
+        await using (var guc = new NpgsqlCommand("SELECT set_config('app.acceso', 'plataforma', false)", conexion))
+        {
+            await guc.ExecuteNonQueryAsync();
+        }
+
+        await using var comando = new NpgsqlCommand(
+            "SELECT activo, updated_at FROM certificados_fiscales WHERE id_certificado = $1", conexion);
+        comando.Parameters.AddWithValue(idCertificado);
+
+        await using var lector = await comando.ExecuteReaderAsync();
+        await lector.ReadAsync();
+        return (lector.GetBoolean(0), lector.GetFieldValue<DateTimeOffset>(1));
+    }
+
+    /// <summary>Conjunct (a): bajo <c>ways_app</c> escaneado como tenant B, la fila de tenant A es
+    /// invisible aunque el parámetro <c>idTenant</c> pasado sea el de A — RLS, no el WHERE
+    /// explícito, es lo que la protege (defensa en profundidad).</summary>
+    [Fact]
+    public async Task ConjuncoIdTenant_UnTenantAjenoNoPuedeDesactivarLaFilaDeOtroTenant()
+    {
+        var idEmpresaA = await SembrarTenantConEmpresaAsync(nameof(ConjuncoIdTenant_UnTenantAjenoNoPuedeDesactivarLaFilaDeOtroTenant) + "-A");
+        await using var dbSiembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTenantA = (await dbSiembra.Empresas.FindAsync(idEmpresaA))!.IdTenant;
+        var idTenantB = await SembrarOtroTenantAsync(nameof(ConjuncoIdTenant_UnTenantAjenoNoPuedeDesactivarLaFilaDeOtroTenant) + "-B");
+
+        var idCertificado = await SembrarCertificadoRawAsync(idTenantA, idEmpresaA, AmbienteFiscal.Homologacion, activo: true, eliminado: false);
+
+        await using var dbTenantB = fixture.CrearContextoDeAplicacion(
+            new TenantActualFijo(ModoDeAcceso.Tenant, idTenantB));
+
+        var afectadas = await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+            dbTenantB, idTenantA, idEmpresaA, AmbienteFiscal.Homologacion, Ahora.AddMinutes(1));
+
+        Assert.Equal(0, afectadas);
+        Assert.True((await LeerEstadoAsync(idCertificado)).Activo);
+    }
+
+    private async Task<int> SembrarOtroTenantAsync(string nombre)
+    {
+        await using var siembra = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var ahora = DateTimeOffset.UtcNow;
+        var tenant = new Tenant { Nombre = nombre, Estado = EstadoTenant.Activo, CreatedAt = ahora, UpdatedAt = ahora };
+        siembra.Tenants.Add(tenant);
+        await siembra.SaveChangesAsync();
+        return tenant.Id;
+    }
+
+    [Fact]
+    public async Task ConjuntoIdEmpresa_UnaEmpresaHermanaMantieneSuCertificadoActivo()
+    {
+        var idEmpresaA = await SembrarTenantConEmpresaAsync(nameof(ConjuntoIdEmpresa_UnaEmpresaHermanaMantieneSuCertificadoActivo) + "-A");
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTenant = (await db.Empresas.FindAsync(idEmpresaA))!.IdTenant;
+
+        var empresaB = new Empresa
+        {
+            IdTenant = idTenant, RazonSocial = "Hermana", CreatedAt = Ahora, UpdatedAt = Ahora
+        };
+        db.Empresas.Add(empresaB);
+        await db.SaveChangesAsync();
+
+        var idCertificadoA = await SembrarCertificadoRawAsync(idTenant, idEmpresaA, AmbienteFiscal.Homologacion, activo: true, eliminado: false);
+        var idCertificadoB = await SembrarCertificadoRawAsync(idTenant, empresaB.Id, AmbienteFiscal.Homologacion, activo: true, eliminado: false);
+
+        await using var dbAccion = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var afectadas = await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+            dbAccion, idTenant, idEmpresaA, AmbienteFiscal.Homologacion, Ahora.AddMinutes(1));
+
+        Assert.Equal(1, afectadas);
+        Assert.False((await LeerEstadoAsync(idCertificadoA)).Activo);
+        Assert.True((await LeerEstadoAsync(idCertificadoB)).Activo);
+    }
+
+    [Fact]
+    public async Task ConjuntoAmbiente_ElCertificadoDeProduccionSigueActivoMientrasHomologacionRota()
+    {
+        var idEmpresa = await SembrarTenantConEmpresaAsync(nameof(ConjuntoAmbiente_ElCertificadoDeProduccionSigueActivoMientrasHomologacionRota));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTenant = (await db.Empresas.FindAsync(idEmpresa))!.IdTenant;
+
+        var idHomo = await SembrarCertificadoRawAsync(idTenant, idEmpresa, AmbienteFiscal.Homologacion, activo: true, eliminado: false);
+        var idProd = await SembrarCertificadoRawAsync(idTenant, idEmpresa, AmbienteFiscal.Produccion, activo: true, eliminado: false);
+
+        await using var dbAccion = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var afectadas = await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+            dbAccion, idTenant, idEmpresa, AmbienteFiscal.Homologacion, Ahora.AddMinutes(1));
+
+        Assert.Equal(1, afectadas);
+        Assert.False((await LeerEstadoAsync(idHomo)).Activo);
+        Assert.True((await LeerEstadoAsync(idProd)).Activo);
+    }
+
+    /// <summary>Conjunct (d), mutation-proof-tests regla 4: se prueba sobre el CONTEO de filas
+    /// afectadas (0), no sobre el estado final (que ya era <c>false</c> de todos modos y sería un
+    /// test overdeterminado).</summary>
+    [Fact]
+    public async Task ConjuntoActivo_UnCertificadoYaInactivoNoSeCuentaComoAfectado()
+    {
+        var idEmpresa = await SembrarTenantConEmpresaAsync(nameof(ConjuntoActivo_UnCertificadoYaInactivoNoSeCuentaComoAfectado));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTenant = (await db.Empresas.FindAsync(idEmpresa))!.IdTenant;
+
+        await SembrarCertificadoRawAsync(idTenant, idEmpresa, AmbienteFiscal.Homologacion, activo: false, eliminado: false);
+
+        await using var dbAccion = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var afectadas = await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+            dbAccion, idTenant, idEmpresa, AmbienteFiscal.Homologacion, Ahora.AddMinutes(1));
+
+        Assert.Equal(0, afectadas);
+    }
+
+    [Fact]
+    public async Task ConjuntoDeletedAt_UnGemeloDadoDeBajaNiSeResucitaNiSeCuenta()
+    {
+        var idEmpresa = await SembrarTenantConEmpresaAsync(nameof(ConjuntoDeletedAt_UnGemeloDadoDeBajaNiSeResucitaNiSeCuenta));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var idTenant = (await db.Empresas.FindAsync(idEmpresa))!.IdTenant;
+
+        // Soft-deleted PERO todavía marcado activo=true en la fila (estado posible: se dio de
+        // baja lógica sin pasar por la desactivación explícita) — el filtro `deleted_at IS NULL`
+        // lo tiene que dejar afuera igual.
+        var idGemelo = await SembrarCertificadoRawAsync(idTenant, idEmpresa, AmbienteFiscal.Homologacion, activo: true, eliminado: true);
+
+        await using var dbAccion = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+        var afectadas = await DesactivadorDeCertificadoFiscal.DesactivarActivoAsync(
+            dbAccion, idTenant, idEmpresa, AmbienteFiscal.Homologacion, Ahora.AddMinutes(1));
+
+        Assert.Equal(0, afectadas);
+        Assert.True((await LeerEstadoAsync(idGemelo)).Activo);
+    }
+
+    // --- Rotación atómica end-to-end (spec certificados-fiscales) ---
+
+    [Fact]
+    public async Task RegistrarUnSegundoCertificadoRotaElPrimeroDentroDeUnaSolaTransaccion()
+    {
+        var ctx = await PrepararAsync(nameof(RegistrarUnSegundoCertificadoRotaElPrimeroDentroDeUnaSolaTransaccion));
+
+        var (pfx1, password1) = GenerarPfx("CN=Ways Test Rotacion 1");
+        var alta1 = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo v1", "20111111112", pfx1, password1));
+        Assert.Equal(HttpStatusCode.OK, alta1.StatusCode);
+
+        var (pfx2, password2) = GenerarPfx("CN=Ways Test Rotacion 2");
+        var alta2 = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
+            ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo v2", "20111111112", pfx2, password2));
+        Assert.Equal(HttpStatusCode.OK, alta2.StatusCode);
+
+        var listadoRespuesta = await ctx.Admin.GetAsync("/api/fiscal/certificados");
+        var listado = await listadoRespuesta.Content.ReadFromJsonAsync<List<CertificadoFiscalDto>>(OpcionesJson);
+        Assert.NotNull(listado);
+        var activos = listado!.Where(c => c.IdEmpresa == ctx.IdEmpresa && c.Ambiente == AmbienteFiscal.Homologacion && c.Activo);
+        Assert.Single(activos);
+        Assert.Equal("Homo v2", activos.Single().Alias);
+    }
+
+    // --- Target 59 (reasertado a nivel ABM): sin clave maestra, el alta falla y no queda fila. ---
+
+    [Fact]
+    public async Task RegistrarSinClaveMaestraConfiguradaNoEscribeNingunaFila()
+    {
+        var idEmpresa = await SembrarTenantConEmpresaAsync(nameof(RegistrarSinClaveMaestraConfiguradaNoEscribeNingunaFila));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var configuracionVacia = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+        var almacen = new CifradoDeClavesFiscales(db, configuracionVacia);
+        var reloj = new RelojFijoDeReferencia(Ahora);
+        var servicio = new ServicioDeCertificados(db, reloj, almacen);
+
+        var (pfx, password) = GenerarPfx("CN=Ways Test Sin Clave Maestra");
+
+        await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() => servicio.RegistrarAsync(
+            new RegistroDeCertificadoFiscal(idEmpresa, AmbienteFiscal.Homologacion, "Alias", "20111111112", pfx, password)));
+
+        // Conteo ACOTADO a la empresa de este test — db está en modo plataforma (sin filtro de
+        // tenant), y la colección "secuencial" comparte una sola base entre TODOS los tests de
+        // esta clase, así que un conteo global vería filas de otros tests, no de este alta.
+        var cantidad = await db.CertificadosFiscales.CountAsync(c => c.IdEmpresa == idEmpresa);
+        Assert.Equal(0, cantidad);
+    }
+
+    private sealed class RelojFijoDeReferencia(DateTimeOffset ahora) : Application.Abstracciones.IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+}

--- a/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
@@ -158,6 +158,52 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
         Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
     }
 
+    // --- Target 63 (GET, judgment-day 19a-slice-4 ronda 1 juez B): matriz de roles sobre la
+    // lectura — el ABM de escritura ya tenía la matriz completa, el GET no. ---
+
+    [Fact]
+    public async Task UnAdminEsAceptadoAlListarCertificadosFiscales()
+    {
+        var ctx = await PrepararAsync(nameof(UnAdminEsAceptadoAlListarCertificadosFiscales));
+
+        var respuesta = await ctx.Admin.GetAsync("/api/fiscal/certificados");
+
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(nameof(RolConocido.Supervisor))]
+    [InlineData(nameof(RolConocido.Vendedor))]
+    public async Task UnSupervisorOVendedorEsRechazadoAlListarCertificadosFiscales(string rol)
+    {
+        var ctx = await PrepararAsync(nameof(UnSupervisorOVendedorEsRechazadoAlListarCertificadosFiscales) + rol);
+        var cliente = rol == nameof(RolConocido.Supervisor) ? ctx.Supervisor : ctx.Vendedor;
+
+        var respuesta = await cliente.GetAsync("/api/fiscal/certificados");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnRootEsRechazadoAlListarCertificadosFiscales()
+    {
+        var ctx = await PrepararAsync(nameof(UnRootEsRechazadoAlListarCertificadosFiscales));
+
+        var respuesta = await ctx.Root.GetAsync("/api/fiscal/certificados");
+
+        Assert.Equal(HttpStatusCode.Forbidden, respuesta.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnAnonimoEsRechazadoAlListarCertificadosFiscales()
+    {
+        using var cliente = fixture.CreateClient();
+
+        var respuesta = await cliente.GetAsync("/api/fiscal/certificados");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, respuesta.StatusCode);
+    }
+
     [Fact]
     public async Task UnAdminEsAceptadoAlCargarLaCondicionFiscalDeUnaEmpresa()
     {

--- a/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
@@ -544,6 +544,41 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
         Assert.Equal(0, cantidad);
     }
 
+    // --- Completación del fix 3 de la ronda 2 (arbitraje del orquestador): el finally que zerea
+    // datos.Pfx tiene que cubrir TAMBIÉN el camino de fallo más probable del ABM — password
+    // incorrecta en CargarPfx —, no solo el camino feliz. ---
+
+    /// <summary>El try/finally arranca ANTES de <c>CargarPfx</c> (fix de completación):
+    /// <c>pfx_invalido</c> por password incorrecta es una excepción, y aun así
+    /// <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory"/> tiene que
+    /// haber corrido sobre <paramref name="datos"/>.Pfx antes de que la excepción llegue al
+    /// caller — mismo array, misma referencia, por eso se asertea el contenido DESPUÉS de la
+    /// llamada en vez de un mock/spy sobre ZeroMemory.</summary>
+    [Fact]
+    public async Task RegistrarConPasswordIncorrectaLimpiaElBufferPfxAunqueFalleLaCarga()
+    {
+        var idEmpresa = await SembrarTenantConEmpresaAsync(
+            nameof(RegistrarConPasswordIncorrectaLimpiaElBufferPfxAunqueFalleLaCarga));
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var almacen = new CifradoDeClavesFiscales(db, ConfiguracionConClaveMaestra());
+        var reloj = new RelojFijoDeReferencia(Ahora);
+        var servicio = new ServicioDeCertificados(db, reloj, almacen);
+
+        var (pfx, _) = GenerarPfx("CN=Ways Test Password Incorrecta");
+        // Guard: el PFX generado no es todo-cero de entrada — si no lo fuera, el assert final
+        // sería un falso-positivo trivial (nunca hubo nada que zerear).
+        Assert.Contains(pfx, b => b != 0);
+
+        var datos = new RegistroDeCertificadoFiscal(
+            idEmpresa, AmbienteFiscal.Homologacion, "Alias", "20111111112", pfx, "password-incorrecta-a-proposito");
+
+        var error = await Assert.ThrowsAsync<Domain.Common.ErrorDominio>(() => servicio.RegistrarAsync(datos));
+
+        Assert.Equal("pfx_invalido", error.Codigo);
+        Assert.All(pfx, b => Assert.Equal(0, b));
+    }
+
     private sealed class RelojFijoDeReferencia(DateTimeOffset ahora) : Application.Abstracciones.IRelojDelSistema
     {
         public DateTimeOffset Ahora { get; } = ahora;

--- a/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
+++ b/tests/Ways.IntegrationTests/ServicioDeCertificadosTests.cs
@@ -128,7 +128,7 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
         var respuesta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
             ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20111111112", pfx, password));
 
-        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, respuesta.StatusCode);
     }
 
     [Theory]
@@ -223,7 +223,7 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
 
         var alta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
             ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo a desactivar", "20111111112", pfx, password));
-        Assert.Equal(HttpStatusCode.OK, alta.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
         var creado = await alta.Content.ReadFromJsonAsync<CertificadoFiscalDto>(OpcionesJson);
 
         var respuesta = await ctx.Admin.DeleteAsync($"/api/fiscal/certificados/{creado!.Id}");
@@ -256,7 +256,7 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
 
         var alta = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
             ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo principal", "20222222223", pfx, password));
-        Assert.Equal(HttpStatusCode.OK, alta.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, alta.StatusCode);
 
         var listado = await ctx.Admin.GetAsync("/api/fiscal/certificados");
         Assert.Equal(HttpStatusCode.OK, listado.StatusCode);
@@ -504,12 +504,12 @@ public class ServicioDeCertificadosTests(WaysApiFixture fixture) : IClassFixture
         var (pfx1, password1) = GenerarPfx("CN=Ways Test Rotacion 1");
         var alta1 = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
             ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo v1", "20111111112", pfx1, password1));
-        Assert.Equal(HttpStatusCode.OK, alta1.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, alta1.StatusCode);
 
         var (pfx2, password2) = GenerarPfx("CN=Ways Test Rotacion 2");
         var alta2 = await ctx.Admin.PostAsJsonAsync("/api/fiscal/certificados", new RegistroDeCertificadoFiscal(
             ctx.IdEmpresa, AmbienteFiscal.Homologacion, "Homo v2", "20111111112", pfx2, password2));
-        Assert.Equal(HttpStatusCode.OK, alta2.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, alta2.StatusCode);
 
         var listadoRespuesta = await ctx.Admin.GetAsync("/api/fiscal/certificados");
         var listado = await listadoRespuesta.Content.ReadFromJsonAsync<List<CertificadoFiscalDto>>(OpcionesJson);

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -124,7 +124,16 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
         ("PUT", "/api/usuarios/{id:int}"),
         ("POST", "/api/usuarios/{id:int}/password"),
         ("POST", "/api/usuarios/{id:int}/desbloquear"),
-        ("DELETE", "/api/usuarios/{id:int}")
+        ("DELETE", "/api/usuarios/{id:int}"),
+
+        // stage-19a-slice4 (task 4.7/4.8): ABM de certificados fiscales + carga de condición
+        // fiscal de empresa / número fiscal de PV — AdministracionFiscal (solo Admin, sin
+        // Vendedor, sin Root), superficie administrativa propia igual que GestionDeUsuarios/
+        // GestionDeOrganizacion de arriba — nunca GestionDeCatalogo.
+        ("POST", "/api/fiscal/certificados/"),
+        ("DELETE", "/api/fiscal/certificados/{id:int}"),
+        ("PUT", "/api/fiscal/empresas/{id:int}/condicion-fiscal"),
+        ("PUT", "/api/fiscal/puntos-venta/{id:int}/numero-fiscal")
     ];
 
     [Fact]

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -340,7 +340,14 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
 
             foreach (var (prefijo, policyExigida) in PrefijosDeLecturaMasEstrictosQueOperacionDePos)
             {
-                if (!patron.StartsWith(prefijo, StringComparison.Ordinal))
+                // Match por SEGMENTO, no por substring crudo (judgment-day 19a-slice-4 ronda 2
+                // juez A, SUGGESTION): "/api/fiscal" no puede capturar un futuro
+                // "/api/fiscalizacion" solo porque comparte el prefijo de caracteres — o el patrón
+                // es EXACTAMENTE el prefijo, o el prefijo sigue con un separador de ruta.
+                var coincideSegmento = patron.Equals(prefijo, StringComparison.Ordinal)
+                    || patron.StartsWith(prefijo + "/", StringComparison.Ordinal);
+
+                if (!coincideSegmento)
                 {
                     continue;
                 }

--- a/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
+++ b/tests/Ways.IntegrationTests/SuperficieDeAutorizacionTests.cs
@@ -290,4 +290,75 @@ public class SuperficieDeAutorizacionTests(WaysApiFixture fixture) : IClassFixtu
             faltantes.Count == 0,
             $"Endpoint(s) GET sin OperacionDePos (o una policy más estricta) bajo las superficies re-gateadas: {string.Join(", ", faltantes)}");
     }
+
+    /// <summary>
+    /// TERCER guard (judgment-day 19a-slice-4, ronda 1, juez B — 3ra ocurrencia de la clase
+    /// GET-authz omitido, después de <c>/api/catalogos-fiscales</c> (Slice 1) y
+    /// <c>/api/presupuestos</c> (WARNING preexistente, señalado en judgment-day Slice 5 ronda 2
+    /// juez A): los dos guards de arriba solo saben pedir "algo al menos tan estricto como
+    /// OperacionDePos" — un Vendedor/Supervisor colándose vía OperacionDePos en un GET bajo
+    /// <c>/api/fiscal</c> sería una regresión real de superficie (material de clave privada
+    /// cifrado, identidad legal del emisor) que NINGUNO de los dos detecta. Este walker registra
+    /// prefijos cuya policy exigida es MÁS estricta que <see cref="Politicas.OperacionDePos"/> y
+    /// falla-cerrado si algún GET bajo ellos no apila esa policy exacta O lleva
+    /// <see cref="IAllowAnonymous"/> — sin este segundo chequeo, un <c>.AllowAnonymous()</c>
+    /// agregado sobre un endpoint que YA heredaba la policy del grupo pasaría desapercibido: la
+    /// metadata de <see cref="IAuthorizeData"/> del grupo sigue presente, es el middleware de
+    /// autorización el que la ignora en runtime al ver <see cref="IAllowAnonymous"/>.
+    /// </summary>
+    private static readonly (string Prefijo, string PolicyExigida)[] PrefijosDeLecturaMasEstrictosQueOperacionDePos =
+    [
+        // stage-19a-slice4 (target 63, judgment-day ronda 1 juez B): GET /api/fiscal/certificados
+        // — solo Admin, mismo criterio que POST/PUT/DELETE del mismo grupo (FiscalEndpoints.cs).
+        // Registrado a nivel de prefijo de GRUPO ("/api/fiscal"), no de ruta puntual, para que un
+        // GET nuevo bajo /api/fiscal/empresas/... o /api/fiscal/puntos-venta/... (sin GET hoy)
+        // caiga bajo este guard sin edición.
+        ("/api/fiscal", Politicas.AdministracionFiscal)
+    ];
+
+    [Fact]
+    public void TodoEndpointGetBajoSuperficiesMasEstrictasQueOperacionDePosApilaSuPolicyExigida()
+    {
+        var fuente = fixture.Services.GetRequiredService<EndpointDataSource>();
+
+        var faltantes = new List<string>();
+
+        foreach (var endpoint in fuente.Endpoints)
+        {
+            if (endpoint is not RouteEndpoint ruta)
+            {
+                continue;
+            }
+
+            var metodos = ruta.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods;
+            if (metodos is null || !metodos.Contains("GET"))
+            {
+                continue;
+            }
+
+            var patron = ruta.RoutePattern.RawText ?? string.Empty;
+
+            foreach (var (prefijo, policyExigida) in PrefijosDeLecturaMasEstrictosQueOperacionDePos)
+            {
+                if (!patron.StartsWith(prefijo, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var noEsAnonimo = ruta.Metadata.GetMetadata<IAllowAnonymous>() is null;
+                var apilaLaPolicyExigida = noEsAnonimo && ruta.Metadata
+                    .GetOrderedMetadata<IAuthorizeData>()
+                    .Any(dato => dato.Policy == policyExigida);
+
+                if (!apilaLaPolicyExigida)
+                {
+                    faltantes.Add($"GET {patron} (esperaba {policyExigida})");
+                }
+            }
+        }
+
+        Assert.True(
+            faltantes.Count == 0,
+            $"Endpoint(s) GET sin su policy exigida bajo una superficie más estricta que OperacionDePos: {string.Join(", ", faltantes)}");
+    }
 }


### PR DESCRIPTION
## Resumen

Slice 4 de la 19a: la numeración fiscal con su disciplina propia y el almacén cifrado de certificados — el slice de seguridad de la sub-etapa.

- `AsignadorDeNumeroFiscal`: el número se toma DENTRO de la transacción del llamador (la disciplina OPUESTA al asignador hermano — un número quemado DETIENE la serie ARCA con el 10016), con el lock de `numeraciones_fiscales` como PREFIJO SINGLETON del orden total (D1: un lock sostenido a través de I/O de red debe ser prefijo — probado por `pg_locks` en sus dos mitades). La reconciliación REPORTA divergencia y JAMÁS auto-repara (`proximo_numero` intocable — D13, ahora con test de deuda no-trivial).
- `CifradoDeClavesFiscales`: AES-256-GCM con AAD que ata el ciphertext a su fila (SIN `id_clave_maestra` — la rotación no es cambio de identidad), clave maestra desde entorno versionada, I4 inercia, ZeroMemory de TODOS los buffers en TODOS los caminos de salida (incluido el de password incorrecta — la compleción cazada por la pasada acotada de B), y la crypto exception traducida a un 409 OPACO que no ayuda a un atacante sondeando filas.
- ABM bajo `AdministracionFiscal` (la 12ª policy, solo Admin) con lectura solo-metadata + el TERCER guard estructural de superficies (cierra para siempre la clase GET-sin-authz que ya se coló tres veces en el repo, con el chequeo de ausencia de `IAllowAnonymous`).

## Judgment-day (2 rondas + compleción arbitrada, limpia al cierre)

- **Ronda 1 — juez B REJECT** (D13 sin test, la carrera por suerte, el GET sin authz) → fixes `48a4ed8` con el rendezvous REAL de interceptor (mutante lost-update con doble `1` genuino, determinista 3/3) → re-ronda B APPROVE.
- **Ronda 2 — juez A REJECT** (la CryptographicException pelada contra el contrato del propio doc-comment + 3 WARNINGs + 1 SUGGESTION) → fixes `fb70eec` → **la pasada acotada de B cazó el fix incompleto** (el finally del PFX no cubría el camino más probable) → compleción `2dddb53` bajo arbitraje registrado → confirmación B + re-ronda A APPROVE con cero hallazgos.
- El apply fue además REANUDADO tras un stop del dueño, cerrando en la reanudación el gap real del ZeroMemory de la clave privada descifrada que el agente interrumpido había encontrado.

## Suites

- Dirigidos 33/33 + Fiscal 73/73 · full Integration 1698/1698 (re-corrida regla 17) · `Politicas.cs` exactamente +1 · cero migraciones nuevas · cero material de clave en el repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)