### PR TITLE
feat(web): relaciones de organizacion en la UI raiz y selector de tenant en el alta (slice 2 de etapa 20)

### DIFF
--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -518,7 +518,54 @@ phases:
       NOT INTRODUCED HERE: Reposicion.test.tsx's first-punto-de-venta test fails
       intermittently under the full-suite run (1 of 3 runs on this branch, 1 of 4
       runs on main with the branch stashed; 12/12 when the file runs alone).
-      Slices 3-5 pending.
+      TASK 2.17 ADDED MID-SLICE ON AN OWNER-REPORTED BUG, on the same branch
+      feat/stage20-slice2-web-relaciones and web-only. As a platform actor,
+      creating a user with rol Admin always failed with the backend 400
+      tenant_requerido because the create form offered no tenant. The server
+      already supported it (CrearUsuario accepts int? IdTenant,
+      Contratos.cs:43-49) and the web mirror had dropped the field, which is a
+      dto-contract-honesty violation on the web side. Delivered - tipos.ts
+      mirrors idTenant on CrearUsuario and ActualizarUsuario is deliberately
+      left alone because the server record does NOT accept a tenant
+      (Contratos.cs:51-55); a tenant select in the create form rendered ONLY
+      for a platform actor, so a tenant admin never enumerates tenants (S5) and
+      sends idTenant null, which ServicioDeUsuarios.CrearAsync ignores in
+      favour of Actor.IdTenant; the options derive from the ALREADY-LOADED rows
+      via the existing opcionesDeTenant(filas) minus the platform token, so NO
+      second fetch was added and D15 still holds; a client-side mirror of
+      PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance for guidance only (rol
+      Root disables the selector and clears idTenant IN STATE, any other rol
+      makes it required) with the server left untouched as the authority and
+      its 400 still surfacing through the existing error path; and
+      react-async-state rule 5 applied so the selector is inert while the list
+      loads and while a save is in flight. FIVE MUTATIONS RUN FOR REAL
+      (M14-M18, table in tasks.md), ALL KILLED, no survivors - dropping
+      idTenant from the payload builder killed 3 tests, dropping the state
+      clear killed the Root test on the rendered value, dropping the
+      ofreceTenant gate killed 2, dropping the assignable-tenants filter killed
+      the option-set test and dropping tenantsCargando killed the inert-while-
+      loading test. ONE INACCURACY IN A TEST DOC-COMMENT was found by running
+      M15 and corrected rather than left standing - the draft claimed the M4
+      confound applied, but the select's value derives from the SAME state that
+      travels in the POST so there is no independent fallback. TWO PREMISES OF
+      THE LAUNCH BRIEF DID NOT HOLD AND ARE RECORDED, NOT ABSORBED - there is
+      no tenant fetch in slice 2 to reuse (D15 forbids one) so the reused state
+      is the derived opcionesDeTenant(filas), and Usuarios.tsx had no
+      esPlataforma notion (Empresas.tsx:30 and PuntosVenta.tsx:41 do), which
+      was introduced here with the identical rolId === ROL.Root definition.
+      KNOWN GAP STATED - deriving from loaded rows means a platform actor can
+      only assign a tenant present on the current page, and GET /api/usuarios
+      defaults to tamanio 25; every tenant is provisioned with its admin user
+      so a zero-user tenant does not normally exist, and the reachable case is
+      the 26th tenant onward. Closing it needs either the platform-only
+      listarTenants() fetch or the server-side pagination already deferred with
+      a reopen condition, and that is an orchestrator decision, not an
+      apply-phase one. SUITES after 2.17 - npm run test 63 files / 997 tests
+      green, npm run build (tsc -b plus vite) clean, npm run lint exit 0 with
+      the same five pre-existing warnings. Diff of the addition measured with
+      'git diff --stat -- src' against the slice-2 tip - 3 files, 270
+      insertions plus 4 deletions, of which Usuarios.test.tsx is 182. ZERO
+      BACKEND FILE, zero schema, zero migration. Slices 3-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -574,7 +574,41 @@ phases:
       option set is untouched, still opcionesDeTenant(filas) with zero second
       fetch (D15). SUITES after the gap closure - npm run test 63 files / 999
       tests green, npm run build clean, npm run lint exit 0 with the same
-      five pre-existing warnings. Slices 3-5 pending.
+      five pre-existing warnings. JUDGMENT-DAY SLICE 2 ROUND 1 CORRECTED, web
+      only, no backend and no schema. Confirmed items fixed - C1 the tenant
+      universe no longer catches to an empty list in silence (visible error plus
+      a retry hung off opening "Nuevo"), C2 Guardar is inert for a platform
+      actor while that universe is loading or failed (a disabled select is
+      exempt from HTML constraint validation, so required alone let a POST with
+      idTenant null through), C3 the tenant FILTER of Empresas and PuntosVenta
+      is gated on esPlataforma exactly like the tenant COLUMN already was, C4
+      tenants that are not Activo are still offered but their option label now
+      carries the estado (the server never inspects the destination tenant's
+      estado, so a user created inside a suspended tenant silently could not log
+      in), S1 the unreachable non-platform arm of tenantsAsignables deleted,
+      S2 the filter reconciliation written back to state instead of only derived
+      at render, S3 the post-write refresh reloads with the APPLIED search term
+      rather than the input draft, S4 the password POST split off the profile
+      PUT so a committed write is never reported as a failure, S5 homonym owners
+      disambiguated by id in the pure option helpers, S6 the rol-root branch
+      downgraded to defence-in-depth (GET /roles cannot return Root for any
+      actor) with the misleading comments rewritten, S7 ocupado cleared in a
+      finally regardless of generation, S8 the repeated page-size rationale
+      reduced to one, the Tenants invalidation doc-comment made truthful and the
+      cuentaDePlataforma fixture given rol Root. TWO ITEMS DEFERRED BY THE
+      ORCHESTRATOR AND RECORDED, NOT FIXED - the unpaginated 25-row window the
+      usuarios filter operates on (named in task 2.12, code untouched, server
+      pagination already deferred here) and the orphan option's id suffix
+      (Reconciliacion 10, label deliberately unchanged). Eleven mutations run
+      for real and KILLED (M20, M20b, M21, M22, M23, M24, M25, M26, M26b, M27,
+      M28, M29); THREE HONEST SURVIVORS recorded as survivors, not dressed up -
+      M21b the same-tick re-entrancy guard, M30 and M30b the ungated finally,
+      all three unreachable today and kept as the trap slice 5's delete buttons
+      will need. M17 is SUPERSEDED, not re-targeted - its clause was the dead
+      arm S1 removed. SUITES after the correction - npm run test 63 files /
+      1015 tests green, npm run build (tsc -b plus vite) clean, npm run lint
+      exit 0 with the same five pre-existing warnings, measured against the
+      pre-change baseline. Slices 3-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -458,7 +458,67 @@ phases:
       Contratos.cs and NombreDeTenantAsync now state the two real cases, and the
       never-fabricate-"Plataforma" rule is unchanged. ZERO SCHEMA HELD ACROSS THE
       CORRECTION: no migration, no DDL, InicializadorDeBaseDeDatos.cs /
-      Politicas.cs / ManejadorDeErrores.cs still untouched. Slices 2-5 pending.
+      Politicas.cs / ManejadorDeErrores.cs still untouched. PR #165 merged to
+      main as commit 5f0018f, so tasks 1.15 and 1.16 are now checked. SLICE 2
+      IMPLEMENTED (tasks 2.1-2.14 checked; 2.15 judgment-day and 2.16 PR belong
+      to the orchestrator). Branch feat/stage20-slice2-web-relaciones off main -
+      the launch prompt's branch name, not the planning name
+      feat/stage20-slice2-proyeccion-web that tasks.md still records; same slice,
+      different label. Six work-unit commits, web-only: tipos.ts mirror plus 23
+      pre-existing fixture files, the five pure helpers plus organizacion.test.ts,
+      then one commit per screen (Tenants, Empresas, PuntosVenta, Usuarios).
+      BUDGET OVERFLOW MEASURED AND REPORTED, NOT ABSORBED and NOT split
+      unilaterally - 'git diff main --stat -- src' gives 34 files, 1909
+      insertions plus 289 deletions = 2198 changed lines against an estimate of
+      ~430 and the 800-line budget (OD1); ignoring pure re-indentation
+      ('git diff -w') it is 1741 plus 121 = 1862; production is ~1054 and tests
+      are ~1144, and the four screens alone are 443 insertions plus 120 deletions
+      with -w. Same shape the orchestrator already ruled on for slice 1: a small
+      production surface carrying the evidence web-descriptor-tests and
+      mutation-proof-tests demand (the five new test files are 1078 lines). THE
+      PRE-APPROVED 2a/2b DEGRADATION IS NO LONGER A CLEAN CUT and this is stated
+      rather than forced: names, filters and the react-async-state retrofit live
+      in the same four screen bodies, so a names-vs-filters cut would split single
+      functions across two PRs; the clean cut is per screen and the six commits
+      are already shaped for it. THIRTEEN MUTATIONS RUN FOR REAL (M1-M13, table
+      in tasks.md): twelve killed with their exact failure messages recorded, and
+      M10 SURVIVED and is recorded as a survivor rather than dressed up as a kill
+      - deleting every generation guard from Empresas.tsx left 6/6 green, because
+      react-async-state rule 9 (block every action that could supersede an
+      in-flight operation) already closes that window on the three organization
+      screens; the guards stay as defence-in-depth for slice 5's delete buttons.
+      Usuarios.tsx is the exception and M11 kills there: its search box is
+      reachable while a load is in flight, a genuine two-reads-in-flight window,
+      and it has its own stale-response test written per mutation-proof rule 7
+      (the stale promise is resolved inside act and the assertion is synchronous
+      after the flush, so a retrying matcher cannot pass on its first tick). ONE
+      TEST DEFECT was found by running M4 and fixed rather than rationalised: the
+      empresa-clearing test asserted only toHaveValue('') after switching tenants,
+      which the derived empresaVigente fallback satisfies on its own - it now
+      returns the tenant filter to "Todos" and requires the full list back, which
+      only a genuine setFiltroEmpresa(SIN_FILTRO) produces. RECONCILIACION 9
+      HONOURED IN THE WEB: etiquetaDeTenant discriminates on idTenant and never on
+      the name, so a null name with a present idTenant renders as the D13 orphan
+      marker and never as "Plataforma"; M1 kills that on all four surfaces. The
+      "Plataforma" literal is supplied by the web (D14) and a tenant literally
+      named "Plataforma" stays distinguishable in the filter by key (the
+      sin-tenant token, which no String(idTenant) can produce) and by label (the
+      "(sin tenant)" suffix); M2 kills the key collapse. TASK 2.3 HAD NO FILE TO
+      MODIFY - src/Ways.Web/src/api/usuarios.ts does not exist, UsuarioListado
+      lives in tipos.ts and Usuarios.tsx calls api.get directly; its substance is
+      delivered by task 2.1 and no empty indirection module was created just to
+      match the wording. SUITES: npm run test 63 files / 991 tests green, npm run
+      build (tsc -b plus vite) clean, npm run lint exit 0 with the same five
+      pre-existing warnings as main, dotnet build Ways.slnx clean. The three
+      dotnet test suites were NOT run because this slice touches zero backend
+      files ('git diff main --name-only' outside src/Ways.Web/ is empty). ZERO
+      SCHEMA HELD: no migration file, has-pending-model-changes clean,
+      InicializadorDeBaseDeDatos.cs / Politicas.cs / ManejadorDeErrores.cs
+      untouched, zero physical deletes, zero DDL. PRE-EXISTING FLAKE OBSERVED AND
+      NOT INTRODUCED HERE: Reposicion.test.tsx's first-punto-de-venta test fails
+      intermittently under the full-suite run (1 of 3 runs on this branch, 1 of 4
+      runs on main with the branch stashed; 12/12 when the file runs alone).
+      Slices 3-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -599,7 +599,7 @@ phases:
       ORCHESTRATOR AND RECORDED, NOT FIXED - the unpaginated 25-row window the
       usuarios filter operates on (named in task 2.12, code untouched, server
       pagination already deferred here) and the orphan option's id suffix
-      (Reconciliacion 10, label deliberately unchanged). Eleven mutations run
+      (Reconciliacion 10, label deliberately unchanged). Twelve mutations run
       for real and KILLED (M20, M20b, M21, M22, M23, M24, M25, M26, M26b, M27,
       M28, M29); THREE HONEST SURVIVORS recorded as survivors, not dressed up -
       M21b the same-tick re-entrancy guard, M30 and M30b the ungated finally,
@@ -608,7 +608,34 @@ phases:
       arm S1 removed. SUITES after the correction - npm run test 63 files /
       1015 tests green, npm run build (tsc -b plus vite) clean, npm run lint
       exit 0 with the same five pre-existing warnings, measured against the
-      pre-change baseline. Slices 3-5 pending.
+      pre-change baseline. JUDGMENT-DAY SLICE 2 ROUND 2 CORRECTED (FINAL
+      round), web only, no backend and no schema. Confirmed by BOTH judges and
+      fixed - R2-1 the tenant-universe failure now has its OWN rendered banner
+      derived from tenantsDePlataformaFallo instead of sharing the error slot,
+      which clobbered in both directions; R2-2 the password-POST failure moved
+      to the red slot while the committed PUT keeps its green confirmation,
+      both visible and the form still closes; R2-3 the S7 ungated finally
+      replicated to Empresas and PuntosVenta, the last two of the four screens.
+      Single-judge items fixed - R2-4 the "Nuevo" retry guarded on
+      tenantsDePlataformaCargando, R2-5 the guardar() re-check announces itself
+      instead of exiting silently, R2-6 the platform option included in
+      desempatarHomonimos's collision map (keys untouched), R2-7 the usuarios
+      tenant FILTER and COLUMN gated on esPlataforma for parity with C3, R2-8
+      the PuntosVenta empresa write-back reconciled against the tenant-narrowed
+      option set, R2-9 the Tenants invalidation rationale corrected (form and
+      table are independent state), R2-10 the records - this Eleven-to-Twelve
+      count, the blank line that severed M20-M30b from their table header, the
+      stale supporting clause of Reconciliacion 10, and the note that the
+      (baja) arm of etiquetaDeTenantAsignable is unreachable through the API
+      today. ONE ITEM RECORDED WITH NO CODE CHANGE, BY DECISION - crafted
+      tenant names that pre-embed a generated suffix are misleading copy only,
+      the keys stay true and the text is platform-authored. Round 2 mutations -
+      SEVEN KILLED (M31, M32, M33, M34, M34b, M36, M37) and THREE HONEST
+      SURVIVORS recorded as survivors, not dressed up (M35 the M21b class, M38
+      and M38b the M30/M30b class, all unreachable today). SUITES after the
+      round-2 correction - npm run test 63 files / 1021 tests green, npm run
+      build (tsc -b plus vite) clean, npm run lint exit 0 with the same five
+      pre-existing warnings. Slices 3-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -615,7 +615,7 @@ phases:
       which clobbered in both directions; R2-2 the password-POST failure moved
       to the red slot while the committed PUT keeps its green confirmation,
       both visible and the form still closes; R2-3 the S7 ungated finally
-      replicated to Empresas and PuntosVenta, the last two of the four screens.
+      replicated to Empresas and PuntosVenta for the POST-WRITE REFRESH only. NOT four-screen parity — the final re-judgment found the generation-mismatch returns inside the WRITE paths themselves (Usuarios.tsx:213/:220/:231, Tenants.tsx:88/:95, Empresas.tsx:79-84, PuntosVenta.tsx:107-113) still exit with ocupado latched; unreachable today by rule 9, carried to slice 5 as a binding input.
       Single-judge items fixed - R2-4 the "Nuevo" retry guarded on
       tenantsDePlataformaCargando, R2-5 the guardar() re-check announces itself
       instead of exiting silently, R2-6 the platform option included in

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -565,7 +565,16 @@ phases:
       the same five pre-existing warnings. Diff of the addition measured with
       'git diff --stat -- src' against the slice-2 tip - 3 files, 270
       insertions plus 4 deletions, of which Usuarios.test.tsx is 182. ZERO
-      BACKEND FILE, zero schema, zero migration. Slices 3-5 pending.
+      BACKEND FILE, zero schema, zero migration. PAGE-SIZE GAP CLOSED, narrow
+      web-only follow-up on the same branch - the create selector now sources
+      its options from clienteDeOrganizacion.listarTenants() (GET
+      /plataforma/tenants, SoloPlataforma) gated strictly on esPlataforma, so
+      a platform actor can assign any tenant regardless of the loaded users'
+      page and a tenant admin never calls it (S5, M19 killed); the FILTER
+      option set is untouched, still opcionesDeTenant(filas) with zero second
+      fetch (D15). SUITES after the gap closure - npm run test 63 files / 999
+      tests green, npm run build clean, npm run lint exit 0 with the same
+      five pre-existing warnings. Slices 3-5 pending.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -120,6 +120,22 @@ carry the entire safety argument.**
    `ServicioDeUsuarios.NombreDeTenantAsync`), both of which name the two null cases instead of the
    `iff`, and asserted by `ElListadoDeUsuariosLlevaElTenantDeCadaCuentaYNuncaFabricaLaEtiquetaPlataforma`
    plus `UnaCuentaCuyoTenantFueDadoDeBajaNoTraeNombreDeTenantEnNingunoDeLosTresCaminos`.
+10. **The orphan option's id suffix (`— (tenant 7)`) is NOT a violation of the "no raw owner id"
+    sentence, and the label is deliberately left alone.** `tenant-organization`'s
+    *"owner ids MUST NOT be displayed as the identity of the owner"* targets rows that HAVE an
+    owner: the requirement is that a real owner is presented by its name, never by its number, and
+    that is what every non-orphan row and every non-orphan option does. An orphan is the D13
+    anomaly — the owning tenant is soft-deleted, so there is **no name to display** — and its
+    filter option still needs a key the operator can tell apart from another orphan's. The id
+    suffix is that handle, and it is the *anomaly's* rendering, not an owner identity: presenting
+    it as an owner would require claiming the number identifies something the row can name, which
+    is exactly what it cannot do. Replacing it with a bare `—` would collapse two distinct orphan
+    tenants into one indistinguishable option (the case `desempata los huérfanos con su id para que
+    no compartan etiqueta` pins). The spec sentence is left **byte-identical** — deltas of this
+    change are not edited mid-flight — and is read through this reconciliation, the same handling
+    Reconciliación 1 gives OD6 and Reconciliación 9 gives S1. Task 2.13's assertion still holds
+    unchanged: no **cell** presents an id as the owner's identity. *(judgment-day round 1, judge A
+    SUGGESTION; deferred by the orchestrator with no code change.)*
 
 ## Binding Verify Criteria (all slices)
 
@@ -523,7 +539,13 @@ impossible by construction, and satisfies S5 (a filter can never disclose an out
   it; the empresa filter narrows the rows. *(TO-R1, TO-R3)*
 - [x] 2.12 [P] Create `src/Ways.Web/src/paginas/Usuarios.test.tsx` — `"Plataforma"` renders for
   `idTenant === null` and the tenant name renders otherwise; the tenant filter narrows the rows; a
-  single-tenant dataset offers exactly one tenant option (S5). *(UT-R1, TO-R3)*
+  single-tenant dataset offers exactly one tenant option (S5). **The usuarios filter operates on an
+  unpaginated 25-row window** (`GET /api/usuarios` default `tamanio` 25, no pager rendered,
+  `pagina.total` unused): it filters what is on screen, not the tenant's users, so a tenant with
+  users past row 25 shows fewer rows than it has. Pre-existing truncation, made more visible by the
+  filter, **left in the code deliberately** — server-side pagination is already deferred with a
+  reopen condition in `state.yaml` — and named here rather than hidden (judgment-day round 1,
+  judge A WARNING, deferred by the orchestrator). *(UT-R1, TO-R3)*
 - [x] 2.13 [P] Assertion across the four screen tests: **no cell presents `idTenant` or `idEmpresa`
   as the owner's identity** — the raw ids survive only as `<select value>` filter keys.
   *(TO-R1; Success Criterion "no raw owner id is displayed")*
@@ -589,11 +611,27 @@ planning name `feat/stage20-slice2-proyeccion-web` — same slice, different bra
 | M12 | 2.5 | Rule 9: an in-flight write blocks every action that could supersede it, not just Submit | `disabled={ocupado !== null}` removed from the row's "Editar" | **KILLED** — `Received element is not disabled` |
 | M13 | 2.5 | Rule 6: the post-write refresh sits OUTSIDE the write's try/catch, so a committed write is never reported as a failure | the success aviso moved back inside the write path | **KILLED** — `Unable to find an element with the text: Se actualizó "Sur SRL".` |
 | M14 | 2.17 | `idTenant: datos.idTenant` in the create payload builder — the exact field whose absence produced the owner's 400 `tenant_requerido` | the line deleted from the `CrearUsuario` literal (`as CrearUsuario` to keep it compiling) | **KILLED, 3 tests** — `expected { usuario: 'nuevo.admin', …(4) } to match object { usuario: 'nuevo.admin', …(3) }`, plus `… to match object { rolId: 1, idTenant: null }` and `… to match object { rolId: 4, idTenant: null }` |
-| M15 | 2.17 | The rol `onChange` clears `idTenant` **in state**, not only in the rendering | `onCambio({ ...valor, rolId })` — the `rolId === ROL.Root ? null : …` clear dropped | **KILLED** — `el rol Root deshabilita el selector y limpia el tenant ya elegido`: `expect(element).toHaveValue()` / `Expected the element to have value: ` / `Received: 2` |
+| M15 | 2.17 | The rol `onChange` clears `idTenant` **in state**, not only in the rendering | `onCambio({ ...valor, rolId })` — the `rolId === ROL.Root ? null : …` clear dropped | **KILLED** — `el rol Root deshabilita el selector y limpia el tenant ya elegido`: `expect(element).toHaveValue()` / `Expected the element to have value: ` / `Received: 2`. **DOWNGRADED in round 1 to "defence-in-depth, unreachable through `/roles`"** — see the note below the table; the kill is real but it kills a branch a real actor cannot enter |
 | M16 | 2.17 | `ofreceTenant` gates the selector — S5 anti-oracle: a tenant admin never enumerates tenants | `{esNuevo && (` — the `ofreceTenant` conjunct dropped | **KILLED, 2 tests** — `expected document not to contain element, found <select`, and `expected "vi.fn()" to be called at least once` (the now-visible `required` select blocks submission, so the POST never fires — incidental proof that the `required` copy matches real enforcement, `react-async-state` rule 7) |
-| M17 | 2.17 | The create selector offers only ASSIGNABLE tenants — the platform token is not an id and the server rejects it for every non-root rol | `const tenantsAsignables = opcionesTenant` — the `VALOR_SIN_TENANT` filter dropped | **KILLED** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(2) ]` |
+| M17 | 2.17 | ~~The create selector offers only ASSIGNABLE tenants — the platform token is not an id~~ | ~~`const tenantsAsignables = opcionesTenant` — the `VALOR_SIN_TENANT` filter dropped~~ | **SUPERSEDED in round 1 — the clause no longer exists.** The `VALOR_SIN_TENANT` filter lived on the `!esPlataforma` arm of `tenantsAsignables`, which round 1 proved unreachable (the selector renders only under `ofreceTenant={esPlataforma}`) and removed as dead code. The kill recorded here was real when it ran, against code that is gone; it is **not** re-targeted to a different clause and **not** left standing as if it still guarded something. The surviving property of that selector — its option set — is now guarded by M22 and M26b |
 | M18 | 2.17 | `react-async-state` rule 5: the selector is part of the full-window disabled state while the list (its own option source) is still loading | `disabled={guardando \|\| esRolDePlataforma}` — `tenantsCargando` dropped | **KILLED** — `el selector queda inerte mientras la lista está cargando`: `expect(element).toBeDisabled()` / `Received element is not disabled` |
 | M19 | 2.17 (page-size gap closure) | S5 anti-oracle: a tenant admin must never call `listarTenants()`, not even in the background | `if (!esPlataforma) return` deleted from the tenant-universe fetch effect | **KILLED** — `un admin de tenant nunca pide el universo de tenants (listarTenants)`: `expected "vi.fn()" to not be called with arguments: [ '/plataforma/tenants' ]`, received 3 calls including it |
+
+| M20 | R1-C1 | `react-async-state` rule 7: the tenant-universe `.catch` SURFACES the failure instead of silently setting `[]` | `setError(ERROR_TENANTS)` deleted from the catch | **KILLED, 2 tests** — `un fallo del universo de tenants se rinde en pantalla y abrir "Nuevo" lo reintenta` and `Guardar queda inerte cuando el universo de tenants falló`: `Unable to find an element with the text: /No se pudo cargar la lista de tenants/` |
+| M20b | R1-C1 | The retry hangs off opening "Nuevo" — the effect's `[esPlataforma]` deps never re-fire on their own | `if (esPlataforma && tenantsDePlataformaFallo) cargarTenantsDePlataforma()` deleted from the "Nuevo" handler | **KILLED** — `expected 1 to be 2` (the second `GET /plataforma/tenants` never happens) |
+| M21 | R1-C2 | `disabled={guardando \|\| sinTenantAsignable}` on Guardar — a `disabled` `<select>` is EXEMPT from HTML constraint validation, so `required` does not block the POST during the load/failure window | `disabled={guardando}` | **KILLED, 2 tests** — `expect(element).toBeDisabled()` / `Received element is not disabled`, on both the loading and the failed window |
+| M21b | R1-C2 | The same guard re-checked inside `guardar()` (rule 9: a same-tick double click beats the `disabled` attribute) | `if (formulario.id === null && universoDeTenantsIndisponible) return` deleted | **SURVIVED, 24/24 green — recorded as a survivor.** `userEvent.click` honours the `disabled` attribute, so the handler is never entered; the guard exists for the same-tick race the DOM cannot be made to produce here. Same class as the re-entrancy guards already on this screen |
+| M22 | R1-C4 | The assignable-tenant label MARKS a non-`Activo` estado — the server never inspects the destination tenant's estado, so a user created inside a suspended tenant silently cannot log in | `return nombre` — the `estado === 'Activo' ? … : \`${nombre} (${estado.toLowerCase()})\`` marker dropped | **KILLED, 2 tests across 2 files** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(3) ]` (the helper unit test and the screen test) |
+| M23 | R1-S2 | The filter reconciliation is WRITTEN to state in `cargar`, not only derived at render | `setFiltroTenant((prev) => seleccionVigente(…))` deleted | **KILLED** — `un filtro invalidado por una búsqueda no resucita cuando las filas vuelven`: `Expected the element to have value: ` / `Received: 3`. The derived fallback is the confound and it is named in the test: while the option is missing it blanks the `<select>` on its own, so the discriminating observation is that the filter must NOT reapply itself when the rows come back |
+| M24 | R1-S3 | The post-write refresh reloads with the APPLIED search term, not the input draft | `await cargar(token, busqueda, true)` | **KILLED** — `expected '/usuarios?busqueda=juan' to be '/usuarios'` (text typed and never searched narrowed the table after a Baja) |
+| M25 | R1-S4 | The password POST has its own `try`: a committed PUT is never reported as a failure (rule 6) | the POST moved back inside the PUT's `try` | **KILLED** — `Unable to find an element with the text: /no se pudo cambiar la contraseña/` (the screen said "No se pudo guardar." for a profile that had already committed) |
+| M26 | R1-S5 | `desempatarHomonimos` in `opcionesDeTenant` — two DISTINCT tenants sharing a free-text name render byte-identical options | the `desempatarHomonimos(…, 'tenant')` call dropped | **KILLED** — `desempata con el id a dos tenants distintos que comparten nombre` |
+| M26b | R1-S5 | The same disambiguation on the create selector (`opcionesDeTenantAsignable`) — same class, and the surface where picking the wrong twin assigns the user to the wrong tenant | the `desempatarHomonimos(opciones, 'tenant')` call dropped | **KILLED** — `expected [ 'Comercio Sur', 'Comercio Sur' ] to deeply equal [ 'Comercio Sur (tenant 2)', …(1) ]` |
+| M27 | R1-S5 | The same disambiguation on `opcionesDeEmpresa`, over the equally free-text razón social | the `desempatarHomonimos(…, 'empresa')` call dropped | **KILLED** — `desempata con el id a dos empresas distintas que comparten razón social` |
+| M28 | R1-C3 | `esPlataforma &&` gates the tenant FILTER of `Empresas` with the same criterion that already gated the tenant COLUMN | `{true && (` | **KILLED** — `un admin de tenant no ve el filtro por tenant, igual que no ve la columna`: `expect(element).not.toBeInTheDocument()` |
+| M29 | R1-C3 | The same gate on `PuntosVenta` — and only on the TENANT filter; the empresa filter stays for every actor | `{true && (` | **KILLED** — `un admin de tenant no ve el filtro por tenant, pero sí el de empresa`: `expect(element).not.toBeInTheDocument()` |
+| M30 | R1-S7 | `refrescarTrasEscribir` clears `ocupado` in a `finally` REGARDLESS of the generation — a token mismatch used to `return` with the flag still on, freezing every action | the `if (generacion.current === token)` gate put back on the `finally` (`Tenants.tsx`) | **SURVIVED, 4/4 green — recorded as a survivor.** Stated by the finding itself: unreachable today, because rule 9 disables every action that could bump the generation while `ocupado` is set. Fixed as a trap for slice 5's delete buttons, which add exactly such actions |
+| M30b | R1-S7 | The same, on `Usuarios.tsx` | the `if (generacion.current === token)` gate put back on the `finally` | **SURVIVED, 24/24 green — same reason as M30, recorded not dressed up** |
 
 **No survivors among M14-M18.** One inaccuracy in a test's own doc-comment was found by running M15 and
 corrected rather than left standing: the first draft claimed the M4 confound applied (a derived
@@ -610,6 +648,39 @@ changes nothing observable and the suite stays green. They are kept as defence-i
 which adds delete buttons to exactly these screens. `Usuarios.tsx` is different — its search box is
 reachable while a load is in flight, which is a genuine two-reads-in-flight window — and that is
 where M11 kills.
+
+**Round 1 — M15 is DOWNGRADED to defence-in-depth, and the comment that oversold it is rewritten.**
+Judge B asked whether the create selector's Root branch guards anything reachable. It does not:
+`PoliticaDeRoles.RolesAsignablesPor` (`PoliticaDeRoles.cs:30-35`) returns
+`[Admin, Supervisor, Vendedor]` for a Root actor and `[Supervisor, Vendedor]` for an Admin —
+**Root is in no actor's list**, so `GET /roles` (`ServicioDeUsuarios.RolesAsignablesAsync`, which
+projects exactly that list) can never put a Root `<option>` in the rol `<select>`. The rol-root
+branch is therefore unreachable from this screen, and M15 kills a branch a real actor cannot enter.
+The code is KEPT as defence-in-depth against a future change to the rol catalogue, but its record is
+corrected on both counts: the table row now says so, and the doc-comment of `FormularioUsuario`
+plus the inline comment on the rol `onChange` no longer claim the clear prevents a live 403 — the
+live clause there is the tenant `required` for every other rol, whose absence is the real
+400 `tenant_requerido`. The test fixture keeps its Root rol row on purpose: it is what makes the
+defence-in-depth branch exercisable at all, and the doc-comment now says that is what it is.
+
+**Round 1 — three honest survivors, stated rather than papered over.** M21b (the `guardar()`
+re-entrancy guard), M30 and M30b (the ungated `finally` that clears `ocupado`) all survived their
+mutations with the suite fully green, and are recorded as survivors in the table. M21b guards a
+same-tick double click that `userEvent` cannot produce, because it honours the `disabled`
+attribute. M30/M30b guard a token mismatch that rule 9 makes unreachable **today** — the finding
+that produced them said exactly that ("unreachable today, a trap for slice 5's delete buttons"),
+and the fix is taken for that reason, not because a test proves it. Same handling M10 already got.
+
+**Round 1 — the filter write-back is REPLICATED to `Empresas`/`PuntosVenta` without a reachable
+repro, and that is stated.** The state write-back that M23 kills on `Usuarios.tsx` is applied to the
+other two screens under `react-async-state` rule 10 (any correctness pattern established on one
+surface is replicated across every sibling with the same interaction). Those two screens have **no
+search box**: their only row-set change is the post-write refresh, which reloads the full list, so
+the resurrection sequence judge A demonstrated (narrow → the option disappears → widen → the option
+returns) has no reachable trigger there. Mutating their write-back therefore SURVIVES by
+construction and no test is invented to pretend otherwise; the shared pure helper
+`seleccionVigente` carries its own unit tests, and slice 5 — which adds deletions to those screens
+— is where the trigger becomes reachable.
 
 **One test defect was found by running M4 and was fixed, not rationalised.** The first draft of the
 empresa-clearing test asserted only `toHaveValue('')` after switching tenants, which the derived

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -531,6 +531,24 @@ impossible by construction, and satisfies S5 (a filter can never disclose an out
   `npm --prefix src/Ways.Web run build` (typecheck) and `npm --prefix src/Ways.Web run lint` all
   clean; re-assert V1-V6 on this slice's diff (a web-only slice must still touch zero migrations and
   zero backend guard files).
+- [x] 2.17 **Tenant selector on user creation — owner-reported mid-slice, bounded addition.** The
+  owner hit a real defect while testing: as a platform actor, creating a user with rol Admin from
+  `Usuarios.tsx` always failed with the backend 400 `tenant_requerido` because the create form had
+  no way to choose a tenant. The server already supported it (`CrearUsuario` accepts
+  `int? IdTenant`, `Contratos.cs:43-49`) and the web mirror had dropped the field — a
+  **`dto-contract-honesty`** violation on the web side. Delivered: (a) `tipos.ts` mirrors
+  `idTenant: number | null` on `CrearUsuario`; `ActualizarUsuario` is left alone because the server
+  record does **not** accept a tenant (`Contratos.cs:51-55`) and inventing one would be the same
+  violation in reverse; (b) a tenant `<select>` in the create form, rendered **only** for a platform
+  actor (`esNuevo && ofreceTenant`) — a tenant admin never sees a tenant list (S5) and sends
+  `idTenant: null`, which `ServicioDeUsuarios.CrearAsync` ignores in favour of `Actor.IdTenant`;
+  (c) options derived from the **already-loaded rows** via the existing `opcionesDeTenant(filas)`,
+  minus the platform token, so **no second fetch** was added and D15 still holds; (d) a client-side
+  mirror of `PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance` for guidance only — rol Root disables
+  the selector and clears `idTenant` **in state**, any other rol makes it `required`; the server
+  stays the authority and its 400 still surfaces through the existing error path, untouched;
+  (e) **`react-async-state`** rule 5 — the selector is inert while the list is loading and while a
+  save is in flight. Five mutations run for real (M14-M18 below). *(UT-R1; design D15, spec S5)*
 - [ ] 2.15 `judgment-day` round to a clean round.
 - [ ] 2.16 Open PR 2 `feat/stage20-slice2-proyeccion-web`, merge to `main` after the clean round.
 
@@ -557,6 +575,17 @@ planning name `feat/stage20-slice2-proyeccion-web` — same slice, different bra
 | M11 | 2.7 | The generation guard of `Usuarios.cargar` — the ONE reachable stale-read window in this slice | `if (generacion.current !== token) return` deleted before `setPagina` | **KILLED** — `una respuesta de búsqueda vieja que aterriza tarde no pisa a la nueva`: `expected [ 'vendedor.sur', 'vendedor.este' ] to deeply equal [ 'staff' ]` |
 | M12 | 2.5 | Rule 9: an in-flight write blocks every action that could supersede it, not just Submit | `disabled={ocupado !== null}` removed from the row's "Editar" | **KILLED** — `Received element is not disabled` |
 | M13 | 2.5 | Rule 6: the post-write refresh sits OUTSIDE the write's try/catch, so a committed write is never reported as a failure | the success aviso moved back inside the write path | **KILLED** — `Unable to find an element with the text: Se actualizó "Sur SRL".` |
+| M14 | 2.17 | `idTenant: datos.idTenant` in the create payload builder — the exact field whose absence produced the owner's 400 `tenant_requerido` | the line deleted from the `CrearUsuario` literal (`as CrearUsuario` to keep it compiling) | **KILLED, 3 tests** — `expected { usuario: 'nuevo.admin', …(4) } to match object { usuario: 'nuevo.admin', …(3) }`, plus `… to match object { rolId: 1, idTenant: null }` and `… to match object { rolId: 4, idTenant: null }` |
+| M15 | 2.17 | The rol `onChange` clears `idTenant` **in state**, not only in the rendering | `onCambio({ ...valor, rolId })` — the `rolId === ROL.Root ? null : …` clear dropped | **KILLED** — `el rol Root deshabilita el selector y limpia el tenant ya elegido`: `expect(element).toHaveValue()` / `Expected the element to have value: ` / `Received: 2` |
+| M16 | 2.17 | `ofreceTenant` gates the selector — S5 anti-oracle: a tenant admin never enumerates tenants | `{esNuevo && (` — the `ofreceTenant` conjunct dropped | **KILLED, 2 tests** — `expected document not to contain element, found <select`, and `expected "vi.fn()" to be called at least once` (the now-visible `required` select blocks submission, so the POST never fires — incidental proof that the `required` copy matches real enforcement, `react-async-state` rule 7) |
+| M17 | 2.17 | The create selector offers only ASSIGNABLE tenants — the platform token is not an id and the server rejects it for every non-root rol | `const tenantsAsignables = opcionesTenant` — the `VALOR_SIN_TENANT` filter dropped | **KILLED** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(2) ]` |
+| M18 | 2.17 | `react-async-state` rule 5: the selector is part of the full-window disabled state while the list (its own option source) is still loading | `disabled={guardando \|\| esRolDePlataforma}` — `tenantsCargando` dropped | **KILLED** — `el selector queda inerte mientras la lista está cargando`: `expect(element).toBeDisabled()` / `Received element is not disabled` |
+
+**No survivors among M14-M18.** One inaccuracy in a test's own doc-comment was found by running M15 and
+corrected rather than left standing: the first draft claimed the M4 confound applied (a derived
+fallback masking a missing state clear), but here the `<select>`'s `value` is derived from the SAME
+`valor.idTenant` that travels in the POST, so there is no independent fallback and both observations
+discriminate. M15 in fact dies on the rendered value, and the comment now says so.
 
 **M10 is the honest survivor of this slice, and it is stated rather than papered over.** The
 generation gate on `Tenants.tsx`, `Empresas.tsx` and `PuntosVenta.tsx` guards a window that
@@ -638,6 +667,28 @@ that, because a stale `'30'` would become a valid option again and silently reap
   stashed**. Alone, the file passes 12/12. The file's only change in this slice is two fixture
   fields. Not fixed here — it is outside slice 2's scope — but recorded so nobody reads a red
   suite as slice 2's doing.
+
+- **Task 2.17's launch brief carried two factual premises that did NOT hold, and the corrections are
+  recorded rather than silently absorbed.** (1) It said slice 2 already had "a tenant fetch for its
+  filter" to reuse. There is no tenant fetch anywhere in slice 2 and there must not be: **D15**
+  forbids it, and `tasks.md`'s own binding note under slice 2 says so. The state actually reused is
+  the derived `opcionesDeTenant(filas)`, which is what the brief's real instruction ("do not add a
+  second fetch") demanded. (2) It said `Usuarios.tsx` already had the `esPlataforma` notion — it did
+  not; `Empresas.tsx:30` and `PuntosVenta.tsx:41` do, and `Usuarios.tsx` only had the inline
+  `actual?.rolId === ROL.Root` inside `puedeEditar`. `esPlataforma` was introduced here with the
+  identical `rolId === ROL.Root` definition its two sibling screens use (`react-async-state` rule 10).
+
+- **KNOWN GAP OF THE DERIVED OPTION SET, STATED NOT HIDDEN.** Because the create selector derives
+  its options from the loaded rows (D15, no second fetch), a platform actor can only assign a tenant
+  that has at least one user **on the current page**. `GET /api/usuarios` is the one paginated
+  listing and its default `tamanio` is 25 (`UsuariosEndpoints.cs:21`), and the screen never sends a
+  page parameter. In practice every tenant is provisioned WITH its admin user
+  (`ServicioDeAprovisionamiento`), so a tenant with zero users does not normally exist; the reachable
+  case is the 26th-and-beyond tenant. Closing it needs either the platform-only
+  `listarTenants()` fetch (which D15 rules out for the shared screens, though `Usuarios.tsx`'s
+  selector is platform-only and would not 403) or the server-side pagination already deferred with a
+  reopen condition in `state.yaml`. **Not decided here** — this was a bounded bug fix, and widening
+  it to a fetch/pagination decision is the orchestrator's call.
 
 - **Verify criteria re-asserted on this slice's diff (V1-V6, V13).** Zero files under
   `Migraciones/`; `dotnet ef migrations has-pending-model-changes` → *"No changes have been made to

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -549,6 +549,19 @@ impossible by construction, and satisfies S5 (a filter can never disclose an out
   stays the authority and its 400 still surfaces through the existing error path, untouched;
   (e) **`react-async-state`** rule 5 — the selector is inert while the list is loading and while a
   save is in flight. Five mutations run for real (M14-M18 below). *(UT-R1; design D15, spec S5)*
+  **Page-size gap closed as a narrow web-only follow-up on the same branch.** (c) above left a known
+  gap, stated in tasks.md and state.yaml: deriving the create selector's options from the
+  already-loaded rows meant a platform actor could only assign a tenant with a user on the current
+  page (`tamanio` 25). Closed by fetching the full tenant universe via
+  `clienteDeOrganizacion.listarTenants()` (`GET /plataforma/tenants`, `Politicas.SoloPlataforma`) —
+  gated **strictly** on `esPlataforma`, so a tenant admin never calls it (S5) — while the **filter**
+  option set (D15) is left untouched, still derived from the loaded rows with zero second fetch.
+  No estado filtering is applied to the fetched list — the server is the authority on business
+  rules — and results are sorted by name. `react-async-state` rule 5 still gates the selector, now
+  on the tenant fetch's own loading flag (`tenantsDePlataformaCargando`), not the row list's.
+  One mutation run for real, M19 below (dropping the `esPlataforma` guard on the new fetch),
+  observed RED on the tenant-admin test, then reverted and observed GREEN again; M14-M18 stay
+  valid unmodified. *(UT-R1; design D15, spec S5)*
 - [ ] 2.15 `judgment-day` round to a clean round.
 - [ ] 2.16 Open PR 2 `feat/stage20-slice2-proyeccion-web`, merge to `main` after the clean round.
 
@@ -580,6 +593,7 @@ planning name `feat/stage20-slice2-proyeccion-web` — same slice, different bra
 | M16 | 2.17 | `ofreceTenant` gates the selector — S5 anti-oracle: a tenant admin never enumerates tenants | `{esNuevo && (` — the `ofreceTenant` conjunct dropped | **KILLED, 2 tests** — `expected document not to contain element, found <select`, and `expected "vi.fn()" to be called at least once` (the now-visible `required` select blocks submission, so the POST never fires — incidental proof that the `required` copy matches real enforcement, `react-async-state` rule 7) |
 | M17 | 2.17 | The create selector offers only ASSIGNABLE tenants — the platform token is not an id and the server rejects it for every non-root rol | `const tenantsAsignables = opcionesTenant` — the `VALOR_SIN_TENANT` filter dropped | **KILLED** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(2) ]` |
 | M18 | 2.17 | `react-async-state` rule 5: the selector is part of the full-window disabled state while the list (its own option source) is still loading | `disabled={guardando \|\| esRolDePlataforma}` — `tenantsCargando` dropped | **KILLED** — `el selector queda inerte mientras la lista está cargando`: `expect(element).toBeDisabled()` / `Received element is not disabled` |
+| M19 | 2.17 (page-size gap closure) | S5 anti-oracle: a tenant admin must never call `listarTenants()`, not even in the background | `if (!esPlataforma) return` deleted from the tenant-universe fetch effect | **KILLED** — `un admin de tenant nunca pide el universo de tenants (listarTenants)`: `expected "vi.fn()" to not be called with arguments: [ '/plataforma/tenants' ]`, received 3 calls including it |
 
 **No survivors among M14-M18.** One inaccuracy in a test's own doc-comment was found by running M15 and
 corrected rather than left standing: the first draft claimed the M4 confound applied (a derived
@@ -689,6 +703,14 @@ that, because a stale `'30'` would become a valid option again and silently reap
   selector is platform-only and would not 403) or the server-side pagination already deferred with a
   reopen condition in `state.yaml`. **Not decided here** — this was a bounded bug fix, and widening
   it to a fetch/pagination decision is the orchestrator's call.
+
+  **CLOSED as a narrow web-only follow-up (still on `feat/stage20-slice2-web-relaciones`).** The
+  orchestrator chose the platform-only `listarTenants()` fetch over the pagination alternative:
+  `Usuarios.tsx`'s create selector is reachable **only** by a platform actor, and
+  `GET /plataforma/tenants` is `Politicas.SoloPlataforma`, so it never 403s for that actor and adds
+  no scope creep. The **filter** option set is untouched — still `opcionesDeTenant(filas)`, D15
+  still holds there, zero second fetch on that path. The 26th-tenant-onward case is now reachable
+  regardless of which page the loaded users happen to fall on.
 
 - **Verify criteria re-asserted on this slice's diff (V1-V6, V13).** Zero files under
   `Migraciones/`; `dotnet ef migrations has-pending-model-changes` → *"No changes have been made to

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1199,6 +1199,30 @@ written)** — transcribed from `design.md:383-398`:
 
 ## Slice 5: Deletion web — buttons, confirmation and code→copy (PR 5)
 
+**BINDING — INPUTS CARRIED FROM SLICE 2 (judgment-day FINAL re-judgment, round budget exhausted).**
+None has user impact today; every one becomes reachable exactly when this slice adds delete buttons
+to the four screens, so this slice closes them deliberately.
+
+1. **`ocupado` latches on generation mismatch inside the WRITE paths.** R2-3 replicated the ungated
+   `finally` only to the post-write refresh. The mismatch `return`s inside the writes themselves —
+   `Usuarios.tsx:213/:220/:231`, `Tenants.tsx:88/:95`, `Empresas.tsx:79-84`,
+   `PuntosVenta.tsx:107-113` — still exit with `ocupado` set and would freeze the screen. Unreachable
+   today (rule 9 disables every generation bumper while `ocupado` is set). **Delete buttons are the
+   first second bumper; close this before adding them.**
+2. **`ERROR_ALTA_SIN_TENANTS` lives in the shared `error` slot** (`Usuarios.tsx:177`) that R2-1
+   proved unsafe for that class — a later successful load erases it. Unreachable (M35 survivor). Give
+   it its own slot or fold it into the tenant-universe banner when touching that form.
+3. **Sentinel leaks into copy on a crafted name.** With a tenant literally named
+   `"Plataforma (sin tenant)"`, `desempatarHomonimos` suffixes the platform option as
+   `(tenant sin-tenant)` (`organizacion.ts:147-154`). Keys untouched, platform-authored, copy only.
+   Exclude the platform option from the SUFFIX (keep it in the collision count) so the sentinel never
+   renders.
+4. Cosmetics: `errorPassword` not cleared on Cancelar/Buscar; the tenant-failure banner at
+   `Usuarios.tsx:350` is not gated on `esPlataforma` (cannot fire for an admin, but every sibling
+   element is gated — add the gate for parity); identifier typo `tenanteReconciliado`
+   (`PuntosVenta.tsx:71`).
+
+
 **Branch**: `feat/stage20-slice5-bajas-web`. **Start**: PRs 2 and 4 merged. **Finish**: the four root
 screens can delete, behind a confirmation gate and the full `react-async-state` write discipline, and
 every 409 `codigo` maps to its own copy; docs 09/10 carry the Etapa 20 note. **Depends on**: slice 2

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -300,11 +300,11 @@ decouples slice 1 from slice 4's cascade and keeps Part A independently mergeabl
   file, `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` /
   `ManejadorDeErrores.cs` untouched, zero physical deletes, zero DDL). Full Domain + Application +
   Integration suites green; `dotnet build Ways.slnx` clean.
-- [ ] 1.15 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a clean
+- [x] 1.15 `judgment-day` round: two blind review agents, fix confirmed findings, re-judge to a clean
   round.
-- [ ] 1.16 Open PR 1 `feat/stage20-slice1-proyeccion-api` (`branch-pr`, conventional commits, no AI
+- [x] 1.16 Open PR 1 `feat/stage20-slice1-proyeccion-api` (`branch-pr`, conventional commits, no AI
   attribution), record the mutation evidence for tasks 1.7-1.12 in the PR body (V11), merge to `main`
-  after the clean round.
+  after the clean round. **PR #165 merged to `main` as commit `5f0018f`.**
 
 
 ### Mutation evidence — slice 1 (`mutation-proof-tests` rule 2, produced, not reasoned)
@@ -488,51 +488,164 @@ second fetch: `GET /api/plataforma/tenants` is `Politicas.SoloPlataforma` while 
 for exactly the users the screen was built for. Deriving from the rows also makes an empty option set
 impossible by construction, and satisfies S5 (a filter can never disclose an out-of-scope tenant).
 
-- [ ] 2.1 Modify `src/Ways.Web/src/api/tipos.ts` — mirror the four DTO shapes from slice 1, with
+- [x] 2.1 Modify `src/Ways.Web/src/api/tipos.ts` — mirror the four DTO shapes from slice 1, with
   `nombreTenant`/`razonSocialEmpresa`/`idTenant` nullable exactly as the server declares them.
   *(TO-R1, TO-R2, UT-R1)*
-- [ ] 2.2 Modify `src/Ways.Web/src/api/organizacion.ts` — five **pure** helpers, no React, no fetch:
+- [x] 2.2 Modify `src/Ways.Web/src/api/organizacion.ts` — five **pure** helpers, no React, no fetch:
   `opcionesDeTenant`, `opcionesDeEmpresa` (narrowed by the selected tenant), `filtrarPorTenant`,
   `filtrarPorEmpresa`, `etiquetaDeTenant` (`null` → the literal `"Plataforma"`). *(TO-R3, UT-R1;
   design D14, D15)*
-- [ ] 2.3 Modify `src/Ways.Web/src/api/usuarios.ts` — mirror `UsuarioListado`'s two new fields. The
+- [x] 2.3 Modify `src/Ways.Web/src/api/usuarios.ts` — mirror `UsuarioListado`'s two new fields. The
   `eliminar` call already exists and is **not** touched in this slice. *(UT-R1)*
-- [ ] 2.4 Modify `src/Ways.Web/src/paginas/Tenants.tsx` — three count columns (empresas, puntos de
+- [x] 2.4 Modify `src/Ways.Web/src/paginas/Tenants.tsx` — three count columns (empresas, puntos de
   venta, usuarios). *(TO-R2)*
-- [ ] 2.5 Modify `src/Ways.Web/src/paginas/Empresas.tsx` — tenant **name** column replacing the raw
+- [x] 2.5 Modify `src/Ways.Web/src/paginas/Empresas.tsx` — tenant **name** column replacing the raw
   integer at `:156`; tenant filter over the loaded list. *(TO-R1, TO-R3)*
-- [ ] 2.6 Modify `src/Ways.Web/src/paginas/PuntosVenta.tsx` — tenant name and empresa razón social
+- [x] 2.6 Modify `src/Ways.Web/src/paginas/PuntosVenta.tsx` — tenant name and empresa razón social
   columns replacing the two integers at `:216-217`; tenant filter **and** empresa filter, where
   selecting a tenant **narrows** the empresa options and **clears** an empresa selection that no
   longer belongs to it. *(TO-R1, TO-R3; design D15)*
-- [ ] 2.7 Modify `src/Ways.Web/src/paginas/Usuarios.tsx` — tenant column rendering the tenant name,
+- [x] 2.7 Modify `src/Ways.Web/src/paginas/Usuarios.tsx` — tenant column rendering the tenant name,
   or the literal **"Plataforma"** when `idTenant === null` (never an empty cell); tenant filter.
   *(UT-R1, TO-R3; design D14)*
-- [ ] 2.8 [P] Create `src/Ways.Web/src/api/organizacion.test.ts` — **`web-descriptor-tests`**: one
+- [x] 2.8 [P] Create `src/Ways.Web/src/api/organizacion.test.ts` — **`web-descriptor-tests`**: one
   case per helper branch — `opcionesDeTenant` dedup + ordering + the `null` option,
   `opcionesDeEmpresa` narrowing to the selected tenant, `filtrarPorTenant`/`filtrarPorEmpresa`
   including the "no selection" identity case, `etiquetaDeTenant`'s null branch. *(TO-R3, UT-R1)*
-- [ ] 2.9 [P] Create `src/Ways.Web/src/paginas/Tenants.test.tsx` — the three counts render from the
+- [x] 2.9 [P] Create `src/Ways.Web/src/paginas/Tenants.test.tsx` — the three counts render from the
   DTO, with pairwise-distinct values so a column swap is killed. *(TO-R2)*
-- [ ] 2.10 [P] Create `src/Ways.Web/src/paginas/Empresas.test.tsx` — the tenant **name** renders (not
+- [x] 2.10 [P] Create `src/Ways.Web/src/paginas/Empresas.test.tsx` — the tenant **name** renders (not
   the id); selecting a tenant narrows the rendered rows **with no additional network request**
   (assert the mocked client's call count); clearing the filter restores the full loaded list.
   *(TO-R1, TO-R3)*
-- [ ] 2.11 [P] Create `src/Ways.Web/src/paginas/PuntosVenta.test.tsx` — both owner names render;
+- [x] 2.11 [P] Create `src/Ways.Web/src/paginas/PuntosVenta.test.tsx` — both owner names render;
   selecting a tenant narrows the empresa select **and** clears an empresa that no longer belongs to
   it; the empresa filter narrows the rows. *(TO-R1, TO-R3)*
-- [ ] 2.12 [P] Create `src/Ways.Web/src/paginas/Usuarios.test.tsx` — `"Plataforma"` renders for
+- [x] 2.12 [P] Create `src/Ways.Web/src/paginas/Usuarios.test.tsx` — `"Plataforma"` renders for
   `idTenant === null` and the tenant name renders otherwise; the tenant filter narrows the rows; a
   single-tenant dataset offers exactly one tenant option (S5). *(UT-R1, TO-R3)*
-- [ ] 2.13 [P] Assertion across the four screen tests: **no cell presents `idTenant` or `idEmpresa`
+- [x] 2.13 [P] Assertion across the four screen tests: **no cell presents `idTenant` or `idEmpresa`
   as the owner's identity** — the raw ids survive only as `<select value>` filter keys.
   *(TO-R1; Success Criterion "no raw owner id is displayed")*
-- [ ] 2.14 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`,
+- [x] 2.14 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`,
   `npm --prefix src/Ways.Web run build` (typecheck) and `npm --prefix src/Ways.Web run lint` all
   clean; re-assert V1-V6 on this slice's diff (a web-only slice must still touch zero migrations and
   zero backend guard files).
 - [ ] 2.15 `judgment-day` round to a clean round.
 - [ ] 2.16 Open PR 2 `feat/stage20-slice2-proyeccion-web`, merge to `main` after the clean round.
+
+### Mutation evidence — slice 2 (`mutation-proof-tests` rule 2, produced, not reasoned)
+
+Every mutation below was applied to the working tree, the named suite was run, the result was
+observed, and the mutation was then reverted and the suite observed GREEN again. Command:
+`npx vitest run <file>` from `src/Ways.Web`. **Branch as delivered**:
+`feat/stage20-slice2-web-relaciones` (the launch prompt's name; `tasks.md` above still records the
+planning name `feat/stage20-slice2-proyeccion-web` — same slice, different branch label).
+
+| # | Task | Clause under test | Mutation applied | Observed result |
+|---|---|---|---|---|
+| M1 | 2.2, 2.5, 2.6, 2.7 | `etiquetaDeTenant` discriminates on `idTenant`, never on the name (Reconciliación 9) | body replaced by `return fila.nombreTenant ?? ETIQUETA_PLATAFORMA` | **KILLED, 4 tests across 4 files** — `un huérfano … NO se rinde como plataforma`: `expected 'Plataforma' to be '—'`; plus the orphan test of `Empresas`, `PuntosVenta` and `Usuarios` |
+| M2 | 2.2, 2.7 | `claveDeTenant` gives platform staff a token no `String(idTenant)` can produce | `return String(idTenant)` | **KILLED, 4 tests** — `expected [ '9', 'null' ] to deeply equal [ 'sin-tenant', '9' ]`, and the "Plataforma" homonym filter test returned the tenant row instead of the staff row |
+| M3 | 2.2, 2.6 | `opcionesDeEmpresa` narrows to the selected tenant (D15) | `for (const fila of filas)` — the `filtrarPorTenant` call dropped | **KILLED, 3 tests** — `expected [ '11', '10', '20' ] to deeply equal [ '11', '10' ]` |
+| M4 | 2.6 | `cambiarFiltroDeTenant` CLEARS the empresa state, not just its rendering | body replaced by `setFiltroEmpresa((prev) => prev)` | **SURVIVED at first**, then KILLED after the test was re-routed below the confound. The confound is real and named in the test: the derived `empresaVigente` fallback already blanks the `<select>`, so asserting the blank proves nothing. The discriminating observation is that returning the tenant filter to "Todos" must NOT resurrect the foreign empresa — `expected [ 'PV Este' ] to deeply equal [ 'PV Centro', 'PV Anexo', 'PV Este' ]` |
+| M5 | 2.4, 2.9 | The three count columns are not interchangeable | `cantidadEmpresas` and `cantidadPuntosVenta` swapped in the `<td>`s | **KILLED** — `rinde los tres contadores de cada tenant en su propia columna` |
+| M6 | 2.5 | `Empresas` actually applies the tenant filter | `const visibles = items` | **KILLED, 2 tests** — `expected [ 'Sur SRL', 'Sur Anexo SA', …(1) ] to deeply equal [ 'Este SRL' ]` |
+| M7 | 2.5, 2.13 | The empresas tenant column renders the NAME, not the id | `<td>{e.idTenant}</td>` | **KILLED, 3 tests** including the task-2.13 no-raw-id assertion |
+| M8 | 2.7 | `Usuarios` actually applies the tenant filter | `const visibles = filas` | **KILLED, 3 tests** — `expected [ 'vendedor.sur', …(2) ] to deeply equal [ 'vendedor.este' ]` |
+| M9 | 2.6 | The empresa column marks a missing razón social as an anomaly, not as an id | `?? String(p.idEmpresa)` | **KILLED** — the orphan PV test |
+| M10 | — | ALL generation guards of `Empresas.tsx` deleted at once | every `generacion.current` check removed (0 left) | **SURVIVED, 6/6 green — recorded as a survivor, not dressed up as a kill.** See the note below: on the three organization screens the stale-read window is closed by `react-async-state` rule 9 (nothing can supersede an in-flight operation), so the gate is defence-in-depth there and has nothing of its own to prove |
+| M11 | 2.7 | The generation guard of `Usuarios.cargar` — the ONE reachable stale-read window in this slice | `if (generacion.current !== token) return` deleted before `setPagina` | **KILLED** — `una respuesta de búsqueda vieja que aterriza tarde no pisa a la nueva`: `expected [ 'vendedor.sur', 'vendedor.este' ] to deeply equal [ 'staff' ]` |
+| M12 | 2.5 | Rule 9: an in-flight write blocks every action that could supersede it, not just Submit | `disabled={ocupado !== null}` removed from the row's "Editar" | **KILLED** — `Received element is not disabled` |
+| M13 | 2.5 | Rule 6: the post-write refresh sits OUTSIDE the write's try/catch, so a committed write is never reported as a failure | the success aviso moved back inside the write path | **KILLED** — `Unable to find an element with the text: Se actualizó "Sur SRL".` |
+
+**M10 is the honest survivor of this slice, and it is stated rather than papered over.** The
+generation gate on `Tenants.tsx`, `Empresas.tsx` and `PuntosVenta.tsx` guards a window that
+`react-async-state` rule 9 already closes: while a write is outstanding every action that could
+supersede it is disabled, and while a read is outstanding the table is replaced by the loading
+indicator, so no second operation can start. Deleting all four guards from `Empresas.tsx` therefore
+changes nothing observable and the suite stays green. They are kept as defence-in-depth for slice 5,
+which adds delete buttons to exactly these screens. `Usuarios.tsx` is different — its search box is
+reachable while a load is in flight, which is a genuine two-reads-in-flight window — and that is
+where M11 kills.
+
+**One test defect was found by running M4 and was fixed, not rationalised.** The first draft of the
+empresa-clearing test asserted only `toHaveValue('')` after switching tenants, which the derived
+`empresaVigente` fallback satisfies on its own. The assertion now returns the tenant filter to
+"Todos" and requires the full list back: only a genuine `setFiltroEmpresa(SIN_FILTRO)` produces
+that, because a stale `'30'` would become a valid option again and silently reapply itself.
+
+### Slice 2 delivery notes
+
+- **BUDGET OVERFLOW, MEASURED AND REPORTED, NOT ABSORBED — AND NOT SPLIT UNILATERALLY.**
+  `git diff main --stat -- src`: **34 files, 1 909 insertions + 289 deletions = 2 198 changed
+  lines** against an estimate of ~430 and an operative budget of 800 (OD1). Ignoring
+  pure re-indentation (`git diff -w`): **1 741 + 121 = 1 862**. The split is production **~1 054**
+  / tests **~1 144**, and the production figure is itself inflated: the four screens account for
+  443 insertions and 120 deletions with `-w`, the rest is the mechanical `tipos.ts` mirror plus
+  58 lines of fixture fields across 23 pre-existing test files.
+
+  The shape is the same one the orchestrator already ruled on for slice 1: a small production
+  surface carrying a large body of demanded evidence. The five new test files are 1 078 lines,
+  required by `web-descriptor-tests` (a colocated test per helper branch, smoke-only is not done)
+  and `mutation-proof-tests` (a named clause plus recorded evidence per test).
+
+  **The pre-approved degradation for this slice (`2a` names and counts / `2b` filters) is no
+  longer a clean cut** and this is stated rather than forced: the filter derivation, the column
+  rendering and the `react-async-state` retrofit live in the same four screen bodies, so cutting
+  along names-vs-filters would split single functions across two PRs. The cut that IS clean is
+  per screen, and the six commits are already shaped for it:
+  `tipos.ts` mirror → helpers + their tests → Tenants → Empresas → PuntosVenta → Usuarios.
+  **This is an orchestrator decision, not an apply-phase one**, and no PR was opened.
+
+- **Task 2.3 has no file to modify: `src/Ways.Web/src/api/usuarios.ts` does not exist.**
+  `UsuarioListado` is declared in `tipos.ts` and `Usuarios.tsx` calls `api.get` directly — there is
+  no usuarios client module, and the `eliminar` call the task mentions is an inline
+  `api.delete` in the screen. The task's substance (mirror the two new fields) is delivered by
+  task 2.1. **No module was created just to satisfy the task's wording**: an empty indirection
+  layer would be dead code. Marked done on that basis, recorded here rather than silently.
+
+- **`react-async-state` was applied to all four screens, which is most of the production delta
+  beyond the columns and filters.** The screens combine React state with async fetch/save, so the
+  skill's activation contract fires. What landed, per screen: a generation ref with its
+  invalidation contract documented on the ref; a token check before every state application after
+  every await, including the `finally` that clears the flags and the opt-in rethrow of the loader;
+  a per-operation `ocupado` flag that disables the form AND every row action for the whole window
+  from click until the post-write refresh lands (rule 9, not token reconciliation); and the
+  post-write refresh isolated from the write's try/catch with a distinguishable message
+  (rule 6). `Usuarios.tsx` also gained `key={formulario.id ?? 'nuevo'}` on the form subtree
+  (rule 8) and a re-entrancy guard on every handler. M10-M13 are the evidence, including the
+  survivor.
+
+- **The filter selection is DERIVED, not synchronised by an effect.** `tenantVigente` /
+  `empresaVigente` fall back to "no filter" when the stored selection is not among the options
+  derived from the currently loaded rows, so a refresh that removes a row can never leave a
+  `<select>` pointing at an option that no longer exists — without a `useEffect` that would fire a
+  second render pass. The one place state IS mutated is `cambiarFiltroDeTenant`, and it uses a
+  functional updater built from `prev` (rule 1), never from closure state.
+
+- **A tenant literally named "Plataforma" stays distinguishable in the filter.** The column renders
+  the literal `"Plataforma"` for `idTenant === null` (D14), so a homonym tenant renders the same
+  text — `nombre` is free text and that is unavoidable. The filter is where it must not collapse:
+  the platform option's key is the token `sin-tenant` (never any `String(idTenant)`) and its label
+  carries the suffix `(sin tenant)`, so the two options are distinct by key AND by label. M2 kills
+  the key collapse; the `Usuarios` homonym test kills the label collapse.
+
+- **Pre-existing flake observed, NOT introduced by this slice.**
+  `Reposicion.test.tsx > arranca con el primer punto de venta cargado, sin ?dias= en la consulta`
+  fails intermittently under the full-suite run (`TypeError: Cannot read properties of undefined
+  (reading '0')` at line 152 — `apiGetMock.mock.calls.find(...)` returns `undefined`). Measured:
+  **1 failure in 3 full runs on this branch, and 1 failure in 4 full runs on `main` with the branch
+  stashed**. Alone, the file passes 12/12. The file's only change in this slice is two fixture
+  fields. Not fixed here — it is outside slice 2's scope — but recorded so nobody reads a red
+  suite as slice 2's doing.
+
+- **Verify criteria re-asserted on this slice's diff (V1-V6, V13).** Zero files under
+  `Migraciones/`; `dotnet ef migrations has-pending-model-changes` → *"No changes have been made to
+  the model since the last migration"*; `InicializadorDeBaseDeDatos.cs`, `Politicas.cs` and
+  `ManejadorDeErrores.cs` all pass `git diff main --exit-code`; zero `ExecuteDelete`/`RemoveRange`/
+  `DELETE FROM` additions; zero DDL. `git diff main --name-only` outside `src/Ways.Web/` is
+  **empty** — this slice touches no backend file at all, which is why the three dotnet test suites
+  were not run (`dotnet build Ways.slnx` was, and is clean).
 
 ---
 

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -129,9 +129,15 @@ carry the entire safety argument.**
     filter option still needs a key the operator can tell apart from another orphan's. The id
     suffix is that handle, and it is the *anomaly's* rendering, not an owner identity: presenting
     it as an owner would require claiming the number identifies something the row can name, which
-    is exactly what it cannot do. Replacing it with a bare `—` would collapse two distinct orphan
-    tenants into one indistinguishable option (the case `desempata los huérfanos con su id para que
-    no compartan etiqueta` pins). The spec sentence is left **byte-identical** — deltas of this
+    is exactly what it cannot do. **The supporting argument is corrected in round 2**: the original
+    wording said a bare `—` "would collapse two distinct orphan tenants into one indistinguishable
+    option", and that is no longer true — `desempatarHomonimos` now resolves exactly that collision
+    on its own, so a bare `—` would come out as `— (tenant 7)` / `— (tenant 8)` anyway. The reason
+    the suffix is built into `etiquetaDeOpcionDeTenant` instead of being left to the generic
+    tie-break is that the anomaly must be legible **even when there is only one orphan**: with a
+    single orphan there is no collision to break, and a bare `—` would render an option the
+    operator cannot tell from the empty/placeholder state. The conclusion is unchanged: the label
+    stays as it is. The spec sentence is left **byte-identical** — deltas of this
     change are not edited mid-flight — and is read through this reconciliation, the same handling
     Reconciliación 1 gives OD6 and Reconciliación 9 gives S1. Task 2.13's assertion still holds
     unchanged: no **cell** presents an id as the owner's identity. *(judgment-day round 1, judge A
@@ -616,12 +622,11 @@ planning name `feat/stage20-slice2-proyeccion-web` — same slice, different bra
 | M17 | 2.17 | ~~The create selector offers only ASSIGNABLE tenants — the platform token is not an id~~ | ~~`const tenantsAsignables = opcionesTenant` — the `VALOR_SIN_TENANT` filter dropped~~ | **SUPERSEDED in round 1 — the clause no longer exists.** The `VALOR_SIN_TENANT` filter lived on the `!esPlataforma` arm of `tenantsAsignables`, which round 1 proved unreachable (the selector renders only under `ofreceTenant={esPlataforma}`) and removed as dead code. The kill recorded here was real when it ran, against code that is gone; it is **not** re-targeted to a different clause and **not** left standing as if it still guarded something. The surviving property of that selector — its option set — is now guarded by M22 and M26b |
 | M18 | 2.17 | `react-async-state` rule 5: the selector is part of the full-window disabled state while the list (its own option source) is still loading | `disabled={guardando \|\| esRolDePlataforma}` — `tenantsCargando` dropped | **KILLED** — `el selector queda inerte mientras la lista está cargando`: `expect(element).toBeDisabled()` / `Received element is not disabled` |
 | M19 | 2.17 (page-size gap closure) | S5 anti-oracle: a tenant admin must never call `listarTenants()`, not even in the background | `if (!esPlataforma) return` deleted from the tenant-universe fetch effect | **KILLED** — `un admin de tenant nunca pide el universo de tenants (listarTenants)`: `expected "vi.fn()" to not be called with arguments: [ '/plataforma/tenants' ]`, received 3 calls including it |
-
 | M20 | R1-C1 | `react-async-state` rule 7: the tenant-universe `.catch` SURFACES the failure instead of silently setting `[]` | `setError(ERROR_TENANTS)` deleted from the catch | **KILLED, 2 tests** — `un fallo del universo de tenants se rinde en pantalla y abrir "Nuevo" lo reintenta` and `Guardar queda inerte cuando el universo de tenants falló`: `Unable to find an element with the text: /No se pudo cargar la lista de tenants/` |
 | M20b | R1-C1 | The retry hangs off opening "Nuevo" — the effect's `[esPlataforma]` deps never re-fire on their own | `if (esPlataforma && tenantsDePlataformaFallo) cargarTenantsDePlataforma()` deleted from the "Nuevo" handler | **KILLED** — `expected 1 to be 2` (the second `GET /plataforma/tenants` never happens) |
 | M21 | R1-C2 | `disabled={guardando \|\| sinTenantAsignable}` on Guardar — a `disabled` `<select>` is EXEMPT from HTML constraint validation, so `required` does not block the POST during the load/failure window | `disabled={guardando}` | **KILLED, 2 tests** — `expect(element).toBeDisabled()` / `Received element is not disabled`, on both the loading and the failed window |
 | M21b | R1-C2 | The same guard re-checked inside `guardar()` (rule 9: a same-tick double click beats the `disabled` attribute) | `if (formulario.id === null && universoDeTenantsIndisponible) return` deleted | **SURVIVED, 24/24 green — recorded as a survivor.** `userEvent.click` honours the `disabled` attribute, so the handler is never entered; the guard exists for the same-tick race the DOM cannot be made to produce here. Same class as the re-entrancy guards already on this screen |
-| M22 | R1-C4 | The assignable-tenant label MARKS a non-`Activo` estado — the server never inspects the destination tenant's estado, so a user created inside a suspended tenant silently cannot log in | `return nombre` — the `estado === 'Activo' ? … : \`${nombre} (${estado.toLowerCase()})\`` marker dropped | **KILLED, 2 tests across 2 files** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(3) ]` (the helper unit test and the screen test) |
+| M22 | R1-C4 | The assignable-tenant label MARKS a non-`Activo` estado — the server never inspects the destination tenant's estado, so a user created inside a suspended tenant silently cannot log in | `return nombre` — the `estado === 'Activo' ? … : \`${nombre} (${estado.toLowerCase()})\`` marker dropped | **KILLED, 2 tests across 2 files** — `expected [ 'Elegí un tenant', …(3) ] to deeply equal [ 'Elegí un tenant', …(3) ]` (the helper unit test and the screen test). **Scope corrected in round 2**: only the `(suspendido)` half of this clause is a live path. A tenant in `Baja` is soft-deleted and `GET /plataforma/tenants` does not list it, so the `(baja)` arm is defence-in-depth, not a real listing row — the `Baja` fixture exists to exercise the branch and the doc-comments of `etiquetaDeTenantAsignable` and of both tests now say so instead of presenting it as something an operator can see. The code is kept in case the listing stops filtering them |
 | M23 | R1-S2 | The filter reconciliation is WRITTEN to state in `cargar`, not only derived at render | `setFiltroTenant((prev) => seleccionVigente(…))` deleted | **KILLED** — `un filtro invalidado por una búsqueda no resucita cuando las filas vuelven`: `Expected the element to have value: ` / `Received: 3`. The derived fallback is the confound and it is named in the test: while the option is missing it blanks the `<select>` on its own, so the discriminating observation is that the filter must NOT reapply itself when the rows come back |
 | M24 | R1-S3 | The post-write refresh reloads with the APPLIED search term, not the input draft | `await cargar(token, busqueda, true)` | **KILLED** — `expected '/usuarios?busqueda=juan' to be '/usuarios'` (text typed and never searched narrowed the table after a Baja) |
 | M25 | R1-S4 | The password POST has its own `try`: a committed PUT is never reported as a failure (rule 6) | the POST moved back inside the PUT's `try` | **KILLED** — `Unable to find an element with the text: /no se pudo cambiar la contraseña/` (the screen said "No se pudo guardar." for a profile that had already committed) |
@@ -687,6 +692,43 @@ empresa-clearing test asserted only `toHaveValue('')` after switching tenants, w
 `empresaVigente` fallback satisfies on its own. The assertion now returns the tenant filter to
 "Todos" and requires the full list back: only a genuine `setFiltroEmpresa(SIN_FILTRO)` produces
 that, because a stale `'30'` would become a valid option again and silently reapply itself.
+
+### Mutation evidence — slice 2, judgment-day round 2 (FINAL round)
+
+Same protocol as above: every mutation was applied to the working tree, `npx vitest run <file>` was
+run from `src/Ways.Web`, the result was OBSERVED, then reverted and observed GREEN again.
+
+| # | Finding | Clause under test | Mutation applied | Observed result |
+|---|---|---|---|---|
+| M31 | R2-1 | The tenant-universe failure has its OWN rendered banner, derived from `tenantsDePlataformaFallo`, and never travels through the shared `error` slot | `setError(ERROR_TENANTS)` put back in the `.catch` and the dedicated banner removed | **KILLED, 2 tests** — `el fallo del universo de tenants sobrevive a una carga de usuarios que resuelve después`: `Unable to find an element with the text: /No se pudo cargar la lista de tenants/`; and the reverse direction, `el fallo del universo y el del listado de usuarios se rinden los dos`: `Unable to find an element with the text: Se cayó el listado de usuarios.` — the shared slot clobbers in BOTH directions and each test pins one |
+| M32 | R2-2 | The password-POST failure goes to the RED slot while the committed PUT's confirmation stays in the green one | the `setErrorPassword(…)` call replaced by an assignment to `mensajeOk` ("Usuario … actualizado, pero no se pudo cambiar la contraseña. …"), routing the failure back into `aviso` | **KILLED** — `el fallo de la contraseña va en rojo y la confirmación del perfil se queda en verde`: `expect(element).toHaveClass("alert-danger")`. The assertion is on the alert VARIANT, not the text: the text alone cannot tell a failure announced in `alert-success` from one announced in `alert-danger` |
+| M33 | R2-4 | `!tenantsDePlataformaCargando` guards the "Nuevo" retry against a duplicate in-flight `GET /plataforma/tenants` | the conjunct dropped | **KILLED** — `dos clicks seguidos en "Nuevo" disparan un solo reintento`: `expected 3 to be 2` |
+| M34 | R2-7 | `esPlataforma &&` gates the tenant FILTER of `Usuarios`, parity with C3 on the sibling screens | `{true && (` on the filter, and both tenant-cell gates dropped | **KILLED** — `un admin de tenant no ve el filtro ni la columna de tenant`: `expected document not to contain element, found <select` |
+| M34b | R2-7 | The same gate on the tenant COLUMN, mutated ALONE so the column assertion is not overdetermined by the filter one | only `{esPlataforma && <th>Tenant</th>}` and `{esPlataforma && <td>…</td>}` dropped | **KILLED** — same test, `expected document not to contain element, found <th>`. Run separately on purpose: killing the pair together would not have proven the column half |
+| M35 | R2-5 | The `guardar()` re-check announces itself instead of exiting silently | `setError(ERROR_ALTA_SIN_TENANTS)` removed, back to the bare `return` | **SURVIVED, 28/28 green — recorded as a survivor, not dressed up.** Exactly the M21b class and the finding said so: `userEvent.click` honours the `disabled` attribute, so the handler is never entered and the DOM cannot produce the same-tick double click the guard exists for. The silent exit is removed because a guard that can fire must be able to say why, not because a test proves it |
+| M36 | R2-6 | The platform option enters `desempatarHomonimos`'s collision map — a tenant named literally `Plataforma (sin tenant)` produced two byte-identical labels | the pre-round-2 shape restored: `porClave.get(VALOR_SIN_TENANT)` taken out before the tie-break, which is then run over the filtered rest | **KILLED** — `un tenant llamado exactamente como la opción de plataforma no queda con etiqueta idéntica`: `expected 1 to be 2` (the two labels collapse into one). The pre-existing `"Plataforma"`-alone case does NOT cover this: there the fixed `(sin tenant)` suffix already separated them |
+| M37 | R2-8 | The empresa write-back reconciles against the tenant-NARROWED option set, the same one the render uses | `seleccionVigente(opcionesDeEmpresa(filas), prev)` — the `tenanteReconciliado` argument dropped | **KILLED** — `la empresa elegida no resucita cuando un refresco la saca del tenant vigente`: `expected [ 'PV Anexo' ] to deeply equal [ 'PV Centro', 'PV Anexo', 'PV Este' ]`. Same confound and same discriminating observation as M4/M23: while the tenant filter is still on, both versions paint identically |
+| M38 | R2-3 | `Empresas.tsx` clears `ocupado` in an UNGATED `finally`, and its token check moved inside the try so the mismatch path also reaches it | the `if (generacion.current === token)` gate put back on the `finally` | **SURVIVED, 15/15 green — recorded as a survivor.** Identical to M30/M30b and for the identical reason: rule 9 disables every action that could bump the generation while `ocupado` is set, so the frozen-flag window is unreachable today. Taken as the trap slice 5's delete buttons will need |
+| M38b | R2-3 | The same, on `PuntosVenta.tsx` | the same gate put back | **SURVIVED, 15/15 green — same reason, recorded not dressed up** |
+
+**Round 2 — R2-1 needed its confound named before it could be killed.** The obvious test (mount,
+let `/plataforma/tenants` fail, assert the banner) passes with the failure routed through `error`
+too, because on the default mock ordering the users list resolves FIRST and its `setError('')` has
+already run. The kill only happens once the ordering is inverted by hand — tenants rejects, the
+banner is asserted, and only THEN the users promise resolves — which is why both promises are
+controlled explicitly in that test. Its sibling pins the opposite direction: `ERROR_TENANTS` must
+not bury a genuine users-list failure.
+
+**Round 2 — two honest survivors, M35 and M38/M38b.** Neither is presented as a kill. M35 is the
+M21b class (the DOM cannot produce the race the guard covers); M38/M38b are the M30/M30b class
+(rule 9 closes the window today). All three fixes are taken for replication and honesty reasons
+stated by the findings themselves, and slice 5 is where they become reachable.
+
+**Round 2 — one item recorded with NO code change, by decision.** Crafted tenant names that
+pre-embed a generated suffix (`"Foo (suspendido)"`, `"Bar (tenant 3)"`) can make a label read as if
+the web had marked it. This is misleading COPY only: the option keys stay true, the filtering and
+the create payload are driven by those keys, and the text is authored by a platform actor about
+their own tenants. No defence is added and none is planned.
 
 ### Slice 2 delivery notes
 

--- a/src/Ways.Web/src/api/organizacion.test.ts
+++ b/src/Ways.Web/src/api/organizacion.test.ts
@@ -8,11 +8,14 @@ import {
   filtrarPorTenant,
   opcionesDeEmpresa,
   opcionesDeTenant,
+  opcionesDeTenantAsignable,
+  seleccionVigente,
   SIN_FILTRO,
   VALOR_SIN_TENANT,
   type FilaConEmpresa,
   type FilaConTenant,
 } from './organizacion'
+import type { EstadoTenant, TenantListado } from './tipos'
 
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tarea 2.8) — `web-descriptor-tests`: los
 // cinco helpers puros de `organizacion.ts` con un caso por rama, no un happy path.
@@ -119,8 +122,97 @@ describe('opcionesDeTenant', () => {
     ])
   })
 
+  /**
+   * Cláusula bajo prueba: `desempatarHomonimos` dentro de `opcionesDeTenant`. `nombre` es texto
+   * libre, así que dos tenants DISTINTOS pueden compartirlo: sin desempate las dos opciones son
+   * byte a byte idénticas y el operador elige a ciegas. El desempate del huérfano no cubre este
+   * caso — acá los dos nombres existen — así que es una cláusula propia.
+   */
+  it('desempata con el id a dos tenants distintos que comparten nombre', () => {
+    const opciones = opcionesDeTenant([fila(2, 'Comercio Sur'), fila(3, 'Comercio Sur')])
+
+    expect(opciones).toEqual([
+      { valor: '2', etiqueta: 'Comercio Sur (tenant 2)' },
+      { valor: '3', etiqueta: 'Comercio Sur (tenant 3)' },
+    ])
+    expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+  })
+
+  /** El desempate toca SOLO a las que colisionan: un nombre único no se ensucia con su id. */
+  it('no le agrega el id a un tenant cuyo nombre no se repite', () => {
+    const opciones = opcionesDeTenant([fila(2, 'Comercio Sur'), fila(3, 'Comercio Sur'), fila(4, 'Único')])
+
+    expect(opciones.find((o) => o.valor === '4')).toEqual({ valor: '4', etiqueta: 'Único' })
+  })
+
   it('sobre una lista vacía no ofrece ninguna opción', () => {
     expect(opcionesDeTenant([])).toEqual([])
+  })
+})
+
+describe('opcionesDeTenantAsignable', () => {
+  function tenant(id: number, nombre: string, estado: EstadoTenant = 'Activo'): TenantListado {
+    return {
+      id,
+      nombre,
+      estado,
+      createdAt: '2026-01-01T10:00:00-03:00',
+      cantidadEmpresas: 0,
+      cantidadPuntosVenta: 0,
+      cantidadUsuarios: 0,
+    }
+  }
+
+  it('ordena por etiqueta y no toca el nombre de un tenant activo', () => {
+    expect(opcionesDeTenantAsignable([tenant(3, 'Zapatería Norte'), tenant(2, 'Comercio Sur')])).toEqual([
+      { valor: '2', etiqueta: 'Comercio Sur' },
+      { valor: '3', etiqueta: 'Zapatería Norte' },
+    ])
+  })
+
+  /**
+   * Cláusula bajo prueba: la marca de estado. El servidor es la autoridad y `CrearAsync` NO mira
+   * el estado del tenant destino, así que un tenant suspendido o dado de baja se sigue ofreciendo
+   * —el operador puede pre-crear ahí a propósito— pero sin la marca el usuario creado adentro
+   * simplemente no podría iniciar sesión y nada en la pantalla lo diría.
+   */
+  it('marca en la etiqueta a los tenants que no están activos, sin sacarlos de la lista', () => {
+    const opciones = opcionesDeTenantAsignable([
+      tenant(2, 'Comercio Sur'),
+      tenant(3, 'Almacén Este', 'Suspendido'),
+      tenant(4, 'Kiosco Viejo', 'Baja'),
+    ])
+
+    expect(opciones).toEqual([
+      { valor: '3', etiqueta: 'Almacén Este (suspendido)' },
+      { valor: '2', etiqueta: 'Comercio Sur' },
+      { valor: '4', etiqueta: 'Kiosco Viejo (baja)' },
+    ])
+  })
+
+  it('desempata con el id a dos tenants asignables que comparten nombre', () => {
+    const opciones = opcionesDeTenantAsignable([tenant(2, 'Comercio Sur'), tenant(3, 'Comercio Sur')])
+
+    expect(opciones.map((o) => o.etiqueta)).toEqual(['Comercio Sur (tenant 2)', 'Comercio Sur (tenant 3)'])
+  })
+})
+
+describe('seleccionVigente', () => {
+  const opciones = [
+    { valor: '2', etiqueta: 'Comercio Sur' },
+    { valor: '3', etiqueta: 'Almacén Este' },
+  ]
+
+  it('respeta una selección que sigue estando entre las opciones', () => {
+    expect(seleccionVigente(opciones, '3')).toBe('3')
+  })
+
+  it('apaga una selección que ya no está entre las opciones', () => {
+    expect(seleccionVigente(opciones, '9')).toBe(SIN_FILTRO)
+  })
+
+  it('deja pasar el "sin filtro" sin buscarlo entre las opciones', () => {
+    expect(seleccionVigente([], SIN_FILTRO)).toBe(SIN_FILTRO)
   })
 })
 
@@ -152,6 +244,20 @@ describe('opcionesDeEmpresa', () => {
 
     expect(opciones.map((o) => o.valor).sort()).toEqual(['30', '31'])
     expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+  })
+
+  /** Cláusula bajo prueba: `desempatarHomonimos` en `opcionesDeEmpresa` — la misma de
+   * `opcionesDeTenant`, sobre la razón social, que también es texto libre. */
+  it('desempata con el id a dos empresas distintas que comparten razón social', () => {
+    const opciones = opcionesDeEmpresa([
+      filaPv(1, 'Tenant Uno', 30, 'Sur SRL'),
+      filaPv(1, 'Tenant Uno', 31, 'Sur SRL'),
+    ])
+
+    expect(opciones).toEqual([
+      { valor: '30', etiqueta: 'Sur SRL (empresa 30)' },
+      { valor: '31', etiqueta: 'Sur SRL (empresa 31)' },
+    ])
   })
 })
 

--- a/src/Ways.Web/src/api/organizacion.test.ts
+++ b/src/Ways.Web/src/api/organizacion.test.ts
@@ -145,6 +145,26 @@ describe('opcionesDeTenant', () => {
     expect(opciones.find((o) => o.valor === '4')).toEqual({ valor: '4', etiqueta: 'Único' })
   })
 
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-6): la opción de plataforma entra al mapa de colisiones de
+   * `desempatarHomonimos`. `ETIQUETA_OPCION_PLATAFORMA` es texto fijo y `nombre` es texto libre, así
+   * que un tenant llamado LITERALMENTE "Plataforma (sin tenant)" produce la MISMA etiqueta. El caso
+   * de arriba ("Plataforma" a secas) no lo cubre: ahí las dos etiquetas ya diferían por el sufijo.
+   * Las claves quedan intactas — la del personal de plataforma sigue sin ser ningún `String(id)`.
+   */
+  it('un tenant llamado exactamente como la opción de plataforma no queda con etiqueta idéntica', () => {
+    const opciones = opcionesDeTenant([fila(9, ETIQUETA_OPCION_PLATAFORMA), fila(null, null)])
+
+    expect(opciones.map((o) => o.valor)).toEqual([VALOR_SIN_TENANT, '9'])
+    expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+    expect(opciones.find((o) => o.valor === '9')?.etiqueta).toBe(
+      `${ETIQUETA_OPCION_PLATAFORMA} (tenant 9)`,
+    )
+    expect(opciones.find((o) => o.valor === VALOR_SIN_TENANT)?.etiqueta).toBe(
+      `${ETIQUETA_OPCION_PLATAFORMA} (tenant ${VALOR_SIN_TENANT})`,
+    )
+  })
+
   it('sobre una lista vacía no ofrece ninguna opción', () => {
     expect(opcionesDeTenant([])).toEqual([])
   })
@@ -172,9 +192,13 @@ describe('opcionesDeTenantAsignable', () => {
 
   /**
    * Cláusula bajo prueba: la marca de estado. El servidor es la autoridad y `CrearAsync` NO mira
-   * el estado del tenant destino, así que un tenant suspendido o dado de baja se sigue ofreciendo
-   * —el operador puede pre-crear ahí a propósito— pero sin la marca el usuario creado adentro
-   * simplemente no podría iniciar sesión y nada en la pantalla lo diría.
+   * el estado del tenant destino, así que un tenant suspendido se sigue ofreciendo —el operador
+   * puede pre-crear ahí a propósito— pero sin la marca el usuario creado adentro simplemente no
+   * podría iniciar sesión y nada en la pantalla lo diría. Esa es la mitad VIVA de la cláusula.
+   *
+   * La fila `Baja` NO es una fila real del listado: un tenant en `Baja` está borrado lógicamente y
+   * `GET /plataforma/tenants` no lo devuelve, así que esa rama es defensa en profundidad y el
+   * fixture existe solo para ejercitarla. Se mantiene por si el listado dejara de filtrarlos.
    */
   it('marca en la etiqueta a los tenants que no están activos, sin sacarlos de la lista', () => {
     const opciones = opcionesDeTenantAsignable([

--- a/src/Ways.Web/src/api/organizacion.test.ts
+++ b/src/Ways.Web/src/api/organizacion.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ETIQUETA_OPCION_PLATAFORMA,
+  ETIQUETA_PLATAFORMA,
+  ETIQUETA_SIN_DUENIO,
+  etiquetaDeTenant,
+  filtrarPorEmpresa,
+  filtrarPorTenant,
+  opcionesDeEmpresa,
+  opcionesDeTenant,
+  SIN_FILTRO,
+  VALOR_SIN_TENANT,
+  type FilaConEmpresa,
+  type FilaConTenant,
+} from './organizacion'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tarea 2.8) — `web-descriptor-tests`: los
+// cinco helpers puros de `organizacion.ts` con un caso por rama, no un happy path.
+
+function fila(idTenant: number | null, nombreTenant: string | null): FilaConTenant {
+  return { idTenant, nombreTenant }
+}
+
+function filaPv(
+  idTenant: number | null,
+  nombreTenant: string | null,
+  idEmpresa: number,
+  razonSocialEmpresa: string | null,
+): FilaConEmpresa {
+  return { idTenant, nombreTenant, idEmpresa, razonSocialEmpresa }
+}
+
+describe('etiquetaDeTenant', () => {
+  it('rinde el literal "Plataforma" cuando idTenant es null', () => {
+    expect(etiquetaDeTenant(fila(null, null))).toBe(ETIQUETA_PLATAFORMA)
+  })
+
+  it('rinde el nombre del tenant cuando la cuenta tiene tenant', () => {
+    expect(etiquetaDeTenant(fila(2, 'Comercio Sur'))).toBe('Comercio Sur')
+  })
+
+  /**
+   * Cláusula bajo prueba: el discriminador de `etiquetaDeTenant` es `idTenant`, NO el nombre
+   * (Reconciliación 9 / design D13). Un nombre nulo con idTenant presente es un HUÉRFANO — el
+   * tenant dueño quedó dado de baja — y NO puede rendirse como personal de plataforma. Los dos
+   * casos comparten `nombreTenant === null`, así que un helper que se apoyara en el nombre
+   * devolvería "Plataforma" acá.
+   */
+  it('un huérfano (idTenant presente, nombre nulo) NO se rinde como plataforma', () => {
+    expect(etiquetaDeTenant(fila(7, null))).toBe(ETIQUETA_SIN_DUENIO)
+    expect(etiquetaDeTenant(fila(7, null))).not.toBe(ETIQUETA_PLATAFORMA)
+  })
+
+  /**
+   * Cláusula bajo prueba: la etiqueta "Plataforma" la fabrica la WEB (design D14) y un tenant
+   * puede llamarse literalmente así. Los dos rinden el mismo texto en la columna, pero son filas
+   * distintas y el filtro las distingue por `idTenant` — ver la prueba de `opcionesDeTenant`.
+   */
+  it('un tenant llamado "Plataforma" rinde su propio nombre y no se confunde con la etiqueta', () => {
+    const tenantHomonimo = fila(9, 'Plataforma')
+
+    expect(etiquetaDeTenant(tenantHomonimo)).toBe('Plataforma')
+    expect(tenantHomonimo.idTenant).not.toBeNull()
+  })
+})
+
+describe('opcionesDeTenant', () => {
+  it('deduplica por idTenant y ordena por etiqueta', () => {
+    const opciones = opcionesDeTenant([
+      fila(3, 'Zapatería Norte'),
+      fila(2, 'Comercio Sur'),
+      fila(3, 'Zapatería Norte'),
+      fila(1, 'Almacén Este'),
+    ])
+
+    expect(opciones).toEqual([
+      { valor: '1', etiqueta: 'Almacén Este' },
+      { valor: '2', etiqueta: 'Comercio Sur' },
+      { valor: '3', etiqueta: 'Zapatería Norte' },
+    ])
+  })
+
+  it('agrega la opción de plataforma primero y solo si alguna fila no tiene tenant', () => {
+    const conPlataforma = opcionesDeTenant([fila(2, 'Comercio Sur'), fila(null, null)])
+    const sinPlataforma = opcionesDeTenant([fila(2, 'Comercio Sur')])
+
+    expect(conPlataforma[0]).toEqual({ valor: VALOR_SIN_TENANT, etiqueta: ETIQUETA_OPCION_PLATAFORMA })
+    expect(conPlataforma).toHaveLength(2)
+    expect(sinPlataforma.map((o) => o.valor)).toEqual(['2'])
+  })
+
+  /**
+   * Cláusula bajo prueba: `claveDeTenant` devuelve un token que ningún `String(idTenant)` puede
+   * producir. Si la opción de plataforma compartiera clave con un tenant, elegir una filtraría la
+   * otra. El caso adversario es un tenant llamado literalmente "Plataforma": mismas ganas de
+   * confundirse en la etiqueta, claves obligatoriamente distintas.
+   */
+  it('un tenant llamado "Plataforma" y el personal de plataforma son dos opciones distinguibles', () => {
+    const opciones = opcionesDeTenant([fila(9, 'Plataforma'), fila(null, null)])
+
+    expect(opciones).toHaveLength(2)
+    expect(opciones.map((o) => o.valor)).toEqual([VALOR_SIN_TENANT, '9'])
+    expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+    expect(opciones.find((o) => o.valor === '9')?.etiqueta).toBe('Plataforma')
+  })
+
+  it('desempata los huérfanos con su id para que no compartan etiqueta', () => {
+    const opciones = opcionesDeTenant([fila(7, null), fila(8, null)])
+
+    expect(opciones.map((o) => o.valor).sort()).toEqual(['7', '8'])
+    expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+  })
+
+  /** Spec S5: las opciones salen de las filas ya cargadas, así que un dataset de un solo tenant
+   * ofrece exactamente una opción — el nombre de otro tenant no puede aparecer. */
+  it('un dataset de un solo tenant ofrece exactamente una opción', () => {
+    expect(opcionesDeTenant([fila(1, 'Tenant Uno'), fila(1, 'Tenant Uno')])).toEqual([
+      { valor: '1', etiqueta: 'Tenant Uno' },
+    ])
+  })
+
+  it('sobre una lista vacía no ofrece ninguna opción', () => {
+    expect(opcionesDeTenant([])).toEqual([])
+  })
+})
+
+describe('opcionesDeEmpresa', () => {
+  const filas = [
+    filaPv(1, 'Tenant Uno', 10, 'Este SRL'),
+    filaPv(1, 'Tenant Uno', 11, 'Anexo SA'),
+    filaPv(2, 'Tenant Dos', 20, 'Sur SRL'),
+    filaPv(2, 'Tenant Dos', 20, 'Sur SRL'),
+  ]
+
+  it('sin tenant seleccionado ofrece todas las empresas, deduplicadas y ordenadas', () => {
+    expect(opcionesDeEmpresa(filas)).toEqual([
+      { valor: '11', etiqueta: 'Anexo SA' },
+      { valor: '10', etiqueta: 'Este SRL' },
+      { valor: '20', etiqueta: 'Sur SRL' },
+    ])
+  })
+
+  /** Cláusula bajo prueba: el angostamiento por tenant de design D15 — elegir un tenant saca del
+   * `<select>` de empresa a las empresas de los demás. */
+  it('angosta las opciones al tenant seleccionado', () => {
+    expect(opcionesDeEmpresa(filas, '1').map((o) => o.valor)).toEqual(['11', '10'])
+    expect(opcionesDeEmpresa(filas, '2').map((o) => o.valor)).toEqual(['20'])
+  })
+
+  it('desempata las empresas sin razón social con su id', () => {
+    const opciones = opcionesDeEmpresa([filaPv(1, 'Tenant Uno', 30, null), filaPv(1, 'Tenant Uno', 31, null)])
+
+    expect(opciones.map((o) => o.valor).sort()).toEqual(['30', '31'])
+    expect(new Set(opciones.map((o) => o.etiqueta)).size).toBe(2)
+  })
+})
+
+describe('filtrarPorTenant', () => {
+  const filas = [fila(1, 'Uno'), fila(2, 'Dos'), fila(null, null), fila(1, 'Uno')]
+
+  it('sin selección devuelve la lista entera (identidad)', () => {
+    expect(filtrarPorTenant(filas, SIN_FILTRO)).toEqual(filas)
+  })
+
+  it('con un id devuelve solo las filas de ese tenant', () => {
+    expect(filtrarPorTenant(filas, '1')).toEqual([fila(1, 'Uno'), fila(1, 'Uno')])
+  })
+
+  /** Cláusula bajo prueba: la rama `VALOR_SIN_TENANT` compara contra `null`, no contra
+   * `Number('sin-tenant')` — que sería `NaN` y no coincidiría con ninguna fila. */
+  it('con el token de plataforma devuelve solo las filas sin tenant', () => {
+    expect(filtrarPorTenant(filas, VALOR_SIN_TENANT)).toEqual([fila(null, null)])
+  })
+
+  it('no muta la lista original', () => {
+    const original = [...filas]
+    filtrarPorTenant(filas, '1')
+
+    expect(filas).toEqual(original)
+  })
+})
+
+describe('filtrarPorEmpresa', () => {
+  const filas = [{ idEmpresa: 10 }, { idEmpresa: 11 }, { idEmpresa: 10 }]
+
+  it('sin selección devuelve la lista entera (identidad)', () => {
+    expect(filtrarPorEmpresa(filas, SIN_FILTRO)).toEqual(filas)
+  })
+
+  it('con un id devuelve solo las filas de esa empresa', () => {
+    expect(filtrarPorEmpresa(filas, '10')).toEqual([{ idEmpresa: 10 }, { idEmpresa: 10 }])
+  })
+})

--- a/src/Ways.Web/src/api/organizacion.ts
+++ b/src/Ways.Web/src/api/organizacion.ts
@@ -30,3 +30,134 @@ export const clienteDeOrganizacion = {
   editarPuntoVenta: (id: number, datos: PuntoVentaEdicion) =>
     api.put<PuntoVentaListado>(`/puntos-venta/${id}`, datos),
 }
+
+// --- Filtros por dueño y etiquetas (stage-20, slice 2 · design D14, D15) ---
+//
+// Helpers PUROS: sin React y sin fetch. Las opciones de cada filtro se derivan de las filas YA
+// CARGADAS, nunca de una segunda consulta (D15): `GET /api/plataforma/tenants` es
+// `Politicas.SoloPlataforma` mientras que `Empresas.tsx` y `PuntosVenta.tsx` los abre también un
+// admin de tenant bajo `GestionDeOrganizacion` — pedir la lista de tenants daría 403 justo para
+// los usuarios para los que se hizo la pantalla. Derivar de las filas además hace imposible por
+// construcción que un filtro delate un tenant fuera del alcance del actor (spec S5).
+
+/** Valor de "sin filtro" de los `<select>`: el string vacío, que es lo que rinde un `<option>`
+ * sin `value`. `filtrarPorTenant`/`filtrarPorEmpresa` lo tratan como identidad. */
+export const SIN_FILTRO = ''
+
+/** Valor del `<option>` de personal de plataforma. NO es un id: es deliberadamente un token que
+ * ningún `String(idTenant)` puede producir, así una cuenta sin tenant y el tenant número 7 nunca
+ * comparten clave de filtro. */
+export const VALOR_SIN_TENANT = 'sin-tenant'
+
+/** Copia de la web para una cuenta sin tenant (design D14). El servidor NUNCA manda este literal:
+ * `nombre` es texto libre, así que un tenant llamado "Plataforma" sería indistinguible del
+ * personal de plataforma si el servidor lo fabricara. */
+export const ETIQUETA_PLATAFORMA = 'Plataforma'
+
+/** Etiqueta del `<option>` de personal de plataforma. Lleva el sufijo a propósito: un tenant
+ * puede llamarse literalmente "Plataforma" y las dos opciones quedarían visualmente idénticas
+ * (tendrían claves distintas igual, pero el operador no podría elegir a ciegas). */
+export const ETIQUETA_OPCION_PLATAFORMA = 'Plataforma (sin tenant)'
+
+/** Marca de dueño sin nombre — el huérfano de design D13, que NO es personal de plataforma. */
+export const ETIQUETA_SIN_DUENIO = '—'
+
+export type OpcionDeFiltro = { valor: string; etiqueta: string }
+
+/** Lo mínimo que una fila necesita para entrar a los filtros/etiquetas de tenant. `idTenant` es
+ * `number` en organización y `number | null` en usuarios; el tipo acepta los dos. */
+export type FilaConTenant = { idTenant: number | null; nombreTenant: string | null }
+
+export type FilaConEmpresa = FilaConTenant & { idEmpresa: number; razonSocialEmpresa: string | null }
+
+/**
+ * Etiqueta de la columna "Tenant". El discriminador es `idTenant`, NUNCA el nombre
+ * (Reconciliación 9): un `nombreTenant` nulo con `idTenant` nulo es personal de plataforma, y un
+ * `nombreTenant` nulo con `idTenant` presente es un huérfano — un tenant dado de baja lógicamente
+ * que todavía tiene hijos vivos. Son dos cosas distintas y se rinden distinto.
+ */
+export function etiquetaDeTenant(fila: FilaConTenant): string {
+  if (fila.idTenant === null) return ETIQUETA_PLATAFORMA
+
+  return fila.nombreTenant ?? ETIQUETA_SIN_DUENIO
+}
+
+function etiquetaDeOpcionDeTenant(fila: FilaConTenant): string {
+  if (fila.idTenant === null) return ETIQUETA_OPCION_PLATAFORMA
+
+  // El id desempata: dos tenants huérfanos distintos no pueden compartir etiqueta.
+  return fila.nombreTenant ?? `${ETIQUETA_SIN_DUENIO} (tenant ${fila.idTenant})`
+}
+
+function claveDeTenant(idTenant: number | null): string {
+  return idTenant === null ? VALOR_SIN_TENANT : String(idTenant)
+}
+
+function ordenarPorEtiqueta(opciones: OpcionDeFiltro[]): OpcionDeFiltro[] {
+  return opciones.sort((a, b) => a.etiqueta.localeCompare(b.etiqueta, 'es'))
+}
+
+/**
+ * Opciones del filtro por tenant, deduplicadas por `idTenant` y ordenadas por etiqueta. La opción
+ * de plataforma va primero (no es un tenant, es la ausencia de uno) y solo aparece si alguna fila
+ * cargada la tiene: un dataset de un solo tenant ofrece exactamente una opción (S5).
+ */
+export function opcionesDeTenant(filas: readonly FilaConTenant[]): OpcionDeFiltro[] {
+  const porClave = new Map<string, OpcionDeFiltro>()
+
+  for (const fila of filas) {
+    const valor = claveDeTenant(fila.idTenant)
+    if (!porClave.has(valor)) porClave.set(valor, { valor, etiqueta: etiquetaDeOpcionDeTenant(fila) })
+  }
+
+  const plataforma = porClave.get(VALOR_SIN_TENANT)
+  const tenants = ordenarPorEtiqueta([...porClave.values()].filter((o) => o.valor !== VALOR_SIN_TENANT))
+
+  return plataforma ? [plataforma, ...tenants] : tenants
+}
+
+/**
+ * Opciones del filtro por empresa, deduplicadas por `idEmpresa` y ordenadas por razón social.
+ * Cuando hay un tenant seleccionado las opciones se ANGOSTAN a ese tenant (design D15): el
+ * operador no puede elegir una empresa que el filtro de arriba ya sacó de la vista.
+ */
+export function opcionesDeEmpresa(
+  filas: readonly FilaConEmpresa[],
+  tenantSeleccionado: string = SIN_FILTRO,
+): OpcionDeFiltro[] {
+  const porClave = new Map<string, OpcionDeFiltro>()
+
+  for (const fila of filtrarPorTenant(filas, tenantSeleccionado)) {
+    const valor = String(fila.idEmpresa)
+    if (porClave.has(valor)) continue
+
+    porClave.set(valor, {
+      valor,
+      etiqueta: fila.razonSocialEmpresa ?? `${ETIQUETA_SIN_DUENIO} (empresa ${fila.idEmpresa})`,
+    })
+  }
+
+  return ordenarPorEtiqueta([...porClave.values()])
+}
+
+/** Filtra sobre la lista YA CARGADA. `SIN_FILTRO` es la identidad: devuelve la lista entera. */
+export function filtrarPorTenant<T extends FilaConTenant>(filas: readonly T[], seleccion: string): T[] {
+  if (seleccion === SIN_FILTRO) return [...filas]
+  if (seleccion === VALOR_SIN_TENANT) return filas.filter((f) => f.idTenant === null)
+
+  const id = Number(seleccion)
+
+  return filas.filter((f) => f.idTenant === id)
+}
+
+/** Filtra sobre la lista YA CARGADA. `SIN_FILTRO` es la identidad: devuelve la lista entera. */
+export function filtrarPorEmpresa<T extends { idEmpresa: number }>(
+  filas: readonly T[],
+  seleccion: string,
+): T[] {
+  if (seleccion === SIN_FILTRO) return [...filas]
+
+  const id = Number(seleccion)
+
+  return filas.filter((f) => f.idEmpresa === id)
+}

--- a/src/Ways.Web/src/api/organizacion.ts
+++ b/src/Ways.Web/src/api/organizacion.ts
@@ -99,10 +99,14 @@ function ordenarPorEtiqueta(opciones: OpcionDeFiltro[]): OpcionDeFiltro[] {
 }
 
 /**
- * Desempata etiquetas repetidas con el id de cada opción. `nombre`/`razon_social` son texto libre:
- * dos dueños DISTINTOS pueden compartirlo y las opciones quedarían byte a byte idénticas, así que
- * el operador elegiría a ciegas. Solo se toca a las que colisionan — es el mismo desempate que ya
- * llevan los huérfanos, aplicado ahora también a los homónimos con nombre.
+ * Desempata etiquetas repetidas con la CLAVE de cada opción. `nombre`/`razon_social` son texto
+ * libre: dos dueños DISTINTOS pueden compartirlo y las opciones quedarían byte a byte idénticas,
+ * así que el operador elegiría a ciegas. Solo se toca a las que colisionan — es el mismo desempate
+ * que ya llevan los huérfanos, aplicado ahora también a los homónimos con nombre.
+ *
+ * La opción de plataforma entra al mapa como una más: `ETIQUETA_OPCION_PLATAFORMA` es texto fijo y
+ * un tenant puede llamarse literalmente así, con lo que las dos etiquetas colisionarían. Su clave
+ * (`VALOR_SIN_TENANT`) no se toca — el sufijo es la clave, no un id fabricado.
  */
 function desempatarHomonimos(opciones: OpcionDeFiltro[], sustantivo: string): OpcionDeFiltro[] {
   const repeticiones = new Map<string, number>()
@@ -140,10 +144,12 @@ export function opcionesDeTenant(filas: readonly FilaConTenant[]): OpcionDeFiltr
     if (!porClave.has(valor)) porClave.set(valor, { valor, etiqueta: etiquetaDeOpcionDeTenant(fila) })
   }
 
-  const plataforma = porClave.get(VALOR_SIN_TENANT)
-  const tenants = ordenarPorEtiqueta(
-    desempatarHomonimos([...porClave.values()].filter((o) => o.valor !== VALOR_SIN_TENANT), 'tenant'),
-  )
+  // El desempate corre sobre el conjunto COMPLETO, plataforma incluida: recién después se aparta
+  // esa opción para dejarla primera. Excluirla del mapa dejaba dos etiquetas idénticas cuando un
+  // tenant se llama literalmente "Plataforma (sin tenant)".
+  const desempatadas = desempatarHomonimos([...porClave.values()], 'tenant')
+  const plataforma = desempatadas.find((o) => o.valor === VALOR_SIN_TENANT)
+  const tenants = ordenarPorEtiqueta(desempatadas.filter((o) => o.valor !== VALOR_SIN_TENANT))
 
   return plataforma ? [plataforma, ...tenants] : tenants
 }
@@ -164,6 +170,9 @@ export function opcionesDeTenantAsignable(tenants: readonly TenantListado[]): Op
   return ordenarPorEtiqueta(desempatarHomonimos(opciones, 'tenant'))
 }
 
+/** La marca que llega por la API hoy es `(suspendido)`: un tenant en `Baja` está borrado
+ * lógicamente y `GET /plataforma/tenants` no lo lista, así que la rama `(baja)` es defensa en
+ * profundidad, no un camino vivo. Se conserva por si el listado dejara de filtrarlos. */
 function etiquetaDeTenantAsignable(nombre: string, estado: EstadoTenant): string {
   return estado === 'Activo' ? nombre : `${nombre} (${estado.toLowerCase()})`
 }

--- a/src/Ways.Web/src/api/organizacion.ts
+++ b/src/Ways.Web/src/api/organizacion.ts
@@ -10,6 +10,7 @@ import { api } from './cliente'
 import type {
   EmpresaEdicion,
   EmpresaListado,
+  EstadoTenant,
   PuntoVentaEdicion,
   PuntoVentaListado,
   TenantEdicion,
@@ -98,6 +99,35 @@ function ordenarPorEtiqueta(opciones: OpcionDeFiltro[]): OpcionDeFiltro[] {
 }
 
 /**
+ * Desempata etiquetas repetidas con el id de cada opción. `nombre`/`razon_social` son texto libre:
+ * dos dueños DISTINTOS pueden compartirlo y las opciones quedarían byte a byte idénticas, así que
+ * el operador elegiría a ciegas. Solo se toca a las que colisionan — es el mismo desempate que ya
+ * llevan los huérfanos, aplicado ahora también a los homónimos con nombre.
+ */
+function desempatarHomonimos(opciones: OpcionDeFiltro[], sustantivo: string): OpcionDeFiltro[] {
+  const repeticiones = new Map<string, number>()
+  for (const opcion of opciones) {
+    repeticiones.set(opcion.etiqueta, (repeticiones.get(opcion.etiqueta) ?? 0) + 1)
+  }
+
+  return opciones.map((opcion) =>
+    (repeticiones.get(opcion.etiqueta) ?? 0) > 1
+      ? { ...opcion, etiqueta: `${opcion.etiqueta} (${sustantivo} ${opcion.valor})` }
+      : opcion,
+  )
+}
+
+/**
+ * Reconcilia una selección de filtro contra las opciones vigentes: si la opción elegida ya no
+ * existe, la selección vuelve a "sin filtro". Se usa para DERIVAR lo que se pinta y para escribir
+ * de vuelta el estado después de cada carga — derivarlo solo al pintar dejaba viva una selección
+ * inválida, que se reaplicaba sola en cuanto la opción reaparecía.
+ */
+export function seleccionVigente(opciones: readonly OpcionDeFiltro[], seleccion: string): string {
+  return seleccion === SIN_FILTRO || opciones.some((o) => o.valor === seleccion) ? seleccion : SIN_FILTRO
+}
+
+/**
  * Opciones del filtro por tenant, deduplicadas por `idTenant` y ordenadas por etiqueta. La opción
  * de plataforma va primero (no es un tenant, es la ausencia de uno) y solo aparece si alguna fila
  * cargada la tiene: un dataset de un solo tenant ofrece exactamente una opción (S5).
@@ -111,9 +141,31 @@ export function opcionesDeTenant(filas: readonly FilaConTenant[]): OpcionDeFiltr
   }
 
   const plataforma = porClave.get(VALOR_SIN_TENANT)
-  const tenants = ordenarPorEtiqueta([...porClave.values()].filter((o) => o.valor !== VALOR_SIN_TENANT))
+  const tenants = ordenarPorEtiqueta(
+    desempatarHomonimos([...porClave.values()].filter((o) => o.valor !== VALOR_SIN_TENANT), 'tenant'),
+  )
 
   return plataforma ? [plataforma, ...tenants] : tenants
+}
+
+/**
+ * Opciones del selector de tenant del ALTA de usuarios: el universo COMPLETO que devuelve
+ * `listarTenants()`, no las filas cargadas. Un tenant que no está Activo se ofrece IGUAL — el
+ * servidor es la autoridad y `ServicioDeUsuarios.CrearAsync` no mira el estado del tenant destino,
+ * así que el operador puede pre-crear dentro de uno suspendido — pero la etiqueta lo marca: un
+ * usuario creado ahí no va a poder iniciar sesión, y sin la marca eso sería invisible.
+ */
+export function opcionesDeTenantAsignable(tenants: readonly TenantListado[]): OpcionDeFiltro[] {
+  const opciones = tenants.map((t) => ({
+    valor: String(t.id),
+    etiqueta: etiquetaDeTenantAsignable(t.nombre, t.estado),
+  }))
+
+  return ordenarPorEtiqueta(desempatarHomonimos(opciones, 'tenant'))
+}
+
+function etiquetaDeTenantAsignable(nombre: string, estado: EstadoTenant): string {
+  return estado === 'Activo' ? nombre : `${nombre} (${estado.toLowerCase()})`
 }
 
 /**
@@ -137,7 +189,7 @@ export function opcionesDeEmpresa(
     })
   }
 
-  return ordenarPorEtiqueta([...porClave.values()])
+  return ordenarPorEtiqueta(desempatarHomonimos([...porClave.values()], 'empresa'))
 }
 
 /** Filtra sobre la lista YA CARGADA. `SIN_FILTRO` es la identidad: devuelve la lista entera. */

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -20,6 +20,14 @@ export type UsuarioAutenticado = {
   idTenant: number | null
 }
 
+/**
+ * Espejo de `Ways.Application.Usuarios.UsuarioListado`. `nombreTenant` llega en `null` en DOS
+ * casos distintos y la pantalla los tiene que distinguir (design D13/D14, Reconciliación 9):
+ * cuenta de plataforma (`idTenant === null`) y huérfano (tenant dueño dado de baja lógicamente,
+ * `idTenant` no nulo). NO es un "si y solo si": un nombre nulo no implica plataforma. El
+ * discriminador es `idTenant`, y la etiqueta "Plataforma" la pone la web —
+ * `etiquetaDeTenant` en `organizacion.ts` — nunca el servidor.
+ */
 export type UsuarioListado = {
   id: number
   usuario: string
@@ -29,6 +37,8 @@ export type UsuarioListado = {
   estado: EstadoUsuario
   ultimaConexion: string | null
   createdAt: string
+  idTenant: number | null
+  nombreTenant: string | null
 }
 
 export type RolListado = {
@@ -298,25 +308,37 @@ export const ZONAS_HORARIAS_OFRECIDAS: { id: string; etiqueta: string }[] = [
 
 export type EstadoTenant = 'Activo' | 'Suspendido' | 'Baja'
 
+/** Los tres contadores son hijos VIVOS del tenant (el servidor los proyecta con el filtro de
+ * baja lógica adentro) y `cantidadUsuarios` no cuenta al personal de plataforma. */
 export type TenantListado = {
   id: number
   nombre: string
   estado: EstadoTenant
   createdAt: string
+  cantidadEmpresas: number
+  cantidadPuntosVenta: number
+  cantidadUsuarios: number
 }
 
 export type TenantEdicion = { nombre: string }
 
+/** `nombreTenant` es nullable a propósito (design D13): si el tenant dueño quedó dado de baja, la
+ * empresa se sigue listando con el nombre en `null` y se muestra como anomalía en vez de
+ * desaparecer. `idTenant` deja de renderizarse y pasa a ser la clave del filtro por tenant. */
 export type EmpresaListado = {
   id: number
   idTenant: number
   razonSocial: string
   nombreFantasia: string | null
   cuit: string | null
+  nombreTenant: string | null
 }
 
 export type EmpresaEdicion = { razonSocial: string; nombreFantasia: string | null; cuit: string | null }
 
+/** Los dos nombres de dueño son nullable por el mismo criterio que `EmpresaListado.nombreTenant`
+ * (design D13); `idTenant` e `idEmpresa` dejan de renderizarse y quedan como claves de los dos
+ * filtros. */
 export type PuntoVentaListado = {
   id: number
   idTenant: number
@@ -328,6 +350,8 @@ export type PuntoVentaListado = {
   instagram: string | null
   facebook: string | null
   web: string | null
+  nombreTenant: string | null
+  razonSocialEmpresa: string | null
 }
 
 /** `idEmpresa` no es editable acá: es estructural, no descriptivo (misma razón que en el

--- a/src/Ways.Web/src/api/tipos.ts
+++ b/src/Ways.Web/src/api/tipos.ts
@@ -54,14 +54,24 @@ export type PaginaDe<T> = {
   tamanio: number
 }
 
+/**
+ * Espejo de `Ways.Application.Usuarios.CrearUsuario`. `idTenant` solo lo aprovecha un actor de
+ * plataforma para elegir a qué tenant pertenece la cuenta creada; para un actor de tenant el
+ * servidor lo IGNORA y usa el suyo (`ServicioDeUsuarios.CrearAsync`), así que la web manda `null`.
+ * El rol root exige `null` y cualquier otro rol exige un valor
+ * (`PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance` — 400 `tenant_requerido`).
+ */
 export type CrearUsuario = {
   usuario: string
   mail: string
   rolId: number
   password: string
   estado: EstadoUsuario
+  idTenant: number | null
 }
 
+/** Espejo de `Ways.Application.Usuarios.ActualizarUsuario`, que NO acepta `idTenant`: el tenant de
+ * una cuenta no se reasigna por edición, el servidor valida el rol contra `usuario.IdTenant`. */
 export type ActualizarUsuario = {
   usuario: string
   mail: string

--- a/src/Ways.Web/src/paginas/Auditoria.test.tsx
+++ b/src/Ways.Web/src/paginas/Auditoria.test.tsx
@@ -38,6 +38,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function filaFixture(sobrescribir: Partial<FilaDeAuditoria> = {}): FilaDeAuditoria {

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -39,6 +39,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/CompraEditor.test.tsx
+++ b/src/Ways.Web/src/paginas/CompraEditor.test.tsx
@@ -116,6 +116,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
+++ b/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
@@ -38,6 +38,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
+++ b/src/Ways.Web/src/paginas/ConteoDeInventario.test.tsx
@@ -59,6 +59,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorriente.test.tsx
@@ -115,6 +115,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
+++ b/src/Ways.Web/src/paginas/CuentaCorrienteDeProveedor.test.tsx
@@ -87,6 +87,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Empresas.test.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.test.tsx
@@ -1,0 +1,233 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Empresas } from './Empresas'
+import { ETIQUETA_SIN_DUENIO } from '../api/organizacion'
+import { ROL } from '../api/tipos'
+import type { EmpresaListado, UsuarioAutenticado } from '../api/tipos'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.10 y 2.13).
+
+const apiGetMock = vi.fn()
+const apiPutMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'root',
+    mail: 'root@ways.test',
+    rolId: ROL.Root,
+    rol: 'Root',
+    ultimaConexion: null,
+    idTenant: null,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const empresaSur: EmpresaListado = {
+  id: 10,
+  idTenant: 2,
+  razonSocial: 'Sur SRL',
+  nombreFantasia: null,
+  cuit: null,
+  nombreTenant: 'Comercio Sur',
+}
+
+const empresaAnexo: EmpresaListado = {
+  id: 11,
+  idTenant: 2,
+  razonSocial: 'Sur Anexo SA',
+  nombreFantasia: null,
+  cuit: null,
+  nombreTenant: 'Comercio Sur',
+}
+
+const empresaEste: EmpresaListado = {
+  id: 12,
+  idTenant: 3,
+  razonSocial: 'Este SRL',
+  nombreFantasia: null,
+  cuit: null,
+  nombreTenant: 'Almacén Este',
+}
+
+function montar(items: EmpresaListado[] = [empresaSur, empresaAnexo, empresaEste]) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/empresas') return Promise.resolve(items)
+
+    return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+  })
+
+  return render(<Empresas />)
+}
+
+function razonesSocialesVisibles() {
+  return screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((f) => within(f).getAllByRole('cell')[2]?.textContent ?? '')
+}
+
+describe('Empresas (stage-20, slice 2 — nombre de tenant y filtro)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPutMock.mockReset()
+    usuarioActual = usuarioFixture()
+  })
+
+  it('rinde el NOMBRE del tenant en la columna, nunca el id', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    const fila = screen.getByRole('row', { name: /Sur SRL/ })
+    const celdas = within(fila).getAllByRole('cell')
+
+    // Columnas: ID · Tenant · Razón social · Nombre de fantasía · CUIT · Acciones
+    expect(celdas[1]).toHaveTextContent('Comercio Sur')
+    expect(celdas[1]).not.toHaveTextContent('2')
+  })
+
+  /** Tarea 2.13: ningún `<td>` presenta `idTenant` como identidad del dueño; el id sobrevive
+   * solo como `value` del `<option>` del filtro. */
+  it('no presenta idTenant como identidad del dueño en ninguna celda', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    for (const fila of screen.getAllByRole('row').slice(1)) {
+      expect(within(fila).getAllByRole('cell')[1]).not.toHaveTextContent(/^\d+$/)
+    }
+
+    expect(screen.getByLabelText('Tenant')).toHaveValue('')
+    expect(within(screen.getByLabelText('Tenant')).getByRole('option', { name: 'Comercio Sur' })).toHaveValue('2')
+  })
+
+  /** Un `nombreTenant` nulo con `idTenant` presente es el HUÉRFANO de design D13: se rinde como
+   * anomalía, y jamás como "Plataforma" (Reconciliación 9). */
+  it('una empresa cuyo tenant fue dado de baja rinde la marca de sin dueño, no "Plataforma"', async () => {
+    montar([{ ...empresaSur, nombreTenant: null }])
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    const celdas = within(screen.getByRole('row', { name: /Sur SRL/ })).getAllByRole('cell')
+    expect(celdas[1]).toHaveTextContent(ETIQUETA_SIN_DUENIO)
+    expect(screen.queryByText('Plataforma')).not.toBeInTheDocument()
+  })
+
+  it('elegir un tenant angosta las filas SIN pedir nada más a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    const llamadasAlCargar = apiGetMock.mock.calls.length
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '3')
+
+    expect(razonesSocialesVisibles()).toEqual(['Este SRL'])
+    expect(apiGetMock.mock.calls).toHaveLength(llamadasAlCargar)
+  })
+
+  it('limpiar el filtro restaura la lista cargada completa', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '3')
+    expect(razonesSocialesVisibles()).toEqual(['Este SRL'])
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '')
+    expect(razonesSocialesVisibles()).toEqual(['Sur SRL', 'Sur Anexo SA', 'Este SRL'])
+  })
+
+  /**
+   * Cláusula bajo prueba: la ventana inerte cubre TODA la escritura y su refresco
+   * (`react-async-state` reglas 5 y 9), no solo el botón de Guardar. Mientras el PUT está en
+   * vuelo, abrir OTRA fila supersedería una escritura a medio terminar, así que "Editar" también
+   * tiene que estar inerte; y mientras el refresco posterior está en vuelo no hay tabla en
+   * pantalla, así que no queda ninguna acción alcanzable.
+   */
+  it('durante el guardado y su refresco no queda ninguna acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    let resolverPut!: (empresa: EmpresaListado) => void
+    let resolverRefresco!: (items: EmpresaListado[]) => void
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/empresas') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([empresaSur, empresaEste])
+
+      return new Promise<EmpresaListado[]>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+    apiPutMock.mockImplementation(
+      () =>
+        new Promise<EmpresaListado>((resolver) => {
+          resolverPut = resolver
+        }),
+    )
+
+    render(<Empresas />)
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(screen.getAllByRole('button', { name: 'Editar' })[0])
+    await usuario.click(screen.getByRole('button', { name: /Guardar/ }))
+
+    // PUT en vuelo: el formulario y TODOS los "Editar" de la tabla están inertes.
+    expect(screen.getByRole('button', { name: 'Guardando…' })).toBeDisabled()
+    expect(screen.getByLabelText('Razón social')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeDisabled()
+    for (const boton of screen.getAllByRole('button', { name: 'Editar' })) {
+      expect(boton).toBeDisabled()
+    }
+
+    await act(async () => {
+      resolverPut(empresaSur)
+      await Promise.resolve()
+    })
+
+    // Refresco en vuelo: el aviso de éxito ya está, la tabla no — no hay acción que apretar.
+    await waitFor(() => expect(screen.getByText('Se actualizó "Sur SRL".')).toBeInTheDocument())
+    expect(screen.getByText('Cargando…')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button', { name: 'Editar' })).toHaveLength(0)
+
+    await act(async () => {
+      resolverRefresco([empresaSur, empresaEste])
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Editar' })[0]).toBeEnabled())
+  })
+
+  it('las opciones del filtro se deducen de las filas cargadas: un tenant, una opción (S5)', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([empresaSur, empresaAnexo])
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    const opciones = within(screen.getByLabelText('Tenant')).getAllByRole('option')
+    expect(opciones.map((o) => o.textContent)).toEqual(['Todos', 'Comercio Sur'])
+    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Empresas.test.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.test.tsx
@@ -221,13 +221,19 @@ describe('Empresas (stage-20, slice 2 — nombre de tenant y filtro)', () => {
     await waitFor(() => expect(screen.getAllByRole('button', { name: 'Editar' })[0]).toBeEnabled())
   })
 
-  it('las opciones del filtro se deducen de las filas cargadas: un tenant, una opción (S5)', async () => {
+  /**
+   * Cláusula bajo prueba: el `esPlataforma &&` que gatea el filtro por tenant, con el MISMO
+   * criterio que ya gateaba la columna. Un admin de tenant solo puede recibir filas de su propio
+   * tenant (S5), así que el filtro le ofrecía una única opción y no angostaba nada: un control
+   * muerto. La otra mitad —que un actor de plataforma SÍ lo ve— la cubre el test del filtro.
+   */
+  it('un admin de tenant no ve el filtro por tenant, igual que no ve la columna', async () => {
     usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
     montar([empresaSur, empresaAnexo])
     await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
 
-    const opciones = within(screen.getByLabelText('Tenant')).getAllByRole('option')
-    expect(opciones.map((o) => o.textContent)).toEqual(['Todos', 'Comercio Sur'])
+    expect(screen.queryByLabelText('Tenant')).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Tenant' })).not.toBeInTheDocument()
     expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -84,19 +84,24 @@ export function Empresas() {
       return
     }
 
-    if (generacion.current !== token) return
-
     // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
     // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
+    //
+    // `ocupado` se apaga en el `finally` SIN mirar la generación, igual que en `Tenants.tsx` y
+    // `Usuarios.tsx`: mientras hay una escritura en vuelo la pantalla bloquea todo lo que podría
+    // supersederla (regla 9), así que la bandera nunca puede ser la de una operación más nueva —
+    // y salir por el chequeo de generación la dejaría prendida para siempre.
     const mensajeOk = `Se actualizó "${datos.razonSocial}".`
-    setFormulario(null)
-    setAviso(mensajeOk)
     try {
+      if (generacion.current !== token) return
+
+      setFormulario(null)
+      setAviso(mensajeOk)
       await cargar(token, true)
     } catch {
       if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      if (generacion.current === token) setOcupado(null)
+      setOcupado(null)
     }
   }
 

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -5,6 +5,7 @@ import {
   etiquetaDeTenant,
   filtrarPorTenant,
   opcionesDeTenant,
+  seleccionVigente,
   SIN_FILTRO,
 } from '../api/organizacion'
 import type { EmpresaListado } from '../api/tipos'
@@ -46,6 +47,7 @@ export function Empresas() {
       const filas = await clienteDeOrganizacion.listarEmpresas()
       if (generacion.current !== token) return
       setItems(filas)
+      setFiltroTenant((prev) => seleccionVigente(opcionesDeTenant(filas), prev))
       setError('')
     } catch (e) {
       if (generacion.current !== token) return
@@ -99,10 +101,11 @@ export function Empresas() {
   }
 
   // Las opciones se derivan de las filas cargadas; si la selección vigente desaparece de la lista
-  // (un refresco trajo otras filas), el filtro cae solo a "todos" en vez de dejar un `<select>`
-  // apuntando a una opción inexistente.
+  // (un refresco trajo otras filas), el filtro cae a "todos". Además de derivarlo acá, `cargar`
+  // escribe la reconciliación en el ESTADO: si solo se derivara, la selección inválida seguiría
+  // viva y se reaplicaría sola en cuanto la opción reapareciera.
   const opcionesTenant = opcionesDeTenant(items)
-  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const tenantVigente = seleccionVigente(opcionesTenant, filtroTenant)
   const visibles = filtrarPorTenant(items, tenantVigente)
 
   return (
@@ -182,26 +185,31 @@ export function Empresas() {
           <Cargando />
         ) : (
           <>
-            <div className="row g-2 mb-3">
-              <div className="col-md-4">
-                <label className="form-label" htmlFor="e-filtro-tenant">
-                  Tenant
-                </label>
-                <select
-                  id="e-filtro-tenant"
-                  className="form-select rounded-0"
-                  value={tenantVigente}
-                  onChange={(e) => setFiltroTenant(e.target.value)}
-                >
-                  <option value={SIN_FILTRO}>Todos</option>
-                  {opcionesTenant.map((o) => (
-                    <option key={o.valor} value={o.valor}>
-                      {o.etiqueta}
-                    </option>
-                  ))}
-                </select>
+            {/* El filtro por tenant se rinde con el mismo criterio que la COLUMNA de tenant: solo
+                para un actor de plataforma. Un admin de tenant ve una sola opción —la suya— y
+                filtrar por ella no angosta nada. */}
+            {esPlataforma && (
+              <div className="row g-2 mb-3">
+                <div className="col-md-4">
+                  <label className="form-label" htmlFor="e-filtro-tenant">
+                    Tenant
+                  </label>
+                  <select
+                    id="e-filtro-tenant"
+                    className="form-select rounded-0"
+                    value={tenantVigente}
+                    onChange={(e) => setFiltroTenant(e.target.value)}
+                  >
+                    <option value={SIN_FILTRO}>Todos</option>
+                    {opcionesTenant.map((o) => (
+                      <option key={o.valor} value={o.valor}>
+                        {o.etiqueta}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="table-responsive">
               <table className="table table-striped table-hover table-bordered align-middle">

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ErrorApi } from '../api/cliente'
-import { clienteDeOrganizacion } from '../api/organizacion'
+import {
+  clienteDeOrganizacion,
+  etiquetaDeTenant,
+  filtrarPorTenant,
+  opcionesDeTenant,
+  SIN_FILTRO,
+} from '../api/organizacion'
 import type { EmpresaListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -9,11 +15,15 @@ import { ROL } from '../api/tipos'
 
 type Formulario = { id: number; razonSocial: string; nombreFantasia: string; cuit: string }
 
+const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+
 /**
  * Lectura/edición de empresas — sin alta ni baja (ambas siguen siendo plataforma-only vía
  * aprovisionamiento, `NuevoTenant.tsx`). El backend ya filtra por alcance: la plataforma ve
  * todas las empresas de todos los tenants, un admin de tenant solo ve la(s) propia(s) — esta
- * pantalla no filtra nada por su cuenta.
+ * pantalla no filtra nada por su cuenta contra el servidor. El filtro por tenant de abajo opera
+ * sobre la lista YA CARGADA y sus opciones salen de esas mismas filas (design D15), así que no
+ * puede delatar un tenant fuera del alcance del actor.
  */
 export function Empresas() {
   const { usuario } = useAuth()
@@ -24,45 +34,76 @@ export function Empresas() {
   const [error, setError] = useState('')
   const [aviso, setAviso] = useState('')
   const [formulario, setFormulario] = useState<Formulario | null>(null)
-  const [guardando, setGuardando] = useState(false)
+  const [ocupado, setOcupado] = useState<number | null>(null)
+  const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
 
-  const cargar = useCallback(async () => {
+  /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
+  const generacion = useRef(0)
+
+  const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
-    setError('')
     try {
-      setItems(await clienteDeOrganizacion.listarEmpresas())
+      const filas = await clienteDeOrganizacion.listarEmpresas()
+      if (generacion.current !== token) return
+      setItems(filas)
+      setError('')
     } catch (e) {
+      if (generacion.current !== token) return
+      if (propagar) throw e
       setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar las empresas.')
     } finally {
-      setCargando(false)
+      if (generacion.current === token) setCargando(false)
     }
   }, [])
 
   useEffect(() => {
-    void cargar()
+    void cargar(++generacion.current)
   }, [cargar])
 
   async function guardar() {
-    if (!formulario) return
+    if (!formulario || ocupado !== null) return
 
-    setGuardando(true)
+    const datos = formulario
+    const token = ++generacion.current
+    setOcupado(datos.id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion.editarEmpresa(formulario.id, {
-        razonSocial: formulario.razonSocial,
-        nombreFantasia: formulario.nombreFantasia || null,
-        cuit: formulario.cuit || null,
+      await clienteDeOrganizacion.editarEmpresa(datos.id, {
+        razonSocial: datos.razonSocial,
+        nombreFantasia: datos.nombreFantasia || null,
+        cuit: datos.cuit || null,
       })
-      setAviso(`Se actualizó "${formulario.razonSocial}".`)
-      setFormulario(null)
-      await cargar()
     } catch (e) {
+      if (generacion.current !== token) return
       setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+      setOcupado(null)
+
+      return
+    }
+
+    if (generacion.current !== token) return
+
+    // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+    // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
+    const mensajeOk = `Se actualizó "${datos.razonSocial}".`
+    setFormulario(null)
+    setAviso(mensajeOk)
+    try {
+      await cargar(token, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      setGuardando(false)
+      if (generacion.current === token) setOcupado(null)
     }
   }
+
+  // Las opciones se derivan de las filas cargadas; si la selección vigente desaparece de la lista
+  // (un refresco trajo otras filas), el filtro cae solo a "todos" en vez de dejar un `<select>`
+  // apuntando a una opción inexistente.
+  const opcionesTenant = opcionesDeTenant(items)
+  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const visibles = filtrarPorTenant(items, tenantVigente)
 
   return (
     <div className="container-fluid py-4">
@@ -91,6 +132,7 @@ export function Empresas() {
                 maxLength={150}
                 value={formulario.razonSocial}
                 onChange={(e) => setFormulario({ ...formulario, razonSocial: e.target.value })}
+                disabled={ocupado !== null}
                 required
               />
             </div>
@@ -104,6 +146,7 @@ export function Empresas() {
                 maxLength={150}
                 value={formulario.nombreFantasia}
                 onChange={(e) => setFormulario({ ...formulario, nombreFantasia: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-3">
@@ -116,17 +159,18 @@ export function Empresas() {
                 maxLength={13}
                 value={formulario.cuit}
                 onChange={(e) => setFormulario({ ...formulario, cuit: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={guardando}>
-                {guardando ? 'Guardando…' : 'Guardar'}
+              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+                {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setFormulario(null)}
-                disabled={guardando}
+                disabled={ocupado !== null}
               >
                 Cancelar
               </button>
@@ -137,54 +181,78 @@ export function Empresas() {
         {cargando ? (
           <Cargando />
         ) : (
-          <div className="table-responsive">
-            <table className="table table-striped table-hover table-bordered align-middle">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  {esPlataforma && <th>Tenant</th>}
-                  <th>Razón social</th>
-                  <th>Nombre de fantasía</th>
-                  <th>CUIT</th>
-                  <th className="text-end">Acciones</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((e) => (
-                  <tr key={e.id}>
-                    <td>{String(e.id).padStart(4, '0')}</td>
-                    {esPlataforma && <td>{e.idTenant}</td>}
-                    <td>{e.razonSocial}</td>
-                    <td>{e.nombreFantasia ?? '—'}</td>
-                    <td>{e.cuit ?? '—'}</td>
-                    <td className="text-end">
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-outline-primary rounded-0"
-                        onClick={() =>
-                          setFormulario({
-                            id: e.id,
-                            razonSocial: e.razonSocial,
-                            nombreFantasia: e.nombreFantasia ?? '',
-                            cuit: e.cuit ?? '',
-                          })
-                        }
-                      >
-                        Editar
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-                {items.length === 0 && (
+          <>
+            <div className="row g-2 mb-3">
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="e-filtro-tenant">
+                  Tenant
+                </label>
+                <select
+                  id="e-filtro-tenant"
+                  className="form-select rounded-0"
+                  value={tenantVigente}
+                  onChange={(e) => setFiltroTenant(e.target.value)}
+                >
+                  <option value={SIN_FILTRO}>Todos</option>
+                  {opcionesTenant.map((o) => (
+                    <option key={o.valor} value={o.valor}>
+                      {o.etiqueta}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="table-responsive">
+              <table className="table table-striped table-hover table-bordered align-middle">
+                <thead>
                   <tr>
-                    <td colSpan={esPlataforma ? 6 : 5} className="text-center text-muted py-4">
-                      No hay empresas cargadas.
-                    </td>
+                    <th>ID</th>
+                    {esPlataforma && <th>Tenant</th>}
+                    <th>Razón social</th>
+                    <th>Nombre de fantasía</th>
+                    <th>CUIT</th>
+                    <th className="text-end">Acciones</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {visibles.map((e) => (
+                    <tr key={e.id}>
+                      <td>{String(e.id).padStart(4, '0')}</td>
+                      {esPlataforma && <td>{etiquetaDeTenant(e)}</td>}
+                      <td>{e.razonSocial}</td>
+                      <td>{e.nombreFantasia ?? '—'}</td>
+                      <td>{e.cuit ?? '—'}</td>
+                      <td className="text-end">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-primary rounded-0"
+                          onClick={() =>
+                            setFormulario({
+                              id: e.id,
+                              razonSocial: e.razonSocial,
+                              nombreFantasia: e.nombreFantasia ?? '',
+                              cuit: e.cuit ?? '',
+                            })
+                          }
+                          disabled={ocupado !== null}
+                        >
+                          Editar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {visibles.length === 0 && (
+                    <tr>
+                      <td colSpan={esPlataforma ? 6 : 5} className="text-center text-muted py-4">
+                        No hay empresas cargadas.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </Box>
     </div>

--- a/src/Ways.Web/src/paginas/Existencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Existencias.test.tsx
@@ -64,6 +64,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const puntoVentaNorte: PuntoVentaListado = {
@@ -77,6 +79,8 @@ const puntoVentaNorte: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function filaFixture(sobrescribir: Partial<FilaExistencia> = {}): FilaExistencia {

--- a/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
+++ b/src/Ways.Web/src/paginas/FacturarRemitos.test.tsx
@@ -38,6 +38,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/HistoricoDeCajas.test.tsx
+++ b/src/Ways.Web/src/paginas/HistoricoDeCajas.test.tsx
@@ -59,6 +59,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const puntoVentaNorte: PuntoVentaListado = {
@@ -72,6 +74,8 @@ const puntoVentaNorte: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function filaFixture(sobrescribir: Partial<FilaDeHistoricoDeCajas> = {}): FilaDeHistoricoDeCajas {

--- a/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenDeCompra.test.tsx
@@ -81,6 +81,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/OrdenesDeCompra.test.tsx
+++ b/src/Ways.Web/src/paginas/OrdenesDeCompra.test.tsx
@@ -80,6 +80,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Parametros.test.tsx
+++ b/src/Ways.Web/src/paginas/Parametros.test.tsx
@@ -23,6 +23,7 @@ const empresaUno: EmpresaListado = {
   razonSocial: 'Empresa Uno SA',
   nombreFantasia: null,
   cuit: null,
+  nombreTenant: 'Tenant Demo',
 }
 
 const puntoVentaUno: PuntoVentaListado = {
@@ -36,6 +37,8 @@ const puntoVentaUno: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function mockearRutasBase(items: ParametroListado[] = []) {

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -65,6 +65,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Presupuesto.test.tsx
+++ b/src/Ways.Web/src/paginas/Presupuesto.test.tsx
@@ -39,6 +39,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Presupuestos.test.tsx
+++ b/src/Ways.Web/src/paginas/Presupuestos.test.tsx
@@ -37,6 +37,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -225,4 +225,56 @@ describe('PuntosVenta (stage-20, slice 2 — nombres de dueño y dos filtros)', 
     expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
     expect(screen.queryByText('Este SRL')).not.toBeInTheDocument()
   })
+
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-8): la reconciliación ESCRITA de `filtroEmpresa` en `cargar`
+   * corre contra el conjunto ANGOSTADO por el tenant vigente —`opcionesDeEmpresa(filas, tenant)`—,
+   * el mismo que rinde la pantalla, y no contra `opcionesDeEmpresa(filas)` sin angostar.
+   *
+   * El confundidor es el fallback derivado de siempre (`empresaVigente`): mientras el filtro de
+   * tenant sigue puesto, las dos versiones pintan lo mismo, porque la opción inválida no está en el
+   * `<select>` igual. La observación discriminante es la de M4/M23: volver el tenant a "Todos" no
+   * puede RESUCITAR una empresa que ya no le pertenece al tenant que estaba elegido.
+   */
+  it('la empresa elegida no resucita cuando un refresco la saca del tenant vigente', async () => {
+    const usuario = userEvent.setup()
+    const pvAnexoMudado = pvFixture({
+      id: 101,
+      idTenant: 3,
+      nombreTenant: 'Almacén Este',
+      idEmpresa: 21,
+      nombre: 'PV Anexo',
+      razonSocialEmpresa: 'Sur Anexo SA',
+    })
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/puntos-venta') {
+        cargas += 1
+
+        return Promise.resolve(
+          cargas === 1 ? [pvSurCentro, pvSurAnexo, pvEste] : [pvSurCentro, pvAnexoMudado, pvEste],
+        )
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<PuntosVenta />)
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '2')
+    await usuario.selectOptions(screen.getByLabelText('Empresa'), '21')
+    expect(nombresVisibles()).toEqual(['PV Anexo'])
+
+    // Única vía de recarga de esta pantalla: el refresco post-escritura.
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await waitFor(() => expect(cargas).toBe(2))
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '')
+
+    expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo', 'PV Este'])
+    expect(screen.getByLabelText('Empresa')).toHaveValue('')
+  })
 })

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PuntosVenta } from './PuntosVenta'
+import { ETIQUETA_SIN_DUENIO } from '../api/organizacion'
+import { ROL } from '../api/tipos'
+import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.11 y 2.13).
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'root',
+    mail: 'root@ways.test',
+    rolId: ROL.Root,
+    rol: 'Root',
+    ultimaConexion: null,
+    idTenant: null,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+function pvFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 100,
+    idTenant: 2,
+    idEmpresa: 20,
+    nombre: 'PV Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    nombreTenant: 'Comercio Sur',
+    razonSocialEmpresa: 'Sur SRL',
+    ...sobrescribir,
+  }
+}
+
+// Dos tenants, y el tenant 2 con DOS empresas: sin la segunda empresa del mismo dueño el
+// angostamiento del filtro de empresa no tendría nada que angostar.
+const pvSurCentro = pvFixture()
+const pvSurAnexo = pvFixture({ id: 101, idEmpresa: 21, nombre: 'PV Anexo', razonSocialEmpresa: 'Sur Anexo SA' })
+const pvEste = pvFixture({
+  id: 102,
+  idTenant: 3,
+  idEmpresa: 30,
+  nombre: 'PV Este',
+  nombreTenant: 'Almacén Este',
+  razonSocialEmpresa: 'Este SRL',
+})
+
+function montar(items: PuntoVentaListado[] = [pvSurCentro, pvSurAnexo, pvEste]) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/puntos-venta') return Promise.resolve(items)
+
+    return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+  })
+
+  return render(<PuntosVenta />)
+}
+
+/** Columnas (root): ID · Tenant · Empresa · Nombre · Domicilio · Acciones. */
+function nombresVisibles() {
+  return screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((f) => within(f).getAllByRole('cell')[3]?.textContent ?? '')
+}
+
+function opcionesDe(etiqueta: string) {
+  return within(screen.getByLabelText(etiqueta))
+    .getAllByRole('option')
+    .map((o) => o.textContent)
+}
+
+describe('PuntosVenta (stage-20, slice 2 — nombres de dueño y dos filtros)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    usuarioActual = usuarioFixture()
+  })
+
+  it('rinde los DOS nombres de dueño, nunca los dos enteros', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    const celdas = within(screen.getByRole('row', { name: /PV Centro/ })).getAllByRole('cell')
+    expect(celdas[1]).toHaveTextContent('Comercio Sur')
+    expect(celdas[2]).toHaveTextContent('Sur SRL')
+    expect(celdas[1]).not.toHaveTextContent('2')
+    expect(celdas[2]).not.toHaveTextContent('20')
+  })
+
+  /** Tarea 2.13: ni `idTenant` ni `idEmpresa` se presentan como identidad de un dueño; los dos
+   * sobreviven solo como `value` de los `<option>` de los filtros. */
+  it('no presenta idTenant ni idEmpresa como identidad del dueño en ninguna celda', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    for (const fila of screen.getAllByRole('row').slice(1)) {
+      const celdas = within(fila).getAllByRole('cell')
+      expect(celdas[1]).not.toHaveTextContent(/^\d+$/)
+      expect(celdas[2]).not.toHaveTextContent(/^\d+$/)
+    }
+
+    expect(within(screen.getByLabelText('Tenant')).getByRole('option', { name: 'Comercio Sur' })).toHaveValue('2')
+    expect(within(screen.getByLabelText('Empresa')).getByRole('option', { name: 'Sur SRL' })).toHaveValue('20')
+  })
+
+  it('un punto de venta huérfano rinde la marca de sin dueño en las dos columnas', async () => {
+    montar([pvFixture({ nombreTenant: null, razonSocialEmpresa: null })])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    const celdas = within(screen.getByRole('row', { name: /PV Centro/ })).getAllByRole('cell')
+    expect(celdas[1]).toHaveTextContent(ETIQUETA_SIN_DUENIO)
+    expect(celdas[2]).toHaveTextContent(ETIQUETA_SIN_DUENIO)
+    expect(screen.queryByText('Plataforma')).not.toBeInTheDocument()
+  })
+
+  it('elegir un tenant angosta las filas y las opciones del filtro de empresa (D15)', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    expect(opcionesDe('Empresa')).toEqual(['Todas', 'Este SRL', 'Sur Anexo SA', 'Sur SRL'])
+
+    const llamadasAlCargar = apiGetMock.mock.calls.length
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '2')
+
+    expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo'])
+    expect(opcionesDe('Empresa')).toEqual(['Todas', 'Sur Anexo SA', 'Sur SRL'])
+    expect(apiGetMock.mock.calls).toHaveLength(llamadasAlCargar)
+  })
+
+  /** Cláusula bajo prueba: `cambiarFiltroDeTenant` limpia la empresa elegida SOLO cuando deja de
+   * pertenecer al tenant nuevo. Las dos ramas se ejercitan: la que limpia y la que respeta. */
+  it('elegir un tenant limpia la empresa que ya no le pertenece, y respeta la que sí', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.selectOptions(screen.getByLabelText('Empresa'), '30')
+    expect(nombresVisibles()).toEqual(['PV Este'])
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '2')
+    expect(screen.getByLabelText('Empresa')).toHaveValue('')
+    expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo'])
+
+    // Confundidor a esquivar (`mutation-proof-tests` regla 3): la deriva de `empresaVigente` sola
+    // ya blanquea el `<select>`, así que asertar eso no distingue "limpió el estado" de "no lo
+    // limpió pero la opción no existe". Lo que solo la limpieza REAL del estado produce es que
+    // volver a "Todos" NO resucite la empresa 30: si `filtroEmpresa` siguiera valiendo '30',
+    // volvería a ser una opción válida y el filtro se reaplicaría solo.
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '')
+    expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo', 'PV Este'])
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '2')
+
+    await usuario.selectOptions(screen.getByLabelText('Empresa'), '21')
+    expect(nombresVisibles()).toEqual(['PV Anexo'])
+
+    // El tenant 2 sigue siendo el dueño de la empresa 21: la selección se respeta.
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '2')
+    expect(screen.getByLabelText('Empresa')).toHaveValue('21')
+    expect(nombresVisibles()).toEqual(['PV Anexo'])
+  })
+
+  it('el filtro de empresa angosta las filas sin pedir nada más a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    const llamadasAlCargar = apiGetMock.mock.calls.length
+    await usuario.selectOptions(screen.getByLabelText('Empresa'), '20')
+
+    expect(nombresVisibles()).toEqual(['PV Centro'])
+    expect(apiGetMock.mock.calls).toHaveLength(llamadasAlCargar)
+
+    await usuario.selectOptions(screen.getByLabelText('Empresa'), '')
+    expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo', 'PV Este'])
+  })
+
+  it('las opciones del filtro se deducen de las filas cargadas: un tenant, una opción (S5)', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([pvSurCentro, pvSurAnexo])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    expect(opcionesDe('Tenant')).toEqual(['Todos', 'Comercio Sur'])
+    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+    expect(screen.queryByText('Este SRL')).not.toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -208,12 +208,20 @@ describe('PuntosVenta (stage-20, slice 2 — nombres de dueño y dos filtros)', 
     expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo', 'PV Este'])
   })
 
-  it('las opciones del filtro se deducen de las filas cargadas: un tenant, una opción (S5)', async () => {
+  /**
+   * Cláusula bajo prueba: el `esPlataforma &&` que gatea el filtro por TENANT, con el MISMO
+   * criterio que ya gateaba la columna. Un admin de tenant solo puede recibir filas de su propio
+   * tenant (S5), así que ese filtro le ofrecía una única opción y no angostaba nada. El filtro por
+   * EMPRESA sí le sirve —tiene varias— y por eso se queda: el test asserta las dos mitades.
+   */
+  it('un admin de tenant no ve el filtro por tenant, pero sí el de empresa', async () => {
     usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
     montar([pvSurCentro, pvSurAnexo])
     await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
 
-    expect(opcionesDe('Tenant')).toEqual(['Todos', 'Comercio Sur'])
+    expect(screen.queryByLabelText('Tenant')).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Tenant' })).not.toBeInTheDocument()
+    expect(opcionesDe('Empresa')).toEqual(['Todas', 'Sur Anexo SA', 'Sur SRL'])
     expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
     expect(screen.queryByText('Este SRL')).not.toBeInTheDocument()
   })

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -1,6 +1,15 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ErrorApi } from '../api/cliente'
-import { clienteDeOrganizacion } from '../api/organizacion'
+import {
+  clienteDeOrganizacion,
+  ETIQUETA_SIN_DUENIO,
+  etiquetaDeTenant,
+  filtrarPorEmpresa,
+  filtrarPorTenant,
+  opcionesDeEmpresa,
+  opcionesDeTenant,
+  SIN_FILTRO,
+} from '../api/organizacion'
 import type { PuntoVentaListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
@@ -18,10 +27,14 @@ type Formulario = {
   web: string
 }
 
+const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+
 /**
  * Lectura/edición de puntos de venta — mismo patrón que <c>Empresas.tsx</c>: sin alta ni baja
  * (plataforma-only vía aprovisionamiento), el backend ya filtra por alcance.
  * <c>idEmpresa</c> no se edita acá: es estructural (a qué empresa pertenece), no descriptivo.
+ * Los dos filtros (tenant y empresa) operan sobre la lista YA CARGADA y sus opciones salen de
+ * esas mismas filas (design D15).
  */
 export function PuntosVenta() {
   const { usuario } = useAuth()
@@ -32,48 +45,94 @@ export function PuntosVenta() {
   const [error, setError] = useState('')
   const [aviso, setAviso] = useState('')
   const [formulario, setFormulario] = useState<Formulario | null>(null)
-  const [guardando, setGuardando] = useState(false)
+  const [ocupado, setOcupado] = useState<number | null>(null)
+  const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
+  const [filtroEmpresa, setFiltroEmpresa] = useState(SIN_FILTRO)
 
-  const cargar = useCallback(async () => {
+  /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
+  const generacion = useRef(0)
+
+  const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
-    setError('')
     try {
-      setItems(await clienteDeOrganizacion.listarPuntosVenta())
+      const filas = await clienteDeOrganizacion.listarPuntosVenta()
+      if (generacion.current !== token) return
+      setItems(filas)
+      setError('')
     } catch (e) {
+      if (generacion.current !== token) return
+      if (propagar) throw e
       setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta.')
     } finally {
-      setCargando(false)
+      if (generacion.current === token) setCargando(false)
     }
   }, [])
 
   useEffect(() => {
-    void cargar()
+    void cargar(++generacion.current)
   }, [cargar])
 
   async function guardar() {
-    if (!formulario) return
+    if (!formulario || ocupado !== null) return
 
-    setGuardando(true)
+    const datos = formulario
+    const token = ++generacion.current
+    setOcupado(datos.id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion.editarPuntoVenta(formulario.id, {
-        nombre: formulario.nombre,
-        domicilio: formulario.domicilio || null,
-        horario: formulario.horario || null,
-        whatsapp: formulario.whatsapp || null,
-        instagram: formulario.instagram || null,
-        facebook: formulario.facebook || null,
-        web: formulario.web || null,
+      await clienteDeOrganizacion.editarPuntoVenta(datos.id, {
+        nombre: datos.nombre,
+        domicilio: datos.domicilio || null,
+        horario: datos.horario || null,
+        whatsapp: datos.whatsapp || null,
+        instagram: datos.instagram || null,
+        facebook: datos.facebook || null,
+        web: datos.web || null,
       })
-      setAviso(`Se actualizó "${formulario.nombre}".`)
-      setFormulario(null)
-      await cargar()
     } catch (e) {
+      if (generacion.current !== token) return
       setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
-    } finally {
-      setGuardando(false)
+      setOcupado(null)
+
+      return
     }
+
+    if (generacion.current !== token) return
+
+    // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+    // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
+    const mensajeOk = `Se actualizó "${datos.nombre}".`
+    setFormulario(null)
+    setAviso(mensajeOk)
+    try {
+      await cargar(token, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
+    } finally {
+      if (generacion.current === token) setOcupado(null)
+    }
+  }
+
+  // Derivación pura, sin efectos: elegir un tenant ANGOSTA las opciones de empresa (design D15).
+  // El fallback a "todas" cubre además el caso en que un refresco se llevó puesta la fila que
+  // sostenía la opción elegida, sin dejar el `<select>` apuntando a una opción inexistente.
+  const opcionesTenant = opcionesDeTenant(items)
+  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const opcionesEmpresa = opcionesDeEmpresa(items, tenantVigente)
+  const empresaVigente = opcionesEmpresa.some((o) => o.valor === filtroEmpresa) ? filtroEmpresa : SIN_FILTRO
+  const visibles = filtrarPorEmpresa(filtrarPorTenant(items, tenantVigente), empresaVigente)
+
+  /** Elegir un tenant LIMPIA la empresa seleccionada cuando esa empresa ya no le pertenece
+   * (design D15) — si le sigue perteneciendo, la selección se respeta. El updater se arma desde
+   * `prev`, nunca leyendo el estado por closure (`react-async-state` regla 1). */
+  function cambiarFiltroDeTenant(valor: string) {
+    setFiltroTenant(valor)
+    setFiltroEmpresa((prev) =>
+      prev === SIN_FILTRO || opcionesDeEmpresa(items, valor).some((o) => o.valor === prev)
+        ? prev
+        : SIN_FILTRO,
+    )
   }
 
   return (
@@ -103,6 +162,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.nombre}
                 onChange={(e) => setFormulario({ ...formulario, nombre: e.target.value })}
+                disabled={ocupado !== null}
                 required
               />
             </div>
@@ -116,6 +176,7 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.domicilio}
                 onChange={(e) => setFormulario({ ...formulario, domicilio: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-3">
@@ -128,6 +189,7 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.horario}
                 onChange={(e) => setFormulario({ ...formulario, horario: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-2">
@@ -140,6 +202,7 @@ export function PuntosVenta() {
                 maxLength={30}
                 value={formulario.whatsapp}
                 onChange={(e) => setFormulario({ ...formulario, whatsapp: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-3">
@@ -152,6 +215,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.instagram}
                 onChange={(e) => setFormulario({ ...formulario, instagram: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-3">
@@ -164,6 +228,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.facebook}
                 onChange={(e) => setFormulario({ ...formulario, facebook: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-md-3">
@@ -176,17 +241,18 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.web}
                 onChange={(e) => setFormulario({ ...formulario, web: e.target.value })}
+                disabled={ocupado !== null}
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={guardando}>
-                {guardando ? 'Guardando…' : 'Guardar'}
+              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+                {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setFormulario(null)}
-                disabled={guardando}
+                disabled={ocupado !== null}
               >
                 Cancelar
               </button>
@@ -197,58 +263,100 @@ export function PuntosVenta() {
         {cargando ? (
           <Cargando />
         ) : (
-          <div className="table-responsive">
-            <table className="table table-striped table-hover table-bordered align-middle">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  {esPlataforma && <th>Tenant</th>}
-                  <th>Empresa</th>
-                  <th>Nombre</th>
-                  <th>Domicilio</th>
-                  <th className="text-end">Acciones</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((p) => (
-                  <tr key={p.id}>
-                    <td>{String(p.id).padStart(4, '0')}</td>
-                    {esPlataforma && <td>{p.idTenant}</td>}
-                    <td>{p.idEmpresa}</td>
-                    <td>{p.nombre}</td>
-                    <td>{p.domicilio ?? '—'}</td>
-                    <td className="text-end">
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-outline-primary rounded-0"
-                        onClick={() =>
-                          setFormulario({
-                            id: p.id,
-                            nombre: p.nombre,
-                            domicilio: p.domicilio ?? '',
-                            horario: p.horario ?? '',
-                            whatsapp: p.whatsapp ?? '',
-                            instagram: p.instagram ?? '',
-                            facebook: p.facebook ?? '',
-                            web: p.web ?? '',
-                          })
-                        }
-                      >
-                        Editar
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-                {items.length === 0 && (
+          <>
+            <div className="row g-2 mb-3">
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="pv-filtro-tenant">
+                  Tenant
+                </label>
+                <select
+                  id="pv-filtro-tenant"
+                  className="form-select rounded-0"
+                  value={tenantVigente}
+                  onChange={(e) => cambiarFiltroDeTenant(e.target.value)}
+                >
+                  <option value={SIN_FILTRO}>Todos</option>
+                  {opcionesTenant.map((o) => (
+                    <option key={o.valor} value={o.valor}>
+                      {o.etiqueta}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="pv-filtro-empresa">
+                  Empresa
+                </label>
+                <select
+                  id="pv-filtro-empresa"
+                  className="form-select rounded-0"
+                  value={empresaVigente}
+                  onChange={(e) => setFiltroEmpresa(e.target.value)}
+                >
+                  <option value={SIN_FILTRO}>Todas</option>
+                  {opcionesEmpresa.map((o) => (
+                    <option key={o.valor} value={o.valor}>
+                      {o.etiqueta}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="table-responsive">
+              <table className="table table-striped table-hover table-bordered align-middle">
+                <thead>
                   <tr>
-                    <td colSpan={esPlataforma ? 6 : 5} className="text-center text-muted py-4">
-                      No hay puntos de venta cargados.
-                    </td>
+                    <th>ID</th>
+                    {esPlataforma && <th>Tenant</th>}
+                    <th>Empresa</th>
+                    <th>Nombre</th>
+                    <th>Domicilio</th>
+                    <th className="text-end">Acciones</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {visibles.map((p) => (
+                    <tr key={p.id}>
+                      <td>{String(p.id).padStart(4, '0')}</td>
+                      {esPlataforma && <td>{etiquetaDeTenant(p)}</td>}
+                      <td>{p.razonSocialEmpresa ?? ETIQUETA_SIN_DUENIO}</td>
+                      <td>{p.nombre}</td>
+                      <td>{p.domicilio ?? '—'}</td>
+                      <td className="text-end">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-primary rounded-0"
+                          onClick={() =>
+                            setFormulario({
+                              id: p.id,
+                              nombre: p.nombre,
+                              domicilio: p.domicilio ?? '',
+                              horario: p.horario ?? '',
+                              whatsapp: p.whatsapp ?? '',
+                              instagram: p.instagram ?? '',
+                              facebook: p.facebook ?? '',
+                              web: p.web ?? '',
+                            })
+                          }
+                          disabled={ocupado !== null}
+                        >
+                          Editar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {visibles.length === 0 && (
+                    <tr>
+                      <td colSpan={esPlataforma ? 6 : 5} className="text-center text-muted py-4">
+                        No hay puntos de venta cargados.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </Box>
     </div>

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -8,6 +8,7 @@ import {
   filtrarPorTenant,
   opcionesDeEmpresa,
   opcionesDeTenant,
+  seleccionVigente,
   SIN_FILTRO,
 } from '../api/organizacion'
 import type { PuntoVentaListado } from '../api/tipos'
@@ -58,6 +59,11 @@ export function PuntosVenta() {
       const filas = await clienteDeOrganizacion.listarPuntosVenta()
       if (generacion.current !== token) return
       setItems(filas)
+      // Reconciliación ESCRITA en el estado, no solo derivada al pintar: una selección que las
+      // filas nuevas ya no sostienen se apaga, en vez de quedar viva y reaplicarse sola cuando la
+      // opción reaparece. Los dos updaters se arman desde `prev` (`react-async-state` regla 1).
+      setFiltroTenant((prev) => seleccionVigente(opcionesDeTenant(filas), prev))
+      setFiltroEmpresa((prev) => seleccionVigente(opcionesDeEmpresa(filas), prev))
       setError('')
     } catch (e) {
       if (generacion.current !== token) return
@@ -118,9 +124,9 @@ export function PuntosVenta() {
   // El fallback a "todas" cubre además el caso en que un refresco se llevó puesta la fila que
   // sostenía la opción elegida, sin dejar el `<select>` apuntando a una opción inexistente.
   const opcionesTenant = opcionesDeTenant(items)
-  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const tenantVigente = seleccionVigente(opcionesTenant, filtroTenant)
   const opcionesEmpresa = opcionesDeEmpresa(items, tenantVigente)
-  const empresaVigente = opcionesEmpresa.some((o) => o.valor === filtroEmpresa) ? filtroEmpresa : SIN_FILTRO
+  const empresaVigente = seleccionVigente(opcionesEmpresa, filtroEmpresa)
   const visibles = filtrarPorEmpresa(filtrarPorTenant(items, tenantVigente), empresaVigente)
 
   /** Elegir un tenant LIMPIA la empresa seleccionada cuando esa empresa ya no le pertenece
@@ -265,24 +271,29 @@ export function PuntosVenta() {
         ) : (
           <>
             <div className="row g-2 mb-3">
-              <div className="col-md-4">
-                <label className="form-label" htmlFor="pv-filtro-tenant">
-                  Tenant
-                </label>
-                <select
-                  id="pv-filtro-tenant"
-                  className="form-select rounded-0"
-                  value={tenantVigente}
-                  onChange={(e) => cambiarFiltroDeTenant(e.target.value)}
-                >
-                  <option value={SIN_FILTRO}>Todos</option>
-                  {opcionesTenant.map((o) => (
-                    <option key={o.valor} value={o.valor}>
-                      {o.etiqueta}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              {/* El filtro por tenant se rinde con el mismo criterio que la COLUMNA de tenant: solo
+                  para un actor de plataforma. Un admin de tenant ve una sola opción —la suya— y
+                  filtrar por ella no angosta nada. El de empresa sí le sirve y queda para todos. */}
+              {esPlataforma && (
+                <div className="col-md-4">
+                  <label className="form-label" htmlFor="pv-filtro-tenant">
+                    Tenant
+                  </label>
+                  <select
+                    id="pv-filtro-tenant"
+                    className="form-select rounded-0"
+                    value={tenantVigente}
+                    onChange={(e) => cambiarFiltroDeTenant(e.target.value)}
+                  >
+                    <option value={SIN_FILTRO}>Todos</option>
+                    {opcionesTenant.map((o) => (
+                      <option key={o.valor} value={o.valor}>
+                        {o.etiqueta}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div className="col-md-4">
                 <label className="form-label" htmlFor="pv-filtro-empresa">
                   Empresa

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -52,6 +52,10 @@ export function PuntosVenta() {
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
+  /** Espejo SIEMPRE al día de `filtroTenant`. `cargar` es un `useCallback` sin dependencias, así
+   * que no puede leer el estado por closure sin quedarse con una foto vieja; y la reconciliación
+   * de la empresa necesita el tenant YA reconciliado, no el `prev` de su propio updater. */
+  const filtroTenantVigente = useRef(SIN_FILTRO)
 
   const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
@@ -61,9 +65,13 @@ export function PuntosVenta() {
       setItems(filas)
       // Reconciliación ESCRITA en el estado, no solo derivada al pintar: una selección que las
       // filas nuevas ya no sostienen se apaga, en vez de quedar viva y reaplicarse sola cuando la
-      // opción reaparece. Los dos updaters se arman desde `prev` (`react-async-state` regla 1).
-      setFiltroTenant((prev) => seleccionVigente(opcionesDeTenant(filas), prev))
-      setFiltroEmpresa((prev) => seleccionVigente(opcionesDeEmpresa(filas), prev))
+      // opción reaparece. La empresa se reconcilia contra el MISMO conjunto ANGOSTADO que rinde la
+      // pantalla (`opcionesDeEmpresa(filas, tenant)`, design D15): contra el conjunto sin angostar
+      // sobrevivía una empresa de otro tenant que el `<select>` ya no ofrece.
+      const tenanteReconciliado = seleccionVigente(opcionesDeTenant(filas), filtroTenantVigente.current)
+      filtroTenantVigente.current = tenanteReconciliado
+      setFiltroTenant(tenanteReconciliado)
+      setFiltroEmpresa((prev) => seleccionVigente(opcionesDeEmpresa(filas, tenanteReconciliado), prev))
       setError('')
     } catch (e) {
       if (generacion.current !== token) return
@@ -104,19 +112,24 @@ export function PuntosVenta() {
       return
     }
 
-    if (generacion.current !== token) return
-
     // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
     // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
+    //
+    // `ocupado` se apaga en el `finally` SIN mirar la generación, igual que en `Tenants.tsx` y
+    // `Usuarios.tsx`: mientras hay una escritura en vuelo la pantalla bloquea todo lo que podría
+    // supersederla (regla 9), así que la bandera nunca puede ser la de una operación más nueva —
+    // y salir por el chequeo de generación la dejaría prendida para siempre.
     const mensajeOk = `Se actualizó "${datos.nombre}".`
-    setFormulario(null)
-    setAviso(mensajeOk)
     try {
+      if (generacion.current !== token) return
+
+      setFormulario(null)
+      setAviso(mensajeOk)
       await cargar(token, true)
     } catch {
       if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      if (generacion.current === token) setOcupado(null)
+      setOcupado(null)
     }
   }
 
@@ -133,6 +146,7 @@ export function PuntosVenta() {
    * (design D15) — si le sigue perteneciendo, la selección se respeta. El updater se arma desde
    * `prev`, nunca leyendo el estado por closure (`react-async-state` regla 1). */
   function cambiarFiltroDeTenant(valor: string) {
+    filtroTenantVigente.current = valor
     setFiltroTenant(valor)
     setFiltroEmpresa((prev) =>
       prev === SIN_FILTRO || opcionesDeEmpresa(items, valor).some((o) => o.valor === prev)

--- a/src/Ways.Web/src/paginas/Remito.test.tsx
+++ b/src/Ways.Web/src/paginas/Remito.test.tsx
@@ -39,6 +39,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Remitos.test.tsx
+++ b/src/Ways.Web/src/paginas/Remitos.test.tsx
@@ -37,6 +37,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Reposicion.test.tsx
+++ b/src/Ways.Web/src/paginas/Reposicion.test.tsx
@@ -59,6 +59,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const puntoVentaNorte: PuntoVentaListado = {
@@ -72,6 +74,8 @@ const puntoVentaNorte: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function filaFixture(sobrescribir: Partial<FilaDeReposicion> = {}): FilaDeReposicion {

--- a/src/Ways.Web/src/paginas/Tablero.test.tsx
+++ b/src/Ways.Web/src/paginas/Tablero.test.tsx
@@ -88,7 +88,14 @@ vi.mock('../auth/useAuth', () => ({
   useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
 }))
 
-const empresaUno: EmpresaListado = { id: 1, idTenant: 1, razonSocial: 'Empresa Uno SA', nombreFantasia: null, cuit: null }
+const empresaUno: EmpresaListado = {
+  id: 1,
+  idTenant: 1,
+  razonSocial: 'Empresa Uno SA',
+  nombreFantasia: null,
+  cuit: null,
+  nombreTenant: 'Tenant Demo',
+}
 
 function ventasFixture(sobrescribir: Partial<ResumenDeVentas> = {}): ResumenDeVentas {
   return {
@@ -130,6 +137,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const medioEfectivo: MedioPagoListado = {

--- a/src/Ways.Web/src/paginas/Tenants.test.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Tenants } from './Tenants'
+import type { TenantListado } from '../api/tipos'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.9 y 2.13).
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+/**
+ * Los tres contadores son pairwise-distintos ENTRE SÍ y distintos del id y de los contadores del
+ * otro tenant (`mutation-proof-tests` regla 12b): con valores iguales, intercambiar dos columnas
+ * de la tabla no cambiaría nada de lo que el test ve.
+ */
+const tenantUno: TenantListado = {
+  id: 1,
+  nombre: 'Comercio Sur',
+  estado: 'Activo',
+  createdAt: '2026-01-15T10:00:00-03:00',
+  cantidadEmpresas: 2,
+  cantidadPuntosVenta: 3,
+  cantidadUsuarios: 4,
+}
+
+const tenantDos: TenantListado = {
+  id: 2,
+  nombre: 'Almacén Este',
+  estado: 'Suspendido',
+  createdAt: '2026-02-20T10:00:00-03:00',
+  cantidadEmpresas: 5,
+  cantidadPuntosVenta: 6,
+  cantidadUsuarios: 7,
+}
+
+function montar(items: TenantListado[] = [tenantUno, tenantDos]) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/plataforma/tenants') return Promise.resolve(items)
+
+    return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+  })
+
+  return render(
+    <MemoryRouter>
+      <Tenants />
+    </MemoryRouter>,
+  )
+}
+
+function celdas(nombre: string) {
+  const fila = screen.getByRole('row', { name: new RegExp(nombre) })
+
+  return within(fila).getAllByRole('cell')
+}
+
+describe('Tenants (stage-20, slice 2 — contadores de hijos)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+  })
+
+  it('rinde los tres contadores de cada tenant en su propia columna', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    // Columnas: ID · Nombre · Estado · Empresas · Puntos de venta · Usuarios · Creado · Acciones
+    const uno = celdas('Comercio Sur')
+    expect(uno[3]).toHaveTextContent('2')
+    expect(uno[4]).toHaveTextContent('3')
+    expect(uno[5]).toHaveTextContent('4')
+
+    const dos = celdas('Almacén Este')
+    expect(dos[3]).toHaveTextContent('5')
+    expect(dos[4]).toHaveTextContent('6')
+    expect(dos[5]).toHaveTextContent('7')
+  })
+
+  it('encabeza las tres columnas con su nombre, en orden', () => {
+    montar()
+
+    return waitFor(() => {
+      const encabezados = screen.getAllByRole('columnheader').map((h) => h.textContent)
+      expect(encabezados).toEqual([
+        'ID',
+        'Nombre',
+        'Estado',
+        'Empresas',
+        'Puntos de venta',
+        'Usuarios',
+        'Creado',
+        'Acciones',
+      ])
+    })
+  })
+
+  it('un tenant sin hijos rinde ceros, no celdas vacías', async () => {
+    montar([{ ...tenantUno, cantidadEmpresas: 0, cantidadPuntosVenta: 0, cantidadUsuarios: 0 }])
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    const fila = celdas('Comercio Sur')
+    expect(fila[3]).toHaveTextContent('0')
+    expect(fila[4]).toHaveTextContent('0')
+    expect(fila[5]).toHaveTextContent('0')
+  })
+
+  /** Tarea 2.13: ninguna celda presenta un id crudo como identidad de un dueño. En esta pantalla
+   * el único id que se rinde es el del PROPIO tenant (columna ID, su identidad, no la de un
+   * dueño) y ninguna columna nueva lo repite. */
+  it('no presenta ids de dueño: el único id de la fila es el del propio tenant', async () => {
+    montar([tenantUno])
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    const fila = celdas('Comercio Sur')
+    expect(fila[0]).toHaveTextContent('0001')
+    expect(fila.filter((c) => c.textContent === '1')).toHaveLength(0)
+  })
+})

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import type { EstadoTenant, TenantListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+
+const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
 /**
  * ABM (parcial) de tenants — plataforma-only. El alta completa (tenant + empresa + punto de
@@ -18,55 +20,100 @@ export function Tenants() {
   const [error, setError] = useState('')
   const [aviso, setAviso] = useState('')
   const [edicion, setEdicion] = useState<{ id: number; nombre: string } | null>(null)
-  const [guardando, setGuardando] = useState(false)
+  const [ocupado, setOcupado] = useState<number | null>(null)
 
-  const cargar = useCallback(async () => {
+  /**
+   * Contrato de invalidación (`react-async-state` reglas 2-4): TODA operación que supersede lo
+   * que hay en pantalla incrementa la generación ANTES de tocar el estado, y toda aplicación de
+   * estado posterior a un `await` — incluido el `finally` que apaga las banderas y el rethrow del
+   * refresco — la vuelve a chequear. Mientras hay una escritura en vuelo (`ocupado`), la pantalla
+   * bloquea todas las acciones que podrían supersederla (regla 9), así que la generación queda
+   * para el desfasaje de LECTURAS.
+   */
+  const generacion = useRef(0)
+
+  const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
-    setError('')
     try {
-      setItems(await clienteDeOrganizacion.listarTenants())
+      const filas = await clienteDeOrganizacion.listarTenants()
+      if (generacion.current !== token) return
+      setItems(filas)
+      setError('')
     } catch (e) {
+      if (generacion.current !== token) return
+      if (propagar) throw e
       setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los tenants.')
     } finally {
-      setCargando(false)
+      if (generacion.current === token) setCargando(false)
     }
   }, [])
 
   useEffect(() => {
-    void cargar()
+    void cargar(++generacion.current)
   }, [cargar])
 
-  async function guardarNombre() {
-    if (!edicion) return
+  /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string) {
+    if (generacion.current !== token) return
 
-    setGuardando(true)
-    setError('')
-    setAviso('')
+    setAviso(mensajeOk)
     try {
-      await clienteDeOrganizacion.editarTenant(edicion.id, { nombre: edicion.nombre })
-      setAviso(`Se actualizó el tenant "${edicion.nombre}".`)
-      setEdicion(null)
-      await cargar()
-    } catch (e) {
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+      await cargar(token, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      setGuardando(false)
+      if (generacion.current === token) setOcupado(null)
     }
   }
 
+  async function guardarNombre() {
+    if (!edicion || ocupado !== null) return
+
+    const { id, nombre } = edicion
+    const token = ++generacion.current
+    setOcupado(id)
+    setError('')
+    setAviso('')
+    try {
+      await clienteDeOrganizacion.editarTenant(id, { nombre })
+    } catch (e) {
+      if (generacion.current !== token) return
+      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+      setOcupado(null)
+
+      return
+    }
+
+    if (generacion.current !== token) return
+    setEdicion(null)
+    await refrescarTrasEscribir(token, `Se actualizó el tenant "${nombre}".`)
+  }
+
   async function cambiarEstado(tenant: TenantListado, accion: 'suspenderTenant' | 'reactivarTenant') {
+    if (ocupado !== null) return
+
     const verbo = accion === 'suspenderTenant' ? 'suspender' : 'reactivar'
     if (!confirm(`¿${verbo === 'suspender' ? 'Suspender' : 'Reactivar'} el tenant "${tenant.nombre}"?`)) return
 
+    const token = ++generacion.current
+    setOcupado(tenant.id)
     setError('')
     setAviso('')
     try {
       await clienteDeOrganizacion[accion](tenant.id)
-      setAviso(`Tenant "${tenant.nombre}" ${verbo === 'suspender' ? 'suspendido' : 'reactivado'}.`)
-      await cargar()
     } catch (e) {
+      if (generacion.current !== token) return
       setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+      setOcupado(null)
+
+      return
     }
+
+    await refrescarTrasEscribir(
+      token,
+      `Tenant "${tenant.nombre}" ${verbo === 'suspender' ? 'suspendido' : 'reactivado'}.`,
+    )
   }
 
   const herramientas = (
@@ -104,18 +151,19 @@ export function Tenants() {
                 maxLength={150}
                 value={edicion.nombre}
                 onChange={(e) => setEdicion({ ...edicion, nombre: e.target.value })}
+                disabled={ocupado !== null}
                 required
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={guardando}>
-                {guardando ? 'Guardando…' : 'Guardar'}
+              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+                {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setEdicion(null)}
-                disabled={guardando}
+                disabled={ocupado !== null}
               >
                 Cancelar
               </button>
@@ -133,6 +181,9 @@ export function Tenants() {
                   <th>ID</th>
                   <th>Nombre</th>
                   <th>Estado</th>
+                  <th className="text-end">Empresas</th>
+                  <th className="text-end">Puntos de venta</th>
+                  <th className="text-end">Usuarios</th>
                   <th>Creado</th>
                   <th className="text-end">Acciones</th>
                 </tr>
@@ -145,12 +196,16 @@ export function Tenants() {
                     <td>
                       <EtiquetaEstado estado={t.estado} />
                     </td>
+                    <td className="text-end">{t.cantidadEmpresas}</td>
+                    <td className="text-end">{t.cantidadPuntosVenta}</td>
+                    <td className="text-end">{t.cantidadUsuarios}</td>
                     <td>{new Date(t.createdAt).toLocaleDateString('es-AR')}</td>
                     <td className="text-end text-nowrap">
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-primary rounded-0 me-1"
                         onClick={() => setEdicion({ id: t.id, nombre: t.nombre })}
+                        disabled={ocupado !== null}
                       >
                         Editar
                       </button>
@@ -159,6 +214,7 @@ export function Tenants() {
                           type="button"
                           className="btn btn-sm btn-outline-warning rounded-0"
                           onClick={() => cambiarEstado(t, 'suspenderTenant')}
+                          disabled={ocupado !== null}
                         >
                           Suspender
                         </button>
@@ -168,6 +224,7 @@ export function Tenants() {
                           type="button"
                           className="btn btn-sm btn-outline-success rounded-0"
                           onClick={() => cambiarEstado(t, 'reactivarTenant')}
+                          disabled={ocupado !== null}
                         >
                           Reactivar
                         </button>
@@ -177,7 +234,7 @@ export function Tenants() {
                 ))}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={5} className="text-center text-muted py-4">
+                    <td colSpan={8} className="text-center text-muted py-4">
                       No hay tenants cargados.
                     </td>
                   </tr>

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -23,12 +23,19 @@ export function Tenants() {
   const [ocupado, setOcupado] = useState<number | null>(null)
 
   /**
-   * Contrato de invalidación (`react-async-state` reglas 2-4): TODA operación que supersede lo
-   * que hay en pantalla incrementa la generación ANTES de tocar el estado, y toda aplicación de
-   * estado posterior a un `await` — incluido el `finally` que apaga las banderas y el rethrow del
-   * refresco — la vuelve a chequear. Mientras hay una escritura en vuelo (`ocupado`), la pantalla
-   * bloquea todas las acciones que podrían supersederla (regla 9), así que la generación queda
-   * para el desfasaje de LECTURAS.
+   * Contrato de invalidación (`react-async-state` reglas 2-4): toda operación que puede pisar una
+   * LECTURA en vuelo —el montaje y cada escritura— incrementa la generación ANTES de tocar el
+   * estado, y toda aplicación de estado posterior a un `await` la vuelve a chequear.
+   *
+   * Abrir el formulario de edición y cancelarlo NO la incrementan, a diferencia de lo que pide la
+   * regla 3 en el caso general: acá el formulario no supersede a la tabla —son dos porciones de
+   * estado independientes, y una carga en vuelo no pisa nada de lo que el formulario muestra—
+   * mientras que incrementarla ahí descartaría esa carga y, como el `finally` de `cargar` está
+   * gateado por generación, dejaría la pantalla clavada en "Cargando…" para siempre.
+   *
+   * Mientras hay una escritura en vuelo (`ocupado`) la pantalla bloquea todas las acciones que
+   * podrían supersederla (regla 9). Por eso el `finally` de `refrescarTrasEscribir` apaga
+   * `ocupado` SIN mirar la generación: la bandera no puede ser la de una operación más nueva.
    */
   const generacion = useRef(0)
 
@@ -55,15 +62,15 @@ export function Tenants() {
   /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
    * commiteó nunca se reporta como fallida (`react-async-state` regla 6). */
   async function refrescarTrasEscribir(token: number, mensajeOk: string) {
-    if (generacion.current !== token) return
-
-    setAviso(mensajeOk)
     try {
+      if (generacion.current !== token) return
+
+      setAviso(mensajeOk)
       await cargar(token, true)
     } catch {
       if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      if (generacion.current === token) setOcupado(null)
+      setOcupado(null)
     }
   }
 

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -28,10 +28,10 @@ export function Tenants() {
    * estado, y toda aplicación de estado posterior a un `await` la vuelve a chequear.
    *
    * Abrir el formulario de edición y cancelarlo NO la incrementan, a diferencia de lo que pide la
-   * regla 3 en el caso general: acá el formulario no supersede a la tabla —son dos porciones de
-   * estado independientes, y una carga en vuelo no pisa nada de lo que el formulario muestra—
-   * mientras que incrementarla ahí descartaría esa carga y, como el `finally` de `cargar` está
-   * gateado por generación, dejaría la pantalla clavada en "Cargando…" para siempre.
+   * regla 3 en el caso general: formulario y tabla son porciones de estado INDEPENDIENTES, así que
+   * ninguna lectura en vuelo queda superseded por abrirlo o cerrarlo. Incrementarla ahí
+   * descartaría esa carga y, como el `finally` de `cargar` está gateado por generación, dejaría la
+   * pantalla clavada en "Cargando…" para siempre.
    *
    * Mientras hay una escritura en vuelo (`ocupado`) la pantalla bloquea todas las acciones que
    * podrían supersederla (regla 9). Por eso el `finally` de `refrescarTrasEscribir` apaga

--- a/src/Ways.Web/src/paginas/Tesoreria.test.tsx
+++ b/src/Ways.Web/src/paginas/Tesoreria.test.tsx
@@ -59,6 +59,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const puntoVentaNorte: PuntoVentaListado = {
@@ -72,6 +74,8 @@ const puntoVentaNorte: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function movimientoFixture(sobrescribir: Partial<MovimientoTesoreriaListado> = {}): MovimientoTesoreriaListado {

--- a/src/Ways.Web/src/paginas/Transferencias.test.tsx
+++ b/src/Ways.Web/src/paginas/Transferencias.test.tsx
@@ -60,6 +60,8 @@ function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): Punto
     instagram: null,
     facebook: null,
     web: null,
+    nombreTenant: 'Tenant Demo',
+    razonSocialEmpresa: 'Empresa Demo',
     ...sobrescribir,
   }
 }

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Usuarios } from './Usuarios'
 import { ETIQUETA_OPCION_PLATAFORMA, ETIQUETA_PLATAFORMA, ETIQUETA_SIN_DUENIO } from '../api/organizacion'
 import { ROL } from '../api/tipos'
-import type { PaginaDe, RolListado, UsuarioAutenticado, UsuarioListado } from '../api/tipos'
+import type { PaginaDe, RolListado, TenantListado, UsuarioAutenticado, UsuarioListado } from '../api/tipos'
 
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.12 y 2.13).
 
@@ -86,9 +86,42 @@ const cuentaDePlataforma = usuarioFixture({
   nombreTenant: null,
 })
 
-function montar(items: UsuarioListado[] = [cuentaDeTenant, cuentaDeOtroTenant, cuentaDePlataforma]) {
+/**
+ * Fixture del universo de tenants pedido a `GET /plataforma/tenants` (tarea 2.17, gap de tamaño
+ * de página). Por defecto se deriva de las filas montadas — igual que el viejo
+ * `opcionesDeTenant(filas)` — así los tests que no ejercitan el gap no se enteran del cambio de
+ * fuente; los que sí lo ejercitan pasan una lista explícita con un tenant AUSENTE de las filas.
+ */
+function tenantFixture(id: number, nombre: string): TenantListado {
+  return {
+    id,
+    nombre,
+    estado: 'Activo',
+    createdAt: '2026-01-01T10:00:00-03:00',
+    cantidadEmpresas: 0,
+    cantidadPuntosVenta: 0,
+    cantidadUsuarios: 0,
+  }
+}
+
+function tenantsDesdeFilas(items: UsuarioListado[]): TenantListado[] {
+  const porId = new Map<number, string>()
+  for (const item of items) {
+    if (item.idTenant !== null && !porId.has(item.idTenant)) {
+      porId.set(item.idTenant, item.nombreTenant ?? `Tenant ${item.idTenant}`)
+    }
+  }
+
+  return [...porId.entries()].map(([id, nombre]) => tenantFixture(id, nombre))
+}
+
+function montar(
+  items: UsuarioListado[] = [cuentaDeTenant, cuentaDeOtroTenant, cuentaDePlataforma],
+  tenantsDePlataforma: TenantListado[] = tenantsDesdeFilas(items),
+) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/roles') return Promise.resolve(ROLES)
+    if (ruta === '/plataforma/tenants') return Promise.resolve(tenantsDePlataforma)
     if (ruta.startsWith('/usuarios')) {
       return Promise.resolve<PaginaDe<UsuarioListado>>({
         items,
@@ -444,33 +477,85 @@ describe('Usuarios (stage-20, tarea 2.17 — selector de tenant en el alta)', ()
 
   /**
    * Cláusula bajo prueba: `disabled={guardando || tenantsCargando || esRolDePlataforma}` —
-   * `react-async-state` regla 5. El selector se sirve de las filas ya cargadas, así que mientras
-   * la carga está en vuelo la lista todavía no es la definitiva y no se puede elegir de ella.
+   * `react-async-state` regla 5. Para un actor de plataforma `tenantsCargando` es
+   * `tenantsDePlataformaCargando` — el propio `GET /plataforma/tenants` en vuelo, no la carga de
+   * la página de usuarios — así que el `<select>` queda inerte hasta que SU fuente de opciones
+   * llega, no la de la tabla.
    */
-  it('el selector queda inerte mientras la lista está cargando', async () => {
+  it('el selector queda inerte mientras la lista de tenants está cargando', async () => {
     const usuario = userEvent.setup()
-    let resolverCarga!: (pagina: PaginaDe<UsuarioListado>) => void
-    const cargaPendiente = new Promise<PaginaDe<UsuarioListado>>((resolver) => {
-      resolverCarga = resolver
+    let resolverTenants!: (tenants: TenantListado[]) => void
+    const tenantsPendientes = new Promise<TenantListado[]>((resolver) => {
+      resolverTenants = resolver
     })
 
     apiGetMock.mockImplementation((ruta: string) => {
       if (ruta === '/roles') return Promise.resolve(ROLES)
-      if (ruta.startsWith('/usuarios')) return cargaPendiente
+      if (ruta === '/plataforma/tenants') return tenantsPendientes
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
 
       return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
     })
 
     render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
     await abrirAlta(usuario)
 
     expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toBeDisabled()
 
     await act(async () => {
-      resolverCarga({ items: [cuentaDeTenant], total: 1, pagina: 1, tamanio: 20 })
-      await cargaPendiente
+      resolverTenants([tenantFixture(2, 'Comercio Sur')])
+      await tenantsPendientes
     })
 
     expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toBeEnabled()
+  })
+
+  /**
+   * Cláusula bajo prueba (gap de tamaño de página, cerrado a continuación de la tarea 2.17): el
+   * selector del alta pide el universo COMPLETO de tenants vía `listarTenants()`, no
+   * `opcionesDeTenant(filas)`. Antes de este cierre un tenant sin ningún usuario en la página
+   * cargada (tamaño 25) era imposible de asignar; acá el tenant fixture "Tenant Fantasma" no
+   * tiene NINGUNA fila entre los usuarios montados y aun así debe aparecer, ordenado junto a los
+   * demás.
+   */
+  it('el universo de tenants del selector incluye uno sin usuarios en la página actual', async () => {
+    const usuario = userEvent.setup()
+    montar(
+      [cuentaDeTenant, cuentaDeOtroTenant, cuentaDePlataforma],
+      [tenantFixture(2, 'Comercio Sur'), tenantFixture(3, 'Almacén Este'), tenantFixture(99, 'Tenant Fantasma')],
+    )
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    const selector = screen.getByLabelText(SELECTOR_DE_ALTA)
+    const etiquetas = within(selector)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+
+    expect(etiquetas).toEqual(['Elegí un tenant', 'Almacén Este', 'Comercio Sur', 'Tenant Fantasma'])
+    expect(apiGetMock).toHaveBeenCalledWith('/plataforma/tenants')
+  })
+
+  /**
+   * Cláusula bajo prueba, anti-oráculo de la anterior (spec S5): un admin de tenant JAMÁS pide el
+   * universo de tenants, ni siquiera de fondo — `GET /plataforma/tenants` es `SoloPlataforma` y
+   * un admin de tenant no debe poder enumerar tenants ajenos. Verificado corriendo la mutación
+   * (M19): sacar la guarda `esPlataforma` del efecto de fetch hace que este test falle porque el
+   * mock SÍ ve la llamada.
+   */
+  it('un admin de tenant nunca pide el universo de tenants (listarTenants)', async () => {
+    usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    expect(apiGetMock).not.toHaveBeenCalledWith('/plataforma/tenants')
   })
 })

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1,0 +1,298 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Usuarios } from './Usuarios'
+import { ETIQUETA_OPCION_PLATAFORMA, ETIQUETA_PLATAFORMA, ETIQUETA_SIN_DUENIO } from '../api/organizacion'
+import { ROL } from '../api/tipos'
+import type { PaginaDe, RolListado, UsuarioAutenticado, UsuarioListado } from '../api/tipos'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.12 y 2.13).
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function autenticadoFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 1,
+    usuario: 'root',
+    mail: 'root@ways.test',
+    rolId: ROL.Root,
+    rol: 'Root',
+    ultimaConexion: null,
+    idTenant: null,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = autenticadoFixture()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
+}))
+
+const ROLES: RolListado[] = [{ id: ROL.Vendedor, nombre: 'Vendedor', descripcion: null }]
+
+function usuarioFixture(sobrescribir: Partial<UsuarioListado> = {}): UsuarioListado {
+  return {
+    id: 50,
+    usuario: 'vendedor.sur',
+    mail: 'vendedor.sur@ways.test',
+    rolId: ROL.Vendedor,
+    rol: 'Vendedor',
+    estado: 'Activo',
+    ultimaConexion: null,
+    createdAt: '2026-03-01T10:00:00-03:00',
+    idTenant: 2,
+    nombreTenant: 'Comercio Sur',
+    ...sobrescribir,
+  }
+}
+
+const cuentaDeTenant = usuarioFixture()
+const cuentaDeOtroTenant = usuarioFixture({
+  id: 51,
+  usuario: 'vendedor.este',
+  mail: 'vendedor.este@ways.test',
+  idTenant: 3,
+  nombreTenant: 'Almacén Este',
+})
+const cuentaDePlataforma = usuarioFixture({
+  id: 52,
+  usuario: 'staff',
+  mail: 'staff@ways.test',
+  idTenant: null,
+  nombreTenant: null,
+})
+
+function montar(items: UsuarioListado[] = [cuentaDeTenant, cuentaDeOtroTenant, cuentaDePlataforma]) {
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta === '/roles') return Promise.resolve(ROLES)
+    if (ruta.startsWith('/usuarios')) {
+      return Promise.resolve<PaginaDe<UsuarioListado>>({
+        items,
+        total: items.length,
+        pagina: 1,
+        tamanio: 20,
+      })
+    }
+
+    return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+  })
+
+  return render(<Usuarios />)
+}
+
+/** Columnas: ID · Usuario · Mail · Tenant · Rol · Estado · Última conexión · Acciones. */
+const COLUMNA_TENANT = 3
+
+function usuariosVisibles() {
+  return screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((f) => within(f).getAllByRole('cell')[1]?.textContent ?? '')
+}
+
+function celdaDeTenant(nombreDeUsuario: string) {
+  const fila = screen.getByRole('row', { name: new RegExp(nombreDeUsuario) })
+
+  return within(fila).getAllByRole('cell')[COLUMNA_TENANT]
+}
+
+describe('Usuarios (stage-20, slice 2 — columna de tenant y filtro)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    usuarioActual = autenticadoFixture()
+  })
+
+  it('rinde el nombre del tenant para una cuenta de tenant', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    expect(celdaDeTenant('vendedor.sur')).toHaveTextContent('Comercio Sur')
+  })
+
+  /**
+   * Cláusula bajo prueba: la etiqueta "Plataforma" la pone LA WEB (design D14). El servidor manda
+   * `nombreTenant = null` y el discriminador es `idTenant === null`.
+   */
+  it('rinde el literal "Plataforma" para una cuenta sin tenant, nunca una celda vacía', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('staff')).toBeInTheDocument())
+
+    const celda = celdaDeTenant('staff')
+    expect(celda).toHaveTextContent(ETIQUETA_PLATAFORMA)
+    expect(celda.textContent?.trim()).not.toBe('')
+  })
+
+  /**
+   * Cláusula bajo prueba: la MISMA (Reconciliación 9), por su lado adverso. Las dos filas llegan
+   * con `nombreTenant === null`; solo `idTenant` las distingue. Una pantalla que se apoyara en el
+   * nombre rendiría "Plataforma" en las dos y presentaría un huérfano como personal de
+   * plataforma. Las dos cuentas conviven en el mismo dataset a propósito.
+   */
+  it('un huérfano y el personal de plataforma comparten nombre nulo y se rinden DISTINTO', async () => {
+    const huerfano = usuarioFixture({ id: 53, usuario: 'huerfano', idTenant: 7, nombreTenant: null })
+    montar([huerfano, cuentaDePlataforma])
+    await waitFor(() => expect(screen.getByText('huerfano')).toBeInTheDocument())
+
+    expect(celdaDeTenant('huerfano')).toHaveTextContent(ETIQUETA_SIN_DUENIO)
+    expect(celdaDeTenant('huerfano')).not.toHaveTextContent(ETIQUETA_PLATAFORMA)
+    expect(celdaDeTenant('staff')).toHaveTextContent(ETIQUETA_PLATAFORMA)
+  })
+
+  it('el filtro por tenant angosta las filas sin pedir nada más a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    const llamadasAlCargar = apiGetMock.mock.calls.length
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '3')
+
+    expect(usuariosVisibles()).toEqual(['vendedor.este'])
+    expect(apiGetMock.mock.calls).toHaveLength(llamadasAlCargar)
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '')
+    expect(usuariosVisibles()).toEqual(['vendedor.sur', 'vendedor.este', 'staff'])
+  })
+
+  it('el filtro ofrece la opción de plataforma y aísla al personal sin tenant', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('staff')).toBeInTheDocument())
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), ETIQUETA_OPCION_PLATAFORMA)
+
+    expect(usuariosVisibles()).toEqual(['staff'])
+  })
+
+  /**
+   * Cláusula bajo prueba: el filtro NO confunde a un tenant llamado literalmente "Plataforma" con
+   * el personal de plataforma. La columna rinde el mismo texto en las dos filas — `nombre` es
+   * texto libre — así que el único separador es la clave del `<option>`, que para la cuenta sin
+   * tenant no es ningún `String(idTenant)`.
+   */
+  it('un tenant llamado "Plataforma" no se confunde con el personal de plataforma', async () => {
+    const usuario = userEvent.setup()
+    const cuentaDeTenantHomonimo = usuarioFixture({
+      id: 54,
+      usuario: 'cuenta.homonima',
+      idTenant: 9,
+      nombreTenant: 'Plataforma',
+    })
+    montar([cuentaDeTenantHomonimo, cuentaDePlataforma])
+    await waitFor(() => expect(screen.getByText('cuenta.homonima')).toBeInTheDocument())
+
+    expect(celdaDeTenant('cuenta.homonima')).toHaveTextContent(ETIQUETA_PLATAFORMA)
+    expect(celdaDeTenant('staff')).toHaveTextContent(ETIQUETA_PLATAFORMA)
+
+    const etiquetas = within(screen.getByLabelText('Tenant'))
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    expect(new Set(etiquetas).size).toBe(etiquetas.length)
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), ETIQUETA_OPCION_PLATAFORMA)
+    expect(usuariosVisibles()).toEqual(['staff'])
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '9')
+    expect(usuariosVisibles()).toEqual(['cuenta.homonima'])
+  })
+
+  /** Spec S5: un admin de tenant no puede enumerar el nombre de otro tenant — las opciones salen
+   * de las filas que ya recibió, y el servidor solo le manda las suyas. */
+  it('un dataset de un solo tenant ofrece exactamente una opción de tenant', async () => {
+    usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    const etiquetas = within(screen.getByLabelText('Tenant'))
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    expect(etiquetas).toEqual(['Todos', 'Comercio Sur'])
+    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: la guarda de generación de `cargar` (`react-async-state` regla 2). La
+   * búsqueda es el ÚNICO camino de estas cuatro pantallas que puede tener dos LECTURAS en vuelo
+   * — las escrituras bloquean todo lo que podría supersederlas (regla 9) — así que acá la guarda
+   * es carga viva, no defensa en profundidad.
+   *
+   * El confundidor a esquivar es el de la regla 7: un `waitFor` que aserte "sigue estando lo
+   * nuevo" sale verde en su primer tick, ANTES de que el microtask viejo aterrice, y no prueba
+   * nada. Por eso la promesa vieja se resuelve DENTRO de `act` y la aserción va sincrónica
+   * después del flush.
+   */
+  it('una respuesta de búsqueda vieja que aterriza tarde no pisa a la nueva', async () => {
+    const usuario = userEvent.setup()
+    let resolverVieja!: (pagina: PaginaDe<UsuarioListado>) => void
+    const vieja = new Promise<PaginaDe<UsuarioListado>>((resolver) => {
+      resolverVieja = resolver
+    })
+
+    function pagina(items: UsuarioListado[]): PaginaDe<UsuarioListado> {
+      return { items, total: items.length, pagina: 1, tamanio: 20 }
+    }
+
+    let busquedas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta.startsWith('/usuarios')) {
+        busquedas += 1
+        if (busquedas === 1) return Promise.resolve(pagina([cuentaDeTenant, cuentaDeOtroTenant]))
+        if (busquedas === 2) return vieja
+
+        return Promise.resolve(pagina([cuentaDePlataforma]))
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.type(screen.getByPlaceholderText('Buscar usuario o mail…'), 'sur')
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    await usuario.clear(screen.getByPlaceholderText('Buscar usuario o mail…'))
+    await usuario.type(screen.getByPlaceholderText('Buscar usuario o mail…'), 'staff')
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+    await waitFor(() => expect(screen.getByText('staff')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverVieja(pagina([cuentaDeTenant, cuentaDeOtroTenant]))
+      await vieja
+    })
+
+    expect(usuariosVisibles()).toEqual(['staff'])
+    expect(screen.queryByText('vendedor.sur')).not.toBeInTheDocument()
+  })
+
+  /** Tarea 2.13: `idTenant` no se presenta como identidad del dueño en ninguna celda. */
+  it('no presenta idTenant como identidad del dueño en ninguna celda', async () => {
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    for (const fila of screen.getAllByRole('row').slice(1)) {
+      expect(within(fila).getAllByRole('cell')[COLUMNA_TENANT]).not.toHaveTextContent(/^\d+$/)
+    }
+
+    expect(within(screen.getByLabelText('Tenant')).getByRole('option', { name: 'Comercio Sur' })).toHaveValue('2')
+  })
+})

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1,7 +1,8 @@
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Usuarios } from './Usuarios'
+import { ErrorApi } from '../api/cliente'
 import { ETIQUETA_OPCION_PLATAFORMA, ETIQUETA_PLATAFORMA, ETIQUETA_SIN_DUENIO } from '../api/organizacion'
 import { ROL } from '../api/tipos'
 import type { PaginaDe, RolListado, TenantListado, UsuarioAutenticado, UsuarioListado } from '../api/tipos'
@@ -10,13 +11,15 @@ import type { PaginaDe, RolListado, TenantListado, UsuarioAutenticado, UsuarioLi
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
+const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown])),
-    put: vi.fn(),
-    delete: vi.fn(),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
+    delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
     estado: number
@@ -78,10 +81,15 @@ const cuentaDeOtroTenant = usuarioFixture({
   idTenant: 3,
   nombreTenant: 'Almacén Este',
 })
+/** `idTenant: null` obliga a `rolId: Root`: `PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance`
+ * rechaza cualquier otro rol sin tenant, así que un fixture con Vendedor y sin tenant sería una
+ * entidad que el servidor no puede haber emitido. */
 const cuentaDePlataforma = usuarioFixture({
   id: 52,
   usuario: 'staff',
   mail: 'staff@ways.test',
+  rolId: ROL.Root,
+  rol: 'Root',
   idTenant: null,
   nombreTenant: null,
 })
@@ -557,5 +565,244 @@ describe('Usuarios (stage-20, tarea 2.17 — selector de tenant en el alta)', ()
     await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
 
     expect(apiGetMock).not.toHaveBeenCalledWith('/plataforma/tenants')
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 — correcciones de la ronda 1 de judgment-day.
+
+describe('Usuarios (slice 2, ronda 1 — universo de tenants, filtro y escrituras)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function paginaDe(items: UsuarioListado[]): PaginaDe<UsuarioListado> {
+    return { items, total: items.length, pagina: 1, tamanio: 20 }
+  }
+
+  function rutasDeUsuarios() {
+    return apiGetMock.mock.calls.map(([ruta]) => ruta as string).filter((r) => r.startsWith('/usuarios'))
+  }
+
+  /**
+   * Cláusula bajo prueba: el `setError(ERROR_TENANTS)` del `.catch` del universo de tenants
+   * (`react-async-state` regla 7). Sin él, un actor de plataforma se quedaba con un `<select>`
+   * `required` habilitado y VACÍO: la validación HTML se negaba a mandar el formulario sin decir
+   * por qué, y las dependencias del efecto (`[esPlataforma]`) no lo reintentaban nunca. El
+   * reintento se cuelga de abrir "Nuevo", que es el único momento en que el universo hace falta.
+   */
+  it('un fallo del universo de tenants se rinde en pantalla y abrir "Nuevo" lo reintenta', async () => {
+    const usuario = userEvent.setup()
+    let intentos = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') {
+        intentos += 1
+
+        return intentos === 1
+          ? Promise.reject(new ErrorApi(503, 'no_disponible', 'Se cayó el servicio.'))
+          : Promise.resolve([tenantFixture(2, 'Comercio Sur')])
+      }
+      if (ruta.startsWith('/usuarios')) return Promise.resolve(paginaDe([cuentaDeTenant]))
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument())
+    expect(intentos).toBe(1)
+
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+
+    await waitFor(() => expect(intentos).toBe(2))
+    await waitFor(() =>
+      expect(
+        within(screen.getByLabelText(SELECTOR_DE_ALTA)).getByRole('option', { name: 'Comercio Sur' }),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/No se pudo cargar la lista de tenants/)).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: `disabled={guardando || sinTenantAsignable}` en Guardar. Un control
+   * `disabled` queda EXENTO de la validación de restricciones de HTML, así que el `required` del
+   * `<select>` de tenant no frena nada mientras el universo carga o falló: el POST saldría con
+   * `idTenant: null` y un rol que no es root, y el servidor contestaría 400 `tenant_requerido`.
+   */
+  it('Guardar queda inerte para un actor de plataforma mientras el universo de tenants no está', async () => {
+    const usuario = userEvent.setup()
+    let resolverTenants!: (tenants: TenantListado[]) => void
+    const pendientes = new Promise<TenantListado[]>((resolver) => {
+      resolverTenants = resolver
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return pendientes
+      if (ruta.startsWith('/usuarios')) return Promise.resolve(paginaDe([cuentaDeTenant]))
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
+
+    await act(async () => {
+      resolverTenants([tenantFixture(2, 'Comercio Sur')])
+      await pendientes
+    })
+
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeEnabled()
+  })
+
+  /** La otra mitad de la misma cláusula: si el universo FALLÓ, Guardar sigue inerte — no hay
+   * tenant que mandar y el 400 del servidor sería la única señal. */
+  it('Guardar queda inerte cuando el universo de tenants falló', async () => {
+    const usuario = userEvent.setup()
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') {
+        return Promise.reject(new ErrorApi(503, 'no_disponible', 'Se cayó el servicio.'))
+      }
+      if (ruta.startsWith('/usuarios')) return Promise.resolve(paginaDe([cuentaDeTenant]))
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument())
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled())
+  })
+
+  /**
+   * Cláusula bajo prueba: la marca de estado de `opcionesDeTenantAsignable`, vista desde la
+   * pantalla. El servidor no mira el estado del tenant destino al crear, así que un tenant
+   * suspendido se sigue ofreciendo — pero un usuario creado adentro no va a poder entrar, y sin la
+   * marca eso no se ve en ningún lado.
+   */
+  it('el selector del alta marca a los tenants que no están activos y no los esconde', async () => {
+    const usuario = userEvent.setup()
+    montar(
+      [cuentaDeTenant],
+      [
+        tenantFixture(2, 'Comercio Sur'),
+        { ...tenantFixture(3, 'Almacén Este'), estado: 'Suspendido' },
+        { ...tenantFixture(4, 'Kiosco Viejo'), estado: 'Baja' },
+      ],
+    )
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+
+    const etiquetas = within(screen.getByLabelText(SELECTOR_DE_ALTA))
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+
+    expect(etiquetas).toEqual([
+      'Elegí un tenant',
+      'Almacén Este (suspendido)',
+      'Comercio Sur',
+      'Kiosco Viejo (baja)',
+    ])
+  })
+
+  /**
+   * Cláusula bajo prueba: el `setFiltroTenant((prev) => seleccionVigente(...))` de `cargar` — la
+   * reconciliación ESCRITA en el estado. Derivarla solo al pintar (`tenantVigente`) no alcanza: la
+   * selección inválida sigue viva en `filtroTenant` y se reaplica sola en cuanto la opción
+   * reaparece. El confundidor es justamente ese fallback derivado, así que la observación
+   * discriminante no es "el filtro se ve en Todos mientras la opción no está" sino "las filas
+   * vuelven ENTERAS cuando la opción reaparece".
+   */
+  it('un filtro invalidado por una búsqueda no resucita cuando las filas vuelven', async () => {
+    const usuario = userEvent.setup()
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.resolve(tenantsDesdeFilas([cuentaDeTenant]))
+      if (ruta.startsWith('/usuarios?')) return Promise.resolve(paginaDe([cuentaDeTenant]))
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.resolve(paginaDe([cuentaDeTenant, cuentaDeOtroTenant, cuentaDePlataforma]))
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.este')).toBeInTheDocument())
+
+    await usuario.selectOptions(screen.getByLabelText('Tenant'), '3')
+    expect(usuariosVisibles()).toEqual(['vendedor.este'])
+
+    await usuario.type(screen.getByPlaceholderText('Buscar usuario o mail…'), 'sur')
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+    await waitFor(() => expect(usuariosVisibles()).toEqual(['vendedor.sur']))
+
+    await usuario.clear(screen.getByPlaceholderText('Buscar usuario o mail…'))
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    await waitFor(() => expect(screen.getByText('vendedor.este')).toBeInTheDocument())
+    expect(screen.getByLabelText('Tenant')).toHaveValue('')
+    expect(usuariosVisibles()).toEqual(['vendedor.sur', 'vendedor.este', 'staff'])
+  })
+
+  /**
+   * Cláusula bajo prueba: `cargar(token, busquedaAplicada, true)` en `refrescarTrasEscribir` — el
+   * término REALMENTE aplicado, no el borrador del input. Con `busqueda` el refresco post-baja
+   * angostaba la tabla con un texto que el operador tipeó y nunca buscó.
+   */
+  it('el refresco post-escritura usa el término buscado, no el borrador tipeado', async () => {
+    const usuario = userEvent.setup()
+    vi.stubGlobal('confirm', () => true)
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.type(screen.getByPlaceholderText('Buscar usuario o mail…'), 'juan')
+    await usuario.click(
+      within(screen.getByRole('row', { name: /vendedor\.sur/ })).getByRole('button', { name: 'Baja' }),
+    )
+
+    await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/usuarios/50'))
+    await waitFor(() => expect(screen.getByText(/dado de baja/)).toBeInTheDocument())
+
+    expect(rutasDeUsuarios().at(-1)).toBe('/usuarios')
+    expect(usuariosVisibles()).toEqual(['vendedor.sur', 'vendedor.este', 'staff'])
+  })
+
+  /**
+   * Cláusula bajo prueba: el `try` propio del POST de contraseña. Compartir el `try` con el PUT
+   * hacía que un fallo del cambio de contraseña reportara "No se pudo guardar." aunque el perfil
+   * YA estaba commiteado — `react-async-state` regla 6, una escritura commiteada nunca se reporta
+   * como fallida.
+   */
+  it('un fallo del cambio de contraseña no reporta el PUT ya commiteado como fallido', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    apiPostMock.mockRejectedValue(new ErrorApi(400, 'password_debil', 'La contraseña es muy corta.'))
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    const llamadasAlCargar = rutasDeUsuarios().length
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.type(screen.getByLabelText('Contraseña'), 'corta')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(screen.getByText(/no se pudo cambiar la contraseña/)).toBeInTheDocument())
+    expect(apiPutMock).toHaveBeenCalledWith('/usuarios/50', expect.anything())
+    expect(screen.getByText(/actualizado/)).toBeInTheDocument()
+    expect(screen.queryByText('No se pudo guardar.')).not.toBeInTheDocument()
+    expect(rutasDeUsuarios().length).toBeGreaterThan(llamadasAlCargar)
   })
 })

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -9,11 +9,12 @@ import type { PaginaDe, RolListado, UsuarioAutenticado, UsuarioListado } from '.
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.12 y 2.13).
 
 const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
-    post: vi.fn(),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown])),
     put: vi.fn(),
     delete: vi.fn(),
   },
@@ -47,7 +48,11 @@ vi.mock('../auth/useAuth', () => ({
   useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: vi.fn() }),
 }))
 
-const ROLES: RolListado[] = [{ id: ROL.Vendedor, nombre: 'Vendedor', descripcion: null }]
+const ROLES: RolListado[] = [
+  { id: ROL.Vendedor, nombre: 'Vendedor', descripcion: null },
+  { id: ROL.Admin, nombre: 'Admin', descripcion: null },
+  { id: ROL.Root, nombre: 'Root', descripcion: null },
+]
 
 function usuarioFixture(sobrescribir: Partial<UsuarioListado> = {}): UsuarioListado {
   return {
@@ -294,5 +299,178 @@ describe('Usuarios (stage-20, slice 2 — columna de tenant y filtro)', () => {
     }
 
     expect(within(screen.getByLabelText('Tenant')).getByRole('option', { name: 'Comercio Sur' })).toHaveValue('2')
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, tarea 2.17 (bug reportado por el dueño a mitad del
+// slice): un actor de plataforma no podía crear un Admin porque el alta no ofrecía tenant y el
+// servidor la rechazaba con 400 `tenant_requerido`.
+
+const SELECTOR_DE_ALTA = 'Tenant de la cuenta'
+
+describe('Usuarios (stage-20, tarea 2.17 — selector de tenant en el alta)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  async function abrirAlta(usuario: ReturnType<typeof userEvent.setup>) {
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+  }
+
+  async function completarDatosBasicos(usuario: ReturnType<typeof userEvent.setup>) {
+    await usuario.type(screen.getByLabelText('Usuario'), 'nuevo.admin')
+    await usuario.type(screen.getByLabelText('Mail'), 'nuevo.admin@ways.test')
+    await usuario.type(screen.getByLabelText('Contraseña'), 'unaClaveLarga')
+  }
+
+  function cuerpoDelAlta() {
+    const llamada = apiPostMock.mock.calls.find(([ruta]) => ruta === '/usuarios')
+    expect(llamada, 'no se emitió el POST /usuarios').toBeDefined()
+
+    return llamada![1] as Record<string, unknown>
+  }
+
+  /**
+   * Cláusula bajo prueba: `esNuevo && ofreceTenant` en `FormularioUsuario` — el selector existe
+   * para un actor de plataforma, y sus opciones salen de `tenantsAsignables`, que es
+   * `opcionesDeTenant(filas)` MENOS el token de plataforma (que no es un id y ningún rol que no
+   * sea root puede llevar).
+   */
+  it('ofrece el selector de tenant a un actor de plataforma, sin la opción de plataforma', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    const selector = screen.getByLabelText(SELECTOR_DE_ALTA)
+    const etiquetas = within(selector)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+
+    expect(etiquetas).toEqual(['Elegí un tenant', 'Almacén Este', 'Comercio Sur'])
+    expect(etiquetas).not.toContain(ETIQUETA_OPCION_PLATAFORMA)
+  })
+
+  /**
+   * Cláusula bajo prueba: la MISMA, por su lado adverso (spec S5, anti-oráculo). Un admin de
+   * tenant no enumera tenants: crea dentro del suyo y el servidor se lo impone
+   * (`ServicioDeUsuarios.CrearAsync`: `Actor.EsDePlataforma ? datos.IdTenant : Actor.IdTenant`).
+   */
+  it('un admin de tenant no ve el selector de tenant en el alta', async () => {
+    const usuario = userEvent.setup()
+    usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    expect(screen.getByLabelText('Usuario')).toBeInTheDocument()
+    expect(screen.queryByLabelText(SELECTOR_DE_ALTA)).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `onChange` del rol LIMPIA `idTenant` en el estado.
+   *
+   * A diferencia de M4, acá NO hay un fallback derivado que enmascare la falta de limpieza: el
+   * `value` del `<select>` se deriva del MISMO `valor.idTenant` que viaja en el POST, así que un
+   * estado sucio se ve en las dos observaciones. Verificado corriendo la mutación (M15): quitar la
+   * limpieza deja el `<select>` en `2` estando deshabilitado. El cuerpo del POST se asserta igual
+   * porque es lo único que el servidor ve — con rol root y tenant, contesta 403.
+   */
+  it('el rol Root deshabilita el selector y limpia el tenant ya elegido', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    await usuario.selectOptions(screen.getByLabelText(SELECTOR_DE_ALTA), '2')
+    expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toHaveValue('2')
+
+    await usuario.selectOptions(screen.getByLabelText('Rol'), String(ROL.Root))
+
+    expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toBeDisabled()
+    expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toHaveValue('')
+
+    await completarDatosBasicos(usuario)
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalled())
+    expect(cuerpoDelAlta()).toMatchObject({ rolId: ROL.Root, idTenant: null })
+  })
+
+  /**
+   * Cláusula bajo prueba: `idTenant: datos.idTenant` en el constructor del payload de alta — el
+   * campo que faltaba y que producía el 400 `tenant_requerido` que reportó el dueño.
+   */
+  it('el alta de un rol de tenant manda el idTenant elegido', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    await usuario.selectOptions(screen.getByLabelText('Rol'), String(ROL.Admin))
+    await usuario.selectOptions(screen.getByLabelText(SELECTOR_DE_ALTA), '3')
+    await completarDatosBasicos(usuario)
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalled())
+    expect(cuerpoDelAlta()).toMatchObject({
+      usuario: 'nuevo.admin',
+      mail: 'nuevo.admin@ways.test',
+      rolId: ROL.Admin,
+      idTenant: 3,
+    })
+  })
+
+  /**
+   * Cláusula bajo prueba: un admin de tenant manda `idTenant: null` — el `FORMULARIO_VACIO` no
+   * arrastra tenant y no hay selector que lo llene. El servidor le impone el suyo.
+   */
+  it('el alta de un admin de tenant manda idTenant null', async () => {
+    const usuario = userEvent.setup()
+    usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+    await abrirAlta(usuario)
+
+    await completarDatosBasicos(usuario)
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalled())
+    expect(cuerpoDelAlta()).toMatchObject({ rolId: ROL.Vendedor, idTenant: null })
+  })
+
+  /**
+   * Cláusula bajo prueba: `disabled={guardando || tenantsCargando || esRolDePlataforma}` —
+   * `react-async-state` regla 5. El selector se sirve de las filas ya cargadas, así que mientras
+   * la carga está en vuelo la lista todavía no es la definitiva y no se puede elegir de ella.
+   */
+  it('el selector queda inerte mientras la lista está cargando', async () => {
+    const usuario = userEvent.setup()
+    let resolverCarga!: (pagina: PaginaDe<UsuarioListado>) => void
+    const cargaPendiente = new Promise<PaginaDe<UsuarioListado>>((resolver) => {
+      resolverCarga = resolver
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta.startsWith('/usuarios')) return cargaPendiente
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await abrirAlta(usuario)
+
+    expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toBeDisabled()
+
+    await act(async () => {
+      resolverCarga({ items: [cuentaDeTenant], total: 1, pagina: 1, tamanio: 20 })
+      await cargaPendiente
+    })
+
+    expect(screen.getByLabelText(SELECTOR_DE_ALTA)).toBeEnabled()
   })
 })

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Usuarios } from './Usuarios'
@@ -260,18 +260,31 @@ describe('Usuarios (stage-20, slice 2 — columna de tenant y filtro)', () => {
     expect(usuariosVisibles()).toEqual(['cuenta.homonima'])
   })
 
-  /** Spec S5: un admin de tenant no puede enumerar el nombre de otro tenant — las opciones salen
-   * de las filas que ya recibió, y el servidor solo le manda las suyas. */
-  it('un dataset de un solo tenant ofrece exactamente una opción de tenant', async () => {
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-7): `esPlataforma &&` gatea el FILTRO por tenant y la COLUMNA
+   * de tenant, con el mismo criterio que ya rige en `Empresas.tsx` y `PuntosVenta.tsx`. Para un
+   * admin de tenant TODAS las filas son de su propio tenant —el servidor solo le manda esas—, así
+   * que la columna repite el mismo nombre en cada fila y el filtro ofrece una sola opción que no
+   * angosta nada: los dos son controles muertos.
+   */
+  it('un admin de tenant no ve el filtro ni la columna de tenant; un actor de plataforma sí', async () => {
     usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
     montar([cuentaDeTenant])
     await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
 
-    const etiquetas = within(screen.getByLabelText('Tenant'))
-      .getAllByRole('option')
-      .map((o) => o.textContent)
-    expect(etiquetas).toEqual(['Todos', 'Comercio Sur'])
-    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Tenant')).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Tenant' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Comercio Sur')).not.toBeInTheDocument()
+
+    cleanup()
+    apiGetMock.mockReset()
+    usuarioActual = autenticadoFixture()
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    expect(screen.getByLabelText('Tenant')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Tenant' })).toBeInTheDocument()
+    expect(celdaDeTenant('vendedor.sur')).toHaveTextContent('Comercio Sur')
   })
 
   /**
@@ -694,6 +707,10 @@ describe('Usuarios (slice 2, ronda 1 — universo de tenants, filtro y escritura
    * pantalla. El servidor no mira el estado del tenant destino al crear, así que un tenant
    * suspendido se sigue ofreciendo — pero un usuario creado adentro no va a poder entrar, y sin la
    * marca eso no se ve en ningún lado.
+   *
+   * `Kiosco Viejo (baja)` NO es una fila que el listado pueda devolver hoy: un tenant en `Baja` está
+   * borrado lógicamente y `GET /plataforma/tenants` lo filtra. Está acá para ejercitar la rama, que
+   * se conserva como defensa en profundidad, no para presentarla como algo que el operador ve.
    */
   it('el selector del alta marca a los tenants que no están activos y no los esconde', async () => {
     const usuario = userEvent.setup()
@@ -804,5 +821,166 @@ describe('Usuarios (slice 2, ronda 1 — universo de tenants, filtro y escritura
     expect(screen.getByText(/actualizado/)).toBeInTheDocument()
     expect(screen.queryByText('No se pudo guardar.')).not.toBeInTheDocument()
     expect(rutasDeUsuarios().length).toBeGreaterThan(llamadasAlCargar)
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 2 — correcciones de la ronda 2 de judgment-day.
+
+describe('Usuarios (slice 2, ronda 2 — slots de aviso separados y reintento del universo)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  function paginaDe(items: UsuarioListado[]): PaginaDe<UsuarioListado> {
+    return { items, total: items.length, pagina: 1, tamanio: 20 }
+  }
+
+  /**
+   * Cláusula bajo prueba (R2-1): el fallo del universo de tenants tiene BANNER PROPIO, derivado de
+   * `tenantsDePlataformaFallo`, y NO viaja por el slot compartido `error`.
+   *
+   * El confundidor es el orden de llegada: si el 503 de `/plataforma/tenants` aterriza DESPUÉS del
+   * 200 de `/usuarios`, el `setError('')` del camino feliz ya corrió y el banner sobrevive aunque
+   * el fallo esté ruteado por `error`. Por eso las dos promesas se controlan a mano y el orden se
+   * invierte a propósito: tenants RECHAZA primero, los usuarios resuelven DESPUÉS. Con el fallo en
+   * `error`, ese `setError('')` posterior lo borra y la pantalla no dice nada.
+   */
+  it('el fallo del universo de tenants sobrevive a una carga de usuarios que resuelve después', async () => {
+    let rechazarTenants!: (e: unknown) => void
+    let resolverUsuarios!: (p: PaginaDe<UsuarioListado>) => void
+    const tenantsPendientes = new Promise<TenantListado[]>((_, rechazar) => {
+      rechazarTenants = rechazar
+    })
+    const usuariosPendientes = new Promise<PaginaDe<UsuarioListado>>((resolver) => {
+      resolverUsuarios = resolver
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return tenantsPendientes
+      if (ruta.startsWith('/usuarios')) return usuariosPendientes
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+
+    await act(async () => {
+      rechazarTenants(new ErrorApi(503, 'no_disponible', 'Se cayó el servicio.'))
+      await tenantsPendientes.catch(() => undefined)
+    })
+    expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument()
+
+    await act(async () => {
+      resolverUsuarios(paginaDe([cuentaDeTenant]))
+      await usuariosPendientes
+    })
+
+    expect(screen.getByText('vendedor.sur')).toBeInTheDocument()
+    expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument()
+  })
+
+  /**
+   * La otra mitad de la misma cláusula: el banner del universo no tapa un fallo REAL del listado de
+   * usuarios. Los dos se rinden a la vez, cada uno en su slot.
+   */
+  it('el fallo del universo y el del listado de usuarios se rinden los dos, no uno sobre el otro', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') {
+        return Promise.reject(new ErrorApi(503, 'no_disponible', 'Se cayó el servicio.'))
+      }
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.reject(new ErrorApi(500, 'error', 'Se cayó el listado de usuarios.'))
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+
+    await waitFor(() => expect(screen.getByText('Se cayó el listado de usuarios.')).toBeInTheDocument())
+    expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba (R2-2): el fallo del POST de contraseña va al slot ROJO y la confirmación
+   * del PUT ya commiteado se queda en el verde. Los dos se ven, y la aserción es sobre la VARIANTE
+   * del alert, no solo sobre el texto: anunciar un fallo dentro de `alert-success` es exactamente
+   * el defecto, y el texto solo no lo distingue.
+   */
+  it('el fallo de la contraseña va en rojo y la confirmación del perfil se queda en verde', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    apiPostMock.mockRejectedValue(new ErrorApi(400, 'password_debil', 'La contraseña es muy corta.'))
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.type(screen.getByLabelText('Contraseña'), 'corta')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(screen.getByText(/no se pudo cambiar la contraseña/)).toBeInTheDocument())
+
+    const fallo = screen.getByText(/no se pudo cambiar la contraseña/)
+    expect(fallo).toHaveClass('alert-danger')
+    expect(fallo).not.toHaveClass('alert-success')
+
+    const confirmacion = screen.getByText('Usuario "vendedor.sur" actualizado.')
+    expect(confirmacion).toHaveClass('alert-success')
+    expect(confirmacion).not.toHaveTextContent(/contraseña/)
+
+    // El perfil commiteó: el formulario se cierra igual.
+    expect(screen.queryByLabelText('Mail')).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba (R2-4): `!tenantsDePlataformaCargando` en el reintento colgado de "Nuevo".
+   * Sin ella, cada click mientras el reintento está EN VUELO dispara otro `GET /plataforma/tenants`.
+   */
+  it('dos clicks seguidos en "Nuevo" disparan un solo reintento del universo de tenants', async () => {
+    const usuario = userEvent.setup()
+    let intentos = 0
+    let resolverReintento!: (tenants: TenantListado[]) => void
+    const reintento = new Promise<TenantListado[]>((resolver) => {
+      resolverReintento = resolver
+    })
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') {
+        intentos += 1
+
+        return intentos === 1
+          ? Promise.reject(new ErrorApi(503, 'no_disponible', 'Se cayó el servicio.'))
+          : reintento
+      }
+      if (ruta.startsWith('/usuarios')) return Promise.resolve(paginaDe([cuentaDeTenant]))
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument())
+    expect(intentos).toBe(1)
+
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+
+    expect(intentos).toBe(2)
+
+    await act(async () => {
+      resolverReintento([tenantFixture(2, 'Comercio Sur')])
+      await reintento
+    })
+
+    expect(screen.queryByText(/No se pudo cargar la lista de tenants/)).not.toBeInTheDocument()
+    expect(intentos).toBe(2)
   })
 })

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, ErrorApi } from '../api/cliente'
 import {
+  clienteDeOrganizacion,
   etiquetaDeTenant,
   filtrarPorTenant,
   opcionesDeTenant,
@@ -15,6 +16,7 @@ import type {
   EstadoUsuario,
   PaginaDe,
   RolListado,
+  TenantListado,
   UsuarioListado,
 } from '../api/tipos'
 import { Box } from '../componentes/Box'
@@ -51,7 +53,10 @@ const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista.
  * (design D14), y el discriminador es `idTenant`, no el nombre: un `nombreTenant` nulo con
  * `idTenant` presente es un huérfano (tenant dado de baja), no personal de plataforma
  * (Reconciliación 9). El filtro por tenant deriva sus opciones de las filas ya cargadas, así
- * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5).
+ * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5). El selector de
+ * tenant del ALTA es la excepción: para un actor de plataforma pide el universo completo vía
+ * `clienteDeOrganizacion.listarTenants()`, así puede asignar un tenant sin usuarios en la página
+ * actual (gap de tamaño de página cerrado a continuación de la tarea 2.17).
  */
 export function Usuarios() {
   const { usuario: actual } = useAuth()
@@ -65,9 +70,14 @@ export function Usuarios() {
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState(false)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
+  const [tenantsDePlataforma, setTenantsDePlataforma] = useState<TenantListado[]>([])
+  const [tenantsDePlataformaCargando, setTenantsDePlataformaCargando] = useState(false)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
+  /** Generación propia: el universo de tenants no depende del ciclo búsqueda/escritura de
+   * `generacion` y no debe descartarse por una acción no relacionada (ej. un alta en curso). */
+  const generacionTenants = useRef(0)
 
   const cargar = useCallback(async (token: number, termino: string, propagar = false) => {
     setCargando(true)
@@ -95,6 +105,34 @@ export function Usuarios() {
     void cargar(++generacion.current, '')
     api.get<RolListado[]>('/roles').then(setRoles).catch(() => setRoles([]))
   }, [cargar])
+
+  const esPlataforma = actual?.rolId === ROL.Root
+
+  /** Universo COMPLETO de tenants para el selector del ALTA (tarea 2.17, gap del tamaño de
+   * página): `opcionesDeTenant(filas)` solo ve tenants con un usuario en la página actual
+   * (`tamanio` 25), así que un tenant sin usuario ahí quedaba imposible de asignar. Se pide
+   * SOLO para un actor de plataforma — `GET /plataforma/tenants` es `SoloPlataforma` y jamás
+   * 403 para este actor, pero un admin de tenant no debe enumerar tenants (spec S5) — y el
+   * filtro de la tabla sigue sin tocar (design D15, sin segunda consulta ahí). */
+  useEffect(() => {
+    if (!esPlataforma) return
+
+    const token = ++generacionTenants.current
+    setTenantsDePlataformaCargando(true)
+    clienteDeOrganizacion
+      .listarTenants()
+      .then((lista) => {
+        if (generacionTenants.current !== token) return
+        setTenantsDePlataforma(lista)
+      })
+      .catch(() => {
+        if (generacionTenants.current !== token) return
+        setTenantsDePlataforma([])
+      })
+      .finally(() => {
+        if (generacionTenants.current === token) setTenantsDePlataformaCargando(false)
+      })
+  }, [esPlataforma])
 
   async function guardar() {
     if (!formulario || ocupado) return
@@ -186,22 +224,26 @@ export function Usuarios() {
     void accion(() => api.delete(`/usuarios/${u.id}`), `Usuario "${u.usuario}" dado de baja.`)
   }
 
-  const esPlataforma = actual?.rolId === ROL.Root
-
   // El backend valida igual; esto solo evita mostrar botones que van a fallar.
   const puedeEditar = (u: UsuarioListado) =>
     u.rolId !== ROL.Root || actual?.rolId === ROL.Root
 
-  // Derivación pura sobre la página YA CARGADA: sin fetch nuevo y sin parámetro de consulta.
+  // Derivación pura sobre la página YA CARGADA: sin fetch nuevo y sin parámetro de consulta. Esto
+  // sigue rigiendo el FILTRO de la tabla (design D15) — solo el selector del ALTA cambia de fuente.
   const filas = pagina?.items ?? []
   const opcionesTenant = opcionesDeTenant(filas)
   const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
   const visibles = filtrarPorTenant(filas, tenantVigente)
 
   // El alta necesita un tenant REAL: la opción de personal de plataforma no es un id y el
-  // servidor la rechazaría para cualquier rol que no sea root. Sale de las mismas filas ya
-  // cargadas que alimentan el filtro — sin una segunda consulta (design D15).
-  const tenantsAsignables = opcionesTenant.filter((o) => o.valor !== VALOR_SIN_TENANT)
+  // servidor la rechazaría para cualquier rol que no sea root. Para un actor de plataforma sale
+  // del universo completo pedido arriba (tarea 2.17, gap de tamaño de página); un admin de
+  // tenant nunca ve el selector, así que su rama solo necesita ser un valor válido, no el mejor.
+  const tenantsAsignables = esPlataforma
+    ? [...tenantsDePlataforma]
+        .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+        .map((t) => ({ valor: String(t.id), etiqueta: t.nombre }))
+    : opcionesTenant.filter((o) => o.valor !== VALOR_SIN_TENANT)
 
   const herramientas = (
     <nav className="p-2 d-flex gap-2">
@@ -250,7 +292,7 @@ export function Usuarios() {
             roles={roles}
             tenants={tenantsAsignables}
             ofreceTenant={esPlataforma}
-            tenantsCargando={cargando}
+            tenantsCargando={esPlataforma ? tenantsDePlataformaCargando : cargando}
             guardando={ocupado}
             onCambio={setFormulario}
             onGuardar={guardar}
@@ -393,9 +435,12 @@ function EtiquetaEstado({ estado }: { estado: EstadoUsuario }) {
 }
 
 /**
- * `tenants` es el conjunto de tenants ASIGNABLES derivado de las filas ya cargadas, y solo se
- * ofrece a un actor de plataforma (`ofreceTenant`): un admin de tenant no enumera tenants —
- * crea siempre dentro del suyo y el servidor se lo impone (spec S5).
+ * `tenants` es el conjunto de tenants ASIGNABLES, y solo se ofrece a un actor de plataforma
+ * (`ofreceTenant`): un admin de tenant no enumera tenants — crea siempre dentro del suyo y el
+ * servidor se lo impone (spec S5). Para un actor de plataforma sale del universo completo pedido
+ * vía `clienteDeOrganizacion.listarTenants()` (tarea 2.17, gap de tamaño de página): las filas ya
+ * cargadas de `Usuarios` solo cubren la página actual, así que un tenant sin usuario ahí quedaba
+ * imposible de asignar.
  *
  * El selector espeja `PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance`, que sigue siendo la
  * autoridad: root SIEMPRE es de plataforma (tenant nulo) y cualquier otro rol SIEMPRE necesita

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, ErrorApi } from '../api/cliente'
+import { etiquetaDeTenant, filtrarPorTenant, opcionesDeTenant, SIN_FILTRO } from '../api/organizacion'
 import { ESTADOS_USUARIO, ROL } from '../api/tipos'
 import type {
   ActualizarUsuario,
@@ -31,6 +32,16 @@ const FORMULARIO_VACIO: Formulario = {
   password: '',
 }
 
+const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+
+/**
+ * ABM de usuarios. La columna "Tenant" rinde el nombre del tenant de la cuenta o el literal
+ * "Plataforma" cuando `idTenant` es null — esa copia la pone la web, nunca el servidor
+ * (design D14), y el discriminador es `idTenant`, no el nombre: un `nombreTenant` nulo con
+ * `idTenant` presente es un huérfano (tenant dado de baja), no personal de plataforma
+ * (Reconciliación 9). El filtro por tenant deriva sus opciones de las filas ya cargadas, así
+ * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5).
+ */
 export function Usuarios() {
   const { usuario: actual } = useAuth()
 
@@ -41,90 +52,137 @@ export function Usuarios() {
   const [error, setError] = useState('')
   const [aviso, setAviso] = useState('')
   const [formulario, setFormulario] = useState<Formulario | null>(null)
-  const [guardando, setGuardando] = useState(false)
+  const [ocupado, setOcupado] = useState(false)
+  const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
 
-  const cargar = useCallback(async (termino: string) => {
+  /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
+  const generacion = useRef(0)
+
+  const cargar = useCallback(async (token: number, termino: string, propagar = false) => {
     setCargando(true)
-    setError('')
     try {
       const parametros = termino ? `?busqueda=${encodeURIComponent(termino)}` : ''
-      setPagina(await api.get<PaginaDe<UsuarioListado>>(`/usuarios${parametros}`))
+      const respuesta = await api.get<PaginaDe<UsuarioListado>>(`/usuarios${parametros}`)
+      if (generacion.current !== token) return
+      setPagina(respuesta)
+      setError('')
     } catch (e) {
+      if (generacion.current !== token) return
+      if (propagar) throw e
       setError(e instanceof ErrorApi ? e.message : 'No se pudieron cargar los usuarios.')
     } finally {
-      setCargando(false)
+      if (generacion.current === token) setCargando(false)
     }
   }, [])
 
+  function buscar(termino: string) {
+    if (ocupado) return
+    void cargar(++generacion.current, termino)
+  }
+
   useEffect(() => {
-    void cargar('')
+    void cargar(++generacion.current, '')
     api.get<RolListado[]>('/roles').then(setRoles).catch(() => setRoles([]))
   }, [cargar])
 
   async function guardar() {
-    if (!formulario) return
+    if (!formulario || ocupado) return
 
-    setGuardando(true)
+    const datos = formulario
+    const token = ++generacion.current
+    setOcupado(true)
     setError('')
     setAviso('')
 
+    let mensajeOk: string
     try {
-      if (formulario.id === null) {
-        const datos: CrearUsuario = {
-          usuario: formulario.usuario,
-          mail: formulario.mail,
-          rolId: formulario.rolId,
-          password: formulario.password,
-          estado: formulario.estado,
+      if (datos.id === null) {
+        const alta: CrearUsuario = {
+          usuario: datos.usuario,
+          mail: datos.mail,
+          rolId: datos.rolId,
+          password: datos.password,
+          estado: datos.estado,
         }
-        await api.post('/usuarios', datos)
-        setAviso(`Usuario "${formulario.usuario}" creado.`)
+        await api.post('/usuarios', alta)
+        mensajeOk = `Usuario "${datos.usuario}" creado.`
       } else {
-        const datos: ActualizarUsuario = {
-          usuario: formulario.usuario,
-          mail: formulario.mail,
-          rolId: formulario.rolId,
-          estado: formulario.estado,
+        const edicion: ActualizarUsuario = {
+          usuario: datos.usuario,
+          mail: datos.mail,
+          rolId: datos.rolId,
+          estado: datos.estado,
         }
-        await api.put(`/usuarios/${formulario.id}`, datos)
+        await api.put(`/usuarios/${datos.id}`, edicion)
 
-        if (formulario.password) {
-          await api.post(`/usuarios/${formulario.id}/password`, {
-            passwordNueva: formulario.password,
-          })
+        if (datos.password) {
+          await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
         }
-        setAviso(`Usuario "${formulario.usuario}" actualizado.`)
+        mensajeOk = `Usuario "${datos.usuario}" actualizado.`
       }
-
-      setFormulario(null)
-      await cargar(busqueda)
     } catch (e) {
+      if (generacion.current !== token) return
       setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+      setOcupado(false)
+
+      return
+    }
+
+    if (generacion.current !== token) return
+    setFormulario(null)
+    await refrescarTrasEscribir(token, mensajeOk)
+  }
+
+  /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string) {
+    if (generacion.current !== token) return
+
+    setAviso(mensajeOk)
+    try {
+      await cargar(token, busqueda, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      setGuardando(false)
+      if (generacion.current === token) setOcupado(false)
     }
   }
 
-  async function accion(promesa: Promise<unknown>, mensajeOk: string) {
+  async function accion(construirPromesa: () => Promise<unknown>, mensajeOk: string) {
+    if (ocupado) return
+
+    const token = ++generacion.current
+    setOcupado(true)
     setError('')
     setAviso('')
     try {
-      await promesa
-      setAviso(mensajeOk)
-      await cargar(busqueda)
+      await construirPromesa()
     } catch (e) {
+      if (generacion.current !== token) return
       setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+      setOcupado(false)
+
+      return
     }
+
+    await refrescarTrasEscribir(token, mensajeOk)
   }
 
   function eliminar(u: UsuarioListado) {
+    if (ocupado) return
     if (!confirm(`¿Dar de baja al usuario "${u.usuario}"?`)) return
-    void accion(api.delete(`/usuarios/${u.id}`), `Usuario "${u.usuario}" dado de baja.`)
+    void accion(() => api.delete(`/usuarios/${u.id}`), `Usuario "${u.usuario}" dado de baja.`)
   }
 
   // El backend valida igual; esto solo evita mostrar botones que van a fallar.
   const puedeEditar = (u: UsuarioListado) =>
     u.rolId !== ROL.Root || actual?.rolId === ROL.Root
+
+  // Derivación pura sobre la página YA CARGADA: sin fetch nuevo y sin parámetro de consulta.
+  const filas = pagina?.items ?? []
+  const opcionesTenant = opcionesDeTenant(filas)
+  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const visibles = filtrarPorTenant(filas, tenantVigente)
 
   const herramientas = (
     <nav className="p-2 d-flex gap-2">
@@ -134,12 +192,14 @@ export function Usuarios() {
         placeholder="Buscar usuario o mail…"
         value={busqueda}
         onChange={(e) => setBusqueda(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' && cargar(busqueda)}
+        onKeyDown={(e) => e.key === 'Enter' && buscar(busqueda)}
+        disabled={ocupado}
       />
       <button
         type="button"
         className="btn btn-sm btn-outline-light rounded-0"
-        onClick={() => cargar(busqueda)}
+        onClick={() => buscar(busqueda)}
+        disabled={ocupado}
       >
         Buscar
       </button>
@@ -151,6 +211,7 @@ export function Usuarios() {
           setAviso('')
           setError('')
         }}
+        disabled={ocupado}
       >
         Nuevo
       </button>
@@ -165,9 +226,10 @@ export function Usuarios() {
 
         {formulario && (
           <FormularioUsuario
+            key={formulario.id ?? 'nuevo'}
             valor={formulario}
             roles={roles}
-            guardando={guardando}
+            guardando={ocupado}
             onCambio={setFormulario}
             onGuardar={guardar}
             onCancelar={() => setFormulario(null)}
@@ -177,91 +239,119 @@ export function Usuarios() {
         {cargando ? (
           <Cargando />
         ) : (
-          <div className="table-responsive">
-            <table className="table table-striped table-hover table-bordered align-middle">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Usuario</th>
-                  <th>Mail</th>
-                  <th>Rol</th>
-                  <th>Estado</th>
-                  <th>Última conexión</th>
-                  <th className="text-end">Acciones</th>
-                </tr>
-              </thead>
-              <tbody>
-                {pagina?.items.map((u) => (
-                  <tr key={u.id}>
-                    <td>{String(u.id).padStart(4, '0')}</td>
-                    <td>{u.usuario}</td>
-                    <td>{u.mail}</td>
-                    <td>{u.rol}</td>
-                    <td>
-                      <EtiquetaEstado estado={u.estado} />
-                    </td>
-                    <td>
-                      {u.ultimaConexion
-                        ? new Date(u.ultimaConexion).toLocaleString('es-AR')
-                        : '—'}
-                    </td>
-                    <td className="text-end text-nowrap">
-                      {puedeEditar(u) && (
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-primary rounded-0 me-1"
-                          onClick={() => {
-                            setFormulario({
-                              id: u.id,
-                              usuario: u.usuario,
-                              mail: u.mail,
-                              rolId: u.rolId,
-                              estado: u.estado,
-                              password: '',
-                            })
-                            setAviso('')
-                            setError('')
-                          }}
-                        >
-                          Editar
-                        </button>
-                      )}
-                      {u.estado === 'Bloqueado' && (
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-warning rounded-0 me-1"
-                          onClick={() =>
-                            accion(
-                              api.post(`/usuarios/${u.id}/desbloquear`),
-                              `Usuario "${u.usuario}" desbloqueado.`,
-                            )
-                          }
-                        >
-                          Desbloquear
-                        </button>
-                      )}
-                      {puedeEditar(u) && u.rolId !== ROL.Root && u.id !== actual?.id && (
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-danger rounded-0"
-                          onClick={() => eliminar(u)}
-                        >
-                          Baja
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-                {pagina?.items.length === 0 && (
+          <>
+            <div className="row g-2 mb-3">
+              <div className="col-md-4">
+                <label className="form-label" htmlFor="u-filtro-tenant">
+                  Tenant
+                </label>
+                <select
+                  id="u-filtro-tenant"
+                  className="form-select rounded-0"
+                  value={tenantVigente}
+                  onChange={(e) => setFiltroTenant(e.target.value)}
+                >
+                  <option value={SIN_FILTRO}>Todos</option>
+                  {opcionesTenant.map((o) => (
+                    <option key={o.valor} value={o.valor}>
+                      {o.etiqueta}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="table-responsive">
+              <table className="table table-striped table-hover table-bordered align-middle">
+                <thead>
                   <tr>
-                    <td colSpan={7} className="text-center text-muted py-4">
-                      No hay usuarios que coincidan con la búsqueda.
-                    </td>
+                    <th>ID</th>
+                    <th>Usuario</th>
+                    <th>Mail</th>
+                    <th>Tenant</th>
+                    <th>Rol</th>
+                    <th>Estado</th>
+                    <th>Última conexión</th>
+                    <th className="text-end">Acciones</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {visibles.map((u) => (
+                    <tr key={u.id}>
+                      <td>{String(u.id).padStart(4, '0')}</td>
+                      <td>{u.usuario}</td>
+                      <td>{u.mail}</td>
+                      <td>{etiquetaDeTenant(u)}</td>
+                      <td>{u.rol}</td>
+                      <td>
+                        <EtiquetaEstado estado={u.estado} />
+                      </td>
+                      <td>
+                        {u.ultimaConexion
+                          ? new Date(u.ultimaConexion).toLocaleString('es-AR')
+                          : '—'}
+                      </td>
+                      <td className="text-end text-nowrap">
+                        {puedeEditar(u) && (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-primary rounded-0 me-1"
+                            onClick={() => {
+                              setFormulario({
+                                id: u.id,
+                                usuario: u.usuario,
+                                mail: u.mail,
+                                rolId: u.rolId,
+                                estado: u.estado,
+                                password: '',
+                              })
+                              setAviso('')
+                              setError('')
+                            }}
+                            disabled={ocupado}
+                          >
+                            Editar
+                          </button>
+                        )}
+                        {u.estado === 'Bloqueado' && (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-warning rounded-0 me-1"
+                            onClick={() =>
+                              accion(
+                                () => api.post(`/usuarios/${u.id}/desbloquear`),
+                                `Usuario "${u.usuario}" desbloqueado.`,
+                              )
+                            }
+                            disabled={ocupado}
+                          >
+                            Desbloquear
+                          </button>
+                        )}
+                        {puedeEditar(u) && u.rolId !== ROL.Root && u.id !== actual?.id && (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-danger rounded-0"
+                            onClick={() => eliminar(u)}
+                            disabled={ocupado}
+                          >
+                            Baja
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                  {visibles.length === 0 && (
+                    <tr>
+                      <td colSpan={8} className="text-center text-muted py-4">
+                        No hay usuarios que coincidan con la búsqueda.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </Box>
     </div>

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -5,8 +5,9 @@ import {
   etiquetaDeTenant,
   filtrarPorTenant,
   opcionesDeTenant,
+  opcionesDeTenantAsignable,
+  seleccionVigente,
   SIN_FILTRO,
-  VALOR_SIN_TENANT,
 } from '../api/organizacion'
 import type { OpcionDeFiltro } from '../api/organizacion'
 import { ESTADOS_USUARIO, ROL } from '../api/tipos'
@@ -47,16 +48,16 @@ const FORMULARIO_VACIO: Formulario = {
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
+const ERROR_TENANTS =
+  'No se pudo cargar la lista de tenants: no se pueden crear usuarios hasta que llegue. Abrí "Nuevo" para reintentar.'
+
 /**
  * ABM de usuarios. La columna "Tenant" rinde el nombre del tenant de la cuenta o el literal
  * "Plataforma" cuando `idTenant` es null — esa copia la pone la web, nunca el servidor
  * (design D14), y el discriminador es `idTenant`, no el nombre: un `nombreTenant` nulo con
  * `idTenant` presente es un huérfano (tenant dado de baja), no personal de plataforma
  * (Reconciliación 9). El filtro por tenant deriva sus opciones de las filas ya cargadas, así
- * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5). El selector de
- * tenant del ALTA es la excepción: para un actor de plataforma pide el universo completo vía
- * `clienteDeOrganizacion.listarTenants()`, así puede asignar un tenant sin usuarios en la página
- * actual (gap de tamaño de página cerrado a continuación de la tarea 2.17).
+ * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5).
  */
 export function Usuarios() {
   const { usuario: actual } = useAuth()
@@ -64,6 +65,9 @@ export function Usuarios() {
   const [pagina, setPagina] = useState<PaginaDe<UsuarioListado> | null>(null)
   const [roles, setRoles] = useState<RolListado[]>([])
   const [busqueda, setBusqueda] = useState('')
+  /** Término REALMENTE aplicado a la tabla: lo escribe `buscar()`, nunca el tipeo. El refresco
+   * post-escritura usa este y no el borrador del input, que puede tener texto sin buscar. */
+  const [busquedaAplicada, setBusquedaAplicada] = useState('')
   const [cargando, setCargando] = useState(true)
   const [error, setError] = useState('')
   const [aviso, setAviso] = useState('')
@@ -72,6 +76,7 @@ export function Usuarios() {
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
   const [tenantsDePlataforma, setTenantsDePlataforma] = useState<TenantListado[]>([])
   const [tenantsDePlataformaCargando, setTenantsDePlataformaCargando] = useState(false)
+  const [tenantsDePlataformaFallo, setTenantsDePlataformaFallo] = useState(false)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
@@ -86,6 +91,7 @@ export function Usuarios() {
       const respuesta = await api.get<PaginaDe<UsuarioListado>>(`/usuarios${parametros}`)
       if (generacion.current !== token) return
       setPagina(respuesta)
+      setFiltroTenant((prev) => seleccionVigente(opcionesDeTenant(respuesta.items), prev))
       setError('')
     } catch (e) {
       if (generacion.current !== token) return
@@ -98,6 +104,7 @@ export function Usuarios() {
 
   function buscar(termino: string) {
     if (ocupado) return
+    setBusquedaAplicada(termino)
     void cargar(++generacion.current, termino)
   }
 
@@ -113,10 +120,12 @@ export function Usuarios() {
    * (`tamanio` 25), así que un tenant sin usuario ahí quedaba imposible de asignar. Se pide
    * SOLO para un actor de plataforma — `GET /plataforma/tenants` es `SoloPlataforma` y jamás
    * 403 para este actor, pero un admin de tenant no debe enumerar tenants (spec S5) — y el
-   * filtro de la tabla sigue sin tocar (design D15, sin segunda consulta ahí). */
-  useEffect(() => {
-    if (!esPlataforma) return
-
+   * filtro de la tabla sigue sin tocar (design D15, sin segunda consulta ahí).
+   *
+   * El fallo NO se traga (`react-async-state` regla 7): sin universo el `<select>` requerido
+   * quedaría vacío y el alta sería imposible sin decir por qué. Se rinde el error y abrir "Nuevo"
+   * reintenta, que es el único momento en que el universo hace falta. */
+  const cargarTenantsDePlataforma = useCallback(() => {
     const token = ++generacionTenants.current
     setTenantsDePlataformaCargando(true)
     clienteDeOrganizacion
@@ -124,18 +133,36 @@ export function Usuarios() {
       .then((lista) => {
         if (generacionTenants.current !== token) return
         setTenantsDePlataforma(lista)
+        setTenantsDePlataformaFallo(false)
       })
       .catch(() => {
         if (generacionTenants.current !== token) return
         setTenantsDePlataforma([])
+        setTenantsDePlataformaFallo(true)
+        setError(ERROR_TENANTS)
       })
       .finally(() => {
         if (generacionTenants.current === token) setTenantsDePlataformaCargando(false)
       })
-  }, [esPlataforma])
+  }, [])
+
+  useEffect(() => {
+    if (!esPlataforma) return
+
+    cargarTenantsDePlataforma()
+  }, [esPlataforma, cargarTenantsDePlataforma])
+
+  /** El alta de un actor de plataforma NO puede mandarse sin universo de tenants: el `<select>` es
+   * `required` pero mientras está `disabled` la validación HTML del formulario no lo mira, así que
+   * el POST saldría con `idTenant: null` y el servidor lo rechazaría con 400 `tenant_requerido`.
+   * Guardar queda inerte en esa ventana (`react-async-state` regla 5) y `guardar()` lo re-chequea,
+   * porque un doble click en el mismo tick le gana al atributo `disabled` (regla 9). */
+  const universoDeTenantsIndisponible =
+    esPlataforma && (tenantsDePlataformaCargando || tenantsDePlataformaFallo)
 
   async function guardar() {
     if (!formulario || ocupado) return
+    if (formulario.id === null && universoDeTenantsIndisponible) return
 
     const datos = formulario
     const token = ++generacion.current
@@ -164,10 +191,6 @@ export function Usuarios() {
           estado: datos.estado,
         }
         await api.put(`/usuarios/${datos.id}`, edicion)
-
-        if (datos.password) {
-          await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
-        }
         mensajeOk = `Usuario "${datos.usuario}" actualizado.`
       }
     } catch (e) {
@@ -179,22 +202,43 @@ export function Usuarios() {
     }
 
     if (generacion.current !== token) return
+
+    // El cambio de contraseña es una SEGUNDA escritura y lleva su propio try: el PUT de arriba ya
+    // commiteó, así que un fallo acá no puede reportarse como "no se pudo guardar"
+    // (`react-async-state` regla 6). Se avisa exactamente qué quedó hecho y qué no.
+    if (datos.id !== null && datos.password) {
+      try {
+        await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
+      } catch (e) {
+        if (generacion.current !== token) return
+        const detalle = e instanceof ErrorApi ? e.message : 'Reintentá el cambio de contraseña.'
+        mensajeOk = `Usuario "${datos.usuario}" actualizado, pero no se pudo cambiar la contraseña. ${detalle}`
+      }
+    }
+
     setFormulario(null)
     await refrescarTrasEscribir(token, mensajeOk)
   }
 
   /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
-   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). */
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). Refresca con el término
+   * REALMENTE aplicado, no con el borrador del input: tipear sin buscar y dar de baja una fila no
+   * puede angostar la tabla por un texto que el operador nunca aplicó.
+   *
+   * `ocupado` se apaga en el `finally` SIN mirar la generación, a diferencia del resto de las
+   * aplicaciones de estado: mientras hay una escritura en vuelo la pantalla bloquea todo lo que
+   * podría supersederla (regla 9), así que la bandera nunca puede ser la de una operación más
+   * nueva — y salir por el chequeo de generación la dejaría prendida para siempre. */
   async function refrescarTrasEscribir(token: number, mensajeOk: string) {
-    if (generacion.current !== token) return
-
-    setAviso(mensajeOk)
     try {
-      await cargar(token, busqueda, true)
+      if (generacion.current !== token) return
+
+      setAviso(mensajeOk)
+      await cargar(token, busquedaAplicada, true)
     } catch {
       if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
     } finally {
-      if (generacion.current === token) setOcupado(false)
+      setOcupado(false)
     }
   }
 
@@ -232,18 +276,12 @@ export function Usuarios() {
   // sigue rigiendo el FILTRO de la tabla (design D15) — solo el selector del ALTA cambia de fuente.
   const filas = pagina?.items ?? []
   const opcionesTenant = opcionesDeTenant(filas)
-  const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
+  const tenantVigente = seleccionVigente(opcionesTenant, filtroTenant)
   const visibles = filtrarPorTenant(filas, tenantVigente)
 
-  // El alta necesita un tenant REAL: la opción de personal de plataforma no es un id y el
-  // servidor la rechazaría para cualquier rol que no sea root. Para un actor de plataforma sale
-  // del universo completo pedido arriba (tarea 2.17, gap de tamaño de página); un admin de
-  // tenant nunca ve el selector, así que su rama solo necesita ser un valor válido, no el mejor.
-  const tenantsAsignables = esPlataforma
-    ? [...tenantsDePlataforma]
-        .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
-        .map((t) => ({ valor: String(t.id), etiqueta: t.nombre }))
-    : opcionesTenant.filter((o) => o.valor !== VALOR_SIN_TENANT)
+  // El selector del alta solo se rinde para un actor de plataforma (`ofreceTenant`), así que su
+  // única fuente es el universo pedido arriba.
+  const tenantsAsignables = opcionesDeTenantAsignable(tenantsDePlataforma)
 
   const herramientas = (
     <nav className="p-2 d-flex gap-2">
@@ -271,6 +309,8 @@ export function Usuarios() {
           setFormulario({ ...FORMULARIO_VACIO })
           setAviso('')
           setError('')
+          // Reintento del universo de tenants: abrir el alta es el único momento en que hace falta.
+          if (esPlataforma && tenantsDePlataformaFallo) cargarTenantsDePlataforma()
         }}
         disabled={ocupado}
       >
@@ -293,6 +333,7 @@ export function Usuarios() {
             tenants={tenantsAsignables}
             ofreceTenant={esPlataforma}
             tenantsCargando={esPlataforma ? tenantsDePlataformaCargando : cargando}
+            tenantIndisponible={universoDeTenantsIndisponible}
             guardando={ocupado}
             onCambio={setFormulario}
             onGuardar={guardar}
@@ -437,15 +478,16 @@ function EtiquetaEstado({ estado }: { estado: EstadoUsuario }) {
 /**
  * `tenants` es el conjunto de tenants ASIGNABLES, y solo se ofrece a un actor de plataforma
  * (`ofreceTenant`): un admin de tenant no enumera tenants — crea siempre dentro del suyo y el
- * servidor se lo impone (spec S5). Para un actor de plataforma sale del universo completo pedido
- * vía `clienteDeOrganizacion.listarTenants()` (tarea 2.17, gap de tamaño de página): las filas ya
- * cargadas de `Usuarios` solo cubren la página actual, así que un tenant sin usuario ahí quedaba
- * imposible de asignar.
+ * servidor se lo impone (spec S5).
  *
  * El selector espeja `PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance`, que sigue siendo la
  * autoridad: root SIEMPRE es de plataforma (tenant nulo) y cualquier otro rol SIEMPRE necesita
- * uno. Acá eso es guía — evita mandar una combinación que el servidor ya rechaza con 403 o con
- * 400 `tenant_requerido`, y si igual se manda, el 400 se rinde por el camino de error de siempre.
+ * uno. La rama de rol root es DEFENSA EN PROFUNDIDAD, no un camino vivo: `GET /roles`
+ * (`PoliticaDeRoles.RolesAsignablesPor`) no devuelve Root para NINGÚN actor, ni siquiera para un
+ * root, así que la opción no llega al `<select>` de rol y la combinación rol-root-con-tenant no es
+ * alcanzable desde esta pantalla. La rama existe por si el catálogo de roles cambiara. Lo que sí
+ * es camino vivo es el `required` del tenant para cualquier otro rol: sin él el servidor contesta
+ * 400 `tenant_requerido`, y ese error se rinde por el camino de siempre.
  */
 function FormularioUsuario({
   valor,
@@ -453,6 +495,7 @@ function FormularioUsuario({
   tenants,
   ofreceTenant,
   tenantsCargando,
+  tenantIndisponible,
   guardando,
   onCambio,
   onGuardar,
@@ -463,6 +506,7 @@ function FormularioUsuario({
   tenants: OpcionDeFiltro[]
   ofreceTenant: boolean
   tenantsCargando: boolean
+  tenantIndisponible: boolean
   guardando: boolean
   onCambio: (f: Formulario) => void
   onGuardar: () => void
@@ -470,6 +514,7 @@ function FormularioUsuario({
 }) {
   const esNuevo = valor.id === null
   const esRolDePlataforma = valor.rolId === ROL.Root
+  const sinTenantAsignable = esNuevo && ofreceTenant && tenantIndisponible
 
   return (
     <form
@@ -523,8 +568,7 @@ function FormularioUsuario({
           value={valor.rolId}
           onChange={(e) => {
             // El tenant se limpia en el ESTADO, no solo al pintarlo: el alta manda `idTenant` tal
-            // cual, así que un valor que quedara acá viajaría con un rol root y el servidor lo
-            // rechazaría con 403.
+            // cual. Defensa en profundidad — ver el doc-comment: `GET /roles` no ofrece Root.
             const rolId = Number(e.target.value)
             onCambio({ ...valor, rolId, idTenant: rolId === ROL.Root ? null : valor.idTenant })
           }}
@@ -549,7 +593,7 @@ function FormularioUsuario({
             onChange={(e) =>
               onCambio({ ...valor, idTenant: e.target.value === '' ? null : Number(e.target.value) })
             }
-            disabled={guardando || tenantsCargando || esRolDePlataforma}
+            disabled={guardando || tenantsCargando || esRolDePlataforma || sinTenantAsignable}
             required
           >
             <option value="">
@@ -557,7 +601,9 @@ function FormularioUsuario({
                 ? 'Sin tenant (plataforma)'
                 : tenantsCargando
                   ? 'Cargando…'
-                  : 'Elegí un tenant'}
+                  : sinTenantAsignable
+                    ? 'No se pudo cargar la lista'
+                    : 'Elegí un tenant'}
             </option>
             {tenants.map((t) => (
               <option key={t.valor} value={t.valor}>
@@ -602,7 +648,11 @@ function FormularioUsuario({
       </div>
 
       <div className="col-12 d-flex gap-2">
-        <button type="submit" className="btn btn-success rounded-0" disabled={guardando}>
+        <button
+          type="submit"
+          className="btn btn-success rounded-0"
+          disabled={guardando || sinTenantAsignable}
+        >
           {guardando ? 'Guardando…' : 'Guardar'}
         </button>
         <button

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, ErrorApi } from '../api/cliente'
-import { etiquetaDeTenant, filtrarPorTenant, opcionesDeTenant, SIN_FILTRO } from '../api/organizacion'
+import {
+  etiquetaDeTenant,
+  filtrarPorTenant,
+  opcionesDeTenant,
+  SIN_FILTRO,
+  VALOR_SIN_TENANT,
+} from '../api/organizacion'
+import type { OpcionDeFiltro } from '../api/organizacion'
 import { ESTADOS_USUARIO, ROL } from '../api/tipos'
 import type {
   ActualizarUsuario,
@@ -21,6 +28,9 @@ type Formulario = {
   rolId: number
   estado: EstadoUsuario
   password: string
+  /** Solo se manda en el alta: `ActualizarUsuario` no acepta tenant. `null` es a la vez el valor
+   * del rol root y el que manda un admin de tenant, a quien el servidor le impone el suyo. */
+  idTenant: number | null
 }
 
 const FORMULARIO_VACIO: Formulario = {
@@ -30,6 +40,7 @@ const FORMULARIO_VACIO: Formulario = {
   rolId: ROL.Vendedor,
   estado: 'Activo',
   password: '',
+  idTenant: null,
 }
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
@@ -103,6 +114,7 @@ export function Usuarios() {
           rolId: datos.rolId,
           password: datos.password,
           estado: datos.estado,
+          idTenant: datos.idTenant,
         }
         await api.post('/usuarios', alta)
         mensajeOk = `Usuario "${datos.usuario}" creado.`
@@ -174,6 +186,8 @@ export function Usuarios() {
     void accion(() => api.delete(`/usuarios/${u.id}`), `Usuario "${u.usuario}" dado de baja.`)
   }
 
+  const esPlataforma = actual?.rolId === ROL.Root
+
   // El backend valida igual; esto solo evita mostrar botones que van a fallar.
   const puedeEditar = (u: UsuarioListado) =>
     u.rolId !== ROL.Root || actual?.rolId === ROL.Root
@@ -183,6 +197,11 @@ export function Usuarios() {
   const opcionesTenant = opcionesDeTenant(filas)
   const tenantVigente = opcionesTenant.some((o) => o.valor === filtroTenant) ? filtroTenant : SIN_FILTRO
   const visibles = filtrarPorTenant(filas, tenantVigente)
+
+  // El alta necesita un tenant REAL: la opción de personal de plataforma no es un id y el
+  // servidor la rechazaría para cualquier rol que no sea root. Sale de las mismas filas ya
+  // cargadas que alimentan el filtro — sin una segunda consulta (design D15).
+  const tenantsAsignables = opcionesTenant.filter((o) => o.valor !== VALOR_SIN_TENANT)
 
   const herramientas = (
     <nav className="p-2 d-flex gap-2">
@@ -229,6 +248,9 @@ export function Usuarios() {
             key={formulario.id ?? 'nuevo'}
             valor={formulario}
             roles={roles}
+            tenants={tenantsAsignables}
+            ofreceTenant={esPlataforma}
+            tenantsCargando={cargando}
             guardando={ocupado}
             onCambio={setFormulario}
             onGuardar={guardar}
@@ -304,6 +326,7 @@ export function Usuarios() {
                                 rolId: u.rolId,
                                 estado: u.estado,
                                 password: '',
+                                idTenant: u.idTenant,
                               })
                               setAviso('')
                               setError('')
@@ -369,9 +392,22 @@ function EtiquetaEstado({ estado }: { estado: EstadoUsuario }) {
   return <span className={`badge rounded-0 ${clase}`}>{estado}</span>
 }
 
+/**
+ * `tenants` es el conjunto de tenants ASIGNABLES derivado de las filas ya cargadas, y solo se
+ * ofrece a un actor de plataforma (`ofreceTenant`): un admin de tenant no enumera tenants —
+ * crea siempre dentro del suyo y el servidor se lo impone (spec S5).
+ *
+ * El selector espeja `PoliticaDeRoles.ValidarConsistenciaDeRolYAlcance`, que sigue siendo la
+ * autoridad: root SIEMPRE es de plataforma (tenant nulo) y cualquier otro rol SIEMPRE necesita
+ * uno. Acá eso es guía — evita mandar una combinación que el servidor ya rechaza con 403 o con
+ * 400 `tenant_requerido`, y si igual se manda, el 400 se rinde por el camino de error de siempre.
+ */
 function FormularioUsuario({
   valor,
   roles,
+  tenants,
+  ofreceTenant,
+  tenantsCargando,
   guardando,
   onCambio,
   onGuardar,
@@ -379,12 +415,16 @@ function FormularioUsuario({
 }: {
   valor: Formulario
   roles: RolListado[]
+  tenants: OpcionDeFiltro[]
+  ofreceTenant: boolean
+  tenantsCargando: boolean
   guardando: boolean
   onCambio: (f: Formulario) => void
   onGuardar: () => void
   onCancelar: () => void
 }) {
   const esNuevo = valor.id === null
+  const esRolDePlataforma = valor.rolId === ROL.Root
 
   return (
     <form
@@ -436,7 +476,13 @@ function FormularioUsuario({
           id="f-rol"
           className="form-select rounded-0"
           value={valor.rolId}
-          onChange={(e) => onCambio({ ...valor, rolId: Number(e.target.value) })}
+          onChange={(e) => {
+            // El tenant se limpia en el ESTADO, no solo al pintarlo: el alta manda `idTenant` tal
+            // cual, así que un valor que quedara acá viajaría con un rol root y el servidor lo
+            // rechazaría con 403.
+            const rolId = Number(e.target.value)
+            onCambio({ ...valor, rolId, idTenant: rolId === ROL.Root ? null : valor.idTenant })
+          }}
         >
           {roles.map((r) => (
             <option key={r.id} value={r.id}>
@@ -445,6 +491,37 @@ function FormularioUsuario({
           ))}
         </select>
       </div>
+
+      {esNuevo && ofreceTenant && (
+        <div className="col-md-3">
+          <label className="form-label" htmlFor="f-tenant">
+            Tenant de la cuenta
+          </label>
+          <select
+            id="f-tenant"
+            className="form-select rounded-0"
+            value={valor.idTenant === null ? '' : String(valor.idTenant)}
+            onChange={(e) =>
+              onCambio({ ...valor, idTenant: e.target.value === '' ? null : Number(e.target.value) })
+            }
+            disabled={guardando || tenantsCargando || esRolDePlataforma}
+            required
+          >
+            <option value="">
+              {esRolDePlataforma
+                ? 'Sin tenant (plataforma)'
+                : tenantsCargando
+                  ? 'Cargando…'
+                  : 'Elegí un tenant'}
+            </option>
+            {tenants.map((t) => (
+              <option key={t.valor} value={t.valor}>
+                {t.etiqueta}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div className="col-md-2">
         <label className="form-label" htmlFor="f-estado">

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -51,13 +51,16 @@ const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista.
 const ERROR_TENANTS =
   'No se pudo cargar la lista de tenants: no se pueden crear usuarios hasta que llegue. Abrí "Nuevo" para reintentar.'
 
+const ERROR_ALTA_SIN_TENANTS = 'No se puede crear el usuario: todavía falta la lista de tenants.'
+
 /**
  * ABM de usuarios. La columna "Tenant" rinde el nombre del tenant de la cuenta o el literal
  * "Plataforma" cuando `idTenant` es null — esa copia la pone la web, nunca el servidor
  * (design D14), y el discriminador es `idTenant`, no el nombre: un `nombreTenant` nulo con
  * `idTenant` presente es un huérfano (tenant dado de baja), no personal de plataforma
- * (Reconciliación 9). El filtro por tenant deriva sus opciones de las filas ya cargadas, así
- * que un admin de tenant nunca puede enumerar el nombre de otro tenant (spec S5).
+ * (Reconciliación 9). La columna y el filtro por tenant se rinden con el MISMO criterio que en
+ * `Empresas`/`PuntosVenta`: solo para un actor de plataforma. Un admin de tenant ve una sola
+ * opción —la suya— y filtrar por ella no angosta nada (spec S5).
  */
 export function Usuarios() {
   const { usuario: actual } = useAuth()
@@ -70,6 +73,10 @@ export function Usuarios() {
   const [busquedaAplicada, setBusquedaAplicada] = useState('')
   const [cargando, setCargando] = useState(true)
   const [error, setError] = useState('')
+  /** Slot PROPIO del fallo de la segunda escritura del alta/edición (el POST de contraseña). No
+   * puede viajar en `aviso` —el PUT sí commiteó, pero esto es un fallo y va en rojo— ni en `error`
+   * —el refresco post-escritura lo limpia al terminar bien. */
+  const [errorPassword, setErrorPassword] = useState('')
   const [aviso, setAviso] = useState('')
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState(false)
@@ -124,7 +131,12 @@ export function Usuarios() {
    *
    * El fallo NO se traga (`react-async-state` regla 7): sin universo el `<select>` requerido
    * quedaría vacío y el alta sería imposible sin decir por qué. Se rinde el error y abrir "Nuevo"
-   * reintenta, que es el único momento en que el universo hace falta. */
+   * reintenta, que es el único momento en que el universo hace falta.
+   *
+   * Ese fallo tiene BANNER PROPIO, derivado de `tenantsDePlataformaFallo`, y no pasa por `error`:
+   * son dos fuentes independientes y el slot compartido las pisaba en los dos sentidos — un
+   * `setError('')` de la tabla borraba este aviso con el universo todavía caído, y este aviso
+   * tapaba un fallo real del listado de usuarios. Un reintento exitoso lo apaga. */
   const cargarTenantsDePlataforma = useCallback(() => {
     const token = ++generacionTenants.current
     setTenantsDePlataformaCargando(true)
@@ -139,7 +151,6 @@ export function Usuarios() {
         if (generacionTenants.current !== token) return
         setTenantsDePlataforma([])
         setTenantsDePlataformaFallo(true)
-        setError(ERROR_TENANTS)
       })
       .finally(() => {
         if (generacionTenants.current === token) setTenantsDePlataformaCargando(false)
@@ -162,12 +173,17 @@ export function Usuarios() {
 
   async function guardar() {
     if (!formulario || ocupado) return
-    if (formulario.id === null && universoDeTenantsIndisponible) return
+    if (formulario.id === null && universoDeTenantsIndisponible) {
+      setError(ERROR_ALTA_SIN_TENANTS)
+
+      return
+    }
 
     const datos = formulario
     const token = ++generacion.current
     setOcupado(true)
     setError('')
+    setErrorPassword('')
     setAviso('')
 
     let mensajeOk: string
@@ -205,14 +221,16 @@ export function Usuarios() {
 
     // El cambio de contraseña es una SEGUNDA escritura y lleva su propio try: el PUT de arriba ya
     // commiteó, así que un fallo acá no puede reportarse como "no se pudo guardar"
-    // (`react-async-state` regla 6). Se avisa exactamente qué quedó hecho y qué no.
+    // (`react-async-state` regla 6). Las dos mitades se rinden POR SEPARADO y a la vez: la
+    // confirmación del PUT commiteado en el aviso verde, el fallo de la contraseña en rojo. Meter
+    // el fallo en el aviso verde lo anunciaba como parte de un éxito.
     if (datos.id !== null && datos.password) {
       try {
         await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
       } catch (e) {
         if (generacion.current !== token) return
         const detalle = e instanceof ErrorApi ? e.message : 'Reintentá el cambio de contraseña.'
-        mensajeOk = `Usuario "${datos.usuario}" actualizado, pero no se pudo cambiar la contraseña. ${detalle}`
+        setErrorPassword(`Se guardó el perfil, pero no se pudo cambiar la contraseña. ${detalle}`)
       }
     }
 
@@ -248,6 +266,7 @@ export function Usuarios() {
     const token = ++generacion.current
     setOcupado(true)
     setError('')
+    setErrorPassword('')
     setAviso('')
     try {
       await construirPromesa()
@@ -309,8 +328,13 @@ export function Usuarios() {
           setFormulario({ ...FORMULARIO_VACIO })
           setAviso('')
           setError('')
+          setErrorPassword('')
           // Reintento del universo de tenants: abrir el alta es el único momento en que hace falta.
-          if (esPlataforma && tenantsDePlataformaFallo) cargarTenantsDePlataforma()
+          // `!tenantsDePlataformaCargando` evita que reabrir "Nuevo" con el reintento EN VUELO
+          // dispare un segundo `GET /plataforma/tenants` por click.
+          if (esPlataforma && tenantsDePlataformaFallo && !tenantsDePlataformaCargando) {
+            cargarTenantsDePlataforma()
+          }
         }}
         disabled={ocupado}
       >
@@ -323,6 +347,10 @@ export function Usuarios() {
     <div className="container-fluid py-4">
       <Box titulo="Usuarios" variante="inverse" herramientas={herramientas}>
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
+        {tenantsDePlataformaFallo && (
+          <div className="alert alert-danger rounded-0">{ERROR_TENANTS}</div>
+        )}
+        {errorPassword && <div className="alert alert-danger rounded-0">{errorPassword}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
 
         {formulario && (
@@ -345,26 +373,32 @@ export function Usuarios() {
           <Cargando />
         ) : (
           <>
-            <div className="row g-2 mb-3">
-              <div className="col-md-4">
-                <label className="form-label" htmlFor="u-filtro-tenant">
-                  Tenant
-                </label>
-                <select
-                  id="u-filtro-tenant"
-                  className="form-select rounded-0"
-                  value={tenantVigente}
-                  onChange={(e) => setFiltroTenant(e.target.value)}
-                >
-                  <option value={SIN_FILTRO}>Todos</option>
-                  {opcionesTenant.map((o) => (
-                    <option key={o.valor} value={o.valor}>
-                      {o.etiqueta}
-                    </option>
-                  ))}
-                </select>
+            {/* El filtro por tenant se rinde con el mismo criterio que la COLUMNA de tenant: solo
+                para un actor de plataforma. Para un admin de tenant TODAS las filas son de su
+                propio tenant, así que la columna repite el mismo nombre y el filtro no angosta
+                nada — misma paridad que `Empresas.tsx` y `PuntosVenta.tsx`. */}
+            {esPlataforma && (
+              <div className="row g-2 mb-3">
+                <div className="col-md-4">
+                  <label className="form-label" htmlFor="u-filtro-tenant">
+                    Tenant
+                  </label>
+                  <select
+                    id="u-filtro-tenant"
+                    className="form-select rounded-0"
+                    value={tenantVigente}
+                    onChange={(e) => setFiltroTenant(e.target.value)}
+                  >
+                    <option value={SIN_FILTRO}>Todos</option>
+                    {opcionesTenant.map((o) => (
+                      <option key={o.valor} value={o.valor}>
+                        {o.etiqueta}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="table-responsive">
               <table className="table table-striped table-hover table-bordered align-middle">
@@ -373,7 +407,7 @@ export function Usuarios() {
                     <th>ID</th>
                     <th>Usuario</th>
                     <th>Mail</th>
-                    <th>Tenant</th>
+                    {esPlataforma && <th>Tenant</th>}
                     <th>Rol</th>
                     <th>Estado</th>
                     <th>Última conexión</th>
@@ -386,7 +420,7 @@ export function Usuarios() {
                       <td>{String(u.id).padStart(4, '0')}</td>
                       <td>{u.usuario}</td>
                       <td>{u.mail}</td>
-                      <td>{etiquetaDeTenant(u)}</td>
+                      {esPlataforma && <td>{etiquetaDeTenant(u)}</td>}
                       <td>{u.rol}</td>
                       <td>
                         <EtiquetaEstado estado={u.estado} />
@@ -413,6 +447,7 @@ export function Usuarios() {
                               })
                               setAviso('')
                               setError('')
+                              setErrorPassword('')
                             }}
                             disabled={ocupado}
                           >
@@ -449,7 +484,7 @@ export function Usuarios() {
                   ))}
                   {visibles.length === 0 && (
                     <tr>
-                      <td colSpan={8} className="text-center text-muted py-4">
+                      <td colSpan={esPlataforma ? 8 : 7} className="text-center text-muted py-4">
                         No hay usuarios que coincidan con la búsqueda.
                       </td>
                     </tr>

--- a/src/Ways.Web/src/paginas/Vencimientos.test.tsx
+++ b/src/Ways.Web/src/paginas/Vencimientos.test.tsx
@@ -59,6 +59,8 @@ const puntoVentaCentro: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 const puntoVentaNorte: PuntoVentaListado = {
@@ -72,6 +74,8 @@ const puntoVentaNorte: PuntoVentaListado = {
   instagram: null,
   facebook: null,
   web: null,
+  nombreTenant: 'Tenant Demo',
+  razonSocialEmpresa: 'Empresa Demo',
 }
 
 function filaFixture(sobrescribir: Partial<FilaDeVencimiento> = {}): FilaDeVencimiento {


### PR DESCRIPTION
Closes #166

## Resumen

Slice 2 de 5 de la etapa 20. Las cuatro pantallas del ABM raiz dejan de mostrar ids crudos y pasan a mostrar a que pertenece cada cosa.

- Empresas y Puntos de venta muestran el nombre del tenant (y de la empresa) en vez del entero.
- Usuarios gana la columna de tenant; Tenants gana los contadores de empresas, puntos de venta y usuarios.
- Filtros por tenant en las tres pantallas y por empresa en Puntos de venta. Las opciones se derivan de las filas que el actor ya ve: un admin de tenant nunca enumera otros tenants.
- **Bug reportado por el dueno y arreglado en este mismo slice**: el alta de usuario no tenia selector de tenant, asi que desde plataforma era imposible crear el admin de un tenant. Ahora aparece "Tenant de la cuenta" solo para actor de plataforma, alimentado por `GET /plataforma/tenants`, obligatorio para roles no-root y deshabilitado para root.
- Retrofit `react-async-state` en las cuatro pantallas: generacion por token y ventana deshabilitada completa durante cargas y escrituras.

Solo web. Cero backend, cero esquema.

## Decisiones que cargan peso

**La web pone "Plataforma"; el servidor jamas lo fabrica.** Y un huerfano (tenant dado de baja) NO es personal de plataforma: son dos casos y se rinden distinto. La clave del filtro es un token que ninguna serializacion de id puede producir, asi que un tenant que se llame literalmente "Plataforma" sigue siendo distinguible.

**Un slot de estado, un dueno.** El arreglo del selector paso por dos rondas porque el fetch de tenants compartia el slot de `error` con el listado y se pisaban. Ahora cada fuente de error tiene su propio estado renderizado.

**Homonimos desempatados por id.** Dos tenants con el mismo nombre libre reciben sufijo con su id; los tenants suspendidos se ofrecen igual (el servidor es la autoridad) pero con marca visible, porque no existe regla del servidor que impida crear una cuenta dentro de un tenant suspendido.

## Judgment-day: APROBADO en ronda limpia

Dos rondas de correccion y dos re-judgments acotadas, ambos jueces ciegos en paralelo.

- **Ronda 0** — 1 CRITICO confirmado por ambos: el fetch de tenants tragaba su fallo a lista vacia; un actor de plataforma quedaba con un select `required` vacio, sin mensaje ni reintento — la misma clase de bug que el arreglo vino a resolver, con menos diagnostico que el 400 original. Mas 3 confirmados y 8 de un solo juez.
- **Ronda 1** — el critico cerrado y verificado por ambos; 3 defectos introducidos por el fix (slot de error compartido, falla de contrasena en alert verde, replica parcial del `finally`).
- **Ronda 2** — todo cerrado. Los cuatro residuos son inalcanzables hoy y van como entrada vinculante del slice 5, que agrega los botones de baja que los vuelven alcanzables.

## Evidencia de mutacion

38 mutaciones ejecutadas de verdad (M1-M38b). 32 muertas con su mensaje real; **6 sobrevivientes registradas como tales**, no disfrazadas: guards de generacion en pantallas donde ninguna segunda operacion puede arrancar, y re-chequeos que `userEvent` no puede alcanzar porque honra `disabled`. Una mutacion (M15) falsifico el propio doc-comment del test y se corrigio el comentario.

## Tamano: 2600 lineas contra un presupuesto de 800

Excepcion autorizada por el dueno. Produccion ~1100, evidencia ~1500. El corte pre-aprobado (nombres vs filtros) dejo de ser limpio porque ambos viven en las mismas cuatro pantallas.

## Suites

```
npm run test    63 archivos / 1021 tests
npm run build   tsc + vite limpio
npm run lint    exit 0 (5 warnings preexistentes)
dotnet build    0 errores; cero archivos backend en el diff
```

Flake preexistente anotada: `Reposicion.test.tsx` falla 1 de 4 corridas tambien en `main`, 12/12 sola.
