### PR TITLE
feat(organizacion): proyecta nombres de dueno y contadores de hijos en los listados raiz (slice 1 de etapa 20)

### DIFF
--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/design.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/design.md
@@ -1,0 +1,528 @@
+# Design: Stage 20 — Organization relationships and usage-guarded logical deletion
+
+## Technical Approach
+
+**Ask EF what points at this row, ask the clock whether the customer put it there, and refuse loudly
+— and because no constraint can ever fire behind that refusal, every classification decision is
+pinned by a checked-in inventory instead of by a hope.**
+
+The proposal is the ratified contract (`state.yaml:9-55`, `db_gate: ZERO-SCHEMA-RATIFIED`). This
+design fixes the *how* and arbitrates the seven things the proposal deliberately left open
+(A: untimestamped types · B: the completeness test · C: `IModel` access · D: query cost ·
+E: query filters · F: cascade atomicity · G: concurrency), and corrects three claims that did not
+survive contact with the tree.
+
+Nine structural facts decide the shape. Each was read, not assumed.
+
+1. **`Empresa` and `PuntoVenta` carry no navigation properties.** `Empresa : EntidadTenant` has
+   `Id, RazonSocial, NombreFantasia, Cuit, IdCondicionFiscal` and nothing else (`Empresa.cs:9-26`);
+   the existing projections read raw ids (`ServicioDeOrganizacion.cs:95, 136-138`). Owner names can
+   therefore only be projected as **correlated scalar subqueries**, never as `e.Tenant!.Nombre` —
+   which also removes the INNER-JOIN-drops-the-row trap for free.
+
+2. **There is no endpoint that creates a second empresa or a second punto de venta.**
+   `AprovisionamientoEndpoints` exposes only `POST /api/plataforma/tenants`, and
+   `OrganizacionEndpoints.cs` has no `POST` at all. Every tenant in the tree therefore has exactly
+   **one** empresa and **one** punto de venta. Consequence the proposal did not draw: decision 3's
+   structural minimums fire on **every** empresa/PV delete attempt, so `empresa_en_uso` and
+   `punto_venta_en_uso` are **unreachable through the API today** — see D8 and T1.
+
+3. **A cascade-deleted admin cannot reach the 403 branch.** The login lookup runs under the
+   `"BajaLogica"` filter (`ServicioDeAutenticacion.cs:85-87`, no `IgnoreQueryFilters`), so a
+   soft-deleted usuario is `null` and the request dies at `:104` with **401
+   `credenciales_invalidas`**. The `tenant is null → 403 tenant_suspendido` branch (`:141-147`) is
+   correct and untouched, but for a tenant this stage deletes it is **unreachable**, because the
+   cascade takes the admin with it. See T2.
+
+4. **The clock is read once and stamped everywhere.** `ServicioDeAprovisionamiento.cs:46`
+   (`var ahora = reloj.Ahora;`) reaches the tenant (`:53-54`), empresa (`:69-70`), punto de venta
+   (`:79-80`), área (`:89-90`), medios de pago (`:104-105`), lista de precios (`:121-122`), cliente
+   (`:142-143`) and admin (`:158-160`). B3 holds exactly.
+
+5. **The metadata-walk idiom is already the house style.** `AplicarFiltroDeBajaLogica`
+   (`WaysDbContext.cs:426-447`) and `AplicarFiltroDeTenantEnTenant` (`:477-486`) both walk
+   `modelBuilder.Model` by reflection to install behaviour uniformly. The guard is the third.
+
+6. **Nobody implements `IWaysDbContext` by hand.** `rg ": IWaysDbContext"` over `src/` and `tests/`
+   returns **zero** matches; the four test files that name the type consume it as a parameter and
+   pass a real `WaysDbContext` on the InMemory provider. C's blast radius is therefore one line.
+
+7. **The model can be built without a database, and the repo already does it.**
+   `tests/Ways.Application.Tests/Persistencia/Modelo*Tests.cs` construct `WaysDbContext` over
+   `UseNpgsql(...)` with a connection string that is never opened, then read `db.Model` (see
+   `ModeloDeOrganizacionTests.cs:17-30`). The completeness nets live there, cost no container, and
+   need no interface change.
+
+8. **Raw ADO on the caller's connection is the established escape hatch**, with its two documented
+   traps: never `Database.SqlQuery<T>`/`FromSqlRaw` against this model, and always open through
+   `Database.OpenConnectionAsync` so `InterceptorDeContextoDeTenant` sets the RLS GUCs
+   (`AsignadorDeNumeroCliente.cs:9-35`). `pg_advisory_xact_lock($1, $2)` on that same connection is
+   the concurrency idiom (`ServicioDeOfertas.cs:602-623`).
+
+9. **The InMemory provider blocks transactions**, and this repo already paid that bill once:
+   `ServicioDeOfertas.ActualizarAsync`'s tests moved from `ServicioDeOfertasTests` to
+   `OfertasEndpointsTests` when the advisory lock landed (`ServicioDeOfertas.cs:43-46`). The same
+   relocation is a **budgeted cost of slice 4**, not a discovery — see D12.
+
+**Size note.** The 800-word budget of `sdd-design` is overridden by the project precedent the
+orchestrator named as binding (archived stage-17/18/19a `design.md`), which the prompt's Slice
+column and mutation-target requirements presuppose.
+
+## Architecture Decisions
+
+| # | Slice | Decision | Alternatives considered | Rationale |
+|---|---|---|---|---|
+| **D1** | 3 | **`IWaysDbContext` gains `IModel Model { get; }`.** One line on the interface, **zero** lines anywhere else — `DbContext.Model` already satisfies it implicitly | (a) A dedicated port `IInventarioDeDependientes` implemented in Infrastructure. (b) Inject `IModel` as its own DI service (`sp => sp.GetRequiredService<WaysDbContext>().Model`) | The interface's own doc-comment sets the criterion — *"`DatabaseFacade` es la misma abstracción de EF Core que ya expone la superficie pública de cualquier `DbContext`, no un tipo de Infrastructure"* (`:150-152`) — and `IModel` satisfies it **identically**: it is EF Core, it is already public on every `DbContext`, and `DbSet<T>` (37 of them on this interface) is a heavier EF leak than `IModel` is. (a) buys a boundary whose only implementation is `=> contexto.Model` while moving a walk that Infrastructure already performs twice into a third place; (b) adds a registration and a lifetime question (the model is effectively a singleton, the context is scoped) to avoid a line the doc-comment already authorises. **Blast radius, verified (fact 6): zero hand-written implementations, zero fakes, zero mocks.** The `DbSet<NumeracionCliente>` precedent also settles that exposure here is per-need, not per-purity |
+| **D2** | 3 | **The metadata walk is a pure static function, split from the executor.** `InventarioDeDependientes.Construir(IModel, Type ancla) → IReadOnlyList<RamaDeUso>` has no DB, no clock and no DI; `InspectorDeUso` renders those branches into one statement and runs it | One class doing both; a method on `InspectorDeUso` | The `MaquinaDeEstadosCae` / `PoliticaDeRoles` pattern: the part that must be exhaustively tested is pure, so its whole truth table is a unit test with no container. It is also what makes net **N3** (the golden inventory) possible at all — a golden over a function that needs a live database is a golden nobody regenerates |
+| **D3** | 3 | **Three buckets, keyed on the DEPENDENT ENTITY TYPE, evaluated in a fixed order: carve-out → timestamped → untimestamped.** The classifier is **total by construction** | A four-bucket scheme with an explicit `Desconocido`; classify per FK instead of per type | See **A** below. Per-type is right because the discriminator is a property of the *table* (does it carry `created_at`), never of the *column* that points at us — `MovimientoStock` contributes two branches (`IdPuntoVenta`, `IdPuntoVentaDestino`) and both are untimestamped for the same reason. A `Desconocido` bucket is rejected as theatre: any `else` branch that throws at **runtime** converts a future stage's omission into a **production 500 on a delete attempt** instead of a red test at build time. Totality plus N1-N3 moves the detection to where it belongs |
+| **D4** | 3 | **The completeness requirement ships as FOUR named nets (N1-N4), and this design records that the proposal's literal wording is unachievable.** A total classifier has no "unclassified" state, so a test asserting *"every type falls into exactly one bucket"* is a tautology — forbidden by `mutation-proof-tests` rule 1 | Ship the tautology; assert bucket membership against a hand-written type list | See **B** below. N3 (the checked-in inventory golden) is the executable form of the proposal's intent: a future stage that adds a referencing table gets a **red test naming the exact table and column**, which is what *"fails the build"* was actually asking for. Recorded as a deliberate substitution, not a silent one |
+| **D5** | 3 | **One statement per delete attempt: `UNION ALL` of `SELECT '<tabla>' WHERE EXISTS (…)` branches, outer `LIMIT 1`, parameterised raw ADO on the caller's connection.** Returns the first blocking table name, or `null` | ~40 sequential `AnyAsync` round trips; one `COUNT(*)` per table; a single giant `OR EXISTS` | See **D** below |
+| **D6** | 3 | **The guard drops `"BajaLogica"` and keeps tenant isolation — and both fall out of the mechanism rather than being configured.** Raw SQL applies no EF query filter (so a soft-deleted dependent still blocks, proposal decision 6 side effect A); RLS lives on the connection, so it still applies. **No `id_tenant` conjunct is added to any branch** | Add `AND d.id_tenant = @idTenant` to every branch as defence in depth; run the guard through EF with `IgnoreQueryFilters(["BajaLogica"])` per type | See **E** below. The extra conjunct is rejected on **direction of failure**: it can only ever *narrow* the result, and a narrowing bug under-blocks, which is the one direction this stage refuses. The EF route needs `Set<T>()` on the interface, dynamic generic dispatch over ~40 CLR types and ~40 round trips, to reproduce filter semantics the raw route gets for free |
+| **D7** | 4 | **One transaction, one advisory lock, one clock reading, ONE evaluation of the guard — no pre-check.** Order: `pg_advisory_xact_lock(idTenant, −20)` → re-read the anchor → structural minimum → usage guard → `momento = reloj.Ahora` → cascade + anchor writes → single `SaveChangesAsync` → COMMIT | A cheap pre-check outside the transaction plus an authoritative re-check inside ("belt and braces") | `mutation-proof-tests` rule 3 names the pre-check-mirroring-a-guard shape as **this repository's most common confound** (stage 17 slices 3 and 5, all conjuncts surviving). Running the guard once removes the confound instead of writing tests to defeat it, and it costs one aborted empty transaction on the 409 path — nothing, on an action a platform operator performs a handful of times a year |
+| **D8** | 4 | **Structural minimums stay ordered before the usage guard (proposal decision 3), and this design records that they make `empresa_en_uso` / `punto_venta_en_uso` unreachable through the API.** Their tests are **below-the-confound service-level tests** with a hand-seeded second empresa/PV | Reorder usage before minimum so both codes are API-reachable; drop the empresa/PV DELETE routes as dead surface | Fact 2. Reordering would answer *"delete the tenant instead"* with *"there is data here"* — the strictly less actionable message, which is exactly what decision 3 rejected. Dropping the routes would leave the tenant cascade as the only deletion path and re-open the asymmetry the stage exists to close. The honest cost is that two of the six 409 codes are proven below the API until a create-empresa endpoint exists; `mutation-proof-tests` rule 3 already prescribes that exact remedy |
+| **D9** | 4 | **The cascade is `Where(hijo.IdPadre == id)` over live rows only, in one `SaveChangesAsync`, sharing one `momento` across `DeletedAt` AND `UpdatedAt` of parent and every child.** Write **order is not claimed** | Order children-first and assert the sequence; cascade with `IgnoreQueryFilters` to also re-stamp already-deleted children | See **F** below. EF chooses statement order inside one `SaveChanges`; claiming an order we do not control would be a lie a structural test could not honestly assert (rule 13). **Atomicity** is the property, and one transaction delivers it. Re-stamping already-deleted children would destroy the restore-by-instant property by overwriting an older, unrelated deletion |
+| **D10** | 4 | **Tenant deletion writes `Estado = EstadoTenant.Baja` and `DeletedAt` in the same `SaveChangesAsync`** — the enum's first writer (proposal decision 1) | Write only `DeletedAt`; a separate statement for the estado | `Tenant.PuedeOperar` is `Estado == Activo && DeletedAt is null` (`Tenant.cs:20`), so the two agree by construction only if they are written together. Two statements admit an interleaving where the row is deleted but still `activo` |
+| **D11** | 4 | **One `pg_advisory_xact_lock(idTenant, −20)` per deletion transaction, keyed on the TENANT, not on the entity — and the POS takes no lock of this family.** Negative second argument on purpose | Lock on the entity id; `SELECT … FOR UPDATE` on the anchor row; no lock at all | See **G** below. Keying on the tenant serialises tenant/empresa/PV deletions of the same tenant against **each other** (which is what breaks the shared-instant property), while leaving every operational path untouched — the stage-19a D1 lesson inverted: an admin action must never enter the counter's lock order. The constant is **negative** because the two-int advisory keyspace is already shared with `ServicioDeOfertas` (`idTenant, idOferta`) and `ServicioDePrecios` (`idTenant, par`), both of which pass **positive** ids; a negative constant cannot collide with any of them. A tenant-less anchor (platform `Usuario`, `IdTenant is null`) uses `(0, −20)` — identity ids start at 1 |
+| **D12** | 4 | **`Usuario` deletion takes NO transaction and NO lock**: `PoliticaDeRoles` (unchanged, first) → usage guard → the existing single-`momento` write + audit row, in the implicit `SaveChangesAsync` transaction | Give it the same transaction+lock as the three organization entities, for symmetry | It has no cascade, so the shared-instant property is already trivially satisfied by one `SaveChanges`, and the lock closes no race it faces (a sale stamping the employee never takes it — G). The symmetry would buy nothing and cost the `ExecutionStrategy` wrapper plus the InMemory relocation of *every* `EliminarAsync` test. **The guard alone already forces some relocation (fact 9): the raw SQL cannot run on InMemory.** Budgeted, not discovered — see the Testing Strategy |
+| **D13** | 1 | **Owner names are correlated scalar subqueries returning `string?`, and child counts are correlated `Count()` subqueries — one statement per list endpoint, asserted with `ContadorDeComandos`** | `Include`/navigation dot-access; a second round trip; a denormalised column | Fact 1 leaves no navigation to dot into, and the subquery form is the one that keeps the dependent row when the principal is filtered out. `string?` instead of `string` is deliberate: an orphan renders as an anomaly (`—`) instead of vanishing, which **decouples slice 1 from the cascade of slice 4** — Part A must be independently mergeable, and it cannot be if its correctness depends on Part B existing |
+| **D14** | 1/2 | **`UsuarioListado` carries `int? IdTenant` and `string? NombreTenant`; the server sends `null` for platform staff and the WEB renders the literal *"Plataforma"*** | The server projects the literal `"Plataforma"` (proposal decision 8's wording) | `nombre` is free text: a tenant actually named *"Plataforma"* would be indistinguishable from platform staff, and the filter — which keys on `idTenant` — would then disagree with the column it sits above. Rendering copy is also the web's job under the language contract. **Judgment call correcting the proposal's wording**; the observable outcome (never an empty cell) is preserved |
+| **D15** | 2 | **Filter options are derived from the ALREADY-LOADED rows, never from a second fetch.** The empresa filter on `PuntosVenta.tsx` narrows to the selected tenant, and selecting a tenant clears an empresa selection that no longer belongs to it | Call `listarTenants()` to populate the select | `GET /api/plataforma/tenants` is `Politicas.SoloPlataforma` while `Empresas.tsx` / `PuntosVenta.tsx` are reachable by a tenant admin under `GestionDeOrganizacion` (`OrganizacionEndpoints.cs:19-21, 44-46`) — a fetch would 403 for exactly the users the screen was built for. Deriving from the rows also makes an empty option-set impossible by construction |
+
+---
+
+### A — The classification buckets (the untimestamped problem)
+
+`GetReferencingForeignKeys()` returns the complete dependent set; it does not say how to interrogate
+each dependent, because **15 referencing domain types do not inherit `EntidadBase` and have no
+`created_at` column** (verified on `Stock.cs` and `ArticuloEmpresa.cs`; the full list is in the
+proposal's decision 4). Classification is on the **dependent entity type**, in this order:
+
+| Order | Bucket | Membership test | Branch emitted | Why it is correct |
+|---|---|---|---|---|
+| 1 | **`Excluido`** (carve-out) | CLR type ∈ a `FrozenSet` of **exactly two**: `Ways.Domain.Auditoria.Auditoria` (B5) and `NumeracionCliente` | **none** | `Auditoria` is a trail *about* the entity, and logical deletion keeps the referenced row so the trail keeps rendering. `NumeracionCliente` is the provisioning counter inserted by raw SQL in `AsignadorDeNumeroCliente.AsegurarContadorAsync` (`:38-51`) — not an `EntidadBase`, not customer data, and the **only** untimestamped row provisioning creates |
+| 2 | **`Marcado`** (timestamped) | `typeof(EntidadBase).IsAssignableFrom(t.ClrType)` **and** the type has a property whose column is `created_at` | `WHERE <fk> = @id AND d.created_at > @ancla` | B3 exactly. Provisioned rows share the anchor's instant and are excluded by the **strict** `>` |
+| 3 | **`SinMarca`** (untimestamped) | everything else | `WHERE <fk> = @id` (existence) | Provisioning creates **no** row of any untimestamped type except the carved-out counter, so existence already means usage — and it fails safe |
+
+The classifier is **total**: every type lands in exactly one bucket, so no runtime `else` can throw.
+`Construir` nevertheless throws `InvalidOperationException` **naming the CLR type and the FK** for the
+three *mechanical* impossibilities — an entity type with no mapped table, a `Marcado` type whose
+`created_at` column cannot be resolved, or an FK whose principal properties are not all readable from
+the anchor. Those are build-time failures via N1, never production 500s: nothing calls the generator
+at request time without N1 having run in CI first.
+
+**Composite and alternate-key FKs need no special case.** The branch predicate is built by zipping
+`fk.Properties` (dependent columns) with `fk.PrincipalKey.Properties` (principal properties) and
+reading each principal value off the loaded anchor — so `(id_punto_venta, id_tenant)` against
+`ak_puntos_venta_id_punto_venta_id_tenant` produces a two-conjunct branch automatically, and
+`MovimientoStock` contributes two independent branches. **Nullable FKs need no special case either**:
+`IdEmpresa IS NULL` means *shared catalogue row* on `Cliente`/`Proveedor`/`Oferta`/
+`ConfiguracionDeCatalogo<T>`, and `fk = @id` does not match `NULL`, so a shared row correctly does
+not block an empresa's deletion.
+
+### B — The completeness test, made real
+
+The proposal asks for a test that *"fails the build when a referencing type is not classified"*.
+With a total classifier (A) that state does not exist, so the literal test would assert a tautology.
+**Four nets deliver the intent instead.** All four live in
+`tests/Ways.Application.Tests/Persistencia/` beside the existing `Modelo*Tests.cs`, over the real
+Npgsql model with no container (fact 7) — except N4, which needs a database.
+
+| Net | Lives in | Asserts | Goes red when |
+|---|---|---|---|
+| **N1 — totality** | `InventarioDeDependientesTests` | `Construir(db.Model, T)` succeeds for **all four** anchors, and the emitted branch count equals `GetReferencingForeignKeys().Count()` minus the carved-out FKs. No FK is silently dropped | A future type has no mapped table, no resolvable `created_at`, or an unreadable principal key — the exception **names it** |
+| **N2 — the rule is read off the TABLE, not restated from the code** | idem | For every branch: `rama.UsaAncla == entityType.GetProperties().Any(p => p.GetColumnName() == "created_at")`, computed independently in the test | The classifier is mutated to `EntidadTenant`, inverted, or hardcoded |
+| **N3 — the inventory golden (the trip-wire)** | idem + `Fixtures/inventario-de-dependientes.txt` | A sorted, checked-in line per branch: `<ancla> \| <tabla> \| <columnas> \| <bucket>`, including one `excluido` line per carve-out so the file also pins the two-member carve-out set | **Any** FK added, removed, retargeted or reclassified by a future stage — with a diff naming the exact table and column. Regeneration is a deliberate edit recorded in the PR |
+| **N4 — pristine regression** | `tests/Ways.IntegrationTests/BajasDeOrganizacionTests.cs` | A **freshly provisioned** tenant, its empresa, its punto de venta and its admin are all pristine | The single-clock-reading property of `ServicioDeAprovisionamiento.cs:46` breaks, **or** a future stage makes provisioning create an untimestamped row (which would silently make every new tenant undeletable) |
+
+Stated honestly: **N3 does not prove the classification is correct — it proves no classification
+changes silently.** N2 proves the rule is derived from the table. N1 proves the mechanism is total.
+N4 is the only one that can see the provisioning baseline drifting. Together they are the guarantee;
+individually none of them is.
+
+### C — `IModel` access
+
+**Decision: expose `IModel Model { get; }` on `IWaysDbContext`** (D1). Verified blast radius:
+
+- `rg ": IWaysDbContext"` over `src/` and `tests/` → **0 matches**. `WaysDbContext` is the only
+  implementation and already inherits `DbContext.Model`, so the interface change adds **zero**
+  implementation lines and breaks **zero** test doubles.
+- The four test files that mention `IWaysDbContext` (`CifradoDeClavesFiscalesTests`,
+  `EscriturasDeCuentaCorrienteProveedorTests`, `ExistenciasTests`, `TesoreriaTests`) consume it as a
+  parameter type and pass a real `WaysDbContext`. Unaffected.
+- The completeness nets (B) do **not** consume the interface at all — they read
+  `WaysDbContext.Model` directly, exactly as `ModeloDeOrganizacionTests.cs:37` already does.
+
+### D — Query cost
+
+| Option | Cost for a pristine tenant (~40 branches) | Cost for a blocked tenant | Verdict |
+|---|---|---|---|
+| ~40 sequential `AnyAsync` | 40 × RTT + 40 plans | 1..40 × RTT | **Rejected** — the round trips dominate and nothing short-circuits across them |
+| One `UNION ALL` of `EXISTS`, outer `LIMIT 1` | 1 × RTT, one plan (~40 index probes returning nothing) | 1 × RTT; the `Append` node **stops at the first branch that yields a row** | **Selected** |
+| One `COUNT(*)` per table | strictly worse (no `LIMIT`, no early exit) | worse | Rejected |
+
+Honest accounting, not hand-waving:
+
+- **Every branch is an index probe, by EF convention.** EF Core's `ForeignKeyIndexConvention` creates
+  an index on the dependent FK properties of every mapped FK unless an explicit index already covers
+  them. The design does **not** assume it: a read-only verify step compares the branch set against
+  `pg_indexes` and reports any branch with no supporting index. It cannot *fix* one — that would be
+  DDL, and the gate is ZERO-SCHEMA — so an uncovered branch becomes a named finding for a later
+  stage, not a silent seq scan nobody knew about.
+- **Planning ~40 branches is real** (single-digit milliseconds) and is paid once per delete attempt.
+- **This is not on any hot path.** Four admin-only routes, performed a handful of times a year, each
+  already behind an authorization policy and an operator confirmation.
+- Verdict: **acceptable, batched.** Not over-engineered: there is no caching, no materialised
+  summary, no background job, and the statement is regenerated per call from metadata that is itself
+  a process-lifetime singleton.
+
+**Injection surface.** Identifiers come from `IEntityType`/`IProperty` metadata only — never from a
+request — are schema-qualified and double-quoted, and are rejected by the generator unless they match
+`^[a-z_][a-z0-9_]*$`. Every anchor id and the anchor's `CreatedAt` is a **parameter**
+(`ParametrosDeComando.Agregar`, the `AsignadorDeNumeroCliente` idiom). No user-supplied string ever
+reaches the statement.
+
+### E — Query filters, precisely
+
+| Filter | What the guard needs | How it is achieved | Test |
+|---|---|---|---|
+| `"BajaLogica"` | **Dropped.** A soft-deleted dependent **still blocks** — the ratified reading of B2 (*"did the customer ever operate here"*, proposal decision 6 side effect A and question-round item 2, and an explicit Success Criterion) | Raw SQL applies no EF query filter. Nothing is configured; the semantics fall out | Load an article, delete it logically, assert the tenant is **still** `tenant_en_uso` |
+| `"Tenant"` (EF) | Irrelevant to a raw statement, and **not reintroduced as a conjunct** | The anchor was already resolved through the filtered EF read (`BuscarEmpresaAsync` → `PoliticaDeRoles.ValidarAlcanceDeTenant`), so the guard never runs on an anchor the caller may not see | The existing 404-not-403 scope tests, unchanged |
+| RLS (connection) | **Kept.** A tenant admin sees every dependent of their own tenant, so the guard cannot under-count; a platform actor sees everything, which is correct | Lives on the connection, opened through `Database.OpenConnectionAsync` so `InterceptorDeContextoDeTenant` sets the GUCs | Cross-tenant integration test on the `ways_app` connection (`mutation-proof-tests` rule 5) |
+
+**On leakage**: the guard's entire output is a **table name** (or `null`). It returns no row, no id
+and no count, so there is no channel through which another tenant's data can leak — the worst a
+mistake could produce is a wrong verdict, and the FK predicate `fk = @id` over globally-unique
+identity ids cannot match another tenant's row.
+
+> **The prompt's framing and the ratified proposal disagree here.** The prompt states *"a logically
+> deleted child must NOT block deletion"*; the proposal settled the **opposite** and requires a test
+> proving it (`proposal.md:506`, question round item 2). **This design implements the proposal**, per
+> the binding-contract rule, and records the disagreement as **T3** with its exact one-conjunct
+> reversal. It is the only place where the two inputs cannot both be satisfied.
+
+### F — Cascade, atomicity and the shared instant
+
+```
+DELETE /api/plataforma/tenants/{id}                       [SoloPlataforma]
+  ├─ BuscarTenantAsync(id)                    → 404 if already deleted ("BajaLogica" hides it)
+  └─ db.Database.CreateExecutionStrategy().ExecuteAsync:   ← ADR-16 trap: never BeginTransaction outside
+       BEGIN
+        1. SELECT pg_advisory_xact_lock($idTenant, $-20)         ← D11
+        2. re-read the anchor under the lock                     → 404 if a concurrent delete won
+        3. structural minimum (empresa / PV only)                → 409 ultima_empresa_del_tenant | …
+        4. InspectorDeUso.PrimeraDependenciaEnUsoAsync(ancla)    → 409 <entidad>_en_uso   ← ONCE (D7)
+        5. var momento = reloj.Ahora;                            ← ONE reading, parent + all children
+        6. usuarios  WHERE id_tenant = @id : DeletedAt = UpdatedAt = momento
+           puntos_venta WHERE id_tenant = @id : idem
+           empresas   WHERE id_tenant = @id : idem
+           tenant     : DeletedAt = UpdatedAt = momento, Estado = EstadoTenant.Baja   ← D10
+        7. await db.SaveChangesAsync(ct)                         ← ONE call, EF orders the statements
+       COMMIT
+```
+
+- **The cascade set is provably three rows.** Every `EntidadTenant` descendant references the tenant,
+  so a tenant with any usage at all is blocked at step 4; a tenant that reaches step 6 is pristine,
+  and a pristine tenant has exactly the provisioned empresa, punto de venta and admin. The code is
+  still written generically (`Where(x.IdTenant == id)`) so it cannot miss a row the reasoning did not
+  anticipate.
+- **`DELETE /api/empresas/{id}`** cascades to `puntos_venta WHERE id_empresa = @id` under the same
+  shape. `DELETE /api/puntos-venta/{id}` has no children. `DELETE /api/usuarios/{id}` has no children
+  and no transaction (D12).
+- **Only live children are cascaded** — an already-deleted child keeps its own older instant, which
+  is what keeps `UPDATE … SET deleted_at = NULL WHERE deleted_at = '<instant>'` an **exact** restore.
+- **Order is not claimed** (D9). One `SaveChangesAsync` inside one transaction gives atomicity; EF
+  chooses the statement order and this design does not pretend otherwise.
+- **`EstadoTenant.Baja`'s existing readers, unchanged**: `Tenant.PuedeOperar` (`:20`) is already
+  `Activo && DeletedAt is null`; `CambiarEstadoTenantAsync` already refuses to suspend or reactivate
+  a `Baja` tenant with `tenant_dado_de_baja` (`ServicioDeOrganizacion.cs:67-72`); login already
+  handles it (fact 3, and see **T2**).
+
+### G — Concurrency, and the residual race stated plainly
+
+| Race | Outcome without a lock | Verdict |
+|---|---|---|
+| Two operators delete the **same** tenant | Both pass the guard; two different instants land on the same row; children may carry instant A while the parent carries instant B, breaking restore-by-instant | **Closed by D11** — the second waits, re-reads under the lock at step 2 and gets a clean **404** |
+| Delete a tenant while deleting one of its empresas | Two transactions, different rows, two instants, both commit | **Closed by D11** — same lock key (the tenant), so they serialise |
+| Delete two entities of **different** tenants | No interaction | Not a race; different lock keys, full concurrency preserved |
+| **A sale is created while the tenant is being deleted** | The guard reads *pristine*, the checkout's `INSERT` touches different rows, both commit. Result: a soft-deleted tenant owning a post-anchor comprobante | **OPEN. Accepted.** |
+
+**Why the last one stays open.** Closing it requires the checkout to take the deletion lock, which
+puts a platform-admin action into the POS hot path — precisely the failure mode stage 19a's D1 was
+designed to prevent (*"no existing path can ever queue behind"* an admin operation). The window is
+milliseconds, on an action performed a handful of times a year, and it requires the operator to
+delete a tenant that is **actively selling at that instant**. And because of B1 **nothing is
+destroyed**: recovery is `UPDATE tenants SET deleted_at = NULL, estado = 'activo' WHERE id = …` plus
+`UPDATE <hijos> SET deleted_at = NULL WHERE deleted_at = '<the shared instant>'`. Registered as
+**R1**, with its reopen condition: the first automated or bulk deletion path.
+
+**Lock-order claim, and its honest form.** The deletion transaction takes exactly one advisory lock
+plus row locks on `tenants`, `empresas`, `puntos_venta` and `usuarios` — **none** of which appears in
+the program's total order (`numeraciones_fiscales → turnos_caja → comprobantes_venta → presupuestos →
+remitos → lotes → stock/stock_lotes → clientes → ledger INSERT`). The lock sets are **disjoint**, so
+no deadlock against an operational path is expressible. Asserted **structurally** (the deletion path
+touches only organization tables — an `rg` over the new methods), not by a probabilistic race:
+`mutation-proof-tests` rule 13 is explicit that a single-resource race test is blind to order and
+that a live deadlock cannot be forced through raw ADO.
+
+## `db-error-backstops` — structurally N/A
+
+Every FK in `WaysDbContext`/`Configuraciones/*.cs` is `DeleteBehavior.Restrict`, but **B1 forbids
+physical deletion**, and `Restrict` contributes exactly zero protection against
+`UPDATE … SET deleted_at`. **No Postgres constraint can ever fire on any path this stage adds**, so
+there is no SQLSTATE `23503` to classify and no branch to add to `ManejadorDeErrores.cs` — the file
+is **untouched**, and that is a binding verify criterion (V6).
+
+The consequence must be said out loud: **the application guard is the sole line of defence.** There
+is no database backstop behind it, so its tests are not good practice, they are the entire safety
+argument. That is why D4's four nets and the four `never_degrade` items of `state.yaml:256-262` are
+non-negotiable, and why the guard is deliberately shipped **inert** in slice 3 (no caller until slice
+4) so it can be reviewed on its own merits before anything can invoke it.
+
+## Interfaces / Contracts
+
+```csharp
+// src/Ways.Application/Organizacion/InventarioDeDependientes.cs
+// PURO (D2): sin base, sin reloj, sin DI — para que el golden N3 se pueda regenerar sin contenedor.
+public enum ClasificacionDeDependiente { Excluido, Marcado, SinMarca }
+
+/// <param name="Columnas">Columnas dependientes de la FK, zipeadas con las del principal.</param>
+public sealed record RamaDeUso(
+    string Tabla,                       // schema-qualified, quoted at render time
+    IReadOnlyList<string> Columnas,
+    IReadOnlyList<string> PropiedadesDelPrincipal,
+    ClasificacionDeDependiente Clasificacion)
+{
+    public bool UsaAncla => Clasificacion is ClasificacionDeDependiente.Marcado;
+}
+
+public static class InventarioDeDependientes
+{
+    /// <summary>B5 + el contador de aprovisionamiento. EXACTAMENTE dos, cada uno con su razón
+    /// escrita y su test propio (proposal decisión 4).</summary>
+    public static readonly FrozenSet<Type> Excluidos =
+        FrozenSet.Create(typeof(Ways.Domain.Auditoria.Auditoria), typeof(NumeracionCliente));
+
+    /// <summary>Lanza <see cref="InvalidOperationException"/> NOMBRANDO el tipo y la FK ante las
+    /// tres imposibilidades mecánicas (sin tabla mapeada, sin columna created_at en un tipo
+    /// Marcado, clave principal no legible). N1 es quien lo ejecuta en CI.</summary>
+    public static IReadOnlyList<RamaDeUso> Construir(IModel modelo, Type tipoAncla);
+}
+
+// src/Ways.Application/Organizacion/InspectorDeUso.cs
+public sealed class InspectorDeUso(IWaysDbContext db)
+{
+    /// <summary>Devuelve el NOMBRE de la primera tabla que bloquea, o null si la entidad es
+    /// prístina. Una sola ida y vuelta (D5). ADO crudo sobre la conexión/transacción del
+    /// llamador — nunca SqlQuery/FromSqlRaw (trampa de stage-1 slice 2).</summary>
+    public Task<string?> PrimeraDependenciaEnUsoAsync(
+        Type tipoAncla, IReadOnlyList<object> valoresDeClave, DateTimeOffset ancla,
+        CancellationToken ct = default);
+}
+```
+
+Rendered statement (punto de venta, abbreviated):
+
+```sql
+SELECT tabla FROM (
+  SELECT 'comprobantes_venta' AS tabla WHERE EXISTS (
+    SELECT 1 FROM public."comprobantes_venta" d WHERE d."id_punto_venta" = $1 AND d."created_at" > $2)
+  UNION ALL
+  SELECT 'movimientos_stock'  AS tabla WHERE EXISTS (
+    SELECT 1 FROM public."movimientos_stock"  d WHERE d."id_punto_venta_destino" = $1)
+  UNION ALL …
+) AS ramas LIMIT 1
+```
+
+DTO changes — every added field with its consumer (`dto-contract-honesty` rule 1):
+
+| Record | Added | Consumer | Slice |
+|---|---|---|---|
+| `TenantListado` | `int CantidadEmpresas, int CantidadPuntosVenta, int CantidadUsuarios` | three columns on `Tenants.tsx` | 1 / 2 |
+| `EmpresaListado` | `string? NombreTenant` | tenant column + filter label on `Empresas.tsx` | 1 / 2 |
+| `PuntoVentaListado` | `string? NombreTenant, string? RazonSocialEmpresa` | two columns + two filters on `PuntosVenta.tsx` | 1 / 2 |
+| `UsuarioListado` | `int? IdTenant, string? NombreTenant` | tenant column (`"Plataforma"` when null, D14) + tenant filter on `Usuarios.tsx` | 1 / 2 |
+
+**The three pre-existing id fields keep a consumer and must not be deleted.**
+`EmpresaListado.IdTenant` and `PuntoVentaListado.IdTenant`/`.IdEmpresa` stop being *rendered* and
+become the **filter keys** (`<select value>`). Named here so a reviewer applying
+`dto-contract-honesty` does not read them as newly dead.
+
+**Counts exclude logically deleted rows for free**: the correlated `Count()` subqueries run inside
+the LINQ tree, so the `"BajaLogica"` filter applies to them automatically — asserted, not assumed.
+
+## File Changes
+
+| File | Action | Slice | Description |
+|---|---|---|---|
+| `src/Ways.Application/Abstracciones/IWaysDbContext.cs` | Modify | 3 | `+1 line`: `IModel Model { get; }` with the doc-comment argument (D1) |
+| `src/Ways.Application/Organizacion/InventarioDeDependientes.cs` | **Create** | 3 | Pure metadata walk, three buckets, two carve-outs (D2, D3) |
+| `src/Ways.Application/Organizacion/InspectorDeUso.cs` | **Create** | 3 | Statement rendering + raw-ADO execution (D5, D6) |
+| `src/Ways.Api/Programa.cs` (or the DI module) | Modify | 3 | Register `InspectorDeUso` (scoped). **No caller until slice 4 — the slice is inert** |
+| `src/Ways.Application/Organizacion/Contratos.cs` | Modify | 1 | Three DTOs gain owner names / counts |
+| `src/Ways.Application/Usuarios/Contratos.cs` | Modify | 1 | `UsuarioListado` gains `IdTenant` + `NombreTenant` |
+| `src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs` | Modify | 1, 4 | Slice 1: three joined projections. Slice 4: `EliminarTenantAsync`/`EliminarEmpresaAsync`/`EliminarPuntoVentaAsync`, cascade, minimums; the class doc-comment's *"este servicio no crea ni elimina nada"* is corrected |
+| `src/Ways.Application/Usuarios/ServicioDeUsuarios.cs` | Modify | 1, 4 | Slice 1: the projection at `:76-79` and `:90-92`. Slice 4: one guard call after `PoliticaDeRoles` at `:296` (D12) |
+| `src/Ways.Application/Organizacion/EtiquetasDeTablas.cs` | **Create** | 4 | Decision 9's label dictionary (`comprobantes_venta` → *"ventas"*), fallback *"datos cargados"* |
+| `src/Ways.Api/Endpoints/OrganizacionEndpoints.cs` | Modify | 4 | Three `MapDelete`; the class doc-comment's *"acá no hay `POST` ni `DELETE` a propósito"* (`:11-13`) is corrected |
+| `src/Ways.Api/Seguridad/Politicas.cs` | **Untouched** | — | Binding criterion V5. Zero new policies |
+| `src/Ways.Api/Seguridad/ManejadorDeErrores.cs` | **Untouched** | — | Binding criterion V6 — no SQLSTATE can fire |
+| `src/Ways.Infrastructure/Persistencia/**` | **Untouched** | — | Binding criterion V1-V3. No migration, no configuration, no initializer change |
+| `src/Ways.Web/src/api/tipos.ts` | Modify | 2 | The four DTO mirrors |
+| `src/Ways.Web/src/api/organizacion.ts` | Modify | 2, 4 | Slice 2: pure helpers `opcionesDeTenant`, `opcionesDeEmpresa`, `filtrarPorTenant`, `filtrarPorEmpresa`, `etiquetaDeTenant`. Slice 5: `eliminarTenant/Empresa/PuntoVenta` |
+| `src/Ways.Web/src/api/organizacion.test.ts` | **Create** | 2 | `web-descriptor-tests`: unit tests per helper branch |
+| `src/Ways.Web/src/api/usuarios.ts` | Modify | 2 | `UsuarioListado` mirror (the `eliminar` call already exists) |
+| `src/Ways.Web/src/paginas/{Tenants,Empresas,PuntosVenta,Usuarios}.tsx` | Modify | 2, 5 | Slice 2: name columns, counts, filters. Slice 5: delete button + confirmation + `codigo`→copy |
+| `src/Ways.Web/src/paginas/{Tenants,Empresas,PuntosVenta,Usuarios}.test.tsx` | **Create** | 2, 5 | **No test file exists for any of the four screens today** — coverage is created |
+| `tests/Ways.Application.Tests/Persistencia/InventarioDeDependientesTests.cs` | **Create** | 3 | N1, N2, N3 |
+| `tests/Ways.Application.Tests/Persistencia/Fixtures/inventario-de-dependientes.txt` | **Create** | 3 | N3's golden |
+| `tests/Ways.Application.Tests/Organizacion/InspectorDeUsoTests.cs` | **Create** | 3 | Statement rendering: bucket → predicate, composite FK, quoting, parameter binding |
+| `tests/Ways.IntegrationTests/BajasDeOrganizacionTests.cs` | **Create** | 4 | N4, the guard end to end, cascade, minimums, RLS, carve-outs, boundary |
+| `tests/Ways.Application.Tests/{Organizacion/ServicioDeOrganizacionTests,Usuarios/ServicioDeUsuariosTests}.cs` | Modify | 4 | **Relocation** of the deletion cases to the integration suite (fact 9, D12) |
+| `docs/09-multi-tenancy.md`, `docs/10-modelo-de-datos.md` | Modify | 5 | An "Etapa 20" note: deletion semantics + the guard. **No schema table changes** |
+
+## Guarded writes — conjunct enumeration (`mutation-proof-tests` rule 3, up front)
+
+The deletion writes are EF `SaveChanges` UPDATEs keyed by PK, so the only hand-written predicates are
+the cascade scopes and the minimum counts. Listed **before** any test is written.
+
+| # | Statement | Conjuncts | The test that kills each |
+|---|---|---|---|
+| **U1** | `usuarios WHERE IdTenant == @id` (cascade) | (a) `IdTenant == id` | A **sibling tenant** seeded with its own admin: its usuario stays live, asserted by identity and by exact count (rule 12c) |
+| **U2** | `puntos_venta WHERE IdTenant == @id` | (a) `IdTenant == id` | Same sibling-tenant pair |
+| **U3** | `empresas WHERE IdTenant == @id` | (a) `IdTenant == id` | Same sibling-tenant pair |
+| **U4** | `puntos_venta WHERE IdEmpresa == @id` (empresa cascade) | (a) `IdEmpresa == id` | A **second empresa of the SAME tenant**, hand-seeded (fact 2): its PV stays live |
+| **U5** | `COUNT(empresas WHERE IdTenant == @id)` (minimum) | (a) `IdTenant == id` | A sibling tenant's empresa must not be counted, or the minimum never fires |
+| **U6** | `COUNT(puntos_venta WHERE IdEmpresa == @id)` | (a) `IdEmpresa == id` | A sibling empresa's PV must not be counted |
+| **U7** | Guard branch, `Marcado` | (a) `<fk> = @id` · (b) `created_at > @ancla` **strict** | (a) a dependent of a **sibling** entity must not block. (b) **two kills**: a row created **exactly at** the anchor must **not** block (rule 14 boundary fixture, under `RelojFijo`), and a row one tick later **must** block |
+| **U8** | Guard branch, `SinMarca` | (a) `<fk> = @id` only | Adding `AND created_at > @ancla` must fail to compile/execute (no such column); a `Stock` row for the PV blocks with no timestamp involved |
+
+## Testing Strategy
+
+| Layer | What | Approach | Slice |
+|---|---|---|---|
+| Model (no container) | **N1, N2, N3** | Real Npgsql model over an unopened connection, `Modelo*Tests.cs` pattern (fact 7) | 3 |
+| Application unit | Statement rendering per bucket; composite-FK branch (two conjuncts); alternate-key principal; identifier quoting + the `^[a-z_][a-z0-9_]*$` rejection; parameter count and binding order | `InspectorDeUsoTests`, pure string assertions over `Construir` + the renderer | 3 |
+| Application unit | The label dictionary: a mapped table → its Spanish word; an **unmapped** table → *"datos cargados"* | Pure | 4 |
+| Integration | **N4**: a freshly provisioned tenant / empresa / PV / admin are all pristine | `BajasDeOrganizacionTests`, real Postgres | 4 |
+| Integration | **B2 proven**: load **one article** (no sale, no movement) ⇒ the tenant, its empresa and its punto de venta each return their own named 409 | The `never_degrade` item | 4 |
+| Integration | The two carve-outs, independently: an entity with **only** `auditoria` rows past the anchor is deletable; an entity with **only** its provisioned `numeraciones_clientes` row is deletable | The `never_degrade` item | 4 |
+| Integration | A **soft-deleted** dependent **still blocks** (E, D6) | Load an article, delete it, retry the tenant delete | 4 |
+| Integration | Cascade: one `deleted_at` **instant** shared by tenant + empresa + PV + admin, `estado = 'baja'` on the tenant; an already-deleted child keeps its **older** instant | Assert the instant equality, not just non-null | 4 |
+| Integration | U1-U6 sibling kills; U7's boundary pair under `RelojFijo`; U8 | `mutation-proof-tests` rules 12c and 14 | 4 |
+| Integration | `ultima_empresa_del_tenant` / `ultimo_punto_venta_de_la_empresa` fire on their exact condition and **not** on any other | Below-the-confound with a hand-seeded second empresa/PV (D8) | 4 |
+| Integration | `usuario_en_uso` **after** `PoliticaDeRoles`: Root target, self-deletion and out-of-scope-404 behaviour byte-identical | Relocated + extended cases (D12) | 4 |
+| Integration | A second DELETE on an already-deleted row ⇒ **404**, not 500 | Idempotent-safe | 4 |
+| Integration | **A cascade-deleted admin cannot log in ⇒ 401 `credenciales_invalidas`** (fact 3, T2), and a **suspended** tenant still ⇒ 403 `tenant_suspendido` (unchanged) | Two tests, two codes, the second a regression | 4 |
+| Integration | Cross-tenant isolation on all four new routes, **read and write pair**, on the `ways_app` connection | Rule 5 — a superuser fixture proves nothing | 4 |
+| Integration | **One** round trip per list endpoint; counts exclude soft-deleted children; the **orphan** case (an empresa whose tenant is soft-deleted still appears, `nombreTenant = null`) | `ContadorDeComandos`, the `VentasCheckoutTests:930` precedent | 1 |
+| Integration | Every positional field of the four listing DTOs read back with **pairwise-distinct** values; a sibling row of the same tenant on every listing test | Rules 12b and 12c | 1 |
+| Vitest (unit) | `opcionesDeTenant` / `opcionesDeEmpresa` (dedup, ordering, the `null` → *"Plataforma"* option), `filtrarPorTenant` / `filtrarPorEmpresa`, `etiquetaDeTenant` | Colocated `organizacion.test.ts`, `web-descriptor-tests` | 2 |
+| Vitest (component) | The tenant select filters the rendered rows; selecting a tenant **narrows** the empresa select and **clears** an empresa that no longer belongs to it; `"Plataforma"` renders for `idTenant === null` | RTL + `user-event`, `vi.mock('../api/cliente')` | 2 |
+| Vitest (component) | Delete: confirmation gate; full-window disabled per entity; supersede blocked while a write is outstanding; re-entrancy guard; post-write refresh failure reports *"se eliminó, pero no se pudo actualizar la vista"*; each 409 `codigo` maps to its own copy | `react-async-state` rules 2-6, 9; **rule 10: the pattern is replicated across all four screens in the same PR** | 5 |
+| **Structural only (honest limits)** | (a) **Zero physical deletes**: repository scan for `ExecuteDelete`, `Remove(`, `RemoveRange(` and `DELETE FROM` over the four tables. (b) **Zero migrations**: no new file under `Migraciones/`, `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` untouched. (c) **Disjoint lock sets**: the deletion methods touch only organization tables (rule 13 — a live deadlock cannot be forced through raw ADO). (d) **FK index coverage**: the branch set compared against `pg_indexes`, reporting uncovered branches without fixing them (D, ZERO-SCHEMA) | Named as structural, never dressed up as a runtime kill | 4 |
+
+## Slicing (5 PRs, stacked-to-main, `review_budget_lines: 800`)
+
+| # | Branch | Content | ~Lines | Depends on | Rollback |
+|---|---|---|---|---|---|
+| 1 | `feat/stage20-slice1-proyeccion-api` | D13, D14 server side: the four DTOs, the correlated-subquery projections in `ServicioDeOrganizacion` + `ServicioDeUsuarios`, one-round-trip / orphan / counts-exclude-deleted / pairwise-distinct tests | ~390 | — | Revert. DTO fields disappear; the web slice is not merged yet |
+| 2 | `feat/stage20-slice2-proyeccion-web` | D14 web side, D15: `tipos.ts`, the five pure helpers + `organizacion.test.ts`, name columns and counts on the four screens, tenant filter ×3 and empresa filter ×1, the **first** Vitest files for these screens | ~430 | 1 | Revert. The screens return to rendering ids |
+| 3 | `feat/stage20-slice3-inspector-de-uso` | D1, D2, D3, D5, D6: the `IModel` line, `InventarioDeDependientes`, `InspectorDeUso`, the DI registration, **N1 + N2 + N3** and the rendering unit suite. **No caller — inert by construction** | ~470 | — | Revert. Nothing calls it; the guard cannot have run |
+| 4 | `feat/stage20-slice4-bajas-api` | D7-D12: three DELETE routes, three `EliminarAsync`, the cascade, the two minimums, the `Usuario` guard, the six 409 codes, the label dictionary, **N4**, U1-U8, RLS, the carve-outs, the login regression, the test relocations | ~490 | 1, 3 | Revert removes three routes and one guard call. Rows already soft-deleted stay soft-deleted and hidden — a **pre-existing, supported state** (`Usuario` has produced it since stage 1) |
+| 5 | `feat/stage20-slice5-bajas-web` | Delete button + confirmation on the four screens, `codigo`→copy mapping, the `react-async-state` write discipline replicated across all four, docs 09/10 | ~340 | 2, 4 | Revert removes buttons. The API still works; nobody can press it |
+
+Merge order `1 → 2 → 3 → 4 → 5`. **Slices 1-2 (Part A) and 3-5 (Part B) are independent**: slice 3
+depends on nothing (it is inert), and D13's nullable owner name is what keeps slice 1 correct without
+slice 4's cascade.
+
+**Decision needed before apply: No** (the gate is `ZERO-SCHEMA-RATIFIED`, `state.yaml:9-55`) ·
+**Chained PRs recommended: Yes** (`chain_strategy: stacked-to-main`, one `judgment-day` round per
+slice) · **800-line budget risk: Low** — every slice sits at roughly half the budget, and three split
+points are pre-authorized. The named inflators are slice 4's test matrix and its **test relocations**
+(fact 9), and slice 2's four from-scratch Vitest files.
+
+**Pre-approved degradation**, in the proposal's priority order: (1) slice 4 splits into `4a`
+(tenant + empresa + cascade + minimums, U1-U6) and `4b` (punto de venta + the `Usuario` guard +
+relocations, U7-U8); (2) slice 3 splits into `3a` (`IModel` + `InventarioDeDependientes` + N1-N3) and
+`3b` (`InspectorDeUso` + rendering); (3) slice 2 splits into `2a` (names and counts) and `2b`
+(filters). **Never degraded**: N1-N4, the two carve-out tests, the "one article blocks" test and the
+zero-physical-delete scan (`state.yaml:256-262`).
+
+## Binding verify criteria
+
+1. **Zero new files** under `src/Ways.Infrastructure/Persistencia/Migraciones/` — the last migration
+   at propose time is still the last one; `dotnet ef migrations has-pending-model-changes` **clean**.
+2. `InicializadorDeBaseDeDatos.cs` **untouched** (`git diff --exit-code`).
+3. **Zero** `CREATE`/`ALTER`/`DROP`/`INSERT`/`UPDATE`-DDL statements anywhere in the diff outside the
+   guard's generated read-only `SELECT`.
+4. **Zero physical deletes**: repository scan for `ExecuteDelete`, `Remove(`, `RemoveRange(` and
+   `DELETE FROM` over `tenants`, `empresas`, `puntos_venta`, `usuarios`.
+5. `src/Ways.Api/Seguridad/Politicas.cs` **untouched** — zero new policies; all four DELETEs reuse the
+   policy of the group they belong to.
+6. `src/Ways.Api/Seguridad/ManejadorDeErrores.cs` **untouched** — no SQLSTATE branch, because none can
+   fire (`db-error-backstops` N/A).
+7. `IWaysDbContext.cs` gains **exactly one** member (`IModel Model`) and **zero** implementations
+   change (fact 6, asserted by `rg ": IWaysDbContext"` returning only the compile-time satisfaction
+   by `WaysDbContext`).
+8. **N3's golden is checked in and green**, and any regeneration in the PR is accompanied by a written
+   classification decision for each changed line.
+9. Each of the four list endpoints performs **exactly one** database round trip (`ContadorDeComandos`).
+10. `InspectorDeUso` has **zero callers** in the slice-3 diff (`rg` over `src/`).
+11. Mutation evidence recorded in the PR body for **every** U-row belonging to that slice; structural
+    rows record the file/state/definition assertion instead of a runtime failure, **and say so**.
+12. Domain / Application / Integration / Vitest suites green; `tsc -b`, `oxlint`, `vite build` clean.
+
+## Threat Matrix
+
+**N/A** — this change adds four additive authenticated routes under **existing** policies, runs no
+shell command, spawns no subprocess, automates no VCS/PR action, classifies no executable file and
+integrates with no external process. Its one genuinely new boundary is **dynamically generated SQL**,
+which is not a threat-matrix row but is closed explicitly in **D**: identifiers come from EF metadata
+only and are pattern-validated; every value is a bound parameter; the statement is read-only
+(`SELECT`/`EXISTS`), so even a defect could not mutate a row.
+
+## Migration / Rollout
+
+**No migration required.** Zero DDL, zero data statements, zero seed changes (the ratified gate).
+Rollout is five merges; `git revert` is the complete rollback at every level. The only durable trace
+is a row an operator actually deleted, which is a `deleted_at` (and possibly `estado = 'baja'`) that a
+one-line `UPDATE` reverses — **the data was never destroyed (B1)**. There is no unrecoverable action
+in this stage.
+
+## Open questions / tensions
+
+- [ ] **T1 — two of the six 409 codes are unreachable through the API today.** No endpoint creates a
+      second empresa or a second punto de venta (fact 2), so decision 3's structural minimum fires on
+      every empresa/PV delete attempt and `empresa_en_uso` / `punto_venta_en_uso` can only be proven
+      **below the API** (D8). The routes are still correct and become live the day a create-empresa
+      or create-PV endpoint ships. `sdd-tasks` must not write an API-level test for those two codes —
+      it would pass for the wrong reason (`mutation-proof-tests` rule 3).
+- [ ] **T2 — a Success Criterion is wrong about the login code.** The proposal requires *"a deleted
+      tenant's user … receives 403 `tenant_suspendido`"*. Verified (fact 3): the cascade soft-deletes
+      the admin, the login lookup runs under `"BajaLogica"`, so the user is not found and the request
+      dies at `ServicioDeAutenticacion.cs:104` with **401 `credenciales_invalidas`**. The property the
+      criterion cares about — *cannot log in, cleanly, no crash* — holds; only the code differs. The
+      403 branch stays reachable for a **suspended** tenant and is asserted unchanged.
+- [ ] **T3 — the launch prompt and the ratified proposal disagree on soft-deleted dependents.** The
+      prompt states *"a logically deleted child must NOT block deletion"*; the proposal settled the
+      opposite (decision 6 side effect A, question round item 2) and requires a test proving it
+      (`proposal.md:506`). **This design implements the proposal.** Reversal cost, exactly as the
+      proposal states: add `AND d.deleted_at IS NULL` to every `Marcado` branch (and to `SinMarca`
+      branches whose table has the column), plus flipping one test. **Needs an owner ruling before
+      slice 3 is written**, because it changes what N3's golden and the guard's tests assert.
+- [ ] **T4 — the completeness test the proposal describes cannot exist as written.** A total
+      classifier has no unclassified state (A), so *"fails the build on an unclassified type"* is
+      delivered by **N3's golden inventory** instead of by a bucket-membership assertion (D4). This is
+      a substitution, recorded rather than silently performed; if the owner reads the proposal's
+      wording as binding literally, the alternative is a `Desconocido` bucket that throws at request
+      time — strictly worse, because it turns a future omission into a production 500.
+- [ ] **T5 — R1, the sale-during-deletion race, stays open** (G). Accepted: closing it would put a
+      platform-admin lock into the POS hot path. Reopen condition: any automated or bulk deletion
+      path.
+- [ ] **T6 — FK index coverage is verified, not guaranteed.** EF Core's `ForeignKeyIndexConvention`
+      should give every branch an index, but the gate forbids adding one if it does not. An uncovered
+      branch is reported by the structural check and becomes a finding for a later stage, not a
+      blocker here (D).
+- [ ] **Deferred, unchanged**: force/override delete, undelete/restore, retro-guarding the other
+      unguarded soft deletes, `Estado` for empresa/PV, server-side pagination, the
+      minimum-administrators invariant, and the owner's reserved carryovers (`state.yaml:263-280`).

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/explore.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/explore.md
@@ -1,0 +1,197 @@
+# Explore — stage-20: organization relationships and logical deletion
+
+Date: 2026-09-04
+Trigger: owner testing the running application reported that the root (platform) admin UI shows
+tenants, empresas, puntos de venta and usuarios as four unrelated flat lists, and that nothing can
+be deleted or disabled except suspending a tenant.
+
+This document records what was verified in the codebase, not what was assumed.
+
+---
+
+## 1. Reported symptoms, verified
+
+### 1.1 Relationships are in the model but never projected
+
+| Screen | What the DTO carries | What the screen renders |
+|---|---|---|
+| `Empresas.tsx` | `EmpresaListado.idTenant` (`api/tipos.ts:310-316`) | raw integer, `Empresas.tsx:156` — no tenant name |
+| `PuntosVenta.tsx` | `PuntoVentaListado.idTenant`, `.idEmpresa` (`api/tipos.ts:320-331`) | raw integers, `PuntosVenta.tsx:216-217` — no names |
+| `Usuarios.tsx` | `UsuarioListado` (`api/tipos.ts:23-32`) has **no** tenant/empresa/PV field at all | no tenant column exists |
+| `Tenants.tsx` | `TenantListado` (`api/tipos.ts:301-306`) — id, nombre, estado, createdAt | no child counts, no navigation to children |
+
+None of the three list screens offers a filter by tenant, and `PuntosVenta.tsx` offers no filter by
+empresa. The hierarchy defined in `docs/09-multi-tenancy.md` (tenant -> empresa -> punto de venta)
+is therefore invisible to a platform operator.
+
+The data is present server-side; the gap is projection, not schema.
+
+### 1.2 Deletion does not exist for organization entities
+
+`OrganizacionEndpoints.cs:12-13` states that create and delete are platform-only via
+`ServicioDeAprovisionamiento` (ADR-16), and that the absence of `POST`/`DELETE` in that file is
+deliberate. However `AprovisionamientoEndpoints.cs` exposes **only** `POST /api/plataforma/tenants`.
+There is no `DELETE` for tenant, empresa or punto de venta anywhere in the API surface. The delete
+path the comment defers to was never implemented.
+
+Additionally:
+
+- `Empresa` (`src/Ways.Domain/Organizacion/Empresa.cs`) and `PuntoVenta` have no `Estado` field.
+  Only `Tenant` has one (`EstadoTenant`, with suspend/reactivate endpoints), which is exactly the
+  asymmetry the owner observed.
+- `Usuario` **does** already support logical deletion: `DELETE /api/usuarios/{id}`
+  (`UsuariosEndpoints.cs:57`), wired in `Usuarios.tsx:120-122` behind a "Baja" button, plus an
+  `Inactivo`/`Bloqueado` state. The owner's report is inaccurate on this one point; the button is
+  conditionally hidden for Root targets, for self, and when `puedeEditar` is false.
+
+### 1.3 Soft-delete plumbing already exists
+
+`EntidadBase` (`src/Ways.Domain/Common/EntidadBase.cs`) declares `CreatedAt`, `UpdatedAt` and
+`DeletedAt` on every persisted entity, and `WaysDbContext.AplicarFiltroDeBajaLogica`
+(`WaysDbContext.cs:426-447`) installs a `"BajaLogica"` query filter on every `EntidadBase`
+descendant. Tenants, empresas and puntos de venta already have `deleted_at` columns and are already
+filtered. **No migration is required to delete them logically** — only endpoints, a guard, and UI.
+
+---
+
+## 2. Dependency graph (input to the guard design)
+
+### 2.1 Delete behaviour gives no protection
+
+Every FK in `WaysDbContext`/`Configuraciones/*.cs` is `DeleteBehavior.Restrict`, and there is no
+cascade anywhere. But **every delete in this codebase is logical** (`UPDATE ... SET deleted_at`),
+which never triggers a Postgres FK check. `Restrict` therefore contributes zero protection to the
+requested behaviour. Any "blocked when in use" rule must be an explicit application-level check.
+
+### 2.2 Referencing entities
+
+- **Tenant** — referenced by essentially every `EntidadTenant` descendant via `IdTenant`
+  (~40 tables spanning structural config, user catalogs and operational records).
+- **Empresa** — `PuntoVenta.IdEmpresa` (not null), `ArticuloEmpresa`, `CertificadoFiscal`,
+  `Parametro` (not null); `Cliente`, `Proveedor`, `Oferta`, `ConfiguracionDeCatalogo<T>` (nullable,
+  where null means "shared catalog row").
+- **PuntoVenta** — 18 referencing FKs including `ComprobanteVenta`, `ComprobanteCompra`,
+  `TurnoCaja`, `Stock`, `StockLote`, `MovimientoStock` (two FKs: `IdPuntoVenta` and
+  `IdPuntoVentaDestino`), `NumeracionComprobante` and `NumeracionFiscal` (PK members), `Presupuesto`,
+  `Remito`, `OrdenCompra`, `Gasto`, `MovimientoTesoreria`, `MovimientoCuentaCorriente`, `Auditoria`.
+- **Usuario** — referenced as actor/employee by `Auditoria.IdActor` and by `IdEmpleado` /
+  `IdEmpleadoApertura` / `IdEmpleadoCierre` on comprobantes, cajas, movimientos, presupuestos,
+  remitos and ordenes de compra. `Usuario.IdTenant` is nullable (null = platform staff) and
+  `Usuario` does not inherit `EntidadTenant`.
+
+### 2.3 A provisioned tenant is not empty
+
+`ServicioDeAprovisionamiento.CrearTenantAsync` (`ServicioDeAprovisionamiento.cs:28-170`) creates, in
+one transaction: 1 tenant, 1 empresa, 1 punto de venta, 1 area ("General"), 2 medios de pago
+("Efectivo", "Transferencia"), 1 lista de precios ("General", default), 1 cliente
+("Consumidor Final", numero 1), 1 `numeraciones_clientes` counter row, and 1 `admin` usuario.
+
+Therefore "never used" **cannot** mean "zero referencing rows". Every freshly provisioned tenant
+already has nine dependent rows.
+
+### 2.4 The discriminator: a single clock reading
+
+`ServicioDeAprovisionamiento.cs:46` reads the clock **once** (`var ahora = reloj.Ahora;`) and stamps
+that identical instant onto `CreatedAt`/`UpdatedAt` of every row it creates, including the `Tenant`
+row itself (lines 53-54, 69-70, 79-80, 89-90, 104-105, 121-122, 142-143, 158-160).
+
+This yields an exact, template-version-independent discriminator:
+
+> An entity is **pristine** if and only if no dependent row exists whose `CreatedAt` is strictly
+> greater than that entity's own `CreatedAt`.
+
+Everything born with the provisioning template shares the tenant's timestamp and is excluded.
+Anything the user created afterwards — an article, a client, a supplier, a sale, a second punto de
+venta — is strictly later and counts as usage.
+
+Caveat recorded: `numeraciones_clientes` is inserted by raw SQL in
+`AsignadorDeNumeroCliente.AsegurarContadorAsync` and carries no `CreatedAt`; it is not an
+`EntidadBase` and is therefore outside the discriminator entirely (it is a counter row, not user
+data).
+
+---
+
+## 3. Existing conventions to follow
+
+### 3.1 No existing delete checks dependents
+
+`ServicioDeUsuarios.EliminarAsync` (`ServicioDeUsuarios.cs:266-286`),
+`ServicioDeCatalogo<T,...>.EliminarAsync` (`ServicioDeCatalogo.cs:106-114`),
+`ServicioDeClientes.EliminarAsync`, `ServicioDeProveedores.EliminarAsync`,
+`ServicioDeArticulos.EliminarAsync` and `ServicioDeOfertas.EliminarAsync` all stamp `DeletedAt` with
+no dependent check. Guards that do exist are about protected rows ("Consumidor Final") and role
+policy, never about usage. This change introduces the first dependent guard in the codebase.
+
+### 3.2 Error shape
+
+`ManejadorDeErrores` (`src/Ways.Api/Seguridad/ManejadorDeErrores.cs:13-87`) maps `ErrorDominio` to
+`(EstadoHttp, Message, Codigo)`. The idiomatic rejection shape is a pre-check throwing
+`ErrorDominio.Conflicto("<codigo_snake_case>", "<mensaje>")` -> HTTP 409, as
+`ServicioDeUsuarios.ExigirDisponibilidadAsync` does for `usuario_duplicado` / `mail_duplicado`.
+The front end receives it as `ErrorApi { estado, codigo, mensaje }` (`api/cliente.ts:8-16, 60-63`).
+
+Note for the `db-error-backstops` skill: that skill's SQLSTATE backstop does not apply here, because
+no physical DELETE occurs and no Postgres constraint can fire. The application guard is the sole
+line of defence, so its tests carry the whole burden.
+
+### 3.3 Role policy on user deletion
+
+`PoliticaDeRoles.ValidarPuedeIntervenirSobre` (`PoliticaDeRoles.cs:59-81`): actor must be Root or
+Admin; a Root target may only be touched by Root and may never be deleted; self-deletion is
+forbidden. `ValidarAlcanceDeTenant` (lines 85-108) returns 404 rather than 403 for out-of-scope
+access, deliberately, to avoid an existence oracle (ADR-8).
+
+### 3.4 Test layout
+
+- Domain unit: `tests/Ways.Domain.Tests/<Area>/<Class>Tests.cs`
+- Application unit: `tests/Ways.Application.Tests/<Area>/<Class>Tests.cs` — closest templates
+  `Organizacion/ServicioDeOrganizacionTests.cs`, `Usuarios/ServicioDeUsuariosTests.cs`
+- Integration: flat under `tests/Ways.IntegrationTests/`, `[Collection("Ways.IntegrationTests secuencial")]`
+  — closest templates `OrganizacionTests.cs`, `BackstopClientesYProveedoresTests.cs`
+- Web: colocated `*.test.tsx` next to the component (Vitest + RTL)
+
+---
+
+## 4. Options considered for the guard
+
+| Option | Coverage | Failure direction | Verdict |
+|---|---|---|---|
+| Enumerate dependent tables by hand | ~40 `AnyAsync` calls for tenant alone | **Unsafe** — a table added in a future stage and forgotten makes a used tenant deletable, silently | rejected |
+| Reflect over `EntidadTenant` descendants | tenant only; does not generalise to empresa/PV/usuario whose FK property names vary (`IdEmpleado`, `IdEmpleadoApertura`, `IdActor`, `IdPuntoVentaDestino`) | safe | partial, rejected |
+| Query EF's own FK metadata via `IEntityType.GetReferencingForeignKeys()` | complete and automatic for all four entities, including FKs added later | **Safe** — an unmapped case blocks deletion rather than permitting it | **selected** |
+
+The selected option follows a pattern already idiomatic in this codebase: `AplicarFiltroDeBajaLogica`
+and `AplicarFiltroDeTenantEnTenant` (`WaysDbContext.cs:426-488`) already walk the EF model by
+reflection to install behaviour uniformly.
+
+---
+
+## 5. Owner decisions taken during exploration
+
+1. **Physical deletion is never permitted.** All deletion remains logical (`DeletedAt`), consistent
+   with the `EntidadBase` convention "las bajas son siempre lógicas".
+2. **Anything the user loaded counts as usage.** Not only operational records: articles, clients,
+   suppliers and any other user-created row block deletion. Only the provisioning baseline does not.
+   This replaced an earlier proposal that would have let a tenant with 3000 articles and zero sales
+   remain deletable.
+3. **Audit rows do not block.** `Auditoria.IdActor`/`IdPuntoVenta` are a trail *about* the entity,
+   not data the user operated; and because deletion is logical the referenced row survives, so the
+   trail keeps rendering. Recorded as an explicit carve-out, to be re-confirmed at spec time.
+
+## 6. Open questions for the proposal phase
+
+- Whether deleting a tenant should cascade the logical deletion to its children (otherwise orphaned
+  empresas remain visible in the root list). Exploration recommends yes.
+- Whether structural minimums should be enforced: a tenant must keep at least one empresa, an
+  empresa at least one punto de venta. Exploration recommends yes, as a separate named 409.
+- Whether `Usuario` deletion should gain the same dependent guard it currently lacks, or keep its
+  present unguarded behaviour. Exploration recommends aligning it with the other three.
+
+## 7. Out of scope
+
+- Any change to `Estado`/suspension semantics for empresa or punto de venta. The owner asked for
+  deletion, not disabling; `Tenant.Estado` stays as it is.
+- Any schema migration. The change is designed to require none; if design discovers one is needed,
+  the project's mandatory DB gate applies and work stops for owner approval.
+- The unfinished `stage-18-etiquetas-y-consulta` change, which is blocked on a physical measurement
+  by the owner and is untouched by this work.

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/proposal.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/proposal.md
@@ -1,0 +1,603 @@
+# Proposal: Stage 20 — Organization relationships and usage-guarded logical deletion
+
+## Intent
+
+The owner tested the running application and reported two things about the platform (root) admin
+surface. `explore.md` verified both against the code, and corrected one of them.
+
+| Fact | Evidence | Consequence |
+|---|---|---|
+| **The hierarchy exists in the model and is never projected** | `EmpresaListado.IdTenant`, `PuntoVentaListado.IdTenant/.IdEmpresa` carry raw integers (`Contratos.cs:24,28-38`) and the screens render those integers (`Empresas.tsx:156`, `PuntosVenta.tsx:216-217`) | A platform operator reads `2` and cannot tell which tenant that is. Four flat lists, zero navigable relationship |
+| **`UsuarioListado` carries no tenant at all** | `Usuarios/Contratos.cs:19-27` — `Id, Usuario, Mail, RolId, Rol, Estado, UltimaConexion, CreatedAt` | The root user list cannot even be **grouped** by tenant, let alone filtered. The data is one join away |
+| **No DELETE exists for tenant, empresa or punto de venta** | `OrganizacionEndpoints.cs:12-13` defers alta/baja to `ServicioDeAprovisionamiento` (ADR-16), but `AprovisionamientoEndpoints.cs` exposes **only** `POST /api/plataforma/tenants` | The delete path the comment defers to was **never implemented**. The only lever is suspension, and only for tenants |
+| **`EstadoTenant.Baja` is a latent value with zero writers** | The enum declares it (`EstadoTenant.cs:16`, *"los datos quedan para exportación"*), `Tenant.PuedeOperar` reads it, login rejects it (`ServicioDeAutenticacion.cs:141`), `CambiarEstadoTenantAsync` refuses to touch it (`ServicioDeOrganizacion.cs:67`), `Tenants.tsx:12` documents its absence — and **nothing ever assigns it** (`Estado = EstadoTenant.` grep: only `Activo`, twice) | Stage 17's *"PRE latente"* pattern, already in the tree. This stage is its writer |
+| **The soft-delete plumbing is already installed** | `EntidadBase` gives `DeletedAt` to all four entities; `AplicarFiltroDeBajaLogica` (`WaysDbContext.cs:426-447`) installs the `"BajaLogica"` filter on every descendant; `estado_tenant` was created with `activo,baja,suspendido` in the **first** migration (`20260801011312_Organizacion.cs:18`) | **Zero migrations.** What is missing is endpoints, a guard, and UI |
+| **The owner's report was wrong on one point** | `Usuario` **does** already delete logically: `DELETE /api/usuarios/{id}` (`UsuariosEndpoints.cs:57`) wired to a "Baja" button (`Usuarios.tsx:120-122`) | The gap there is not the endpoint — it is that the endpoint has **no dependent guard at all** |
+
+Three costs the platform operator pays today. **Orientation**: with more than one tenant, the root
+screens stop being administrable — you cannot answer *"which empresas does this tenant have?"*
+without reading integers out of a database. **Reversibility**: a mistyped provisioning run, a
+cancelled trial, a duplicated empresa are permanent; the platform accumulates rows nobody can
+retire. **Safety**: the one deletion that does exist (`Usuario`) checks role policy and nothing
+else — it will happily retire the employee whose id is stamped on ten thousand comprobantes.
+
+**What stage 20 delivers.** The root surface shows the hierarchy it already owns, and the platform
+gains a delete that is *safe by construction*: it refuses on anything the customer has actually
+touched, and it discovers what "touched" means from EF's own model rather than from a list a human
+has to remember to update.
+
+## Binding owner decisions (settled — do not reopen)
+
+| # | Decision | Consequence for this proposal |
+|---|---|---|
+| **B1** | **Physical deletion is never permitted.** All deletion is logical (`DeletedAt`), per `EntidadBase` | No `DELETE FROM` anywhere. No FK constraint can ever fire — see B5's corollary in Risks |
+| **B2** | **"In use" means the customer loaded or operated *anything* beyond the provisioning baseline** — articles, clients, suppliers, a second punto de venta, not only transactional records. Only what `ServicioDeAprovisionamiento` created is pristine | A tenant with 3 000 articles and zero sales is **not** deletable. This replaced an earlier, narrower reading |
+| **B3** | **The discriminator is `dependiente.CreatedAt > entidad.CreatedAt`**, valid because `ServicioDeAprovisionamiento.cs:46` reads the clock **once** (`var ahora = reloj.Ahora;`) and stamps that identical instant on every provisioned row, the `Tenant` included (`:53-54, 69-70, 79-80, 89-90, 104-105, 121-122, 142-143, 158-160`) | Template-version independent: the baseline is defined by a timestamp identity, never by a hardcoded row count |
+| **B4** | **The dependent set comes from EF metadata** (`IEntityType.GetReferencingForeignKeys()`), never a hand-maintained table list | A hand list **fails unsafe** (one forgotten table makes a used entity deletable, silently). Metadata **fails safe** |
+| **B5** | **Audit rows do not block.** `Auditoria.IdActor` and `Auditoria.IdPuntoVenta` are a trail *about* the entity, not data the customer operated — and because deletion is logical the referenced row survives, so the trail keeps rendering | One named carve-out, in code, with its reason and its own test (decision 4) |
+
+## Scope
+
+### In Scope
+
+**Part A — project the hierarchy in the root UI**
+
+- `EmpresaListado` gains `NombreTenant`; `PuntoVentaListado` gains `NombreTenant` and
+  `RazonSocialEmpresa`; `UsuarioListado` gains `IdTenant` and `NombreTenant` (it carries **neither**
+  today); `TenantListado` gains `CantidadEmpresas`, `CantidadPuntosVenta` and `CantidadUsuarios`.
+- Filtering: by tenant on `Empresas.tsx`, `PuntosVenta.tsx` and `Usuarios.tsx`; additionally by
+  empresa on `PuntosVenta.tsx`. Client-side over the already-loaded list (decision 7).
+- The four screens render owner **names**, never raw ids.
+
+**Part B — usage-guarded logical deletion**
+
+- `DELETE /api/plataforma/tenants/{id}`, `DELETE /api/empresas/{id}`,
+  `DELETE /api/puntos-venta/{id}` — logical, never physical.
+- `InspectorDeUso`: one Application service that walks EF metadata, classifies every referencing FK
+  into exactly one of three buckets (decision 4), and answers *"is this entity pristine?"* in a
+  single round trip.
+- Cascade on a pristine parent, scoped to the organization projection and the authentication
+  surface (decision 2).
+- Structural minimums with their own named 409s (decision 3).
+- `Usuario` deletion gains the same dependent guard (decision 5), keeping every existing
+  `PoliticaDeRoles` rule intact.
+- Tenant deletion writes `Estado = EstadoTenant.Baja` **and** `DeletedAt` (decision 1).
+- Six new `ErrorDominio.Conflicto` codes, their `ErrorApi` surfacing, and the web confirmation +
+  message mapping.
+
+### Out of Scope
+
+- **Any schema migration.** The gate below is the contract: zero migrations, zero DDL, zero data
+  statements. **Reopen condition**: if design discovers a schema change is genuinely required, work
+  **stops** and the owner approves a model summary first (CLAUDE.md DB gate).
+- **`Estado` / suspension for empresa or punto de venta.** The owner asked for deletion, not
+  disabling. `Tenant.Estado` semantics are unchanged; `Empresa` and `PuntoVenta` gain no state field.
+  **Reopen condition**: an explicit owner request.
+- **A force/override delete** that bypasses the guard for a used entity. The platform's existing
+  recourse for a customer it wants to stop serving is **suspension**, which already works.
+  **Reopen condition**: the first real support case that needs it — at which point it needs an
+  audit trail and a confirmation ceremony this stage is not designing blind.
+- **Undelete / restore.** Rows are recoverable by hand (`deleted_at = NULL`), and `EstadoTenant.Baja`
+  is deliberately not reachable from suspend/reactivate (`ServicioDeOrganizacion.cs:67-72`). A
+  restore endpoint is its own change with its own guard question.
+- **Retro-guarding the other soft deletes.** `ServicioDeCatalogo<T>`, `ServicioDeClientes`,
+  `ServicioDeProveedores`, `ServicioDeArticulos` and `ServicioDeOfertas` all delete without a
+  dependent check (`explore.md:118-123`). This stage builds the mechanism and applies it to the four
+  organization entities only. **Reopen condition**: a later stage reuses `InspectorDeUso` — it is
+  designed to be entity-agnostic precisely so that is a one-line adoption.
+- **Server-side pagination or server-side filtering** of the four lists (decision 7).
+- **Navigating from a tenant row into its children** (drill-down). Counts, not navigation.
+- **The owner's reserved carryovers** — the `importe` CHECK micro-gate, the `articulos_empresas`
+  replace-set gap, `stage-18-etiquetas-y-consulta` (blocked on a physical measurement). Untouched.
+
+## Capabilities
+
+### New Capabilities
+
+- **`bajas-de-organizacion`** — what logical deletion means for the organization hierarchy: the
+  pristine/used discriminator and why a single clock reading makes it exact; how the dependent set is
+  discovered and why a hand list is forbidden; the three classification buckets and the two named
+  carve-outs; the cascade rule and its boundary; the structural minimums; the complete 409 code set;
+  and the invariant that no row is ever physically deleted.
+
+### Modified Capabilities
+
+- **`tenant-organization`** — **ADDED**: the read projection carries owner names and child counts;
+  a platform-only logical deletion surface exists for tenant, empresa and punto de venta (the
+  counterpart the existing *Platform-Only Creation* requirement never got); tenant deletion is the
+  first and only writer of `EstadoTenant.Baja`. **UNCHANGED (asserted)**: provisioning, suspension /
+  reactivation, tenant isolation, and every existing edit route.
+- **`usuarios-tenant-scoping`** — **ADDED**: the usuarios listing DTO carries the account's tenant
+  identity and name (platform actors only see more than one value); `Usuario` logical deletion is
+  guarded by the same usage rule as the organization entities, **after** the existing
+  `PoliticaDeRoles.ValidarPuedeIntervenirSobre` checks, never instead of them.
+
+**Not modified**: every other capability. No policy is added or changed
+(`Politicas.SoloPlataforma`, `Politicas.GestionDeOrganizacion`, `Politicas.LecturaDePuntosVenta` and
+`Politicas.GestionDeUsuarios` cover the whole surface), and no operational path is touched.
+
+## Approach
+
+**Ask EF what points at this row, ask the clock whether the customer put it there, and refuse
+loudly.** Three properties carry the whole stage:
+
+1. **The dependent set is derived, not remembered.** `IEntityType.GetReferencingForeignKeys()`
+   enumerates every FK pointing at `Tenant`, `Empresa`, `PuntoVenta` and `Usuario`, including the
+   awkward ones a human list forgets — `MovimientoStock.IdPuntoVentaDestino`,
+   `TurnoCaja.IdEmpleadoApertura`/`IdEmpleadoCierre`, and the composite `(id, id_tenant)` keys. This
+   is the idiom the codebase already uses: `AplicarFiltroDeBajaLogica` and
+   `AplicarFiltroDeTenantEnTenant` (`WaysDbContext.cs:426-486`) both walk the EF model by reflection
+   to install behaviour uniformly.
+2. **The baseline is a timestamp identity, not a count.** B3. `EXISTS (SELECT 1 FROM t WHERE fk = @id
+   AND created_at > @ancla)` — nine provisioned rows share the tenant's `created_at` and are
+   excluded; the first article the customer loads is strictly later and blocks.
+3. **The guard fails safe in every direction.** A new table added by a future stage is discovered
+   automatically. A dependent EF cannot classify **breaks a test at build time** rather than silently
+   permitting a delete (decision 4). A dependent with no timestamp blocks on existence. There is no
+   path in which forgetting something makes deletion *easier*.
+
+**The corollary that must be stated out loud.** Because deletion is logical (B1), **no Postgres
+constraint can ever fire** — every FK in `WaysDbContext` is `DeleteBehavior.Restrict`, and `Restrict`
+contributes exactly zero protection against `UPDATE ... SET deleted_at`. The `db-error-backstops`
+skill's SQLSTATE `23503` backstop **does not apply to this change**. The application guard is the
+sole line of defence, and its tests carry the entire burden. This is recorded as the stage's top
+risk, and it is why decision 4's completeness test is non-negotiable.
+
+## Decisiones
+
+Nine decisions: the explore's three open questions resolved, plus six the proposal had to take.
+
+---
+
+### 1 — **Tenant deletion writes `Estado = Baja` *and* `DeletedAt`, in one transaction. It is `EstadoTenant.Baja`'s first writer.**
+
+`EstadoTenant.Baja` has a reader in three places and a writer in none (Intent table). Writing only
+`DeletedAt` would leave the latent value latent forever, and would leave two contradictory notions of
+"gone" in the same row. Writing only `Estado = Baja` would leave the tenant visible in the root list.
+
+**Decision.** Both, atomically. `Tenant.PuedeOperar` (`Tenant.cs:20`) is already
+`Estado == Activo && DeletedAt is null`, so the two agree by construction.
+
+**The verified safety property.** A deleted tenant's users cannot authenticate, and the failure is a
+clean 403, not a crash: `ServicioDeAutenticacion.cs:137-147` reads the tenant through the
+`"BajaLogica"` filter, gets `null`, and the guard is `tenant is null || !tenant.PuedeOperar` →
+`ErrorDominio("tenant_suspendido", …, 403)`. The `null` branch already exists and is already correct.
+
+**Cost of reversing.** `UPDATE tenants SET deleted_at = NULL, estado = 'activo'` on one row.
+
+---
+
+### 2 — **Cascade: yes, and its boundary is "what the root UI shows plus what can authenticate". Nothing else. (Explore open question 1 — recommendation adopted, boundary added.)**
+
+Deleting a tenant logically deletes **its empresas, its puntos de venta, and its usuarios**. Deleting
+an empresa logically deletes **its puntos de venta**.
+
+**Why cascade at all.** Without it, deleting tenant 4 leaves its empresa in `Empresas.tsx` pointing
+at a tenant that no longer resolves — the root list would render an orphan, which is the exact defect
+Part A exists to remove.
+
+**Why the boundary stops there** — and this is the part the explore did not state. A wide cascade over
+the whole provisioning template (`areas`, `medios_pago`, `listas_precio`, the *Consumidor Final*
+client) would contradict the domain's own stated intent: `EstadoTenant.Baja` is documented as *"No se
+elimina físicamente: los datos quedan para exportación"* (`EstadoTenant.cs:15`). Rows that are
+invisible in the root UI and unreachable by any login are already inert; deleting them buys nothing
+and costs the export promise.
+
+**Why this is cheap to guarantee.** A tenant with a used child is **not deletable in the first
+place** — every `EntidadTenant` descendant references the tenant, so any usage at all blocks at the
+tenant. The cascade therefore only ever runs over the pristine provisioning baseline: one empresa,
+one punto de venta, one admin. It is a small, provable set, not an unbounded sweep.
+
+**One shared `DeletedAt` instant** for the parent and every cascaded child — one `reloj.Ahora`, the
+`ServicioDeUsuarios.EliminarAsync:302` idiom (*"un único `momento` para la entidad Y el payload"*).
+That instant is what makes a manual restore unambiguous.
+
+**Cost of reversing.** `UPDATE … SET deleted_at = NULL WHERE deleted_at = '<the shared instant>'`.
+
+---
+
+### 3 — **Structural minimums: yes, with two separate named 409s, checked before the usage guard. (Explore open question 2 — adopted.)**
+
+- A tenant must keep **at least one** empresa → `ultima_empresa_del_tenant`.
+- An empresa must keep **at least one** punto de venta → `ultimo_punto_venta_de_la_empresa`.
+
+**Why separate codes, not one generic "in use".** They mean opposite things to the operator.
+*"In use"* says *"there is data here, this is not the row you want to delete."* *"Last empresa"*
+says *"this row is fine to delete — you are trying to delete it the wrong way; delete the tenant."*
+Collapsing them would send the operator hunting for data that does not exist.
+
+**Ordering.** Structural minimum is checked **before** usage, because it is a cheap `COUNT` on one
+table and its message is more actionable. A pristine single-empresa tenant is deleted through the
+**tenant**, whose cascade (decision 2) takes the empresa with it — so the minimum never becomes a
+prison.
+
+**Deliberately not enforced here**: a minimum number of admins per tenant. Flagged in the question
+round; `PoliticaDeRoles` already forbids self-deletion and Root-target deletion, so the reachable
+failure is narrow, and inventing a role invariant in an autonomous run is worse than naming the gap.
+
+**Cost of reversing.** Delete two pre-checks.
+
+---
+
+### 4 — **The dependent set is discovered from EF metadata (B4) and classified into exactly three buckets, with a completeness test that fails the build on an unclassified type.**
+
+`GetReferencingForeignKeys()` returns the complete set. It does **not** tell us how to interrogate
+each dependent, because **15 domain entity types do not inherit `EntidadBase` and therefore have no
+`created_at` column at all** — `Stock`, `StockLote`, `MovimientoStock`, `MovimientoCaja`,
+`MovimientoTesoreria`, `ArqueoTurno`, `MovimientoCuentaCorriente`,
+`MovimientoCuentaCorrienteProveedor`, `Auditoria`, `ArticuloEmpresa`, `OfertaLista`,
+`NumeracionCliente`, `NumeracionArticulo`, `NumeracionComprobante`, `NumeracionFiscal` (verified:
+`Stock.cs` and `ArticuloEmpresa.cs` carry no timestamp property whatsoever). B3's discriminator is
+**not universally applicable**, and the explore did not say so.
+
+| Bucket | Rule | Why it is correct |
+|---|---|---|
+| **1 — timestamped** | `EntidadBase` descendant → blocks iff `EXISTS (fk = @id AND created_at > @ancla)` | B3 exactly |
+| **2 — untimestamped** | not `EntidadBase` → blocks iff **any** row references the entity | Provisioning creates **no** row of any of these types **except** `numeraciones_clientes` (`explore.md:107-110`). Existence therefore already means usage, and it fails safe |
+| **3 — carve-out** | an explicitly named type with a written reason and its own test | Exactly two members: `Auditoria` (B5) and `NumeracionCliente` (the provisioning counter, inserted by raw SQL in `AsignadorDeNumeroCliente.AsegurarContadorAsync`, not an `EntidadBase`, not customer data) |
+
+**The completeness test is the safety mechanism, and it is the single most important test of the
+stage.** It walks `GetReferencingForeignKeys()` for all four entities and asserts every discovered
+type falls into exactly one bucket. A future stage that adds an untimestamped table gets a **red
+test naming the type**, not a silent hole. Buckets 1 and 2 are derived from the model, so the only
+hand-written artifact is the two-member carve-out list — and a forgotten carve-out over-blocks
+(annoying) instead of under-blocking (unsafe).
+
+**Nullable FKs need no special rule**: `Cliente`, `Proveedor`, `Oferta` and
+`ConfiguracionDeCatalogo<T>` use `IdEmpresa NULL` to mean *"shared catalog row"*, and `fk = @id`
+simply does not match `NULL`. A shared row correctly does not block an empresa's deletion.
+
+**Cost of reversing.** The service has one caller per entity. Deleting it deletes the guard.
+
+---
+
+### 5 — **`Usuario` deletion gains the guard, positioned after `PoliticaDeRoles`, never instead of it. (Explore open question 3 — adopted.)**
+
+`ServicioDeUsuarios.EliminarAsync` (`:292-317`) validates role policy and then stamps `DeletedAt`
+with **no dependent check** — so today the platform can retire the employee stamped on
+`ComprobanteVenta.IdEmpleado`, `TurnoCaja.IdEmpleadoApertura`/`IdEmpleadoCierre`, `Presupuesto`,
+`Remito` and `OrdenCompra` rows.
+
+**Decision.** Insert the same `InspectorDeUso` check **after** `ValidarPuedeIntervenirSobre` and
+before the `DeletedAt` write, yielding `usuario_en_uso`. Every existing rule is preserved verbatim:
+Root targets are still undeletable, self-deletion is still forbidden, the audit record is still
+written, `ValidarAlcanceDeTenant`'s deliberate 404-not-403 (ADR-8, anti-existence-oracle) is
+untouched.
+
+**The one behavioural consequence, stated honestly.** The `admin` account created by provisioning has
+the tenant's `created_at`, so it is pristine — until it logs in and does anything. This is correct
+under B2: an admin who has operated is exactly the account whose history must not lose its actor. The
+platform's remaining lever for a departing employee is the **existing** `Inactivo`/`Bloqueado` state,
+which is what that state is for.
+
+**Cost of reversing.** Remove one call.
+
+---
+
+### 6 — **One query, generated from metadata, executed as parameterised raw SQL — and its two side effects are exactly the semantics we want.**
+
+`Tenant` has ~40 referencing FKs. Forty sequential `AnyAsync` round trips per delete attempt is
+absurd; the guard composes **one** statement of `SELECT '<tabla>' … WHERE fk = @id [AND created_at >
+@ancla] LIMIT 1` branches joined by `UNION ALL`, with an outer `LIMIT 1`. It returns the **name of
+the first blocking table** or nothing. Precedent for raw ADO in this codebase:
+`AsignadorDeNumeroComprobante` and `EscriturasDeCuentaCorriente`.
+
+**Injection.** Identifiers come from EF metadata; entity ids and the anchor are **parameters**. No
+user-supplied string ever reaches the statement.
+
+**Side effect A — query filters are bypassed, and that is the intended rule.** Raw SQL does not apply
+`"BajaLogica"`, so a **soft-deleted** dependent still blocks. Deliberate: B2 asks *"did the customer
+ever operate here"*, not *"is there live data right now"*. A customer who loaded 3 000 articles and
+then deleted them operated. It also fails safe.
+
+**Side effect B — RLS still applies**, because it lives on the connection, not on EF. A tenant admin
+deleting their own empresa sees every dependent of their own tenant, so the guard cannot under-count;
+tenant deletion is platform-only and platform sees everything (`app_es_plataforma()`). Asserted by a
+cross-tenant integration test.
+
+**The one interface question for design.** `IWaysDbContext` exposes `DatabaseFacade Database` but not
+`IModel Model` (`IWaysDbContext.cs:153`). The proposal's recommendation is to add `IModel Model
+{ get; }` under the interface's own stated criterion — *"`DatabaseFacade` is the same EF Core
+abstraction any `DbContext` already exposes, not a type from Infrastructure"* (`:150-152`) — which
+`IModel` satisfies identically. **`sdd-design` confirms or replaces it with a dedicated port**; the
+alternative is one extra abstraction, not a redesign.
+
+**Cost of reversing.** One file.
+
+---
+
+### 7 — **Filtering is client-side over the already-loaded list. No new endpoint, no query parameter, no pagination.**
+
+All four screens already `GET` the full list into `useState` with no paging
+(`ServicioDeOrganizacion.ListarTenantsAsync` and siblings return `IReadOnlyList<T>` unbounded). At
+platform scale — tenants, empresas, puntos de venta, staff accounts — that is tens of rows, not
+thousands.
+
+**Decision.** A `<select>` per screen filtering the loaded array. Zero API surface added by Part A
+beyond the DTO fields.
+
+**When this stops being true**, it stops being true for the whole screen (the unbounded list, not the
+filter), and the answer is server-side pagination for all four at once — a different change with a
+different shape. Naming that now prevents a half-server/half-client filter later.
+
+**Cost of reversing.** The filter becomes a query parameter; the projections already carry the ids.
+
+---
+
+### 8 — **Owner names are projected by join in the existing `Select`, not denormalised and not fetched separately.**
+
+`ListarEmpresasAsync` already projects into a DTO inside the `Select` (`ServicioDeOrganizacion.cs:92-96`);
+adding `e.Tenant.Nombre` extends the same expression into one `LEFT JOIN`. Counts on `TenantListado`
+are correlated sub-selects in the same statement. Two N+1 shapes are thereby avoided by construction,
+and an integration test asserts a **single** round trip per list endpoint.
+
+**`UsuarioListado` is the exception worth naming**: it gains **two** fields, `IdTenant` (which it has
+never carried) and `NombreTenant`. `Usuario.IdTenant` is nullable — `null` means platform staff — so
+the projection renders *"Plataforma"*, never an empty cell that reads like missing data.
+
+**Cost of reversing.** Remove fields from a record and a `Select`.
+
+---
+
+### 9 — **Error messages name the blocked entity in plain Spanish and degrade to a generic phrase; the code is always exact.**
+
+Decision 6 yields the blocking table's name. The message maps it through a small label dictionary
+(`comprobantes_venta` → *"ventas"*, `articulos` → *"artículos"*, …) and falls back to *"datos
+cargados"* for an unmapped table.
+
+**Why the dictionary is not the hand-list B4 forbids.** B4's list would have decided **whether** to
+block; this one only decides **how to word** an already-decided block. A missing entry costs a vaguer
+sentence, never a wrong verdict — the failure directions are not comparable.
+
+`ErrorDominio.Conflicto("<codigo_snake_case>", "<mensaje>")` → HTTP 409 → `ErrorApi { estado, codigo,
+mensaje }` (`ManejadorDeErrores.cs:13-87`, `api/cliente.ts:8-16,60-63`), the
+`usuario_duplicado`/`mail_duplicado` idiom. The **web** keys its copy off `codigo`, never off
+`mensaje`.
+
+**Cost of reversing.** Drop the dictionary; messages get generic.
+
+---
+
+## Modelo de datos propuesto — **CERO CAMBIOS DE SCHEMA**
+
+> **DB CHANGE GATE (CLAUDE.md) — this section is the contract.** Any DDL or data statement proposed
+> by a later phase is a **scope violation that reopens the gate**.
+
+**Gate verdict proposed: ZERO migrations, ZERO tables, ZERO columns, ZERO enums, ZERO `ALTER`, ZERO
+indexes, ZERO data statements, ZERO seed changes.**
+
+Everything this change writes already exists in the schema:
+
+| What the change writes | Where it already exists |
+|---|---|
+| `tenants.deleted_at`, `empresas.deleted_at`, `puntos_venta.deleted_at`, `usuarios.deleted_at` | `EntidadBase` (`EntidadBase.cs`), configured per entity (e.g. `TenantConfiguration.cs:33`) |
+| The `"BajaLogica"` filter that hides them | `WaysDbContext.AplicarFiltroDeBajaLogica` (`:426-447`) |
+| `tenants.estado = 'baja'` | Native pg enum `estado_tenant` created with **`activo,baja,suspendido`** in the first migration (`20260801011312_Organizacion.cs:18`) — the value is already in the database, only its writer was missing |
+| Owner names and child counts | Read-only projections over existing FKs. A projection is not a schema change |
+
+**Binding criteria for verify.**
+
+1. **No new file** under `src/Ways.Infrastructure/Persistencia/Migraciones/`. The last migration of
+   the tree at propose time **must still be the last one** at verify.
+2. `dotnet ef migrations has-pending-model-changes` **clean**.
+3. **Zero** `CREATE`/`ALTER`/`DROP`/`INSERT`/`UPDATE`-DDL statements introduced anywhere in the diff
+   outside the guard's generated read-only `SELECT`.
+4. `InicializadorDeBaseDeDatos.cs` **untouched**.
+
+**Precedent**: stages 10, 11, 13 and 18 delivered complete stages with zero DDL.
+
+## API surface
+
+| Route | Method | Policy | Status |
+|---|---|---|---|
+| `/api/plataforma/tenants` | GET | `SoloPlataforma` | **Modified** — DTO gains three counts |
+| `/api/plataforma/tenants/{id}` | **DELETE** | `SoloPlataforma` | **New** — logical, guarded, cascading |
+| `/api/empresas` | GET | `GestionDeOrganizacion` | **Modified** — DTO gains `NombreTenant` |
+| `/api/empresas/{id}` | **DELETE** | `GestionDeOrganizacion` | **New** |
+| `/api/puntos-venta` | GET | `LecturaDePuntosVenta` | **Modified** — DTO gains two owner names |
+| `/api/puntos-venta/{id}` | **DELETE** | `GestionDeOrganizacion` | **New** — note the asymmetry: read is `LecturaDePuntosVenta` (the POS selector uses it, `OrganizacionEndpoints.cs:64-66`), write is not |
+| `/api/usuarios` | GET | existing | **Modified** — DTO gains `IdTenant` + `NombreTenant` |
+| `/api/usuarios/{id}` | DELETE | existing | **Modified** — same route, guard added (decision 5) |
+| `…/suspender`, `…/reactivar`, every `PUT` | — | — | **Unchanged**, asserted |
+
+**Zero new policies.** All four DELETEs reuse the policy of the group they belong to.
+
+### Error codes (complete set)
+
+| Code | HTTP | Raised when |
+|---|---|---|
+| `tenant_en_uso` | 409 | The tenant has a dependent past the provisioning baseline |
+| `empresa_en_uso` | 409 | Idem, empresa |
+| `punto_venta_en_uso` | 409 | Idem, punto de venta |
+| `usuario_en_uso` | 409 | Idem, usuario (decision 5) |
+| `ultima_empresa_del_tenant` | 409 | Deleting the tenant's only empresa (decision 3) |
+| `ultimo_punto_venta_de_la_empresa` | 409 | Deleting the empresa's only punto de venta |
+
+Reused unchanged: `tenant_dado_de_baja` (409), the `PoliticaDeRoles` role errors, and
+`ErrorDominio.NoEncontrado` (404) for an already-deleted row — the `"BajaLogica"` filter makes it
+invisible, so a second DELETE is a clean 404, and **DELETE is therefore idempotent-safe**.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|---|---|---|
+| `src/Ways.Application/Organizacion/Contratos.cs` | Modified | Three DTOs gain owner names; `TenantListado` gains three counts |
+| `src/Ways.Application/Usuarios/Contratos.cs` | Modified | `UsuarioListado` gains `IdTenant` + `NombreTenant` |
+| `src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs` | Modified | Joined projections; three `EliminarAsync` methods; cascade; structural minimums |
+| `src/Ways.Application/Organizacion/InspectorDeUso.cs` | **New** | The metadata walk, the three buckets, the generated statement (decisions 4 and 6) |
+| `src/Ways.Application/Usuarios/ServicioDeUsuarios.cs` | Modified | One guard call inserted after `PoliticaDeRoles` (decision 5) |
+| `src/Ways.Application/Abstracciones/IWaysDbContext.cs` | Modified | `IModel Model { get; }` — pending design confirmation (decision 6) |
+| `src/Ways.Api/Endpoints/OrganizacionEndpoints.cs` | Modified | Three DELETE routes; the class doc-comment's *"acá no hay `POST` ni `DELETE` a propósito"* is corrected |
+| `src/Ways.Api/Seguridad/Politicas.cs` | **Untouched** | Binding criterion |
+| `src/Ways.Infrastructure/Persistencia/**` | **Untouched** except the `IModel` exposure | Binding criterion: no migration, no configuration change |
+| `src/Ways.Web/src/api/tipos.ts` + `api/organizacion.ts` + `api/usuarios.ts` | Modified | DTO fields; three `eliminar*` calls |
+| `src/Ways.Web/src/paginas/{Tenants,Empresas,PuntosVenta,Usuarios}.tsx` | Modified | Name columns, counts, filters, delete button + confirmation, 409 code→copy mapping |
+| `src/Ways.Web/src/paginas/*.test.tsx` | **New** | **No test file exists for any of the four screens today** — Vitest coverage is created, not extended |
+| `tests/Ways.Application.Tests/Organizacion/*` | New/Modified | `InspectorDeUsoTests` (including the completeness test), extended `ServicioDeOrganizacionTests` |
+| `tests/Ways.IntegrationTests/*` | New/Modified | End-to-end delete/guard/cascade/RLS, single-round-trip assertions |
+| `docs/09-multi-tenancy.md`, `docs/10-modelo-de-datos.md` | Modified | An "Etapa 20" note: deletion semantics and the guard. **No schema table changes** |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **The application guard is the *only* defence** — B1 means no FK constraint can fire, so `db-error-backstops`' SQLSTATE backstop does not apply and a guard bug is unbacked | **High if unmanaged** | Decision 4's completeness test (build-time detection of unclassified dependents); a per-bucket test; an integration test that deletes a used entity of each of the four kinds and asserts the exact 409 code; mutation-proof tests over the `>` in the discriminator |
+| **A forgotten dependent silently permits a delete** | Low, by design | B4 + decision 4: the set is derived, and an unclassifiable type is a **red test**, not a hole |
+| **Clock equality is not exactly equal** — if a future refactor made `ServicioDeAprovisionamiento` read `reloj.Ahora` more than once, the baseline splits and a fresh tenant becomes undeletable | Low | A regression test asserting that a freshly provisioned tenant is **pristine**, which fails the moment the single-reading property is broken. It guards `:46` from a distance |
+| **Cascade deletes more than intended** | Low | Decision 2's boundary is three entity types, and it only ever runs over a pristine tenant; the shared-instant rule makes a manual restore exact |
+| **A tenant becomes undeletable forever** after one article was loaded and deleted (decision 6, side effect A) | Med | Accepted and named: suspension remains the platform's lever, and a force-delete is a registered out-of-scope item with its reopen condition |
+| **A tenant loses its last admin** and becomes unadministrable | Low | Flagged, not silently solved (decision 3, question round item 3). `PoliticaDeRoles` already blocks self- and Root-deletion |
+| **~40 `UNION ALL` branches for a tenant are slow** | Low | Each branch is an indexed `fk = @id` with `LIMIT 1`, on an operation a platform operator performs a handful of times a year. Not on any hot path |
+| **RLS makes the guard under-count for a tenant admin** | Low | Structurally impossible (all dependents share the actor's tenant); asserted by a cross-tenant integration test anyway |
+| **Review budget** — two coherent but independent parts | Med | Five slices, stacked-to-main; Part A (1-2) and Part B (3-5) are independently mergeable and independently valuable |
+
+## Rollback Plan
+
+**No database artifact exists to roll back** — the stage ships zero migrations, so `git revert` is
+the complete rollback at every level.
+
+| Slice | Rollback |
+|---|---|
+| **1 — projection API** | Revert. DTO fields disappear; the web slice is not merged yet |
+| **2 — projection web** | Revert. The screens return to rendering ids |
+| **3 — the guard** | Revert. `InspectorDeUso` has **no caller** until slice 4 — this slice is inert by construction |
+| **4 — deletion API** | Revert removes three routes and one guard call. Rows already soft-deleted stay soft-deleted and stay hidden; that is a **pre-existing, supported state** (`Usuario` has produced it since stage 1) |
+| **5 — deletion web** | Revert removes buttons. The API still works; nobody can press it |
+| **Whole stage** | `git revert` of the five merges. The only durable trace is any row an operator actually deleted, which is a `deleted_at` (and possibly `estado = 'baja'`) that a one-line `UPDATE` reverses — **the data was never destroyed (B1)** |
+
+**There is no unrecoverable action in this stage.** That is the direct dividend of B1.
+
+## Dependencies
+
+- **Etapa 1** (archived) — the organization hierarchy, `EntidadBase`/`DeletedAt`, the `"BajaLogica"`
+  filter, `estado_tenant` with `baja` already in it, RLS.
+- **`ServicioDeAprovisionamiento`** (ADR-16) — the single-clock-reading property (B3) that the entire
+  discriminator rests on.
+- **`PoliticaDeRoles`** — consumed unchanged by decision 5.
+- **EF Core `IEntityType.GetReferencingForeignKeys()`** — .NET 10 / EF Core, no new package.
+- **`IRelojDelSistema` / `RelojFijo`** — the deletion instant and its tests.
+- **No new NuGet package, no new web dependency, no migration, no external service.**
+- Skills: `mutation-proof-tests`, `dto-contract-honesty`, `web-descriptor-tests`,
+  `work-unit-commits`, `judgment-day` before every PR. **`db-error-backstops` is explicitly
+  N/A** — see Approach.
+- **Blocked on nothing.** No owner action is required beyond the DB-gate ratification of "zero
+  schema".
+
+## Success Criteria
+
+- [ ] **Zero new migrations**; `has-pending-model-changes` clean; `InicializadorDeBaseDeDatos.cs`
+      untouched.
+- [ ] Each of the four root screens renders owner **names**; no raw owner id is displayed anywhere.
+- [ ] `Usuarios.tsx` shows a tenant column, rendering *"Plataforma"* for `IdTenant is null`.
+- [ ] `Tenants.tsx` shows empresa / punto de venta / usuario counts, and each list endpoint performs
+      **one** database round trip (asserted, not assumed).
+- [ ] Filtering by tenant works on empresas, puntos de venta and usuarios; by empresa on puntos de
+      venta.
+- [ ] A **freshly provisioned** tenant is deletable, and deleting it soft-deletes its empresa, its
+      punto de venta and its admin usuario, all sharing **one** `deleted_at` instant, with
+      `estado = 'baja'` on the tenant.
+- [ ] Loading **one article** (no sale, no movement) makes that tenant, its empresa and its punto de
+      venta undeletable, each with its own named 409 — **B2 proven, not asserted**.
+- [ ] The completeness test enumerates `GetReferencingForeignKeys()` for all four entities and fails
+      on any dependent type outside the three buckets.
+- [ ] The two carve-outs are proven independently: an entity with **only** `auditoria` rows past the
+      anchor is deletable; an entity with **only** its provisioned `numeraciones_clientes` row is
+      deletable.
+- [ ] A **soft-deleted** dependent still blocks (decision 6, side effect A), proven by a test.
+- [ ] `ultima_empresa_del_tenant` and `ultimo_punto_venta_de_la_empresa` fire on their exact
+      conditions and **not** on any other.
+- [ ] Deleting a used `Usuario` returns `usuario_en_uso`, **and** every pre-existing
+      `PoliticaDeRoles` behaviour (Root target, self, out-of-scope 404) is byte-identical.
+- [ ] A second DELETE on an already-deleted row returns **404**, not 500.
+- [ ] A deleted tenant's user cannot log in and receives **403 `tenant_suspendido`**, not a crash.
+- [ ] **Zero physical deletes** in the whole diff — a repository scan for `ExecuteDelete`,
+      `Remove(`, `RemoveRange(` and `DELETE FROM` on the four tables.
+- [ ] Cross-tenant isolation holds for every new route (RLS read **and** write pair).
+- [ ] Domain / Application / Integration / Vitest suites green.
+
+## Plan de slices (tentative — `sdd-tasks` owns the final breakdown)
+
+Stacked-to-main, one `judgment-day` round per slice (`protocolo-pr-solo-dev`).
+
+| # | Branch | Content | ~lines |
+|---|---|---|---|
+| 1 | `feat/stage20-slice1-proyeccion-api` | The four DTOs gain owner names and counts; joined projections in `ServicioDeOrganizacion` and `ServicioDeUsuarios`; single-round-trip integration assertions | ~380 |
+| 2 | `feat/stage20-slice2-proyeccion-web` | `tipos.ts`; name columns and counts on the four screens; tenant filter (×3) and empresa filter (×1); the **first** Vitest files for these screens | ~420 |
+| 3 | `feat/stage20-slice3-inspector-de-uso` | `InspectorDeUso`: metadata walk, three buckets, two carve-outs, generated statement, `IModel` exposure; the completeness test and the per-bucket suite. **No caller — inert** | ~470 |
+| 4 | `feat/stage20-slice4-bajas-api` | Three DELETE routes; `EliminarAsync` ×3; cascade; structural minimums; the `Usuario` guard; the six 409 codes; the label dictionary; end-to-end + RLS tests | ~480 |
+| 5 | `feat/stage20-slice5-bajas-web` | Delete buttons + confirmation on the four screens; `codigo`→copy mapping; docs 09/10 note | ~330 |
+
+Merge order `1 → 2 → 3 → 4 → 5`. **Slices 1-2 (Part A) and 3-5 (Part B) are independent**: Part A
+ships standalone value if Part B stalls, and slice 3 is deliberately inert so the guard can be
+reviewed on its own merits before anything can call it.
+
+**Pre-approved degradation**, in priority order:
+
+1. **If slice 4 overflows** — split `4a` (tenant + empresa + cascade + minimums) and `4b` (punto de
+   venta + the `Usuario` guard).
+2. **If slice 3 overflows** — split `3a` (metadata walk + buckets + completeness test) and `3b` (the
+   generated statement + carve-outs).
+3. **If slice 2 overflows** — split `2a` (names and counts) and `2b` (filters).
+4. **Never degraded**: the completeness test, the two carve-out tests, the "one article blocks"
+   test, and the zero-physical-delete scan. A guard without those is a guard nobody should trust.
+
+**Review Workload Forecast (preliminary — `sdd-tasks` produces the binding one)**
+
+- Estimated total: **~2 080 lines** across 5 slices, calibrated against stages 13-18 (which came in
+  1.5-3× naive estimates because test depth inflates a slice). This stage's inflators are the guard's
+  test matrix and the four new Vitest files; it has **no** schema, no concurrency and no protocol
+  work, so the multiplier should sit at the low end. Realistic outturn: **5-6 PRs**.
+- `Decision needed before apply: Yes` — the owner ratifies the **zero-schema** gate before slice 1.
+- `Chained PRs recommended: Yes` — `chain_strategy: stacked-to-main`
+- `800-line budget risk: Low` — every slice is estimated at roughly half the budget, and three split
+  points are pre-authorized.
+- `size:exception` anticipated: **No**.
+
+## Tensiones con el explore
+
+| # | Explore position | Verdict |
+|---|---|---|
+| 1 | Open question 1 — *"whether deleting a tenant should cascade … Exploration recommends yes"* | **Adopted, with the boundary the explore did not draw** (decision 2): cascade covers empresas, puntos de venta and usuarios — **not** the rest of the provisioning template, because `EstadoTenant.Baja`'s own doc-comment promises *"los datos quedan para exportación"* |
+| 2 | Open question 2 — structural minimums, *"recommends yes, as a separate named 409"* | **Adopted, plus an ordering rule** (decision 3): the minimum is checked **before** usage, because its message is the more actionable one and the pristine single-empresa case is answered by the cascade |
+| 3 | Open question 3 — *"whether `Usuario` deletion should gain the same dependent guard"* | **Adopted, with a position stated** (decision 5): the guard goes **after** `PoliticaDeRoles`, and the consequence — a provisioned admin stops being deletable the moment it operates — is named rather than discovered later |
+| 4 | *"An entity is pristine iff no dependent row exists whose `CreatedAt` is strictly greater"* (`:100-102`) | **Ratified, and found to be incomplete.** **15 domain types have no `created_at` at all** (`Stock`, `ArticuloEmpresa`, `MovimientoStock`, the four `Numeracion*`, `Auditoria`, …), so the discriminator cannot be applied uniformly. Decision 4 adds the three buckets and the completeness test that makes the gap fail loudly |
+| 5 | *"`numeraciones_clientes` … is not an `EntidadBase` and is therefore outside the discriminator entirely"* (`:107-110`) | **Ratified and promoted.** In decision 4's scheme it is not merely "outside" — it is the **only** untimestamped type provisioning creates, so it is one of exactly two named carve-outs, with its own test |
+| 6 | `GetReferencingForeignKeys()` selected because *"an unmapped case blocks deletion rather than permitting it"* (`:161`) | **Ratified, and the property made verifiable** (decision 4): the fail-safe claim is only true if an unmapped case is **detected**, so the completeness test is what converts the argument into a guarantee |
+| 7 | *"`Empresa` and `PuntoVenta` have no `Estado` field. Only `Tenant` has one"* (`:39-41`) | **Left as is**, per the explore's own out-of-scope §7 — and decision 1 uses the asymmetry productively: tenant deletion becomes `EstadoTenant.Baja`'s first writer, retiring a latent enum value instead of adding two new state fields |
+
+**New material the explore did not raise**: that `EstadoTenant.Baja` is a **latent value with zero
+writers** and this stage is its natural writer (decision 1); that soft-deleted login already degrades
+correctly to 403 through the existing `tenant is null` branch (decision 1); that **15 types carry no
+timestamp**, which breaks the uniform discriminator (decision 4); that raw SQL gives the *desired*
+filter-bypass semantics for free while RLS still applies (decision 6); that `IWaysDbContext` exposes
+`DatabaseFacade` but not `IModel`, and the interface's own doc-comment supplies the argument for
+adding it (decision 6); that nullable `IdEmpresa` shared-catalogue rows need no special case
+(decision 4); that **no Vitest file exists for any of the four screens**, so Part A creates coverage
+rather than extending it; and that `db-error-backstops` is structurally inapplicable here, which
+promotes the guard's tests from good practice to sole defence (Approach, Risks).
+
+## Proposal question round
+
+Execution mode is `auto`, so these were resolved rather than asked. Each records its assumption so a
+correction is cheap. **None blocks spec or design.**
+
+1. **Should a tenant be forced to keep at least one administrator?** Assumed **no rule added**
+   (decision 3): `PoliticaDeRoles` already blocks self-deletion and Root targets, so the reachable
+   failure is narrow. Inventing a role invariant autonomously is worse than naming the gap. If the
+   owner wants it, it is one more pre-check and one more 409 (`ultimo_admin_del_tenant`).
+2. **Should a customer who loaded data and then deleted it become deletable again?** Assumed **no**
+   (decision 6, side effect A): usage is *"ever operated"*, not *"has live data"*. This is the
+   strictest reading of B2 and the one that fails safe. Reversing it is one `AND deleted_at IS NULL`.
+3. **Should the platform have a force-delete override?** Assumed **no** — suspension is the existing
+   lever, and an override needs an audit ceremony this stage would be designing blind. Registered
+   out-of-scope with its reopen condition.
+4. **Should the tenant cascade sweep the whole provisioning template** (areas, medios de pago, lista
+   de precios, Consumidor Final)? Assumed **no** (decision 2): those rows are invisible and
+   unreachable once the tenant is gone, and the enum's own doc-comment promises the data stays for
+   export.
+5. **Should the root screens navigate from a tenant into its children?** Assumed **counts only** —
+   drill-down is a navigation feature, not a relationship-projection one, and it would pull routing
+   into a stage that otherwise touches four existing screens.
+6. **Does the operator need to see already-deleted rows** (a "show deleted" toggle)? Assumed **no**:
+   the `"BajaLogica"` filter hides them and `IgnoreQueryFilters(["BajaLogica"])` exists for the day
+   the answer changes. A restore feature would be its own change (out of scope).

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/bajas-de-organizacion/spec.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/bajas-de-organizacion/spec.md
@@ -1,0 +1,379 @@
+# Bajas De Organizacion Specification
+
+## Purpose
+
+Defines what logical deletion means for the organization hierarchy (tenant, empresa, punto de
+venta, usuario): the pristine/used discriminator and the single provisioning instant that makes it
+exact; how the dependent set is discovered and why a hand-maintained list is forbidden; the three
+classification buckets, the completeness rule and the two named carve-outs; the cascade rule and
+its boundary; the structural minimums; the complete 409 code set; and the invariant that no row is
+ever physically deleted.
+
+This capability describes the deletion *semantics*. The API surface that exposes them lives in
+`tenant-organization` and `usuarios-tenant-scoping`.
+
+## Requirements
+
+### Requirement: Deletion Is Always Logical, Never Physical
+
+Deleting a tenant, empresa, punto de venta or usuario MUST be performed by stamping `DeletedAt`
+(the `EntidadBase` soft-delete convention). The system MUST NOT issue any physical deletion —
+`DELETE FROM`, `ExecuteDelete`, `ExecuteDeleteAsync`, `Remove(`, `RemoveRange(` — against
+`tenants`, `empresas`, `puntos_venta` or `usuarios`. A physical delete on any of those four tables
+is a violation of this specification, not an implementation choice.
+
+Because the deletion is an `UPDATE`, no Postgres foreign-key constraint can ever fire against it:
+`DeleteBehavior.Restrict` contributes zero protection, and the application-level guard specified
+below is the sole line of defence.
+
+#### Scenario: A deleted row survives in the database
+- GIVEN a pristine tenant that is deleted through the platform surface
+- WHEN the `tenants` table is read with the `"BajaLogica"` query filter ignored
+- THEN the row still exists, with `deleted_at` set to the deletion instant
+
+#### Scenario: The deleted row is invisible to every normal read
+- GIVEN the same deleted tenant
+- WHEN `GET /api/plataforma/tenants` is called
+- THEN the tenant is absent from the listing
+
+#### Scenario: A second deletion of the same row is a clean 404
+- GIVEN an entity that has already been logically deleted
+- WHEN a second DELETE is issued for the same id
+- THEN the response is `404` (the row is invisible to the guard's own lookup), never `500`
+- AND no second `deleted_at` write occurs
+
+#### Scenario: The repository contains no physical delete over the four tables
+- GIVEN the complete diff of this change
+- WHEN the repository is scanned for `ExecuteDelete`, `Remove(`, `RemoveRange(` and `DELETE FROM`
+  targeting `tenants`, `empresas`, `puntos_venta` or `usuarios`
+- THEN zero matches are found
+
+### Requirement: The Pristine Discriminator Is A Strict Timestamp Comparison Against The Entity's Own CreatedAt
+
+An entity MUST be considered **pristine** if and only if no dependent row exists whose `CreatedAt`
+is **strictly greater** than that entity's own `CreatedAt` (the *anchor*), subject to the bucket
+rules below. The comparison MUST be strict (`>`), never `>=`: `ServicioDeAprovisionamiento` reads
+the clock exactly once and stamps that identical instant on every provisioned row including the
+tenant itself, so the whole provisioning baseline is equal to the anchor and MUST NOT block.
+
+The discriminator MUST be template-version independent: it MUST NOT be expressed as a hardcoded
+row count, a hardcoded table list, or a hardcoded knowledge of what the provisioning template
+contains.
+
+#### Scenario: A freshly provisioned tenant is pristine and deletable
+- GIVEN a tenant provisioned seconds ago, with its empresa, punto de venta, area "General", two
+  medios de pago, the General price list, the Consumidor Final cliente, its numeraciones_clientes
+  counter row and its admin usuario
+- WHEN the platform deletes that tenant
+- THEN the deletion succeeds — all nine provisioned rows share the tenant's `created_at` and none
+  is strictly greater than the anchor
+
+#### Scenario: A dependent created at exactly the anchor instant does not block
+- GIVEN a dependent row whose `created_at` is byte-identical to the entity's `created_at`
+- WHEN the guard evaluates the entity
+- THEN that row is not counted as usage — the comparison is `>`, not `>=`
+
+#### Scenario: A dependent created one tick after the anchor blocks
+- GIVEN a dependent row whose `created_at` is one tick later than the entity's `created_at`
+- WHEN the guard evaluates the entity
+- THEN the entity is not pristine and its deletion is refused
+
+#### Scenario: Breaking the single-clock-reading property is detected
+- GIVEN a change that made provisioning read the clock more than once, splitting the baseline into
+  two instants
+- WHEN the "a freshly provisioned tenant is deletable" regression test runs
+- THEN it fails, naming the provisioned dependent that is now strictly later than the anchor
+
+### Requirement: In Use Means Anything The Customer Created Beyond The Provisioning Baseline
+
+"In use" MUST mean that the customer created or operated **anything** past the provisioning
+baseline — catalog data as much as transactional records. Articles, clients, suppliers, price
+lists, a second punto de venta, a second usuario, a sale, a stock movement: all of them MUST block.
+The guard MUST NOT restrict itself to operational or transactional records.
+
+#### Scenario: One article makes the tenant, its empresa and its punto de venta undeletable
+- GIVEN a freshly provisioned tenant in which the customer loaded exactly one article, with no
+  sale, no stock movement and no shift
+- WHEN the platform attempts to delete the tenant, then the empresa, then the punto de venta
+- THEN each attempt is refused with its own named 409: `tenant_en_uso`, `empresa_en_uso`,
+  `punto_venta_en_uso`
+
+#### Scenario: A catalog-only tenant with thousands of rows and zero sales is not deletable
+- GIVEN a tenant with 3 000 articles and zero comprobantes
+- WHEN the platform attempts to delete it
+- THEN it is refused with `tenant_en_uso`
+
+#### Scenario: A second punto de venta blocks its empresa
+- GIVEN an empresa whose provisioned punto de venta was joined by a second one created later
+- WHEN the platform attempts to delete the empresa
+- THEN it is refused with `empresa_en_uso`
+
+### Requirement: The Dependent Set Is Discovered From EF Metadata, Never From A Hand-Maintained List
+
+The set of types and foreign keys that can block a deletion MUST be derived at runtime from the EF
+Core model (`IEntityType.GetReferencingForeignKeys()`) for each of `Tenant`, `Empresa`,
+`PuntoVenta` and `Usuario`. The system MUST NOT enumerate blocking tables in a hand-maintained
+list, because a hand list fails unsafe: one forgotten table silently makes a used entity deletable.
+
+Discovery MUST cover every referencing foreign key regardless of its property name or shape,
+including secondary FKs to the same principal, FKs whose property name does not follow the
+`Id<Entity>` pattern, and composite `(id, id_tenant)` keys.
+
+#### Scenario: A secondary FK to the same principal is discovered
+- GIVEN a `movimientos_stock` row created after the anchor that references a punto de venta only
+  through `id_punto_venta_destino`
+- WHEN that punto de venta's deletion is attempted
+- THEN it is refused with `punto_venta_en_uso`
+
+#### Scenario: Non-conventional FK property names are discovered
+- GIVEN a `turnos_caja` row created after the anchor that references a usuario only through
+  `id_empleado_cierre`
+- WHEN that usuario's deletion is attempted
+- THEN it is refused with `usuario_en_uso`
+
+#### Scenario: A referencing type added by a future stage is covered without editing the guard
+- GIVEN a new entity added to the EF model with a foreign key to `PuntoVenta`
+- WHEN the guard runs
+- THEN that new type participates in the evaluation with no change to the guard's own source
+
+### Requirement: Every Referencing Type Is Classified Into Exactly One Bucket Or The Build Fails
+
+The timestamp discriminator is **not** universally applicable: some referencing types do not
+inherit `EntidadBase` and therefore have no `created_at` column at all (verified:
+`Stock`, `ArticuloEmpresa`). Every type discovered by metadata MUST therefore be classified into
+**exactly one** of three buckets:
+
+| Bucket | Rule |
+|---|---|
+| 1 — timestamped | An `EntidadBase` descendant. Blocks iff a referencing row exists with `created_at > anchor` |
+| 2 — untimestamped | Not an `EntidadBase` descendant. Blocks iff **any** referencing row exists |
+| 3 — carve-out | An explicitly named type with a written reason. Never blocks |
+
+An automated test MUST enumerate `GetReferencingForeignKeys()` for all four principals and assert
+that every discovered type falls into exactly one bucket. A type that falls into **none** MUST fail
+that test, naming the type. A type that falls into **more than one** MUST also fail it, naming the
+type. The system MUST NOT skip, ignore or default an unclassified referencing type under any
+circumstance — silently skipping it would let a used entity be deleted, which is the exact failure
+this requirement exists to make impossible.
+
+This completeness test is the mechanism that converts "the guard fails safe" from a claim into a
+guarantee. It MUST NOT be weakened, conditionally skipped, or degraded.
+
+#### Scenario: The completeness test covers all four principals
+- GIVEN the current EF model
+- WHEN the completeness test runs
+- THEN it enumerates the referencing foreign keys of `Tenant`, `Empresa`, `PuntoVenta` and
+  `Usuario`, and every discovered CLR type is classified into exactly one bucket
+
+#### Scenario: An unclassifiable type turns the build red, naming it
+- GIVEN a future stage adds a referencing entity the classification rules cannot place in any
+  bucket
+- WHEN the completeness test runs
+- THEN it fails with a message naming that exact type — the type is never silently skipped
+
+#### Scenario: A type claimed by two buckets turns the build red
+- GIVEN a type that is both listed as a carve-out and matched by another bucket's rule
+- WHEN the completeness test runs
+- THEN it fails, because classification must be into exactly one bucket
+
+#### Scenario: An untimestamped dependent blocks on mere existence
+- GIVEN a punto de venta with one `stock` row (a type with no `created_at` column)
+- WHEN its deletion is attempted
+- THEN it is refused with `punto_venta_en_uso` — existence alone is usage for bucket 2
+
+#### Scenario: An untimestamped type cannot be evaluated with the timestamp rule
+- GIVEN a bucket-2 type such as `ArticuloEmpresa`
+- WHEN the guard builds its evaluation for that type
+- THEN no `created_at` comparison is applied to it, because the column does not exist
+
+### Requirement: There Are Exactly Two Carve-Outs, Each With A Written Reason And Its Own Test
+
+The carve-out bucket MUST contain exactly two members:
+
+| Type | Reason |
+|---|---|
+| `Auditoria` | The audit trail is a record *about* the entity, not data the customer operated. Because deletion is logical the referenced row survives, so the trail keeps rendering |
+| `NumeracionCliente` | The provisioning counter row (`numeraciones_clientes`), inserted by `AsignadorDeNumeroCliente`; it is not an `EntidadBase` and not customer data |
+
+Audit rows MUST never block a deletion. Adding a third carve-out MUST require an explicit change to
+this specification; the carve-out list MUST NOT grow silently.
+
+#### Scenario: Audit rows alone do not block
+- GIVEN a pristine tenant whose only dependents created after its anchor are `auditoria` rows
+- WHEN the platform deletes the tenant
+- THEN the deletion succeeds
+
+#### Scenario: The provisioning counter row alone does not block
+- GIVEN a pristine tenant whose only untimestamped dependent is its provisioned
+  `numeraciones_clientes` row
+- WHEN the platform deletes the tenant
+- THEN the deletion succeeds
+
+#### Scenario: The carve-out list is asserted to have exactly two members
+- GIVEN the guard's carve-out list
+- WHEN its test runs
+- THEN it asserts the list contains exactly `Auditoria` and `NumeracionCliente` and nothing else
+
+### Requirement: A Soft-Deleted Dependent Still Blocks
+
+Usage MUST mean "the customer ever operated here", not "there is live data right now". A dependent
+row that the customer created and later logically deleted MUST still block. The guard's evaluation
+MUST therefore not be subject to the `"BajaLogica"` query filter.
+
+#### Scenario: A deleted article still blocks its tenant
+- GIVEN a tenant in which the customer created one article and then deleted it logically
+- WHEN the platform attempts to delete the tenant
+- THEN it is refused with `tenant_en_uso`
+
+#### Scenario: Row-level security still applies to the guard
+- GIVEN a tenant admin deleting an entity of their own tenant
+- WHEN the guard evaluates dependents
+- THEN it sees every dependent of that tenant and cannot under-count
+- AND it can never observe a dependent belonging to another tenant
+
+### Requirement: A Shared-Catalog Row With A NULL Owner Does Not Block
+
+Rows whose owning foreign key is `NULL` by design — `Cliente`, `Proveedor`, `Oferta` and
+`ConfiguracionDeCatalogo<T>` use `id_empresa IS NULL` to mean "shared catalog row" — MUST NOT block
+the deletion of any specific empresa.
+
+#### Scenario: A shared catalog row does not block an empresa
+- GIVEN a shared catalog row with `id_empresa IS NULL`, created after the empresa's anchor
+- WHEN that empresa's deletion is attempted
+- THEN the shared row does not contribute to the usage verdict
+
+### Requirement: Cascade Is Bounded To The Organization Projection And Shares One Instant
+
+Deleting a tenant MUST logically delete, in the same transaction, its empresas, its puntos de venta
+and its usuarios. Deleting an empresa MUST logically delete its puntos de venta. The parent and
+every cascaded child MUST receive **the same** `DeletedAt` instant, obtained from a single clock
+reading, so that a manual restore is unambiguous.
+
+The cascade MUST NOT extend beyond those three child types. The rest of the provisioning template —
+areas, medios de pago, listas de precio, the Consumidor Final cliente, numeraciones — MUST be left
+untouched, because those rows are already invisible and unreachable once the tenant is gone and
+`EstadoTenant.Baja` promises the data stays available for export.
+
+#### Scenario: No orphan remains visible after a tenant is deleted
+- GIVEN a pristine tenant with one empresa, one punto de venta and one admin usuario
+- WHEN the platform deletes the tenant
+- THEN `GET /api/empresas`, `GET /api/puntos-venta` and `GET /api/usuarios` return none of those
+  rows for a platform actor — nothing points at a tenant that no longer resolves
+
+#### Scenario: Parent and children share one deletion instant
+- GIVEN the same deletion
+- WHEN the four rows are read with query filters ignored
+- THEN all four carry an identical `deleted_at` value
+
+#### Scenario: The rest of the provisioning template survives
+- GIVEN the same deletion
+- WHEN `areas`, `medios_pago`, `listas_precio`, `clientes` and `numeraciones_clientes` of that
+  tenant are read with query filters ignored
+- THEN their rows are present with `deleted_at IS NULL`
+
+#### Scenario: Deleting an empresa cascades only to its puntos de venta
+- GIVEN a pristine empresa with one punto de venta, inside a tenant that has another empresa
+- WHEN the platform deletes that empresa
+- THEN the empresa and its punto de venta are logically deleted with the same instant, and the
+  tenant and its usuarios are untouched
+
+#### Scenario: An already-deleted child keeps its original deletion instant
+- GIVEN a pristine tenant whose only empresa was already logically deleted earlier
+- WHEN the platform deletes the tenant
+- THEN the deletion succeeds and the already-deleted empresa keeps its **original** `deleted_at` —
+  the cascade MUST NOT re-stamp a row that is already logically deleted
+
+#### Scenario: The cascade never runs over used data
+- GIVEN a tenant with any dependent past its anchor
+- WHEN its deletion is attempted
+- THEN it is refused before any cascade is attempted — the cascade only ever runs over a pristine
+  provisioning baseline
+
+### Requirement: Structural Minimums Are Checked Before The Usage Guard, With Their Own Named Codes
+
+A tenant MUST always keep at least one empresa, and an empresa MUST always keep at least one punto
+de venta. Deleting the last one MUST be refused with `ultima_empresa_del_tenant` and
+`ultimo_punto_venta_de_la_empresa` respectively — never with a generic "in use" code, because the
+two mean opposite things to the operator ("there is data here" versus "delete the parent instead").
+
+The structural minimum MUST be evaluated **before** the usage guard. The count MUST consider only
+rows that are not logically deleted.
+
+#### Scenario: Deleting a tenant's only empresa is refused
+- GIVEN a pristine tenant with exactly one empresa
+- WHEN the platform attempts to delete that empresa
+- THEN it is refused with `409 ultima_empresa_del_tenant`
+- AND the tenant itself remains deletable, taking the empresa with it through the cascade
+
+#### Scenario: Deleting one of two empresas succeeds
+- GIVEN a tenant with two pristine empresas
+- WHEN the platform deletes one of them
+- THEN the deletion succeeds
+
+#### Scenario: Deleting an empresa's only punto de venta is refused
+- GIVEN an empresa with exactly one punto de venta
+- WHEN the platform attempts to delete that punto de venta
+- THEN it is refused with `409 ultimo_punto_venta_de_la_empresa`
+
+#### Scenario: Already-deleted siblings do not count towards the minimum
+- GIVEN a tenant that had two empresas, one of which was already logically deleted
+- WHEN the platform attempts to delete the remaining empresa
+- THEN it is refused with `409 ultima_empresa_del_tenant` — the deleted sibling is not counted as a
+  surviving empresa
+
+#### Scenario: The structural minimum wins over the usage verdict
+- GIVEN a tenant's only empresa, which also has usage past its anchor
+- WHEN its deletion is attempted
+- THEN the response is `409 ultima_empresa_del_tenant`, not `409 empresa_en_uso`
+
+### Requirement: The Complete 409 Code Set Is Exactly Six Codes
+
+Every refusal introduced by this capability MUST be raised as
+`ErrorDominio.Conflicto("<codigo_snake_case>", "<mensaje>")`, mapped to HTTP `409` and surfaced to
+the front end as `ErrorApi { estado, codigo, mensaje }`. The complete set is:
+
+| Code | Raised when |
+|---|---|
+| `tenant_en_uso` | The tenant has a blocking dependent past the provisioning baseline |
+| `empresa_en_uso` | Idem, empresa |
+| `punto_venta_en_uso` | Idem, punto de venta |
+| `usuario_en_uso` | Idem, usuario |
+| `ultima_empresa_del_tenant` | Deleting the tenant's only surviving empresa |
+| `ultimo_punto_venta_de_la_empresa` | Deleting the empresa's only surviving punto de venta |
+
+The message SHOULD name the blocking data in plain Spanish and MUST degrade to a generic phrase
+when the blocking table has no label. The `codigo` MUST always be exact regardless of the message,
+and the web MUST key its copy off `codigo`, never off `mensaje`.
+
+#### Scenario: Each code fires on its exact condition and no other
+- GIVEN one fixture per code, constructed to satisfy only that code's condition
+- WHEN each deletion is attempted
+- THEN each returns HTTP `409` with exactly its own `codigo`
+
+#### Scenario: An unlabelled blocking table still yields the exact code
+- GIVEN a blocking table with no entry in the message label dictionary
+- WHEN the deletion is refused
+- THEN the `codigo` is exact and the `mensaje` degrades to a generic phrase
+
+#### Scenario: The web maps copy from the code
+- GIVEN a `409` response carrying `codigo = "ultima_empresa_del_tenant"`
+- WHEN the front end renders the failure
+- THEN the copy it shows is selected by `codigo`, and changing `mensaje` does not change which copy
+  is selected
+
+### Requirement: Deletion Never Becomes A Cross-Tenant Existence Oracle
+
+A tenant-scoped actor attempting to delete an entity outside their own tenant MUST receive `404`,
+never `403` and never a `409` that discloses the entity's state. This preserves
+`PoliticaDeRoles.ValidarAlcanceDeTenant`'s deliberate anti-existence-oracle behaviour (ADR-8).
+
+#### Scenario: An out-of-scope delete is indistinguishable from a non-existent id
+- GIVEN an admin of tenant 1 and an empresa belonging to tenant 2
+- WHEN the admin issues a DELETE for that empresa's id
+- THEN the response is `404`, identical in status and body shape to a DELETE for an id that does
+  not exist at all
+
+#### Scenario: An out-of-scope used entity does not leak its usage
+- GIVEN an admin of tenant 1 and a heavily used empresa belonging to tenant 2
+- WHEN the admin issues a DELETE for that empresa's id
+- THEN the response is `404`, never `409 empresa_en_uso`

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/tenant-organization/spec.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/tenant-organization/spec.md
@@ -1,0 +1,168 @@
+# Delta for Tenant Organization
+
+## ADDED Requirements
+
+### Requirement: Organization Listings Project Owner Names, Never Raw Ids
+
+`EmpresaListado` MUST carry the owning tenant's **name**, and `PuntoVentaListado` MUST carry both
+the owning tenant's name and the owning empresa's razón social. Every field added to these DTOs
+MUST have a consumer: `Empresas.tsx` MUST render the tenant name and `PuntosVenta.tsx` MUST render
+the tenant name and the empresa razón social, in place of the raw integers rendered today. The
+existing owner ids MUST remain in the DTOs — they are the filter keys — but MUST NOT be displayed
+as the identity of the owner anywhere in the four root screens.
+
+The names MUST be projected inside the existing list query. Each list endpoint MUST execute a
+single database round trip; no per-row lookup is permitted.
+
+#### Scenario: The empresas listing shows the tenant name
+- GIVEN tenant 2 named "Comercio Sur" with one empresa
+- WHEN a platform actor calls `GET /api/empresas`
+- THEN the empresa entry carries `nombreTenant = "Comercio Sur"`
+- AND `Empresas.tsx` renders "Comercio Sur", not `2`
+
+#### Scenario: The puntos de venta listing shows both owner names
+- GIVEN a punto de venta of empresa "Sur SRL" under tenant "Comercio Sur"
+- WHEN a platform actor calls `GET /api/puntos-venta`
+- THEN the entry carries `nombreTenant = "Comercio Sur"` and `razonSocialEmpresa = "Sur SRL"`
+- AND `PuntosVenta.tsx` renders both names, not two integers
+
+#### Scenario: Listing owner names costs one round trip
+- GIVEN a tenant with 20 empresas
+- WHEN `GET /api/empresas` is called
+- THEN exactly one database round trip is executed — no N+1 per empresa
+
+#### Scenario: No raw owner id is displayed
+- GIVEN the four root screens rendered with data
+- WHEN their descriptors are inspected
+- THEN no cell presents `idTenant` or `idEmpresa` as the owner's identity
+
+### Requirement: The Tenants Listing Carries Live Child Counts
+
+`TenantListado` MUST carry `CantidadEmpresas`, `CantidadPuntosVenta` and `CantidadUsuarios`, and
+`Tenants.tsx` MUST render all three. The counts MUST exclude logically deleted rows: a child whose
+`deleted_at` is set MUST NOT be counted. `CantidadUsuarios` MUST count only usuarios belonging to
+that tenant; platform staff (`id_tenant IS NULL`) MUST NOT be counted under any tenant.
+
+The counts MUST be produced within the same single round trip as the listing.
+
+#### Scenario: Counts reflect the surviving children
+- GIVEN a tenant with 2 empresas, 3 puntos de venta and 4 usuarios, none deleted
+- WHEN a platform actor calls `GET /api/plataforma/tenants`
+- THEN the tenant entry reports 2, 3 and 4
+- AND `Tenants.tsx` renders those three numbers
+
+#### Scenario: Logically deleted children are not counted
+- GIVEN the same tenant after one of its empresas and one of its usuarios were logically deleted
+- WHEN the listing is read again
+- THEN the counts report 1 empresa and 3 usuarios
+
+#### Scenario: Platform staff are counted under no tenant
+- GIVEN a platform user with `id_tenant IS NULL`
+- WHEN the tenants listing is read
+- THEN no tenant's `cantidadUsuarios` includes that account
+
+#### Scenario: Counting costs no extra round trip
+- GIVEN five tenants
+- WHEN `GET /api/plataforma/tenants` is called
+- THEN exactly one database round trip is executed
+
+### Requirement: The Root Screens Filter By Owner Over The Already-Loaded List
+
+`Empresas.tsx`, `PuntosVenta.tsx` and `Usuarios.tsx` MUST offer a filter by tenant, and
+`PuntosVenta.tsx` MUST additionally offer a filter by empresa. Filtering MUST operate on the
+already-loaded list. No query parameter, no new endpoint and no server-side pagination is added by
+this requirement.
+
+The set of values offered by a filter MUST be derived from the rows the actor can already see, so a
+filter never discloses the existence or name of an entity outside the actor's scope.
+
+#### Scenario: Filtering empresas by tenant narrows the list
+- GIVEN a platform actor viewing empresas of three tenants
+- WHEN they select one tenant in the filter
+- THEN only that tenant's empresas remain visible, with no additional network request
+
+#### Scenario: Filtering puntos de venta by empresa narrows the list
+- GIVEN a platform actor viewing puntos de venta of several empresas
+- WHEN they select one empresa in the filter
+- THEN only that empresa's puntos de venta remain visible
+
+#### Scenario: A tenant admin's filter offers only their own tenant
+- GIVEN an admin of tenant 1 viewing `GET /api/empresas`
+- WHEN the tenant filter is rendered
+- THEN it offers only tenant 1 — no other tenant's name is present in the response or in the DOM
+
+#### Scenario: Clearing the filter restores the full loaded list
+- GIVEN an active tenant filter
+- WHEN the operator clears it
+- THEN the full previously-loaded list is shown again
+
+### Requirement: Platform Logical Deletion Surface For Tenant, Empresa And Punto De Venta
+
+The system MUST expose `DELETE /api/plataforma/tenants/{id}`, `DELETE /api/empresas/{id}` and
+`DELETE /api/puntos-venta/{id}`. Each MUST apply the semantics of the `bajas-de-organizacion`
+capability: logical deletion only, structural minimum first, then the usage guard, then the
+bounded same-instant cascade.
+
+Authorization MUST reuse the policy of the group each route already belongs to —
+`Politicas.SoloPlataforma` for tenant routes, `Politicas.GestionDeOrganizacion` for empresa and
+punto de venta routes. **No new authorization policy is added**; `Politicas.cs` MUST remain
+untouched. Note the deliberate asymmetry on puntos de venta: reading the list stays under
+`Politicas.LecturaDePuntosVenta` (the POS selector needs it), while deleting does not.
+
+Every existing route of this surface — provisioning, suspension, reactivation and every `PUT` —
+MUST remain unchanged in behaviour and in authorization.
+
+#### Scenario: A platform actor deletes a pristine tenant
+- GIVEN a root user and a freshly provisioned tenant
+- WHEN they call `DELETE /api/plataforma/tenants/{id}`
+- THEN the deletion succeeds and the tenant disappears from the listing
+
+#### Scenario: A tenant admin cannot reach the tenant delete route
+- GIVEN a user with the tenant `admin` role
+- WHEN they call `DELETE /api/plataforma/tenants/{id}`
+- THEN the request is rejected by `Politicas.SoloPlataforma`
+
+#### Scenario: A vendedor cannot delete a punto de venta they can list
+- GIVEN a vendedor who can call `GET /api/puntos-venta` through `LecturaDePuntosVenta`
+- WHEN they call `DELETE /api/puntos-venta/{id}`
+- THEN the request is rejected by `Politicas.GestionDeOrganizacion`
+
+#### Scenario: No new policy exists after the change
+- GIVEN the diff of this change
+- WHEN `src/Ways.Api/Seguridad/Politicas.cs` is inspected
+- THEN it is byte-identical to its state before the change
+
+#### Scenario: Suspension and reactivation are unchanged
+- GIVEN the existing suspend and reactivate endpoints
+- WHEN their pre-existing scenarios are exercised
+- THEN they behave exactly as before, and neither writes nor reads `deleted_at`
+
+### Requirement: Tenant Deletion Is The Only Writer Of EstadoTenant.Baja
+
+Deleting a tenant MUST set `Estado = EstadoTenant.Baja` **and** `DeletedAt` atomically, in one
+transaction. Writing only one of the two is a violation: `DeletedAt` alone leaves the documented
+`Baja` value latent forever, and `Estado = Baja` alone leaves the tenant visible in the root
+listing. No other operation MAY write `EstadoTenant.Baja` — suspension and reactivation MUST
+continue to refuse to touch it.
+
+#### Scenario: A deleted tenant carries both markers
+- GIVEN a pristine tenant that is deleted
+- WHEN the row is read with query filters ignored
+- THEN `estado = 'baja'` and `deleted_at` is set, from the same transaction
+
+#### Scenario: A deleted tenant's user cannot log in and gets a clean 403
+- GIVEN a tenant that was deleted and one of its usuarios
+- WHEN that usuario attempts to log in
+- THEN the login is rejected with `403 tenant_suspendido` — not a crash, not a 500
+
+#### Scenario: Reactivation cannot resurrect a deleted tenant
+- GIVEN a deleted tenant (`estado = 'baja'`, `deleted_at` set)
+- WHEN the reactivate endpoint is called for it
+- THEN it is refused with `404` — the `"BajaLogica"` filter hides the row from the lookup
+- AND the pre-existing `409 tenant_dado_de_baja` guard is preserved unchanged as the backstop for
+  any path that reaches a `Baja` tenant without the filter
+
+#### Scenario: Suspension never writes Baja
+- GIVEN an active tenant
+- WHEN it is suspended
+- THEN `estado = 'suspendido'` and `deleted_at IS NULL`

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/usuarios-tenant-scoping/spec.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/specs/usuarios-tenant-scoping/spec.md
@@ -1,0 +1,96 @@
+# Delta for Usuarios Tenant Scoping
+
+## ADDED Requirements
+
+### Requirement: The Usuarios Listing Carries The Account's Tenant Identity
+
+`UsuarioListado` — which today carries no tenant field at all — MUST gain `IdTenant` (nullable,
+mirroring the column's own semantics) and `NombreTenant`. `NombreTenant` MUST be `null` if and
+only if `IdTenant` is `null`; the API MUST NOT fabricate a display label. `Usuarios.tsx` MUST
+render a tenant column that shows the tenant name for a tenant account and the literal
+**"Plataforma"** for an account whose `IdTenant` is `null`, never an empty cell that reads like
+missing data.
+
+The name MUST be projected inside the existing list query: `GET /api/usuarios` MUST still execute a
+single database round trip.
+
+#### Scenario: A tenant account shows its tenant name
+- GIVEN a `vendedor` of tenant 2 named "Comercio Sur"
+- WHEN a platform actor calls `GET /api/usuarios`
+- THEN that entry carries `idTenant = 2` and `nombreTenant = "Comercio Sur"`
+- AND `Usuarios.tsx` renders "Comercio Sur" in the tenant column
+
+#### Scenario: Platform staff render as Plataforma
+- GIVEN the seeded `root` account with `id_tenant IS NULL`
+- WHEN the listing is read
+- THEN the entry carries `idTenant = null` and `nombreTenant = null`
+- AND `Usuarios.tsx` renders "Plataforma" for that row
+
+#### Scenario: The tenant column costs no extra round trip
+- GIVEN a tenant with 30 usuarios
+- WHEN `GET /api/usuarios` is called
+- THEN exactly one database round trip is executed
+
+#### Scenario: A tenant admin never enumerates another tenant's name
+- GIVEN an admin of tenant 1
+- WHEN they call `GET /api/usuarios` and apply the tenant filter
+- THEN every returned row carries `idTenant = 1`, the filter offers only tenant 1, and no other
+  tenant's name appears in the response or in the rendered screen
+
+### Requirement: Usuario Deletion Gains The Usage Guard After PoliticaDeRoles, Never Instead Of It
+
+`DELETE /api/usuarios/{id}` MUST keep every existing rule of
+`PoliticaDeRoles.ValidarPuedeIntervenirSobre` — the actor must be Root or Admin, a Root target may
+never be deleted, self-deletion is forbidden — and MUST keep
+`PoliticaDeRoles.ValidarAlcanceDeTenant`'s deliberate `404`-not-`403` behaviour for an
+out-of-scope target (ADR-8). The usage guard of the `bajas-de-organizacion` capability MUST be
+applied **after** those checks and **before** the `DeletedAt` write, refusing with
+`409 usuario_en_uso`. The audit record MUST still be written for a successful deletion. The route
+and its policy (`Politicas.GestionDeUsuarios`) MUST NOT change.
+
+The consequence is accepted and explicit: the `admin` account created by provisioning is pristine
+until it operates, and stops being deletable the moment it does. The platform's lever for a
+departing employee who has operated remains the existing `Inactivo` / `Bloqueado` state.
+
+#### Scenario: A usuario who has sold cannot be deleted
+- GIVEN a `vendedor` stamped as `id_empleado` on at least one comprobante de venta created after
+  that usuario's own `created_at`
+- WHEN an admin attempts to delete them
+- THEN the request is refused with `409 usuario_en_uso`
+- AND `deleted_at` is not written
+
+#### Scenario: A never-used usuario is still deletable
+- GIVEN a `vendedor` created yesterday who has opened no shift, sold nothing and appears on no
+  document
+- WHEN an admin deletes them
+- THEN the deletion succeeds, `deleted_at` is stamped, and the audit record is written
+
+#### Scenario: The provisioned admin is pristine until it operates
+- GIVEN a freshly provisioned tenant whose `admin` shares the tenant's `created_at`
+- WHEN a platform actor deletes that admin
+- THEN the deletion succeeds
+- AND after the same admin has opened a shift, the identical request is refused with
+  `409 usuario_en_uso`
+
+#### Scenario: Role policy is evaluated before the usage guard
+- GIVEN a Root target that also has heavy usage
+- WHEN a deletion is attempted
+- THEN the refusal is the pre-existing `PoliticaDeRoles` error for a Root target, not
+  `usuario_en_uso`
+
+#### Scenario: Self-deletion is still forbidden regardless of usage
+- GIVEN an admin with no usage at all
+- WHEN they attempt to delete their own account
+- THEN the pre-existing self-deletion refusal applies, unchanged
+
+#### Scenario: An out-of-scope target stays a 404, never a usage disclosure
+- GIVEN an admin of tenant 1 and a heavily used `vendedor` of tenant 2
+- WHEN the admin issues a DELETE for that vendedor's id
+- THEN the response is `404`, never `403` and never `409 usuario_en_uso`
+
+#### Scenario: Audit rows referencing the usuario do not block
+- GIVEN a usuario whose only dependents past their anchor are `auditoria` rows with
+  `id_actor` pointing at them
+- WHEN an admin deletes them
+- THEN the deletion succeeds and the audit trail keeps rendering, because the row survives
+  logically

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -535,21 +535,21 @@ notes:
   deferred_with_reopen_conditions:
     - Force/override delete for a used entity — suspension is the existing
       lever; an override needs an audit ceremony this stage would design
-      blind. REOPEN: the first real support case that needs it.
+      blind. REOPEN — the first real support case that needs it.
     - Undelete/restore endpoint — rows are recoverable by hand and
       EstadoTenant.Baja is deliberately unreachable from suspend/reactivate.
-      REOPEN: its own change, with its own guard question.
+      REOPEN — its own change, with its own guard question.
     - Retro-guarding the other unguarded soft deletes (ServicioDeCatalogo<T>,
       Clientes, Proveedores, Articulos, Ofertas). InspectorDeUso is designed
-      entity-agnostic so adoption is a one-line change. REOPEN: a later stage.
-    - Estado/suspension for empresa and punto de venta. REOPEN: explicit owner
+      entity-agnostic so adoption is a one-line change. REOPEN — a later stage.
+    - Estado/suspension for empresa and punto de venta. REOPEN — explicit owner
       request.
-    - Server-side pagination/filtering for the four root lists (decision 7:
+    - Server-side pagination/filtering for the four root lists (decision 7 —
       when the client-side filter stops being viable, the unbounded list is
-      what broke, and all four screens move together). REOPEN: list size.
+      what broke, and all four screens move together). REOPEN — list size.
     - A minimum-administrators-per-tenant invariant
       (ultimo_admin_del_tenant) — flagged in the proposal question round
-      rather than invented autonomously. REOPEN: owner answer.
+      rather than invented autonomously. REOPEN — owner answer.
   known_trap_from_explore: >-
     The structured 'phases:' block of this file must be kept ACCURATE by every
     later phase — stage-18's state.yaml left it stale while the real progress

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -1,0 +1,527 @@
+change: stage-20-organizacion-relaciones-y-bajas
+phase: propose
+status: done
+artifact_store: hybrid
+execution_mode: auto
+delivery_strategy: auto-chain
+chain_strategy: stacked-to-main
+review_budget_lines: 800
+db_gate: ZERO-SCHEMA-RATIFIED
+db_gate_approval: >-
+  RATIFIED 2026-09-04 by the orchestrator under the owner's explicit autonomous
+  mandate ("hace todo en modo autonomo"). RATIFICATION BASIS: CLAUDE.md's
+  mandatory DB gate governs "creating or modifying ANY database schema". This
+  stage creates and modifies NONE, so the gate is NOT TRIGGERED — there is no
+  model summary to present and nothing for the owner to approve. The four
+  binding verify criteria below are what keep that true; if ANY later phase
+  proposes DDL, a migration, a data statement or a seed change, the gate
+  REOPENS immediately and work STOPS for owner approval before that change is
+  written. The orchestrator independently verified the three load-bearing
+  claims in the tree before ratifying: EstadoTenant.Baja exists in
+  src/Ways.Domain/Organizacion/EstadoTenant.cs with the doc comment "Dado de
+  baja. No se elimina fisicamente: los datos quedan para exportacion";
+  20260801011312_Organizacion.cs:18 declares the enum as
+  'activo,baja,suspendido'; and IWaysDbContext.cs:153 exposes DatabaseFacade
+  but not IModel.
+  ---
+  PROPOSED 2026-09-04 by sdd-propose under the delegated autonomous mandate:
+  ZERO SCHEMA CHANGES for the whole stage — zero migrations, zero tables,
+  zero columns, zero enum values, zero ALTER, zero indexes, zero data
+  statements, zero seed changes. AWAITING OWNER RATIFICATION before slice 1.
+  BASIS (each item verified in the tree, not assumed): (1) deleted_at already
+  exists on tenants, empresas, puntos_venta and usuarios via EntidadBase, and
+  is configured per entity (TenantConfiguration.cs:33); (2) the "BajaLogica"
+  query filter is already installed on every EntidadBase descendant
+  (WaysDbContext.AplicarFiltroDeBajaLogica, :426-447); (3) the native
+  PostgreSQL enum estado_tenant was created with ALL THREE values
+  'activo,baja,suspendido' in the FIRST migration
+  (20260801011312_Organizacion.cs:18) — 'baja' is already in the database and
+  only its WRITER was missing, so decision 1 adds a writer, not a value;
+  (4) owner names and child counts are read-only projections over existing
+  FKs, and a projection is not a schema change. The section
+  'Modelo de datos propuesto — CERO CAMBIOS DE SCHEMA' of proposal.md IS THE
+  CONTRACT: any DDL or data statement proposed by a later phase is a scope
+  violation that REOPENS the gate and stops work for owner approval.
+  BINDING VERIFY CRITERIA: (a) no new file under
+  src/Ways.Infrastructure/Persistencia/Migraciones/ — the last migration of
+  the tree at propose time must STILL be the last one at verify;
+  (b) 'dotnet ef migrations has-pending-model-changes' clean;
+  (c) InicializadorDeBaseDeDatos.cs untouched; (d) zero physical deletes in
+  the diff (repository scan for ExecuteDelete, Remove(, RemoveRange( and
+  'DELETE FROM' over the four tables) — binding owner decision B1.
+  AUTHORIZATION SURFACE: Politicas.cs UNTOUCHED — all four DELETE routes
+  reuse the policy of the group they already belong to (SoloPlataforma,
+  GestionDeOrganizacion, and the existing usuarios policy). Zero new
+  policies. Precedent for a zero-DDL stage: stages 10, 11, 13 and 18.
+orchestrator_decisions:
+  OD1: >-
+    SESSION PREFLIGHT (decided before propose, not reopened by any phase):
+    execution_mode=auto, artifact_store=hybrid (openspec files AND Engram via
+    mem_save with capture_prompt:false), delivery_strategy=auto-chain,
+    chain_strategy=stacked-to-main, review_budget_lines=800. The 800-line
+    budget replaces the 400-line default of sdd-phase-common section E for
+    this change only; the five forecast slices all sit at roughly half of it,
+    so the budget risk is LOW and three split points are pre-authorized.
+  OD2: >-
+    LANGUAGE CONTRACT: every SDD artifact of this change is written in
+    ENGLISH (proposal.md, state.yaml, specs, design, tasks, reports).
+    C#/TS identifiers are English; database objects follow the Spanish
+    snake_case convention of docs/10-modelo-de-datos.md; user-facing API
+    messages and web copy stay in Spanish, following the target context
+    (the six new 409 messages are Spanish strings, their CODES are Spanish
+    snake_case per the existing ErrorDominio idiom).
+  OD3: >-
+    SCOPE SHAPE: the stage is TWO coherent parts under one change — Part A
+    (project the organization hierarchy in the root UI: owner names instead
+    of raw ids, a tenant column on usuarios, tenant/empresa filters, child
+    counts on tenants) and Part B (usage-guarded logical deletion for tenant,
+    empresa, punto de venta, plus alignment of the existing but unguarded
+    Usuario deletion). Slices 1-2 deliver Part A and 3-5 deliver Part B, and
+    they are INDEPENDENT ON PURPOSE: Part A ships standalone value if Part B
+    stalls, and slice 3 (the guard) is deliberately INERT — it has no caller
+    until slice 4 — so the guard can be reviewed on its own merits before
+    anything can invoke it.
+  OD4: >-
+    T3 ARBITRATED — A SOFT-DELETED DEPENDENT STILL BLOCKS. The sdd-design
+    launch prompt written by the orchestrator contained the line "a logically
+    deleted child must NOT block deletion", which CONTRADICTS what proposal.md
+    and the spec had already settled. The contradiction was the orchestrator's
+    own drafting error, not an open product question, and it is resolved in
+    favour of the proposal: a dependent the customer created and later deleted
+    STILL blocks. RATIONALE: the owner's binding words were "lo que sea que el
+    usuario ya haya operado" — the customer operated; deleting the row
+    afterwards does not rewind that history. It is also the fail-safe
+    direction (it over-blocks), and the permissive reading would let anyone
+    mass-delete their data and then delete the entity that held it. This is a
+    ONE-LINE REVERSIBLE KNOB, recorded as such: reversing it means adding
+    "AND d.deleted_at IS NULL" per branch, flipping one test, and regenerating
+    the N3 inventory golden. Note this rule is NOT in tension with S2 — the
+    usage guard counts history (deleted dependents count) while the structural
+    minimum counts live siblings (deleted siblings do not). Two different
+    questions, both failing safe.
+  OD5: >-
+    T1 ACCEPTED AS A KNOWN LATENCY, SCOPE NOT EXPANDED. Design established
+    that Ways has NO endpoint creating a second empresa or punto de venta —
+    OrganizacionEndpoints.cs exposes only GET and PUT for both, and
+    ServicioDeAprovisionamiento creates exactly one of each. Consequence: the
+    structural minimum fires on EVERY empresa/PV delete attempt through the
+    API, so empresa_en_uso and punto_venta_en_uso are reachable only below the
+    API layer, and empresa/PV deletion ships LATENT — correct, tested, and
+    unreachable until creation endpoints exist. This is the same shape as
+    EstadoTenant.Baja, which shipped in stage 1 and waited until now for its
+    writer. The orchestrator did NOT add creation endpoints: the owner asked
+    to be able to DELETE things created by mistake, not to create more, and
+    silently widening scope is the owner's call to make, not the
+    orchestrator's. sdd-tasks MUST NOT write API-level tests for those two
+    codes, and the latency MUST be reported to the owner at delivery.
+  OD6: >-
+    T2 ACCEPTED — design's correction stands over the proposal. A
+    cascade-deleted admin receives 401 credenciales_invalidas, NOT 403
+    tenant_suspendido: the login lookup runs under the "BajaLogica" query
+    filter with no IgnoreQueryFilters, so the user is simply not found.
+    Orchestrator verified ServicioDeAutenticacion.cs:74-75 declares
+    credenciales_invalidas with status 401. The proposal's Success Criterion
+    is wrong and design's version is the one tasks must implement.
+phases:
+  explore:
+    status: done
+    date: 2026-09-04
+    artifact: explore.md
+    depends_on: []
+    notes: >-
+      Triggered by the owner testing the running application: the root admin
+      surface shows tenants, empresas, puntos de venta and usuarios as four
+      unrelated flat lists, and nothing can be deleted except suspending a
+      tenant. VERIFIED, not assumed: the relationships are in the DTOs but
+      rendered as raw integers (Empresas.tsx:156, PuntosVenta.tsx:216-217);
+      UsuarioListado carries NO tenant field at all (Contratos.cs:19-27);
+      there is NO DELETE for tenant/empresa/punto de venta anywhere in the
+      API surface — OrganizacionEndpoints.cs:12-13 defers alta/baja to
+      ServicioDeAprovisionamiento (ADR-16) but AprovisionamientoEndpoints.cs
+      exposes ONLY POST /api/plataforma/tenants, so the delete path that
+      comment defers to was never implemented. CORRECTED THE OWNER'S REPORT
+      on one point: Usuario DOES already delete logically
+      (UsuariosEndpoints.cs:57, wired at Usuarios.tsx:120-122) — its gap is
+      the absence of any dependent guard, not the absence of the endpoint.
+      CENTRAL FINDING: every delete in this codebase is logical, so
+      DeleteBehavior.Restrict contributes ZERO protection and any
+      "blocked when in use" rule must be an explicit application check.
+      Three guard options compared; EF metadata via
+      IEntityType.GetReferencingForeignKeys() selected because a hand list
+      FAILS UNSAFE while metadata FAILS SAFE. Left three open questions
+      (cascade, structural minimums, Usuario guard), all recommended yes.
+  propose:
+    status: done
+    date: 2026-09-04
+    artifact: proposal.md
+    depends_on: [explore]
+    notes: >-
+      Nine numbered decisions: the explore's three open questions resolved
+      (cascade YES with a boundary, structural minimums YES with an ordering
+      rule, Usuario guard YES positioned after PoliticaDeRoles) plus six the
+      proposal had to take. NEW MATERIAL THE EXPLORE DID NOT FIND, in order
+      of impact: (a) EstadoTenant.Baja is a LATENT VALUE WITH ZERO WRITERS —
+      the enum declares it (EstadoTenant.cs:16), Tenant.PuedeOperar reads it,
+      login rejects it (ServicioDeAutenticacion.cs:141),
+      CambiarEstadoTenantAsync refuses to touch it
+      (ServicioDeOrganizacion.cs:67) and Tenants.tsx:12 documents its
+      absence, but 'Estado = EstadoTenant.' resolves ONLY to Activo, twice —
+      this is stage 17's "PRE latente" pattern already in the tree, and
+      tenant deletion is its natural writer (decision 1); (b) the B3
+      discriminator IS NOT UNIFORMLY APPLICABLE — 15 domain types do not
+      inherit EntidadBase and have NO created_at column at all (Stock,
+      StockLote, MovimientoStock, MovimientoCaja, MovimientoTesoreria,
+      ArqueoTurno, MovimientoCuentaCorriente,
+      MovimientoCuentaCorrienteProveedor, Auditoria, ArticuloEmpresa,
+      OfertaLista and the four Numeracion*), verified by reading Stock.cs and
+      ArticuloEmpresa.cs which carry no timestamp property whatsoever — hence
+      decision 4's THREE BUCKETS (timestamped / untimestamped / carve-out)
+      and the COMPLETENESS TEST that converts the "fails safe" argument into
+      a guarantee by failing the build on any unclassified dependent type;
+      (c) soft-deleting a tenant already degrades login correctly to 403
+      through the EXISTING 'tenant is null' branch, so decision 1 needs no
+      auth change; (d) raw parameterised SQL gives the DESIRED filter-bypass
+      semantics for free (a soft-deleted dependent still blocks, which is the
+      strictest reading of B2) while RLS still applies at the connection
+      level, so the guard cannot under-count for a tenant admin; (e)
+      IWaysDbContext exposes DatabaseFacade but NOT IModel
+      (IWaysDbContext.cs:153) — the interface's own doc-comment (:150-152)
+      supplies the exact argument for adding IModel, flagged for sdd-design
+      to confirm or replace with a dedicated port; (f) nullable IdEmpresa
+      shared-catalogue rows need no special case because fk = @id does not
+      match NULL; (g) NO Vitest file exists for ANY of the four screens, so
+      Part A CREATES coverage rather than extending it; (h) db-error-backstops
+      is STRUCTURALLY INAPPLICABLE (no physical DELETE means no SQLSTATE
+      23503 can ever fire), which promotes the guard's tests from good
+      practice to SOLE DEFENCE and is recorded as the stage's top risk.
+      Six new 409 codes proposed: tenant_en_uso, empresa_en_uso,
+      punto_venta_en_uso, usuario_en_uso, ultima_empresa_del_tenant,
+      ultimo_punto_venta_de_la_empresa. Plan: 5 slices stacked-to-main
+      (~2080 lines), budget risk LOW against 800, three split points
+      pre-authorized, four items never degradable.
+  spec:
+    status: done
+    date: 2026-09-04
+    artifact: specs/
+    depends_on: [propose]
+    notes: >-
+      Three capability specs written under specs/: bajas-de-organizacion (NEW,
+      full spec — 12 requirements, 41 scenarios), tenant-organization (DELTA,
+      5 ADDED requirements, 21 scenarios) and usuarios-tenant-scoping (DELTA,
+      2 ADDED requirements, 11 scenarios). Total 19 requirements / 73
+      scenarios. NOTHING WAS REMOVED, MODIFIED OR RENAMED in either delta —
+      every existing requirement of both capabilities stays byte-identical, so
+      archive replaces nothing. THE COMPLETENESS RULE IS SPECIFIED AS A
+      REQUIREMENT, NOT A CLAIM ("Every Referencing Type Is Classified Into
+      Exactly One Bucket Or The Build Fails"): a type in NO bucket fails the
+      test naming it, a type in MORE THAN ONE bucket also fails, and skipping
+      or defaulting an unclassified type is a spec violation — that is what
+      converts B4's "fails safe" into a guarantee given that
+      db-error-backstops is structurally N/A. SPEC-LEVEL DECISIONS taken where
+      the proposal was silent, each cheap to reverse: (S1) NombreTenant on
+      UsuarioListado is NULL exactly when IdTenant is NULL and the literal
+      "Plataforma" is rendered by the WEB, not fabricated by the API
+      (dto-contract-honesty: the DTO carries the truth, the screen carries the
+      copy); (S2) the structural-minimum COUNT excludes logically deleted
+      siblings, so a tenant whose second empresa was already deleted still
+      gets ultima_empresa_del_tenant on the survivor; (S3) the cascade MUST
+      NOT re-stamp a child that was already logically deleted — it keeps its
+      ORIGINAL deleted_at, otherwise the shared-instant restore rule of
+      decision 2 would be destroyed for the earlier deletion; (S4) reactivate
+      on a deleted tenant is a 404 (BajaLogica hides the row from
+      BuscarTenantAsync) and the pre-existing 409 tenant_dado_de_baja stays as
+      an unreachable backstop — verified in ServicioDeOrganizacion.cs:62-72;
+      (S5) filter option sets are derived from the rows the actor can already
+      see, so a filter can never disclose an out-of-scope tenant name;
+      (S6) when a structural minimum AND usage both apply, the structural code
+      wins (decision 3's ordering, made observable). ANTI-ORACLE encoded twice
+      (bajas-de-organizacion and usuarios-tenant-scoping): an out-of-scope
+      DELETE is 404, never 403 and never a 409 that discloses usage. ZERO
+      SCHEMA is preserved — no requirement asks for a column, a table, an
+      index or a migration.
+  design:
+    status: done
+    date: 2026-09-04
+    artifact: design.md
+    depends_on: [propose]
+    notes: >-
+      Fifteen decisions (D1-D15) plus the seven arbitrations the prompt named
+      (A untimestamped types, B the completeness test, C IModel access, D query
+      cost, E query filters, F cascade atomicity, G concurrency). NINE
+      STRUCTURAL FACTS VERIFIED IN THE TREE, three of which CORRECT the
+      proposal: (1) Empresa/PuntoVenta carry NO navigation properties
+      (Empresa.cs:9-26), so owner names can only be correlated scalar
+      subqueries — which also removes the INNER-JOIN-drops-the-row trap;
+      (2) NO ENDPOINT CREATES A SECOND EMPRESA OR PUNTO DE VENTA
+      (AprovisionamientoEndpoints exposes only POST /api/plataforma/tenants and
+      OrganizacionEndpoints has no POST), so decision 3's structural minimums
+      fire on EVERY empresa/PV delete attempt and empresa_en_uso /
+      punto_venta_en_uso are UNREACHABLE THROUGH THE API today — their tests
+      must be below-the-confound service-level tests (T1, mutation-proof rule
+      3); (3) a cascade-deleted admin gets 401 credenciales_invalidas, NOT the
+      403 tenant_suspendido the proposal's Success Criteria claims — the login
+      lookup runs under "BajaLogica" (ServicioDeAutenticacion.cs:85-87, no
+      IgnoreQueryFilters) so the user is not found and dies at :104; the 403
+      branch stays reachable only for a SUSPENDED tenant (T2). C RESOLVED:
+      expose IModel on IWaysDbContext — blast radius VERIFIED as ONE LINE
+      (rg ": IWaysDbContext" over src/ and tests/ returns ZERO matches; no
+      hand-written implementation, no fake, no mock exists), and DbContext.Model
+      already satisfies it implicitly; a dedicated port was rejected because its
+      only implementation would be "=> contexto.Model". B RESOLVED HONESTLY:
+      the classifier is TOTAL by construction (carve-out -> timestamped ->
+      untimestamped), so the proposal's literal "fails the build on an
+      unclassified type" would be a TAUTOLOGY forbidden by mutation-proof rule
+      1 — replaced by FOUR NAMED NETS: N1 totality (Construir throws NAMING the
+      type on the three mechanical impossibilities), N2 the bucket is read off
+      the TABLE (created_at column) not restated from the code, N3 a CHECKED-IN
+      SORTED GOLDEN INVENTORY of every (anchor, table, columns, bucket) that
+      goes red with a diff naming any FK a future stage adds/removes/reclassifies
+      — this is the executable form of the proposal's intent — and N4 the
+      pristine regression. N1-N3 need NO container: they build the real Npgsql
+      model over an unopened connection, the existing
+      tests/Ways.Application.Tests/Persistencia/Modelo*Tests.cs pattern.
+      D RESOLVED: one UNION ALL statement with an outer LIMIT 1 (the Append node
+      stops at the first blocking branch); ~40 sequential AnyAsync rejected on
+      round trips; accepted honestly for an admin-only action, with a read-only
+      pg_indexes coverage check that REPORTS an uncovered branch but cannot fix
+      it (ZERO-SCHEMA). F RESOLVED: one ExecutionStrategy transaction, one
+      advisory lock, ONE evaluation of the guard (no pre-check — mutation-proof
+      rule 3 names the pre-check/guard duality as this repo's most common
+      confound), one reloj.Ahora shared by parent and every child on DeletedAt
+      AND UpdatedAt, Estado = Baja in the same SaveChangesAsync; write ORDER is
+      deliberately NOT claimed (EF owns it inside one SaveChanges) — atomicity
+      is the property. G RESOLVED: pg_advisory_xact_lock(idTenant, -20) keyed on
+      the TENANT, not the entity, with a NEGATIVE constant because the two-int
+      advisory keyspace is already shared with ServicioDeOfertas (idTenant,
+      idOferta) and ServicioDePrecios (idTenant, par), both positive; the POS
+      takes no lock of this family, so the lock sets are DISJOINT from the total
+      order (numeraciones_fiscales -> turnos_caja -> ... -> ledger) and no
+      deadlock is expressible. RESIDUAL RACE R1 STATED AND ACCEPTED: a sale
+      committed between the guard's read and the deletion's commit yields a
+      soft-deleted tenant owning a post-anchor comprobante — closing it would
+      put a platform-admin lock into the POS hot path (the stage-19a D1 lesson),
+      and B1 makes recovery a one-line UPDATE. Usuario deletion takes NO
+      transaction and NO lock (D12): no cascade, and the lock closes no race it
+      faces. BUDGETED COST NAMED, NOT DISCOVERED: the guard's raw SQL cannot run
+      on the InMemory provider, so the EliminarAsync cases of
+      ServicioDeOrganizacionTests and ServicioDeUsuariosTests RELOCATE to the
+      integration suite — the exact ServicioDeOfertas.ActualizarAsync precedent
+      (ServicioDeOfertas.cs:43-46). TENSION T3 REQUIRING AN OWNER RULING BEFORE
+      SLICE 3: the launch prompt says "a logically deleted child must NOT block
+      deletion" while the proposal settled the OPPOSITE (decision 6 side effect
+      A, question round item 2) and requires a test proving it (proposal.md:506).
+      The design IMPLEMENTS THE PROPOSAL per the binding-contract rule and
+      records the exact reversal (add AND d.deleted_at IS NULL to every branch,
+      flip one test). db-error-backstops declared STRUCTURALLY N/A with
+      ManejadorDeErrores.cs untouched as verify criterion V6. Threat matrix N/A;
+      the one new boundary (generated SQL) is closed by metadata-only
+      pattern-validated identifiers, bound parameters and a read-only statement.
+      Twelve binding verify criteria; U1-U8 guarded-write conjuncts enumerated
+      up front; five slices unchanged from the proposal with every design
+      element assigned a Slice column, budget risk LOW against 800.
+  tasks:
+    status: done
+    date: 2026-09-04
+    artifact: tasks.md
+    depends_on: [spec, design]
+    notes: >-
+      Binding breakdown: 5 slices, 103 tasks (16/16/20/39/12), stacked-to-main, merge order
+      1 -> 2 -> 3 -> 4 -> 5. Per-slice estimates: 1 ~390, 2 ~430, 3 ~470,
+      4 ~530, 5 ~340 (total ~2160). Budget risk LOW against 800; every slice
+      sits at roughly half the cap and the three design split points are
+      carried as pre-approved degradation. Decision needed before apply: NO
+      (the db_gate is ZERO-SCHEMA-RATIFIED). THE THREE ORCHESTRATOR
+      ARBITRATIONS ARE TRANSCRIBED AS BINDING NOTES AT THE TOP AND IN THE
+      SLICE THAT OWNS THEM: OD4 (a soft-deleted dependent STILL blocks — no
+      'AND d.deleted_at IS NULL' branch anywhere; asserted at rendering level
+      in task 3.14 and behaviourally in task 4.15; recorded as a one-line
+      reversible knob in InspectorDeUso's doc-comment), OD5 (NO API-level test
+      for empresa_en_uso / punto_venta_en_uso — they are proven below the API
+      with a hand-seeded second empresa/PV in tasks 4.12/4.21/4.26; no creation
+      endpoint is added; the latency is reported to the owner at delivery in
+      task 5.12) and OD6 (a cascade-deleted admin gets 401
+      credenciales_invalidas, task 4.31, with the 403 tenant_suspendido branch
+      re-asserted as a regression for a SUSPENDED tenant). SIX RECONCILIACIONES
+      REGISTERED, the load-bearing one being that the tenant-organization
+      scenario 'a deleted tenant's user ... gets a clean 403' is SUPERSEDED by
+      OD6 — the spec text is left byte-identical and verify must read it through
+      Reconciliación 1 rather than as a failed criterion. Design's T3 is closed
+      by OD4, T1 by OD5, T4 adopted as the four nets N1-N4 (N3's checked-in
+      sorted golden inventory is the actual trip-wire, and the proposal's
+      literal 'fails the build on an unclassified type' is delivered by it
+      rather than by a tautological bucket-membership assertion). N1-N4, the two
+      carve-out tests, the 'one article blocks' test and the zero-physical-delete
+      scan are carried as NEVER-DEGRADABLE tasks. U1-U8 transcribed verbatim
+      into slice 4's header before any test is written (mutation-proof rule 3),
+      each paired with its own task-level kill. The EliminarAsync test
+      relocation to the integration suite is BUDGETED in slice 4's ~530 (design
+      said ~490) and owned by task 4.10, which also requires the PR body to
+      state that every moved case is behaviour-identical. 13 binding verify
+      criteria carried to every slice, including the ZERO-SCHEMA set (last
+      migration stays 20260822002214_FiscalArcaEtapa19a.cs,
+      has-pending-model-changes clean, InicializadorDeBaseDeDatos.cs /
+      Politicas.cs / ManejadorDeErrores.cs untouched, zero physical deletes).
+      db-error-backstops declared STRUCTURALLY N/A in the header and per slice.
+      The per-slice delivery ritual is stated explicitly so apply follows it:
+      implement -> all relevant test commands green -> judgment-day dual blind
+      review to a clean round -> PR (branch-pr, conventional commits, no AI
+      attribution) -> merge -> next slice. Integration-suite discipline
+      restated as binding: Docker required, NEVER two integration suites
+      concurrently against the same daemon.
+  apply:
+    status: in_progress
+    date: 2026-09-04
+    artifact: tasks.md + PRs
+    depends_on: [tasks]
+    notes: >-
+      SLICE 1 IMPLEMENTED (tasks 1.1-1.14 checked; 1.15 judgment-day and 1.16 PR
+      belong to the orchestrator). Branch feat/stage20-slice1-proyeccion-api off
+      main, 2 commits, ~470 changed lines (additions + deletions) against the
+      800-line budget. Six files: Organizacion/Contratos.cs,
+      Organizacion/ServicioDeOrganizacion.cs, Usuarios/Contratos.cs,
+      Usuarios/ServicioDeUsuarios.cs, WaysApiFixture.cs (one optional params
+      IInterceptor[] parameter, zero call sites changed) and the new
+      tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs (7 tests).
+      ZERO-SCHEMA HELD AND VERIFIED, not assumed: zero files under Migraciones/
+      in the diff, the last migration is still 20260822002214_FiscalArcaEtapa19a,
+      'dotnet ef migrations has-pending-model-changes' reports "No changes have
+      been made to the model since the last migration",
+      InicializadorDeBaseDeDatos.cs / Politicas.cs / ManejadorDeErrores.cs
+      untouched (git diff main --name-only returns them nowhere), zero
+      ExecuteDelete/Remove(/RemoveRange(/DELETE FROM added, zero DDL. SUITES:
+      dotnet build Ways.slnx clean (2 pre-existing NU1903 warnings on SSH.NET),
+      Domain 545/545, Application 373/373, Integration 1732/1732 in 18m08s, run
+      once and alone against the Docker daemon per the binding discipline (trx at
+      tests/Ways.IntegrationTests/TestResults/slice1.trx). SIX MUTATIONS RUN FOR
+      REAL (M1-M6, table in tasks.md): each applied, the named test observed RED
+      with its exact failure message, reverted, observed GREEN. Task 1.13 ships
+      WITHOUT mutation evidence ON PURPOSE and says so: it is a regression over
+      the pre-existing "Tenant" query filter plus RLS, not over a clause this
+      slice introduces. TWO DEFECTS IN THE TESTS THEMSELVES were found by running
+      the mutations rather than reasoning about them, and both were fixed: (a)
+      task 1.11's pairwise-distinctness rested on an order-dependent id > 4
+      assertion — now guaranteed by construction with three deliberately
+      unbalanced filler tenants that desynchronise the four identity sequences;
+      (b) task 1.12's first draft asserted S1's iff over every row and went red
+      against the orphan seeded by task 1.10 — the iff holds for the
+      platform/tenant distinction but NOT for the D13 orphan, so the assertion
+      now states the direction the API actually owes. JUDGMENT CALL RECORDED, NOT
+      SILENT: the four listing records are also returned by the detail/edit
+      endpoints, and neither the spec nor the design says what those must carry.
+      Filling them with 0/null would be exactly the accepted-and-dropped shape
+      dto-contract-honesty forbids, so Obtener*/Actualizar*/Suspender/Reactivar
+      re-project. The three Obtener* still cost ONE round trip (they project
+      instead of loading the entity and validate scope on the projected IdTenant,
+      preserving BuscarX's 404-then-ADR-8 order); the four write paths cost one
+      extra read. The single-round-trip budget of TO-R1/UT-R1 is about the
+      LISTINGS, which are the ones that scale with row count. Slices 2-5 pending.
+  verify:
+    status: pending
+    artifact: verify-report.md
+    depends_on: [apply]
+  archive:
+    status: pending
+    artifact: archive-report.md
+    depends_on: [verify]
+dependencies:
+  stages:
+    - stage-1-organization-and-catalogs (archived) — the organization hierarchy,
+      EntidadBase/DeletedAt, the "BajaLogica" query filter, the estado_tenant enum
+      already carrying 'baja', and RLS.
+  code:
+    - ServicioDeAprovisionamiento (ADR-16) — the SINGLE clock reading at :46 that
+      stamps one identical instant on every provisioned row including the tenant
+      itself; the entire pristine/used discriminator rests on this property.
+    - PoliticaDeRoles — consumed UNCHANGED by decision 5 (the usage guard is
+      inserted after ValidarPuedeIntervenirSobre, never instead of it).
+    - WaysDbContext.AplicarFiltroDeBajaLogica / AplicarFiltroDeTenantEnTenant —
+      the existing metadata-walk idiom the guard follows.
+    - IRelojDelSistema / RelojFijo — the shared deletion instant and its tests.
+  platform:
+    - EF Core IEntityType.GetReferencingForeignKeys() (.NET 10) — no new package.
+    - NO new NuGet package, NO new web dependency, NO migration, NO external service.
+  skills:
+    - mutation-proof-tests, dto-contract-honesty, web-descriptor-tests,
+      work-unit-commits, judgment-day (before every PR).
+    - db-error-backstops is EXPLICITLY N/A for this change — see the note below.
+  blocked_on: >-
+    Nothing external. The only gate is the owner's ratification of the
+    ZERO-SCHEMA db_gate before slice 1.
+notes:
+  binding_owner_decisions:
+    B1: >-
+      PHYSICAL DELETION IS NEVER PERMITTED. All deletion stays logical
+      (DeletedAt), consistent with the EntidadBase convention. Enforced as a
+      verify criterion: a repository scan for ExecuteDelete, Remove(,
+      RemoveRange( and 'DELETE FROM' over tenants, empresas, puntos_venta and
+      usuarios. Direct dividend: NOTHING in this stage is unrecoverable, so
+      rollback is git revert plus at most a one-line UPDATE.
+    B2: >-
+      "IN USE" MEANS THE CUSTOMER LOADED OR OPERATED ANYTHING BEYOND THE
+      PROVISIONING BASELINE — articles, clients, suppliers, a second punto de
+      venta, not only transactional records. Only what
+      ServicioDeAprovisionamiento created counts as pristine. A tenant with
+      3000 articles and zero sales is NOT deletable. This replaced an earlier,
+      narrower reading during explore.
+    B3: >-
+      THE DISCRIMINATOR IS dependent.CreatedAt > entity.CreatedAt, valid
+      because ServicioDeAprovisionamiento.cs:46 reads the clock ONCE
+      ('var ahora = reloj.Ahora;') and stamps that identical instant on every
+      provisioned row including the Tenant itself (:53-54, 69-70, 79-80,
+      89-90, 104-105, 121-122, 142-143, 158-160). Template-version
+      independent. GUARDED FROM A DISTANCE by a regression test asserting a
+      freshly provisioned tenant is pristine — it fails the moment a refactor
+      breaks the single-reading property.
+    B4: >-
+      THE DEPENDENT SET IS DISCOVERED FROM EF METADATA
+      (IEntityType.GetReferencingForeignKeys()), NEVER a hand-maintained table
+      list. A hand list fails UNSAFE (one forgotten table silently makes a
+      used entity deletable); metadata fails SAFE. Decision 4 makes the
+      fail-safe claim VERIFIABLE via the completeness test, because a
+      fail-safe property that is never detected is only a hope.
+    B5: >-
+      AUDIT ROWS DO NOT BLOCK DELETION. Auditoria.IdActor and
+      Auditoria.IdPuntoVenta are a trail ABOUT the entity, not data the
+      customer operated, and because deletion is logical the referenced row
+      survives so the trail keeps rendering. Implemented as ONE of exactly
+      TWO named carve-outs (the other is NumeracionCliente, the provisioning
+      counter row), each with a written reason in code and its own test.
+  db_error_backstops_not_applicable: >-
+    The db-error-backstops skill's SQLSTATE backstop DOES NOT APPLY to this
+    change. Every FK in WaysDbContext is DeleteBehavior.Restrict, but B1 means
+    no physical DELETE ever runs, so no Postgres constraint can EVER fire
+    against an UPDATE ... SET deleted_at. The application guard is the SOLE
+    line of defence and its tests carry the entire burden. Recorded as the
+    stage's top risk; it is why decision 4's completeness test is listed among
+    the four items that may never be degraded.
+  never_degrade:
+    - The completeness test (every referencing FK classified into exactly one
+      of the three buckets; an unclassified type is a RED TEST naming it).
+    - The two carve-out tests (auditoria-only and numeraciones_clientes-only
+      entities remain deletable).
+    - The "one article blocks" test — B2 proven end to end, not asserted.
+    - The zero-physical-delete repository scan.
+  deferred_with_reopen_conditions:
+    - Force/override delete for a used entity — suspension is the existing
+      lever; an override needs an audit ceremony this stage would design
+      blind. REOPEN: the first real support case that needs it.
+    - Undelete/restore endpoint — rows are recoverable by hand and
+      EstadoTenant.Baja is deliberately unreachable from suspend/reactivate.
+      REOPEN: its own change, with its own guard question.
+    - Retro-guarding the other unguarded soft deletes (ServicioDeCatalogo<T>,
+      Clientes, Proveedores, Articulos, Ofertas). InspectorDeUso is designed
+      entity-agnostic so adoption is a one-line change. REOPEN: a later stage.
+    - Estado/suspension for empresa and punto de venta. REOPEN: explicit owner
+      request.
+    - Server-side pagination/filtering for the four root lists (decision 7:
+      when the client-side filter stops being viable, the unbounded list is
+      what broke, and all four screens move together). REOPEN: list size.
+    - A minimum-administrators-per-tenant invariant
+      (ultimo_admin_del_tenant) — flagged in the proposal question round
+      rather than invented autonomously. REOPEN: owner answer.
+  known_trap_from_explore: >-
+    The structured 'phases:' block of this file must be kept ACCURATE by every
+    later phase — stage-18's state.yaml left it stale while the real progress
+    lived in a trailing comment block. Each phase updates its own entry
+    (status, date, artifact, notes) as part of its work, and the trailing
+    free-text log is NOT an acceptable substitute.

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -376,12 +376,25 @@ phases:
     notes: >-
       SLICE 1 IMPLEMENTED (tasks 1.1-1.14 checked; 1.15 judgment-day and 1.16 PR
       belong to the orchestrator). Branch feat/stage20-slice1-proyeccion-api off
-      main, 2 commits, ~470 changed lines (additions + deletions) against the
-      800-line budget. Six files: Organizacion/Contratos.cs,
+      main, measured with 'git diff main --stat -- src tests' and NOT estimated.
+      After judgment-day round 1, 1285 changed lines (1252 insertions plus 33
+      deletions) against the 800-line budget, with
+      tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs at 1076 lines
+      and 11 [Fact] methods. After judgment-day round 2 (final), 1420 changed
+      lines (1386 insertions plus 34 deletions), of which production is 217 (185
+      plus 32) across four files and tests are 1203, with that same test file at
+      1194 lines and 12 [Fact] methods. ORCHESTRATOR DECISION, recorded verbatim
+      at the round-1 figures it was taken on - slice 1 ships as ONE PR at 1285
+      changed lines against the 800-line budget (OD1), because production is only
+      ~176 lines and the ~1085 test lines are the evidence round 1's review
+      demanded for exactly those 176; splitting would separate the proof from the
+      claim and buy two more review cycles for no gain in review quality. The
+      owner was told the corrected number and offered the split. Six files:
+      Organizacion/Contratos.cs,
       Organizacion/ServicioDeOrganizacion.cs, Usuarios/Contratos.cs,
       Usuarios/ServicioDeUsuarios.cs, WaysApiFixture.cs (one optional params
       IInterceptor[] parameter, zero call sites changed) and the new
-      tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs (7 tests).
+      tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs.
       ZERO-SCHEMA HELD AND VERIFIED, not assumed: zero files under Migraciones/
       in the diff, the last migration is still 20260822002214_FiscalArcaEtapa19a,
       'dotnet ef migrations has-pending-model-changes' reports "No changes have

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -414,7 +414,38 @@ phases:
       instead of loading the entity and validate scope on the projected IdTenant,
       preserving BuscarX's 404-then-ADR-8 order); the four write paths cost one
       extra read. The single-round-trip budget of TO-R1/UT-R1 is about the
-      LISTINGS, which are the ones that scale with row count. Slices 2-5 pending.
+      LISTINGS, which are the ones that scale with row count. JUDGMENT-DAY ROUND
+      1 (task 1.15) CORRECTED SIX CONFIRMED FINDINGS, three of them with new
+      mutation evidence (M7-M9 in tasks.md): (1) IgnoreQueryFilters is applied at
+      QUERY level, so incluirEliminados=true also stripped the soft-delete filter
+      from the correlated tenant-name subquery and the same account showed a
+      soft-deleted tenant's name there while returning null on the other two
+      paths — the subquery now carries an explicit t.DeletedAt == null and the
+      ADR-6 IgnoreQueryFilters call is untouched; (2) every non-listing response
+      path shipped untested (return null; in NombreDeTenantAsync left the whole
+      suite green), closed with three readback tests over
+      Obtener/Actualizar/Suspender/Reactivar of tenant, Obtener/Actualizar of
+      empresa and punto de venta, and the POST 201 / GET {id} / PUT bodies of
+      usuario, with pairwise-distinct values per rule 12b; (3) the three
+      re-projections after SaveChangesAsync used FirstAsync (500) where the
+      sibling read paths return a domain 404 — all three now use
+      FirstOrDefaultAsync + ErrorDominio.NoEncontrado, which is what slice 4's
+      concurrent deleters need; (4) V9 IS NOT LITERALLY SATISFIED FOR USUARIOS
+      and is recorded as Reconciliación 8 in tasks.md instead of being patched
+      away: the criterion means "the projection adds no round trip", the usuarios
+      listing costs 2 because it is the only PAGINATED listing, and that second
+      CountAsync predates this change; the pagination was NOT touched and
+      specs/usuarios-tenant-scoping/spec.md:14-15 and :29-32 are left
+      byte-identical and marked superseded, exactly as Reconciliación 1 handles
+      OD6; (5) RazonSocialEmpresa's e.Id == p.IdEmpresa correlation had no
+      deterministic kill because every fixture tenant owned exactly one empresa —
+      task 1.8 now seeds a second empresa OF THE SAME TENANT with its own punto
+      de venta (rule 12c); (6) the NombreTenant doc-comments published a false
+      contract (null iff IdTenant is null) that the D13 orphan violates — both
+      Contratos.cs and NombreDeTenantAsync now state the two real cases, and the
+      never-fabricate-"Plataforma" rule is unchanged. ZERO SCHEMA HELD ACROSS THE
+      CORRECTION: no migration, no DDL, InicializadorDeBaseDeDatos.cs /
+      Politicas.cs / ManejadorDeErrores.cs still untouched. Slices 2-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -86,6 +86,22 @@ carry the entire safety argument.**
    the same reason. A 530-word checklist cannot carry OD4/OD5/OD6, N1-N4, U1-U8 and the ZERO-SCHEMA
    criteria without dropping load-bearing content, and dropping it is what verify would then have to
    reconstruct by archaeology.
+8. **V9 means "the projection adds no round trip", and for `GET /api/usuarios` the literal reading
+   is false.** Measured on the merged slice-1 code: the three organization listings cost exactly
+   **1** database command each; `GET /api/usuarios` costs **2**. The second one is the pagination
+   `CountAsync` (`ServicioDeUsuarios.cs:70`) — usuarios is the **only paginated** listing — and it
+   **predates this change**: it is emitted by code slice 1 never touched. The projection itself adds
+   **zero** commands on all four endpoints; if it added one, the usuarios count would be 3. Task 1.7
+   asserts exactly that (`1` for each organization listing, `2` for usuarios) and
+   `CadaListadoCuestaExactamenteUnaIdaALaBase`'s doc-comment records the reason at the assertion.
+   **The pagination is NOT changed to make a sentence true.** The sentence *"`GET /api/usuarios`
+   MUST still execute a single database round trip"* (`specs/usuarios-tenant-scoping/spec.md:14-15`)
+   and its scenario *"The tenant column costs no extra round trip"* (`:29-32`) are left
+   **byte-identical** — deltas of this change are not edited mid-flight — and are **superseded by
+   this reconciliation**, the same handling Reconciliación 1 gives OD6. Verify must read V9
+   (`tasks.md`, `design.md:469`) through it: the property the criterion protects (no N+1, no second
+   query per row, no extra round trip **caused by the projection**) is preserved and proven; only
+   the absolute number for the one paginated listing differs.
 
 ## Binding Verify Criteria (all slices)
 
@@ -107,7 +123,10 @@ slice**, and every slice re-asserts V1-V6 (they are invariants of the whole stag
    implementations change (`rg ": IWaysDbContext"` over `src/` and `tests/` returns zero matches).
 8. **N3's golden is checked in and green**; any regeneration inside a PR is accompanied by a written
    classification decision for each changed line.
-9. Each of the four list endpoints performs **exactly one** database round trip (`ContadorDeComandos`).
+9. Each of the four list endpoints performs **exactly one** database round trip (`ContadorDeComandos`)
+   — read through **Reconciliación 8**: the criterion is that the **projection** adds no round trip.
+   `GET /api/usuarios` costs 2 because it is the only paginated listing and its `CountAsync`
+   predates this change; the other three cost 1.
 10. `InspectorDeUso` has **zero callers** in the slice-3 diff (`rg` over `src/`).
 11. Mutation evidence recorded in the PR body for **every** U-row belonging to that slice; structural
     rows record the file/state/definition assertion instead of a runtime failure, **and say so**.
@@ -283,6 +302,9 @@ mutation was then reverted (`git checkout --`) and the test observed GREEN again
 | M4 | 1.10 | The owner name is a correlated **subquery**, not a JOIN | `ListarEmpresasAsync` rewritten as `db.Empresas.Join(db.Tenants, …)` | `UnaEmpresaCuyoTenantFueDadoDeBajaSigueApareciendoConNombreDeTenantNulo` — `Assert.Single() Failure: The collection did not contain any matching items`; the orphan empresa vanished from the listing, which is precisely the trap D13 exists to avoid |
 | M5 | 1.11 | Positional argument order of `TenantListado` | `CantidadEmpresas` and `CantidadPuntosVenta` swapped in `ProyeccionDeTenant` | `CadaCampoPosicionalDeLosCuatroListadosSeLeeDeVueltaConValoresDistintos` — `Expected: 2 / Actual: 3` |
 | M6 | 1.12 | The API never fabricates the `"Plataforma"` literal (S1/D14) | `… .FirstOrDefault() ?? "Plataforma"` in `ServicioDeUsuarios.ListarAsync` | `ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma` — `Assert.Null() Failure: Value is not null / Actual: "Plataforma"` |
+| M7 | 1.15 (ronda 1, hallazgo 1) | The **explicit** `t.DeletedAt == null` of the usuarios subquery — `IgnoreQueryFilters` is query-level, so `incluirEliminados=true` also stripped the filter from the correlated subquery | `.Where(t => t.Id == u.IdTenant && t.DeletedAt == null)` → `.Where(t => t.Id == u.IdTenant)` | `UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos` — `Assert.Null() Failure: Value is not null / Actual: "Huerfano-A-252cafab"`, on the `incluirEliminados=true` path only (the default listing and the detail stayed green — that is the discrepancy the finding named) |
+| M8 | 1.15 (ronda 1, hallazgo 2) | `ServicioDeUsuarios.NombreDeTenantAsync` — the source of `NombreTenant` on **every** non-listing path (`ObtenerAsync`, the `POST` 201 body, the `PUT` body) | body replaced by `return null;` (keeping one instance read so CA1822 does not mask the mutant) | `ElAltaElDetalleYLaEdicionDeUsuarioDevuelvenLosDiezCamposProyectados` — `Assert.Equal() Failure: Strings differ / Expected: "Detalle-usuario-8dc6ccae" / Actual: null`, on the **201 body** of `POST /api/usuarios`. Before this round the same mutation left the entire suite green |
+| M9 | 1.15 (ronda 1, hallazgo 5) | The `e.Id == p.IdEmpresa` correlation of `RazonSocialEmpresa` — needs a sibling of the **same owner** (`mutation-proof-tests` rule 12c) | `.Where(e => e.Id == p.IdEmpresa)` → `.Where(e => e.IdTenant == p.IdTenant)` | `LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios` — `Assert.Equal() Failure: Strings differ / Expected: "Norte Anexo SRL" / Actual: "Norte SRL"`. The kill is deterministic: the tenant now owns two empresas with two puntos de venta, so whichever row the base picks, one of the two assertions fails |
 
 **Task 1.13 carries NO mutation evidence, and that is stated rather than papered over.** It is a
 **regression** test over behaviour this slice does not add: tenant scoping on `GET /api/usuarios`
@@ -334,6 +356,27 @@ excludes ("if you cannot name a clause this change introduces, it is ordinary co
   call sites changed; it is what lets task 1.7 count commands on a service call.
 - **No web file was touched** — `tipos.ts` mirrors land in slice 2, and adding fields to the JSON
   payload is backward compatible for the screens as they stand.
+
+- **Judgment-day, ronda 1 (task 1.15): six confirmed findings, six fixes, three new mutations.**
+  (1) `IgnoreQueryFilters(["BajaLogica"])` is applied at **query** level, so `incluirEliminados=true`
+  also stripped the soft-delete filter from the correlated tenant-name subquery: the same account
+  showed a soft-deleted tenant's name on that path and `null` on the other two. Fixed by making the
+  subquery's predicate explicit (`t.DeletedAt == null`) instead of leaning on the ambient filter;
+  the `IgnoreQueryFilters` call and its ADR-6 comment are untouched. Killed by M7 on all three
+  paths. (2) Every non-listing response path shipped untested — `return null;` in
+  `NombreDeTenantAsync` left the whole suite green. Three new readback tests now cover
+  `Obtener/Actualizar/Suspender/Reactivar` of tenant, `Obtener/Actualizar` of empresa and punto de
+  venta, and the `POST` 201 / `GET {id}` / `PUT` bodies of usuario, with pairwise-distinct values
+  (rule 12b). Killed by M8. (3) The three re-projections after `SaveChangesAsync` used `FirstAsync`,
+  which turns a row that became invisible between write and re-read into a 500 while the sibling
+  read paths return a domain 404; all three now use `FirstOrDefaultAsync` + `ErrorDominio.NoEncontrado`
+  — this matters for slice 4, which adds concurrent deleters on exactly those rows. (4) V9 is not
+  literally satisfied for usuarios: recorded as **Reconciliación 8**, no code change, the spec file
+  left byte-identical. (5) `RazonSocialEmpresa`'s correlation had no deterministic kill (one empresa
+  per tenant); task 1.8's fixture now seeds a second empresa **of the same tenant** with its own
+  punto de venta. Killed by M9. (6) The `NombreTenant` doc-comments claimed null **iff** `IdTenant`
+  is null, which is false for the D13 orphan; both `Contratos.cs` and `NombreDeTenantAsync` now
+  state the two real cases. The "never fabricate `Plataforma`" rule is unchanged.
 
 ---
 

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -102,6 +102,24 @@ carry the entire safety argument.**
    (`tasks.md`, `design.md:469`) through it: the property the criterion protects (no N+1, no second
    query per row, no extra round trip **caused by the projection**) is preserved and proven; only
    the absolute number for the one paginated listing differs.
+9. **S1's `iff` holds for the platform-vs-tenant distinction and is FALSE for the D13 orphan.**
+   The sentence *"`NombreTenant` MUST be `null` if and only if `IdTenant` is `null`"*
+   (`specs/usuarios-tenant-scoping/spec.md:8-9`) reads as a biconditional over every row. The
+   forward direction is what the API actually owes and is implemented and asserted: an account with
+   no tenant (`IdTenant is null`) never carries a name, and the literal `"Plataforma"` is never
+   fabricated server-side. The converse is **deliberately not true**: when the owning tenant is
+   soft-deleted, `IdTenant` is **non-null** and `NombreTenant` is **null**, because D13 chooses to
+   render the orphan as a visible anomaly instead of hiding the row — that is exactly what makes
+   slice 1 correct without slice 4's cascade and therefore independently mergeable. A consumer may
+   **not** read a null name as "this is platform staff"; `IdTenant` is the discriminator, which is
+   why the web's `"Plataforma"` copy (task 2.7) keys off `IdTenant`, never off the name. The spec
+   sentence and the *"Platform staff render as Plataforma"* scenario are left **byte-identical** —
+   deltas of this change are not edited mid-flight — and are **superseded by this reconciliation**,
+   the same handling Reconciliación 1 gives OD6 and Reconciliación 8 gives V9. Recorded in the code
+   at the two places that state the contract (`Usuarios/Contratos.cs`,
+   `ServicioDeUsuarios.NombreDeTenantAsync`), both of which name the two null cases instead of the
+   `iff`, and asserted by `ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma`
+   plus `UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos`.
 
 ## Binding Verify Criteria (all slices)
 
@@ -238,9 +256,11 @@ decouples slice 1 from slice 4's cascade and keeps Part A independently mergeabl
   stop being rendered and become the **filter keys**, named here so a reviewer does not read them as
   newly dead. *(TO-R1, TO-R2; design D13, Interfaces table)*
 - [x] 1.2 Modify `src/Ways.Application/Usuarios/Contratos.cs` — `UsuarioListado` gains
-  `int? IdTenant` and `string? NombreTenant`. **S1 is binding**: `NombreTenant` is `null` **iff**
-  `IdTenant` is `null`; the API **MUST NOT** fabricate the literal `"Plataforma"` — that copy is the
-  web's job (slice 2, task 2.7). *(UT-R1; design D14)*
+  `int? IdTenant` and `string? NombreTenant`. **S1 is binding as read through Reconciliación 9**,
+  not as a literal `iff`: what the API owes is the forward direction (`IdTenant is null` ⇒
+  `NombreTenant is null`, and the literal `"Plataforma"` **MUST NOT** be fabricated server-side —
+  that copy is the web's job, slice 2 task 2.7). The converse does **not** hold: the D13 orphan has
+  a non-null `IdTenant` and a null `NombreTenant`. *(UT-R1; design D14; Reconciliación 9)*
 - [x] 1.3 Modify `ServicioDeOrganizacion.ListarTenantsAsync` — three correlated `Count()` subqueries
   in the same `Select`. The `"BajaLogica"` filter applies inside the LINQ tree, so deleted children
   are excluded **for free** (assert it, do not assume it, task 1.9). `CantidadUsuarios` counts only
@@ -329,19 +349,36 @@ excludes ("if you cannot name a clause this change introduces, it is ordinary co
 
 ### Slice 1 delivery notes
 
-- **BUDGET OVERFLOW, REPORTED RATHER THAN ABSORBED.** Slice 1 landed at **947 authored changed
-  lines of code** (914 additions + 33 deletions over `src/` and `tests/`; the `openspec/` artifacts
-  are excluded from the threshold), against the estimate of **~390** and the operative budget of
-  **800** (OD1). **The estimate was wrong, not the implementation.** 766 of those lines are one
-  net-new file, `tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs`, with **zero
-  deletions**: 517 lines of code, 106 of doc-comment and 36 of inline comment. The task list asks
-  for seven integration tests, one of which (1.11) must read back **35 positional fields** across
+- **BUDGET OVERFLOW, REPORTED RATHER THAN ABSORBED — AND THE OWNER RULED IT SHIPS AS ONE PR.**
+  The figures below are measured with `git diff main --stat -- src tests`; the `openspec/` artifacts
+  are excluded from the threshold. The estimate was **~390** and the operative budget **800** (OD1).
+  **The estimate was wrong, not the implementation.**
+
+  **Orchestrator decision, recorded verbatim:** *slice 1 ships as ONE PR at 1285 changed lines
+  against the 800-line budget (OD1), because production is only ~176 lines and the ~1085 test lines
+  are the evidence round 1's review demanded for exactly those 176 — splitting would separate the
+  proof from the claim and buy two more review cycles for no gain in review quality. The owner was
+  told the corrected number and offered the split.*
+
+  Measurement history, so no number in this file is stale:
+  - **After round 1** (the figures the decision above was taken on): **1285 changed lines**
+    (1252 insertions + 33 deletions), `ProyeccionDeOrganizacionTests.cs` at **1076 lines** with
+    **11 `[Fact]` methods**.
+  - **After round 2** (final): **1420 changed lines** (1386 insertions + 34 deletions), of which
+    production is **217** (185 + 32) across four files and tests are **1203**;
+    `ProyeccionDeOrganizacionTests.cs` is **1194 lines** with **12 `[Fact]` methods**, zero
+    deletions. The delta is round 2's own corrections: the fourth explicit `DeletedAt == null`
+    predicate set, the organization orphan readback test, and the reconciliation/doc-comment
+    honesty fixes. The decision does not change — the ratio it rests on (small production surface,
+    large demanded evidence) only got more pronounced.
+
+  The task list asks for tests one of which (1.11) must read back **35 positional fields** across
   four DTOs, and each of which must carry its named clause and its mutation rationale in the file.
-  The production change is only **172 changed lines** across four files. **No split point was
-  pre-authorized for slice 1**, so this is an orchestrator decision, not an apply-phase one: the
-  natural cut, if one is wanted, is production + `ServicioDeOrganizacion` tests (1.7-1.10) in PR 1a
-  and the `UsuarioListado` projection + tests (1.11-1.13) in PR 1b. Trimming the doc-comments to
-  fit was rejected: they are exactly the content a reviewer needs to check the mutation argument.
+  **No split point was pre-authorized for slice 1**, so this was an orchestrator decision, not an
+  apply-phase one: the natural cut, had one been wanted, was production + `ServicioDeOrganizacion`
+  tests (1.7-1.10) in PR 1a and the `UsuarioListado` projection + tests (1.11-1.13) in PR 1b.
+  Trimming the doc-comments to fit was rejected: they are exactly the content a reviewer needs to
+  check the mutation argument.
 
 - **Detail/edit endpoints re-project after writing.** `Obtener*`/`Actualizar*`/`Suspender`/
   `Reactivar` return the same listing records, and the counters and owner names do not live on the
@@ -377,6 +414,61 @@ excludes ("if you cannot name a clause this change introduces, it is ordinary co
   punto de venta. Killed by M9. (6) The `NombreTenant` doc-comments claimed null **iff** `IdTenant`
   is null, which is false for the D13 orphan; both `Contratos.cs` and `NombreDeTenantAsync` now
   state the two real cases. The "never fabricate `Plataforma`" rule is unchanged.
+
+- **Judgment-day, ronda 2 (task 1.15, FINAL round): seven items, seven fixes, four mutations RUN
+  and all four SURVIVED — recorded as survivors, not dressed up as kills.** (R2-1) The false `iff`
+  was still binding in the artifacts even though round 1 fixed the
+  two code doc-comments: registered as **Reconciliación 9** and task 1.2's wording now points at it;
+  `specs/usuarios-tenant-scoping/spec.md` is left **byte-identical**, the same handling
+  Reconciliación 1 and 8 give their superseded sentences. (R2-2) Round 1's `t.DeletedAt == null`
+  hardening was applied only to `ServicioDeUsuarios.ListarAsync`; the three owner-name subqueries of
+  `ServicioDeOrganizacion` and `ServicioDeUsuarios.NombreDeTenantAsync` still leaned on the ambient
+  filter. All four now carry the explicit predicate, with the rationale written once at
+  `ProyeccionDeEmpresa`. **NO mutation evidence is claimed for any of the four predicates, and the
+  new test says so in its own doc-comment.** The four mutations were nevertheless RUN
+  rather than reasoned about, per `mutation-proof-tests` rule 2 — each predicate deleted in turn,
+  rebuilt, `ProyeccionDeOrganizacionTests` run alone, **12/12 green every time**, then reverted:
+  `t.Id == e.IdTenant && t.DeletedAt == null` → `t.Id == e.IdTenant` **SURVIVED**;
+  `t.Id == p.IdTenant && t.DeletedAt == null` → `t.Id == p.IdTenant` **SURVIVED**;
+  `e.Id == p.IdEmpresa && e.DeletedAt == null` → `e.Id == p.IdEmpresa` **SURVIVED**; and in
+  `NombreDeTenantAsync`, `t.Id == id && t.DeletedAt == null` → `t.Id == id` **SURVIVED** (the
+  `GET /api/usuarios/{id}` arm of
+  `UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos` is the path that
+  clause serves, and it stayed green). That is the
+  expected outcome and the reason the finding was defence-in-depth, not a live defect: no
+  organization path strips `"BajaLogica"` today, so the ambient filter produces the identical
+  result and the clause has nothing of its own to prove yet. They are defence-in-depth for slice 4's
+  deletion writers, and the new
+  `LosHuerfanosDeOrganizacionSeRindenIgualPorElListadoYPorElDetalle` pins the expected D13 behaviour
+  (orphan visible with a null owner name, by listing AND by detail, for all three subqueries) so
+  slice 4 has something to mutate against. (R2-3) `ProyectarTenantAsync` had become byte-identical to
+  the public `ObtenerTenantAsync` after the C3 fix; the helper is deleted and the two write paths
+  call the public method, behaviour identical. (R2-4) The stale line counts in `state.yaml` and in
+  the budget note are replaced by measured figures and the orchestrator's verbatim one-PR decision.
+  (R2-5) `Assert.True(tenant.Id > 4)` passed by a margin of one that came from the production seed
+  the test never establishes: both occurrences now assert `Assert.DoesNotContain(tenant.Id,
+  ContadoresSembrados)`, and the bound is guaranteed by the test's own seeding — `TenantsDeRelleno`
+  is defined as the largest seeded counter, so the tenant under test lands strictly above all three
+  by monotonicity of the identity sequence. (R2-6) The organization readback test's doc-comment
+  claimed a mutation ("replacing the projection body with constants survived the whole suite") that
+  is false — `ProyeccionDeTenant` is the same expression object task 1.11 already reads back through
+  the listing. Corrected to its real added value: **endpoint wiring**, proving the four non-listing
+  routes return that projected record and not one built differently. No mutation is claimed and the
+  M table still lists none for it. (R2-7) M9's "cualquiera sea la fila que elija la base" was
+  stronger than SQL semantics guarantee for an unordered `FirstOrDefault`; softened to what was
+  actually observed (RED on this engine), with the theoretical gap named.
+
+- **CARRIED FORWARD TO SLICE 4, deliberately not patched in round 2.** Round 1's fix (3) made the
+  re-projection after `SaveChangesAsync` return a domain **404** instead of a 500 when the row went
+  invisible between write and re-read (`ServicioDeOrganizacion.ObtenerTenantAsync` as called by
+  `ActualizarTenantAsync`/`CambiarEstadoTenantAsync`, and the empresa/PV equivalents). That means a
+  caller can receive `404` for a write that **did** persist. It is **unreachable today** — no
+  soft-delete writer exists for tenants, empresas or puntos de venta — and the correct fix is a
+  **transaction boundary around write + re-projection**, not a patch to the re-read. **Slice 4 owns
+  it**: its design must decide whether the write and its re-projection share one transaction (so the
+  response can never contradict what was committed) or whether the write paths return the entity
+  they already hold instead of re-reading. Task 4.x must close this explicitly and say which of the
+  two it chose; leaving it as-is is not a valid outcome once the deleters exist.
 
 ---
 
@@ -576,6 +668,21 @@ confound). Do **not** add creation endpoints. This latency is reported to the ow
 
 **BINDING — OD6.** A cascade-deleted admin gets **401 `credenciales_invalidas`**, not 403. The
 `tenant-organization` scenario claiming 403 is superseded (Reconciliación 1).
+
+**BINDING — INPUT CARRIED FROM SLICE 1 (judgment-day ronda 2).** Slice 1's write paths
+(`ActualizarTenantAsync`, `CambiarEstadoTenantAsync`, `ActualizarEmpresaAsync`,
+`ActualizarPuntoVentaAsync`) **re-project after `SaveChangesAsync`** and return a domain `404` when
+the row went invisible between the write and the re-read — so a caller can get `404` for a write that
+persisted. That is unreachable until **this slice** adds the deleters, which is why it was not
+patched in slice 1's round 2. **This slice must close it deliberately** and record which of the two
+options it took: (a) put the write and its re-projection inside **one transaction**, or (b) have the
+write paths return the record they already hold instead of re-reading. Also add the **four**
+explicit `DeletedAt == null` predicates slice 1 shipped as defence-in-depth
+(`ServicioDeOrganizacion.ProyeccionDeEmpresa` ×1 and `ProyeccionDePuntoVenta` ×2,
+`ServicioDeUsuarios.NombreDeTenantAsync` ×1) to the U-row conjunct enumeration: each one **survived
+its mutation in round 2** because nothing strips `"BajaLogica"` on those paths today, and a
+deletion writer is exactly what makes them reachable — each one then needs its own kill. Leaving
+either item as-is is not a valid outcome for this slice.
 
 **BINDING — OD4.** A soft-deleted dependent still blocks (task 4.11).
 

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -324,7 +324,7 @@ mutation was then reverted (`git checkout --`) and the test observed GREEN again
 | M6 | 1.12 | The API never fabricates the `"Plataforma"` literal (S1/D14) | `… .FirstOrDefault() ?? "Plataforma"` in `ServicioDeUsuarios.ListarAsync` | `ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma` — `Assert.Null() Failure: Value is not null / Actual: "Plataforma"` |
 | M7 | 1.15 (ronda 1, hallazgo 1) | The **explicit** `t.DeletedAt == null` of the usuarios subquery — `IgnoreQueryFilters` is query-level, so `incluirEliminados=true` also stripped the filter from the correlated subquery | `.Where(t => t.Id == u.IdTenant && t.DeletedAt == null)` → `.Where(t => t.Id == u.IdTenant)` | `UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos` — `Assert.Null() Failure: Value is not null / Actual: "Huerfano-A-252cafab"`, on the `incluirEliminados=true` path only (the default listing and the detail stayed green — that is the discrepancy the finding named) |
 | M8 | 1.15 (ronda 1, hallazgo 2) | `ServicioDeUsuarios.NombreDeTenantAsync` — the source of `NombreTenant` on **every** non-listing path (`ObtenerAsync`, the `POST` 201 body, the `PUT` body) | body replaced by `return null;` (keeping one instance read so CA1822 does not mask the mutant) | `ElAltaElDetalleYLaEdicionDeUsuarioDevuelvenLosDiezCamposProyectados` — `Assert.Equal() Failure: Strings differ / Expected: "Detalle-usuario-8dc6ccae" / Actual: null`, on the **201 body** of `POST /api/usuarios`. Before this round the same mutation left the entire suite green |
-| M9 | 1.15 (ronda 1, hallazgo 5) | The `e.Id == p.IdEmpresa` correlation of `RazonSocialEmpresa` — needs a sibling of the **same owner** (`mutation-proof-tests` rule 12c) | `.Where(e => e.Id == p.IdEmpresa)` → `.Where(e => e.IdTenant == p.IdTenant)` | `LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios` — `Assert.Equal() Failure: Strings differ / Expected: "Norte Anexo SRL" / Actual: "Norte SRL"`. The kill is deterministic: the tenant now owns two empresas with two puntos de venta, so whichever row the base picks, one of the two assertions fails |
+| M9 | 1.15 (ronda 1, hallazgo 5) | The `e.Id == p.IdEmpresa` correlation of `RazonSocialEmpresa` — needs a sibling of the **same owner** (`mutation-proof-tests` rule 12c) | `.Where(e => e.Id == p.IdEmpresa)` → `.Where(e => e.IdTenant == p.IdTenant)` | `LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios` — `Assert.Equal() Failure: Strings differ / Expected: "Norte Anexo SRL" / Actual: "Norte SRL"`. Observed RED when run; the kill is NOT claimed as universal — an unordered `FirstOrDefault` owes nobody the same row on every correlated evaluation, so in theory the mutant could hit both empresas correctly. Softened here to match the test doc-comment (R2-7) |
 
 **Task 1.13 carries NO mutation evidence, and that is stated rather than papered over.** It is a
 **regression** test over behaviour this slice does not add: tenant scoping on `GET /api/usuarios`
@@ -336,7 +336,7 @@ excludes ("if you cannot name a clause this change introduces, it is ordinary co
 
 1. `Assert.True(tenant.Id > 4)` in task 1.11 was **order-dependent**: on a container where only
    that test ran, the tenant id was 3 and the assertion failed for a reason unrelated to any
-   mutation. Fixed by seeding three **deliberately unbalanced** filler tenants first (different
+   mutation. Fixed by seeding four **deliberately unbalanced** filler tenants first (`TenantsDeRelleno`, defined as the largest seeded counter) (different
    numbers of empresas, puntos de venta and usuarios each), which desynchronises the four identity
    sequences. That is what makes `id`, `idTenant` and `idEmpresa` pairwise distinct **by
    construction** instead of by luck — the exact condition rule 12b needs to kill a swap.
@@ -668,6 +668,32 @@ confound). Do **not** add creation endpoints. This latency is reported to the ow
 
 **BINDING — OD6.** A cascade-deleted admin gets **401 `credenciales_invalidas`**, not 403. The
 `tenant-organization` scenario claiming 403 is superseded (Reconciliación 1).
+
+**BINDING — INPUTS CARRIED FROM SLICE 1 (judgment-day FINAL re-judgment).** Three items were
+confirmed by both judges after the two permitted correction rounds were spent. None has user impact
+today; all three become reachable exactly when this slice adds the deletion writers, so this slice
+closes them deliberately rather than inheriting them silently.
+
+1. **The three `Count` subqueries of `ProyeccionDeTenant` are not hardened.**
+   `ServicioDeOrganizacion.cs:40-42` (`db.Empresas.Count`, `db.PuntosVenta.Count`,
+   `db.Usuarios.Count`) still lean on the ambient `"BajaLogica"` filter, while the four owner-name
+   subqueries carry an explicit `DeletedAt == null` after R2-2. Worse, the file now states two
+   contradictory rules for the identical risk: the doc-comment at `:29-34` says no explicit
+   predicate is needed, and the one at `:116-120` says the opposite. Round 1's M3 already observed
+   this exact mechanism firing on a counter. **This slice must harden the three counters and
+   reconcile the two doc-comments into one rule.**
+2. **Four production predicates ship with four SURVIVING mutants.** `mutation-proof-tests`'s
+   decision gate says a clause whose deletion the suite survives must be **re-routed below the
+   confound, never called done**. Today no path strips the ambient filter, so no RED is reachable
+   and the surviving mutants were honestly recorded rather than dressed up — but the debt is real.
+   **This slice makes them provable**: the deletion writers are the reachable path, so each of the
+   four predicates gets a real kill here, or the predicate is removed as unprovable. Do not carry a
+   third unproven round.
+3. **`TenantsDeRelleno = UsuariosDelTenantLeido` is an unenforced coincidence.**
+   `ProyeccionDeOrganizacionTests.cs:45-50` guarantees the tenant under test outranks every seeded
+   counter only because `4` happens to be the maximum of `{2, 3, 4}`. Lowering that const or raising
+   a sibling silently breaks the bound with no compile-time or runtime check. **Tie it to the actual
+   maximum** when this slice next touches that fixture.
 
 **BINDING — INPUT CARRIED FROM SLICE 1 (judgment-day ronda 2).** Slice 1's write paths
 (`ActualizarTenantAsync`, `CambiarEstadoTenantAsync`, `ActualizarEmpresaAsync`,

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1,0 +1,787 @@
+# Tasks: Stage 20 — Organization relationships and usage-guarded logical deletion
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2 160 across 5 slices (slice 1 ~390 · slice 2 ~430 · slice 3 ~470 · slice 4 ~530 · slice 5 ~340) |
+| 800-line budget risk | **Low** — every slice sits at roughly half the 800-line cap; three split points are pre-authorized |
+| Chained PRs recommended | **Yes** |
+| Suggested split | PR 1 (projection API) → PR 2 (projection web) → PR 3 (the inert guard) → PR 4 (deletion API) → PR 5 (deletion web) |
+| Delivery strategy | auto-chain |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+800-line budget risk: Low
+
+**Both budget lines are stated on purpose, and they do not contradict each other.** The literal
+`400-line budget risk` line is the guard contract's default budget: against 400, three of the five
+slices (430, 470, 530) overflow, so the honest value is **High** — which is precisely why OD1 raised
+the budget for this change. Against the configured `review_budget_lines: 800` (`state.yaml:8`,
+OD1), every slice sits at roughly half the cap and the risk is **Low**. The operative budget for
+this change is **800**.
+
+The DB gate is **ZERO-SCHEMA-RATIFIED** (`state.yaml:9-55`), so no owner decision blocks slice 1.
+The three arbitrations the orchestrator took after design (OD4, OD5, OD6) are transcribed below and
+are binding on every slice. Slice 4 carries the only inflators: its test matrix and the **budgeted**
+relocation of the `EliminarAsync` cases out of the InMemory-backed Application suite (design fact 9,
+D12) — the estimate above already includes both, which is why slice 4 is ~530 and not design's ~490.
+
+**Skill applicability, stated up front.** `mutation-proof-tests` (every test whose purpose is proving
+one specific clause ships with recorded mutation evidence: mutate, watch it fail, revert) ·
+`dto-contract-honesty` (every field added to a DTO has exactly one fate) · `web-descriptor-tests`
+(colocated Vitest tests for descriptors and mapping helpers) · `react-async-state` (token/generation
+gating and a full-window disabled state) · `work-unit-commits` · `judgment-day` before every PR.
+**`db-error-backstops` is STRUCTURALLY N/A for this change**: B1 forbids physical deletion, every FK
+is `DeleteBehavior.Restrict`, and `Restrict` contributes exactly zero protection against
+`UPDATE … SET deleted_at`, so no Postgres SQLSTATE can ever fire on any path this stage adds. There
+is no branch to add to `ManejadorDeErrores.cs`, and its untouched state is verify criterion V6. The
+consequence must be said out loud: **the application guard is the sole line of defence and its tests
+carry the entire safety argument.**
+
+## Orchestrator arbitrations carried into these tasks (binding, do not reopen)
+
+| # | Arbitration | Effect on the task list |
+|---|---|---|
+| **OD4** | **A soft-deleted dependent STILL BLOCKS.** Design's T3 recorded a pending owner ruling; it is now ruled in favour of the proposal and the spec (`bajas-de-organizacion` → *A Soft-Deleted Dependent Still Blocks*) | The guard emits **no** `AND d.deleted_at IS NULL` conjunct on any branch. Task 3.10 asserts its absence and task 4.11 proves the behaviour end to end. Recorded as a **one-line reversible knob** in `InspectorDeUso`'s doc-comment: reversing it means adding that conjunct per branch, flipping task 4.11's test, and regenerating N3's golden. **Not in tension with S2** — the usage guard counts history (deleted dependents count), the structural minimum counts live siblings (deleted siblings do not) |
+| **OD5** | **Ways has no endpoint that creates a second empresa or punto de venta**, so the structural minimum fires on **every** empresa/PV delete through the API. `empresa_en_uso` and `punto_venta_en_uso` are provable **only below the API layer** | **No API-level integration test may be written for those two codes** — it would pass for the wrong reason (`mutation-proof-tests` rule 3). Task 4.13 and task 4.9's empresa/PV halves are written at the service/integration layer with a hand-seeded second empresa/PV. **No creation endpoint is added**: scope is deliberately not expanded. The latency **must be reported to the owner at delivery** (task 5.12) |
+| **OD6** | **A cascade-deleted admin gets `401 credenciales_invalidas`, not `403 tenant_suspendido`** | Task 4.17 implements design's version. The `tenant-organization` spec scenario *"A deleted tenant's user cannot log in and gets a clean 403"* is **superseded**: the property it protects (cannot log in, cleanly, no crash) is preserved, only the code differs. The 403 branch stays reachable for a **suspended** tenant and is asserted unchanged as a regression |
+
+## Reconciliaciones
+
+1. **`tenant-organization` spec scenario "…gets a clean 403" is superseded by OD6.** The scenario is
+   left byte-identical in the spec (deltas of this change must not be edited mid-flight without a
+   record); the deviation is registered here and re-asserted in task 4.17, which ships **two** tests:
+   `401 credenciales_invalidas` for a cascade-deleted admin, `403 tenant_suspendido` for a suspended
+   tenant. Verify must read the spec scenario through this reconciliation.
+2. **Design's T3 is closed by OD4, not left open.** Every occurrence of *"needs an owner ruling
+   before slice 3 is written"* in `design.md:506-512` is resolved: implement the proposal's direction
+   (blocks). No task may emit the `AND d.deleted_at IS NULL` variant.
+3. **Design's T1 is closed by OD5 as an accepted latency, not a scope expansion.** Empresa/PV
+   deletion ships **latent** — correct, tested below the API, and unreachable through the API until
+   creation endpoints exist. Same shape as `EstadoTenant.Baja`, which shipped in stage 1 and waited
+   until this stage for its writer.
+4. **Design's T4 (the completeness test cannot exist as written) is adopted as the four nets N1-N4.**
+   The spec's requirement *"Every Referencing Type Is Classified Into Exactly One Bucket Or The Build
+   Fails"* is delivered by N1 (totality — `Construir` throws **naming** the type and the FK on the
+   three mechanical impossibilities), N2 (the bucket is read off the **table**, not restated from the
+   code), **N3 (the checked-in sorted inventory golden — the actual trip-wire)** and N4 (pristine
+   regression). A `Desconocido` bucket that throws at request time is explicitly **rejected**: it
+   converts a future stage's omission into a production 500 instead of a red test. This is a
+   **substitution recorded, not silently performed**.
+5. **Test relocation is budgeted, not discovered.** The guard's raw SQL cannot run on the InMemory
+   provider, so the `EliminarAsync` cases of `ServicioDeOrganizacionTests` and `ServicioDeUsuariosTests`
+   move to `tests/Ways.IntegrationTests` (the exact `ServicioDeOfertas.ActualizarAsync` precedent).
+   Accounted for in slice 4's ~530-line estimate; task 4.7 owns it.
+6. **U1-U8 (design's guarded-write conjunct enumeration, `design.md:383-398`) are transcribed to
+   slice 4**, the slice that owns every one of those statements, per `mutation-proof-tests` rule 3
+   ("up front, before any test is written"). Each conjunct is paired with its own task-level kill.
+7. **The `sdd-tasks` 530-word size budget is overridden, registered rather than silently exceeded.**
+   The binding project precedent is the archived stage-17/18/19a `tasks.md` shape (per-slice headers,
+   binding verify criteria, the U-row conjunct table, per-task requirement links), which the launch
+   prompt named as the structure to match and which `design.md:66-69` already recorded overriding for
+   the same reason. A 530-word checklist cannot carry OD4/OD5/OD6, N1-N4, U1-U8 and the ZERO-SCHEMA
+   criteria without dropping load-bearing content, and dropping it is what verify would then have to
+   reconstruct by archaeology.
+
+## Binding Verify Criteria (all slices)
+
+Carried from `design.md:451-473` and `state.yaml`'s ratified gate. **None may be relaxed by any
+slice**, and every slice re-asserts V1-V6 (they are invariants of the whole stage, not of one PR).
+
+1. **Zero new files** under `src/Ways.Infrastructure/Persistencia/Migraciones/` — the last migration
+   is and stays `20260822002214_FiscalArcaEtapa19a.cs`.
+2. `dotnet ef migrations has-pending-model-changes` **clean**.
+3. `src/Ways.Infrastructure/Persistencia/InicializadorDeBaseDeDatos.cs` **untouched**
+   (`git diff --exit-code`).
+4. **Zero physical deletes**: repository scan for `ExecuteDelete`, `ExecuteDeleteAsync`, `Remove(`,
+   `RemoveRange(` and `DELETE FROM` over `tenants`, `empresas`, `puntos_venta`, `usuarios`.
+5. `src/Ways.Api/Seguridad/Politicas.cs` **untouched** — zero new policies; all four DELETEs reuse
+   the policy of the group they already belong to.
+6. `src/Ways.Api/Seguridad/ManejadorDeErrores.cs` **untouched** — no SQLSTATE branch, because none
+   can fire (`db-error-backstops` N/A).
+7. `IWaysDbContext.cs` gains **exactly one** member (`IModel Model { get; }`) and **zero**
+   implementations change (`rg ": IWaysDbContext"` over `src/` and `tests/` returns zero matches).
+8. **N3's golden is checked in and green**; any regeneration inside a PR is accompanied by a written
+   classification decision for each changed line.
+9. Each of the four list endpoints performs **exactly one** database round trip (`ContadorDeComandos`).
+10. `InspectorDeUso` has **zero callers** in the slice-3 diff (`rg` over `src/`).
+11. Mutation evidence recorded in the PR body for **every** U-row belonging to that slice; structural
+    rows record the file/state/definition assertion instead of a runtime failure, **and say so**.
+12. Domain / Application / Integration / Vitest suites green; `npm run build` (typecheck), `npm run
+    lint` and `dotnet build Ways.slnx` clean.
+13. **Zero** `CREATE`/`ALTER`/`DROP`/`INSERT`/`UPDATE`-DDL statements anywhere in the diff outside the
+    guard's generated read-only `SELECT`.
+
+## Test commands (a task is not done until its tests pass)
+
+| Command | When |
+|---|---|
+| `dotnet build Ways.slnx` | after every production edit |
+| `dotnet test tests/Ways.Domain.Tests/Ways.Domain.Tests.csproj` | slices 1, 3, 4 (non-regression) |
+| `dotnet test tests/Ways.Application.Tests/Ways.Application.Tests.csproj` | slices 1, 3, 4 |
+| `dotnet test tests/Ways.IntegrationTests/Ways.IntegrationTests.csproj` | slices 1, 4 |
+| `npm --prefix src/Ways.Web run test` | slices 2, 5 |
+| `npm --prefix src/Ways.Web run build` | slices 2, 5 — **this is also the typecheck** |
+| `npm --prefix src/Ways.Web run lint` | slices 2, 5 |
+
+> **Integration suite discipline (binding).** `Ways.IntegrationTests` requires Docker. **NEVER run
+> two integration suites concurrently against the same Docker daemon** — the fixture sets a
+> process-level environment variable and every class shares
+> `[Collection("Ways.IntegrationTests secuencial")]`. Capture the `.trx` on any suspected flake.
+
+## Per-slice delivery ritual (apply MUST follow this, per slice, in order)
+
+1. Implement the slice's tasks on its own branch, cut from `main` (**stacked-to-main**).
+2. Run every relevant test command above until **all green**.
+3. Run the **`judgment-day`** protocol: two independent blind review agents judge the diff, verdicts
+   are compared, confirmed issues are fixed, the diff is re-judged. **Iterate until a clean round**
+   (no confirmed issues).
+4. Only then create the PR (`branch-pr` skill, conventional commits, **no AI attribution, no
+   `Co-Authored-By`**), with the slice's mutation evidence in the PR body (V11).
+5. Merge. Then, and only then, start the next slice.
+
+## Suggested Work Units
+
+Merge order `1 → 2 → 3 → 4 → 5`. **Slices 1-2 (Part A) and 3-5 (Part B) are independent by design**:
+Part A ships standalone value if Part B stalls, and slice 3 depends on nothing because it is inert.
+
+| Unit | Goal | Likely PR | Depends on | Focused test command | Runtime harness | Rollback boundary |
+|---|---|---|---|---|---|---|
+| 1 | Projection API: four DTOs, correlated-subquery projections, one-round-trip proof | PR 1 | — | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~ProyeccionDeOrganizacionTests"` | Testcontainers Postgres 17, `ways_app` role | Revert. DTO fields disappear; the web slice is not merged yet |
+| 2 | Projection web: mirrors, five pure helpers, name columns, counts, four filters, first Vitest files | PR 2 | 1 | `npm --prefix src/Ways.Web run test` | jsdom + RTL + `user-event`, `vi.mock('../api/cliente')` | Revert. The screens return to rendering ids |
+| 3 | The guard, **inert**: `IModel`, `InventarioDeDependientes`, `InspectorDeUso`, N1-N3, rendering suite | PR 3 | — | `dotnet test tests/Ways.Application.Tests --filter "FullyQualifiedName~InventarioDeDependientesTests\|FullyQualifiedName~InspectorDeUsoTests"` | **No container** — the real Npgsql model over an unopened connection (`Modelo*Tests.cs` pattern) | Revert. Nothing calls it; the guard cannot have run |
+| 4 | Deletion API: three routes, three `EliminarAsync`, cascade, minimums, `Usuario` guard, six 409s, N4, U1-U8, RLS, relocations | PR 4 | 1, 3 | `dotnet test tests/Ways.IntegrationTests --filter "FullyQualifiedName~BajasDeOrganizacionTests"` | Real Postgres 17 Testcontainer, `ways_app` (non-superuser, RLS-scoped), `RelojFijo` for the boundary pair | Revert removes three routes and one guard call. Rows already soft-deleted stay soft-deleted and hidden — a **pre-existing, supported state** |
+| 5 | Deletion web: buttons, confirmation, `codigo`→copy, `react-async-state` discipline ×4, docs 09/10 | PR 5 | 2, 4 | `npm --prefix src/Ways.Web run test` | jsdom + RTL | Revert removes buttons. The API still works; nobody can press it |
+
+**Pre-approved degradation**, in priority order: (1) slice 4 splits into `4a` (tenant + empresa +
+cascade + minimums, U1-U6) and `4b` (punto de venta + the `Usuario` guard + relocations, U7-U8);
+(2) slice 3 splits into `3a` (`IModel` + `InventarioDeDependientes` + N1-N3) and `3b`
+(`InspectorDeUso` + rendering); (3) slice 2 splits into `2a` (names and counts) and `2b` (filters).
+**Never degraded** (`state.yaml:409-415`): N1-N4, the two carve-out tests, the "one article blocks"
+test, and the zero-physical-delete scan.
+
+**Requirement tags used below.** `BO-Rn` = `specs/bajas-de-organizacion/spec.md` requirement *n* in
+document order · `TO-Rn` = `specs/tenant-organization/spec.md` ADDED requirement *n* · `UT-Rn` =
+`specs/usuarios-tenant-scoping/spec.md` ADDED requirement *n*.
+
+| Tag | Requirement |
+|---|---|
+| BO-R1 | Deletion Is Always Logical, Never Physical |
+| BO-R2 | The Pristine Discriminator Is A Strict Timestamp Comparison Against The Entity's Own CreatedAt |
+| BO-R3 | In Use Means Anything The Customer Created Beyond The Provisioning Baseline |
+| BO-R4 | The Dependent Set Is Discovered From EF Metadata, Never From A Hand-Maintained List |
+| BO-R5 | Every Referencing Type Is Classified Into Exactly One Bucket Or The Build Fails |
+| BO-R6 | There Are Exactly Two Carve-Outs, Each With A Written Reason And Its Own Test |
+| BO-R7 | A Soft-Deleted Dependent Still Blocks |
+| BO-R8 | A Shared-Catalog Row With A NULL Owner Does Not Block |
+| BO-R9 | Cascade Is Bounded To The Organization Projection And Shares One Instant |
+| BO-R10 | Structural Minimums Are Checked Before The Usage Guard, With Their Own Named Codes |
+| BO-R11 | The Complete 409 Code Set Is Exactly Six Codes |
+| BO-R12 | Deletion Never Becomes A Cross-Tenant Existence Oracle |
+| TO-R1 | Organization Listings Project Owner Names, Never Raw Ids |
+| TO-R2 | The Tenants Listing Carries Live Child Counts |
+| TO-R3 | The Root Screens Filter By Owner Over The Already-Loaded List |
+| TO-R4 | Platform Logical Deletion Surface For Tenant, Empresa And Punto De Venta |
+| TO-R5 | Tenant Deletion Is The Only Writer Of EstadoTenant.Baja |
+| UT-R1 | The Usuarios Listing Carries The Account's Tenant Identity |
+| UT-R2 | Usuario Deletion Gains The Usage Guard After PoliticaDeRoles, Never Instead Of It |
+
+`[P]` marks tasks that may run in parallel with the other `[P]` tasks of the same block. Everything
+not marked `[P]` is sequential and blocks what follows it in its slice.
+
+---
+
+## Slice 1: Projection API — owner names and child counts (PR 1)
+
+**Branch**: `feat/stage20-slice1-proyeccion-api`. **Start**: `main`. **Finish**: the four listing
+DTOs carry owner names and counts, projected as correlated subqueries inside the existing `Select`,
+each list endpoint still costing exactly one round trip. No web consumer yet (slice 2). **Depends
+on**: nothing. **Estimate**: ~390 lines. **Rollback**: revert — the DTO fields disappear and the web
+slice is not merged yet. **Skills**: `dto-contract-honesty` (every added field has exactly one fate),
+`mutation-proof-tests` (rules 12b/12c on the DTO readback), `work-unit-commits`.
+**`db-error-backstops`: N/A** (no SQLSTATE can fire on a read projection).
+
+**Binding note (D13).** `Empresa` and `PuntoVenta` carry **no navigation properties**
+(`Empresa.cs:9-26`), so owner names can only be **correlated scalar subqueries** — never
+`e.Tenant!.Nombre`. This also removes the INNER-JOIN-drops-the-row trap for free. The projected name
+is `string?` **on purpose**: an orphan renders as an anomaly instead of vanishing, which is what
+decouples slice 1 from slice 4's cascade and keeps Part A independently mergeable.
+
+- [x] 1.1 Modify `src/Ways.Application/Organizacion/Contratos.cs` — `TenantListado` gains
+  `int CantidadEmpresas, int CantidadPuntosVenta, int CantidadUsuarios`; `EmpresaListado` gains
+  `string? NombreTenant`; `PuntoVentaListado` gains `string? NombreTenant, string? RazonSocialEmpresa`.
+  **`dto-contract-honesty`**: each field's single consumer is a column in slice 2; the pre-existing
+  `EmpresaListado.IdTenant` and `PuntoVentaListado.IdTenant`/`.IdEmpresa` are **not** deleted — they
+  stop being rendered and become the **filter keys**, named here so a reviewer does not read them as
+  newly dead. *(TO-R1, TO-R2; design D13, Interfaces table)*
+- [x] 1.2 Modify `src/Ways.Application/Usuarios/Contratos.cs` — `UsuarioListado` gains
+  `int? IdTenant` and `string? NombreTenant`. **S1 is binding**: `NombreTenant` is `null` **iff**
+  `IdTenant` is `null`; the API **MUST NOT** fabricate the literal `"Plataforma"` — that copy is the
+  web's job (slice 2, task 2.7). *(UT-R1; design D14)*
+- [x] 1.3 Modify `ServicioDeOrganizacion.ListarTenantsAsync` — three correlated `Count()` subqueries
+  in the same `Select`. The `"BajaLogica"` filter applies inside the LINQ tree, so deleted children
+  are excluded **for free** (assert it, do not assume it, task 1.9). `CantidadUsuarios` counts only
+  usuarios of that tenant; platform staff (`IdTenant is null`) are counted under no tenant.
+  *(TO-R2; design D13)*
+- [x] 1.4 Modify `ServicioDeOrganizacion.ListarEmpresasAsync` — correlated scalar subquery for
+  `NombreTenant` (no navigation exists; fact 1). *(TO-R1)*
+- [x] 1.5 Modify `ServicioDeOrganizacion.ListarPuntosVentaAsync` — two correlated scalar subqueries
+  (`NombreTenant`, `RazonSocialEmpresa`). *(TO-R1)*
+- [x] 1.6 Modify `ServicioDeUsuarios`'s two listing projections (`:76-79`, `:90-92`) — `IdTenant`
+  passthrough plus the correlated `NombreTenant` subquery, both nullable. *(UT-R1)*
+- [x] 1.7 [P] Integration test: **exactly one** database round trip for each of
+  `GET /api/plataforma/tenants`, `GET /api/empresas`, `GET /api/puntos-venta`, `GET /api/usuarios`,
+  via `ContadorDeComandos` (the `VentasCheckoutTests:930` precedent). Four assertions, one per
+  endpoint. **Mutation**: split one projection into a second query, watch the count go to 2, revert.
+  *(TO-R1, TO-R2, UT-R1; verify criterion V9)*
+- [x] 1.8 [P] Integration test: the empresas listing carries the owning tenant's name and the puntos
+  de venta listing carries **both** owner names, with a **sibling row of another tenant** present in
+  every fixture (`mutation-proof-tests` rule 12c) so a projection that ignores the correlation is
+  killed. *(TO-R1)*
+- [x] 1.9 [P] Integration test: counts reflect surviving children only — logically delete one empresa
+  and one usuario and assert the counts drop; assert a platform account with `id_tenant IS NULL` is
+  counted under **no** tenant. *(TO-R2)*
+- [x] 1.10 [P] Integration test — **the orphan case**: an empresa whose tenant row is soft-deleted
+  still appears in the listing with `nombreTenant = null`. This is what makes slice 1 correct
+  **without** slice 4 and must not be weakened into an assumption. *(TO-R1; design D13)*
+- [x] 1.11 [P] Integration test: every **positional** field of the four listing DTOs read back with
+  **pairwise-distinct** values (`mutation-proof-tests` rule 12b), so a swapped record positional
+  argument is killed rather than surviving on equal values. *(TO-R1, TO-R2, UT-R1)*
+- [x] 1.12 [P] Integration test: a tenant usuario carries `idTenant = <its tenant>` and its tenant's
+  name; the seeded `root` account carries `idTenant = null` **and** `nombreTenant = null` — the API
+  never sends the literal `"Plataforma"`. *(UT-R1, S1)*
+- [x] 1.13 [P] Integration test (regression, unchanged behaviour): a tenant admin calling
+  `GET /api/usuarios` receives only their own tenant's rows and never another tenant's name.
+  *(UT-R1)*
+- [x] 1.14 GATE GUARD + non-regression — re-assert V1-V6 and V13 on this slice's diff (no migration
+  file, `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` /
+  `ManejadorDeErrores.cs` untouched, zero physical deletes, zero DDL). Full Domain + Application +
+  Integration suites green; `dotnet build Ways.slnx` clean.
+- [ ] 1.15 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a clean
+  round.
+- [ ] 1.16 Open PR 1 `feat/stage20-slice1-proyeccion-api` (`branch-pr`, conventional commits, no AI
+  attribution), record the mutation evidence for tasks 1.7-1.12 in the PR body (V11), merge to `main`
+  after the clean round.
+
+
+### Mutation evidence — slice 1 (`mutation-proof-tests` rule 2, produced, not reasoned)
+
+Every mutation below was applied to the tree, the named test was run and observed RED, and the
+mutation was then reverted (`git checkout --`) and the test observed GREEN again. Commands:
+`dotnet test tests/Ways.IntegrationTests/Ways.IntegrationTests.csproj --filter "FullyQualifiedName~<test>"`.
+
+| # | Task | Clause under test | Mutation applied | Observed failure |
+|---|---|---|---|---|
+| M1 | 1.7 | The owner name travels inside the same `Select` | `ListarEmpresasAsync` resolves `NombreTenant` from a second `db.Tenants.ToDictionaryAsync` query | `CadaListadoCuestaExactamenteUnaIdaALaBase` — `Assert.Equal() Failure: Values differ` (1 → 2 commands) |
+| M2 | 1.8 | The correlation `t.Id == e.IdTenant` | `db.Tenants.Select(t => t.Nombre).FirstOrDefault()` — correlation dropped | `LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios` — `Assert.Equal() Failure: Strings differ` (both empresas report the same tenant) |
+| M3 | 1.9 | The `"BajaLogica"` filter runs inside the correlated `Count` | `db.Usuarios.IgnoreQueryFilters(new[] { "BajaLogica" }).Count(...)` | `LosContadoresDelTenantCuentanSoloHijosVivosYNuncaAlPersonalDePlataforma` — `Expected: 1 / Actual: 2`. Note for the reviewer: EF applies `IgnoreQueryFilters` at **query** level, so the deleted *empresa* is the first count that stops dropping — the test still dies on exactly the clause it names (deleted children must not count), just on the first of the three |
+| M3b | 1.9 | The tenant correlation of `CantidadUsuarios` | `db.Usuarios.Count()` — correlation dropped, so platform staff would be counted | same test — `Assert.Equal() Failure: Values differ` |
+| M4 | 1.10 | The owner name is a correlated **subquery**, not a JOIN | `ListarEmpresasAsync` rewritten as `db.Empresas.Join(db.Tenants, …)` | `UnaEmpresaCuyoTenantFueDadoDeBajaSigueApareciendoConNombreDeTenantNulo` — `Assert.Single() Failure: The collection did not contain any matching items`; the orphan empresa vanished from the listing, which is precisely the trap D13 exists to avoid |
+| M5 | 1.11 | Positional argument order of `TenantListado` | `CantidadEmpresas` and `CantidadPuntosVenta` swapped in `ProyeccionDeTenant` | `CadaCampoPosicionalDeLosCuatroListadosSeLeeDeVueltaConValoresDistintos` — `Expected: 2 / Actual: 3` |
+| M6 | 1.12 | The API never fabricates the `"Plataforma"` literal (S1/D14) | `… .FirstOrDefault() ?? "Plataforma"` in `ServicioDeUsuarios.ListarAsync` | `ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma` — `Assert.Null() Failure: Value is not null / Actual: "Plataforma"` |
+
+**Task 1.13 carries NO mutation evidence, and that is stated rather than papered over.** It is a
+**regression** test over behaviour this slice does not add: tenant scoping on `GET /api/usuarios`
+comes from the EF `"Tenant"` query filter plus RLS, both pre-existing. Mutating them would be
+mutating infrastructure this slice never touches, which `mutation-proof-tests` rule 1 explicitly
+excludes ("if you cannot name a clause this change introduces, it is ordinary coverage").
+
+**Two test defects were found by running the mutations and were fixed, not rationalised:**
+
+1. `Assert.True(tenant.Id > 4)` in task 1.11 was **order-dependent**: on a container where only
+   that test ran, the tenant id was 3 and the assertion failed for a reason unrelated to any
+   mutation. Fixed by seeding three **deliberately unbalanced** filler tenants first (different
+   numbers of empresas, puntos de venta and usuarios each), which desynchronises the four identity
+   sequences. That is what makes `id`, `idTenant` and `idEmpresa` pairwise distinct **by
+   construction** instead of by luck — the exact condition rule 12b needs to kill a swap.
+2. The first draft of task 1.12 asserted S1's `iff` (`NombreTenant is null` ⟺ `IdTenant is null`)
+   over **every** row, and went red against the orphan row seeded by task 1.10. The `iff` is true
+   of the platform/tenant distinction but **not** of the orphan, which D13 deliberately renders
+   with a null name. The assertion now states the direction the API actually owes (no account
+   without a tenant carries a name, and no row carries the literal) and the doc-comment records
+   why the converse is not claimed.
+
+### Slice 1 delivery notes
+
+- **BUDGET OVERFLOW, REPORTED RATHER THAN ABSORBED.** Slice 1 landed at **947 authored changed
+  lines of code** (914 additions + 33 deletions over `src/` and `tests/`; the `openspec/` artifacts
+  are excluded from the threshold), against the estimate of **~390** and the operative budget of
+  **800** (OD1). **The estimate was wrong, not the implementation.** 766 of those lines are one
+  net-new file, `tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs`, with **zero
+  deletions**: 517 lines of code, 106 of doc-comment and 36 of inline comment. The task list asks
+  for seven integration tests, one of which (1.11) must read back **35 positional fields** across
+  four DTOs, and each of which must carry its named clause and its mutation rationale in the file.
+  The production change is only **172 changed lines** across four files. **No split point was
+  pre-authorized for slice 1**, so this is an orchestrator decision, not an apply-phase one: the
+  natural cut, if one is wanted, is production + `ServicioDeOrganizacion` tests (1.7-1.10) in PR 1a
+  and the `UsuarioListado` projection + tests (1.11-1.13) in PR 1b. Trimming the doc-comments to
+  fit was rejected: they are exactly the content a reviewer needs to check the mutation argument.
+
+- **Detail/edit endpoints re-project after writing.** `Obtener*`/`Actualizar*`/`Suspender`/
+  `Reactivar` return the same listing records, and the counters and owner names do not live on the
+  entity, so the only place they exist is the query. `ObtenerTenantAsync`/`ObtenerEmpresaAsync`/
+  `ObtenerPuntoVentaAsync` still cost **one** round trip (they project instead of loading the
+  entity, and validate scope on the projected `IdTenant`, preserving `BuscarX`'s 404-then-ADR-8
+  order); the four write paths cost one extra read. The single-round-trip budget of TO-R1/UT-R1 is
+  about the **listings**, which are what scale with row count. Alternative rejected: leaving the
+  new fields at `0`/`null` on the detail paths — that is exactly the accepted-and-dropped shape
+  `dto-contract-honesty` forbids.
+- **`WaysApiFixture.CrearContextoDeAplicacion` gained an optional `params IInterceptor[]`.** Zero
+  call sites changed; it is what lets task 1.7 count commands on a service call.
+- **No web file was touched** — `tipos.ts` mirrors land in slice 2, and adding fields to the JSON
+  payload is backward compatible for the screens as they stand.
+
+---
+
+## Slice 2: Projection web — names, counts and filters (PR 2)
+
+**Branch**: `feat/stage20-slice2-proyeccion-web`. **Start**: PR 1 merged. **Finish**: the four root
+screens render owner **names** and counts, never raw owner ids; three tenant filters and one empresa
+filter operate over the already-loaded list; the **first** Vitest files for these four screens exist.
+**Depends on**: slice 1 (the DTO fields). **Estimate**: ~430 lines. **Rollback**: revert — the
+screens return to rendering ids. **Skills**: `web-descriptor-tests` (colocated tests for the pure
+helpers), `dto-contract-honesty` (each mirrored field is consumed by exactly one column or filter),
+`work-unit-commits`.
+
+**Binding note (D15).** Filter option sets are derived from the **already-loaded rows**, never from a
+second fetch: `GET /api/plataforma/tenants` is `Politicas.SoloPlataforma` while `Empresas.tsx` and
+`PuntosVenta.tsx` are reachable by a tenant admin under `GestionDeOrganizacion`, so a fetch would 403
+for exactly the users the screen was built for. Deriving from the rows also makes an empty option set
+impossible by construction, and satisfies S5 (a filter can never disclose an out-of-scope tenant).
+
+- [ ] 2.1 Modify `src/Ways.Web/src/api/tipos.ts` — mirror the four DTO shapes from slice 1, with
+  `nombreTenant`/`razonSocialEmpresa`/`idTenant` nullable exactly as the server declares them.
+  *(TO-R1, TO-R2, UT-R1)*
+- [ ] 2.2 Modify `src/Ways.Web/src/api/organizacion.ts` — five **pure** helpers, no React, no fetch:
+  `opcionesDeTenant`, `opcionesDeEmpresa` (narrowed by the selected tenant), `filtrarPorTenant`,
+  `filtrarPorEmpresa`, `etiquetaDeTenant` (`null` → the literal `"Plataforma"`). *(TO-R3, UT-R1;
+  design D14, D15)*
+- [ ] 2.3 Modify `src/Ways.Web/src/api/usuarios.ts` — mirror `UsuarioListado`'s two new fields. The
+  `eliminar` call already exists and is **not** touched in this slice. *(UT-R1)*
+- [ ] 2.4 Modify `src/Ways.Web/src/paginas/Tenants.tsx` — three count columns (empresas, puntos de
+  venta, usuarios). *(TO-R2)*
+- [ ] 2.5 Modify `src/Ways.Web/src/paginas/Empresas.tsx` — tenant **name** column replacing the raw
+  integer at `:156`; tenant filter over the loaded list. *(TO-R1, TO-R3)*
+- [ ] 2.6 Modify `src/Ways.Web/src/paginas/PuntosVenta.tsx` — tenant name and empresa razón social
+  columns replacing the two integers at `:216-217`; tenant filter **and** empresa filter, where
+  selecting a tenant **narrows** the empresa options and **clears** an empresa selection that no
+  longer belongs to it. *(TO-R1, TO-R3; design D15)*
+- [ ] 2.7 Modify `src/Ways.Web/src/paginas/Usuarios.tsx` — tenant column rendering the tenant name,
+  or the literal **"Plataforma"** when `idTenant === null` (never an empty cell); tenant filter.
+  *(UT-R1, TO-R3; design D14)*
+- [ ] 2.8 [P] Create `src/Ways.Web/src/api/organizacion.test.ts` — **`web-descriptor-tests`**: one
+  case per helper branch — `opcionesDeTenant` dedup + ordering + the `null` option,
+  `opcionesDeEmpresa` narrowing to the selected tenant, `filtrarPorTenant`/`filtrarPorEmpresa`
+  including the "no selection" identity case, `etiquetaDeTenant`'s null branch. *(TO-R3, UT-R1)*
+- [ ] 2.9 [P] Create `src/Ways.Web/src/paginas/Tenants.test.tsx` — the three counts render from the
+  DTO, with pairwise-distinct values so a column swap is killed. *(TO-R2)*
+- [ ] 2.10 [P] Create `src/Ways.Web/src/paginas/Empresas.test.tsx` — the tenant **name** renders (not
+  the id); selecting a tenant narrows the rendered rows **with no additional network request**
+  (assert the mocked client's call count); clearing the filter restores the full loaded list.
+  *(TO-R1, TO-R3)*
+- [ ] 2.11 [P] Create `src/Ways.Web/src/paginas/PuntosVenta.test.tsx` — both owner names render;
+  selecting a tenant narrows the empresa select **and** clears an empresa that no longer belongs to
+  it; the empresa filter narrows the rows. *(TO-R1, TO-R3)*
+- [ ] 2.12 [P] Create `src/Ways.Web/src/paginas/Usuarios.test.tsx` — `"Plataforma"` renders for
+  `idTenant === null` and the tenant name renders otherwise; the tenant filter narrows the rows; a
+  single-tenant dataset offers exactly one tenant option (S5). *(UT-R1, TO-R3)*
+- [ ] 2.13 [P] Assertion across the four screen tests: **no cell presents `idTenant` or `idEmpresa`
+  as the owner's identity** — the raw ids survive only as `<select value>` filter keys.
+  *(TO-R1; Success Criterion "no raw owner id is displayed")*
+- [ ] 2.14 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`,
+  `npm --prefix src/Ways.Web run build` (typecheck) and `npm --prefix src/Ways.Web run lint` all
+  clean; re-assert V1-V6 on this slice's diff (a web-only slice must still touch zero migrations and
+  zero backend guard files).
+- [ ] 2.15 `judgment-day` round to a clean round.
+- [ ] 2.16 Open PR 2 `feat/stage20-slice2-proyeccion-web`, merge to `main` after the clean round.
+
+---
+
+## Slice 3: `InspectorDeUso` — the guard, deliberately INERT (PR 3)
+
+**Branch**: `feat/stage20-slice3-inspector-de-uso`. **Start**: `main` (this slice depends on
+**nothing** — it is inert by construction). **Finish**: `InventarioDeDependientes` (pure metadata
+walk, three buckets, exactly two carve-outs) and `InspectorDeUso` (statement rendering + raw-ADO
+execution) exist and are registered in DI, with **no caller anywhere in `src/`**; N1, N2 and N3 are
+green and N3's golden is checked in. **Depends on**: nothing. **Estimate**: ~470 lines. **Rollback**:
+revert — nothing calls it, so the guard cannot have run. **Skills**: `mutation-proof-tests` (rule 1:
+never assert a tautology — see Reconciliación 4), `work-unit-commits`. **`db-error-backstops`: N/A.**
+
+**Why this slice is inert.** There is no database backstop behind this guard (`db-error-backstops`
+structurally N/A), so it is shipped with no caller **on purpose**: it can be reviewed on its own
+merits before anything can invoke it. Verify criterion V10 asserts the zero-caller property.
+
+**OD4 is binding here.** No branch may emit `AND d.deleted_at IS NULL`. Record the reversal cost as a
+one-line knob in `InspectorDeUso`'s doc-comment (add the conjunct per branch, flip task 4.11's test,
+regenerate N3's golden) — record it, do not implement it.
+
+- [ ] 3.1 Modify `src/Ways.Application/Abstracciones/IWaysDbContext.cs` — add **exactly one** member,
+  `IModel Model { get; }`, with the doc-comment argument the interface itself supplies (`:150-152`:
+  `DatabaseFacade` is the same EF Core abstraction any `DbContext` already exposes). **Zero
+  implementation lines change** — `DbContext.Model` satisfies it implicitly and `rg ": IWaysDbContext"`
+  over `src/` and `tests/` returns zero matches. *(design D1, C; verify criterion V7)*
+- [ ] 3.2 Create `src/Ways.Application/Organizacion/InventarioDeDependientes.cs` — **pure**: no
+  database, no clock, no DI (D2), so N3's golden can be regenerated without a container.
+  `ClasificacionDeDependiente { Excluido, Marcado, SinMarca }`, `RamaDeUso(Tabla, Columnas,
+  PropiedadesDelPrincipal, Clasificacion)` with `UsaAncla => Clasificacion is Marcado`, and
+  `Construir(IModel, Type ancla)`. Classification is **per dependent entity type**, evaluated in the
+  fixed order carve-out → timestamped → untimestamped, and is **total by construction** (no runtime
+  `else` can throw). Branch predicates are built by zipping `fk.Properties` with
+  `fk.PrincipalKey.Properties`, so composite `(id, id_tenant)` and alternate-key FKs need no special
+  case, and `MovimientoStock` contributes **two** independent branches. *(BO-R4, BO-R5; design D3, A)*
+- [ ] 3.3 Same file — `Excluidos` as a `FrozenSet<Type>` with **exactly two** members,
+  `Ways.Domain.Auditoria.Auditoria` and `NumeracionCliente`, **each carrying its written reason in
+  code** (B5: the audit trail is a record *about* the entity and the referenced row survives logical
+  deletion; the provisioning counter is inserted by raw SQL in
+  `AsignadorDeNumeroCliente.AsegurarContadorAsync`, is not an `EntidadBase`, and is not customer
+  data). A carve-out emits **no branch at all**. *(BO-R6)*
+- [ ] 3.4 Same file — `Construir` throws `InvalidOperationException` **naming the CLR type and the
+  FK** for the three *mechanical* impossibilities: an entity type with no mapped table, a `Marcado`
+  type whose `created_at` column cannot be resolved, and an FK whose principal properties are not all
+  readable from the anchor. These are build-time failures via N1, **never** production 500s.
+  *(BO-R5; design A)*
+- [ ] 3.5 Create `src/Ways.Application/Organizacion/InspectorDeUso.cs` —
+  `PrimeraDependenciaEnUsoAsync(Type tipoAncla, IReadOnlyList<object> valoresDeClave,
+  DateTimeOffset ancla, CancellationToken)` returning the **name of the first blocking table** or
+  `null`. One statement: `UNION ALL` of `SELECT '<tabla>' AS tabla WHERE EXISTS (SELECT 1 FROM
+  <tabla> d WHERE <fk> = $n [AND d."created_at" > $m])` with an **outer `LIMIT 1`**. Raw ADO on the
+  **caller's** connection/transaction, opened through `Database.OpenConnectionAsync` so
+  `InterceptorDeContextoDeTenant` sets the RLS GUCs — **never** `Database.SqlQuery<T>` /
+  `FromSqlRaw` against this model (the stage-1 slice-2 trap). *(BO-R4, BO-R7; design D5, D6, D)*
+- [ ] 3.6 Same file — **injection surface closed**: identifiers come from `IEntityType`/`IProperty`
+  metadata only, are schema-qualified and double-quoted, and are **rejected by the generator** unless
+  they match `^[a-z_][a-z0-9_]*$`; every anchor key value and the anchor's `CreatedAt` is a bound
+  **parameter** (`ParametrosDeComando.Agregar`, the `AsignadorDeNumeroCliente` idiom). No
+  user-supplied string ever reaches the statement. *(design D, Threat Matrix)*
+- [ ] 3.7 Same file — doc-comment records **OD4 as a one-line reversible knob**: no
+  `AND d.deleted_at IS NULL` conjunct is emitted, a soft-deleted dependent still blocks, and
+  reversing it means adding that conjunct per branch, flipping task 4.11's test and regenerating
+  N3's golden. Also record **side effect B**: RLS lives on the connection, so it still applies, and
+  **no `id_tenant` conjunct is added** — an extra conjunct can only ever *narrow* the result, and a
+  narrowing bug under-blocks, the one direction this stage refuses. *(BO-R7; design D6, E, OD4)*
+- [ ] 3.8 Modify the DI module (`src/Ways.Api/Programa.cs` or its registration file) — register
+  `InspectorDeUso` **scoped**. **No caller until slice 4.** *(design File Changes)*
+- [ ] 3.9 **N1 — totality.** Create
+  `tests/Ways.Application.Tests/Persistencia/InventarioDeDependientesTests.cs`: `Construir(db.Model,
+  T)` succeeds for **all four** anchors (`Tenant`, `Empresa`, `PuntoVenta`, `Usuario`), and the
+  emitted branch count equals `GetReferencingForeignKeys().Count()` **minus** the carved-out FKs — no
+  FK is silently dropped. Built over the real Npgsql model on an **unopened** connection, the
+  existing `ModeloDeOrganizacionTests.cs:17-30` pattern: **no container**. *(BO-R5; never degradable)*
+- [ ] 3.10 **N2 — the rule is read off the TABLE, not restated from the code.** Same file: for every
+  branch, `rama.UsaAncla == entityType.GetProperties().Any(p => p.GetColumnName() == "created_at")`,
+  computed **independently in the test**. **Mutation**: change the classifier to key on
+  `EntidadTenant`, or invert it, or hardcode a type list — the test must go red each time. *(BO-R5;
+  never degradable)*
+- [ ] 3.11 **N3 — the inventory golden (THE TRIP-WIRE).** Same file plus
+  `tests/Ways.Application.Tests/Persistencia/Fixtures/inventario-de-dependientes.txt`: a **sorted,
+  checked-in** line per branch, `<ancla> | <tabla> | <columnas> | <bucket>`, including one `excluido`
+  line per carve-out so the file also pins the two-member carve-out set. Any FK a future stage adds,
+  removes, retargets or reclassifies produces a **diff naming the exact table and column**.
+  Regeneration is a deliberate edit that must be justified line by line in the PR body (V8). *(BO-R5,
+  BO-R6; never degradable — this is the executable form of the spec's completeness requirement)*
+- [ ] 3.12 [P] Assert the carve-out list contains **exactly** `Auditoria` and `NumeracionCliente` and
+  nothing else, and that neither contributes a branch for any of the four anchors. *(BO-R6)*
+- [ ] 3.13 [P] Create `tests/Ways.Application.Tests/Organizacion/InspectorDeUsoTests.cs` — statement
+  **rendering** (pure string assertions over `Construir` + the renderer): a `Marcado` branch carries
+  the `created_at > @ancla` conjunct with a **strict** `>`; a `SinMarca` branch carries **only**
+  `<fk> = @id`; a composite FK renders **two conjuncts**; an alternate-key principal reads its values
+  off the anchor; identifiers are quoted and schema-qualified; a non-conforming identifier is
+  **rejected**; the parameter count and binding order match the branch order; the outer `LIMIT 1` is
+  present. *(BO-R2, BO-R4, BO-R5)*
+- [ ] 3.14 [P] **OD4 rendering assertion**: no rendered branch contains `deleted_at`. This is the
+  cheap half of OD4 (the behavioural half is task 4.11). *(BO-R7; OD4)*
+- [ ] 3.15 [P] Rendering assertion for **BO-R8**: a nullable FK renders the plain `<fk> = @id`
+  predicate with no `IS NULL` special case — `fk = @id` simply does not match `NULL`, so a shared
+  catalogue row (`id_empresa IS NULL` on `Cliente`/`Proveedor`/`Oferta`/`ConfiguracionDeCatalogo<T>`)
+  cannot block an empresa. The behavioural proof is task 4.21. *(BO-R8)*
+- [ ] 3.16 **[S]** Structural: `rg` over `src/` proves `InspectorDeUso` has **zero callers** in this
+  slice's tree. Recorded as a file/state assertion, **not** a runtime kill. *(verify criterion V10)*
+- [ ] 3.17 **[S]** Structural: `IWaysDbContext.cs` gained **exactly one** member and
+  `rg ": IWaysDbContext"` over `src/` and `tests/` still returns zero hand-written implementations.
+  *(verify criterion V7)*
+- [ ] 3.18 GATE GUARD + non-regression — re-assert V1-V6 and V13 (the guard's generated statement is
+  the **only** SQL in the diff and it is read-only `SELECT`/`EXISTS`); Domain + Application suites
+  green; `dotnet build Ways.slnx` clean.
+- [ ] 3.19 `judgment-day` round to a clean round.
+- [ ] 3.20 Open PR 3 `feat/stage20-slice3-inspector-de-uso`, record N1/N2/N3 mutation evidence in the
+  PR body (V11), merge to `main` after the clean round.
+
+---
+
+## Slice 4: Deletion API — routes, cascade, minimums and the `Usuario` guard (PR 4)
+
+**Branch**: `feat/stage20-slice4-bajas-api`. **Start**: PRs 1 and 3 merged. **Finish**: three DELETE
+routes exist under existing policies, the guard has its first callers, the cascade shares one
+instant, the two structural minimums fire, `Usuario` deletion is guarded after `PoliticaDeRoles`, all
+six 409 codes are live, N4 is green and U1-U8 each have their kill. **Depends on**: slice 1 (nothing
+functional, but it is the merge order) and **slice 3** (the guard). **Estimate**: ~530 lines,
+including the budgeted test relocation. **Rollback**: revert removes three routes and one guard call;
+rows already soft-deleted stay soft-deleted and hidden — a **pre-existing, supported state**
+(`Usuario` has produced it since stage 1). **Skills**: `mutation-proof-tests` (rules 3, 5, 12c, 13,
+14), `work-unit-commits`. **`db-error-backstops`: N/A** — no constraint can fire, so there is no
+SQLSTATE to classify and `ManejadorDeErrores.cs` stays untouched (V6).
+
+**BINDING — OD5.** `empresa_en_uso` and `punto_venta_en_uso` are **unreachable through the API
+today** because no endpoint creates a second empresa or punto de venta, so the structural minimum
+fires first on every attempt. **Do NOT write API-level integration tests for those two codes.** They
+are proven at the service/integration layer with a hand-seeded second empresa/PV (below the
+confound). Do **not** add creation endpoints. This latency is reported to the owner at delivery.
+
+**BINDING — OD6.** A cascade-deleted admin gets **401 `credenciales_invalidas`**, not 403. The
+`tenant-organization` scenario claiming 403 is superseded (Reconciliación 1).
+
+**BINDING — OD4.** A soft-deleted dependent still blocks (task 4.11).
+
+**Guarded-write conjunct enumeration (`mutation-proof-tests` rule 3, up front, before any test is
+written)** — transcribed from `design.md:383-398`:
+
+| # | Statement | Conjuncts | The test that kills each |
+|---|---|---|---|
+| **U1** | `usuarios WHERE IdTenant == @id` (tenant cascade) | (a) `IdTenant == id` | A **sibling tenant** with its own admin: its usuario stays live, asserted by identity **and** by exact count (rule 12c) |
+| **U2** | `puntos_venta WHERE IdTenant == @id` | (a) `IdTenant == id` | Same sibling-tenant pair |
+| **U3** | `empresas WHERE IdTenant == @id` | (a) `IdTenant == id` | Same sibling-tenant pair |
+| **U4** | `puntos_venta WHERE IdEmpresa == @id` (empresa cascade) | (a) `IdEmpresa == id` | A **second empresa of the SAME tenant**, hand-seeded: its PV stays live |
+| **U5** | `COUNT(empresas WHERE IdTenant == @id)` (minimum) | (a) `IdTenant == id` | A sibling tenant's empresa must not be counted, or the minimum never fires |
+| **U6** | `COUNT(puntos_venta WHERE IdEmpresa == @id)` | (a) `IdEmpresa == id` | A sibling empresa's PV must not be counted |
+| **U7** | Guard branch, `Marcado` | (a) `<fk> = @id` · (b) `created_at > @ancla` **strict** | (a) a dependent of a **sibling** entity must not block. (b) **two kills**: a row created **exactly at** the anchor must **not** block (rule 14 boundary fixture under `RelojFijo`), and a row one tick later **must** block |
+| **U8** | Guard branch, `SinMarca` | (a) `<fk> = @id` only | Adding `AND created_at > @ancla` must fail (no such column); a `Stock` row for the PV blocks with no timestamp involved |
+
+### Implementation
+
+- [ ] 4.1 Create `src/Ways.Application/Organizacion/EtiquetasDeTablas.cs` — the label dictionary
+  (`comprobantes_venta` → *"ventas"*, `articulos` → *"artículos"*, …) with the fallback *"datos
+  cargados"* for an unmapped table. **This is not the hand list B4 forbids**: it decides only **how
+  to word** an already-decided block, so a missing entry costs a vaguer sentence, never a wrong
+  verdict. *(BO-R11)*
+- [ ] 4.2 Modify `ServicioDeOrganizacion` — `EliminarTenantAsync`, inside
+  `db.Database.CreateExecutionStrategy().ExecuteAsync` (**never** `BeginTransaction` outside it —
+  the ADR-16 trap), in this exact order: `pg_advisory_xact_lock(idTenant, -20)` → **re-read the
+  anchor under the lock** (404 if a concurrent delete won) → usage guard **evaluated ONCE, with no
+  pre-check** → `var momento = reloj.Ahora` → cascade writes + anchor write → **one**
+  `SaveChangesAsync` → COMMIT. **No pre-check**: `mutation-proof-tests` rule 3 names the
+  pre-check-mirroring-a-guard shape as this repository's most common confound; running the guard once
+  removes the confound instead of writing tests to defeat it. *(BO-R9, TO-R4; design D7, D11, F)*
+- [ ] 4.3 Same method — the tenant write sets `DeletedAt` **and** `Estado = EstadoTenant.Baja` in the
+  **same** `SaveChangesAsync` (two statements would admit an interleaving where the row is deleted but
+  still `activo`). This is the enum value's **first and only writer**; suspension and reactivation
+  keep refusing to touch it. *(TO-R5; design D10)*
+- [ ] 4.4 Same method — the cascade is `Where(hijo.IdTenant == id)` over **live rows only**, covering
+  `usuarios`, `puntos_venta` and `empresas`, all sharing the single `momento` on **both** `DeletedAt`
+  and `UpdatedAt`. **Write order is NOT claimed** — EF chooses statement order inside one
+  `SaveChanges`; atomicity is the property and one transaction delivers it. **S3**: an
+  already-deleted child keeps its **original** `deleted_at`, otherwise the restore-by-instant rule is
+  destroyed for the earlier deletion. The cascade **MUST NOT** extend to areas, medios de pago,
+  listas de precio, the Consumidor Final cliente or numeraciones. *(BO-R9; design D9, S3)*
+- [ ] 4.5 Same service — `EliminarEmpresaAsync`: same transaction/lock shape, with the **structural
+  minimum first** (`ultima_empresa_del_tenant` when the tenant has exactly one surviving empresa),
+  then the usage guard (`empresa_en_uso`), then the cascade to `puntos_venta WHERE IdEmpresa == @id`.
+  **S2**: the minimum's `COUNT` excludes logically deleted siblings. **S6**: when both a minimum and
+  usage apply, the **structural code wins**. *(BO-R10, BO-R9, TO-R4)*
+- [ ] 4.6 Same service — `EliminarPuntoVentaAsync`: structural minimum first
+  (`ultimo_punto_venta_de_la_empresa`), then the usage guard (`punto_venta_en_uso`). No children, no
+  cascade. *(BO-R10, TO-R4)*
+- [ ] 4.7 Same service — the class doc-comment's *"este servicio no crea ni elimina nada"* is
+  corrected; every refusal is raised as `ErrorDominio.Conflicto("<codigo_snake_case>", "<mensaje>")`
+  with the message built through `EtiquetasDeTablas` (Spanish copy, snake_case codes — OD2).
+  *(BO-R11)*
+- [ ] 4.8 Modify `src/Ways.Application/Usuarios/ServicioDeUsuarios.EliminarAsync` (`:296`) — insert
+  **one** guard call **after** `PoliticaDeRoles.ValidarPuedeIntervenirSobre` and **before** the
+  `DeletedAt` write, yielding `usuario_en_uso`. **NO transaction and NO lock** (D12): there is no
+  cascade, so the single-`momento` property is already satisfied by one `SaveChanges`, and the lock
+  closes no race it faces. Every existing rule is preserved verbatim — Root targets undeletable,
+  self-deletion forbidden, `ValidarAlcanceDeTenant`'s deliberate 404-not-403 (ADR-8) untouched, the
+  audit record still written. *(UT-R2, BO-R12)*
+- [ ] 4.9 Modify `src/Ways.Api/Endpoints/OrganizacionEndpoints.cs` — three `MapDelete`:
+  `/api/plataforma/tenants/{id}` under `Politicas.SoloPlataforma`, `/api/empresas/{id}` and
+  `/api/puntos-venta/{id}` under `Politicas.GestionDeOrganizacion` (note the deliberate asymmetry:
+  **reading** puntos de venta stays `LecturaDePuntosVenta` for the POS selector, **deleting** does
+  not). **`Politicas.cs` MUST stay untouched — zero new policies (V5).** The class doc-comment's
+  *"acá no hay `POST` ni `DELETE` a propósito"* (`:11-13`) is corrected. *(TO-R4)*
+- [ ] 4.10 **Budgeted relocation** — move the `EliminarAsync` cases of
+  `tests/Ways.Application.Tests/Organizacion/ServicioDeOrganizacionTests.cs` and
+  `tests/Ways.Application.Tests/Usuarios/ServicioDeUsuariosTests.cs` to
+  `tests/Ways.IntegrationTests/BajasDeOrganizacionTests.cs`: the guard's raw SQL **cannot run on the
+  InMemory provider** (design fact 9, the `ServicioDeOfertas.ActualizarAsync` precedent). Every
+  relocated case must keep asserting the **same** behaviour it asserted before — a relocation that
+  quietly weakens an assertion is a regression, and the PR body must state that each moved case is
+  behaviour-identical. *(UT-R2; Reconciliación 5)*
+
+### Tests (all in `tests/Ways.IntegrationTests/BajasDeOrganizacionTests.cs` unless stated)
+
+- [ ] 4.11 [P] **N4 — pristine regression (never degradable).** A **freshly provisioned** tenant, its
+  empresa, its punto de venta and its admin are **all pristine**. This is the only net that can see
+  the provisioning baseline drifting: it goes red the moment
+  `ServicioDeAprovisionamiento.cs:46`'s single-clock-reading property breaks, or a future stage makes
+  provisioning create an untimestamped row. *(BO-R2; design B/N4)*
+- [ ] 4.12 [P] **"One article blocks" (never degradable).** Load exactly **one article** — no sale,
+  no stock movement, no shift — then attempt to delete the tenant, the empresa and the punto de
+  venta, and assert each returns **its own named 409**: `tenant_en_uso` at the API,
+  `empresa_en_uso`/`punto_venta_en_uso` **below the API** (OD5 — the structural minimum fires first
+  through the routes). **B2 proven, not asserted.** *(BO-R3)*
+- [ ] 4.13 [P] **Carve-out 1 (never degradable)**: an entity whose only dependents past the anchor
+  are `auditoria` rows is **deletable**, and the audit trail keeps rendering afterwards because the
+  referenced row survives logically. *(BO-R6, B5; UT-R2's own audit scenario)*
+- [ ] 4.14 [P] **Carve-out 2 (never degradable)**: a tenant whose only untimestamped dependent is its
+  provisioned `numeraciones_clientes` row is **deletable**. *(BO-R6)*
+- [ ] 4.15 [P] **OD4 behavioural proof**: create one article, **delete it logically**, then attempt
+  the tenant deletion — it is **still** refused with `tenant_en_uso`. Usage means *"the customer ever
+  operated here"*, not *"there is live data right now"*. *(BO-R7; OD4)*
+- [ ] 4.16 [P] Cascade, asserted by **instant equality**, not by non-null: tenant + empresa + punto
+  de venta + admin all carry an **identical** `deleted_at`, and the tenant carries `estado = 'baja'`.
+  Read with query filters ignored. *(BO-R9, TO-R5)*
+- [ ] 4.17 [P] Cascade boundary: after the same deletion, `areas`, `medios_pago`, `listas_precio`,
+  `clientes` and `numeraciones_clientes` of that tenant are **present with `deleted_at IS NULL`**;
+  and `GET /api/empresas`, `GET /api/puntos-venta`, `GET /api/usuarios` return **none** of the
+  cascaded rows for a platform actor (no orphan remains visible). *(BO-R9)*
+- [ ] 4.18 [P] **S3**: a tenant whose only empresa was **already** logically deleted earlier is still
+  deletable, and that empresa keeps its **original, older** `deleted_at` — the cascade must not
+  re-stamp it. *(BO-R9, S3)*
+- [ ] 4.19 [P] Deleting an empresa cascades **only** to its puntos de venta: with a hand-seeded
+  second empresa in the same tenant, the tenant and its usuarios are untouched. *(BO-R9; kills U4)*
+- [ ] 4.20 [P] **U1-U3 sibling kills**: a **sibling tenant** with its own empresa, punto de venta and
+  admin — every one of its rows stays live after the first tenant's deletion, asserted by identity
+  **and** by exact count (rule 12c). *(BO-R9; kills U1, U2, U3)*
+- [ ] 4.21 [P] **U5-U6 minimum kills**, below the API (OD5): a sibling tenant's empresa must not be
+  counted towards `ultima_empresa_del_tenant`, and a sibling empresa's PV must not be counted towards
+  `ultimo_punto_venta_de_la_empresa` — otherwise the minimum never fires. *(BO-R10)*
+- [ ] 4.22 [P] **U7 boundary pair under `RelojFijo`** (rule 14): a dependent created **exactly at**
+  the anchor instant does **not** block; a dependent created **one tick later** does. This is the
+  `>` versus `>=` kill and it is the discriminator's whole correctness. Plus U7(a): a dependent of a
+  **sibling** entity must not block. *(BO-R2)*
+- [ ] 4.23 [P] **U8**: an untimestamped dependent blocks on **mere existence** — one `stock` row for
+  the punto de venta refuses its deletion with no timestamp involved, and no `created_at` comparison
+  is applied to a bucket-2 type (the column does not exist). *(BO-R5)*
+- [ ] 4.24 [P] **BO-R4 discovery scenarios**: a `movimientos_stock` row referencing the punto de
+  venta **only through `id_punto_venta_destino`** blocks it (secondary FK to the same principal); a
+  `turnos_caja` row referencing the usuario **only through `id_empleado_cierre`** blocks it
+  (non-conventional FK property name). *(BO-R4)*
+- [ ] 4.25 [P] **BO-R8 behavioural proof**: a shared catalogue row with `id_empresa IS NULL`, created
+  after the empresa's anchor, does **not** contribute to the usage verdict. *(BO-R8)*
+- [ ] 4.26 [P] **Structural minimums, below the API (OD5)**: `ultima_empresa_del_tenant` and
+  `ultimo_punto_venta_de_la_empresa` fire on their exact condition and **not** on any other; deleting
+  one of **two** pristine empresas succeeds; **S2** — an already-deleted sibling does not count as a
+  survivor, so the last live empresa still gets `ultima_empresa_del_tenant`; **S6** — when a minimum
+  and usage both apply, the response is the **structural** code. *(BO-R10)*
+- [ ] 4.27 [P] **The six-code set, exact**: one fixture per code constructed to satisfy only that
+  code's condition, each returning `409` with exactly its own `codigo`; and an **unlabelled** blocking
+  table still yields the exact `codigo` with the `mensaje` degraded to the generic phrase. Application
+  unit test for the label dictionary itself (mapped table → its Spanish word; unmapped → *"datos
+  cargados"*). *(BO-R11)*
+- [ ] 4.28 [P] **UT-R2 ordering and preservation**: a usuario stamped on a comprobante created after
+  their own `created_at` is refused with `409 usuario_en_uso` and `deleted_at` is **not** written; a
+  never-used usuario is deleted with the audit record written; the provisioned `admin` is deletable
+  **until** it opens a shift and refused afterwards; a **Root target with heavy usage** yields the
+  pre-existing `PoliticaDeRoles` error, **not** `usuario_en_uso`; self-deletion is still forbidden
+  regardless of usage. *(UT-R2)*
+- [ ] 4.29 [P] **BO-R12 / anti-oracle**: an out-of-scope DELETE (empresa or usuario of another
+  tenant) returns **404**, identical in status and body shape to a non-existent id — never 403, never
+  a 409 that discloses usage, even when the target is heavily used. *(BO-R12, UT-R2)*
+- [ ] 4.30 [P] **Idempotent-safe**: a second DELETE on an already-deleted row returns **404**, not
+  500, and writes no second `deleted_at`. *(BO-R1)*
+- [ ] 4.31 [P] **OD6 login pair**: a **cascade-deleted admin** attempting to log in receives
+  **`401 credenciales_invalidas`** (the lookup runs under `"BajaLogica"` with no
+  `IgnoreQueryFilters`, so the user is simply not found and the request dies at
+  `ServicioDeAutenticacion.cs:104`); and — as a **regression** — a **suspended** tenant's user still
+  receives **`403 tenant_suspendido`**. Two tests, two codes. *(TO-R5 as superseded by OD6;
+  Reconciliación 1)*
+- [ ] 4.32 [P] **Cross-tenant RLS, read AND write pair, on the `ways_app` connection** (rule 5 — a
+  superuser fixture proves nothing) for all four routes: the guard sees every dependent of the
+  actor's own tenant (cannot under-count) and can never observe another tenant's dependent.
+  *(BO-R7, BO-R12)*
+- [ ] 4.33 [P] **Authorization regressions**: a tenant `admin` is rejected by
+  `Politicas.SoloPlataforma` on the tenant DELETE; a `vendedor` who can `GET /api/puntos-venta`
+  through `LecturaDePuntosVenta` is rejected by `Politicas.GestionDeOrganizacion` on the PV DELETE;
+  suspension and reactivation behave exactly as before and neither reads nor writes `deleted_at`;
+  reactivating a **deleted** tenant is a **404** (S4) with the pre-existing `409 tenant_dado_de_baja`
+  preserved unchanged as the unreachable backstop. *(TO-R4, TO-R5, S4)*
+- [ ] 4.34 **[S]** Structural: **zero physical deletes** — repository scan for `ExecuteDelete`,
+  `ExecuteDeleteAsync`, `Remove(`, `RemoveRange(` and `DELETE FROM` over `tenants`, `empresas`,
+  `puntos_venta`, `usuarios`. Recorded as a file/state assertion, **never** dressed up as a runtime
+  kill. *(BO-R1; never degradable; verify criterion V4)*
+- [ ] 4.35 **[S]** Structural: **disjoint lock sets** — the deletion methods touch only organization
+  tables, none of which appears in the program's total order (`numeraciones_fiscales → turnos_caja →
+  comprobantes_venta → presupuestos → remitos → lotes → stock/stock_lotes → clientes → ledger
+  INSERT`), so no deadlock against an operational path is expressible. Asserted structurally (rule 13
+  — a live deadlock cannot be forced through raw ADO and a single-resource race test is blind to
+  order). *(design G)*
+- [ ] 4.36 **[S]** Structural: **FK index coverage** — compare the generated branch set against
+  `pg_indexes` and **report** any branch with no supporting index. The check **must not fix** an
+  uncovered branch: that would be DDL and the gate is ZERO-SCHEMA. An uncovered branch becomes a
+  **named finding for a later stage**, not a silent seq scan and not a blocker here. *(design D, T6)*
+- [ ] 4.37 GATE GUARD + non-regression — re-assert V1-V6 and V13; Domain + Application + Integration
+  suites green (**never** run integration suites concurrently against the same Docker daemon);
+  `dotnet build Ways.slnx` clean.
+- [ ] 4.38 `judgment-day` round to a clean round.
+- [ ] 4.39 Open PR 4 `feat/stage20-slice4-bajas-api`, record mutation evidence for **every** U-row
+  (U1-U8) plus N4 in the PR body, with the `[S]` rows recording their file/state/definition assertion
+  **and saying so** (V11), merge to `main` after the clean round.
+
+---
+
+## Slice 5: Deletion web — buttons, confirmation and code→copy (PR 5)
+
+**Branch**: `feat/stage20-slice5-bajas-web`. **Start**: PRs 2 and 4 merged. **Finish**: the four root
+screens can delete, behind a confirmation gate and the full `react-async-state` write discipline, and
+every 409 `codigo` maps to its own copy; docs 09/10 carry the Etapa 20 note. **Depends on**: slice 2
+(the screens) and slice 4 (the routes). **Estimate**: ~340 lines. **Rollback**: revert removes the
+buttons; the API still works but nobody can press it. **Skills**: `react-async-state` (rules 2-6, 9
+and **rule 10: the pattern is replicated across all four screens in the same PR**),
+`web-descriptor-tests`, `dto-contract-honesty`, `work-unit-commits`.
+
+- [ ] 5.1 Modify `src/Ways.Web/src/api/organizacion.ts` — `eliminarTenant`, `eliminarEmpresa`,
+  `eliminarPuntoVenta`. `src/Ways.Web/src/api/usuarios.ts`'s `eliminar` already exists and keeps its
+  signature. *(TO-R4, UT-R2)*
+- [ ] 5.2 Create the `codigo` → copy mapping (a pure module beside the helpers), covering all six
+  codes plus the 404 and the generic fallback. The web keys its copy off **`codigo`**, never off
+  `mensaje`: changing `mensaje` must not change which copy is selected. *(BO-R11)*
+- [ ] 5.3 Modify `Tenants.tsx` — delete button + confirmation gate + the full `react-async-state`
+  write discipline: full-window disabled state per entity while the write is outstanding, supersede
+  blocked while a write is outstanding, re-entrancy guard, and a post-write refresh failure reporting
+  *"se eliminó, pero no se pudo actualizar la vista"*. *(TO-R4)*
+- [ ] 5.4 Modify `Empresas.tsx` — the same pattern, verbatim (rule 10). *(TO-R4)*
+- [ ] 5.5 Modify `PuntosVenta.tsx` — the same pattern, verbatim. *(TO-R4)*
+- [ ] 5.6 Modify `Usuarios.tsx` — the same pattern applied to the **existing** "Baja" button
+  (`:120-122`), which now has to render `usuario_en_uso` and the pre-existing `PoliticaDeRoles`
+  refusals. *(UT-R2)*
+- [ ] 5.7 [P] Extend the four `*.test.tsx` files created in slice 2: the confirmation gate blocks the
+  call until confirmed; the full-window disabled state appears per entity; a second click while a
+  write is outstanding is dropped; the post-write refresh failure renders its own copy; **each 409
+  `codigo` maps to its own copy** and a changed `mensaje` does not change the selection. *(BO-R11,
+  TO-R4, UT-R2; `react-async-state` rules 2-6, 9, 10)*
+- [ ] 5.8 [P] Test: a `404` on delete (already-deleted row, or out-of-scope target) renders the
+  neutral not-found copy — **never** a usage disclosure, preserving the anti-oracle at the UI layer
+  too. *(BO-R12)*
+- [ ] 5.9 Modify `docs/09-multi-tenancy.md` and `docs/10-modelo-de-datos.md` — an **"Etapa 20"** note
+  covering the deletion semantics, the pristine discriminator, the three buckets and two carve-outs,
+  the cascade boundary and the six codes. **No schema table changes** — the stage ships zero DDL.
+- [ ] 5.10 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`, `run build`
+  (typecheck) and `run lint` clean; re-assert V1-V6 on the full stage diff (this is the last slice:
+  the last migration must **still** be `20260822002214_FiscalArcaEtapa19a.cs`,
+  `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` /
+  `ManejadorDeErrores.cs` untouched, zero physical deletes across the whole stage).
+- [ ] 5.11 `judgment-day` round to a clean round.
+- [ ] 5.12 Open PR 5 `feat/stage20-slice5-bajas-web`, merge to `main` after the clean round. **Then
+  report to the owner, at delivery (OD5): empresa and punto de venta deletion ships LATENT** —
+  correct and tested below the API, but unreachable through the API until an endpoint that creates a
+  second empresa or punto de venta exists, because the structural minimum fires first on every
+  attempt. Also report the two deferred items that remain open by decision: **R1** (a sale committed
+  between the guard's read and the deletion's commit — accepted, recovery is a one-line `UPDATE`
+  because nothing is destroyed) and **T6** (FK index coverage is *reported*, not guaranteed, since
+  adding an index would be DDL).
+
+---
+
+## Deferred, unchanged (no task in this stage)
+
+Force/override delete · undelete/restore · retro-guarding the other unguarded soft deletes
+(`ServicioDeCatalogo<T>`, `ServicioDeClientes`, `ServicioDeProveedores`, `ServicioDeArticulos`,
+`ServicioDeOfertas` — `InspectorDeUso` is entity-agnostic so adoption is a one-line change) ·
+`Estado`/suspension for empresa and punto de venta · server-side pagination or filtering for the four
+root lists · the minimum-administrators-per-tenant invariant (`ultimo_admin_del_tenant`) · drill-down
+navigation from a tenant into its children · a "show deleted" toggle · and the owner's reserved
+carryovers (the `importe` CHECK micro-gate, the `articulos_empresas` replace-set gap,
+`stage-18-etiquetas-y-consulta`). Each keeps the reopen condition recorded in `state.yaml:416-433`.

--- a/src/Ways.Application/Organizacion/Contratos.cs
+++ b/src/Ways.Application/Organizacion/Contratos.cs
@@ -15,16 +15,40 @@ public record ResultadoAprovisionamiento(
 // Alta y baja siguen siendo plataforma-only vía ServicioDeAprovisionamiento (ADR-16); estos
 // contratos son solo listado/detalle/edición de datos descriptivos + suspensión de tenants.
 
-public record TenantListado(int Id, string Nombre, EstadoTenant Estado, DateTimeOffset CreatedAt);
+/// <summary>Los tres contadores son hijos VIVOS del tenant (el filtro <c>"BajaLogica"</c> corre
+/// dentro de las subconsultas correlacionadas de <see cref="ServicioDeOrganizacion"/>) y
+/// <paramref name="CantidadUsuarios"/> cuenta solo cuentas del tenant: el personal de plataforma
+/// (<c>id_tenant IS NULL</c>) no se cuenta bajo ningún tenant.</summary>
+public record TenantListado(
+    int Id,
+    string Nombre,
+    EstadoTenant Estado,
+    DateTimeOffset CreatedAt,
+    int CantidadEmpresas,
+    int CantidadPuntosVenta,
+    int CantidadUsuarios);
 
 /// <summary>Solo el nombre: <see cref="EstadoTenant"/> se cambia por las acciones dedicadas
 /// (suspender/reactivar), no por esta edición general.</summary>
 public record TenantEdicion(string Nombre);
 
-public record EmpresaListado(int Id, int IdTenant, string RazonSocial, string? NombreFantasia, string? Cuit);
+/// <summary><paramref name="NombreTenant"/> es nullable a propósito (design D13): si el tenant
+/// dueño quedó dado de baja, la empresa se sigue listando con el nombre en <c>null</c> — se
+/// muestra como anomalía en vez de desaparecer del listado. <paramref name="IdTenant"/> deja de
+/// renderizarse y pasa a ser la clave del filtro por tenant.</summary>
+public record EmpresaListado(
+    int Id,
+    int IdTenant,
+    string RazonSocial,
+    string? NombreFantasia,
+    string? Cuit,
+    string? NombreTenant);
 
 public record EmpresaEdicion(string RazonSocial, string? NombreFantasia, string? Cuit);
 
+/// <summary>Los dos nombres de dueño son nullable por el mismo criterio que
+/// <see cref="EmpresaListado.NombreTenant"/> (design D13); <paramref name="IdTenant"/> e
+/// <paramref name="IdEmpresa"/> dejan de renderizarse y quedan como claves de los dos filtros.</summary>
 public record PuntoVentaListado(
     int Id,
     int IdTenant,
@@ -35,7 +59,9 @@ public record PuntoVentaListado(
     string? Whatsapp,
     string? Instagram,
     string? Facebook,
-    string? Web);
+    string? Web,
+    string? NombreTenant,
+    string? RazonSocialEmpresa);
 
 /// <summary><see cref="PuntoVentaListado.IdEmpresa"/> no es editable acá: es estructural
 /// (a qué empresa pertenece), no descriptivo — moverlo de empresa queda fuera de esta

--- a/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
+++ b/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
@@ -98,9 +98,11 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
     /// <summary>Reproyecta después de escribir: los contadores no viven en la entidad, así que el
     /// único lugar donde están es la consulta. Es una ida extra sobre una acción de plataforma
     /// puntual — el presupuesto de "una sola consulta" es el de los LISTADOS, que son los que
-    /// escalan con la cantidad de filas.</summary>
-    private Task<TenantListado> ProyectarTenantAsync(int id, CancellationToken ct) =>
-        db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstAsync(ct);
+    /// escalan con la cantidad de filas. Si entre la escritura y esta relectura la fila quedó
+    /// invisible, corresponde el mismo 404 de dominio que dan las lecturas, no un 500.</summary>
+    private async Task<TenantListado> ProyectarTenantAsync(int id, CancellationToken ct) =>
+        await db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el tenant {id}.");
 
     private async Task<Tenant> BuscarTenantAsync(int id, CancellationToken ct) =>
         await db.Tenants.FirstOrDefaultAsync(t => t.Id == id, ct)
@@ -154,7 +156,14 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         empresa.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
-        return await db.Empresas.Where(e => e.Id == empresa.Id).Select(ProyeccionDeEmpresa).FirstAsync(ct);
+
+        // Misma forma que ObtenerEmpresaAsync: si la fila quedó invisible entre la escritura y la
+        // relectura, es un 404 de dominio, no un 500.
+        return await db.Empresas
+            .Where(e => e.Id == empresa.Id)
+            .Select(ProyeccionDeEmpresa)
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {id}.");
     }
 
     private async Task<Empresa> BuscarEmpresaAsync(int id, CancellationToken ct)
@@ -220,10 +229,14 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         puntoVenta.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
+
+        // Misma forma que ObtenerPuntoVentaAsync: 404 de dominio, nunca un 500, si la fila quedó
+        // invisible entre la escritura y la relectura.
         return await db.PuntosVenta
             .Where(p => p.Id == puntoVenta.Id)
             .Select(ProyeccionDePuntoVenta)
-            .FirstAsync(ct);
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {id}.");
     }
 
     private async Task<PuntoVenta> BuscarPuntoVentaAsync(int id, CancellationToken ct)

--- a/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
+++ b/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Ways.Application.Abstracciones;
 using Ways.Domain.Common;
@@ -25,17 +26,30 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
 
     // --- Tenants ---
 
+    /// <summary>Los tres contadores son subconsultas correlacionadas dentro del MISMO
+    /// <c>Select</c> (design D13): el listado sigue costando una sola ida a la base, sin N+1 por
+    /// tenant. Al vivir dentro del árbol LINQ, cada <c>Count</c> arrastra el filtro
+    /// <c>"BajaLogica"</c>, así que un hijo dado de baja queda afuera sin predicado explícito. Y
+    /// <c>u.IdTenant == t.Id</c> sobre un <c>int?</c> no matchea nunca contra <c>NULL</c>: el
+    /// personal de plataforma no se cuenta bajo ningún tenant.</summary>
+    private Expression<Func<Tenant, TenantListado>> ProyeccionDeTenant => t => new TenantListado(
+        t.Id,
+        t.Nombre,
+        t.Estado,
+        t.CreatedAt,
+        db.Empresas.Count(e => e.IdTenant == t.Id),
+        db.PuntosVenta.Count(p => p.IdTenant == t.Id),
+        db.Usuarios.Count(u => u.IdTenant == t.Id));
+
     public async Task<IReadOnlyList<TenantListado>> ListarTenantsAsync(CancellationToken ct = default) =>
         await db.Tenants
             .OrderBy(t => t.Nombre)
-            .Select(t => new TenantListado(t.Id, t.Nombre, t.Estado, t.CreatedAt))
+            .Select(ProyeccionDeTenant)
             .ToListAsync(ct);
 
-    public async Task<TenantListado> ObtenerTenantAsync(int id, CancellationToken ct = default)
-    {
-        var tenant = await BuscarTenantAsync(id, ct);
-        return Proyectar(tenant);
-    }
+    public async Task<TenantListado> ObtenerTenantAsync(int id, CancellationToken ct = default) =>
+        await db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el tenant {id}.");
 
     public async Task<TenantListado> ActualizarTenantAsync(
         int id, TenantEdicion datos, CancellationToken ct = default)
@@ -46,7 +60,7 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         tenant.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
-        return Proyectar(tenant);
+        return await ProyectarTenantAsync(tenant.Id, ct);
     }
 
     public Task<TenantListado> SuspenderTenantAsync(int id, CancellationToken ct = default) =>
@@ -78,10 +92,15 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
             await db.SaveChangesAsync(ct);
         }
 
-        return Proyectar(tenant);
+        return await ProyectarTenantAsync(tenant.Id, ct);
     }
 
-    private static TenantListado Proyectar(Tenant t) => new(t.Id, t.Nombre, t.Estado, t.CreatedAt);
+    /// <summary>Reproyecta después de escribir: los contadores no viven en la entidad, así que el
+    /// único lugar donde están es la consulta. Es una ida extra sobre una acción de plataforma
+    /// puntual — el presupuesto de "una sola consulta" es el de los LISTADOS, que son los que
+    /// escalan con la cantidad de filas.</summary>
+    private Task<TenantListado> ProyectarTenantAsync(int id, CancellationToken ct) =>
+        db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstAsync(ct);
 
     private async Task<Tenant> BuscarTenantAsync(int id, CancellationToken ct) =>
         await db.Tenants.FirstOrDefaultAsync(t => t.Id == id, ct)
@@ -89,16 +108,39 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
 
     // --- Empresas ---
 
+    /// <summary>El nombre del tenant se proyecta como subconsulta escalar correlacionada porque
+    /// <see cref="Empresa"/> no tiene propiedad de navegación al tenant (design D13, hecho 1): no
+    /// hay nada a lo que hacerle punto. De paso evita el INNER JOIN que borraría la fila cuando el
+    /// tenant está dado de baja — ahí el nombre queda en <c>null</c> y la empresa se sigue
+    /// listando como anomalía en vez de desaparecer.</summary>
+    private Expression<Func<Empresa, EmpresaListado>> ProyeccionDeEmpresa => e => new EmpresaListado(
+        e.Id,
+        e.IdTenant,
+        e.RazonSocial,
+        e.NombreFantasia,
+        e.Cuit,
+        db.Tenants.Where(t => t.Id == e.IdTenant).Select(t => t.Nombre).FirstOrDefault());
+
     public async Task<IReadOnlyList<EmpresaListado>> ListarEmpresasAsync(CancellationToken ct = default) =>
         await db.Empresas
             .OrderBy(e => e.RazonSocial)
-            .Select(e => new EmpresaListado(e.Id, e.IdTenant, e.RazonSocial, e.NombreFantasia, e.Cuit))
+            .Select(ProyeccionDeEmpresa)
             .ToListAsync(ct);
 
+    /// <summary>Proyecta y recién después valida el alcance, mismo orden que
+    /// <see cref="BuscarEmpresaAsync"/>: primero 404 si no existe (o si el filtro de tenant la
+    /// deja invisible), después la capa explícita de dominio (ADR-8).</summary>
     public async Task<EmpresaListado> ObtenerEmpresaAsync(int id, CancellationToken ct = default)
     {
-        var empresa = await BuscarEmpresaAsync(id, ct);
-        return Proyectar(empresa);
+        var empresa = await db.Empresas
+            .Where(e => e.Id == id)
+            .Select(ProyeccionDeEmpresa)
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe la empresa {id}.");
+
+        PoliticaDeRoles.ValidarAlcanceDeTenant(Actor, empresa.IdTenant);
+
+        return empresa;
     }
 
     public async Task<EmpresaListado> ActualizarEmpresaAsync(
@@ -112,11 +154,8 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         empresa.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
-        return Proyectar(empresa);
+        return await db.Empresas.Where(e => e.Id == empresa.Id).Select(ProyeccionDeEmpresa).FirstAsync(ct);
     }
-
-    private static EmpresaListado Proyectar(Empresa e) =>
-        new(e.Id, e.IdTenant, e.RazonSocial, e.NombreFantasia, e.Cuit);
 
     private async Task<Empresa> BuscarEmpresaAsync(int id, CancellationToken ct)
     {
@@ -130,18 +169,40 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
 
     // --- Puntos de venta ---
 
+    /// <summary>Dos subconsultas escalares correlacionadas, por el mismo motivo que en
+    /// <see cref="ProyeccionDeEmpresa"/>: <see cref="PuntoVenta"/> tampoco tiene navegaciones
+    /// (design D13, hecho 1).</summary>
+    private Expression<Func<PuntoVenta, PuntoVentaListado>> ProyeccionDePuntoVenta => p => new PuntoVentaListado(
+        p.Id,
+        p.IdTenant,
+        p.IdEmpresa,
+        p.Nombre,
+        p.Domicilio,
+        p.Horario,
+        p.Whatsapp,
+        p.Instagram,
+        p.Facebook,
+        p.Web,
+        db.Tenants.Where(t => t.Id == p.IdTenant).Select(t => t.Nombre).FirstOrDefault(),
+        db.Empresas.Where(e => e.Id == p.IdEmpresa).Select(e => e.RazonSocial).FirstOrDefault());
+
     public async Task<IReadOnlyList<PuntoVentaListado>> ListarPuntosVentaAsync(CancellationToken ct = default) =>
         await db.PuntosVenta
             .OrderBy(p => p.Nombre)
-            .Select(p => new PuntoVentaListado(
-                p.Id, p.IdTenant, p.IdEmpresa, p.Nombre,
-                p.Domicilio, p.Horario, p.Whatsapp, p.Instagram, p.Facebook, p.Web))
+            .Select(ProyeccionDePuntoVenta)
             .ToListAsync(ct);
 
     public async Task<PuntoVentaListado> ObtenerPuntoVentaAsync(int id, CancellationToken ct = default)
     {
-        var puntoVenta = await BuscarPuntoVentaAsync(id, ct);
-        return Proyectar(puntoVenta);
+        var puntoVenta = await db.PuntosVenta
+            .Where(p => p.Id == id)
+            .Select(ProyeccionDePuntoVenta)
+            .FirstOrDefaultAsync(ct)
+            ?? throw ErrorDominio.NoEncontrado($"No existe el punto de venta {id}.");
+
+        PoliticaDeRoles.ValidarAlcanceDeTenant(Actor, puntoVenta.IdTenant);
+
+        return puntoVenta;
     }
 
     public async Task<PuntoVentaListado> ActualizarPuntoVentaAsync(
@@ -159,11 +220,11 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         puntoVenta.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
-        return Proyectar(puntoVenta);
+        return await db.PuntosVenta
+            .Where(p => p.Id == puntoVenta.Id)
+            .Select(ProyeccionDePuntoVenta)
+            .FirstAsync(ct);
     }
-
-    private static PuntoVentaListado Proyectar(PuntoVenta p) => new(
-        p.Id, p.IdTenant, p.IdEmpresa, p.Nombre, p.Domicilio, p.Horario, p.Whatsapp, p.Instagram, p.Facebook, p.Web);
 
     private async Task<PuntoVenta> BuscarPuntoVentaAsync(int id, CancellationToken ct)
     {

--- a/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
+++ b/src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs
@@ -47,6 +47,12 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
             .Select(ProyeccionDeTenant)
             .ToListAsync(ct);
 
+    /// <summary>Es también la relectura que usan las escrituras: los contadores no viven en la
+    /// entidad, así que el único lugar donde están es la consulta. Es una ida extra sobre una
+    /// acción de plataforma puntual — el presupuesto de "una sola consulta" es el de los LISTADOS,
+    /// que son los que escalan con la cantidad de filas. Si la fila quedó invisible entre la
+    /// escritura y esta relectura, corresponde el mismo 404 de dominio que dan las lecturas, no un
+    /// 500.</summary>
     public async Task<TenantListado> ObtenerTenantAsync(int id, CancellationToken ct = default) =>
         await db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstOrDefaultAsync(ct)
             ?? throw ErrorDominio.NoEncontrado($"No existe el tenant {id}.");
@@ -60,7 +66,7 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         tenant.UpdatedAt = reloj.Ahora;
 
         await db.SaveChangesAsync(ct);
-        return await ProyectarTenantAsync(tenant.Id, ct);
+        return await ObtenerTenantAsync(tenant.Id, ct);
     }
 
     public Task<TenantListado> SuspenderTenantAsync(int id, CancellationToken ct = default) =>
@@ -92,17 +98,8 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
             await db.SaveChangesAsync(ct);
         }
 
-        return await ProyectarTenantAsync(tenant.Id, ct);
+        return await ObtenerTenantAsync(tenant.Id, ct);
     }
-
-    /// <summary>Reproyecta después de escribir: los contadores no viven en la entidad, así que el
-    /// único lugar donde están es la consulta. Es una ida extra sobre una acción de plataforma
-    /// puntual — el presupuesto de "una sola consulta" es el de los LISTADOS, que son los que
-    /// escalan con la cantidad de filas. Si entre la escritura y esta relectura la fila quedó
-    /// invisible, corresponde el mismo 404 de dominio que dan las lecturas, no un 500.</summary>
-    private async Task<TenantListado> ProyectarTenantAsync(int id, CancellationToken ct) =>
-        await db.Tenants.Where(t => t.Id == id).Select(ProyeccionDeTenant).FirstOrDefaultAsync(ct)
-            ?? throw ErrorDominio.NoEncontrado($"No existe el tenant {id}.");
 
     private async Task<Tenant> BuscarTenantAsync(int id, CancellationToken ct) =>
         await db.Tenants.FirstOrDefaultAsync(t => t.Id == id, ct)
@@ -114,14 +111,23 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
     /// <see cref="Empresa"/> no tiene propiedad de navegación al tenant (design D13, hecho 1): no
     /// hay nada a lo que hacerle punto. De paso evita el INNER JOIN que borraría la fila cuando el
     /// tenant está dado de baja — ahí el nombre queda en <c>null</c> y la empresa se sigue
-    /// listando como anomalía en vez de desaparecer.</summary>
+    /// listando como anomalía en vez de desaparecer.
+    ///
+    /// El <c>t.DeletedAt == null</c> va explícito y no se apoya en el filtro ambiente
+    /// <c>"BajaLogica"</c>: EF aplica <c>IgnoreQueryFilters</c> a nivel CONSULTA, así que la
+    /// consulta externa que lo pidiera se lo sacaría también a esta subconsulta correlacionada y
+    /// el huérfano pasaría a mostrar el nombre de un dueño dado de baja. Vale igual para las dos
+    /// subconsultas de <see cref="ProyeccionDePuntoVenta"/>.</summary>
     private Expression<Func<Empresa, EmpresaListado>> ProyeccionDeEmpresa => e => new EmpresaListado(
         e.Id,
         e.IdTenant,
         e.RazonSocial,
         e.NombreFantasia,
         e.Cuit,
-        db.Tenants.Where(t => t.Id == e.IdTenant).Select(t => t.Nombre).FirstOrDefault());
+        db.Tenants
+            .Where(t => t.Id == e.IdTenant && t.DeletedAt == null)
+            .Select(t => t.Nombre)
+            .FirstOrDefault());
 
     public async Task<IReadOnlyList<EmpresaListado>> ListarEmpresasAsync(CancellationToken ct = default) =>
         await db.Empresas
@@ -192,8 +198,14 @@ public class ServicioDeOrganizacion(IWaysDbContext db, IRelojDelSistema reloj, I
         p.Instagram,
         p.Facebook,
         p.Web,
-        db.Tenants.Where(t => t.Id == p.IdTenant).Select(t => t.Nombre).FirstOrDefault(),
-        db.Empresas.Where(e => e.Id == p.IdEmpresa).Select(e => e.RazonSocial).FirstOrDefault());
+        db.Tenants
+            .Where(t => t.Id == p.IdTenant && t.DeletedAt == null)
+            .Select(t => t.Nombre)
+            .FirstOrDefault(),
+        db.Empresas
+            .Where(e => e.Id == p.IdEmpresa && e.DeletedAt == null)
+            .Select(e => e.RazonSocial)
+            .FirstOrDefault());
 
     public async Task<IReadOnlyList<PuntoVentaListado>> ListarPuntosVentaAsync(CancellationToken ct = default) =>
         await db.PuntosVenta

--- a/src/Ways.Application/Usuarios/Contratos.cs
+++ b/src/Ways.Application/Usuarios/Contratos.cs
@@ -16,6 +16,12 @@ public record UsuarioAutenticado(
     DateTimeOffset? UltimaConexion,
     int? IdTenant);
 
+/// <summary><paramref name="NombreTenant"/> viene en <c>null</c> exactamente cuando
+/// <paramref name="IdTenant"/> es <c>null</c> (personal de plataforma): la API NO fabrica la
+/// etiqueta <c>"Plataforma"</c> — esa copia la pone la web (design D14). El nombre de un tenant
+/// es texto libre, así que un tenant llamado "Plataforma" sería indistinguible de una cuenta de
+/// plataforma si el servidor la inventara, y el filtro, que se apoya en
+/// <paramref name="IdTenant"/>, discreparía de la columna que tiene arriba.</summary>
 public record UsuarioListado(
     int Id,
     string Usuario,
@@ -24,7 +30,9 @@ public record UsuarioListado(
     string Rol,
     EstadoUsuario Estado,
     DateTimeOffset? UltimaConexion,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    int? IdTenant,
+    string? NombreTenant);
 
 /// <summary><paramref name="IdTenant"/> solo lo usa un actor de plataforma para elegir a
 /// qué tenant pertenece la cuenta creada; un actor de tenant siempre crea dentro del suyo

--- a/src/Ways.Application/Usuarios/Contratos.cs
+++ b/src/Ways.Application/Usuarios/Contratos.cs
@@ -16,12 +16,15 @@ public record UsuarioAutenticado(
     DateTimeOffset? UltimaConexion,
     int? IdTenant);
 
-/// <summary><paramref name="NombreTenant"/> viene en <c>null</c> exactamente cuando
-/// <paramref name="IdTenant"/> es <c>null</c> (personal de plataforma): la API NO fabrica la
-/// etiqueta <c>"Plataforma"</c> — esa copia la pone la web (design D14). El nombre de un tenant
-/// es texto libre, así que un tenant llamado "Plataforma" sería indistinguible de una cuenta de
-/// plataforma si el servidor la inventara, y el filtro, que se apoya en
-/// <paramref name="IdTenant"/>, discreparía de la columna que tiene arriba.</summary>
+/// <summary><paramref name="NombreTenant"/> viene en <c>null</c> en dos casos: cuando la cuenta
+/// es de plataforma (<paramref name="IdTenant"/> nulo) y cuando el tenant dueño está dado de baja
+/// lógicamente (<paramref name="IdTenant"/> no nulo, nombre igual ausente — el huérfano de design
+/// D13). No es un "si y solo si": un nombre nulo NO implica personal de plataforma, esa distinción
+/// la da <paramref name="IdTenant"/>. La API tampoco fabrica la etiqueta <c>"Plataforma"</c> —
+/// esa copia la pone la web (design D14). El nombre de un tenant es texto libre, así que un tenant
+/// llamado "Plataforma" sería indistinguible de una cuenta de plataforma si el servidor la
+/// inventara, y el filtro, que se apoya en <paramref name="IdTenant"/>, discreparía de la columna
+/// que tiene arriba.</summary>
 public record UsuarioListado(
     int Id,
     string Usuario,

--- a/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
+++ b/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
@@ -77,7 +77,16 @@ public class ServicioDeUsuarios(
                 u.Id, u.NombreUsuario, u.Mail, u.RolId,
                 u.Rol!.Nombre, u.Estado, u.UltimaConexion, u.CreatedAt,
                 u.IdTenant,
-                db.Tenants.Where(t => t.Id == u.IdTenant).Select(t => t.Nombre).FirstOrDefault()))
+                // El `DeletedAt == null` va explícito y no se apoya en el filtro ambiente:
+                // `IgnoreQueryFilters` se aplica a nivel CONSULTA, así que con
+                // `incluirEliminados` la subconsulta también perdería el filtro y devolvería el
+                // nombre de un tenant dado de baja, discrepando del listado por defecto y de
+                // ObtenerAsync. Con el predicado propio, los tres caminos coinciden (design D13:
+                // el huérfano se muestra con nombre nulo).
+                db.Tenants
+                    .Where(t => t.Id == u.IdTenant && t.DeletedAt == null)
+                    .Select(t => t.Nombre)
+                    .FirstOrDefault()))
             .ToListAsync(ct);
 
         return new PaginaDe<UsuarioListado>(items, total, pagina, tamanio);
@@ -95,9 +104,12 @@ public class ServicioDeUsuarios(
             usuario.IdTenant, await NombreDeTenantAsync(usuario.IdTenant, ct));
     }
 
-    /// <summary>El nombre del tenant de una cuenta, o <c>null</c> si la cuenta es de plataforma
-    /// (design D14, S1): <c>NombreTenant</c> es <c>null</c> si y solo si <c>IdTenant</c> lo es.
-    /// La etiqueta <c>"Plataforma"</c> NO se fabrica acá — es copia de pantalla, la pone la web:
+    /// <summary>El nombre del tenant de una cuenta (design D14, S1). Viene <c>null</c> en dos
+    /// casos, no en uno: cuando la cuenta es de plataforma (<c>IdTenant</c> nulo) y cuando el
+    /// tenant dueño está dado de baja lógicamente — ahí <c>IdTenant</c> NO es nulo y el nombre
+    /// igual falta, porque D13 elige mostrar al huérfano como anomalía en vez de esconderlo. Un
+    /// consumidor no puede leer el nombre nulo como "es personal de plataforma": para eso está
+    /// <c>IdTenant</c>. La etiqueta <c>"Plataforma"</c> NO se fabrica acá — es copia de pantalla, la pone la web:
     /// el nombre de un tenant es texto libre y un tenant que se llamara justo "Plataforma" sería
     /// indistinguible de una cuenta de plataforma. En el listado esto viaja como subconsulta
     /// escalar correlacionada dentro del mismo <c>Select</c>; acá, sobre una sola fila, es una

--- a/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
+++ b/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
@@ -75,7 +75,9 @@ public class ServicioDeUsuarios(
             .Take(tamanio)
             .Select(u => new UsuarioListado(
                 u.Id, u.NombreUsuario, u.Mail, u.RolId,
-                u.Rol!.Nombre, u.Estado, u.UltimaConexion, u.CreatedAt))
+                u.Rol!.Nombre, u.Estado, u.UltimaConexion, u.CreatedAt,
+                u.IdTenant,
+                db.Tenants.Where(t => t.Id == u.IdTenant).Select(t => t.Nombre).FirstOrDefault()))
             .ToListAsync(ct);
 
         return new PaginaDe<UsuarioListado>(items, total, pagina, tamanio);
@@ -89,8 +91,21 @@ public class ServicioDeUsuarios(
 
         return new UsuarioListado(
             usuario.Id, usuario.NombreUsuario, usuario.Mail, usuario.RolId,
-            usuario.Rol!.Nombre, usuario.Estado, usuario.UltimaConexion, usuario.CreatedAt);
+            usuario.Rol!.Nombre, usuario.Estado, usuario.UltimaConexion, usuario.CreatedAt,
+            usuario.IdTenant, await NombreDeTenantAsync(usuario.IdTenant, ct));
     }
+
+    /// <summary>El nombre del tenant de una cuenta, o <c>null</c> si la cuenta es de plataforma
+    /// (design D14, S1): <c>NombreTenant</c> es <c>null</c> si y solo si <c>IdTenant</c> lo es.
+    /// La etiqueta <c>"Plataforma"</c> NO se fabrica acá — es copia de pantalla, la pone la web:
+    /// el nombre de un tenant es texto libre y un tenant que se llamara justo "Plataforma" sería
+    /// indistinguible de una cuenta de plataforma. En el listado esto viaja como subconsulta
+    /// escalar correlacionada dentro del mismo <c>Select</c>; acá, sobre una sola fila, es una
+    /// consulta puntual y solo cuando la cuenta pertenece a un tenant.</summary>
+    private async Task<string?> NombreDeTenantAsync(int? idTenant, CancellationToken ct) =>
+        idTenant is int id
+            ? await db.Tenants.Where(t => t.Id == id).Select(t => t.Nombre).FirstOrDefaultAsync(ct)
+            : null;
 
     public async Task<UsuarioListado> CrearAsync(CrearUsuario datos, CancellationToken ct = default)
     {

--- a/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
+++ b/src/Ways.Application/Usuarios/ServicioDeUsuarios.cs
@@ -116,7 +116,10 @@ public class ServicioDeUsuarios(
     /// consulta puntual y solo cuando la cuenta pertenece a un tenant.</summary>
     private async Task<string?> NombreDeTenantAsync(int? idTenant, CancellationToken ct) =>
         idTenant is int id
-            ? await db.Tenants.Where(t => t.Id == id).Select(t => t.Nombre).FirstOrDefaultAsync(ct)
+            ? await db.Tenants
+                .Where(t => t.Id == id && t.DeletedAt == null)
+                .Select(t => t.Nombre)
+                .FirstOrDefaultAsync(ct)
             : null;
 
     public async Task<UsuarioListado> CrearAsync(CrearUsuario datos, CancellationToken ct = default)

--- a/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
@@ -35,6 +35,23 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     private const string PasswordRoot = "root";
     private const string MailRoot = "test@test.com";
 
+    /// <summary>Los tres contadores que siembran las dos pruebas de readback sobre el tenant que
+    /// leen: 2 empresas, 3 puntos de venta y 4 usuarios. Distintos entre sí para que un
+    /// intercambio posicional entre ellos muera (<c>mutation-proof-tests</c> regla 12b).</summary>
+    private const int EmpresasDelTenantLeido = 2;
+    private const int PuntosVentaDelTenantLeido = 3;
+    private const int UsuariosDelTenantLeido = 4;
+
+    /// <summary>Tenants de relleno que se siembran ANTES del tenant que se lee. Es
+    /// <c>UsuariosDelTenantLeido</c> a propósito: como la secuencia de identidad es monótona, el
+    /// tenant bajo prueba queda con un id estrictamente mayor que el más grande de los tres
+    /// contadores, por construcción y sin depender de ninguna fila que la prueba no siembre.
+    /// Eso es lo que hace que un intercambio posicional entre el id y un contador muera.</summary>
+    private const int TenantsDeRelleno = UsuariosDelTenantLeido;
+
+    private static readonly int[] ContadoresSembrados =
+        [EmpresasDelTenantLeido, PuntosVentaDelTenantLeido, UsuariosDelTenantLeido];
+
     /// <summary>El servidor serializa enums como texto (<c>JsonStringEnumConverter</c>) y el
     /// <c>HttpClient</c> de prueba no hereda esa configuración — mismo criterio, y misma
     /// trampa de <c>PropertyNameCaseInsensitive</c>, que <c>OrganizacionTests.OpcionesJson</c>
@@ -371,8 +388,11 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     /// una sola empresa por tenant, un mutante que correlacionara por <c>e.IdTenant == p.IdTenant</c>
     /// devolvería la misma razón social y sobreviviría. Por eso el tenant A lleva una SEGUNDA
     /// empresa con su propio punto de venta. MUTACIÓN registrada: correlacionar por
-    /// <c>e.IdTenant == p.IdTenant</c> hace que los dos puntos de venta de A reporten la misma
-    /// razón social y una de las dos aserciones se cae, cualquiera sea la fila que elija la base.
+    /// <c>e.IdTenant == p.IdTenant</c> hace que los dos puntos de venta de A reporten una razón
+    /// social que no es la suya y la prueba se cae — observado ROJO al correrla. La muerte no se
+    /// afirma como universal: un <c>FirstOrDefault</c> sin <c>OrderBy</c> no le debe a nadie
+    /// devolver la MISMA fila en cada evaluación correlacionada, así que en teoría el mutante
+    /// podría acertarle a las dos empresas a la vez.
     /// </summary>
     [Fact]
     public async Task LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios()
@@ -559,8 +579,11 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     /// Task 1.11 (<c>mutation-proof-tests</c> regla 12b) — cada campo POSICIONAL de los cuatro
     /// DTOs de listado se lee de vuelta con valores distintos entre sí, para que un argumento
     /// intercambiado en el constructor posicional muera acá en vez de sobrevivir sobre valores
-    /// iguales. Los tres contadores del tenant valen 2, 3 y 4, y el <c>Id</c> se afirma
-    /// explícitamente mayor que 4 para que un swap contra un contador tampoco pueda pasar.
+    /// iguales. Los tres contadores del tenant son <see cref="EmpresasDelTenantLeido"/>,
+    /// <see cref="PuntosVentaDelTenantLeido"/> y <see cref="UsuariosDelTenantLeido"/>, y se afirma
+    /// que el <c>Id</c> no coincide con ninguno de los tres para que un swap contra un contador
+    /// tampoco pueda pasar. La cota la garantiza el relleno que siembra la propia prueba
+    /// (<see cref="TenantsDeRelleno"/>), no ninguna fila del seed de producción.
     /// </summary>
     [Fact]
     public async Task CadaCampoPosicionalDeLosCuatroListadosSeLeeDeVueltaConValoresDistintos()
@@ -574,7 +597,7 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         // argumentos posicionales sobrevive (mutation-proof-tests regla 12b). Además empuja el id
         // del tenant bajo prueba por encima de los tres contadores, de forma determinística y sin
         // depender del orden en que xUnit haya corrido el resto de la clase.
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < TenantsDeRelleno; i++)
         {
             var relleno = await SembrarTenantAsync($"Readback-relleno-{i}-{sufijo}");
 
@@ -632,7 +655,7 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         // --- TenantListado: 7 campos ---
         var tenant = await LeerTenantAsync(cliente, a.Tenant.Id);
         Assert.Equal(a.Tenant.Id, tenant.Id);
-        Assert.True(tenant.Id > 4, "el id tiene que ser distinguible de los tres contadores");
+        Assert.DoesNotContain(tenant.Id, ContadoresSembrados);
         Assert.Equal($"Readback-A-{sufijo}", tenant.Nombre);
         Assert.Equal(EstadoTenant.Activo, tenant.Estado);
         // timestamptz redondea a microsegundos, así que la igualdad exacta contra el valor en
@@ -640,9 +663,9 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         Assert.True(
             (tenant.CreatedAt - a.Tenant.CreatedAt).Duration() < TimeSpan.FromSeconds(1),
             "createdAt tiene que ser el del tenant sembrado");
-        Assert.Equal(2, tenant.CantidadEmpresas);
-        Assert.Equal(3, tenant.CantidadPuntosVenta);
-        Assert.Equal(4, tenant.CantidadUsuarios);
+        Assert.Equal(EmpresasDelTenantLeido, tenant.CantidadEmpresas);
+        Assert.Equal(PuntosVentaDelTenantLeido, tenant.CantidadPuntosVenta);
+        Assert.Equal(UsuariosDelTenantLeido, tenant.CantidadUsuarios);
 
         // --- EmpresaListado: 6 campos ---
         var empresas = await cliente.GetFromJsonAsync<List<EmpresaListado>>("/api/empresas", OpcionesJson);
@@ -838,14 +861,107 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         }
     }
 
+    // ---- ronda 2 de judgment-day: el huérfano en TODOS los caminos de organización ------------
+
+    /// <summary>
+    /// Espejo del lado de organización de
+    /// <see cref="UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos"/>:
+    /// las cláusulas bajo prueba son los <c>DeletedAt == null</c> EXPLÍCITOS de las tres
+    /// subconsultas de dueño (tenant de empresa, tenant de punto de venta, empresa de punto de
+    /// venta). Se afirma que el huérfano se rinde igual por el LISTADO y por el DETALLE —la fila
+    /// se sigue viendo con el nombre del dueño en <c>null</c>, design D13— y que el hermano vivo
+    /// trae su nombre en el mismo request: un predicado que apagara la proyección entera también
+    /// pasaría la aserción de nulidad, así que sola no discrimina.
+    ///
+    /// SIN evidencia de mutación, y se dice en vez de fingirla. Las tres mutaciones se CORRIERON,
+    /// no se razonaron: borrando un predicado por vez y corriendo la clase entera, las tres
+    /// SOBREVIVIERON (12/12 en verde cada una). Es el resultado esperado: hoy ningún camino de
+    /// <c>ServicioDeOrganizacion</c> apaga el filtro ambiente <c>"BajaLogica"</c> —no hay
+    /// <c>incluirEliminados</c> ni <c>IgnoreQueryFilters</c> en el servicio—, así que el filtro
+    /// produce el mismo resultado y la cláusula todavía no tiene nada propio que probar. Los
+    /// predicados son defensa en profundidad para el slice 4, que agrega los escritores de baja
+    /// sobre estas mismas entidades; lo que esta prueba fija hoy es el COMPORTAMIENTO esperado,
+    /// para que ese slice tenga contra qué mutar.
+    /// </summary>
+    [Fact]
+    public async Task LosHuerfanosDeOrganizacionSeRindenIgualPorElListadoYPorElDetalle()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+
+        var huerfana = await SembrarTenantAsync($"Org-huerfano-A-{sufijo}");
+        var viva = await SembrarTenantAsync($"Org-huerfano-B-{sufijo}");
+
+        // Empresa dada de baja con su punto de venta vivo: es el único huérfano que prueba la
+        // tercera subconsulta (empresa de punto de venta), que no depende de la baja del tenant.
+        var empresaSinDuenio = await SembrarEmpresaAsync(viva.Tenant.Id, $"Org anexo {sufijo} SRL");
+        var puntoSinEmpresa = await SembrarPuntoVentaAsync(
+            viva.Tenant.Id, empresaSinDuenio.Id, $"Org local sin empresa {sufijo}");
+
+        await DarDeBajaAlTenantAsync(huerfana.Tenant.Id);
+        await DarDeBajaALaEmpresaAsync(empresaSinDuenio.Id);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var empresas = await cliente.GetFromJsonAsync<List<EmpresaListado>>("/api/empresas", OpcionesJson);
+        Assert.NotNull(empresas);
+        AfirmarEmpresaHuerfana(Assert.Single(empresas!, e => e.Id == huerfana.Empresa.Id));
+        Assert.Equal(
+            viva.Tenant.Nombre,
+            Assert.Single(empresas!, e => e.Id == viva.Empresa.Id).NombreTenant);
+
+        AfirmarEmpresaHuerfana(await LeerCuerpoAsync<EmpresaListado>(
+            await cliente.GetAsync($"/api/empresas/{huerfana.Empresa.Id}")));
+
+        var puntos = await cliente.GetFromJsonAsync<List<PuntoVentaListado>>("/api/puntos-venta", OpcionesJson);
+        Assert.NotNull(puntos);
+        AfirmarPuntoSinTenant(Assert.Single(puntos!, p => p.Id == huerfana.PuntoVenta.Id));
+        AfirmarPuntoSinEmpresa(Assert.Single(puntos!, p => p.Id == puntoSinEmpresa.Id));
+        Assert.Equal(
+            viva.Tenant.Nombre,
+            Assert.Single(puntos!, p => p.Id == viva.PuntoVenta.Id).NombreTenant);
+
+        AfirmarPuntoSinTenant(await LeerCuerpoAsync<PuntoVentaListado>(
+            await cliente.GetAsync($"/api/puntos-venta/{huerfana.PuntoVenta.Id}")));
+        AfirmarPuntoSinEmpresa(await LeerCuerpoAsync<PuntoVentaListado>(
+            await cliente.GetAsync($"/api/puntos-venta/{puntoSinEmpresa.Id}")));
+
+        void AfirmarEmpresaHuerfana(EmpresaListado empresa)
+        {
+            Assert.Equal(huerfana.Tenant.Id, empresa.IdTenant);
+            Assert.Null(empresa.NombreTenant);
+            Assert.Equal(huerfana.Empresa.RazonSocial, empresa.RazonSocial);
+        }
+
+        void AfirmarPuntoSinTenant(PuntoVentaListado punto)
+        {
+            Assert.Equal(huerfana.Tenant.Id, punto.IdTenant);
+            Assert.Null(punto.NombreTenant);
+            // La empresa sigue viva: el nombre que falta es solo el del tenant.
+            Assert.Equal(huerfana.Empresa.RazonSocial, punto.RazonSocialEmpresa);
+        }
+
+        void AfirmarPuntoSinEmpresa(PuntoVentaListado punto)
+        {
+            Assert.Equal(empresaSinDuenio.Id, punto.IdEmpresa);
+            Assert.Null(punto.RazonSocialEmpresa);
+            // El tenant sigue vivo: el nombre que falta es solo el de la empresa.
+            Assert.Equal(viva.Tenant.Nombre, punto.NombreTenant);
+        }
+    }
+
     // ---- ronda 1 de judgment-day: readback de los caminos que NO son el listado ---------------
 
     /// <summary>
-    /// <c>mutation-proof-tests</c> regla 12b sobre los caminos de respuesta que el slice dejaba sin
-    /// leer: detalle, edición, suspensión y reactivación devuelven el MISMO record que el listado,
-    /// y ningún test leía de vuelta los campos nuevos por esos caminos (reemplazar el cuerpo de la
-    /// proyección por constantes sobrevivía a la suite entera). Los tres contadores valen 2, 3 y 4
-    /// —distintos entre sí y distintos del id— para que un intercambio posicional muera acá.
+    /// Lo que agrega esta prueba es el CABLEADO DE LOS ENDPOINTS que no son el listado. El cuerpo
+    /// de <c>ProyeccionDeTenant</c> ya lo lee de vuelta campo a campo la task 1.11 a través de
+    /// <c>GET /api/plataforma/tenants</c>, así que vaciarlo NO sobrevive a la suite. Lo que ningún
+    /// test cubría es que <c>GET {id}</c>, <c>PUT</c>, <c>suspender</c> y <c>reactivar</c> devuelvan
+    /// ESE record proyectado y no uno armado aparte —con los contadores en cero, el nombre viejo o
+    /// el estado anterior—: acá se afirman los siete campos por los cuatro caminos.
+    ///
+    /// SIN evidencia de mutación, y se dice en vez de fingirla: la tabla M no le adjudica ninguna.
+    /// Los tres contadores valen 2, 3 y 4 —distintos entre sí y distintos del id— para que un
+    /// intercambio posicional (<c>mutation-proof-tests</c> regla 12b) muera acá igual.
     /// </summary>
     [Fact]
     public async Task ElDetalleYLasEscriturasDeTenantDevuelvenLosSieteCamposProyectados()
@@ -893,15 +1009,15 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         void AfirmarTenant(TenantListado tenant, string nombreEsperado, EstadoTenant estadoEsperado)
         {
             Assert.Equal(a.Tenant.Id, tenant.Id);
-            Assert.True(tenant.Id > 4, "el id tiene que ser distinguible de los tres contadores");
+            Assert.DoesNotContain(tenant.Id, ContadoresSembrados);
             Assert.Equal(nombreEsperado, tenant.Nombre);
             Assert.Equal(estadoEsperado, tenant.Estado);
             Assert.True(
                 (tenant.CreatedAt - a.Tenant.CreatedAt).Duration() < TimeSpan.FromSeconds(1),
                 "createdAt tiene que ser el del tenant sembrado");
-            Assert.Equal(2, tenant.CantidadEmpresas);
-            Assert.Equal(3, tenant.CantidadPuntosVenta);
-            Assert.Equal(4, tenant.CantidadUsuarios);
+            Assert.Equal(EmpresasDelTenantLeido, tenant.CantidadEmpresas);
+            Assert.Equal(PuntosVentaDelTenantLeido, tenant.CantidadPuntosVenta);
+            Assert.Equal(UsuariosDelTenantLeido, tenant.CantidadUsuarios);
         }
     }
 
@@ -1041,10 +1157,12 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     /// <summary>Relleno DESBALANCEADO, mismo criterio que la task 1.11: cada tenant de relleno se
     /// lleva una cantidad distinta de empresas, puntos de venta y usuarios, así las cuatro
     /// secuencias de identidad se desincronizan y <c>id</c>, <c>idTenant</c> e <c>idEmpresa</c>
-    /// quedan distintos POR CONSTRUCCIÓN, no por el orden en que xUnit corrió la clase.</summary>
+    /// quedan distintos POR CONSTRUCCIÓN, no por el orden en que xUnit corrió la clase. Son
+    /// <see cref="TenantsDeRelleno"/> tenants para que además el id del tenant que se lee quede
+    /// por encima del mayor de los tres contadores.</summary>
     private async Task SembrarRellenoDesbalanceadoAsync(string sufijo)
     {
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < TenantsDeRelleno; i++)
         {
             var relleno = await SembrarTenantAsync($"Relleno-{i}-{sufijo}");
 

--- a/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
@@ -1,0 +1,735 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Ways.Application.Abstracciones;
+using Ways.Application.Auditoria;
+using Ways.Application.Organizacion;
+using Ways.Application.Usuarios;
+using Ways.Domain.Organizacion;
+using Ways.Domain.Usuarios;
+using Ways.Infrastructure.Multitenancy;
+using Ways.Infrastructure.Persistencia;
+using Ways.Infrastructure.Seguridad;
+
+namespace Ways.IntegrationTests;
+
+/// <summary>
+/// Etapa 20, slice 1 (tasks 1.7-1.13): los cuatro listados raíz proyectan NOMBRES de dueño y
+/// contadores de hijos, como subconsultas correlacionadas dentro del mismo <c>Select</c>
+/// (design D13/D14), sin agregar una sola ida más a la base. Corre contra Postgres real: la
+/// forma de la proyección es exactamente lo que se está probando, así que un doble en memoria
+/// no probaría el SQL que efectivamente se genera.
+///
+/// Cada fixture siembra DOS tenants (<c>mutation-proof-tests</c> regla 12c): una proyección que
+/// ignorara la correlación —o que devolviera "el primer tenant"— pasaría con un solo tenant
+/// sembrado y muere acá.
+/// </summary>
+[Collection("Ways.IntegrationTests secuencial")]
+public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixture<WaysApiFixture>
+{
+    private const string Password = "una-contraseña-larga";
+    private const string PasswordRoot = "root";
+    private const string MailRoot = "test@test.com";
+
+    /// <summary>El servidor serializa enums como texto (<c>JsonStringEnumConverter</c>) y el
+    /// <c>HttpClient</c> de prueba no hereda esa configuración — mismo criterio, y misma
+    /// trampa de <c>PropertyNameCaseInsensitive</c>, que <c>OrganizacionTests.OpcionesJson</c>
+    /// documenta en detalle.</summary>
+    private static readonly JsonSerializerOptions OpcionesJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private sealed record Cuenta(int Id, string Mail);
+
+    private sealed record TenantSembrado(
+        Tenant Tenant, Empresa Empresa, PuntoVenta PuntoVenta, Cuenta Admin);
+
+    // ---- siembra ---------------------------------------------------------------------------
+
+    /// <summary>Siembra un tenant con una empresa, un punto de venta y un admin propio, en modo
+    /// plataforma y con hash real — mismo criterio que <c>OrganizacionTests.SembrarTenantAsync</c>:
+    /// la API bajo prueba acá es la de LECTURA, no la de alta.</summary>
+    private async Task<TenantSembrado> SembrarTenantAsync(
+        string nombre,
+        string? razonSocialEmpresa = null,
+        string? nombrePuntoVenta = null,
+        string? nombreUsuarioAdmin = null)
+    {
+        using var _ = fixture.CreateClient(); // arranca el host: siembra roles y el root
+
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var ahora = DateTimeOffset.UtcNow;
+        var tenant = new Tenant
+        {
+            Nombre = nombre,
+            Estado = EstadoTenant.Activo,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync();
+
+        var empresa = new Empresa
+        {
+            IdTenant = tenant.Id,
+            RazonSocial = razonSocialEmpresa ?? $"{nombre} SRL",
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = tenant.Id,
+            IdEmpresa = empresa.Id,
+            Nombre = nombrePuntoVenta ?? $"{nombre} - Local 1",
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        var mailAdmin = $"{nombre.ToLowerInvariant()}@ways.test";
+        var admin = new Usuario
+        {
+            IdTenant = tenant.Id,
+            NombreUsuario = nombreUsuarioAdmin ?? "admin",
+            Mail = mailAdmin,
+            RolId = (int)RolConocido.Admin,
+            PasswordHash = hasheador.Hashear(Password),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(admin);
+        await db.SaveChangesAsync();
+
+        return new TenantSembrado(tenant, empresa, puntoVenta, new Cuenta(admin.Id, mailAdmin));
+    }
+
+    /// <summary>Agrega un usuario más a un tenant ya sembrado.</summary>
+    private async Task<Cuenta> SembrarUsuarioAsync(int idTenant, string nombreUsuario, RolConocido rol)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var ahora = DateTimeOffset.UtcNow;
+        var mail = $"{nombreUsuario}-{Guid.NewGuid():N}@ways.test";
+        var usuario = new Usuario
+        {
+            IdTenant = idTenant,
+            NombreUsuario = nombreUsuario,
+            Mail = mail,
+            RolId = (int)rol,
+            PasswordHash = hasheador.Hashear(Password),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+
+        return new Cuenta(usuario.Id, mail);
+    }
+
+    private async Task<Empresa> SembrarEmpresaAsync(int idTenant, string razonSocial)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var ahora = DateTimeOffset.UtcNow;
+        var empresa = new Empresa
+        {
+            IdTenant = idTenant,
+            RazonSocial = razonSocial,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.Empresas.Add(empresa);
+        await db.SaveChangesAsync();
+
+        return empresa;
+    }
+
+    private async Task<PuntoVenta> SembrarPuntoVentaAsync(int idTenant, int idEmpresa, string nombre)
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var ahora = DateTimeOffset.UtcNow;
+        var puntoVenta = new PuntoVenta
+        {
+            IdTenant = idTenant,
+            IdEmpresa = idEmpresa,
+            Nombre = nombre,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        };
+        db.PuntosVenta.Add(puntoVenta);
+        await db.SaveChangesAsync();
+
+        return puntoVenta;
+    }
+
+    /// <summary>Baja LÓGICA (B1: en esta etapa nada se borra físicamente): escribe
+    /// <c>deleted_at</c> sobre la fila, que es exactamente lo que el slice 4 va a hacer desde el
+    /// servicio. Acá se escribe a mano justamente porque el escritor todavía no existe.</summary>
+    private async Task DarDeBajaAlTenantAsync(int id) =>
+        await DarDeBajaAsync(db => db.Tenants.FirstAsync(t => t.Id == id));
+
+    private async Task DarDeBajaALaEmpresaAsync(int id) =>
+        await DarDeBajaAsync(db => db.Empresas.FirstAsync(e => e.Id == id));
+
+    private async Task DarDeBajaAlUsuarioAsync(int id) =>
+        await DarDeBajaAsync(db => db.Usuarios.FirstAsync(u => u.Id == id));
+
+    private async Task DarDeBajaAsync<T>(Func<WaysDbContext, Task<T>> buscar)
+        where T : Ways.Domain.Common.EntidadBase
+    {
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var fila = await buscar(db);
+        var ahora = DateTimeOffset.UtcNow;
+        fila.DeletedAt = ahora;
+        fila.UpdatedAt = ahora;
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Una cuenta de plataforma (<c>id_tenant IS NULL</c>) sembrada a mano: no hay
+    /// endpoint que las cree, y es la única forma de probar que ningún tenant la cuenta.</summary>
+    private async Task SembrarUsuarioDePlataformaAsync(string nombreUsuario)
+    {
+        var hasheador = new HasheadorPbkdf2();
+        await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma);
+
+        var ahora = DateTimeOffset.UtcNow;
+        db.Usuarios.Add(new Usuario
+        {
+            IdTenant = null,
+            NombreUsuario = nombreUsuario,
+            Mail = $"{nombreUsuario}@ways.test",
+            RolId = (int)RolConocido.Root,
+            PasswordHash = hasheador.Hashear(Password),
+            PasswordAlgoritmo = hasheador.Algoritmo,
+            PasswordActualizadoEl = ahora,
+            CreatedAt = ahora,
+            UpdatedAt = ahora
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<HttpClient> ClienteComoRootAsync()
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(MailRoot, PasswordRoot));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    private async Task<HttpClient> ClienteComoAdminAsync(string mailAdmin)
+    {
+        var cliente = fixture.CreateClient();
+        var login = await cliente.PostAsJsonAsync("/api/auth/login", new SolicitudDeLogin(mailAdmin, Password));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        return cliente;
+    }
+
+    // ---- task 1.7: exactamente una ida a la base por listado ---------------------------------
+
+    /// <summary>Cuenta cada comando que dispara <c>ReaderExecuting</c> — mismo mecanismo que
+    /// <c>VentasCheckoutTests.ContadorDeComandos</c>.</summary>
+    private sealed class ContadorDeComandos : DbCommandInterceptor
+    {
+        public int Consultas { get; private set; }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Consultas++;
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Consultas++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class ContextoFijo(int? idTenant, int usuarioId, RolConocido rol) : IContextoDeUsuario
+    {
+        public bool EstaAutenticado => true;
+        public int UsuarioId => usuarioId;
+        public string NombreUsuario => "contexto-fijo";
+        public RolConocido Rol => rol;
+        public int? IdTenant => idTenant;
+    }
+
+    private sealed class RelojFijo(DateTimeOffset ahora) : IRelojDelSistema
+    {
+        public DateTimeOffset Ahora { get; } = ahora;
+    }
+
+    /// <summary>
+    /// Task 1.7 (criterio V9) — la cláusula bajo prueba es la PROYECCIÓN: los nombres de dueño y
+    /// los contadores viajan DENTRO del mismo <c>Select</c>, nunca en una segunda consulta ni en
+    /// un lookup por fila.
+    ///
+    /// La medición se toma sobre la llamada de servicio, no sobre el request HTTP, y eso es
+    /// deliberado (<c>mutation-proof-tests</c> regla 3, "ruteá por debajo del confound"): el
+    /// pipeline de la API revalida la cookie contra <c>usuarios</c> y <c>tenants</c> en CADA
+    /// request (ADR-2), así que un contador colgado del host mediría esas consultas mezcladas con
+    /// la del listado y el número dejaría de discriminar. Los cuatro endpoints delegan de forma
+    /// directa en estos cuatro métodos (<c>OrganizacionEndpoints</c>/<c>UsuariosEndpoints</c>), y
+    /// que efectivamente sirven esta proyección lo prueban las tasks 1.8-1.13, que sí van por HTTP.
+    ///
+    /// <c>ListarAsync</c> de usuarios vale 2 y no 1 por una razón preexistente a esta etapa: es el
+    /// único listado paginado, así que emite su <c>CountAsync</c> del total además de la página.
+    /// La proyección de tenant no agrega ninguna: si lo hiciera, serían 3.
+    ///
+    /// MUTACIÓN registrada: sacar la subconsulta de <c>ProyeccionDeEmpresa</c> y resolver el
+    /// nombre con una segunda consulta lleva el conteo de empresas de 1 a 2 y la prueba se cae.
+    /// </summary>
+    [Fact]
+    public async Task CadaListadoCuestaExactamenteUnaIdaALaBase()
+    {
+        var a = await SembrarTenantAsync(nameof(CadaListadoCuestaExactamenteUnaIdaALaBase) + "-A");
+        await SembrarTenantAsync(nameof(CadaListadoCuestaExactamenteUnaIdaALaBase) + "-B");
+        await SembrarEmpresaAsync(a.Tenant.Id, "Segunda empresa SRL");
+
+        var reloj = new RelojFijo(DateTimeOffset.UtcNow);
+        var contextoRoot = new ContextoFijo(null, a.Admin.Id, RolConocido.Root);
+
+        Assert.Equal(1, await ContarAsync(async servicio =>
+        {
+            var tenants = await servicio.ListarTenantsAsync();
+            Assert.Contains(tenants, t => t.Id == a.Tenant.Id);
+        }));
+
+        Assert.Equal(1, await ContarAsync(async servicio =>
+        {
+            var empresas = await servicio.ListarEmpresasAsync();
+            Assert.Contains(empresas, e => e.Id == a.Empresa.Id);
+        }));
+
+        Assert.Equal(1, await ContarAsync(async servicio =>
+        {
+            var puntos = await servicio.ListarPuntosVentaAsync();
+            Assert.Contains(puntos, p => p.Id == a.PuntoVenta.Id);
+        }));
+
+        var contadorUsuarios = new ContadorDeComandos();
+        await using (var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma, contadorUsuarios))
+        await using (var dbPlataforma = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma, contadorUsuarios))
+        {
+            var servicio = new ServicioDeUsuarios(
+                db, dbPlataforma, new HasheadorPbkdf2(), reloj, contextoRoot,
+                new ServicioDeAuditoria(db, reloj, contextoRoot));
+
+            var pagina = await servicio.ListarAsync(tamanio: 200);
+            Assert.Contains(pagina.Items, u => u.Id == a.Admin.Id);
+        }
+
+        Assert.Equal(2, contadorUsuarios.Consultas);
+
+        async Task<int> ContarAsync(Func<ServicioDeOrganizacion, Task> accion)
+        {
+            var contador = new ContadorDeComandos();
+            await using var db = fixture.CrearContextoDeAplicacion(TenantActualFijo.Plataforma, contador);
+            await accion(new ServicioDeOrganizacion(db, reloj, contextoRoot));
+            return contador.Consultas;
+        }
+    }
+
+    // ---- task 1.8: los listados llevan los nombres de los dueños ------------------------------
+
+    /// <summary>
+    /// Task 1.8 (TO-R1) — la cláusula bajo prueba es la CORRELACIÓN de las subconsultas escalares
+    /// (<c>t.Id == e.IdTenant</c>, <c>e.Id == p.IdEmpresa</c>). Por eso el fixture siembra dos
+    /// tenants con dos empresas y dos puntos de venta de nombres distintos
+    /// (<c>mutation-proof-tests</c> regla 12c): una proyección que devolviera "el primer tenant"
+    /// —o que se olvidara del <c>Where</c>— sobreviviría con un solo tenant sembrado.
+    ///
+    /// MUTACIÓN registrada: reemplazar el <c>Where</c> de <c>ProyeccionDeEmpresa</c> por un
+    /// <c>db.Tenants.Select(t => t.Nombre).FirstOrDefault()</c> sin correlación hace que ambas
+    /// empresas reporten el mismo nombre y la prueba se cae.
+    /// </summary>
+    [Fact]
+    public async Task LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios()
+    {
+        var a = await SembrarTenantAsync(
+            nameof(LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios) + "-A",
+            razonSocialEmpresa: "Norte SRL",
+            nombrePuntoVenta: "Norte - Local 1");
+        var b = await SembrarTenantAsync(
+            nameof(LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios) + "-B",
+            razonSocialEmpresa: "Sur SA",
+            nombrePuntoVenta: "Sur - Local 1");
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var empresas = await cliente.GetFromJsonAsync<List<EmpresaListado>>("/api/empresas", OpcionesJson);
+        Assert.NotNull(empresas);
+
+        var empresaA = Assert.Single(empresas!, e => e.Id == a.Empresa.Id);
+        var empresaB = Assert.Single(empresas!, e => e.Id == b.Empresa.Id);
+        Assert.Equal(a.Tenant.Nombre, empresaA.NombreTenant);
+        Assert.Equal(b.Tenant.Nombre, empresaB.NombreTenant);
+        Assert.NotEqual(empresaA.NombreTenant, empresaB.NombreTenant);
+
+        var puntos = await cliente.GetFromJsonAsync<List<PuntoVentaListado>>("/api/puntos-venta", OpcionesJson);
+        Assert.NotNull(puntos);
+
+        var puntoA = Assert.Single(puntos!, p => p.Id == a.PuntoVenta.Id);
+        var puntoB = Assert.Single(puntos!, p => p.Id == b.PuntoVenta.Id);
+        Assert.Equal(a.Tenant.Nombre, puntoA.NombreTenant);
+        Assert.Equal("Norte SRL", puntoA.RazonSocialEmpresa);
+        Assert.Equal(b.Tenant.Nombre, puntoB.NombreTenant);
+        Assert.Equal("Sur SA", puntoB.RazonSocialEmpresa);
+    }
+
+    // ---- task 1.9: los contadores solo cuentan hijos vivos ------------------------------------
+
+    /// <summary>
+    /// Task 1.9 (TO-R2) — dos cláusulas bajo prueba: (a) el filtro <c>"BajaLogica"</c> que corre
+    /// DENTRO de cada <c>Count</c> correlacionado, y (b) el <c>u.IdTenant == t.Id</c> sobre un
+    /// <c>int?</c>, que no matchea contra <c>NULL</c> y por eso deja al personal de plataforma
+    /// fuera de todo tenant. Se afirma que los contadores BAJAN, no que valen algo: un contador
+    /// que ignorara la baja lógica devolvería los valores originales.
+    ///
+    /// Los tres contadores arrancan con valores distintos entre sí (2 empresas, 3 puntos de
+    /// venta, 4 usuarios) para que un intercambio de argumentos posicionales muera acá.
+    ///
+    /// MUTACIÓN registrada: cambiar <c>db.Usuarios.Count(u => u.IdTenant == t.Id)</c> por
+    /// <c>db.Usuarios.IgnoreQueryFilters(["BajaLogica"]).Count(...)</c> deja el contador de
+    /// usuarios en 4 después de la baja y la prueba se cae.
+    /// </summary>
+    [Fact]
+    public async Task LosContadoresDelTenantCuentanSoloHijosVivosYNuncaAlPersonalDePlataforma()
+    {
+        var a = await SembrarTenantAsync(
+            nameof(LosContadoresDelTenantCuentanSoloHijosVivosYNuncaAlPersonalDePlataforma) + "-A");
+        var b = await SembrarTenantAsync(
+            nameof(LosContadoresDelTenantCuentanSoloHijosVivosYNuncaAlPersonalDePlataforma) + "-B");
+
+        var segundaEmpresa = await SembrarEmpresaAsync(a.Tenant.Id, "Segunda empresa SRL");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, a.Empresa.Id, "Local 2");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, segundaEmpresa.Id, "Local 3");
+        var vendedor = await SembrarUsuarioAsync(a.Tenant.Id, "vendedor", RolConocido.Vendedor);
+        await SembrarUsuarioAsync(a.Tenant.Id, "supervisor", RolConocido.Supervisor);
+        await SembrarUsuarioAsync(a.Tenant.Id, "cajero", RolConocido.Vendedor);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var antes = await LeerTenantAsync(cliente, a.Tenant.Id);
+        Assert.Equal(2, antes.CantidadEmpresas);
+        Assert.Equal(3, antes.CantidadPuntosVenta);
+        Assert.Equal(4, antes.CantidadUsuarios);
+
+        // El tenant hermano queda intacto: si algún Count perdiera su correlación, sus números
+        // se contaminarían con los del tenant A.
+        var hermano = await LeerTenantAsync(cliente, b.Tenant.Id);
+        Assert.Equal(1, hermano.CantidadEmpresas);
+        Assert.Equal(1, hermano.CantidadPuntosVenta);
+        Assert.Equal(1, hermano.CantidadUsuarios);
+
+        await DarDeBajaALaEmpresaAsync(segundaEmpresa.Id);
+        await DarDeBajaAlUsuarioAsync(vendedor.Id);
+
+        var despues = await LeerTenantAsync(cliente, a.Tenant.Id);
+        Assert.Equal(1, despues.CantidadEmpresas);
+        Assert.Equal(3, despues.CantidadPuntosVenta);
+        Assert.Equal(3, despues.CantidadUsuarios);
+
+        // Personal de plataforma: se siembra UNA cuenta con id_tenant IS NULL y se afirma que la
+        // suma de cantidadUsuarios sobre TODO el listado no se movió. Una proyección que perdiera
+        // la correlación (db.Usuarios.Count() a secas) subiría el contador de cada tenant y la
+        // suma se movería en tantas unidades como tenants haya.
+        var sumaAntes = await SumarUsuariosDeTodosLosTenantsAsync(cliente);
+
+        await SembrarUsuarioDePlataformaAsync($"plataforma-{Guid.NewGuid():N}"[..38]);
+
+        var sumaDespues = await SumarUsuariosDeTodosLosTenantsAsync(cliente);
+        Assert.Equal(sumaAntes, sumaDespues);
+        Assert.Equal(3, (await LeerTenantAsync(cliente, a.Tenant.Id)).CantidadUsuarios);
+    }
+
+    private static async Task<int> SumarUsuariosDeTodosLosTenantsAsync(HttpClient cliente)
+    {
+        var tenants = await cliente.GetFromJsonAsync<List<TenantListado>>("/api/plataforma/tenants", OpcionesJson);
+        Assert.NotNull(tenants);
+        Assert.NotEmpty(tenants!);
+        return tenants!.Sum(t => t.CantidadUsuarios);
+    }
+
+    private static async Task<TenantListado> LeerTenantAsync(HttpClient cliente, int id)
+    {
+        var tenants = await cliente.GetFromJsonAsync<List<TenantListado>>("/api/plataforma/tenants", OpcionesJson);
+        Assert.NotNull(tenants);
+        return Assert.Single(tenants!, t => t.Id == id);
+    }
+
+    // ---- task 1.10: el caso huérfano ---------------------------------------------------------
+
+    /// <summary>
+    /// Task 1.10 (TO-R1, design D13) — la cláusula bajo prueba es que el nombre del dueño viaja
+    /// como subconsulta escalar y NO como un JOIN: con el tenant dado de baja lógicamente, un
+    /// INNER JOIN se llevaría puesta la fila de la empresa y el listado la escondería. Acá la
+    /// empresa se sigue viendo, con <c>nombreTenant = null</c> — una anomalía visible en vez de
+    /// una desaparición silenciosa, que es lo que hace que este slice sea correcto SIN el cascade
+    /// del slice 4 y por lo tanto mergeable por su cuenta.
+    ///
+    /// MUTACIÓN registrada: reescribir la proyección como un <c>join</c> de LINQ contra
+    /// <c>db.Tenants</c> hace desaparecer la empresa del listado y la prueba se cae en el
+    /// <c>Assert.Single</c>.
+    /// </summary>
+    [Fact]
+    public async Task UnaEmpresaCuyoTenantFueDadoDeBajaSigueApareciendoConNombreDeTenantNulo()
+    {
+        var huerfana = await SembrarTenantAsync(
+            nameof(UnaEmpresaCuyoTenantFueDadoDeBajaSigueApareciendoConNombreDeTenantNulo) + "-A");
+        var viva = await SembrarTenantAsync(
+            nameof(UnaEmpresaCuyoTenantFueDadoDeBajaSigueApareciendoConNombreDeTenantNulo) + "-B");
+
+        await DarDeBajaAlTenantAsync(huerfana.Tenant.Id);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var empresas = await cliente.GetFromJsonAsync<List<EmpresaListado>>("/api/empresas", OpcionesJson);
+        Assert.NotNull(empresas);
+
+        var empresaHuerfana = Assert.Single(empresas!, e => e.Id == huerfana.Empresa.Id);
+        Assert.Equal(huerfana.Tenant.Id, empresaHuerfana.IdTenant);
+        Assert.Null(empresaHuerfana.NombreTenant);
+
+        // El hermano vivo sigue mostrando su nombre: la baja del otro tenant no apagó la
+        // proyección entera.
+        Assert.Equal(
+            viva.Tenant.Nombre,
+            Assert.Single(empresas!, e => e.Id == viva.Empresa.Id).NombreTenant);
+
+        var puntos = await cliente.GetFromJsonAsync<List<PuntoVentaListado>>("/api/puntos-venta", OpcionesJson);
+        Assert.NotNull(puntos);
+
+        var puntoHuerfano = Assert.Single(puntos!, p => p.Id == huerfana.PuntoVenta.Id);
+        Assert.Null(puntoHuerfano.NombreTenant);
+        Assert.Equal(huerfana.Empresa.RazonSocial, puntoHuerfano.RazonSocialEmpresa);
+
+        // Y el tenant dado de baja ya no está en su propio listado.
+        var tenants = await cliente.GetFromJsonAsync<List<TenantListado>>("/api/plataforma/tenants", OpcionesJson);
+        Assert.NotNull(tenants);
+        Assert.DoesNotContain(tenants!, t => t.Id == huerfana.Tenant.Id);
+    }
+
+    // ---- task 1.11: readback posicional completo ---------------------------------------------
+
+    /// <summary>
+    /// Task 1.11 (<c>mutation-proof-tests</c> regla 12b) — cada campo POSICIONAL de los cuatro
+    /// DTOs de listado se lee de vuelta con valores distintos entre sí, para que un argumento
+    /// intercambiado en el constructor posicional muera acá en vez de sobrevivir sobre valores
+    /// iguales. Los tres contadores del tenant valen 2, 3 y 4, y el <c>Id</c> se afirma
+    /// explícitamente mayor que 4 para que un swap contra un contador tampoco pueda pasar.
+    /// </summary>
+    [Fact]
+    public async Task CadaCampoPosicionalDeLosCuatroListadosSeLeeDeVueltaConValoresDistintos()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+        var a = await SembrarTenantAsync(
+            $"Readback-A-{sufijo}",
+            razonSocialEmpresa: $"Readback empresa uno {sufijo} SRL",
+            nombrePuntoVenta: $"Readback local uno {sufijo}",
+            nombreUsuarioAdmin: $"readback-admin-{sufijo}");
+        await SembrarTenantAsync(
+            $"Readback-B-{sufijo}",
+            razonSocialEmpresa: $"Readback empresa dos {sufijo} SA",
+            nombrePuntoVenta: $"Readback local dos {sufijo}");
+
+        var segundaEmpresa = await SembrarEmpresaAsync(a.Tenant.Id, $"Readback empresa tres {sufijo} SRL");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, a.Empresa.Id, $"Readback local tres {sufijo}");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, segundaEmpresa.Id, $"Readback local cuatro {sufijo}");
+        await SembrarUsuarioAsync(a.Tenant.Id, $"readback-uno-{sufijo}", RolConocido.Vendedor);
+        await SembrarUsuarioAsync(a.Tenant.Id, $"readback-dos-{sufijo}", RolConocido.Supervisor);
+        await SembrarUsuarioAsync(a.Tenant.Id, $"readback-tres-{sufijo}", RolConocido.Vendedor);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        // Datos descriptivos distintos campo a campo, por PUT, para que ninguno quede en null.
+        var puntoEditado = await cliente.PutAsJsonAsync(
+            $"/api/puntos-venta/{a.PuntoVenta.Id}",
+            new PuntoVentaEdicion(
+                $"Readback local uno {sufijo}",
+                $"Domicilio {sufijo}",
+                $"Horario {sufijo}",
+                $"Whatsapp {sufijo}",
+                $"Instagram {sufijo}",
+                $"Facebook {sufijo}",
+                $"Web {sufijo}"));
+        Assert.Equal(HttpStatusCode.OK, puntoEditado.StatusCode);
+
+        var empresaEditada = await cliente.PutAsJsonAsync(
+            $"/api/empresas/{a.Empresa.Id}",
+            new EmpresaEdicion($"Readback empresa uno {sufijo} SRL", $"Fantasia {sufijo}", "20-11111111-1"));
+        Assert.Equal(HttpStatusCode.OK, empresaEditada.StatusCode);
+
+        // --- TenantListado: 7 campos ---
+        var tenant = await LeerTenantAsync(cliente, a.Tenant.Id);
+        Assert.Equal(a.Tenant.Id, tenant.Id);
+        Assert.True(tenant.Id > 4, "el id tiene que ser distinguible de los tres contadores");
+        Assert.Equal($"Readback-A-{sufijo}", tenant.Nombre);
+        Assert.Equal(EstadoTenant.Activo, tenant.Estado);
+        // timestamptz redondea a microsegundos, así que la igualdad exacta contra el valor en
+        // memoria sería frágil; lo que este campo tiene que probar es que NO se cruzó con otro.
+        Assert.True(
+            (tenant.CreatedAt - a.Tenant.CreatedAt).Duration() < TimeSpan.FromSeconds(1),
+            "createdAt tiene que ser el del tenant sembrado");
+        Assert.Equal(2, tenant.CantidadEmpresas);
+        Assert.Equal(3, tenant.CantidadPuntosVenta);
+        Assert.Equal(4, tenant.CantidadUsuarios);
+
+        // --- EmpresaListado: 6 campos ---
+        var empresas = await cliente.GetFromJsonAsync<List<EmpresaListado>>("/api/empresas", OpcionesJson);
+        Assert.NotNull(empresas);
+        var empresa = Assert.Single(empresas!, e => e.Id == a.Empresa.Id);
+        Assert.Equal(a.Empresa.Id, empresa.Id);
+        Assert.Equal(a.Tenant.Id, empresa.IdTenant);
+        Assert.NotEqual(empresa.Id, empresa.IdTenant);
+        Assert.Equal($"Readback empresa uno {sufijo} SRL", empresa.RazonSocial);
+        Assert.Equal($"Fantasia {sufijo}", empresa.NombreFantasia);
+        Assert.Equal("20-11111111-1", empresa.Cuit);
+        Assert.Equal($"Readback-A-{sufijo}", empresa.NombreTenant);
+
+        // --- PuntoVentaListado: 12 campos ---
+        var puntos = await cliente.GetFromJsonAsync<List<PuntoVentaListado>>("/api/puntos-venta", OpcionesJson);
+        Assert.NotNull(puntos);
+        var punto = Assert.Single(puntos!, p => p.Id == a.PuntoVenta.Id);
+        Assert.Equal(a.PuntoVenta.Id, punto.Id);
+        Assert.Equal(a.Tenant.Id, punto.IdTenant);
+        Assert.Equal(a.Empresa.Id, punto.IdEmpresa);
+        Assert.Equal($"Readback local uno {sufijo}", punto.Nombre);
+        Assert.Equal($"Domicilio {sufijo}", punto.Domicilio);
+        Assert.Equal($"Horario {sufijo}", punto.Horario);
+        Assert.Equal($"Whatsapp {sufijo}", punto.Whatsapp);
+        Assert.Equal($"Instagram {sufijo}", punto.Instagram);
+        Assert.Equal($"Facebook {sufijo}", punto.Facebook);
+        Assert.Equal($"Web {sufijo}", punto.Web);
+        Assert.Equal($"Readback-A-{sufijo}", punto.NombreTenant);
+        Assert.Equal($"Readback empresa uno {sufijo} SRL", punto.RazonSocialEmpresa);
+
+        // --- UsuarioListado: 10 campos ---
+        var pagina = await cliente.GetFromJsonAsync<PaginaDe<UsuarioListado>>(
+            $"/api/usuarios?busqueda=readback-admin-{sufijo}&tamanio=200", OpcionesJson);
+        Assert.NotNull(pagina);
+        var usuario = Assert.Single(pagina!.Items, u => u.Id == a.Admin.Id);
+        Assert.Equal(a.Admin.Id, usuario.Id);
+        Assert.Equal($"readback-admin-{sufijo}", usuario.Usuario);
+        Assert.Equal(a.Admin.Mail, usuario.Mail);
+        Assert.Equal((int)RolConocido.Admin, usuario.RolId);
+        Assert.Equal("admin", usuario.Rol);
+        Assert.Equal(EstadoUsuario.Activo, usuario.Estado);
+        Assert.Null(usuario.UltimaConexion);
+        Assert.NotEqual(default, usuario.CreatedAt);
+        Assert.Equal(a.Tenant.Id, usuario.IdTenant);
+        Assert.Equal($"Readback-A-{sufijo}", usuario.NombreTenant);
+    }
+
+    // ---- task 1.12: identidad de tenant en el listado de usuarios ----------------------------
+
+    /// <summary>
+    /// Task 1.12 (UT-R1, S1) — la cláusula bajo prueba es que la API NUNCA fabrica la etiqueta
+    /// <c>"Plataforma"</c> (design D14): esa copia es de pantalla y la pone la web en el slice 2.
+    /// El nombre de un tenant es texto libre, así que un tenant llamado justo "Plataforma" sería
+    /// indistinguible de una cuenta de plataforma si el servidor la inventara. Se afirma el valor
+    /// discriminante (<c>mutation-proof-tests</c> regla 4): la cuenta de plataforma trae los dos
+    /// campos en <c>null</c>, ninguna fila trae el literal, y ninguna cuenta sin tenant trae
+    /// nombre. La recíproca de S1 queda deliberadamente sin afirmar — ver el comentario al pie.
+    /// </summary>
+    [Fact]
+    public async Task ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma()
+    {
+        var a = await SembrarTenantAsync(
+            nameof(ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma) + "-A");
+        var b = await SembrarTenantAsync(
+            nameof(ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma) + "-B");
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var respuesta = await cliente.GetAsync("/api/usuarios?tamanio=200");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var pagina = await respuesta.Content.ReadFromJsonAsync<PaginaDe<UsuarioListado>>(OpcionesJson);
+        Assert.NotNull(pagina);
+
+        var adminA = Assert.Single(pagina!.Items, u => u.Id == a.Admin.Id);
+        Assert.Equal(a.Tenant.Id, adminA.IdTenant);
+        Assert.Equal(a.Tenant.Nombre, adminA.NombreTenant);
+
+        var adminB = Assert.Single(pagina.Items, u => u.Id == b.Admin.Id);
+        Assert.Equal(b.Tenant.Id, adminB.IdTenant);
+        Assert.Equal(b.Tenant.Nombre, adminB.NombreTenant);
+        Assert.NotEqual(adminA.NombreTenant, adminB.NombreTenant);
+
+        var root = Assert.Single(pagina.Items, u => u.Mail == MailRoot);
+        Assert.Null(root.IdTenant);
+        Assert.Null(root.NombreTenant);
+
+        // El valor discriminante: la API no manda la etiqueta, la manda la web (D14).
+        Assert.DoesNotContain(pagina.Items, u => u.NombreTenant == "Plataforma");
+
+        // La dirección que S1 le exige a la API: NINGUNA cuenta de plataforma trae nombre. La
+        // recíproca ("nombre nulo implica cuenta de plataforma") NO se afirma a propósito: D13
+        // reserva el nombre nulo también para el huérfano —una cuenta cuyo tenant quedó dado de
+        // baja—, que es justamente la anomalía que este slice elige mostrar en vez de esconder.
+        Assert.All(
+            pagina.Items.Where(u => u.IdTenant is null),
+            u => Assert.Null(u.NombreTenant));
+    }
+
+    // ---- task 1.13: regresión de alcance -----------------------------------------------------
+
+    /// <summary>
+    /// Task 1.13 (UT-R1) — regresión: agregar el nombre del tenant a la proyección no abrió un
+    /// canal de enumeración. Un admin de tenant sigue viendo solo sus propias cuentas y el nombre
+    /// del otro tenant no aparece NI en el listado NI en el JSON crudo. El nombre del tenant
+    /// vecino se elige único (un GUID) para que la aserción sobre el cuerpo crudo discrimine de
+    /// verdad.
+    /// </summary>
+    [Fact]
+    public async Task UnAdminDeTenantSoloVeSusCuentasYNuncaElNombreDeOtroTenant()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+        var a = await SembrarTenantAsync($"Alcance-A-{sufijo}");
+        var b = await SembrarTenantAsync($"Alcance-vecino-{sufijo}");
+
+        using var cliente = await ClienteComoAdminAsync(a.Admin.Mail);
+
+        var respuesta = await cliente.GetAsync("/api/usuarios?tamanio=200");
+        Assert.Equal(HttpStatusCode.OK, respuesta.StatusCode);
+
+        var crudo = await respuesta.Content.ReadAsStringAsync();
+        var pagina = JsonSerializer.Deserialize<PaginaDe<UsuarioListado>>(crudo, OpcionesJson);
+        Assert.NotNull(pagina);
+
+        Assert.NotEmpty(pagina!.Items);
+        Assert.All(pagina.Items, u =>
+        {
+            Assert.Equal(a.Tenant.Id, u.IdTenant);
+            Assert.Equal(a.Tenant.Nombre, u.NombreTenant);
+        });
+
+        Assert.DoesNotContain(pagina.Items, u => u.Id == b.Admin.Id);
+        Assert.DoesNotContain($"Alcance-vecino-{sufijo}", crudo, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
@@ -366,6 +366,13 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     /// MUTACIÓN registrada: reemplazar el <c>Where</c> de <c>ProyeccionDeEmpresa</c> por un
     /// <c>db.Tenants.Select(t => t.Nombre).FirstOrDefault()</c> sin correlación hace que ambas
     /// empresas reporten el mismo nombre y la prueba se cae.
+    ///
+    /// Para <c>RazonSocialEmpresa</c> el hermano tiene que ser del MISMO dueño (regla 12c): con
+    /// una sola empresa por tenant, un mutante que correlacionara por <c>e.IdTenant == p.IdTenant</c>
+    /// devolvería la misma razón social y sobreviviría. Por eso el tenant A lleva una SEGUNDA
+    /// empresa con su propio punto de venta. MUTACIÓN registrada: correlacionar por
+    /// <c>e.IdTenant == p.IdTenant</c> hace que los dos puntos de venta de A reporten la misma
+    /// razón social y una de las dos aserciones se cae, cualquiera sea la fila que elija la base.
     /// </summary>
     [Fact]
     public async Task LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios()
@@ -378,6 +385,9 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
             nameof(LosListadosDeEmpresasYPuntosDeVentaLlevanLosNombresDeSusDuenios) + "-B",
             razonSocialEmpresa: "Sur SA",
             nombrePuntoVenta: "Sur - Local 1");
+
+        var anexoDeA = await SembrarEmpresaAsync(a.Tenant.Id, "Norte Anexo SRL");
+        var puntoDelAnexo = await SembrarPuntoVentaAsync(a.Tenant.Id, anexoDeA.Id, "Norte - Local 2");
 
         using var cliente = await ClienteComoRootAsync();
 
@@ -399,6 +409,15 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         Assert.Equal("Norte SRL", puntoA.RazonSocialEmpresa);
         Assert.Equal(b.Tenant.Nombre, puntoB.NombreTenant);
         Assert.Equal("Sur SA", puntoB.RazonSocialEmpresa);
+
+        // El hermano del MISMO dueño: mismo tenant, otra empresa. Un mutante que correlacionara
+        // por tenant tiene que elegir una de las dos razones sociales y romper la otra aserción.
+        var puntoAnexo = Assert.Single(puntos!, p => p.Id == puntoDelAnexo.Id);
+        Assert.Equal(a.Tenant.Nombre, puntoAnexo.NombreTenant);
+        Assert.Equal("Norte Anexo SRL", puntoAnexo.RazonSocialEmpresa);
+        Assert.Equal(a.Tenant.Id, puntoAnexo.IdTenant);
+        Assert.Equal(anexoDeA.Id, puntoAnexo.IdEmpresa);
+        Assert.NotEqual(puntoA.RazonSocialEmpresa, puntoAnexo.RazonSocialEmpresa);
     }
 
     // ---- task 1.9: los contadores solo cuentan hijos vivos ------------------------------------
@@ -762,5 +781,296 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
 
         Assert.DoesNotContain(pagina.Items, u => u.Id == b.Admin.Id);
         Assert.DoesNotContain($"Alcance-vecino-{sufijo}", crudo, StringComparison.Ordinal);
+    }
+
+    // ---- ronda 1 de judgment-day: el huérfano en los TRES caminos de usuarios ----------------
+
+    /// <summary>
+    /// La cláusula bajo prueba es el <c>t.DeletedAt == null</c> EXPLÍCITO de la subconsulta de
+    /// <c>ServicioDeUsuarios.ListarAsync</c>. EF aplica <c>IgnoreQueryFilters</c> a nivel CONSULTA,
+    /// así que con <c>incluirEliminados=true</c> la subconsulta correlacionada perdía también el
+    /// filtro de baja lógica: la MISMA cuenta traía el nombre del tenant dado de baja en ese
+    /// camino y <c>null</c> en el listado por defecto y en el detalle. Se afirman los tres.
+    ///
+    /// El hermano vivo se afirma en el mismo request: un predicado que apagara la proyección
+    /// entera también pasaría la aserción de nulidad, así que sola no discrimina.
+    ///
+    /// MUTACIÓN registrada: sacar <c>&amp;&amp; t.DeletedAt == null</c> de la subconsulta deja el
+    /// camino <c>incluirEliminados=true</c> devolviendo el nombre del tenant y la prueba se cae.
+    /// </summary>
+    [Fact]
+    public async Task UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+
+        var huerfana = await SembrarTenantAsync(
+            $"Huerfano-A-{sufijo}", nombreUsuarioAdmin: $"huerfano-a-{sufijo}");
+        var viva = await SembrarTenantAsync(
+            $"Huerfano-B-{sufijo}", nombreUsuarioAdmin: $"huerfano-b-{sufijo}");
+
+        await DarDeBajaAlTenantAsync(huerfana.Tenant.Id);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var porDefecto = await LeerCuerpoAsync<PaginaDe<UsuarioListado>>(
+            await cliente.GetAsync($"/api/usuarios?busqueda={sufijo}&tamanio=200"));
+        AfirmarHuerfano(Assert.Single(porDefecto.Items, u => u.Id == huerfana.Admin.Id));
+        AfirmarVivo(Assert.Single(porDefecto.Items, u => u.Id == viva.Admin.Id));
+
+        var conEliminados = await LeerCuerpoAsync<PaginaDe<UsuarioListado>>(
+            await cliente.GetAsync($"/api/usuarios?busqueda={sufijo}&incluirEliminados=true&tamanio=200"));
+        AfirmarHuerfano(Assert.Single(conEliminados.Items, u => u.Id == huerfana.Admin.Id));
+        AfirmarVivo(Assert.Single(conEliminados.Items, u => u.Id == viva.Admin.Id));
+
+        AfirmarHuerfano(await LeerCuerpoAsync<UsuarioListado>(
+            await cliente.GetAsync($"/api/usuarios/{huerfana.Admin.Id}")));
+
+        void AfirmarHuerfano(UsuarioListado cuenta)
+        {
+            Assert.Equal(huerfana.Tenant.Id, cuenta.IdTenant);
+            Assert.Null(cuenta.NombreTenant);
+        }
+
+        void AfirmarVivo(UsuarioListado cuenta)
+        {
+            Assert.Equal(viva.Tenant.Id, cuenta.IdTenant);
+            Assert.Equal($"Huerfano-B-{sufijo}", cuenta.NombreTenant);
+        }
+    }
+
+    // ---- ronda 1 de judgment-day: readback de los caminos que NO son el listado ---------------
+
+    /// <summary>
+    /// <c>mutation-proof-tests</c> regla 12b sobre los caminos de respuesta que el slice dejaba sin
+    /// leer: detalle, edición, suspensión y reactivación devuelven el MISMO record que el listado,
+    /// y ningún test leía de vuelta los campos nuevos por esos caminos (reemplazar el cuerpo de la
+    /// proyección por constantes sobrevivía a la suite entera). Los tres contadores valen 2, 3 y 4
+    /// —distintos entre sí y distintos del id— para que un intercambio posicional muera acá.
+    /// </summary>
+    [Fact]
+    public async Task ElDetalleYLasEscriturasDeTenantDevuelvenLosSieteCamposProyectados()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+        await SembrarRellenoDesbalanceadoAsync(sufijo);
+
+        var a = await SembrarTenantAsync(
+            $"Detalle-tenant-{sufijo}", nombreUsuarioAdmin: $"det-admin-{sufijo}");
+        var segundaEmpresa = await SembrarEmpresaAsync(a.Tenant.Id, $"Detalle empresa dos {sufijo} SRL");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, a.Empresa.Id, $"Detalle local dos {sufijo}");
+        await SembrarPuntoVentaAsync(a.Tenant.Id, segundaEmpresa.Id, $"Detalle local tres {sufijo}");
+        await SembrarUsuarioAsync(a.Tenant.Id, $"det-uno-{sufijo}", RolConocido.Vendedor);
+        await SembrarUsuarioAsync(a.Tenant.Id, $"det-dos-{sufijo}", RolConocido.Supervisor);
+        await SembrarUsuarioAsync(a.Tenant.Id, $"det-tres-{sufijo}", RolConocido.Vendedor);
+
+        using var cliente = await ClienteComoRootAsync();
+
+        AfirmarTenant(
+            await LeerCuerpoAsync<TenantListado>(
+                await cliente.GetAsync($"/api/plataforma/tenants/{a.Tenant.Id}")),
+            $"Detalle-tenant-{sufijo}",
+            EstadoTenant.Activo);
+
+        AfirmarTenant(
+            await LeerCuerpoAsync<TenantListado>(
+                await cliente.PutAsJsonAsync(
+                    $"/api/plataforma/tenants/{a.Tenant.Id}",
+                    new TenantEdicion($"Detalle-tenant-editado-{sufijo}"))),
+            $"Detalle-tenant-editado-{sufijo}",
+            EstadoTenant.Activo);
+
+        AfirmarTenant(
+            await LeerCuerpoAsync<TenantListado>(
+                await cliente.PostAsync($"/api/plataforma/tenants/{a.Tenant.Id}/suspender", null)),
+            $"Detalle-tenant-editado-{sufijo}",
+            EstadoTenant.Suspendido);
+
+        AfirmarTenant(
+            await LeerCuerpoAsync<TenantListado>(
+                await cliente.PostAsync($"/api/plataforma/tenants/{a.Tenant.Id}/reactivar", null)),
+            $"Detalle-tenant-editado-{sufijo}",
+            EstadoTenant.Activo);
+
+        void AfirmarTenant(TenantListado tenant, string nombreEsperado, EstadoTenant estadoEsperado)
+        {
+            Assert.Equal(a.Tenant.Id, tenant.Id);
+            Assert.True(tenant.Id > 4, "el id tiene que ser distinguible de los tres contadores");
+            Assert.Equal(nombreEsperado, tenant.Nombre);
+            Assert.Equal(estadoEsperado, tenant.Estado);
+            Assert.True(
+                (tenant.CreatedAt - a.Tenant.CreatedAt).Duration() < TimeSpan.FromSeconds(1),
+                "createdAt tiene que ser el del tenant sembrado");
+            Assert.Equal(2, tenant.CantidadEmpresas);
+            Assert.Equal(3, tenant.CantidadPuntosVenta);
+            Assert.Equal(4, tenant.CantidadUsuarios);
+        }
+    }
+
+    /// <summary>Mismo criterio que la prueba anterior, sobre <c>EmpresaListado</c> (6 campos) y
+    /// <c>PuntoVentaListado</c> (12): detalle y edición devuelven todos los campos con su verdad,
+    /// con <c>id</c>, <c>idTenant</c> e <c>idEmpresa</c> distintos entre sí por construcción.</summary>
+    [Fact]
+    public async Task ElDetalleYLaEdicionDeEmpresaYPuntoDeVentaDevuelvenTodosLosCamposProyectados()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+        await SembrarRellenoDesbalanceadoAsync(sufijo);
+
+        var a = await SembrarTenantAsync(
+            $"Detalle-org-{sufijo}",
+            razonSocialEmpresa: $"Detalle org empresa {sufijo} SRL",
+            nombrePuntoVenta: $"Detalle org local {sufijo}");
+
+        using var cliente = await ClienteComoRootAsync();
+
+        AfirmarEmpresa(await LeerCuerpoAsync<EmpresaListado>(
+            await cliente.PutAsJsonAsync(
+                $"/api/empresas/{a.Empresa.Id}",
+                new EmpresaEdicion(
+                    $"Detalle org empresa {sufijo} SRL", $"Fantasia {sufijo}", "20-22222222-2"))));
+
+        AfirmarEmpresa(await LeerCuerpoAsync<EmpresaListado>(
+            await cliente.GetAsync($"/api/empresas/{a.Empresa.Id}")));
+
+        AfirmarPuntoVenta(await LeerCuerpoAsync<PuntoVentaListado>(
+            await cliente.PutAsJsonAsync(
+                $"/api/puntos-venta/{a.PuntoVenta.Id}",
+                new PuntoVentaEdicion(
+                    $"Detalle org local {sufijo}",
+                    $"Domicilio {sufijo}",
+                    $"Horario {sufijo}",
+                    $"Whatsapp {sufijo}",
+                    $"Instagram {sufijo}",
+                    $"Facebook {sufijo}",
+                    $"Web {sufijo}"))));
+
+        AfirmarPuntoVenta(await LeerCuerpoAsync<PuntoVentaListado>(
+            await cliente.GetAsync($"/api/puntos-venta/{a.PuntoVenta.Id}")));
+
+        void AfirmarEmpresa(EmpresaListado empresa)
+        {
+            Assert.Equal(a.Empresa.Id, empresa.Id);
+            Assert.Equal(a.Tenant.Id, empresa.IdTenant);
+            Assert.NotEqual(empresa.Id, empresa.IdTenant);
+            Assert.Equal($"Detalle org empresa {sufijo} SRL", empresa.RazonSocial);
+            Assert.Equal($"Fantasia {sufijo}", empresa.NombreFantasia);
+            Assert.Equal("20-22222222-2", empresa.Cuit);
+            Assert.Equal($"Detalle-org-{sufijo}", empresa.NombreTenant);
+        }
+
+        void AfirmarPuntoVenta(PuntoVentaListado punto)
+        {
+            Assert.Equal(a.PuntoVenta.Id, punto.Id);
+            Assert.Equal(a.Tenant.Id, punto.IdTenant);
+            Assert.Equal(a.Empresa.Id, punto.IdEmpresa);
+            Assert.NotEqual(punto.Id, punto.IdTenant);
+            Assert.NotEqual(punto.Id, punto.IdEmpresa);
+            Assert.NotEqual(punto.IdTenant, punto.IdEmpresa);
+            Assert.Equal($"Detalle org local {sufijo}", punto.Nombre);
+            Assert.Equal($"Domicilio {sufijo}", punto.Domicilio);
+            Assert.Equal($"Horario {sufijo}", punto.Horario);
+            Assert.Equal($"Whatsapp {sufijo}", punto.Whatsapp);
+            Assert.Equal($"Instagram {sufijo}", punto.Instagram);
+            Assert.Equal($"Facebook {sufijo}", punto.Facebook);
+            Assert.Equal($"Web {sufijo}", punto.Web);
+            Assert.Equal($"Detalle-org-{sufijo}", punto.NombreTenant);
+            Assert.Equal($"Detalle org empresa {sufijo} SRL", punto.RazonSocialEmpresa);
+        }
+    }
+
+    /// <summary>Los tres caminos de <c>UsuarioListado</c> que no son el listado: el 201 del alta,
+    /// el detalle y el cuerpo del PUT — los tres devuelven el record de
+    /// <c>ServicioDeUsuarios.ObtenerAsync</c>, que era el que sobrevivía a un
+    /// <c>NombreDeTenantAsync</c> reemplazado por <c>return null;</c>.</summary>
+    [Fact]
+    public async Task ElAltaElDetalleYLaEdicionDeUsuarioDevuelvenLosDiezCamposProyectados()
+    {
+        var sufijo = Guid.NewGuid().ToString("N")[..8];
+        await SembrarRellenoDesbalanceadoAsync(sufijo);
+
+        var a = await SembrarTenantAsync($"Detalle-usuario-{sufijo}");
+
+        using var cliente = await ClienteComoRootAsync();
+
+        var mailAlta = $"alta-{sufijo}@ways.test";
+        var creado = await LeerCuerpoAsync<UsuarioListado>(
+            await cliente.PostAsJsonAsync(
+                "/api/usuarios",
+                new CrearUsuario(
+                    $"alta-{sufijo}", mailAlta, (int)RolConocido.Supervisor, Password,
+                    EstadoUsuario.Activo, a.Tenant.Id)),
+            HttpStatusCode.Created);
+
+        AfirmarUsuario(creado, $"alta-{sufijo}", mailAlta, RolConocido.Supervisor, "supervisor", EstadoUsuario.Activo);
+
+        AfirmarUsuario(
+            await LeerCuerpoAsync<UsuarioListado>(await cliente.GetAsync($"/api/usuarios/{creado.Id}")),
+            $"alta-{sufijo}", mailAlta, RolConocido.Supervisor, "supervisor", EstadoUsuario.Activo);
+
+        var mailEditado = $"editado-{sufijo}@ways.test";
+        AfirmarUsuario(
+            await LeerCuerpoAsync<UsuarioListado>(
+                await cliente.PutAsJsonAsync(
+                    $"/api/usuarios/{creado.Id}",
+                    new ActualizarUsuario(
+                        $"editado-{sufijo}", mailEditado, (int)RolConocido.Vendedor,
+                        EstadoUsuario.Inactivo))),
+            $"editado-{sufijo}", mailEditado, RolConocido.Vendedor, "vendedor", EstadoUsuario.Inactivo);
+
+        void AfirmarUsuario(
+            UsuarioListado usuario,
+            string nombre,
+            string mail,
+            RolConocido rol,
+            string nombreRol,
+            EstadoUsuario estado)
+        {
+            Assert.Equal(creado.Id, usuario.Id);
+            Assert.Equal(nombre, usuario.Usuario);
+            Assert.Equal(mail, usuario.Mail);
+            Assert.Equal((int)rol, usuario.RolId);
+            Assert.Equal(nombreRol, usuario.Rol);
+            Assert.Equal(estado, usuario.Estado);
+            Assert.Null(usuario.UltimaConexion);
+            Assert.NotEqual(default, usuario.CreatedAt);
+            Assert.Equal(a.Tenant.Id, usuario.IdTenant);
+            Assert.Equal($"Detalle-usuario-{sufijo}", usuario.NombreTenant);
+            Assert.NotEqual(usuario.Id, usuario.IdTenant);
+            Assert.NotEqual(usuario.Id, usuario.RolId);
+        }
+    }
+
+    /// <summary>Relleno DESBALANCEADO, mismo criterio que la task 1.11: cada tenant de relleno se
+    /// lleva una cantidad distinta de empresas, puntos de venta y usuarios, así las cuatro
+    /// secuencias de identidad se desincronizan y <c>id</c>, <c>idTenant</c> e <c>idEmpresa</c>
+    /// quedan distintos POR CONSTRUCCIÓN, no por el orden en que xUnit corrió la clase.</summary>
+    private async Task SembrarRellenoDesbalanceadoAsync(string sufijo)
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            var relleno = await SembrarTenantAsync($"Relleno-{i}-{sufijo}");
+
+            for (var j = 0; j < 2; j++)
+            {
+                var empresaRelleno = await SembrarEmpresaAsync(
+                    relleno.Tenant.Id, $"Relleno {i}-{j} {sufijo} SRL");
+                await SembrarPuntoVentaAsync(
+                    relleno.Tenant.Id, empresaRelleno.Id, $"Relleno local {i}-{j} {sufijo}");
+                await SembrarUsuarioAsync(
+                    relleno.Tenant.Id, $"relleno-{i}-{j}-{sufijo}", RolConocido.Vendedor);
+            }
+
+            await SembrarPuntoVentaAsync(
+                relleno.Tenant.Id, relleno.Empresa.Id, $"Relleno local extra {i} {sufijo}");
+        }
+    }
+
+    private static async Task<T> LeerCuerpoAsync<T>(
+        HttpResponseMessage respuesta, HttpStatusCode esperado = HttpStatusCode.OK)
+    {
+        Assert.Equal(esperado, respuesta.StatusCode);
+
+        var cuerpo = await respuesta.Content.ReadFromJsonAsync<T>(OpcionesJson);
+        Assert.NotNull(cuerpo);
+
+        return cuerpo!;
     }
 }

--- a/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
+++ b/tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs
@@ -547,6 +547,32 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
     public async Task CadaCampoPosicionalDeLosCuatroListadosSeLeeDeVueltaConValoresDistintos()
     {
         var sufijo = Guid.NewGuid().ToString("N")[..8];
+
+        // Relleno DESBALANCEADO antes del tenant que se lee: cada tenant de relleno se lleva una
+        // cantidad distinta de empresas, puntos de venta y usuarios, así las cuatro secuencias de
+        // identidad se desincronizan entre sí. Sin esto, id, idTenant e idEmpresa avanzarían en
+        // lockstep y podrían COINCIDIR, que es exactamente el caso en el que un intercambio de
+        // argumentos posicionales sobrevive (mutation-proof-tests regla 12b). Además empuja el id
+        // del tenant bajo prueba por encima de los tres contadores, de forma determinística y sin
+        // depender del orden en que xUnit haya corrido el resto de la clase.
+        for (var i = 0; i < 3; i++)
+        {
+            var relleno = await SembrarTenantAsync($"Readback-relleno-{i}-{sufijo}");
+
+            for (var j = 0; j < 2; j++)
+            {
+                var empresaRelleno = await SembrarEmpresaAsync(
+                    relleno.Tenant.Id, $"Relleno {i}-{j} {sufijo} SRL");
+                await SembrarPuntoVentaAsync(
+                    relleno.Tenant.Id, empresaRelleno.Id, $"Relleno local {i}-{j} {sufijo}");
+                await SembrarUsuarioAsync(
+                    relleno.Tenant.Id, $"relleno-{i}-{j}-{sufijo}", RolConocido.Vendedor);
+            }
+
+            await SembrarPuntoVentaAsync(
+                relleno.Tenant.Id, relleno.Empresa.Id, $"Relleno local extra {i} {sufijo}");
+        }
+
         var a = await SembrarTenantAsync(
             $"Readback-A-{sufijo}",
             razonSocialEmpresa: $"Readback empresa uno {sufijo} SRL",
@@ -618,6 +644,9 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         Assert.Equal(a.PuntoVenta.Id, punto.Id);
         Assert.Equal(a.Tenant.Id, punto.IdTenant);
         Assert.Equal(a.Empresa.Id, punto.IdEmpresa);
+        Assert.NotEqual(punto.Id, punto.IdTenant);
+        Assert.NotEqual(punto.Id, punto.IdEmpresa);
+        Assert.NotEqual(punto.IdTenant, punto.IdEmpresa);
         Assert.Equal($"Readback local uno {sufijo}", punto.Nombre);
         Assert.Equal($"Domicilio {sufijo}", punto.Domicilio);
         Assert.Equal($"Horario {sufijo}", punto.Horario);
@@ -634,6 +663,8 @@ public class ProyeccionDeOrganizacionTests(WaysApiFixture fixture) : IClassFixtu
         Assert.NotNull(pagina);
         var usuario = Assert.Single(pagina!.Items, u => u.Id == a.Admin.Id);
         Assert.Equal(a.Admin.Id, usuario.Id);
+        Assert.NotEqual(usuario.Id, usuario.IdTenant);
+        Assert.NotEqual(usuario.Id, usuario.RolId);
         Assert.Equal($"readback-admin-{sufijo}", usuario.Usuario);
         Assert.Equal(a.Admin.Mail, usuario.Mail);
         Assert.Equal((int)RolConocido.Admin, usuario.RolId);

--- a/tests/Ways.IntegrationTests/WaysApiFixture.cs
+++ b/tests/Ways.IntegrationTests/WaysApiFixture.cs
@@ -235,7 +235,12 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
     /// setear y hasta un contexto en modo plataforma se topa con <c>WITH CHECK</c> — este
     /// helper es el único lugar donde ese cableado se arma a mano, así que es el único
     /// lugar donde se puede (y se pudo) olvidar.</summary>
-    public WaysDbContext CrearContextoDeAplicacion(ITenantActual tenantActual)
+    /// <param name="interceptoresExtra">Interceptores adicionales, además del de contexto de
+    /// tenant — el caso de uso es un contador de comandos (<c>DbCommandInterceptor</c>) cuando la
+    /// prueba mide idas a la base de una llamada de servicio puntual, sin el ruido de las
+    /// consultas de autenticación que dispara el pipeline HTTP.</param>
+    public WaysDbContext CrearContextoDeAplicacion(
+        ITenantActual tenantActual, params IInterceptor[] interceptoresExtra)
     {
         var opciones = new DbContextOptionsBuilder<WaysDbContext>()
             .UseNpgsql(AppConnectionString, npgsql =>
@@ -262,7 +267,7 @@ public sealed class WaysApiFixture : WebApplicationFactory<Program>, IAsyncLifet
                 npgsql.MapEnum<ResultadoFiscal>("resultado_fiscal");
                 npgsql.MapEnum<AmbienteFiscal>("ambiente_fiscal");
             })
-            .AddInterceptors(new InterceptorDeContextoDeTenant(tenantActual))
+            .AddInterceptors([new InterceptorDeContextoDeTenant(tenantActual), .. interceptoresExtra])
             .Options;
 
         return new WaysDbContext(opciones, tenantActual);


### PR DESCRIPTION
Closes #164

## Resumen

Slice 1 de 5 de la etapa 20. Los cuatro listados del ABM raiz dejan de ser tablas planas sin relacion: cada uno lleva ahora el nombre de su dueno y, en el caso de tenants, los contadores de sus hijos.

- `TenantListado` suma `CantidadEmpresas`, `CantidadPuntosVenta` y `CantidadUsuarios`.
- `EmpresaListado` suma `NombreTenant`; `PuntoVentaListado` suma `NombreTenant` y `RazonSocialEmpresa`.
- `UsuarioListado` suma `IdTenant` y `NombreTenant` — hasta ahora el DTO no llevaba **ningun** dato de tenant.
- Sin consumidor web todavia: eso es el slice 2. Este PR es solo la capa de proyeccion.

## Decisiones que cargan peso

**Subconsultas correlacionadas, no navegacion.** `Empresa` y `PuntoVenta` no tienen propiedades de navegacion, asi que los nombres de dueno solo pueden salir como subconsultas escalares correlacionadas. Ademas esto elimina gratis la trampa del INNER JOIN: un `Join` descartaria en silencio la fila cuyo dueno fue dado de baja. La mutacion M4 lo prueba — reescribir la proyeccion como `Join` hace desaparecer la empresa huerfana.

**El nombre proyectado es `string?` a proposito.** Un huerfano se rinde como anomalia visible en vez de esfumarse del listado. Eso es lo que desacopla este slice de la cascada del slice 4 y lo deja mergeable por su cuenta.

**El servidor jamas fabrica `"Plataforma"`.** `NombreTenant` viaja `null` y esa copia la pone la web. Un tenant que se llamara justo "Plataforma" seria indistinguible de una cuenta de plataforma y envenenaria el filtro.

**Una sola ida a la base por listado.** Asertado con `ContadorDeComandos`: 1 para cada listado de organizacion. El de usuarios cuesta 2 por el `CountAsync` de paginacion, que es **preexistente** y no lo agrega esta proyeccion — queda registrado como Reconciliacion 8 en vez de maquillar el criterio.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/Ways.Application/Organizacion/Contratos.cs` | Los tres DTO de organizacion suman nombres de dueno y contadores |
| `src/Ways.Application/Organizacion/ServicioDeOrganizacion.cs` | Las tres proyecciones con subconsultas correlacionadas; las relecturas post-escritura pasan a `FirstOrDefaultAsync` + 404 de dominio |
| `src/Ways.Application/Usuarios/Contratos.cs` | `UsuarioListado` suma `IdTenant` y `NombreTenant` |
| `src/Ways.Application/Usuarios/ServicioDeUsuarios.cs` | Proyeccion del listado y del detalle, con el `DeletedAt == null` explicito |
| `tests/Ways.IntegrationTests/ProyeccionDeOrganizacionTests.cs` | 12 tests nuevos (1194 lineas) |
| `tests/Ways.IntegrationTests/WaysApiFixture.cs` | `params IInterceptor[]` opcional; cero call sites modificados |

## Judgment-day: APROBADO en ronda limpia

Cero hallazgos severos en las tres rondas. Dos rondas de correccion y dos re-judgments acotadas, ambos jueces ciegos y en paralelo.

- **Ronda 0** — 4 hallazgos confirmados por ambos jueces. El mas grave: `IgnoreQueryFilters(["BajaLogica"])` se filtraba a la subconsulta del nombre de tenant, asi que `?incluirEliminados=true` mostraba el nombre de un tenant dado de baja mientras el listado normal devolvia `null`. Y once caminos de respuesta que no son listado enviaban los campos nuevos **sin una sola assertion**: reemplazar el cuerpo de `NombreDeTenantAsync` por `return null;` dejaba la suite entera en verde.
- **Ronda 1** — los seis cerrados y verificados de forma independiente por ambos jueces.
- **Ronda 2** — siete items de consistencia. Los cuatro predicados defensivos que se agregaron **no son demostrables hoy**: las cuatro mutaciones sobrevivieron y se registro asi, sin inventar un rojo. El slice 4 los vuelve demostrables o los saca.

## Evidencia de mutacion

Nueve mutaciones ejecutadas de verdad — aplicadas, rojo observado, revertidas, verde. La tabla completa esta en `tasks.md`. Dos de ellas encontraron defectos **en los propios tests**: un guard dependiente del orden y secuencias de identidad avanzando al mismo ritmo, que es exactamente la condicion bajo la cual un swap de argumentos posicionales sobrevive.

## Tamano: 1420 lineas contra un presupuesto de 800

Se reporta, no se disimula. Produccion son **217 lineas**; las otras 1203 son los tests, y la mayor parte existe porque la revision los exigio para probar esas 217. Se decidio un solo PR: partirlo separa la prueba de lo que prueba. El label `size:exception` queda a criterio del dueno.

## Suites

```
dotnet build Ways.slnx          Compilacion correcta, 0 errores
Ways.Domain.Tests               545/545
Ways.Application.Tests          373/373
Ways.IntegrationTests          1737/1737
has-pending-model-changes       limpio
```

**Cero esquema, verificado no asumido**: ningun archivo bajo `Migraciones/` (la ultima sigue siendo `20260822002214_FiscalArcaEtapa19a`), `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` / `ManejadorDeErrores.cs` fuera del diff, y cero borrados fisicos.
