### PR TITLE
feat(web): baja de tenants, empresas, puntos de venta y usuarios desde la UI raiz (slice 5 de etapa 20)

### DIFF
--- a/docs/09-multi-tenancy.md
+++ b/docs/09-multi-tenancy.md
@@ -212,3 +212,58 @@ Impacto sobre el doc 08 (ya implementado):
 
 Todo el schema posterior (doc 03) nace con su categoría de scoping ya decidida según la
 tabla de este documento.
+
+## Baja lógica de la organización (Etapa 20 — stage-20-organizacion-relaciones-y-bajas)
+
+La jerarquía tenant → empresa → punto de venta ya se podía crear (aprovisionamiento, ADR-16)
+y editar; desde esta etapa también se puede **dar de baja**, con una única semántica:
+
+- **La baja es SIEMPRE lógica, nunca física.** Se sella `deleted_at` (y, para un tenant,
+  además `EstadoTenant.Baja`); ninguna fila se borra de la base. Todas las FK del modelo son
+  `DeleteBehavior.Restrict`, así que no hay ni un `DELETE FROM` sobre `tenants`, `empresas`,
+  `puntos_venta` ni `usuarios`. Recuperar una baja hecha por error es un `UPDATE` de una
+  columna.
+- **El discriminador "prístino" es una comparación estricta contra el `CreatedAt` de la propia
+  entidad.** Lo que el aprovisionamiento sembró en el mismo instante que la entidad no cuenta
+  como uso; cuenta lo que el cliente creó DESPUÉS de esa marca. Un dependiente que el cliente
+  creó y después dio de baja **sigue bloqueando**: la baja de una fila no borra que hubo
+  operación.
+- **El conjunto de dependientes se descubre de la metadata de EF, nunca de una lista a mano.**
+  Cada tipo que referencia a la entidad cae en exactamente uno de tres buckets (directo,
+  puenteado, ignorado) o el build falla, y hay un inventario ordenado versionado como golden:
+  una tabla nueva que nadie clasifique rompe un test, no la producción. Hay exactamente **dos
+  carve-outs**, cada uno con su motivo escrito y su propio test.
+- **Una fila de catálogo compartido (dueño `NULL`) no bloquea**, en coherencia con la regla de
+  `id_empresa NULL` de este documento.
+- **La cascada está acotada a la proyección de organización y comparte un solo instante.** Dar
+  de baja un tenant da de baja, con el mismo timestamp y dentro de la misma transacción, sus
+  empresas, sus puntos de venta y sus usuarios; dar de baja una empresa arrastra sus puntos de
+  venta. La cascada no toca datos operativos (ventas, stock, caja): esos son justamente los que
+  BLOQUEAN la baja.
+- **Los mínimos estructurales se chequean ANTES del guard de uso**, con códigos propios: un
+  tenant no puede quedarse sin ninguna empresa viva, y una empresa no puede quedarse sin
+  ningún punto de venta vivo. Los hermanos ya dados de baja no cuentan como vivos.
+- **El set completo de rechazos es de seis códigos**: `tenant_en_uso`, `empresa_en_uso`,
+  `punto_venta_en_uso`, `usuario_en_uso`, `ultima_empresa_del_tenant` y
+  `ultimo_punto_venta_de_la_empresa`. Los seis viajan como `409` con su `codigo` exacto; la web
+  elige su copia por el **código**, nunca por el mensaje.
+- **La baja nunca se convierte en un oráculo de existencia entre tenants.** Un admin que apunta
+  a una entidad de otro tenant recibe `404`, idéntico al de un id inexistente — nunca `403` ni
+  un `409` que delate el estado de la fila. Es la misma conducta deliberada de
+  `PoliticaDeRoles.ValidarAlcanceDeTenant` (ADR-8), y la web la respeta en su copia.
+- **Autorización sin policies nuevas**: cada `DELETE` reusa la policy del grupo de rutas al que
+  ya pertenece — `SoloPlataforma` para tenants, `GestionDeOrganizacion` para empresas y puntos
+  de venta. `Politicas.cs` no se tocó.
+- Un admin de un tenant dado de baja **no puede iniciar sesión**: la búsqueda del login corre
+  bajo el query filter de baja lógica, así que la cuenta simplemente no existe y la respuesta es
+  `401 credenciales_invalidas` (no `403 tenant_suspendido`, que sigue siendo la respuesta del
+  tenant **suspendido**).
+
+**Latencia registrada.** Ways no expone hoy ninguna ruta que cree una *segunda* empresa o un
+*segundo* punto de venta, así que a través de la API el mínimo estructural dispara siempre y
+`empresa_en_uso` / `punto_venta_en_uso` solo son alcanzables por debajo de la capa HTTP. La baja
+de empresa y de punto de venta ships **latente**: correcta y probada, y utilizable en cuanto
+exista un alta que permita un segundo hermano.
+
+**Cero DDL.** Esta etapa no crea, altera ni borra ninguna tabla ni columna: `deleted_at` y
+`estado` ya existían desde la etapa 1.

--- a/docs/10-modelo-de-datos.md
+++ b/docs/10-modelo-de-datos.md
@@ -1250,3 +1250,34 @@ etapa; los datos del legacy entran en la etapa 5 (ventas históricas → `items_
 > con la misma forma que el de clientes. El backfill de la migración de Etapa 15 reproduce esta
 > fórmula exacta como el saldo inicial de cada proveedor, así que la lectura no cambia en el
 > momento de la migración — solo su mecanismo, de una agregación en caliente a un libro auditable.
+
+> **Etapa 20 (stage-20-organizacion-relaciones-y-bajas) — baja lógica guardada por uso, CERO
+> DDL.** Esta etapa **no agrega, altera ni borra ninguna tabla ni columna**: la última migración
+> sigue siendo la de la etapa 19a. Usa lo que ya estaba — `deleted_at` en todas las entidades y
+> `estado` en `tenants` — para habilitar la baja de tenant, empresa, punto de venta y usuario:
+>
+> - **Nunca hay borrado físico.** Toda FK del modelo es `Restrict` y la baja es un `UPDATE` de
+>   `deleted_at`; no existe un `DELETE FROM` sobre `tenants`, `empresas`, `puntos_venta` ni
+>   `usuarios`. Deshacer una baja hecha por error es un `UPDATE` de una columna.
+> - **"En uso" = lo que el cliente creó después de la línea base de aprovisionamiento**, medido
+>   con una comparación estricta contra el `created_at` de la propia entidad. Un dependiente ya
+>   dado de baja **sigue bloqueando**: la baja de la fila no borra que hubo operación.
+> - **El conjunto de dependientes sale de la metadata de EF, no de una lista a mano.** Cada tipo
+>   que referencia a la entidad se clasifica en directo / puenteado / ignorado, hay un
+>   inventario ordenado versionado como golden, y una tabla nueva sin clasificar rompe un test
+>   antes de llegar a producción. Toda tabla que este documento agregue en adelante entra por
+>   ese inventario.
+> - **Una fila de catálogo compartido (`id_empresa`/dueño `NULL`) no bloquea**, en coherencia con
+>   la regla de catálogo compartido de §1 y del doc 09.
+> - **La cascada está acotada a la organización y comparte un instante**: tenant → sus empresas,
+>   sus puntos de venta y sus usuarios; empresa → sus puntos de venta. Los datos operativos
+>   (ventas, compras, stock, caja, cuenta corriente) **no se cascadean**: son los que bloquean.
+> - **Mínimos estructurales antes del guard de uso**: un tenant conserva al menos una empresa
+>   viva (`ultima_empresa_del_tenant`) y una empresa al menos un punto de venta vivo
+>   (`ultimo_punto_venta_de_la_empresa`). Los hermanos ya dados de baja no cuentan como vivos.
+> - **Seis códigos `409` en total**: `tenant_en_uso`, `empresa_en_uso`, `punto_venta_en_uso`,
+>   `usuario_en_uso` y los dos mínimos de arriba. Fuera de alcance de tenant la respuesta es
+>   `404`, nunca un `409` que delate el estado de la fila.
+>
+> La baja de **empresa** y de **punto de venta** queda **latente** hasta que exista un alta que
+> cree un segundo hermano: hoy el mínimo estructural dispara primero en todo intento vía API.

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -1163,9 +1163,25 @@ phases:
       SIX other screens keep theirs and are RECORDED as out of scope (Articulos,
       Clientes, Categorias, Ofertas, PaginaCatalogo, Proveedores). ACCESSIBILITY of
       the modal claim: aria-modal, focus to Cancelar on open, focus restored to the
-      trigger on close, Escape = Cancelar and inert while the write is outstanding;
-      no focus trap is needed BECAUSE of C1, since a disabled control is not
-      tabbable. TWENTY MUTATIONS RUN FOR REAL in this round (table in tasks.md):
+      trigger on close, Escape = Cancelar and inert while the write is outstanding.
+      CORRECTED IN ROUND 2 - this paragraph originally claimed that no focus trap
+      was needed BECAUSE of C1, since every other control is disabled and a disabled
+      control is not tabbable. That was FALSE on Usuarios, whose five form fields
+      (f-usuario, f-mail, f-rol, f-estado, f-password) carried no disabled at all,
+      not even during guardando, while bloqueado was applied to the tenant select
+      and to both buttons of the same form; the three sibling screens disabled every
+      field, so it was a rule-10 parity break with five live counterexamples. The
+      claim is TRUE ONLY AFTER R2-1, which adds disabled={bloqueado} to the five.
+      The focus-restore half was true only in jsdom: round 1 captured the trigger
+      with document.activeElement inside a passive useEffect, which runs AFTER the
+      commit that disabled it, so a real browser had already applied the focus-fixup
+      rule and moved focus to body - the ref captured body and restoring it was a
+      no-op. R2-2 captures the trigger SYNCHRONOUSLY in the click handler
+      (event.currentTarget, before any setState) and passes it as the disparador
+      prop, which is why focus restore now works in browsers, with a landmark
+      fallback (Box heading, else the table) when the row is gone. The SIX
+      out-of-scope confirm() screens listed above are unchanged. TWENTY MUTATIONS
+      RUN FOR REAL in round 1 (table in tasks.md):
       EIGHTEEN KILLED with their exact failing test names, TWO HONEST SURVIVORS
       (MS1' and MS3') that now survive for a TRUE construction reason - nothing can
       bump the generation between a write's own mint and its refresh, because the
@@ -1174,6 +1190,63 @@ phases:
       65 files / 1097 tests green in one run, npm run build clean, npm run lint exit
       0 with the same five pre-existing react-refresh warnings. git diff main
       --name-only outside src/Ways.Web/, docs/ and openspec/ is EMPTY.
+      JUDGMENT-DAY ROUND 2 APPLIED (task 5.11, FINAL correction round, no third
+      round, branch feat/stage20-slice5-bajas-web, web only). NO CRITICAL. Five
+      confirmed findings plus one records entry, all fixed. R2-1 WARNING (both) -
+      Usuarios' five form fields escaped the modal gate: f-usuario, f-mail, f-rol,
+      f-estado and f-password carried no disabled, not even during guardando, while
+      bloqueado governed the tenant select and both buttons of the same form. The
+      three sibling screens disable every field, so this was a react-async-state
+      rule-10 parity break and it falsified round 1's 'every other control is
+      disabled' claim. Fixed with disabled={bloqueado} on all five; the gate test
+      asserts the five by label with a message naming the offending field. R2-2
+      WARNING (both, inferential) - focus restore was a no-op in real browsers:
+      ConfirmacionDeBaja captured document.activeElement in a passive useEffect,
+      which runs after the commit that disabled the trigger, and a browser has
+      already applied the focus-fixup rule by then, so the ref captured body. jsdom
+      does not implement the fixup, so the round-1 test passed falsely. The trigger
+      is now captured SYNCHRONOUSLY in the click handler (event.currentTarget,
+      before any setState) on all four screens, held in disparadorDeLaPuerta and
+      passed as the disparador prop; on close the panel restores focus to that
+      element when it is still connected and operable, and otherwise falls back to a
+      stable landmark (the Box heading, else the table) with a one-time tabindex
+      -1. R2-3 SUGGESTION (both) - errorAlta was cleared by pedirBaja and
+      cancelarBaja, contradicting its own documented contract as a LIVE precondition
+      of the open form that unrelated actions must not clear (which is why buscar()
+      already respected it); both setErrorAlta('') calls removed, the asymmetry
+      documented at both call sites. R2-4 SUGGESTION (A) - the Nuevo tenant Link was
+      neutralized by CSS only: Bootstrap's disabled class kills pointer-events and
+      tabIndex -1 removes it from the tab order, but neither cancels an activation
+      that bypasses hit-testing, so the gate could be abandoned by navigating away
+      with the DELETE undecided; an onClick guard now calls preventDefault while
+      bloqueado, and the test measures the NAVIGATION through a route probe inside
+      the MemoryRouter, not the attribute. R2-5 SUGGESTION (A), pre-existing - the
+      edit form survived the deletion of the entity being edited, offering a PUT
+      against a deleted id; after a 204 all four screens now clear it with
+      setEdicion/setFormulario((prev) => (prev?.id === fila.id ? null : prev)), built
+      from prev and id-compared so deleting another row does not close an edit in
+      progress. R2-6 records (both) - the false accessibility paragraph in
+      tasks.md:1901,1910-1913 and in this file at 1164-1168 is rewritten in place:
+      it now says the claim became true BECAUSE of R2-1, names R2-2 as the reason
+      focus restore works in browsers, and records the jsdom caveat; the six
+      out-of-scope confirm() screens stay listed. SEVEN MUTATIONS RUN FOR REAL in
+      this round (table in tasks.md): SEVEN KILLED, ZERO SURVIVORS, zero discarded
+      mutants - MR2-1 (drop disabled on f-mail), MR2-2 (capture in the passive
+      effect again), MR2-2b (drop the landmark fallback), MR2-3a and MR2-3b (put
+      setErrorAlta back in cancelarBaja and in pedirBaja, mutated separately), MR2-4
+      (drop the Link preventDefault) and MR2-5 (drop the edit-form clear), each with
+      its exact failing test and message. ENVIRONMENT FACT RECORDED RATHER THAN
+      HIDDEN - jsdom cannot reproduce the focus-fixup rule natively: once a button
+      is disabled, jsdom treats element.blur() and document.body.focus() as no-ops
+      on a non-focusable area, so document.activeElement stays pinned to the trigger,
+      which is exactly why the round-1 defect shipped green. The R2-2 test therefore
+      brings the blur one tick forward, into the onClick while the button is still
+      enabled; the mechanism differs from a browser's, the observable state the test
+      depends on is identical (focus on body when the gate's mount effect runs), and
+      MR2-2 proves the test discriminates. SUITES AFTER THE ROUND - npm --prefix
+      src/Ways.Web run test 65 files / 1102 tests green, run build clean, run lint
+      exit 0 with the same five pre-existing react-refresh warnings and no new ones.
+      git diff main --name-only outside src/Ways.Web/, docs/ and openspec/ is EMPTY.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -1087,14 +1087,18 @@ phases:
       the same PR. This is exactly the M35/M21b survivor slice 2 recorded as
       unreachable: the delete buttons made it reachable and it now has a real kill.
       THIRTEEN MUTATIONS RUN FOR REAL (MS1-MS12 plus MS7b, table in tasks.md): ten
-      killed with their exact failing test names, TWO HONEST SURVIVORS recorded as
-      survivors and not dressed up (MS1 the post-write generation check and MS3 the
-      ungated finally - both the 'unreachable while rule 9 holds' class carried from
-      slice 2, and the honest result of RUNNING them is that the delete buttons did
-      NOT make them reachable, because the gate is itself disabled during an
-      outstanding write), and ONE DISCARDED as a badly-formed mutant (MS7 was a
-      no-op: confirmarBaja reads baja from the render closure; replaced by MS7b,
-      which kills). THE FOUR CARRY-FORWARD ITEMS OF SLICE 2 ARE CLOSED - (1) the
+      killed with their exact failing test names, TWO SURVIVORS (MS1 and MS3) AND
+      ONE DISCARDED badly-formed mutant (MS7, a no-op: confirmarBaja reads baja from
+      the render closure; replaced by MS7b, which kills). CORRECTION FROM
+      JUDGMENT-DAY ROUND 1 - the MS1 and MS3 survivor RECORDS WERE FALSE. They
+      claimed the mutants were unreachable 'because the gate is itself disabled
+      during an outstanding write'. The gate was never disabled by anything:
+      ConfirmacionDeBaja rendered outside every disabled, so the reachable window was
+      the gate being OPEN, not a write being in flight, and in that window Guardar,
+      Suspender, Reactivar, Buscar and Editar were all live generation bumpers. MS1's
+      clause was the defect rather than a guard, and under MS3's mutant a superseded
+      gate latched ocupadoRef forever. Both rows are corrected in tasks.md and both
+      mutations were re-run after the round-1 fix. THE FOUR CARRY-FORWARD ITEMS OF SLICE 2 ARE CLOSED - (1) the
       generation-mismatch returns inside the write paths no longer latch ocupado:
       every write of the four screens now has ONE ungated finally covering all its
       exits, and refrescarTrasEscribir stopped owning the flag; (2)
@@ -1128,6 +1132,48 @@ phases:
       schema, as the constraint intends. DELIVERY REPORT OWED TO THE OWNER (OD5,
       task 5.12) is in the apply return envelope: empresa and punto de venta
       deletion ships LATENT, plus the two deferred items R1 and T6.
+      JUDGMENT-DAY ROUND 1 APPLIED (task 5.11, first correction round, branch
+      feat/stage20-slice5-bajas-web, web only). ROOT CAUSE CONFIRMED BY BOTH JUDGES
+      AND FIXED: the confirmation gate was not modal and the write token was minted
+      at gate-OPEN. Eight confirmed findings, all eight fixed. C1 CRITICAL - a
+      superseded gate still fired the DELETE and then discarded BOTH outcomes: with
+      the gate open on row B, any still-enabled bumper turned ocupado back to null,
+      the gate re-enabled with a stale token, Confirm sent the DELETE unconditionally
+      and the post-network generation check swallowed the 204 AND the 409, leaving
+      the row listed, the gate open, and every further click repeating a silent
+      DELETE. Fixed on all four screens with one derived bloqueado = ocupado || gate
+      open driving EVERY disabled (table actions, edit form, search, filters, Nuevo;
+      the Nuevo tenant Link gets aria-disabled + tabIndex -1), and with the token
+      minted at CONFIRM as the first synchronous statement after the ocupadoRef
+      guard - a 204 ALWAYS closes and refreshes, a 4xx ALWAYS renders, and the
+      generation now governs only the REFRESH. C2 CRITICAL - Usuarios.cancelarBaja
+      bumped the generation and stranded an in-flight cargar on 'Cargando...'
+      forever; cancelling supersedes nothing, so it no longer bumps on any of the
+      four screens, and the false Tenants comment is corrected. C3 - the MS1/MS3
+      records rewritten and both re-run. C4 - cancel now clears error/aviso on all
+      four screens. C5 - the arrastre preamble is subject-neutral and Empresas
+      phrases its uncounted line honestly ('Sus puntos de venta activos'), because
+      EmpresaListado carries no PV count. C6 - GUIA_POR_CODIGO is a Map, so a
+      server-sent codigo of constructor/toString/__proto__ can no longer resolve
+      against the prototype. C7 - task 5.1's reference to a non-existent
+      src/Ways.Web/src/api/usuarios.ts and a stale test doc-comment corrected. C8 -
+      Tenants' Suspender/Reactivar routed through the same gate (the panel was
+      generalized with pregunta/nota/etiqueta props, defaults unchanged), which
+      removes the native confirm() from the very file that introduced the gate; the
+      SIX other screens keep theirs and are RECORDED as out of scope (Articulos,
+      Clientes, Categorias, Ofertas, PaginaCatalogo, Proveedores). ACCESSIBILITY of
+      the modal claim: aria-modal, focus to Cancelar on open, focus restored to the
+      trigger on close, Escape = Cancelar and inert while the write is outstanding;
+      no focus trap is needed BECAUSE of C1, since a disabled control is not
+      tabbable. TWENTY MUTATIONS RUN FOR REAL in this round (table in tasks.md):
+      EIGHTEEN KILLED with their exact failing test names, TWO HONEST SURVIVORS
+      (MS1' and MS3') that now survive for a TRUE construction reason - nothing can
+      bump the generation between a write's own mint and its refresh, because the
+      full-window block covers every button and every remaining bumper is also
+      guarded by the synchronous ocupadoRef. SUITES AFTER THE ROUND - npm run test
+      65 files / 1097 tests green in one run, npm run build clean, npm run lint exit
+      0 with the same five pre-existing react-refresh warnings. git diff main
+      --name-only outside src/Ways.Web/, docs/ and openspec/ is EMPTY.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -1171,7 +1171,7 @@ phases:
       not even during guardando, while bloqueado was applied to the tenant select
       and to both buttons of the same form; the three sibling screens disabled every
       field, so it was a rule-10 parity break with five live counterexamples. The
-      claim is TRUE ONLY AFTER R2-1, which adds disabled={bloqueado} to the five.
+      claim is TRUE ONLY AFTER R2-1 AND ONLY WITHIN EACH SCREEN — the final re-judgment found the Layout navbar (~25 NavLinks + Salir) ungated, the 409 banner rendered outside the aria-modal dialog, and focus lost during the write; recorded in tasks.md as residuals, not closed, which adds disabled={bloqueado} to the five.
       The focus-restore half was true only in jsdom: round 1 captured the trigger
       with document.activeElement inside a passive useEffect, which runs AFTER the
       commit that disabled it, so a real browser had already applied the focus-fixup

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/state.yaml
@@ -1060,7 +1060,74 @@ phases:
       1780/1780 en 12m49s corrida UNA sola vez y SOLA contra el daemon de Docker,
       cero flakes y cero re-runs; web 63 archivos / 1022 tests, build y lint limpios
       (5 warnings preexistentes de react-refresh); has-pending-model-changes limpio.
-      Slice 5 pending.
+      Slice 5 implemented; judgment-day and PR pending.
+      SLICE 5 IMPLEMENTED (tasks 5.1-5.10 checked, plus 4.38/4.39 closed by PR 171
+      / commit 99b5abe; 5.11 judgment-day and 5.12 PR belong to the orchestrator).
+      Branch feat/stage20-slice5-bajas-web off main, web only. MEASURED with 'git
+      diff main --numstat' and NOT estimated - 13 files, 2035 insertions and 192
+      deletions, of which production is 901 (722 insertions, 179 deletions) and 745
+      ignoring pure re-indentation, tests are 1240 and docs are 86. THE ESTIMATE OF
+      ~340 IS OVERRUN BY ROUGHLY 6x AND THAT IS REPORTED, NOT HIDDEN - three causes,
+      all of them structural rather than scope creep: (a) mutation-proof-tests and
+      web-descriptor-tests demand a test per branch, and rule 10 replicates every
+      pattern across FOUR sibling screens, so 1240 test lines land against a forecast
+      that budgeted for one screen's worth (slice 2 hit the same shape: 1078 test
+      lines against ~430); (b) the four carry-forward items of slice 2 required
+      restructuring EVERY write path of the four screens onto a single ungated
+      finally, which is a whole-file re-indentation on top of the semantic change;
+      (c) a real defect was found while running the mutations and its fix is a fifth
+      cross-cutting change (below). THE NATURAL SPLIT, if the orchestrator wants one,
+      is already cut into the eight commits: 5a = organizacion.ts + bajas.ts +
+      ConfirmacionDeBaja + Tenants + Empresas, 5b = PuntosVenta + Usuarios + docs.
+      A REAL DEFECT FOUND BY A TEST, NOT REASONED ABOUT - the re-entrancy guard of
+      react-async-state rule 9 was written as 'if (ocupado) return' reading STATE,
+      and two clicks of the SAME tick read the same render, so both passed and two
+      DELETEs went out. The slice-5 re-entrancy test failed on the first run and the
+      fix is a synchronous ref mirror (ocupadoRef), replicated to all four screens in
+      the same PR. This is exactly the M35/M21b survivor slice 2 recorded as
+      unreachable: the delete buttons made it reachable and it now has a real kill.
+      THIRTEEN MUTATIONS RUN FOR REAL (MS1-MS12 plus MS7b, table in tasks.md): ten
+      killed with their exact failing test names, TWO HONEST SURVIVORS recorded as
+      survivors and not dressed up (MS1 the post-write generation check and MS3 the
+      ungated finally - both the 'unreachable while rule 9 holds' class carried from
+      slice 2, and the honest result of RUNNING them is that the delete buttons did
+      NOT make them reachable, because the gate is itself disabled during an
+      outstanding write), and ONE DISCARDED as a badly-formed mutant (MS7 was a
+      no-op: confirmarBaja reads baja from the render closure; replaced by MS7b,
+      which kills). THE FOUR CARRY-FORWARD ITEMS OF SLICE 2 ARE CLOSED - (1) the
+      generation-mismatch returns inside the write paths no longer latch ocupado:
+      every write of the four screens now has ONE ungated finally covering all its
+      exits, and refrescarTrasEscribir stopped owning the flag; (2)
+      ERROR_ALTA_SIN_TENANTS has its own slot, and buscar() deliberately does NOT
+      clear it because it reports a LIVE precondition of the open form, while
+      errorPassword is cleared on Cancelar and Buscar because it reports a finished
+      write; (3) the platform option still counts for the collision but never
+      receives the suffix, so the sin-tenant sentinel cannot reach the copy; (4) the
+      tenant-universe banner is gated on esPlataforma and the tenanteReconciliado
+      typo is fixed. ANTI-ORACLE AT THE UI LAYER - a 404 renders a neutral
+      'ya no existe o no esta a tu alcance' with the server message deliberately NOT
+      appended, so a future server text cannot leak through; asserted per screen.
+      THE 500 COPY carries 'verifica el listado antes de reintentar' per the slice-4
+      carry-forward, because the bajas run without automatic retry and a lost ACK
+      means the deletion may have committed. V1-V6 RE-ASSERTED ON THE WHOLE STAGE
+      DIFF (22af91a..HEAD): zero migration files touched by the entire stage, the
+      last migration is still 20260822002214_FiscalArcaEtapa19a.cs,
+      InicializadorDeBaseDeDatos.cs / Politicas.cs / ManejadorDeErrores.cs untouched,
+      zero physical deletes over the four organization tables (the only RemoveRange
+      hit is the pre-existing articulos_empresas replace-set, another table and a
+      known carryover), zero ': IWaysDbContext' implementers. SUITES - npm run test
+      64 files / 1071 tests green, npm run build (tsc -b plus vite) clean, npm run
+      lint exit 0 with the same five pre-existing react-refresh warnings, dotnet
+      build Ways.slnx clean with the 2 pre-existing NU1903 advisories. FLAKE NOTE,
+      recorded rather than swallowed - the first full-suite run reported Remito and
+      one Usuarios selectOptions as failures; both pass in isolation and the very
+      next full run was 1071/1071 green. Same non-reproducible parallel-load class
+      already recorded for this repo; nothing in this slice touches Remito. TWO
+      FILES OUTSIDE src/Ways.Web ARE TOUCHED ON PURPOSE - docs/09-multi-tenancy.md
+      and docs/10-modelo-de-datos.md, which task 5.9 requires. Zero backend and zero
+      schema, as the constraint intends. DELIVERY REPORT OWED TO THE OWNER (OD5,
+      task 5.12) is in the apply return envelope: empresa and punto de venta
+      deletion ships LATENT, plus the two deferred items R1 and T6.
   verify:
     status: pending
     artifact: verify-report.md

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1909,8 +1909,25 @@ fully interactive. Eight findings confirmed; all eight fixed in this round.
 
 Accessibility of the modal claim, all in the shared panel: `aria-modal="true"`, focus moved to
 Cancelar on open, focus restored to the trigger on close, Escape = Cancelar (and inert while the write
-is outstanding). No focus trap is needed *because* of C1: every other control is `disabled`, and a
-disabled control is not tabbable.
+is outstanding).
+
+**Round-2 correction of this paragraph — it was written as true and was not.** Round 1 claimed *"no
+focus trap is needed because of C1: every other control is `disabled`"*. That was **false on
+`Usuarios`**: the five fields of its form (`f-usuario`, `f-mail`, `f-rol`, `f-estado`, `f-password`)
+carried no `disabled` at all — not even during `guardando` — while `bloqueado` was applied to the
+tenant select and to both buttons of the same form. The three sibling screens disabled every field,
+so this was a rule-10 parity break, and the "nothing is tabbable behind the gate" argument had five
+live counterexamples. **After R2-1 the claim is true**, and it is only true because of that fix.
+
+The **focus restore** was also true only in jsdom. Round 1 captured the trigger with
+`document.activeElement` inside a passive `useEffect`, which runs *after* the commit that disabled
+the trigger; a real browser has already applied the focus-fixup rule by then and moved focus to
+`<body>`, so the ref captured `<body>` and "restoring" it was a no-op. jsdom does not implement that
+fixup, which is exactly why the test passed. **After R2-2 the trigger is captured synchronously in
+the click handler** (`event.currentTarget`, before any `setState`) and handed to the panel as the
+`disparador` prop, so focus restore now works in browsers too; when the trigger is gone or inert
+after close (the row was deleted), the panel falls back to a stable landmark — the screen's `Box`
+heading, or the table.
 
 #### Round-1 mutation evidence (V11), run for real
 
@@ -1944,6 +1961,50 @@ and reverted.
 `npm --prefix src/Ways.Web run test` **65 files / 1097 tests green**, `run build` clean, `run lint`
 clean (the same 5 pre-existing `react-refresh` warnings). `git diff main --name-only` outside
 `src/Ways.Web/`, `docs/` and `openspec/` is **empty**.
+
+
+### Slice 5 — judgment-day round 2 (branch `feat/stage20-slice5-bajas-web`) — FINAL round
+
+Two blind judges again. **No CRITICAL.** Five confirmed findings plus one records entry; all fixed in
+this single correction round.
+
+| # | Severity | Finding | Fix |
+|---|---|---|---|
+| R2-1 | WARNING (both) | **`Usuarios`' form fields escaped the modal gate.** `f-usuario`, `f-mail`, `f-rol`, `f-estado` and `f-password` carried NO `disabled` — not even during `guardando` — while `bloqueado` was applied to the tenant select and to both buttons of the *same* form. `Tenants`/`Empresas`/`PuntosVenta` disable every field, so this was a `react-async-state` rule-10 parity break, and it made round 1's "every other control is disabled" claim false | `disabled={bloqueado}` on all five. The `Usuarios` gate test now asserts the five by label, with a message that names the offending field |
+| R2-2 | WARNING (both, inferential) | **Focus restore was a no-op in real browsers.** `ConfirmacionDeBaja` captured `document.activeElement` in a passive `useEffect`, i.e. AFTER the commit that disabled the trigger. A browser applies the focus-fixup rule at that commit and moves focus to `<body>`, so the ref captured `<body>`. jsdom does not implement the fixup, so the round-1 test passed falsely | The trigger is captured **synchronously in the click handler** (`event.currentTarget`, before any `setState`) on all four screens, held in `disparadorDeLaPuerta` and passed to the panel as the `disparador` prop. On close the panel restores focus to THAT element when it is still connected and operable; otherwise (row deleted, control inert) it falls back to a stable landmark — the `Box` heading, else the table — giving it a one-time `tabindex="-1"` so it can receive focus |
+| R2-3 | SUGGESTION (both) | **`errorAlta` cleared on gate open/cancel contradicted its own contract.** `Usuarios.tsx` documents it as a LIVE precondition of the open form (the tenant universe is missing, so the alta is impossible) that unrelated actions must not clear — which is why `buscar()` already respected it — yet `pedirBaja`/`cancelarBaja` cleared it, hiding something still true and leaving "Guardar" inert with no banner to explain why | `setErrorAlta('')` removed from both. `error`/`aviso`/`errorPassword` keep their symmetry; the asymmetry is documented at both call sites |
+| R2-4 | SUGGESTION (A) | **`Nuevo tenant` was neutralized by CSS only.** A `<Link>` takes no `disabled`; Bootstrap's `disabled` class only kills `pointer-events` (mouse hit-testing) and `tabIndex={-1}` only removes it from the tab order. Neither cancels an activation that does not go through hit-testing, so the modal gate could be abandoned by navigating away with the DELETE still undecided | `onClick={(evento) => { if (bloqueado) evento.preventDefault() }}`. The test measures the **navigation** (a route probe inside the `MemoryRouter`), not the attribute |
+| R2-5 | SUGGESTION (A), pre-existing | **The edit form survived the deletion of the entity being edited.** After a 204 the form stayed open with the data of a row that no longer exists, and "Guardar" would PUT against a deleted id | After a 204, `setEdicion`/`setFormulario((prev) => (prev?.id === fila.id ? null : prev))` on all four screens — built from `prev` (`react-async-state` rule 1), and id-compared so deleting ANOTHER row does not close an edit in progress |
+| R2-6 | records (both) | `tasks.md:1901,1910-1913` and `state.yaml:1164-1168` asserted *"every other control is disabled … no focus trap needed"* — false on `Usuarios` until R2-1, and the focus-restore half was true only in jsdom | Both records rewritten in place: the claim now says it became true *because of* R2-1, names R2-2 as the reason focus restore works in browsers, and records the jsdom caveat. The six out-of-scope `confirm()` screens stay listed |
+
+#### Round-2 mutation evidence (V11), run for real
+
+Command: `npx vitest run <file>` from `src/Ways.Web`. Every row was applied to the working tree, run,
+and reverted.
+
+| # | Mutation | Verdict | Evidence |
+|---|---|---|---|
+| MR2-1 | `Usuarios`: drop `disabled={bloqueado}` from `f-mail` | **KILLED** | *"con la puerta abierta no queda ninguna otra accion alcanzable"* — `Error: el campo "Mail" quedo alcanzable: expect(element).toBeDisabled()`, `Received element is not disabled: <input id="f-mail" ...>` — 1 failed / 44 skipped |
+| MR2-2 | `ConfirmacionDeBaja`: capture the trigger in the passive effect again (`document.activeElement`) instead of taking the `disparador` prop | **KILLED** | *"captura el disparador antes del render que lo deshabilita, no despues"* — `expect(element).toHaveFocus()`; *Expected* `<button>Baja</button>`, *Received* `<body>` — 1 failed / 8 passed |
+| MR2-2b | `ConfirmacionDeBaja`: drop the landmark fallback branch of the cleanup | **KILLED** | *"si la fila del disparador desaparecio, el foco cae en el titulo de la pantalla"* — *Expected* `<h5>Tenants</h5>`, *Received* `<body>` |
+| MR2-3a | `Usuarios.cancelarBaja`: put `setErrorAlta('')` back | **KILLED** | *"el rechazo del alta sobrevive a abrir y cancelar la puerta de baja"* — `Unable to find an element with the text: No se puede crear el usuario: todavia falta la lista de tenants.` |
+| MR2-3b | `Usuarios.pedirBaja`: put `setErrorAlta('')` back (the other half — the two were mutated separately) | **KILLED** | same test, same message |
+| MR2-4 | `Tenants`: drop the `if (bloqueado) evento.preventDefault()` of the `Nuevo tenant` `<Link>` | **KILLED** | *"con la puerta abierta, activar Nuevo tenant no navega"* — `expected '/organizacion/nuevo-tenant' to be '/'` |
+| MR2-5 | `Tenants.darDeBaja`: drop the `setEdicion((prev) => ...)` that closes the form of the deleted row | **KILLED** | *"la baja de la fila que se esta editando cierra su formulario"* — `expected document not to contain element, found <strong>Editando tenant 1</strong> instead` |
+
+**Seven mutations, seven kills, zero survivors, zero discarded mutants.**
+
+One environment fact recorded rather than hidden: **jsdom cannot reproduce the focus-fixup rule
+natively.** Once a button is `disabled`, jsdom treats both `element.blur()` and
+`document.body.focus()` as no-ops on a non-focusable area, so `document.activeElement` stays pinned
+to the trigger — which is precisely why the round-1 defect shipped green. The R2-2 test therefore
+brings the blur **one tick forward**, into the `onClick` while the button is still enabled. The
+mechanism differs from a browser's; the observable state the test depends on is identical (focus is
+on `<body>` when the gate's mount effect runs), and MR2-2 proves the test discriminates.
+
+Gate: web `npm --prefix src/Ways.Web run test` **65 files / 1102 tests green**, `run build` clean,
+`run lint` exit 0 with the same **5** pre-existing `react-refresh` warnings (no new ones).
+`git diff main --name-only` outside `src/Ways.Web/`, `docs/` and `openspec/` is **empty**.
 
 ---
 

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1847,6 +1847,37 @@ and **rule 10: the pattern is replicated across all four screens in the same PR*
   the last migration must **still** be `20260822002214_FiscalArcaEtapa19a.cs`,
   `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` /
   `ManejadorDeErrores.cs` untouched, zero physical deletes across the whole stage).
+**RESIDUALS AFTER THE FINAL RE-JUDGMENT OF SLICE 5 (round budget exhausted; both judges closed
+every item; no BLOCKER/CRITICAL). Recorded as the TRUE scope of the "modal" claim and as follow-ups.**
+
+The gate makes each SCREEN inert — every control inside the four root screens is behind `bloqueado`
+(verified control-by-control by both judges). It is NOT modal at DOCUMENT level, and the records
+above must not be read as claiming that:
+
+1. **Navbar escape.** `Layout.tsx` renders ~25 `NavLink`s and the "Salir" button outside any screen's
+   `bloqueado`; with the gate open the operator can navigate away or log out with the DELETE
+   undecided (pre-existing: the navbar was never gated by screen state). Real escape, not advisory.
+   Closing it means a document-level inert (`inert` attribute on the navbar while a gate is open, or
+   a portal-based dialog with a focus trap) — a cross-cutting change outside this stage.
+2. **The 409 banner is outside the `aria-modal` dialog.** On a rejection the gate stays open and the
+   reason renders as a sibling `alert alert-danger` with no `role="alert"`/`aria-live`; `aria-modal`
+   tells ATs to hide everything outside the dialog, so the copy is neither announced nor navigable
+   for exactly the users `aria-modal` was added for. Fix: render the rejection INSIDE the panel, or
+   give the banner `role="alert"` and drop `aria-modal` until a real trap exists.
+3. **Focus is lost during the write and not restored on rejection.** Confirming by keyboard leaves
+   focus on the button the next commit disables; a real browser moves it to `<body>`; on a 409 the
+   gate re-enables but the mount effect (deps `[disparador]`) does not re-run. jsdom cannot see it.
+   Fix: re-focus Cancelar when `ocupado` flips false while mounted.
+4. **Coverage gaps, not defects**: the per-screen `disparador` capture and the R2-5 form-close are
+   mutated/asserted only on the shared component and on Tenants; Empresas/PuntosVenta/Usuarios wiring
+   has no own kill. `tabindex=-1` written on the Box heading is never removed. `disparadorDeLaPuerta`
+   nulled on cancel but not on success. `errorAlta` is browser-unreachable (the guard's predicate is
+   the submit button's own `disabled`), and `confirmarBaja`/`accion` still clear it while
+   `pedirBaja`/`cancelarBaja` preserve it.
+5. **Six other screens keep native `confirm()`** (Articulos, Clientes, Categorias, Ofertas,
+   PaginaCatalogo, Proveedores) — out of stage scope, listed for the rule-10 sweep that adopts the
+   shared gate.
+
 - [ ] 5.11 `judgment-day` round to a clean round.
 - [ ] 5.12 Open PR 5 `feat/stage20-slice5-bajas-web`, merge to `main` after the clean round. **Then
   report to the owner, at delivery (OD5): empresa and punto de venta deletion ships LATENT** —
@@ -1917,7 +1948,7 @@ focus trap is needed because of C1: every other control is `disabled`"*. That wa
 carried no `disabled` at all — not even during `guardando` — while `bloqueado` was applied to the
 tenant select and to both buttons of the same form. The three sibling screens disabled every field,
 so this was a rule-10 parity break, and the "nothing is tabbable behind the gate" argument had five
-live counterexamples. **After R2-1 the claim is true**, and it is only true because of that fix.
+live counterexamples. **After R2-1 the claim is true WITHIN each screen; it is NOT true at document level — see the residuals block before task 5.11 (navbar, banner outside the dialog, focus during the write)**, and it is only true because of that fix.
 
 The **focus restore** was also true only in jsdom. Round 1 captured the trigger with
 `document.activeElement` inside a passive `useEffect`, which runs *after* the commit that disabled

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1503,8 +1503,8 @@ written)** — transcribed from `design.md:383-398`:
 - [x] 4.37 GATE GUARD + non-regression — re-assert V1-V6 and V13; Domain + Application + Integration
   suites green (**never** run integration suites concurrently against the same Docker daemon);
   `dotnet build Ways.slnx` clean.
-- [ ] 4.38 `judgment-day` round to a clean round.
-- [ ] 4.39 Open PR 4 `feat/stage20-slice4-bajas-api`, record mutation evidence for **every** U-row
+- [x] 4.38 `judgment-day` round to a clean round.
+- [x] 4.39 Open PR 4 `feat/stage20-slice4-bajas-api`, record mutation evidence for **every** U-row
   (U1-U8) plus N4 in the PR body, with the `[S]` rows recording their file/state/definition assertion
   **and saying so** (V11), merge to `main` after the clean round.
 
@@ -1814,33 +1814,33 @@ buttons; the API still works but nobody can press it. **Skills**: `react-async-s
 and **rule 10: the pattern is replicated across all four screens in the same PR**),
 `web-descriptor-tests`, `dto-contract-honesty`, `work-unit-commits`.
 
-- [ ] 5.1 Modify `src/Ways.Web/src/api/organizacion.ts` — `eliminarTenant`, `eliminarEmpresa`,
+- [x] 5.1 Modify `src/Ways.Web/src/api/organizacion.ts` — `eliminarTenant`, `eliminarEmpresa`,
   `eliminarPuntoVenta`. `src/Ways.Web/src/api/usuarios.ts`'s `eliminar` already exists and keeps its
   signature. *(TO-R4, UT-R2)*
-- [ ] 5.2 Create the `codigo` → copy mapping (a pure module beside the helpers), covering all six
+- [x] 5.2 Create the `codigo` → copy mapping (a pure module beside the helpers), covering all six
   codes plus the 404 and the generic fallback. The web keys its copy off **`codigo`**, never off
   `mensaje`: changing `mensaje` must not change which copy is selected. *(BO-R11)*
-- [ ] 5.3 Modify `Tenants.tsx` — delete button + confirmation gate + the full `react-async-state`
+- [x] 5.3 Modify `Tenants.tsx` — delete button + confirmation gate + the full `react-async-state`
   write discipline: full-window disabled state per entity while the write is outstanding, supersede
   blocked while a write is outstanding, re-entrancy guard, and a post-write refresh failure reporting
   *"se eliminó, pero no se pudo actualizar la vista"*. *(TO-R4)*
-- [ ] 5.4 Modify `Empresas.tsx` — the same pattern, verbatim (rule 10). *(TO-R4)*
-- [ ] 5.5 Modify `PuntosVenta.tsx` — the same pattern, verbatim. *(TO-R4)*
-- [ ] 5.6 Modify `Usuarios.tsx` — the same pattern applied to the **existing** "Baja" button
+- [x] 5.4 Modify `Empresas.tsx` — the same pattern, verbatim (rule 10). *(TO-R4)*
+- [x] 5.5 Modify `PuntosVenta.tsx` — the same pattern, verbatim. *(TO-R4)*
+- [x] 5.6 Modify `Usuarios.tsx` — the same pattern applied to the **existing** "Baja" button
   (`:120-122`), which now has to render `usuario_en_uso` and the pre-existing `PoliticaDeRoles`
   refusals. *(UT-R2)*
-- [ ] 5.7 [P] Extend the four `*.test.tsx` files created in slice 2: the confirmation gate blocks the
+- [x] 5.7 [P] Extend the four `*.test.tsx` files created in slice 2: the confirmation gate blocks the
   call until confirmed; the full-window disabled state appears per entity; a second click while a
   write is outstanding is dropped; the post-write refresh failure renders its own copy; **each 409
   `codigo` maps to its own copy** and a changed `mensaje` does not change the selection. *(BO-R11,
   TO-R4, UT-R2; `react-async-state` rules 2-6, 9, 10)*
-- [ ] 5.8 [P] Test: a `404` on delete (already-deleted row, or out-of-scope target) renders the
+- [x] 5.8 [P] Test: a `404` on delete (already-deleted row, or out-of-scope target) renders the
   neutral not-found copy — **never** a usage disclosure, preserving the anti-oracle at the UI layer
   too. *(BO-R12)*
-- [ ] 5.9 Modify `docs/09-multi-tenancy.md` and `docs/10-modelo-de-datos.md` — an **"Etapa 20"** note
+- [x] 5.9 Modify `docs/09-multi-tenancy.md` and `docs/10-modelo-de-datos.md` — an **"Etapa 20"** note
   covering the deletion semantics, the pristine discriminator, the three buckets and two carve-outs,
   the cascade boundary and the six codes. **No schema table changes** — the stage ships zero DDL.
-- [ ] 5.10 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`, `run build`
+- [x] 5.10 GATE GUARD + non-regression — `npm --prefix src/Ways.Web run test`, `run build`
   (typecheck) and `run lint` clean; re-assert V1-V6 on the full stage diff (this is the last slice:
   the last migration must **still** be `20260822002214_FiscalArcaEtapa19a.cs`,
   `has-pending-model-changes` clean, `InicializadorDeBaseDeDatos.cs` / `Politicas.cs` /
@@ -1854,6 +1854,34 @@ and **rule 10: the pattern is replicated across all four screens in the same PR*
   between the guard's read and the deletion's commit — accepted, recovery is a one-line `UPDATE`
   because nothing is destroyed) and **T6** (FK index coverage is *reported*, not guaranteed, since
   adding an index would be DDL).
+
+
+### Slice 5 — mutation evidence (V11), run for real
+
+Every row below was applied to the working tree, run, and reverted. Command:
+`npx vitest run --run <files>` from `src/Ways.Web`.
+
+| # | Mutation | Verdict | Evidence |
+|---|---|---|---|
+| MS1 | `Empresas.confirmarBaja`: delete the post-write generation check (`if (generacion.current !== token) return`) | **SURVIVES** | 15/15 green. Honest survivor, same class and same reason as slice 2's M10: `react-async-state` rule 9 disables **every** action that could bump the generation while `ocupado` is set, so the mismatch cannot occur. The guard stays as defence-in-depth |
+| MS2 | `Tenants.confirmarBaja`: re-entrancy guard back to reading state (`ocupado !== null` instead of `ocupadoRef.current`) | **KILLED** | *"un segundo click sobre la confirmación en vuelo se descarta — expected 1 times, but got 2 times"*. **This mutation was originally a real defect**: the guard was written reading state, the test found it, and the fix (a synchronous ref mirror) was replicated to all four screens. Slice 2's M35/M21b survivor now has a real kill |
+| MS3 | `Tenants.confirmarBaja`: gate the `finally` on the generation (`if (generacion.current === token)`) | **SURVIVES** | 12/12 green. Honest survivor: the latch the slice-2 carry-forward describes needs a generation bump *during* an outstanding write, and rule 9 still forbids one — the delete gate is disabled while `ocupado` is set. The ungated `finally` is defence-in-depth with no reachable path today, and it is recorded as such rather than dressed up |
+| MS4 | `bajas.ts`: select the copy off `error.message` instead of `error.codigo` | **KILLED** | 3 tests in `bajas.test.ts` (*"los seis códigos rinden seis copias distintas"*, *"cambiar el mensaje no cambia la copia"*, *"rinde el mensaje del servidor"*) plus the four screen suites |
+| MS5 | `bajas.ts`: remove the `estado === 404` branch | **KILLED** | *"un 404 rinde la copia neutra de inexistencia y no filtra el mensaje del servidor"* + the anti-oracle test of `Tenants` and `PuntosVenta` |
+| MS6 | `bajas.ts`: remove the `estado >= 500` branch | **KILLED** | *"un 500 avisa que el resultado es incierto y manda a verificar el listado"* |
+| MS7 | `PuntosVenta`: replace `pedirBaja(p)` with an inline `setBaja(...)` + `confirmarBaja()` | **inconclusive, discarded** | The mutant is a no-op: `confirmarBaja` reads `baja` from the render closure, which is still `null` in that tick. Not recorded as a survivor — it never expressed "no gate". Replaced by MS7b |
+| MS7b | `PuntosVenta`: the Baja button calls `eliminarPuntoVenta(p.id)` directly (no gate at all) | **KILLED** | 3 tests: *"el botón de baja no llama a la API hasta que se confirma"*, *"cancelar cierra la puerta y no llama nunca a la API"*, *"durante el DELETE y su refresco no queda ninguna acción alcanzable"* |
+| MS8 | `organizacion.ts`: drop the `opcion.valor !== valorSinSufijo` conjunct of `desempatarHomonimos` | **KILLED** | *"la opción de plataforma nunca filtra su clave centinela a la etiqueta"* |
+| MS9 | `Empresas.refrescarTrasEscribir`: the refresh `catch` sets the plain `mensajeOk` instead of appending the refresh-failure notice | **KILLED** | *"un refresco fallido después de la baja no la reporta como fallida"* |
+| MS10 | `Usuarios.guardar`: `setErrorAlta(ERROR_ALTA_SIN_TENANTS)` back to the shared `setError(...)` slot | **KILLED** | *"el rechazo del alta sin universo de tenants sobrevive a una carga posterior"* |
+| MS11 | `bajas.arrastreDeTenant`: drop the `cantidadEmpresas` line from the returned list | **KILLED** | 3 tests in `bajas.test.ts` + the `Tenants` gate test that asserts the three cascade lines in order |
+| MS12 | `bajas.frase`: boundary `cantidad <= 0` → `cantidad < 0` | **KILLED** | *"no lista las familias vacías"* |
+
+**Three survivors, recorded as survivors and not dressed up**: MS1 and MS3 (both the "unreachable
+while rule 9 holds" class carried from slice 2 — the delete buttons did **not** make them reachable,
+because the gate is itself disabled during an outstanding write, and that is the honest result of
+running them rather than the assumed one), and MS7 which was discarded as a badly-formed mutant and
+replaced by MS7b, which kills.
 
 ---
 

--- a/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
+++ b/openspec/changes/stage-20-organizacion-relaciones-y-bajas/tasks.md
@@ -1815,8 +1815,10 @@ and **rule 10: the pattern is replicated across all four screens in the same PR*
 `web-descriptor-tests`, `dto-contract-honesty`, `work-unit-commits`.
 
 - [x] 5.1 Modify `src/Ways.Web/src/api/organizacion.ts` — `eliminarTenant`, `eliminarEmpresa`,
-  `eliminarPuntoVenta`. `src/Ways.Web/src/api/usuarios.ts`'s `eliminar` already exists and keeps its
-  signature. *(TO-R4, UT-R2)*
+  `eliminarPuntoVenta`. **Correction (judgment-day round 1, C7): there is no
+  `src/Ways.Web/src/api/usuarios.ts`** and there never was — `Usuarios.tsx` issues `api.delete` inline
+  against `/usuarios/{id}`, which is what shipped. The original wording described a file that does not
+  exist. *(TO-R4, UT-R2)*
 - [x] 5.2 Create the `codigo` → copy mapping (a pure module beside the helpers), covering all six
   codes plus the 404 and the generic fallback. The web keys its copy off **`codigo`**, never off
   `mensaje`: changing `mensaje` must not change which copy is selected. *(BO-R11)*
@@ -1863,9 +1865,9 @@ Every row below was applied to the working tree, run, and reverted. Command:
 
 | # | Mutation | Verdict | Evidence |
 |---|---|---|---|
-| MS1 | `Empresas.confirmarBaja`: delete the post-write generation check (`if (generacion.current !== token) return`) | **SURVIVES** | 15/15 green. Honest survivor, same class and same reason as slice 2's M10: `react-async-state` rule 9 disables **every** action that could bump the generation while `ocupado` is set, so the mismatch cannot occur. The guard stays as defence-in-depth |
+| MS1 | `Empresas.confirmarBaja`: delete the post-write generation check (`if (generacion.current !== token) return`) | **RECORD WITHDRAWN — the verdict was right, the reason was false** | See *Slice 5 — judgment-day round 1* below. The clause survived, but **not** for the reason recorded: the reachable window was the gate being OPEN, not a write being in flight, and rule 9 did not cover it. Deleting the clause was in fact the FIX; re-run as MR1b-empresas with the true window, it is now **KILLED** |
 | MS2 | `Tenants.confirmarBaja`: re-entrancy guard back to reading state (`ocupado !== null` instead of `ocupadoRef.current`) | **KILLED** | *"un segundo click sobre la confirmación en vuelo se descarta — expected 1 times, but got 2 times"*. **This mutation was originally a real defect**: the guard was written reading state, the test found it, and the fix (a synchronous ref mirror) was replicated to all four screens. Slice 2's M35/M21b survivor now has a real kill |
-| MS3 | `Tenants.confirmarBaja`: gate the `finally` on the generation (`if (generacion.current === token)`) | **SURVIVES** | 12/12 green. Honest survivor: the latch the slice-2 carry-forward describes needs a generation bump *during* an outstanding write, and rule 9 still forbids one — the delete gate is disabled while `ocupado` is set. The ungated `finally` is defence-in-depth with no reachable path today, and it is recorded as such rather than dressed up |
+| MS3 | `Tenants.confirmarBaja`: gate the `finally` on the generation (`if (generacion.current === token)`) | **RECORD CORRECTED — survivor, but NOT for the recorded reason** | See *Slice 5 — judgment-day round 1* below. The claim *"the delete gate is disabled while `ocupado` is set"* was false: the gate rendered outside every `disabled`, so under this mutant a superseded gate latched `ocupadoRef` **forever** — the screen froze. Re-run as MS3' after the round-1 fix, it survives for a reason that is now true: nothing can bump the generation while the gate is open |
 | MS4 | `bajas.ts`: select the copy off `error.message` instead of `error.codigo` | **KILLED** | 3 tests in `bajas.test.ts` (*"los seis códigos rinden seis copias distintas"*, *"cambiar el mensaje no cambia la copia"*, *"rinde el mensaje del servidor"*) plus the four screen suites |
 | MS5 | `bajas.ts`: remove the `estado === 404` branch | **KILLED** | *"un 404 rinde la copia neutra de inexistencia y no filtra el mensaje del servidor"* + the anti-oracle test of `Tenants` and `PuntosVenta` |
 | MS6 | `bajas.ts`: remove the `estado >= 500` branch | **KILLED** | *"un 500 avisa que el resultado es incierto y manda a verificar el listado"* |
@@ -1877,11 +1879,71 @@ Every row below was applied to the working tree, run, and reverted. Command:
 | MS11 | `bajas.arrastreDeTenant`: drop the `cantidadEmpresas` line from the returned list | **KILLED** | 3 tests in `bajas.test.ts` + the `Tenants` gate test that asserts the three cascade lines in order |
 | MS12 | `bajas.frase`: boundary `cantidad <= 0` → `cantidad < 0` | **KILLED** | *"no lista las familias vacías"* |
 
-**Three survivors, recorded as survivors and not dressed up**: MS1 and MS3 (both the "unreachable
-while rule 9 holds" class carried from slice 2 — the delete buttons did **not** make them reachable,
-because the gate is itself disabled during an outstanding write, and that is the honest result of
-running them rather than the assumed one), and MS7 which was discarded as a badly-formed mutant and
-replaced by MS7b, which kills.
+**Two of the three survivor records were WRONG and judgment-day round 1 found them.** MS1 and MS3
+were recorded as *"unreachable while rule 9 holds, because the gate is itself disabled during an
+outstanding write"*. **The gate was never disabled by anything**: `ConfirmacionDeBaja` rendered
+outside the `disabled` of every other control, so the reachable window was not "during a write" but
+"while the gate is OPEN" — and in that window Guardar, Suspender, Reactivar, Buscar and Editar were
+all live and all bumped the generation. MS1's clause was the defect, not a guard; MS3's mutant froze
+the screen. Both records are corrected in place above and re-run below. MS7 stands: it was discarded
+as a badly-formed mutant and replaced by MS7b, which kills.
+
+
+### Slice 5 — judgment-day round 1 (branch `feat/stage20-slice5-bajas-web`)
+
+Two blind judges, both root-causing the same thing: **the confirmation gate was not modal, and the
+write token was minted at gate-OPEN.** `ConfirmacionDeBaja` rendered inline with `role="alertdialog"`
+but no `aria-modal`, no focus move, no Escape, and — the load-bearing part — the page behind it stayed
+fully interactive. Eight findings confirmed; all eight fixed in this round.
+
+| # | Severity | Finding | Fix |
+|---|---|---|---|
+| C1 | CRITICAL (both) | A superseded gate still fired the DELETE and then discarded BOTH outcomes. Open Baja on row B, then use any still-enabled generation bumper (Tenants: Suspender/Guardar; Empresas/PuntosVenta: Guardar; Usuarios: Guardar, `accion`, or Enter in the search): `ocupado` returned to `null`, the gate re-enabled with a stale token, Confirm sent the DELETE unconditionally, and the post-network `if (generacion.current !== token) return` swallowed the 204 **and** the 409 — no close, no aviso, no refresh, no error. Row still listed, gate still open, every further click another silent DELETE | Two changes, on all four screens. (a) **The gate is truly modal**: one derived `bloqueado = ocupado !== null \|\| baja !== null` now drives EVERY `disabled` on the screen — table actions, edit form, search input and button, filters, Nuevo (`Tenants`' `Nuevo tenant` is a `<Link>`: `aria-disabled` + `tabIndex={-1}` + Bootstrap's `disabled`). Rule 9 by construction: nothing can bump the generation while the gate is open. (b) **The token is minted at CONFIRM**, as the first synchronous statement after the `ocupadoRef` re-entrancy guard; `pedirBaja` mints nothing. A 204 ALWAYS closes the gate and refreshes; a 4xx ALWAYS renders. The generation now governs only the REFRESH, which is a read |
+| C2 | CRITICAL (both) | `Usuarios.cancelarBaja` did `++generacion.current`; an in-flight `cargar` then never ran its gated `finally` → "Cargando…" forever, with no table, no error and nothing to press | `cancelarBaja` no longer bumps the generation on any of the four screens: cancelling supersedes nothing, it only closes the gate. C1's block closes the reachable path as well, but the mechanism is fixed too. The false comment at `Tenants.tsx` (*"mientras hay una lectura en vuelo no hay ningún botón que apretar"* — the gate rendered outside the `cargando` branch) is corrected |
+| C3 | WARNING (both) | The MS1/MS3 records were false; MS3 was not a survivor in the sense recorded | The two rows above are rewritten, the survivor paragraph is rewritten, and both mutations were re-run for real (table below) |
+| C4 | WARNING (B) | `cancelarBaja` never cleared `error`: after a 409 the red banner outlived the gate | `error`/`aviso` (and `errorPassword`/`errorAlta` on `Usuarios`) are cleared on cancel, symmetric with `pedirBaja`, on all four screens |
+| C5 | SUGGESTION (both) | *"Se dan de baja junto con él:"* is masculine and lies on `Empresas`; `Empresas` hardcoded an uncounted `arrastra={['Sus puntos de venta']}` | Preamble is now subject-neutral: *"También se dan de baja:"*. `EmpresaListado` carries **no** PV count (`docs/10`, `api/tipos.ts`), so the line is phrased honestly as *"Sus puntos de venta activos"* instead of inventing a number the row does not have |
+| C6 | SUGGESTION (B) | `GUIA_POR_CODIGO` was a plain object, so a server-sent `codigo` of `constructor`/`toString`/`__proto__` resolved against the prototype | It is a `Map`; `Map.get` only sees own keys. Unit test over the four prototype keys |
+| C7 | records (B) | Task 5.1 named `src/Ways.Web/src/api/usuarios.ts`, which does not exist; `Tenants.test.tsx`'s doc-comment named the pre-fix `if (!baja \|\| ocupado !== null)` clause | Both corrected in place |
+| C8 | SUGGESTION (B) | `Tenants.tsx` still used native `confirm()` for Suspender/Reactivar — in the SAME file that introduced the gate (rule 10 inside one file) | Both routed through `ConfirmacionDeBaja`, which was generalized (`pregunta`, `nota`, `etiquetaConfirmar`, `etiquetaEnCurso`; its defaults are still the baja) and now carries the modal discipline. **The six OTHER screens keep their `confirm()` and are out of scope**: `Articulos`, `Clientes`, `Categorias`, `Ofertas`, `PaginaCatalogo`, `Proveedores` — recorded here, not fixed |
+
+Accessibility of the modal claim, all in the shared panel: `aria-modal="true"`, focus moved to
+Cancelar on open, focus restored to the trigger on close, Escape = Cancelar (and inert while the write
+is outstanding). No focus trap is needed *because* of C1: every other control is `disabled`, and a
+disabled control is not tabbable.
+
+#### Round-1 mutation evidence (V11), run for real
+
+Command: `npx vitest run <file>` from `src/Ways.Web`. Every row was applied to the working tree, run,
+and reverted.
+
+| # | Mutation | Verdict | Evidence |
+|---|---|---|---|
+| MR1a-tenants | `Tenants`: `bloqueado` back to `ocupado !== null` | **KILLED** | *"con la puerta abierta no queda ninguna otra acción alcanzable"* + *"suspender pasa por la misma puerta y no llama a la API hasta confirmar"* — 2 failed / 17 passed |
+| MR1a-empresas | `Empresas`: same | **KILLED** | *"con la puerta abierta no queda ninguna otra acción alcanzable"* — 1 failed / 18 passed |
+| MR1a-pv | `PuntosVenta`: same | **KILLED** | *"con la puerta abierta no queda ninguna otra acción alcanzable"* — 1 failed / 19 passed |
+| MR1a-usuarios | `Usuarios`: `bloqueado` back to `ocupado` | **KILLED** | *"con la puerta abierta no queda ninguna otra acción alcanzable"* — 1 failed / 43 passed |
+| MR1b-tenants | `Tenants`: token minted at gate-open + the post-network generation check restored (the exact pre-fix shape) | **KILLED** | *"una generación acuñada entre abrir y confirmar no se traga el 204"* — `TestingLibraryElementError: Unable to find an element with the text: Se dio de baja el tenant "Almacén Este".` |
+| MR1b-empresas | `Empresas`: same | **KILLED** | same test — `Unable to find an element with the text: Se dio de baja la empresa "Este SRL".` |
+| MR1b-pv | `PuntosVenta`: same | **KILLED** | same test — `Unable to find an element with the text: Se dio de baja el punto de venta "PV Este".` |
+| MR1b-usuarios | `Usuarios`: same | **KILLED** | same test — `Unable to find an element with the text: Usuario "vendedor.sur" dado de baja.` |
+| MR2-usuarios | `Usuarios.cancelarBaja`: restore `++generacion.current` | **KILLED** | *"cancelar no clava la pantalla cuando hay una búsqueda en vuelo"* — `expected document not to contain element, found <span` (the "Cargando…" that never clears) |
+| MR4-tenants / -empresas / -pv / -usuarios | `cancelarBaja`/`cancelarConfirmacion`: drop the `setError('')`/`setAviso('')` | **KILLED ×4** | *"cancelar después de un rechazo se lleva el motivo con la puerta"* — `expected document not to contain element, found <div` on each of the four screens |
+| MR5-preambulo | `ConfirmacionDeBaja`: preamble back to *"Se dan de baja junto con él:"* | **KILLED** | *"el preámbulo del arrastre no le pone género al sujeto"* + *"la puerta nombra el arrastre sin inventar una cantidad que la fila no trae"* |
+| MR5-arrastre | `Empresas`: `ARRASTRE_DE_EMPRESA` back to `['Sus puntos de venta']` | **KILLED** | `AssertionError: expected [ 'Sus puntos de venta' ] to deeply equal [ 'Sus puntos de venta activos' ]` |
+| MR6-mapa | `bajas.ts`: the `Map` back to a plain-object lookup | **KILLED** | *"una clave del prototipo no se hace pasar por guía"* — `expected 'Algo bloquea la baja. function Object…' to be 'Algo bloquea la baja.'` |
+| MR8-suspender | `Tenants`: the Suspender button calls `cambiarEstado` directly, with no gate | **KILLED** | *"suspender pasa por la misma puerta…"* (`expected "vi.fn()" to not be called at all, but actually been called 1 times`) + *"cancelar la suspensión no llama nunca a la API"* |
+| MA1-foco | `ConfirmacionDeBaja`: drop `cancelarRef.current?.focus()` | **KILLED** | *"al abrirse se lleva el foco a Cancelar"* |
+| MA2-foco-vuelta | `ConfirmacionDeBaja`: drop the cleanup that restores the trigger's focus | **KILLED** | *"al cerrarse devuelve el foco al disparador"* |
+| MA3-escape | `ConfirmacionDeBaja`: drop the `\|\| ocupado` from the Escape listener | **KILLED** | *"con la escritura en vuelo, Escape no cierra nada"* — `Unable to find an accessible element with the role "alertdialog"` |
+| MA4-aria-modal | `ConfirmacionDeBaja`: remove `aria-modal="true"` | **KILLED** | *"se anuncia como modal, no como un aviso al costado"* |
+| MS1' | `Empresas`: delete the leading generation check of `refrescarTrasEscribir` — the only generation check left on the delete path after C1, since deleting the *post-network* one WAS the fix | **SURVIVES**, and now for a TRUE reason | 19/19 green. Nothing can bump the generation between the DELETE's own mint and its refresh: the full-window `bloqueado` covers every button, and every remaining bumper (`guardar`, `accion`, `buscar`, `confirmarBaja`) is additionally guarded by the synchronous `ocupadoRef`. Unreachable **by construction**, not by the false claim the old MS1 row made |
+| MS3' | `Tenants.darDeBaja`: gate the `finally` on the generation | **SURVIVES**, and now for a TRUE reason | 19/19 green. Same construction argument. Before C1 this mutant froze the screen through a superseded gate; that path no longer exists, and the ungated `finally` stays as defence-in-depth with an argument that is now actually true |
+
+**Two honest survivors (MS1', MS3'), eighteen kills, zero discarded mutants.** Gate: web
+`npm --prefix src/Ways.Web run test` **65 files / 1097 tests green**, `run build` clean, `run lint`
+clean (the same 5 pre-existing `react-refresh` warnings). `git diff main --name-only` outside
+`src/Ways.Web/`, `docs/` and `openspec/` is **empty**.
 
 ---
 

--- a/src/Ways.Web/src/api/bajas.test.ts
+++ b/src/Ways.Web/src/api/bajas.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { arrastreDeTenant, copiaDeFalloDeBaja } from './bajas'
+import { ErrorApi } from './cliente'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5 (tareas 5.2, 5.7 y 5.8).
+
+/** Los seis códigos de la etapa 20, en el orden del spec (`BO-R11`). */
+const SEIS_CODIGOS = [
+  'tenant_en_uso',
+  'empresa_en_uso',
+  'punto_venta_en_uso',
+  'usuario_en_uso',
+  'ultima_empresa_del_tenant',
+  'ultimo_punto_venta_de_la_empresa',
+] as const
+
+describe('copiaDeFalloDeBaja — la copia se elige por código', () => {
+  /**
+   * Cláusula bajo prueba: el `GUIA_POR_CODIGO[error.codigo]`. Con un mapa vacío —o con una copia
+   * genérica compartida— los seis rechazos rendirían el mismo texto y el operador no sabría cuál
+   * de las dos familias le tocó (uso vs. mínimo estructural), que llevan acciones distintas.
+   *
+   * Se asserta que las seis son PAIRWISE distintas, no solo que existen: dos entradas iguales del
+   * mapa pasan cualquier test que mire una sola.
+   */
+  it('los seis códigos rinden seis copias distintas entre sí', () => {
+    const copias = SEIS_CODIGOS.map((codigo) =>
+      copiaDeFalloDeBaja(new ErrorApi(409, codigo, 'mensaje del servidor'), 'el tenant'),
+    )
+
+    expect(new Set(copias).size).toBe(SEIS_CODIGOS.length)
+  })
+
+  /**
+   * Cláusula bajo prueba: que la SELECCIÓN sea `error.codigo` y no `error.message` (spec
+   * `bajas-de-organizacion` → *The web maps copy from the code*). El mensaje cambia entero entre
+   * las dos llamadas; lo que la web agrega tiene que quedar byte a byte igual.
+   */
+  it('cambiar el mensaje no cambia la copia que se elige', () => {
+    const conMensajeLargo = copiaDeFalloDeBaja(
+      new ErrorApi(409, 'ultima_empresa_del_tenant', 'Es la única empresa del tenant.'),
+      'la empresa',
+    )
+    const conMensajeDegradado = copiaDeFalloDeBaja(
+      new ErrorApi(409, 'ultima_empresa_del_tenant', 'Conflicto.'),
+      'la empresa',
+    )
+
+    const guia = 'La baja del tenant se hace desde la pantalla de Tenants.'
+    expect(conMensajeLargo).toContain(guia)
+    expect(conMensajeDegradado).toContain(guia)
+    expect(conMensajeLargo).not.toBe(conMensajeDegradado)
+  })
+
+  /**
+   * Cláusula bajo prueba: el `detalle` que antecede a la guía. El mensaje del servidor es lo único
+   * que nombra QUÉ bloquea (la tabla, el punto de venta, la cantidad); tragarlo en un error
+   * genérico dejaba al operador sin nada accionable.
+   */
+  it('rinde el mensaje del servidor, que es lo único que nombra el bloqueo', () => {
+    const copia = copiaDeFalloDeBaja(
+      new ErrorApi(409, 'tenant_en_uso', 'No se puede dar de baja el tenant porque tiene 3 ventas.'),
+      'el tenant',
+    )
+
+    expect(copia).toContain('porque tiene 3 ventas')
+    expect(copia).toContain('Dá de baja o reasigná esos datos antes de eliminar el tenant.')
+  })
+
+  it('un mensaje vacío no deja el cartel sin texto', () => {
+    const copia = copiaDeFalloDeBaja(new ErrorApi(409, 'empresa_en_uso', '   '), 'la empresa')
+
+    expect(copia).toContain('No se pudo dar de baja la empresa.')
+    expect(copia).toContain('Dá de baja o reasigná esos datos antes de eliminar la empresa.')
+  })
+
+  /**
+   * Cláusula bajo prueba: la rama `error.estado === 404`, ANTES de mirar el código. Un admin de
+   * tenant que apunta a una entidad de otro tenant recibe este mismo 404 (ADR-8), así que la copia
+   * no puede insinuar nada sobre el uso ni sobre el alcance — y el mensaje del servidor NO se
+   * anexa, para que un futuro texto del servidor no filtre por acá (spec BO-R12).
+   */
+  it('un 404 rinde la copia neutra de inexistencia y no filtra el mensaje del servidor', () => {
+    const copia = copiaDeFalloDeBaja(
+      new ErrorApi(404, 'no_encontrado', 'No existe la empresa 77.'),
+      'la empresa',
+    )
+
+    expect(copia).toBe('No se pudo dar de baja la empresa. Ya no existe o no está a tu alcance. Actualizá el listado.')
+    expect(copia).not.toContain('77')
+    expect(copia).not.toMatch(/en uso|tiene|ventas/i)
+  })
+
+  /**
+   * Cláusula bajo prueba: la rama `error.estado >= 500`. Las tres bajas corren SIN reintento
+   * automático, así que un commit cuyo ACK se perdió llega como 500 sobre una baja que sí quedó
+   * hecha: la copia manda a verificar el listado antes de reintentar, nunca a reintentar a ciegas.
+   * (Entrada arrastrada de la slice 4, punto 5.)
+   */
+  it('un 500 avisa que el resultado es incierto y manda a verificar el listado', () => {
+    const copia = copiaDeFalloDeBaja(
+      new ErrorApi(500, 'error_interno', 'Ocurrió un error inesperado.'),
+      'el punto de venta',
+    )
+
+    expect(copia).toContain('verificá el listado antes de reintentar')
+    expect(copia).not.toMatch(/reintentá ahora|volvé a intentar/i)
+  })
+
+  it('un error que no es de la API comparte la copia del resultado incierto', () => {
+    expect(copiaDeFalloDeBaja(new TypeError('Failed to fetch'), 'el usuario')).toContain(
+      'verificá el listado antes de reintentar',
+    )
+  })
+
+  /** Un código que la web no conoce (403, un séptimo código futuro) no rompe: rinde el mensaje. */
+  it('un código desconocido rinde el mensaje del servidor sin guía inventada', () => {
+    const copia = copiaDeFalloDeBaja(
+      new ErrorApi(409, 'codigo_del_futuro', 'Algo nuevo bloquea la baja.'),
+      'el tenant',
+    )
+
+    expect(copia).toBe('Algo nuevo bloquea la baja.')
+  })
+})
+
+describe('arrastreDeTenant', () => {
+  /** Contadores pairwise-distintos: con valores iguales, intercambiar dos líneas no se vería. */
+  it('nombra las tres familias de hijos con su cantidad', () => {
+    expect(arrastreDeTenant({ cantidadEmpresas: 2, cantidadPuntosVenta: 3, cantidadUsuarios: 4 })).toEqual([
+      '2 empresas',
+      '3 puntos de venta',
+      '4 usuarios',
+    ])
+  })
+
+  it('usa el singular cuando hay uno solo', () => {
+    expect(arrastreDeTenant({ cantidadEmpresas: 1, cantidadPuntosVenta: 1, cantidadUsuarios: 1 })).toEqual([
+      '1 empresa',
+      '1 punto de venta',
+      '1 usuario',
+    ])
+  })
+
+  it('no lista las familias vacías', () => {
+    expect(arrastreDeTenant({ cantidadEmpresas: 1, cantidadPuntosVenta: 0, cantidadUsuarios: 0 })).toEqual([
+      '1 empresa',
+    ])
+    expect(arrastreDeTenant({ cantidadEmpresas: 0, cantidadPuntosVenta: 0, cantidadUsuarios: 0 })).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/api/bajas.test.ts
+++ b/src/Ways.Web/src/api/bajas.test.ts
@@ -122,6 +122,21 @@ describe('copiaDeFalloDeBaja — la copia se elige por código', () => {
 
     expect(copia).toBe('Algo nuevo bloquea la baja.')
   })
+
+  /**
+   * Cláusula bajo prueba: que el mapa sea un `Map` y no un objeto literal (judgment-day ronda 1,
+   * C6). El `codigo` viene del SERVIDOR: sobre un objeto, `GUIA['constructor']` resuelve contra el
+   * prototipo y devuelve una función, así que `guia ? … : …` daba verdadero y la copia terminaba
+   * concatenando el `[Function]` — o algo peor con `toString`. Con `Map.get` solo existen las
+   * claves propias y estos tres caen por el fallback como cualquier código desconocido.
+   */
+  it('una clave del prototipo no se hace pasar por guía', () => {
+    for (const codigo of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+      expect(copiaDeFalloDeBaja(new ErrorApi(409, codigo, 'Algo bloquea la baja.'), 'el tenant')).toBe(
+        'Algo bloquea la baja.',
+      )
+    }
+  })
 })
 
 describe('arrastreDeTenant', () => {

--- a/src/Ways.Web/src/api/bajas.ts
+++ b/src/Ways.Web/src/api/bajas.ts
@@ -28,15 +28,20 @@ export type SujetoDeBaja = 'el tenant' | 'la empresa' | 'el punto de venta' | 'e
  *
  * Congelado a propósito y sin `Record<CodigoConocido, …>`: si el servidor sumara un séptimo código,
  * cae por el fallback genérico —que igual rinde el mensaje— en vez de romper el build.
+ *
+ * Es un `Map` y no un objeto literal porque el `codigo` viene del SERVIDOR: sobre un objeto,
+ * `GUIA['constructor']` o `GUIA['toString']` resuelven contra el prototipo y devuelven algo que no
+ * es una guía, así que un código exótico dejaba de caer por el fallback. `Map.get` solo ve las
+ * claves propias.
  */
-const GUIA_POR_CODIGO: Readonly<Record<string, string>> = {
-  tenant_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar el tenant.',
-  empresa_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar la empresa.',
-  punto_venta_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar el punto de venta.',
-  usuario_en_uso: 'Reasigná o dá de baja esas operaciones antes de eliminar la cuenta.',
-  ultima_empresa_del_tenant: 'La baja del tenant se hace desde la pantalla de Tenants.',
-  ultimo_punto_venta_de_la_empresa: 'La baja de la empresa se hace desde la pantalla de Empresas.',
-}
+const GUIA_POR_CODIGO: ReadonlyMap<string, string> = new Map([
+  ['tenant_en_uso', 'Dá de baja o reasigná esos datos antes de eliminar el tenant.'],
+  ['empresa_en_uso', 'Dá de baja o reasigná esos datos antes de eliminar la empresa.'],
+  ['punto_venta_en_uso', 'Dá de baja o reasigná esos datos antes de eliminar el punto de venta.'],
+  ['usuario_en_uso', 'Reasigná o dá de baja esas operaciones antes de eliminar la cuenta.'],
+  ['ultima_empresa_del_tenant', 'La baja del tenant se hace desde la pantalla de Tenants.'],
+  ['ultimo_punto_venta_de_la_empresa', 'La baja de la empresa se hace desde la pantalla de Empresas.'],
+])
 
 /**
  * Copia del 404. Es deliberadamente NEUTRA y NO anexa el mensaje del servidor: un admin de tenant
@@ -73,7 +78,7 @@ export function copiaDeFalloDeBaja(error: unknown, sujeto: SujetoDeBaja): string
   // El mensaje del servidor va primero porque es el que nombra el bloqueo; el encabezado solo lo
   // reemplaza cuando vino vacío, para que nunca quede un alert sin texto.
   const detalle = error.message.trim() || encabezado
-  const guia = GUIA_POR_CODIGO[error.codigo]
+  const guia = GUIA_POR_CODIGO.get(error.codigo)
 
   return guia ? `${detalle} ${guia}` : detalle
 }

--- a/src/Ways.Web/src/api/bajas.ts
+++ b/src/Ways.Web/src/api/bajas.ts
@@ -1,0 +1,109 @@
+/**
+ * Copia de los rechazos de una baja lógica (etapa 20, slice 5).
+ *
+ * Módulo PURO: sin React y sin fetch, para que cada rama se pueda probar sin montar una pantalla.
+ *
+ * Dos reglas, y las dos vienen del spec `bajas-de-organizacion` → *The Complete 409 Code Set Is
+ * Exactly Six Codes*:
+ *
+ * 1. La copia se elige por `codigo` y NUNCA por `mensaje`. El código es contrato; el mensaje es
+ *    texto libre que el servidor degrada a una frase genérica cuando la tabla que bloquea no tiene
+ *    etiqueta. Cambiar el `mensaje` no puede cambiar qué copia se rinde.
+ * 2. El `mensaje` tampoco se tira. Es lo ÚNICO que dice QUÉ bloquea ("…porque tiene 3 ventas") y
+ *    va PRIMERO; la copia elegida por el código va detrás y agrega lo que el mensaje no trae: qué
+ *    hacer al respecto. Tragarlo en un error genérico dejaba al operador sin la única información
+ *    accionable de la respuesta.
+ *
+ * Las dos excepciones a (2) son el 404 y el 5xx, y las dos están justificadas abajo.
+ */
+import { ErrorApi } from './cliente'
+
+/** El sujeto de la baja, tal como entra en la copia ("No se pudo dar de baja **el tenant**"). */
+export type SujetoDeBaja = 'el tenant' | 'la empresa' | 'el punto de venta' | 'el usuario'
+
+/**
+ * Los SEIS códigos de conflicto de la etapa 20, cada uno con su propia guía. Ninguna repite lo que
+ * el mensaje del servidor ya dice: las cuatro de uso indican qué hacer con los datos que bloquean,
+ * y las dos de mínimo estructural indican DÓNDE se hace la baja que sí corresponde.
+ *
+ * Congelado a propósito y sin `Record<CodigoConocido, …>`: si el servidor sumara un séptimo código,
+ * cae por el fallback genérico —que igual rinde el mensaje— en vez de romper el build.
+ */
+const GUIA_POR_CODIGO: Readonly<Record<string, string>> = {
+  tenant_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar el tenant.',
+  empresa_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar la empresa.',
+  punto_venta_en_uso: 'Dá de baja o reasigná esos datos antes de eliminar el punto de venta.',
+  usuario_en_uso: 'Reasigná o dá de baja esas operaciones antes de eliminar la cuenta.',
+  ultima_empresa_del_tenant: 'La baja del tenant se hace desde la pantalla de Tenants.',
+  ultimo_punto_venta_de_la_empresa: 'La baja de la empresa se hace desde la pantalla de Empresas.',
+}
+
+/**
+ * Copia del 404. Es deliberadamente NEUTRA y NO anexa el mensaje del servidor: un admin de tenant
+ * que apunta a una entidad de otro tenant recibe exactamente este 404
+ * (`PoliticaDeRoles.ValidarAlcanceDeTenant`, ADR-8), y la pantalla no puede insinuar que la fila
+ * existe en otro lado. "Ya no existe" es lo mismo que ve quien apunta a un id inventado — que es
+ * justo lo que el anti-oráculo pide, también en la capa de UI.
+ */
+const COPIA_NO_ENCONTRADO = 'Ya no existe o no está a tu alcance. Actualizá el listado.'
+
+/**
+ * Copia del 5xx, y tampoco anexa el mensaje: un 500 no trae detalle útil, trae `error_interno`.
+ * Lo que sí importa es que la baja NO es reintentable automáticamente — las tres bajas corren con
+ * `FabricaDeEstrategiaSinReintento`, así que un commit cuyo ACK se perdió llega como 500 y la baja
+ * PUEDE haber quedado hecha. Decir "reintentá" a secas invitaba a un segundo intento sobre algo ya
+ * borrado; por eso la copia manda a verificar primero.
+ */
+const COPIA_RESULTADO_INCIERTO =
+  'No se pudo confirmar el resultado: verificá el listado antes de reintentar.'
+
+/**
+ * Texto a rendir ante un fallo de baja: `{mensaje del servidor} {guía elegida por el código}`.
+ *
+ * Un error que no es `ErrorApi` (la red se cayó, el fetch explotó) no trae ni código ni mensaje
+ * confiable y comparte la copia del resultado incierto: tampoco se sabe si el servidor commiteó.
+ */
+export function copiaDeFalloDeBaja(error: unknown, sujeto: SujetoDeBaja): string {
+  const encabezado = `No se pudo dar de baja ${sujeto}.`
+
+  if (!(error instanceof ErrorApi)) return `${encabezado} ${COPIA_RESULTADO_INCIERTO}`
+  if (error.estado === 404) return `${encabezado} ${COPIA_NO_ENCONTRADO}`
+  if (error.estado >= 500) return `${encabezado} ${COPIA_RESULTADO_INCIERTO}`
+
+  // El mensaje del servidor va primero porque es el que nombra el bloqueo; el encabezado solo lo
+  // reemplaza cuando vino vacío, para que nunca quede un alert sin texto.
+  const detalle = error.message.trim() || encabezado
+  const guia = GUIA_POR_CODIGO[error.codigo]
+
+  return guia ? `${detalle} ${guia}` : detalle
+}
+
+/** Lo mínimo que la puerta de confirmación del tenant necesita: sus contadores de hijos vivos. */
+export type ContadoresDeTenant = {
+  cantidadEmpresas: number
+  cantidadPuntosVenta: number
+  cantidadUsuarios: number
+}
+
+/**
+ * Lo que se va con el tenant en la MISMA cascada (spec `bajas-de-organizacion` → *Cascade Is
+ * Bounded To The Organization Projection And Shares One Instant*): sus empresas, sus puntos de
+ * venta y sus usuarios. La puerta de confirmación tiene que nombrarlo — dar de baja un tenant no
+ * es dar de baja una fila, y el operador no puede enterarse después.
+ *
+ * Los contadores en cero NO se listan: anunciar "0 usuarios" entre las cosas que se dan de baja es
+ * ruido que compite con las que sí se van.
+ */
+export function arrastreDeTenant(contadores: ContadoresDeTenant): string[] {
+  return [
+    frase(contadores.cantidadEmpresas, 'empresa', 'empresas'),
+    frase(contadores.cantidadPuntosVenta, 'punto de venta', 'puntos de venta'),
+    frase(contadores.cantidadUsuarios, 'usuario', 'usuarios'),
+  ].filter((linea): linea is string => linea !== null)
+}
+
+function frase(cantidad: number, singular: string, plural: string): string | null {
+  if (cantidad <= 0) return null
+
+  return `${cantidad} ${cantidad === 1 ? singular : plural}`
+}

--- a/src/Ways.Web/src/api/organizacion.test.ts
+++ b/src/Ways.Web/src/api/organizacion.test.ts
@@ -160,9 +160,21 @@ describe('opcionesDeTenant', () => {
     expect(opciones.find((o) => o.valor === '9')?.etiqueta).toBe(
       `${ETIQUETA_OPCION_PLATAFORMA} (tenant 9)`,
     )
-    expect(opciones.find((o) => o.valor === VALOR_SIN_TENANT)?.etiqueta).toBe(
-      `${ETIQUETA_OPCION_PLATAFORMA} (tenant ${VALOR_SIN_TENANT})`,
-    )
+  })
+
+  /**
+   * Cláusula bajo prueba (slice 5, entrada arrastrada de la slice 2, punto 3): el
+   * `opcion.valor !== valorSinSufijo` de `desempatarHomonimos`. La opción de plataforma CUENTA
+   * para la colisión —por eso el tenant homónimo sí recibe su sufijo, arriba— pero nunca la
+   * recibe ella: su clave es el centinela interno `sin-tenant`, no un id, y anexarlo rendía
+   * "Plataforma (sin tenant) (tenant sin-tenant)" en la copia que ve el operador.
+   */
+  it('la opción de plataforma nunca filtra su clave centinela a la etiqueta', () => {
+    const opciones = opcionesDeTenant([fila(9, ETIQUETA_OPCION_PLATAFORMA), fila(null, null)])
+    const plataforma = opciones.find((o) => o.valor === VALOR_SIN_TENANT)
+
+    expect(plataforma).toEqual({ valor: VALOR_SIN_TENANT, etiqueta: ETIQUETA_OPCION_PLATAFORMA })
+    expect(plataforma?.etiqueta).not.toContain(VALOR_SIN_TENANT)
   })
 
   it('sobre una lista vacía no ofrece ninguna opción', () => {

--- a/src/Ways.Web/src/api/organizacion.ts
+++ b/src/Ways.Web/src/api/organizacion.ts
@@ -2,9 +2,8 @@
  * Cliente de organización (etapa 4B): tenants (plataforma-only), empresas y puntos de venta
  * (plataforma ve/edita cualquiera, un admin de tenant ve/edita solo los propios — lo
  * garantiza `OrganizacionEndpoints`/`ServicioDeOrganizacion` del lado del servidor, acá no
- * hay lógica de alcance). Alta y baja siguen siendo plataforma-only vía aprovisionamiento
- * (`NuevoTenant.tsx`) — este cliente solo lista/edita datos descriptivos y
- * suspende/reactiva un tenant.
+ * hay lógica de alcance). El alta sigue siendo plataforma-only vía aprovisionamiento
+ * (`NuevoTenant.tsx`); la BAJA (etapa 20) es lógica y vive en los tres `eliminar*` de abajo.
  */
 import { api } from './cliente'
 import type {
@@ -23,13 +22,18 @@ export const clienteDeOrganizacion = {
     api.put<TenantListado>(`/plataforma/tenants/${id}`, datos),
   suspenderTenant: (id: number) => api.post<TenantListado>(`/plataforma/tenants/${id}/suspender`),
   reactivarTenant: (id: number) => api.post<TenantListado>(`/plataforma/tenants/${id}/reactivar`),
+  // Las tres bajas contestan 204 sin cuerpo: `api.delete<void>` y nada que espejar (el DTO de
+  // respuesta no existe, así que no hay contrato que copiar mal).
+  eliminarTenant: (id: number) => api.delete<void>(`/plataforma/tenants/${id}`),
 
   listarEmpresas: () => api.get<EmpresaListado[]>('/empresas'),
   editarEmpresa: (id: number, datos: EmpresaEdicion) => api.put<EmpresaListado>(`/empresas/${id}`, datos),
+  eliminarEmpresa: (id: number) => api.delete<void>(`/empresas/${id}`),
 
   listarPuntosVenta: () => api.get<PuntoVentaListado[]>('/puntos-venta'),
   editarPuntoVenta: (id: number, datos: PuntoVentaEdicion) =>
     api.put<PuntoVentaListado>(`/puntos-venta/${id}`, datos),
+  eliminarPuntoVenta: (id: number) => api.delete<void>(`/puntos-venta/${id}`),
 }
 
 // --- Filtros por dueño y etiquetas (stage-20, slice 2 · design D14, D15) ---
@@ -107,15 +111,24 @@ function ordenarPorEtiqueta(opciones: OpcionDeFiltro[]): OpcionDeFiltro[] {
  * La opción de plataforma entra al mapa como una más: `ETIQUETA_OPCION_PLATAFORMA` es texto fijo y
  * un tenant puede llamarse literalmente así, con lo que las dos etiquetas colisionarían. Su clave
  * (`VALOR_SIN_TENANT`) no se toca — el sufijo es la clave, no un id fabricado.
+ *
+ * `valorSinSufijo` CUENTA para la colisión pero nunca recibe sufijo. Es la opción de plataforma:
+ * su clave es un centinela interno (`sin-tenant`), no un id, y anexárselo rendía la copia
+ * "Plataforma (sin tenant) (tenant sin-tenant)" en cuanto un tenant se llamaba literalmente como
+ * la etiqueta fija. El desempate lo sigue haciendo el otro lado de la colisión, que sí tiene id.
  */
-function desempatarHomonimos(opciones: OpcionDeFiltro[], sustantivo: string): OpcionDeFiltro[] {
+function desempatarHomonimos(
+  opciones: OpcionDeFiltro[],
+  sustantivo: string,
+  valorSinSufijo?: string,
+): OpcionDeFiltro[] {
   const repeticiones = new Map<string, number>()
   for (const opcion of opciones) {
     repeticiones.set(opcion.etiqueta, (repeticiones.get(opcion.etiqueta) ?? 0) + 1)
   }
 
   return opciones.map((opcion) =>
-    (repeticiones.get(opcion.etiqueta) ?? 0) > 1
+    opcion.valor !== valorSinSufijo && (repeticiones.get(opcion.etiqueta) ?? 0) > 1
       ? { ...opcion, etiqueta: `${opcion.etiqueta} (${sustantivo} ${opcion.valor})` }
       : opcion,
   )
@@ -146,8 +159,9 @@ export function opcionesDeTenant(filas: readonly FilaConTenant[]): OpcionDeFiltr
 
   // El desempate corre sobre el conjunto COMPLETO, plataforma incluida: recién después se aparta
   // esa opción para dejarla primera. Excluirla del mapa dejaba dos etiquetas idénticas cuando un
-  // tenant se llama literalmente "Plataforma (sin tenant)".
-  const desempatadas = desempatarHomonimos([...porClave.values()], 'tenant')
+  // tenant se llama literalmente "Plataforma (sin tenant)". Lo que SÍ se excluye es el SUFIJO de
+  // esa opción: su clave es un centinela, no un id, y no puede filtrarse a la copia.
+  const desempatadas = desempatarHomonimos([...porClave.values()], 'tenant', VALOR_SIN_TENANT)
   const plataforma = desempatadas.find((o) => o.valor === VALOR_SIN_TENANT)
   const tenants = ordenarPorEtiqueta(desempatadas.filter((o) => o.valor !== VALOR_SIN_TENANT))
 

--- a/src/Ways.Web/src/componentes/ConfirmacionDeBaja.test.tsx
+++ b/src/Ways.Web/src/componentes/ConfirmacionDeBaja.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConfirmacionDeBaja } from './ConfirmacionDeBaja'
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5, judgment-day ronda 1 (C1 y C5). La puerta es
+// COMPARTIDA por las cuatro pantallas raíz, así que su disciplina modal se prueba UNA vez acá y
+// vale para las cuatro (`react-async-state` regla 10 por construcción).
+
+/** Anfitrión mínimo: la puerta se monta y se desmonta como en las pantallas —`{abierta && …}`— y el
+ * botón "Baja" es el disparador cuyo foco hay que devolver al cerrarla. */
+function Anfitrion({ ocupado = false, alConfirmar = () => {} }: { ocupado?: boolean; alConfirmar?: () => void }) {
+  const [abierta, setAbierta] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setAbierta(true)} disabled={abierta}>
+        Baja
+      </button>
+      <input aria-label="otro control" disabled={abierta} />
+      {abierta && (
+        <ConfirmacionDeBaja
+          titulo={'el tenant "Comercio Sur"'}
+          ocupado={ocupado}
+          onConfirmar={alConfirmar}
+          onCancelar={() => setAbierta(false)}
+        />
+      )}
+    </>
+  )
+}
+
+describe('ConfirmacionDeBaja (slice 5, ronda 1 — disciplina modal)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Cláusula bajo prueba: `aria-modal="true"` sobre el `role="alertdialog"`. Sin él la puerta se
+   * anuncia como un aviso más y no como algo que reclama la pantalla, que es exactamente lo que
+   * hace: mientras está abierta, todo lo demás queda inerte.
+   */
+  it('se anuncia como modal, no como un aviso al costado', async () => {
+    const usuario = userEvent.setup()
+    render(<Anfitrion />)
+
+    await usuario.click(screen.getByRole('button', { name: 'Baja' }))
+
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toHaveAttribute('aria-modal', 'true')
+  })
+
+  /**
+   * Cláusula bajo prueba: el `cancelarRef.current?.focus()` del efecto de apertura. Sin él el foco
+   * se queda en el disparador —o en el `body`, si la fila desapareció— y quien navega por teclado
+   * tiene que buscar a ciegas una puerta que acaba de reclamar la pantalla.
+   */
+  it('al abrirse se lleva el foco a Cancelar', async () => {
+    const usuario = userEvent.setup()
+    render(<Anfitrion />)
+
+    await usuario.click(screen.getByRole('button', { name: 'Baja' }))
+
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toHaveFocus()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `return () => disparadorRef.current?.focus()` de ese mismo efecto.
+   * Cerrar sin devolver el foco lo manda al `body` y pierde el lugar de la tabla.
+   */
+  it('al cerrarse devuelve el foco al disparador', async () => {
+    const usuario = userEvent.setup()
+    render(<Anfitrion />)
+
+    const disparador = screen.getByRole('button', { name: 'Baja' })
+    await usuario.click(disparador)
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(disparador).toHaveFocus()
+  })
+
+  /**
+   * Cláusula bajo prueba: el listener de `Escape` sobre `document`. Es la salida que todo diálogo
+   * modal debe tener; sin ella la puerta solo se cierra con el mouse.
+   */
+  it('Escape equivale a Cancelar', async () => {
+    const usuario = userEvent.setup()
+    const alConfirmar = vi.fn()
+    render(<Anfitrion alConfirmar={alConfirmar} />)
+
+    await usuario.click(screen.getByRole('button', { name: 'Baja' }))
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(alConfirmar).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `|| ocupado` del listener de `Escape`. Con la escritura en vuelo los
+   * dos botones están inertes; que el teclado siga cerrando la puerta la sacaría de la pantalla
+   * mientras el DELETE sigue viajando, y el operador perdería de vista qué se está borrando.
+   */
+  it('con la escritura en vuelo, Escape no cierra nada', async () => {
+    const usuario = userEvent.setup()
+    render(<Anfitrion ocupado />)
+
+    await usuario.click(screen.getByRole('button', { name: 'Baja' }))
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: el preámbulo de `arrastra`. Decía "Se dan de baja junto con él", que es
+   * masculino y miente en `Empresas` ("la empresa"). El sujeto no se nombra: la lista ya lo dice.
+   */
+  it('el preámbulo del arrastre no le pone género al sujeto', () => {
+    render(
+      <ConfirmacionDeBaja
+        titulo={'la empresa "Sur SRL"'}
+        arrastra={['Sus puntos de venta activos']}
+        ocupado={false}
+        onConfirmar={() => {}}
+        onCancelar={() => {}}
+      />,
+    )
+
+    const puerta = screen.getByRole('alertdialog')
+    expect(puerta).toHaveTextContent('También se dan de baja:')
+    expect(puerta).not.toHaveTextContent(/junto con él/)
+  })
+
+  /**
+   * Cláusula bajo prueba: los defaults de `pregunta`/`nota`/`etiquetaConfirmar` frente a los
+   * valores que le pasa `Tenants` para suspender. El panel dejó de ser específico de la baja
+   * (`Tenants` lo reusa para suspender y reactivar) y la nota de la baja lógica no puede colarse
+   * en una acción que no borra nada.
+   */
+  it('reusada para otra acción, cambia verbo y botón y NO habla de baja lógica', () => {
+    render(
+      <ConfirmacionDeBaja
+        titulo={'el tenant "Comercio Sur"'}
+        pregunta="Suspender"
+        nota={null}
+        etiquetaConfirmar="Confirmar suspensión"
+        etiquetaEnCurso="Suspendiendo…"
+        ocupado={false}
+        onConfirmar={() => {}}
+        onCancelar={() => {}}
+      />,
+    )
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar suspensión' })
+    expect(puerta).toHaveTextContent('¿Suspender el tenant "Comercio Sur"?')
+    expect(puerta).not.toHaveTextContent(/baja es lógica/)
+    expect(screen.getByRole('button', { name: 'Confirmar suspensión' })).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/componentes/ConfirmacionDeBaja.test.tsx
+++ b/src/Ways.Web/src/componentes/ConfirmacionDeBaja.test.tsx
@@ -9,13 +9,41 @@ import { ConfirmacionDeBaja } from './ConfirmacionDeBaja'
 // vale para las cuatro (`react-async-state` regla 10 por construcción).
 
 /** Anfitrión mínimo: la puerta se monta y se desmonta como en las pantallas —`{abierta && …}`— y el
- * botón "Baja" es el disparador cuyo foco hay que devolver al cerrarla. */
-function Anfitrion({ ocupado = false, alConfirmar = () => {} }: { ocupado?: boolean; alConfirmar?: () => void }) {
+ * botón "Baja" es el disparador cuyo foco hay que devolver al cerrarla. El disparador se captura
+ * SÍNCRONAMENTE en el `onClick`, antes de cualquier `setState`, igual que en las cuatro pantallas
+ * raíz: cuando la puerta se monta, ese botón ya está `disabled`.
+ *
+ * `conFixup` reproduce la *focus fixup rule* del navegador: deshabilitar el elemento enfocado le
+ * saca el foco y lo manda al `<body>`. jsdom NO la aplica, y tampoco se la puede forzar en su
+ * momento real —una vez que el botón quedó `disabled`, jsdom trata `blur()` y `document.body.
+ * focus()` como no-ops sobre un área no focusable, así que `document.activeElement` se queda
+ * pegado al botón—. Por eso el blur se ADELANTA un tick, al `onClick`, cuando el botón todavía
+ * está habilitado: el mecanismo difiere, pero el estado observable es exactamente el que importa
+ * —el foco ya está en el `<body>` cuando corre el efecto de montaje de la puerta—, que es donde
+ * la captura tardía leía `document.activeElement`. */
+function Anfitrion({
+  ocupado = false,
+  alConfirmar = () => {},
+  conFixup = false,
+}: {
+  ocupado?: boolean
+  alConfirmar?: () => void
+  conFixup?: boolean
+}) {
   const [abierta, setAbierta] = useState(false)
+  const [disparador, setDisparador] = useState<HTMLElement | null>(null)
 
   return (
     <>
-      <button type="button" onClick={() => setAbierta(true)} disabled={abierta}>
+      <button
+        type="button"
+        onClick={(evento) => {
+          setDisparador(evento.currentTarget)
+          if (conFixup) evento.currentTarget.blur()
+          setAbierta(true)
+        }}
+        disabled={abierta}
+      >
         Baja
       </button>
       <input aria-label="otro control" disabled={abierta} />
@@ -23,11 +51,54 @@ function Anfitrion({ ocupado = false, alConfirmar = () => {} }: { ocupado?: bool
         <ConfirmacionDeBaja
           titulo={'el tenant "Comercio Sur"'}
           ocupado={ocupado}
+          disparador={disparador}
           onConfirmar={alConfirmar}
           onCancelar={() => setAbierta(false)}
         />
       )}
     </>
+  )
+}
+
+/** Anfitrión con la forma real de una pantalla (`Box`: `div.box > header > h5`) y una fila que
+ * DESAPARECE al confirmar, que es lo que pasa cuando la baja sale bien. */
+function AnfitrionQuePierdeLaFila() {
+  const [fila, setFila] = useState(true)
+  const [abierta, setAbierta] = useState(false)
+  const [disparador, setDisparador] = useState<HTMLElement | null>(null)
+
+  return (
+    <div className="box">
+      <header>
+        <h5>Tenants</h5>
+      </header>
+      <div className="body p-3">
+        {fila && (
+          <button
+            type="button"
+            onClick={(evento) => {
+              setDisparador(evento.currentTarget)
+              setAbierta(true)
+            }}
+            disabled={abierta}
+          >
+            Baja
+          </button>
+        )}
+        {abierta && (
+          <ConfirmacionDeBaja
+            titulo={'el tenant "Comercio Sur"'}
+            ocupado={false}
+            disparador={disparador}
+            onConfirmar={() => {
+              setFila(false)
+              setAbierta(false)
+            }}
+            onCancelar={() => setAbierta(false)}
+          />
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -65,8 +136,8 @@ describe('ConfirmacionDeBaja (slice 5, ronda 1 — disciplina modal)', () => {
   })
 
   /**
-   * Cláusula bajo prueba: el `return () => disparadorRef.current?.focus()` de ese mismo efecto.
-   * Cerrar sin devolver el foco lo manda al `body` y pierde el lugar de la tabla.
+   * Cláusula bajo prueba: el `return` del efecto de apertura, que devuelve el foco al disparador
+   * recibido por prop. Cerrar sin devolverlo lo manda al `body` y pierde el lugar de la tabla.
    */
   it('al cerrarse devuelve el foco al disparador', async () => {
     const usuario = userEvent.setup()
@@ -77,6 +148,55 @@ describe('ConfirmacionDeBaja (slice 5, ronda 1 — disciplina modal)', () => {
     await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
 
     expect(disparador).toHaveFocus()
+  })
+
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-2): que el disparador llegue por PROP —capturado en el
+   * `onClick`, antes de cualquier `setState`— y no de un `document.activeElement` leído dentro del
+   * efecto de montaje. Ese efecto pasivo corre DESPUÉS del commit que dejó el disparador
+   * `disabled`, y un navegador real ya aplicó ahí la *focus fixup rule*: el foco está en el
+   * `<body>`, así que la captura tardía se quedaba con el `<body>` y "devolver el foco" era un
+   * no-op.
+   *
+   * Honestidad sobre el entorno: jsdom NO implementa esa corrección de foco, y por eso el defecto
+   * pasaba verde. Tampoco se la puede reproducir en su instante real —sobre un botón ya `disabled`,
+   * `blur()` y `document.body.focus()` son no-ops en jsdom—, así que el anfitrión (`conFixup`)
+   * adelanta el blur al `onClick`. Lo que el test observa es idéntico: cuando la puerta monta, el
+   * foco está en el `<body>` y no en el disparador.
+   */
+  it('captura el disparador antes del render que lo deshabilita, no después', async () => {
+    const usuario = userEvent.setup()
+    render(<Anfitrion conFixup />)
+
+    const disparador = screen.getByRole('button', { name: 'Baja' })
+    await usuario.click(disparador)
+
+    // El navegador ya se llevó el foco al `<body>`: lo único que sabe quién abrió la puerta es la
+    // prop capturada en el `onClick`.
+    expect(disparador).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toHaveFocus()
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(disparador).toHaveFocus()
+    expect(document.body).not.toHaveFocus()
+  })
+
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-2): la rama de respaldo del cierre —`esAlcanzable` en `false`
+   * → `regresoRef`—. Cuando la baja sale bien, la fila que tenía el disparador ya no existe:
+   * enfocar un nodo desprendido no hace nada y el foco se queda en el `<body>`, o sea al principio
+   * de todo el documento. El respaldo es un punto de referencia estable de la pantalla.
+   */
+  it('si la fila del disparador desapareció, el foco cae en el título de la pantalla', async () => {
+    const usuario = userEvent.setup()
+    render(<AnfitrionQuePierdeLaFila />)
+
+    await usuario.click(screen.getByRole('button', { name: 'Baja' }))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    expect(screen.queryByRole('button', { name: 'Baja' })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Tenants' })).toHaveFocus()
   })
 
   /**

--- a/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
+++ b/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
@@ -1,0 +1,54 @@
+/**
+ * Puerta de confirmación de una baja lógica (etapa 20, slice 5), compartida por las CUATRO
+ * pantallas raíz — `react-async-state` regla 10: el patrón se replica en todas las superficies
+ * hermanas, y la forma más barata de garantizarlo es que haya una sola.
+ *
+ * NO usa `window.confirm`: la puerta tiene que NOMBRAR qué se va a borrar, y en el caso del
+ * tenant eso incluye a sus hijos, que se van con él en la misma cascada. Un `confirm` nativo
+ * bloquea el hilo, no se puede rendir con listas y —lo que importa acá— no se puede dejar
+ * inerte mientras el DELETE está en vuelo.
+ */
+type Props = {
+  /** Qué se está por dar de baja, ya nombrado ("el tenant \"Comercio Sur\""). */
+  titulo: string
+  /** Lo que se va con él. Vacío cuando la baja no arrastra nada. */
+  arrastra?: readonly string[]
+  /** `true` mientras el DELETE (y su refresco) están en vuelo: la puerta entera queda inerte. */
+  ocupado: boolean
+  onConfirmar: () => void
+  onCancelar: () => void
+}
+
+export function ConfirmacionDeBaja({ titulo, arrastra = [], ocupado, onConfirmar, onCancelar }: Props) {
+  return (
+    <div className="alert alert-warning rounded-0" role="alertdialog" aria-label="Confirmar baja">
+      <p className="mb-2">
+        <strong>¿Dar de baja {titulo}?</strong>
+      </p>
+      {arrastra.length > 0 && (
+        <>
+          <p className="mb-1">Se dan de baja junto con él:</p>
+          <ul className="mb-2">
+            {arrastra.map((linea) => (
+              <li key={linea}>{linea}</li>
+            ))}
+          </ul>
+        </>
+      )}
+      <p className="mb-3">La baja es lógica: los datos dejan de verse, pero no se borran de la base.</p>
+      <div className="d-flex gap-2">
+        <button type="button" className="btn btn-danger rounded-0" onClick={onConfirmar} disabled={ocupado}>
+          {ocupado ? 'Dando de baja…' : 'Confirmar baja'}
+        </button>
+        <button
+          type="button"
+          className="btn btn-outline-secondary rounded-0"
+          onClick={onCancelar}
+          disabled={ocupado}
+        >
+          Cancelar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
+++ b/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
@@ -1,7 +1,16 @@
+import { useEffect, useRef } from 'react'
+
 /**
- * Puerta de confirmación de una baja lógica (etapa 20, slice 5), compartida por las CUATRO
- * pantallas raíz — `react-async-state` regla 10: el patrón se replica en todas las superficies
- * hermanas, y la forma más barata de garantizarlo es que haya una sola.
+ * Puerta MODAL de confirmación (etapa 20, slice 5), compartida por las CUATRO pantallas raíz —
+ * `react-async-state` regla 10: el patrón se replica en todas las superficies hermanas, y la forma
+ * más barata de garantizarlo es que haya una sola. Sus valores por defecto son los de la baja
+ * lógica (de ahí el nombre), pero el panel es genérico: `Tenants` lo reusa para suspender y
+ * reactivar, que estaban con `confirm()` nativo en el MISMO archivo que introdujo la puerta.
+ *
+ * MODAL DE VERDAD, y ahí está la seguridad: mientras esta puerta está montada, la pantalla que la
+ * monta deja INERTE todo el resto de sus controles (`bloqueado = ocupado || puerta abierta`). Eso
+ * es la regla 9 por construcción —nada puede supersederla— y de paso hace innecesaria una trampa
+ * de foco: un control deshabilitado no es tabulable, así que no queda nada afuera para enfocar.
  *
  * NO usa `window.confirm`: la puerta tiene que NOMBRAR qué se va a borrar, y en el caso del
  * tenant eso incluye a sus hijos, que se van con él en la misma cascada. Un `confirm` nativo
@@ -9,25 +18,80 @@
  * inerte mientras el DELETE está en vuelo.
  */
 type Props = {
-  /** Qué se está por dar de baja, ya nombrado ("el tenant \"Comercio Sur\""). */
+  /** Qué se está por tocar, ya nombrado ("el tenant \"Comercio Sur\""). */
   titulo: string
-  /** Lo que se va con él. Vacío cuando la baja no arrastra nada. */
+  /** Verbo de la acción, ya conjugado en infinitivo. Por defecto, el de la baja. */
+  pregunta?: string
+  /** Lo que se va con él. Vacío cuando la acción no arrastra nada. */
   arrastra?: readonly string[]
-  /** `true` mientras el DELETE (y su refresco) están en vuelo: la puerta entera queda inerte. */
+  /** Aclaración bajo la pregunta. Por defecto, la de la baja lógica; `null` la omite. */
+  nota?: string | null
+  /** Etiqueta del botón que confirma, y nombre accesible de la puerta. */
+  etiquetaConfirmar?: string
+  /** Etiqueta de ese mismo botón mientras la escritura está en vuelo. */
+  etiquetaEnCurso?: string
+  /** `true` mientras la escritura (y su refresco) están en vuelo: la puerta entera queda inerte. */
   ocupado: boolean
   onConfirmar: () => void
   onCancelar: () => void
 }
 
-export function ConfirmacionDeBaja({ titulo, arrastra = [], ocupado, onConfirmar, onCancelar }: Props) {
+const NOTA_DE_BAJA_LOGICA = 'La baja es lógica: los datos dejan de verse, pero no se borran de la base.'
+
+export function ConfirmacionDeBaja({
+  titulo,
+  pregunta = 'Dar de baja',
+  arrastra = [],
+  nota = NOTA_DE_BAJA_LOGICA,
+  etiquetaConfirmar = 'Confirmar baja',
+  etiquetaEnCurso = 'Dando de baja…',
+  ocupado,
+  onConfirmar,
+  onCancelar,
+}: Props) {
+  const cancelarRef = useRef<HTMLButtonElement>(null)
+  /** Quién tenía el foco cuando la puerta se abrió, para devolvérselo al cerrarla. Si esa fila ya
+   * no existe (la baja salió bien), enfocar un nodo desprendido es un no-op inofensivo. */
+  const disparadorRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    disparadorRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    cancelarRef.current?.focus()
+
+    return () => disparadorRef.current?.focus()
+  }, [])
+
+  /** Escape = Cancelar, y se escucha en `document` y no en el panel a propósito: el foco puede
+   * haberse ido a la nada si la fila que lo tenía desapareció. Mientras la escritura está en vuelo
+   * no cancela nada, igual que el botón. */
+  useEffect(() => {
+    function alTeclado(evento: KeyboardEvent) {
+      if (evento.key !== 'Escape' || ocupado) return
+
+      evento.preventDefault()
+      onCancelar()
+    }
+
+    document.addEventListener('keydown', alTeclado)
+
+    return () => document.removeEventListener('keydown', alTeclado)
+  }, [ocupado, onCancelar])
+
   return (
-    <div className="alert alert-warning rounded-0" role="alertdialog" aria-label="Confirmar baja">
+    <div
+      className="alert alert-warning rounded-0"
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={etiquetaConfirmar}
+    >
       <p className="mb-2">
-        <strong>¿Dar de baja {titulo}?</strong>
+        <strong>
+          ¿{pregunta} {titulo}?
+        </strong>
       </p>
       {arrastra.length > 0 && (
         <>
-          <p className="mb-1">Se dan de baja junto con él:</p>
+          <p className="mb-1">También se dan de baja:</p>
           <ul className="mb-2">
             {arrastra.map((linea) => (
               <li key={linea}>{linea}</li>
@@ -35,12 +99,13 @@ export function ConfirmacionDeBaja({ titulo, arrastra = [], ocupado, onConfirmar
           </ul>
         </>
       )}
-      <p className="mb-3">La baja es lógica: los datos dejan de verse, pero no se borran de la base.</p>
+      {nota && <p className="mb-3">{nota}</p>}
       <div className="d-flex gap-2">
         <button type="button" className="btn btn-danger rounded-0" onClick={onConfirmar} disabled={ocupado}>
-          {ocupado ? 'Dando de baja…' : 'Confirmar baja'}
+          {ocupado ? etiquetaEnCurso : etiquetaConfirmar}
         </button>
         <button
+          ref={cancelarRef}
           type="button"
           className="btn btn-outline-secondary rounded-0"
           onClick={onCancelar}

--- a/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
+++ b/src/Ways.Web/src/componentes/ConfirmacionDeBaja.tsx
@@ -32,8 +32,28 @@ type Props = {
   etiquetaEnCurso?: string
   /** `true` mientras la escritura (y su refresco) están en vuelo: la puerta entera queda inerte. */
   ocupado: boolean
+  /**
+   * Control que abrió la puerta, capturado SÍNCRONAMENTE en su `onClick` (antes de cualquier
+   * `setState`). No se puede leer acá con `document.activeElement`: para cuando el efecto de
+   * montaje corre, el commit que abrió la puerta ya dejó ese control `disabled` y el navegador
+   * aplicó la *focus fixup rule* —el foco ya está en el `<body>`—, así que la captura tardía
+   * devolvía el foco a la nada. jsdom no reproduce esa corrección, por eso el defecto pasaba los
+   * tests: el del componente lo fuerza a mano.
+   */
+  disparador?: HTMLElement | null
   onConfirmar: () => void
   onCancelar: () => void
+}
+
+/** Un disparador sirve para devolverle el foco solo si sigue en el documento y sigue siendo
+ * operable: la fila puede haber desaparecido (la baja salió bien) o quedar inerte. */
+function esAlcanzable(elemento: HTMLElement | null): elemento is HTMLElement {
+  return (
+    elemento !== null &&
+    elemento.isConnected &&
+    !elemento.matches(':disabled') &&
+    elemento.getAttribute('aria-disabled') !== 'true'
+  )
 }
 
 const NOTA_DE_BAJA_LOGICA = 'La baja es lógica: los datos dejan de verse, pero no se borran de la base.'
@@ -46,20 +66,38 @@ export function ConfirmacionDeBaja({
   etiquetaConfirmar = 'Confirmar baja',
   etiquetaEnCurso = 'Dando de baja…',
   ocupado,
+  disparador = null,
   onConfirmar,
   onCancelar,
 }: Props) {
   const cancelarRef = useRef<HTMLButtonElement>(null)
-  /** Quién tenía el foco cuando la puerta se abrió, para devolvérselo al cerrarla. Si esa fila ya
-   * no existe (la baja salió bien), enfocar un nodo desprendido es un no-op inofensivo. */
-  const disparadorRef = useRef<HTMLElement | null>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  /** Adónde va el foco cuando el disparador ya no sirve (la fila que lo contenía se fue con la
+   * baja): un punto de referencia estable de la pantalla —el título de la `Box` o, si no hay, la
+   * tabla— en vez del `<body>`, que deja a quien navega por teclado al principio de todo. */
+  const regresoRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    disparadorRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    regresoRef.current =
+      panelRef.current?.closest('.box')?.querySelector<HTMLElement>('header h5, table') ?? null
     cancelarRef.current?.focus()
 
-    return () => disparadorRef.current?.focus()
-  }, [])
+    return () => {
+      if (esAlcanzable(disparador)) {
+        disparador.focus()
+
+        return
+      }
+
+      const regreso = regresoRef.current
+      if (!regreso) return
+
+      // Un encabezado o una tabla no son tabulables: para poder recibir el foco necesitan un
+      // `tabindex` que React no rinde (no es un nodo suyo) y que se pone una sola vez.
+      if (!regreso.hasAttribute('tabindex')) regreso.setAttribute('tabindex', '-1')
+      regreso.focus()
+    }
+  }, [disparador])
 
   /** Escape = Cancelar, y se escucha en `document` y no en el panel a propósito: el foco puede
    * haberse ido a la nada si la fila que lo tenía desapareció. Mientras la escritura está en vuelo
@@ -79,6 +117,7 @@ export function ConfirmacionDeBaja({
 
   return (
     <div
+      ref={panelRef}
       className="alert alert-warning rounded-0"
       role="alertdialog"
       aria-modal="true"

--- a/src/Ways.Web/src/paginas/Empresas.test.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Empresas } from './Empresas'
@@ -440,5 +440,129 @@ describe('Empresas (stage-20, slice 5 — baja lógica)', () => {
     await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
 
     expect(botonDeBajaDe('Sur SRL')).toBeEnabled()
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5, judgment-day ronda 1 (C1, C4 y C5). Mismo
+// patrón que `Tenants.test.tsx`, replicado en la misma PR (`react-async-state` regla 10).
+
+describe('Empresas (slice 5, ronda 1 — la puerta es modal y el token se acuña al confirmar)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = usuarioFixture()
+  })
+
+  /** Cláusula bajo prueba: `bloqueado = ocupado !== null || baja !== null` en todos los `disabled`
+   * — ver el test gemelo de `Tenants.test.tsx`. */
+  it('con la puerta abierta no queda ninguna otra acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /Sur SRL/ })).getAllByRole('button', { name: 'Editar' })[0],
+    )
+    await usuario.click(botonDeBajaDe('Este SRL'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+      ...screen.getAllByRole('button', { name: 'Guardar' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+    expect(screen.getByLabelText('Razón social')).toBeDisabled()
+    expect(screen.getByLabelText('Tenant')).toBeDisabled()
+    expect(within(puerta).getByRole('button', { name: 'Confirmar baja' })).toBeEnabled()
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/empresas') return Promise.resolve([empresaSur, empresaAnexo])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+    expect(apiDeleteMock).toHaveBeenCalledWith('/empresas/12')
+    expect(screen.queryByText('Este SRL')).not.toBeInTheDocument()
+  })
+
+  /** Cláusula bajo prueba: el token acuñado al CONFIRMAR — ver el test gemelo de `Tenants.test.tsx`,
+   * incluido el porqué de bajar hasta el `<form>` para acuñar una generación en esa ventana. */
+  it('una generación acuñada entre abrir y confirmar no se traga el 204', async () => {
+    const usuario = userEvent.setup()
+    const { container } = montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /Sur SRL/ })).getAllByRole('button', { name: 'Editar' })[0],
+    )
+    await usuario.click(botonDeBajaDe('Este SRL'))
+
+    const form = container.querySelector('form')
+    if (!form) throw new Error('no hay formulario de edición abierto')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+    await waitFor(() => expect(screen.getByText('Se actualizó "Sur SRL".')).toBeInTheDocument())
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/empresas') return Promise.resolve([empresaSur, empresaAnexo])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText('Se dio de baja la empresa "Este SRL".')).toBeInTheDocument())
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Este SRL')).not.toBeInTheDocument()
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: el `setError('')` de `cancelarBaja` — ver `Tenants.test.tsx`. */
+  it('cancelar después de un rechazo se lleva el motivo con la puerta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'empresa_en_uso', 'No se puede dar de baja la empresa porque tiene 4 ventas.'),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(screen.getByText(/porque tiene 4 ventas/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/porque tiene 4 ventas/)).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: `ARRASTRE_DE_EMPRESA`. `EmpresaListado` NO trae un contador de puntos de
+   * venta —a diferencia de `TenantListado`, que trae los tres—, así que la puerta no puede decir
+   * cuántos son y no inventa un número: nombra la familia y aclara "activos", que es lo que la
+   * cascada efectivamente se lleva.
+   */
+  it('la puerta nombra el arrastre sin inventar una cantidad que la fila no trae', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    expect(within(puerta).getAllByRole('listitem').map((i) => i.textContent)).toEqual([
+      'Sus puntos de venta activos',
+    ])
+    expect(puerta).toHaveTextContent('También se dan de baja:')
+    expect(puerta).not.toHaveTextContent(/junto con él/)
   })
 })

--- a/src/Ways.Web/src/paginas/Empresas.test.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.test.tsx
@@ -2,21 +2,23 @@ import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Empresas } from './Empresas'
+import { ErrorApi } from '../api/cliente'
 import { ETIQUETA_SIN_DUENIO } from '../api/organizacion'
 import { ROL } from '../api/tipos'
 import type { EmpresaListado, UsuarioAutenticado } from '../api/tipos'
 
-// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.10 y 2.13).
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.10 y 2.13) y slice 5 (5.4, 5.7, 5.8).
 
 const apiGetMock = vi.fn()
 const apiPutMock = vi.fn()
+const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: vi.fn(),
     put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
-    delete: vi.fn(),
+    delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
     estado: number
@@ -235,5 +237,208 @@ describe('Empresas (stage-20, slice 2 — nombre de tenant y filtro)', () => {
     expect(screen.queryByLabelText('Tenant')).not.toBeInTheDocument()
     expect(screen.queryByRole('columnheader', { name: 'Tenant' })).not.toBeInTheDocument()
     expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5 (tareas 5.4, 5.7 y 5.8). El patrón es el
+// MISMO que el de `Tenants.tsx` y se replica en la misma PR (`react-async-state` regla 10).
+
+function botonDeBajaDe(razonSocial: string) {
+  return within(screen.getByRole('row', { name: new RegExp(razonSocial) })).getByRole('button', {
+    name: 'Baja',
+  })
+}
+
+describe('Empresas (stage-20, slice 5 — baja lógica)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = usuarioFixture()
+  })
+
+  it('el botón de baja no llama a la API hasta que se confirma', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toHaveTextContent(
+      '¿Dar de baja la empresa "Sur SRL"?',
+    )
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/empresas/10'))
+    await waitFor(() => expect(screen.getByText('Se dio de baja la empresa "Sur SRL".')).toBeInTheDocument())
+  })
+
+  it('cancelar cierra la puerta y no llama nunca a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /** Cláusula bajo prueba: la ventana inerte completa — ver el test gemelo de `Tenants.test.tsx`. */
+  it('durante el DELETE y su refresco no queda ninguna acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    let resolverDelete!: () => void
+    let resolverRefresco!: (items: EmpresaListado[]) => void
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/empresas') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([empresaSur, empresaEste])
+
+      return new Promise<EmpresaListado[]>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+    apiDeleteMock.mockImplementation(
+      () =>
+        new Promise<void>((resolver) => {
+          resolverDelete = resolver
+        }),
+    )
+
+    render(<Empresas />)
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    expect(screen.getByRole('button', { name: 'Dando de baja…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeDisabled()
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+
+    await act(async () => {
+      resolverDelete()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByText('Se dio de baja la empresa "Sur SRL".')).toBeInTheDocument())
+    expect(screen.getByText('Cargando…')).toBeInTheDocument()
+
+    await act(async () => {
+      resolverRefresco([empresaEste])
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Baja' })[0]).toBeEnabled())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: `ocupadoRef`, la guarda de re-entrancia del mismo tick (regla 9). */
+  it('un segundo click sobre la confirmación en vuelo se descarta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockImplementation(() => new Promise<void>(() => {}))
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    const confirmar = screen.getByRole('button', { name: 'Confirmar baja' })
+    await act(async () => {
+      confirmar.click()
+      confirmar.click()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('un refresco fallido después de la baja no la reporta como fallida', async () => {
+    const usuario = userEvent.setup()
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/empresas') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([empresaSur])
+
+      return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+    })
+
+    render(<Empresas />)
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Se dio de baja la empresa "Sur SRL". Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  /**
+   * Cláusula bajo prueba: la elección de copia por `codigo`. `ultima_empresa_del_tenant` es el
+   * mínimo estructural, que es OTRA cosa que `empresa_en_uso`: la acción que corresponde no es
+   * limpiar datos, es dar de baja el tenant. Con una copia genérica compartida el operador se iba
+   * a borrar filas que no eran el problema.
+   */
+  it('un 409 ultima_empresa_del_tenant rinde su guía propia y el mensaje del servidor', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(
+        409,
+        'ultima_empresa_del_tenant',
+        'Es la única empresa del tenant: si querés eliminarla, dá de baja el tenant.',
+      ),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText(/Es la única empresa del tenant/)).toBeInTheDocument())
+    expect(screen.getByText(/La baja del tenant se hace desde la pantalla de Tenants\./)).toBeInTheDocument()
+  })
+
+  /** Anti-oráculo (BO-R12) en la capa de UI: un 404 nunca insinúa uso ni alcance. */
+  it('un 404 rinde la copia neutra de inexistencia, nunca una pista de uso', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(new ErrorApi(404, 'no_encontrado', 'No existe la empresa 10.'))
+    montar()
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('Sur SRL'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No se pudo dar de baja la empresa. Ya no existe o no está a tu alcance. Actualizá el listado.'),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/en uso|tiene \d+/)).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: que el botón de baja NO esté gateado en `esPlataforma`, a diferencia de
+   * la columna y el filtro de tenant. `DELETE /api/empresas/{id}` reusa la policy del grupo
+   * (`GestionDeOrganizacion`, root+admin), así que un admin de tenant puede dar de baja las
+   * propias — esconderle el botón sería una restricción que el servidor no tiene.
+   */
+  it('un admin de tenant ve el botón de baja, que su policy sí le permite', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([empresaSur, empresaAnexo])
+    await waitFor(() => expect(screen.getByText('Sur SRL')).toBeInTheDocument())
+
+    expect(botonDeBajaDe('Sur SRL')).toBeEnabled()
   })
 })

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -22,6 +22,11 @@ const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista.
 const AVISO_REFRESCO_FALLIDO_BAJA =
   'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
+/** `EmpresaListado` no trae un contador de puntos de venta, así que la puerta no puede decir
+ * cuántos son. Se nombra la familia sin cantidad —y "activos", que es lo que efectivamente cae en
+ * la cascada— en vez de inventar un número que la fila no tiene. */
+const ARRASTRE_DE_EMPRESA = ['Sus puntos de venta activos'] as const
+
 /**
  * Lectura/edición/baja de empresas — el alta sigue siendo plataforma-only vía aprovisionamiento
  * (`NuevoTenant.tsx`); la baja (etapa 20) la puede ejecutar también un admin de tenant sobre las
@@ -44,8 +49,10 @@ export function Empresas() {
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState<number | null>(null)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
-  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
-  const [baja, setBaja] = useState<{ fila: EmpresaListado; token: number } | null>(null)
+  /** Baja pendiente de confirmación: ver `Tenants.tsx`. La puerta es MODAL —`bloqueado` deja
+   * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
+   * escritura, al confirmar. */
+  const [baja, setBaja] = useState<EmpresaListado | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
@@ -122,26 +129,34 @@ export function Empresas() {
     }
   }
 
-  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia. */
+  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
+   * Abrir NO acuña generación: no hay escritura todavía. */
   function pedirBaja(empresa: EmpresaListado) {
     if (ocupadoRef.current) return
 
-    setBaja({ fila: empresa, token: ++generacion.current })
+    setBaja(empresa)
     setError('')
     setAviso('')
   }
 
+  /** Cancelar no supersede nada: solo cierra la puerta. Por eso no acuña generación —hacerlo
+   * descartaba una lectura en vuelo y clavaba la pantalla en "Cargando…"— y limpia los dos avisos,
+   * en simetría con la apertura. */
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
-    ++generacion.current
     setBaja(null)
+    setError('')
+    setAviso('')
   }
 
   async function confirmarBaja() {
     if (!baja || ocupadoRef.current) return
 
-    const { fila, token } = baja
+    // El token se acuña ACÁ, primera sentencia síncrona de la escritura (`react-async-state`
+    // regla 2): ver `Tenants.tsx`.
+    const fila = baja
+    const token = ++generacion.current
     ocupadoRef.current = true
     setOcupado(fila.id)
     setError('')
@@ -150,13 +165,13 @@ export function Empresas() {
       try {
         await clienteDeOrganizacion.eliminarEmpresa(fila.id)
       } catch (e) {
-        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'la empresa'))
+        // Un rechazo SIEMPRE se rinde, con la puerta abierta al lado del motivo.
+        setError(copiaDeFalloDeBaja(e, 'la empresa'))
 
         return
       }
 
-      if (generacion.current !== token) return
-
+      // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
       await refrescarTrasEscribir(
         token,
@@ -168,6 +183,9 @@ export function Empresas() {
       setOcupado(null)
     }
   }
+
+  /** La puerta abierta bloquea la pantalla entera, no solo la escritura en vuelo: ver `Tenants.tsx`. */
+  const bloqueado = ocupado !== null || baja !== null
 
   // Las opciones se derivan de las filas cargadas; si la selección vigente desaparece de la lista
   // (un refresco trajo otras filas), el filtro cae a "todos". Además de derivarlo acá, `cargar`
@@ -185,8 +203,8 @@ export function Empresas() {
 
         {baja && (
           <ConfirmacionDeBaja
-            titulo={`la empresa "${baja.fila.razonSocial}"`}
-            arrastra={['Sus puntos de venta']}
+            titulo={`la empresa "${baja.razonSocial}"`}
+            arrastra={ARRASTRE_DE_EMPRESA}
             ocupado={ocupado !== null}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
@@ -214,7 +232,7 @@ export function Empresas() {
                 maxLength={150}
                 value={formulario.razonSocial}
                 onChange={(e) => setFormulario({ ...formulario, razonSocial: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
                 required
               />
             </div>
@@ -228,7 +246,7 @@ export function Empresas() {
                 maxLength={150}
                 value={formulario.nombreFantasia}
                 onChange={(e) => setFormulario({ ...formulario, nombreFantasia: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-3">
@@ -241,18 +259,18 @@ export function Empresas() {
                 maxLength={13}
                 value={formulario.cuit}
                 onChange={(e) => setFormulario({ ...formulario, cuit: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+              <button type="submit" className="btn btn-success rounded-0" disabled={bloqueado}>
                 {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setFormulario(null)}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               >
                 Cancelar
               </button>
@@ -278,6 +296,7 @@ export function Empresas() {
                     className="form-select rounded-0"
                     value={tenantVigente}
                     onChange={(e) => setFiltroTenant(e.target.value)}
+                    disabled={bloqueado}
                   >
                     <option value={SIN_FILTRO}>Todos</option>
                     {opcionesTenant.map((o) => (
@@ -322,7 +341,7 @@ export function Empresas() {
                               cuit: e.cuit ?? '',
                             })
                           }
-                          disabled={ocupado !== null}
+                          disabled={bloqueado}
                         >
                           Editar
                         </button>
@@ -330,7 +349,7 @@ export function Empresas() {
                           type="button"
                           className="btn btn-sm btn-outline-danger rounded-0"
                           onClick={() => pedirBaja(e)}
-                          disabled={ocupado !== null}
+                          disabled={bloqueado}
                         >
                           Baja
                         </button>

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -53,6 +53,10 @@ export function Empresas() {
    * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
    * escritura, al confirmar. */
   const [baja, setBaja] = useState<EmpresaListado | null>(null)
+  /** Control que abrió la puerta, capturado en el `onClick` y no dentro de la puerta: ver
+   * `ConfirmacionDeBaja.tsx`. Para cuando el efecto de montaje corre, el control ya quedó
+   * `disabled` y el navegador se llevó el foco al `<body>`. */
+  const [disparadorDeLaPuerta, setDisparadorDeLaPuerta] = useState<HTMLElement | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
@@ -131,9 +135,10 @@ export function Empresas() {
 
   /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
    * Abrir NO acuña generación: no hay escritura todavía. */
-  function pedirBaja(empresa: EmpresaListado) {
+  function pedirBaja(empresa: EmpresaListado, disparador: HTMLElement | null) {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(disparador)
     setBaja(empresa)
     setError('')
     setAviso('')
@@ -145,6 +150,7 @@ export function Empresas() {
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(null)
     setBaja(null)
     setError('')
     setAviso('')
@@ -173,6 +179,9 @@ export function Empresas() {
 
       // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
+      // La baja de la fila que se está editando se lleva también su formulario: dejarlo abierto
+      // ofrecía guardar sobre una entidad que ya no existe, y el PUT moría en 404.
+      setFormulario((prev) => (prev?.id === fila.id ? null : prev))
       await refrescarTrasEscribir(
         token,
         `Se dio de baja la empresa "${fila.razonSocial}".`,
@@ -206,6 +215,7 @@ export function Empresas() {
             titulo={`la empresa "${baja.razonSocial}"`}
             arrastra={ARRASTRE_DE_EMPRESA}
             ocupado={ocupado !== null}
+            disparador={disparadorDeLaPuerta}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
           />
@@ -348,7 +358,7 @@ export function Empresas() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-danger rounded-0"
-                          onClick={() => pedirBaja(e)}
+                          onClick={(evento) => pedirBaja(e, evento.currentTarget)}
                           disabled={bloqueado}
                         >
                           Baja

--- a/src/Ways.Web/src/paginas/Empresas.tsx
+++ b/src/Ways.Web/src/paginas/Empresas.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ErrorApi } from '../api/cliente'
+import { copiaDeFalloDeBaja } from '../api/bajas'
 import {
   clienteDeOrganizacion,
   etiquetaDeTenant,
@@ -11,16 +12,22 @@ import {
 import type { EmpresaListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { ConfirmacionDeBaja } from '../componentes/ConfirmacionDeBaja'
 import { useAuth } from '../auth/useAuth'
 import { ROL } from '../api/tipos'
 
 type Formulario = { id: number; razonSocial: string; nombreFantasia: string; cuit: string }
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+const AVISO_REFRESCO_FALLIDO_BAJA =
+  'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
 /**
- * Lectura/edición de empresas — sin alta ni baja (ambas siguen siendo plataforma-only vía
- * aprovisionamiento, `NuevoTenant.tsx`). El backend ya filtra por alcance: la plataforma ve
+ * Lectura/edición/baja de empresas — el alta sigue siendo plataforma-only vía aprovisionamiento
+ * (`NuevoTenant.tsx`); la baja (etapa 20) la puede ejecutar también un admin de tenant sobre las
+ * propias, porque `DELETE /api/empresas/{id}` reusa la policy del grupo
+ * (`GestionDeOrganizacion`) y esta pantalla ya está detrás de esos mismos roles.
+ * El backend ya filtra por alcance: la plataforma ve
  * todas las empresas de todos los tenants, un admin de tenant solo ve la(s) propia(s) — esta
  * pantalla no filtra nada por su cuenta contra el servidor. El filtro por tenant de abajo opera
  * sobre la lista YA CARGADA y sus opciones salen de esas mismas filas (design D15), así que no
@@ -37,9 +44,16 @@ export function Empresas() {
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState<number | null>(null)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
+  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
+  const [baja, setBaja] = useState<{ fila: EmpresaListado; token: number } | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
+  /**
+   * Espejo SÍNCRONO de `ocupado`, y la ÚNICA guarda de re-entrancia válida: ver `Tenants.tsx`.
+   * Dos clicks del MISMO tick leen el mismo render, así que el estado los deja pasar a los dos.
+   */
+  const ocupadoRef = useRef(false)
 
   const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
@@ -62,45 +76,95 @@ export function Empresas() {
     void cargar(++generacion.current)
   }, [cargar])
 
+  /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). NO apaga `ocupado`: de
+   * eso se ocupa el `finally` ungated de cada escritura — ver `Tenants.tsx`. */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string, avisoDeFallo: string) {
+    if (generacion.current !== token) return
+
+    setAviso(mensajeOk)
+    try {
+      await cargar(token, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${avisoDeFallo}`)
+    }
+  }
+
   async function guardar() {
-    if (!formulario || ocupado !== null) return
+    if (!formulario || ocupadoRef.current) return
 
     const datos = formulario
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(datos.id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion.editarEmpresa(datos.id, {
-        razonSocial: datos.razonSocial,
-        nombreFantasia: datos.nombreFantasia || null,
-        cuit: datos.cuit || null,
-      })
-    } catch (e) {
-      if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
-      setOcupado(null)
+      try {
+        await clienteDeOrganizacion.editarEmpresa(datos.id, {
+          razonSocial: datos.razonSocial,
+          nombreFantasia: datos.nombreFantasia || null,
+          cuit: datos.cuit || null,
+        })
+      } catch (e) {
+        if (generacion.current === token) setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
 
-      return
-    }
+        return
+      }
 
-    // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
-    // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
-    //
-    // `ocupado` se apaga en el `finally` SIN mirar la generación, igual que en `Tenants.tsx` y
-    // `Usuarios.tsx`: mientras hay una escritura en vuelo la pantalla bloquea todo lo que podría
-    // supersederla (regla 9), así que la bandera nunca puede ser la de una operación más nueva —
-    // y salir por el chequeo de generación la dejaría prendida para siempre.
-    const mensajeOk = `Se actualizó "${datos.razonSocial}".`
-    try {
       if (generacion.current !== token) return
 
       setFormulario(null)
-      setAviso(mensajeOk)
-      await cargar(token, true)
-    } catch {
-      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
+      await refrescarTrasEscribir(token, `Se actualizó "${datos.razonSocial}".`, AVISO_REFRESCO_FALLIDO)
     } finally {
+      ocupadoRef.current = false
+      setOcupado(null)
+    }
+  }
+
+  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia. */
+  function pedirBaja(empresa: EmpresaListado) {
+    if (ocupadoRef.current) return
+
+    setBaja({ fila: empresa, token: ++generacion.current })
+    setError('')
+    setAviso('')
+  }
+
+  function cancelarBaja() {
+    if (ocupadoRef.current) return
+
+    ++generacion.current
+    setBaja(null)
+  }
+
+  async function confirmarBaja() {
+    if (!baja || ocupadoRef.current) return
+
+    const { fila, token } = baja
+    ocupadoRef.current = true
+    setOcupado(fila.id)
+    setError('')
+    setAviso('')
+    try {
+      try {
+        await clienteDeOrganizacion.eliminarEmpresa(fila.id)
+      } catch (e) {
+        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'la empresa'))
+
+        return
+      }
+
+      if (generacion.current !== token) return
+
+      setBaja(null)
+      await refrescarTrasEscribir(
+        token,
+        `Se dio de baja la empresa "${fila.razonSocial}".`,
+        AVISO_REFRESCO_FALLIDO_BAJA,
+      )
+    } finally {
+      ocupadoRef.current = false
       setOcupado(null)
     }
   }
@@ -118,6 +182,16 @@ export function Empresas() {
       <Box titulo="Empresas" variante="inverse">
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+
+        {baja && (
+          <ConfirmacionDeBaja
+            titulo={`la empresa "${baja.fila.razonSocial}"`}
+            arrastra={['Sus puntos de venta']}
+            ocupado={ocupado !== null}
+            onConfirmar={confirmarBaja}
+            onCancelar={cancelarBaja}
+          />
+        )}
 
         {formulario && (
           <form
@@ -236,10 +310,10 @@ export function Empresas() {
                       <td>{e.razonSocial}</td>
                       <td>{e.nombreFantasia ?? '—'}</td>
                       <td>{e.cuit ?? '—'}</td>
-                      <td className="text-end">
+                      <td className="text-end text-nowrap">
                         <button
                           type="button"
-                          className="btn btn-sm btn-outline-primary rounded-0"
+                          className="btn btn-sm btn-outline-primary rounded-0 me-1"
                           onClick={() =>
                             setFormulario({
                               id: e.id,
@@ -251,6 +325,14 @@ export function Empresas() {
                           disabled={ocupado !== null}
                         >
                           Editar
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-danger rounded-0"
+                          onClick={() => pedirBaja(e)}
+                          disabled={ocupado !== null}
+                        >
+                          Baja
                         </button>
                       </td>
                     </tr>

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PuntosVenta } from './PuntosVenta'
@@ -10,13 +10,14 @@ import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.11 y 2.13) y slice 5 (5.5, 5.7, 5.8).
 
 const apiGetMock = vi.fn()
+const apiPutMock = vi.fn()
 const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: vi.fn(),
-    put: vi.fn(),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
     delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
@@ -511,5 +512,97 @@ describe('PuntosVenta (stage-20, slice 5 — baja lógica)', () => {
     await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
 
     expect(botonDeBajaDe('PV Centro')).toBeEnabled()
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5, judgment-day ronda 1 (C1 y C4). Mismo patrón
+// que `Tenants.test.tsx`, replicado en la misma PR (`react-async-state` regla 10).
+
+describe('PuntosVenta (slice 5, ronda 1 — la puerta es modal y el token se acuña al confirmar)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = usuarioFixture()
+  })
+
+  /** Cláusula bajo prueba: `bloqueado = ocupado !== null || baja !== null` en todos los `disabled`
+   * — ver el test gemelo de `Tenants.test.tsx`. */
+  it('con la puerta abierta no queda ninguna otra acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /PV Centro/ })).getAllByRole('button', { name: 'Editar' })[0],
+    )
+    await usuario.click(botonDeBajaDe('PV Este'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+      ...screen.getAllByRole('button', { name: 'Guardar' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+    expect(screen.getByLabelText('Domicilio')).toBeDisabled()
+    expect(screen.getByLabelText('Empresa')).toBeDisabled()
+    expect(within(puerta).getByRole('button', { name: 'Confirmar baja' })).toBeEnabled()
+
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: el token acuñado al CONFIRMAR — ver el test gemelo de `Tenants.test.tsx`,
+   * incluido el porqué de bajar hasta el `<form>` para acuñar una generación en esa ventana. */
+  it('una generación acuñada entre abrir y confirmar no se traga el 204', async () => {
+    const usuario = userEvent.setup()
+    const { container } = montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /PV Centro/ })).getAllByRole('button', { name: 'Editar' })[0],
+    )
+    await usuario.click(botonDeBajaDe('PV Este'))
+
+    const form = container.querySelector('form')
+    if (!form) throw new Error('no hay formulario de edición abierto')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+    await waitFor(() => expect(screen.getByText('Se actualizó "PV Centro".')).toBeInTheDocument())
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Se dio de baja el punto de venta "PV Este".')).toBeInTheDocument(),
+    )
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: el `setError('')` de `cancelarBaja` — ver `Tenants.test.tsx`. */
+  it('cancelar después de un rechazo se lleva el motivo con la puerta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'punto_venta_en_uso', 'No se puede dar de baja el punto de venta porque tiene 5 ventas.'),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(screen.getByText(/porque tiene 5 ventas/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/porque tiene 5 ventas/)).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -1,21 +1,23 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PuntosVenta } from './PuntosVenta'
+import { ErrorApi } from '../api/cliente'
 import { ETIQUETA_SIN_DUENIO } from '../api/organizacion'
 import { ROL } from '../api/tipos'
 import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
 
-// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.11 y 2.13).
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.11 y 2.13) y slice 5 (5.5, 5.7, 5.8).
 
 const apiGetMock = vi.fn()
+const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: vi.fn(),
     put: vi.fn(),
-    delete: vi.fn(),
+    delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
     estado: number
@@ -105,6 +107,8 @@ function opcionesDe(etiqueta: string) {
 describe('PuntosVenta (stage-20, slice 2 — nombres de dueño y dos filtros)', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiDeleteMock.mockResolvedValue(undefined)
     usuarioActual = usuarioFixture()
   })
 
@@ -276,5 +280,236 @@ describe('PuntosVenta (stage-20, slice 2 — nombres de dueño y dos filtros)', 
 
     expect(nombresVisibles()).toEqual(['PV Centro', 'PV Anexo', 'PV Este'])
     expect(screen.getByLabelText('Empresa')).toHaveValue('')
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5 (tareas 5.5, 5.7 y 5.8). El patrón es el
+// MISMO que el de `Tenants.tsx` y se replica en la misma PR (`react-async-state` regla 10).
+
+function botonDeBajaDe(nombre: string) {
+  return within(screen.getByRole('row', { name: new RegExp(nombre) })).getByRole('button', {
+    name: 'Baja',
+  })
+}
+
+describe('PuntosVenta (stage-20, slice 5 — baja lógica)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = usuarioFixture()
+  })
+
+  it('el botón de baja no llama a la API hasta que se confirma', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toHaveTextContent(
+      '¿Dar de baja el punto de venta "PV Centro"?',
+    )
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/puntos-venta/100'))
+    await waitFor(() =>
+      expect(screen.getByText('Se dio de baja el punto de venta "PV Centro".')).toBeInTheDocument(),
+    )
+  })
+
+  it('cancelar cierra la puerta y no llama nunca a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /** Cláusula bajo prueba: la ventana inerte completa — ver el test gemelo de `Tenants.test.tsx`. */
+  it('durante el DELETE y su refresco no queda ninguna acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    let resolverDelete!: () => void
+    let resolverRefresco!: (items: PuntoVentaListado[]) => void
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/puntos-venta') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([pvSurCentro, pvEste])
+
+      return new Promise<PuntoVentaListado[]>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+    apiDeleteMock.mockImplementation(
+      () =>
+        new Promise<void>((resolver) => {
+          resolverDelete = resolver
+        }),
+    )
+
+    render(<PuntosVenta />)
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    expect(screen.getByRole('button', { name: 'Dando de baja…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeDisabled()
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+
+    await act(async () => {
+      resolverDelete()
+      await Promise.resolve()
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('Se dio de baja el punto de venta "PV Centro".')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Cargando…')).toBeInTheDocument()
+
+    await act(async () => {
+      resolverRefresco([pvEste])
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Baja' })[0]).toBeEnabled())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: `ocupadoRef`, la guarda de re-entrancia del mismo tick (regla 9). */
+  it('un segundo click sobre la confirmación en vuelo se descarta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockImplementation(() => new Promise<void>(() => {}))
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    const confirmar = screen.getByRole('button', { name: 'Confirmar baja' })
+    await act(async () => {
+      confirmar.click()
+      confirmar.click()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('un refresco fallido después de la baja no la reporta como fallida', async () => {
+    const usuario = userEvent.setup()
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/puntos-venta') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([pvSurCentro])
+
+      return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+    })
+
+    render(<PuntosVenta />)
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Se dio de baja el punto de venta "PV Centro". Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  /**
+   * Cláusula bajo prueba: la elección de copia por `codigo` sobre el mínimo estructural de esta
+   * pantalla, que es distinto del de `Empresas` — cada uno manda a dar de baja a su propio padre.
+   */
+  it('un 409 ultimo_punto_venta_de_la_empresa rinde su guía propia y el mensaje del servidor', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(
+        409,
+        'ultimo_punto_venta_de_la_empresa',
+        'Es el único punto de venta de la empresa: si querés eliminarlo, dá de baja la empresa.',
+      ),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/Es el único punto de venta de la empresa/)).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByText(/La baja de la empresa se hace desde la pantalla de Empresas\./),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: la copia de `punto_venta_en_uso`, que NO es la del mínimo estructural.
+   * El mensaje del servidor nombra qué bloquea y se rinde entero.
+   */
+  it('un 409 punto_venta_en_uso rinde su guía propia sin tragarse el mensaje del servidor', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(
+        409,
+        'punto_venta_en_uso',
+        'No se puede dar de baja el punto de venta porque tiene 5 ventas.',
+      ),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText(/porque tiene 5 ventas/)).toBeInTheDocument())
+    expect(
+      screen.getByText(/Dá de baja o reasigná esos datos antes de eliminar el punto de venta\./),
+    ).toBeInTheDocument()
+  })
+
+  /** Anti-oráculo (BO-R12) en la capa de UI: un 404 nunca insinúa uso ni alcance. */
+  it('un 404 rinde la copia neutra de inexistencia, nunca una pista de uso', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(new ErrorApi(404, 'no_encontrado', 'No existe el punto de venta 100.'))
+    montar()
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'No se pudo dar de baja el punto de venta. Ya no existe o no está a tu alcance. Actualizá el listado.',
+        ),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/en uso|tiene \d+/)).not.toBeInTheDocument()
+  })
+
+  /** Paridad con `Empresas`: `DELETE /api/puntos-venta/{id}` es `GestionDeOrganizacion`, que un
+   * admin de tenant tiene — el botón no se le esconde. */
+  it('un admin de tenant ve el botón de baja, que su policy sí le permite', async () => {
+    usuarioActual = usuarioFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    montar([pvSurCentro, pvSurAnexo])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    expect(botonDeBajaDe('PV Centro')).toBeEnabled()
   })
 })

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -55,8 +55,10 @@ export function PuntosVenta() {
   const [ocupado, setOcupado] = useState<number | null>(null)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
   const [filtroEmpresa, setFiltroEmpresa] = useState(SIN_FILTRO)
-  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
-  const [baja, setBaja] = useState<{ fila: PuntoVentaListado; token: number } | null>(null)
+  /** Baja pendiente de confirmación: ver `Tenants.tsx`. La puerta es MODAL —`bloqueado` deja
+   * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
+   * escritura, al confirmar. */
+  const [baja, setBaja] = useState<PuntoVentaListado | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
@@ -149,26 +151,34 @@ export function PuntosVenta() {
     }
   }
 
-  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia. */
+  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
+   * Abrir NO acuña generación: no hay escritura todavía. */
   function pedirBaja(puntoVenta: PuntoVentaListado) {
     if (ocupadoRef.current) return
 
-    setBaja({ fila: puntoVenta, token: ++generacion.current })
+    setBaja(puntoVenta)
     setError('')
     setAviso('')
   }
 
+  /** Cancelar no supersede nada: solo cierra la puerta. Por eso no acuña generación —hacerlo
+   * descartaba una lectura en vuelo y clavaba la pantalla en "Cargando…"— y limpia los dos avisos,
+   * en simetría con la apertura. */
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
-    ++generacion.current
     setBaja(null)
+    setError('')
+    setAviso('')
   }
 
   async function confirmarBaja() {
     if (!baja || ocupadoRef.current) return
 
-    const { fila, token } = baja
+    // El token se acuña ACÁ, primera sentencia síncrona de la escritura (`react-async-state`
+    // regla 2): ver `Tenants.tsx`.
+    const fila = baja
+    const token = ++generacion.current
     ocupadoRef.current = true
     setOcupado(fila.id)
     setError('')
@@ -177,13 +187,13 @@ export function PuntosVenta() {
       try {
         await clienteDeOrganizacion.eliminarPuntoVenta(fila.id)
       } catch (e) {
-        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el punto de venta'))
+        // Un rechazo SIEMPRE se rinde, con la puerta abierta al lado del motivo.
+        setError(copiaDeFalloDeBaja(e, 'el punto de venta'))
 
         return
       }
 
-      if (generacion.current !== token) return
-
+      // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
       await refrescarTrasEscribir(
         token,
@@ -195,6 +205,9 @@ export function PuntosVenta() {
       setOcupado(null)
     }
   }
+
+  /** La puerta abierta bloquea la pantalla entera, no solo la escritura en vuelo: ver `Tenants.tsx`. */
+  const bloqueado = ocupado !== null || baja !== null
 
   // Derivación pura, sin efectos: elegir un tenant ANGOSTA las opciones de empresa (design D15).
   // El fallback a "todas" cubre además el caso en que un refresco se llevó puesta la fila que
@@ -226,7 +239,7 @@ export function PuntosVenta() {
 
         {baja && (
           <ConfirmacionDeBaja
-            titulo={`el punto de venta "${baja.fila.nombre}"`}
+            titulo={`el punto de venta "${baja.nombre}"`}
             ocupado={ocupado !== null}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
@@ -254,7 +267,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.nombre}
                 onChange={(e) => setFormulario({ ...formulario, nombre: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
                 required
               />
             </div>
@@ -268,7 +281,7 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.domicilio}
                 onChange={(e) => setFormulario({ ...formulario, domicilio: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-3">
@@ -281,7 +294,7 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.horario}
                 onChange={(e) => setFormulario({ ...formulario, horario: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-2">
@@ -294,7 +307,7 @@ export function PuntosVenta() {
                 maxLength={30}
                 value={formulario.whatsapp}
                 onChange={(e) => setFormulario({ ...formulario, whatsapp: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-3">
@@ -307,7 +320,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.instagram}
                 onChange={(e) => setFormulario({ ...formulario, instagram: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-3">
@@ -320,7 +333,7 @@ export function PuntosVenta() {
                 maxLength={150}
                 value={formulario.facebook}
                 onChange={(e) => setFormulario({ ...formulario, facebook: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-md-3">
@@ -333,18 +346,18 @@ export function PuntosVenta() {
                 maxLength={255}
                 value={formulario.web}
                 onChange={(e) => setFormulario({ ...formulario, web: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+              <button type="submit" className="btn btn-success rounded-0" disabled={bloqueado}>
                 {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setFormulario(null)}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               >
                 Cancelar
               </button>
@@ -370,6 +383,7 @@ export function PuntosVenta() {
                     className="form-select rounded-0"
                     value={tenantVigente}
                     onChange={(e) => cambiarFiltroDeTenant(e.target.value)}
+                    disabled={bloqueado}
                   >
                     <option value={SIN_FILTRO}>Todos</option>
                     {opcionesTenant.map((o) => (
@@ -389,6 +403,7 @@ export function PuntosVenta() {
                   className="form-select rounded-0"
                   value={empresaVigente}
                   onChange={(e) => setFiltroEmpresa(e.target.value)}
+                  disabled={bloqueado}
                 >
                   <option value={SIN_FILTRO}>Todas</option>
                   {opcionesEmpresa.map((o) => (
@@ -436,7 +451,7 @@ export function PuntosVenta() {
                               web: p.web ?? '',
                             })
                           }
-                          disabled={ocupado !== null}
+                          disabled={bloqueado}
                         >
                           Editar
                         </button>
@@ -444,7 +459,7 @@ export function PuntosVenta() {
                           type="button"
                           className="btn btn-sm btn-outline-danger rounded-0"
                           onClick={() => pedirBaja(p)}
-                          disabled={ocupado !== null}
+                          disabled={bloqueado}
                         >
                           Baja
                         </button>

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ErrorApi } from '../api/cliente'
+import { copiaDeFalloDeBaja } from '../api/bajas'
 import {
   clienteDeOrganizacion,
   ETIQUETA_SIN_DUENIO,
@@ -14,6 +15,7 @@ import {
 import type { PuntoVentaListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { ConfirmacionDeBaja } from '../componentes/ConfirmacionDeBaja'
 import { useAuth } from '../auth/useAuth'
 import { ROL } from '../api/tipos'
 
@@ -29,10 +31,14 @@ type Formulario = {
 }
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+const AVISO_REFRESCO_FALLIDO_BAJA =
+  'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
 /**
- * Lectura/edición de puntos de venta — mismo patrón que <c>Empresas.tsx</c>: sin alta ni baja
- * (plataforma-only vía aprovisionamiento), el backend ya filtra por alcance.
+ * Lectura/edición/baja de puntos de venta — mismo patrón que <c>Empresas.tsx</c>: el alta sigue
+ * siendo plataforma-only vía aprovisionamiento y el backend ya filtra por alcance. La baja
+ * (etapa 20) es <c>Politicas.GestionDeOrganizacion</c>, no <c>LecturaDePuntosVenta</c>: el
+ * selector de PV del POS lee este listado, pero un vendedor no llega a esta pantalla.
  * <c>idEmpresa</c> no se edita acá: es estructural (a qué empresa pertenece), no descriptivo.
  * Los dos filtros (tenant y empresa) operan sobre la lista YA CARGADA y sus opciones salen de
  * esas mismas filas (design D15).
@@ -49,9 +55,16 @@ export function PuntosVenta() {
   const [ocupado, setOcupado] = useState<number | null>(null)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
   const [filtroEmpresa, setFiltroEmpresa] = useState(SIN_FILTRO)
+  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
+  const [baja, setBaja] = useState<{ fila: PuntoVentaListado; token: number } | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
+  /**
+   * Espejo SÍNCRONO de `ocupado`, y la ÚNICA guarda de re-entrancia válida: ver `Tenants.tsx`.
+   * Dos clicks del MISMO tick leen el mismo render, así que el estado los deja pasar a los dos.
+   */
+  const ocupadoRef = useRef(false)
   /** Espejo SIEMPRE al día de `filtroTenant`. `cargar` es un `useCallback` sin dependencias, así
    * que no puede leer el estado por closure sin quedarse con una foto vieja; y la reconciliación
    * de la empresa necesita el tenant YA reconciliado, no el `prev` de su propio updater. */
@@ -68,10 +81,10 @@ export function PuntosVenta() {
       // opción reaparece. La empresa se reconcilia contra el MISMO conjunto ANGOSTADO que rinde la
       // pantalla (`opcionesDeEmpresa(filas, tenant)`, design D15): contra el conjunto sin angostar
       // sobrevivía una empresa de otro tenant que el `<select>` ya no ofrece.
-      const tenanteReconciliado = seleccionVigente(opcionesDeTenant(filas), filtroTenantVigente.current)
-      filtroTenantVigente.current = tenanteReconciliado
-      setFiltroTenant(tenanteReconciliado)
-      setFiltroEmpresa((prev) => seleccionVigente(opcionesDeEmpresa(filas, tenanteReconciliado), prev))
+      const tenantReconciliado = seleccionVigente(opcionesDeTenant(filas), filtroTenantVigente.current)
+      filtroTenantVigente.current = tenantReconciliado
+      setFiltroTenant(tenantReconciliado)
+      setFiltroEmpresa((prev) => seleccionVigente(opcionesDeEmpresa(filas, tenantReconciliado), prev))
       setError('')
     } catch (e) {
       if (generacion.current !== token) return
@@ -86,49 +99,99 @@ export function PuntosVenta() {
     void cargar(++generacion.current)
   }, [cargar])
 
+  /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). NO apaga `ocupado`: de
+   * eso se ocupa el `finally` ungated de cada escritura — ver `Tenants.tsx`. */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string, avisoDeFallo: string) {
+    if (generacion.current !== token) return
+
+    setAviso(mensajeOk)
+    try {
+      await cargar(token, true)
+    } catch {
+      if (generacion.current === token) setAviso(`${mensajeOk} ${avisoDeFallo}`)
+    }
+  }
+
   async function guardar() {
-    if (!formulario || ocupado !== null) return
+    if (!formulario || ocupadoRef.current) return
 
     const datos = formulario
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(datos.id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion.editarPuntoVenta(datos.id, {
-        nombre: datos.nombre,
-        domicilio: datos.domicilio || null,
-        horario: datos.horario || null,
-        whatsapp: datos.whatsapp || null,
-        instagram: datos.instagram || null,
-        facebook: datos.facebook || null,
-        web: datos.web || null,
-      })
-    } catch (e) {
-      if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
-      setOcupado(null)
+      try {
+        await clienteDeOrganizacion.editarPuntoVenta(datos.id, {
+          nombre: datos.nombre,
+          domicilio: datos.domicilio || null,
+          horario: datos.horario || null,
+          whatsapp: datos.whatsapp || null,
+          instagram: datos.instagram || null,
+          facebook: datos.facebook || null,
+          web: datos.web || null,
+        })
+      } catch (e) {
+        if (generacion.current === token) setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
 
-      return
-    }
+        return
+      }
 
-    // El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
-    // commiteó nunca se reporta como fallida (`react-async-state` regla 6).
-    //
-    // `ocupado` se apaga en el `finally` SIN mirar la generación, igual que en `Tenants.tsx` y
-    // `Usuarios.tsx`: mientras hay una escritura en vuelo la pantalla bloquea todo lo que podría
-    // supersederla (regla 9), así que la bandera nunca puede ser la de una operación más nueva —
-    // y salir por el chequeo de generación la dejaría prendida para siempre.
-    const mensajeOk = `Se actualizó "${datos.nombre}".`
-    try {
       if (generacion.current !== token) return
 
       setFormulario(null)
-      setAviso(mensajeOk)
-      await cargar(token, true)
-    } catch {
-      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
+      await refrescarTrasEscribir(token, `Se actualizó "${datos.nombre}".`, AVISO_REFRESCO_FALLIDO)
     } finally {
+      ocupadoRef.current = false
+      setOcupado(null)
+    }
+  }
+
+  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia. */
+  function pedirBaja(puntoVenta: PuntoVentaListado) {
+    if (ocupadoRef.current) return
+
+    setBaja({ fila: puntoVenta, token: ++generacion.current })
+    setError('')
+    setAviso('')
+  }
+
+  function cancelarBaja() {
+    if (ocupadoRef.current) return
+
+    ++generacion.current
+    setBaja(null)
+  }
+
+  async function confirmarBaja() {
+    if (!baja || ocupadoRef.current) return
+
+    const { fila, token } = baja
+    ocupadoRef.current = true
+    setOcupado(fila.id)
+    setError('')
+    setAviso('')
+    try {
+      try {
+        await clienteDeOrganizacion.eliminarPuntoVenta(fila.id)
+      } catch (e) {
+        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el punto de venta'))
+
+        return
+      }
+
+      if (generacion.current !== token) return
+
+      setBaja(null)
+      await refrescarTrasEscribir(
+        token,
+        `Se dio de baja el punto de venta "${fila.nombre}".`,
+        AVISO_REFRESCO_FALLIDO_BAJA,
+      )
+    } finally {
+      ocupadoRef.current = false
       setOcupado(null)
     }
   }
@@ -160,6 +223,15 @@ export function PuntosVenta() {
       <Box titulo="Puntos de venta" variante="inverse">
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+
+        {baja && (
+          <ConfirmacionDeBaja
+            titulo={`el punto de venta "${baja.fila.nombre}"`}
+            ocupado={ocupado !== null}
+            onConfirmar={confirmarBaja}
+            onCancelar={cancelarBaja}
+          />
+        )}
 
         {formulario && (
           <form
@@ -348,10 +420,10 @@ export function PuntosVenta() {
                       <td>{p.razonSocialEmpresa ?? ETIQUETA_SIN_DUENIO}</td>
                       <td>{p.nombre}</td>
                       <td>{p.domicilio ?? '—'}</td>
-                      <td className="text-end">
+                      <td className="text-end text-nowrap">
                         <button
                           type="button"
-                          className="btn btn-sm btn-outline-primary rounded-0"
+                          className="btn btn-sm btn-outline-primary rounded-0 me-1"
                           onClick={() =>
                             setFormulario({
                               id: p.id,
@@ -367,6 +439,14 @@ export function PuntosVenta() {
                           disabled={ocupado !== null}
                         >
                           Editar
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-danger rounded-0"
+                          onClick={() => pedirBaja(p)}
+                          disabled={ocupado !== null}
+                        >
+                          Baja
                         </button>
                       </td>
                     </tr>

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -59,6 +59,10 @@ export function PuntosVenta() {
    * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
    * escritura, al confirmar. */
   const [baja, setBaja] = useState<PuntoVentaListado | null>(null)
+  /** Control que abrió la puerta, capturado en el `onClick` y no dentro de la puerta: ver
+   * `ConfirmacionDeBaja.tsx`. Para cuando el efecto de montaje corre, el control ya quedó
+   * `disabled` y el navegador se llevó el foco al `<body>`. */
+  const [disparadorDeLaPuerta, setDisparadorDeLaPuerta] = useState<HTMLElement | null>(null)
 
   /** Contrato de invalidación: ver `Tenants.tsx` — mismo patrón en las cuatro pantallas raíz. */
   const generacion = useRef(0)
@@ -153,9 +157,10 @@ export function PuntosVenta() {
 
   /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
    * Abrir NO acuña generación: no hay escritura todavía. */
-  function pedirBaja(puntoVenta: PuntoVentaListado) {
+  function pedirBaja(puntoVenta: PuntoVentaListado, disparador: HTMLElement | null) {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(disparador)
     setBaja(puntoVenta)
     setError('')
     setAviso('')
@@ -167,6 +172,7 @@ export function PuntosVenta() {
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(null)
     setBaja(null)
     setError('')
     setAviso('')
@@ -195,6 +201,9 @@ export function PuntosVenta() {
 
       // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
+      // La baja de la fila que se está editando se lleva también su formulario: dejarlo abierto
+      // ofrecía guardar sobre una entidad que ya no existe, y el PUT moría en 404.
+      setFormulario((prev) => (prev?.id === fila.id ? null : prev))
       await refrescarTrasEscribir(
         token,
         `Se dio de baja el punto de venta "${fila.nombre}".`,
@@ -241,6 +250,7 @@ export function PuntosVenta() {
           <ConfirmacionDeBaja
             titulo={`el punto de venta "${baja.nombre}"`}
             ocupado={ocupado !== null}
+            disparador={disparadorDeLaPuerta}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
           />
@@ -458,7 +468,7 @@ export function PuntosVenta() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-danger rounded-0"
-                          onClick={() => pedirBaja(p)}
+                          onClick={(evento) => pedirBaja(p, evento.currentTarget)}
                           disabled={bloqueado}
                         >
                           Baja

--- a/src/Ways.Web/src/paginas/Tenants.test.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tenants } from './Tenants'
 import { ErrorApi } from '../api/cliente'
@@ -56,6 +56,14 @@ const tenantDos: TenantListado = {
   cantidadUsuarios: 7,
 }
 
+/** Sonda de la ruta actual: es la única forma de ver si el `<Link>` "Nuevo tenant" navegó, que es
+ * lo que la clase `disabled` de Bootstrap NO impide (solo apaga el hit-testing del puntero). */
+function SondaDeRuta() {
+  const { pathname } = useLocation()
+
+  return <span data-testid="ruta">{pathname}</span>
+}
+
 function montar(items: TenantListado[] = [tenantUno, tenantDos]) {
   apiGetMock.mockImplementation((ruta: string) => {
     if (ruta === '/plataforma/tenants') return Promise.resolve(items)
@@ -66,6 +74,7 @@ function montar(items: TenantListado[] = [tenantUno, tenantDos]) {
   return render(
     <MemoryRouter>
       <Tenants />
+      <SondaDeRuta />
     </MemoryRouter>,
   )
 }
@@ -446,6 +455,63 @@ describe('Tenants (slice 5, ronda 1 — la puerta es modal y el token se acuña 
     expect(apiDeleteMock).toHaveBeenCalledTimes(1)
     expect(apiDeleteMock).toHaveBeenCalledWith('/plataforma/tenants/2')
     expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-4): el `if (bloqueado) evento.preventDefault()` del `<Link>`
+   * "Nuevo tenant". Un `<a>` no admite `disabled`: la clase `disabled` de Bootstrap solo apaga
+   * `pointer-events` —hit-testing del puntero, puro CSS— y `tabIndex={-1}` solo lo saca del
+   * recorrido de tabulación. Ninguna de las dos cancela una activación que no pase por ahí (Enter
+   * sobre un `<a>` enfocado por programa, un click sintético, una extensión), así que la puerta
+   * modal se podía abandonar navegando a otra pantalla con el DELETE todavía sin decidir.
+   *
+   * El test mide la NAVEGACIÓN, no el atributo: `aria-disabled` ya se afirma en el test de arriba
+   * y no impide nada por sí solo.
+   */
+  it('con la puerta abierta, activar "Nuevo tenant" no navega', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Almacén Este'))
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toBeInTheDocument()
+
+    await usuario.click(screen.getByRole('link', { name: 'Nuevo tenant' }))
+
+    expect(screen.getByTestId('ruta').textContent).toBe('/')
+    // Y la puerta sigue ahí: no se abandonó la decisión a medio tomar.
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba (ronda 2, R2-5): el `setEdicion((prev) => (prev?.id === fila.id ? null :
+   * prev))` posterior al 204. El formulario de edición sobrevivía a la baja de la fila que estaba
+   * editando: quedaba abierto, con los datos de una entidad que ya no existe, y "Guardar" mandaba
+   * un PUT contra un id dado de baja. El updater se arma desde `prev` y compara el id, así que la
+   * baja de OTRA fila no se lleva puesta una edición en curso.
+   */
+  it('la baja de la fila que se está editando cierra su formulario', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /Comercio Sur/ })).getByRole('button', { name: 'Editar' }),
+    )
+    expect(screen.getByText('Editando tenant 1')).toBeInTheDocument()
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/plataforma/tenants') return Promise.resolve([tenantDos])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.queryByText('Comercio Sur')).not.toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledWith('/plataforma/tenants/1')
+    expect(screen.queryByText('Editando tenant 1')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Nombre')).not.toBeInTheDocument()
   })
 
   /**

--- a/src/Ways.Web/src/paginas/Tenants.test.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,13 +9,15 @@ import type { TenantListado } from '../api/tipos'
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.9 y 2.13) y slice 5 (5.3, 5.7, 5.8).
 
 const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+const apiPutMock = vi.fn()
 const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
-    post: vi.fn(),
-    put: vi.fn(),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown])),
+    put: (...args: unknown[]) => apiPutMock(...(args as [string, unknown])),
     delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
@@ -77,7 +79,11 @@ function celdas(nombre: string) {
 describe('Tenants (stage-20, slice 2 — contadores de hijos)', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
     apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
     apiDeleteMock.mockResolvedValue(undefined)
   })
 
@@ -149,7 +155,11 @@ function botonDeBaja(nombre: string) {
 describe('Tenants (stage-20, slice 5 — baja lógica)', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
     apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
     apiDeleteMock.mockResolvedValue(undefined)
   })
 
@@ -266,8 +276,8 @@ describe('Tenants (stage-20, slice 5 — baja lógica)', () => {
   })
 
   /**
-   * Cláusula bajo prueba: el `if (!baja || ocupado !== null) return` de `confirmarBaja`, la guarda
-   * de re-entrancia de la regla 9. Un doble click en el MISMO tick le gana al atributo `disabled`,
+   * Cláusula bajo prueba: el `if (ocupadoRef.current) return` de `darDeBaja`, la guarda de
+   * re-entrancia de la regla 9. Un doble click en el MISMO tick le gana al atributo `disabled`,
    * que solo existe después del re-render, y mandaría dos DELETE sobre la misma fila.
    */
   it('un segundo click sobre la confirmación en vuelo se descarta', async () => {
@@ -362,5 +372,225 @@ describe('Tenants (stage-20, slice 5 — baja lógica)', () => {
       ).toBeInTheDocument(),
     )
     expect(screen.queryByText(/en uso|tiene \d+/)).not.toBeInTheDocument()
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5, judgment-day ronda 1 (C1, C2, C4 y C8).
+
+/** El `<form>` de edición, que es el único disparador de escritura que sigue existiendo en el DOM
+ * con la puerta abierta (sus controles están inertes, pero el elemento sigue ahí). Sirve de
+ * palanca POR DEBAJO del confound (`mutation-proof-tests` regla 3): ningún operador puede llegar
+ * acá con la puerta abierta —no hay campo ni botón habilitado que dispare el submit implícito—,
+ * y por eso mismo es la única forma de acuñar una generación en esa ventana y ver qué hace el
+ * token de la escritura. */
+function formularioDeEdicion(contenedor: HTMLElement) {
+  const form = contenedor.querySelector('form')
+  if (!form) throw new Error('no hay formulario de edición abierto')
+
+  return form
+}
+
+describe('Tenants (slice 5, ronda 1 — la puerta es modal y el token se acuña al confirmar)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+  })
+
+  /**
+   * Cláusula bajo prueba: `bloqueado = ocupado !== null || confirmacion !== null` en TODOS los
+   * `disabled` de la pantalla. Con `ocupado` solo, la puerta abierta dejaba vivos Guardar,
+   * Suspender, Editar y Baja: cualquiera de ellos acuñaba una generación nueva y el DELETE que
+   * salía después de la puerta ya no aplicaba nada (`react-async-state` regla 9 — bloquear la
+   * ventana, no reconciliar tokens).
+   */
+  it('con la puerta abierta no queda ninguna otra acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /Comercio Sur/ })).getByRole('button', { name: 'Editar' }),
+    )
+    await usuario.click(botonDeBaja('Almacén Este'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+      ...screen.getAllByRole('button', { name: 'Suspender' }),
+      ...screen.getAllByRole('button', { name: 'Reactivar' }),
+      ...screen.getAllByRole('button', { name: 'Guardar' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+    expect(screen.getByLabelText('Nombre')).toBeDisabled()
+    expect(screen.getByRole('link', { name: 'Nuevo tenant' })).toHaveAttribute('aria-disabled', 'true')
+
+    // La puerta misma sigue viva: es lo único que el operador puede tocar.
+    expect(within(puerta).getByRole('button', { name: 'Confirmar baja' })).toBeEnabled()
+    expect(within(puerta).getByRole('button', { name: 'Cancelar' })).toBeEnabled()
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/plataforma/tenants') return Promise.resolve([tenantUno])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+    expect(apiDeleteMock).toHaveBeenCalledWith('/plataforma/tenants/2')
+    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: `const token = ++generacion.current` como PRIMERA sentencia síncrona de
+   * `darDeBaja`, y la ausencia del chequeo de generación posterior a la red. Con el token acuñado
+   * al ABRIR la puerta, una generación acuñada en el medio lo dejaba viejo: el DELETE salía igual,
+   * el 204 volvía, y el `if (generacion.current !== token) return` se lo tragaba — la fila seguía
+   * listada, la puerta seguía abierta y cada click repetía un DELETE silencioso.
+   *
+   * El submit se dispara sobre el `<form>` mismo, POR DEBAJO del confound: hoy `bloqueado` deja el
+   * formulario inerte, así que este camino no es alcanzable a mano — y esa es exactamente la razón
+   * por la que el test tiene que bajar hasta acá para ver el token.
+   */
+  it('una generación acuñada entre abrir y confirmar no se traga el 204', async () => {
+    const usuario = userEvent.setup()
+    const { container } = montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(
+      within(screen.getByRole('row', { name: /Comercio Sur/ })).getByRole('button', { name: 'Editar' }),
+    )
+    await usuario.click(botonDeBaja('Almacén Este'))
+
+    await act(async () => {
+      fireEvent.submit(formularioDeEdicion(container))
+    })
+    await waitFor(() => expect(screen.getByText('Se actualizó el tenant "Comercio Sur".')).toBeInTheDocument())
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/plataforma/tenants') return Promise.resolve([tenantUno])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Se dio de baja el tenant "Almacén Este".')).toBeInTheDocument(),
+    )
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Almacén Este')).not.toBeInTheDocument()
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Cláusula bajo prueba: el `setError('')` de `cancelarConfirmacion`. Tras un 409 la puerta queda
+   * abierta con el motivo en rojo al lado; cancelarla sin limpiarlo dejaba el banner huérfano,
+   * hablando de una baja que ya nadie está por hacer.
+   */
+  it('cancelar después de un rechazo se lleva el motivo con la puerta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'tenant_en_uso', 'No se puede dar de baja el tenant porque tiene 3 ventas.'),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(screen.getByText(/porque tiene 3 ventas/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/porque tiene 3 ventas/)).not.toBeInTheDocument()
+  })
+
+  /** Cláusula bajo prueba: el listener de `Escape`, cableado de punta a punta desde la pantalla. */
+  it('Escape cierra la puerta sin llamar a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Cláusula bajo prueba: que Suspender y Reactivar pasen por `pedirConfirmacion` y no por el
+   * `confirm()` nativo que tenían en ESTE MISMO archivo (`react-async-state` regla 10 puertas
+   * adentro). El diálogo del navegador no se puede dejar inerte mientras el POST está en vuelo, y
+   * convivía con una puerta en app a tres líneas de distancia.
+   */
+  it('suspender pasa por la misma puerta y no llama a la API hasta confirmar', async () => {
+    const usuario = userEvent.setup()
+    montar([tenantUno])
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Suspender' }))
+    expect(apiPostMock).not.toHaveBeenCalled()
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar suspensión' })
+    expect(puerta).toHaveTextContent('¿Suspender el tenant "Comercio Sur"?')
+    // Suspender no borra nada: la nota de la baja lógica no puede colarse.
+    expect(puerta).not.toHaveTextContent(/baja es lógica/)
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Baja' })).toBeDisabled()
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/plataforma/tenants') return Promise.resolve([{ ...tenantUno, estado: 'Suspendido' }])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar suspensión' }))
+
+    await waitFor(() => expect(screen.getByText('Tenant "Comercio Sur" suspendido.')).toBeInTheDocument())
+    expect(apiPostMock).toHaveBeenCalledTimes(1)
+    expect(apiPostMock).toHaveBeenCalledWith('/plataforma/tenants/1/suspender')
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('cancelar la suspensión no llama nunca a la API', async () => {
+    const usuario = userEvent.setup()
+    montar([tenantUno])
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Suspender' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiPostMock).not.toHaveBeenCalled()
+  })
+
+  /** Rama gemela: reactivar comparte la puerta con su propia copia, no la de la baja. */
+  it('reactivar pasa por la misma puerta, con su propia copia', async () => {
+    const usuario = userEvent.setup()
+    montar([tenantDos])
+    await waitFor(() => expect(screen.getByText('Almacén Este')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Reactivar' }))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar reactivación' })
+    expect(puerta).toHaveTextContent('¿Reactivar el tenant "Almacén Este"?')
+
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/plataforma/tenants') return Promise.resolve([{ ...tenantDos, estado: 'Activo' }])
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar reactivación' }))
+
+    await waitFor(() => expect(screen.getByText('Tenant "Almacén Este" reactivado.')).toBeInTheDocument())
+    expect(apiPostMock).toHaveBeenCalledWith('/plataforma/tenants/2/reactivar')
   })
 })

--- a/src/Ways.Web/src/paginas/Tenants.test.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.test.tsx
@@ -1,19 +1,22 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tenants } from './Tenants'
+import { ErrorApi } from '../api/cliente'
 import type { TenantListado } from '../api/tipos'
 
-// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.9 y 2.13).
+// stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.9 y 2.13) y slice 5 (5.3, 5.7, 5.8).
 
 const apiGetMock = vi.fn()
+const apiDeleteMock = vi.fn()
 
 vi.mock('../api/cliente', () => ({
   api: {
     get: (...args: unknown[]) => apiGetMock(...(args as [string])),
     post: vi.fn(),
     put: vi.fn(),
-    delete: vi.fn(),
+    delete: (...args: unknown[]) => apiDeleteMock(...(args as [string])),
   },
   ErrorApi: class ErrorApiMock extends Error {
     estado: number
@@ -74,6 +77,8 @@ function celdas(nombre: string) {
 describe('Tenants (stage-20, slice 2 — contadores de hijos)', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiDeleteMock.mockResolvedValue(undefined)
   })
 
   it('rinde los tres contadores de cada tenant en su propia columna', async () => {
@@ -130,5 +135,232 @@ describe('Tenants (stage-20, slice 2 — contadores de hijos)', () => {
     const fila = celdas('Comercio Sur')
     expect(fila[0]).toHaveTextContent('0001')
     expect(fila.filter((c) => c.textContent === '1')).toHaveLength(0)
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5 (tareas 5.3, 5.7 y 5.8).
+
+function botonDeBaja(nombre: string) {
+  return within(screen.getByRole('row', { name: new RegExp(nombre) })).getByRole('button', {
+    name: 'Baja',
+  })
+}
+
+describe('Tenants (stage-20, slice 5 — baja lógica)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiDeleteMock.mockResolvedValue(undefined)
+  })
+
+  /**
+   * Cláusula bajo prueba: el `{baja && <ConfirmacionDeBaja …>}` como PUERTA. Sin ella el botón
+   * llamaría al DELETE directo, y esta baja arrastra empresas, puntos de venta y usuarios: es
+   * exactamente la operación que no puede pasar de un solo click.
+   */
+  it('el botón de baja no llama a la API hasta que se confirma', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/plataforma/tenants/1'))
+  })
+
+  it('cancelar cierra la puerta y no llama nunca a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('button', { name: 'Confirmar baja' })).not.toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `arrastreDeTenant(baja.fila)` que alimenta la puerta. Sin él la
+   * confirmación diría "¿dar de baja el tenant?" y callaría que en la misma cascada se van sus 2
+   * empresas, sus 3 puntos de venta y sus 4 usuarios. Los tres contadores del fixture son
+   * pairwise-distintos, así que intercambiar dos líneas se ve.
+   */
+  it('la puerta nombra lo que se va en la misma cascada', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    expect(puerta).toHaveTextContent('¿Dar de baja el tenant "Comercio Sur"?')
+    expect(within(puerta).getAllByRole('listitem').map((i) => i.textContent)).toEqual([
+      '2 empresas',
+      '3 puntos de venta',
+      '4 usuarios',
+    ])
+  })
+
+  /**
+   * Cláusula bajo prueba: `disabled={ocupado !== null}` sobre TODA la ventana —la puerta y las
+   * acciones de la tabla— desde el click hasta que el refresco aterriza (`react-async-state`
+   * reglas 5 y 9). Con el DELETE en vuelo, otra acción supersedería una escritura a medio hacer.
+   */
+  it('durante el DELETE y su refresco no queda ninguna acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    let resolverDelete!: () => void
+    let resolverRefresco!: (items: TenantListado[]) => void
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/plataforma/tenants') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([tenantUno, tenantDos])
+
+      return new Promise<TenantListado[]>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+    apiDeleteMock.mockImplementation(
+      () =>
+        new Promise<void>((resolver) => {
+          resolverDelete = resolver
+        }),
+    )
+
+    render(
+      <MemoryRouter>
+        <Tenants />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    expect(screen.getByRole('button', { name: 'Dando de baja…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeDisabled()
+    for (const boton of [...screen.getAllByRole('button', { name: 'Editar' }), ...screen.getAllByRole('button', { name: 'Baja' })]) {
+      expect(boton).toBeDisabled()
+    }
+
+    await act(async () => {
+      resolverDelete()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByText('Se dio de baja el tenant "Comercio Sur".')).toBeInTheDocument())
+    expect(screen.getByText('Cargando…')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button', { name: 'Baja' })).toHaveLength(0)
+
+    await act(async () => {
+      resolverRefresco([tenantDos])
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Baja' })[0]).toBeEnabled())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Cláusula bajo prueba: el `if (!baja || ocupado !== null) return` de `confirmarBaja`, la guarda
+   * de re-entrancia de la regla 9. Un doble click en el MISMO tick le gana al atributo `disabled`,
+   * que solo existe después del re-render, y mandaría dos DELETE sobre la misma fila.
+   */
+  it('un segundo click sobre la confirmación en vuelo se descarta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockImplementation(() => new Promise<void>(() => {}))
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    const confirmar = screen.getByRole('button', { name: 'Confirmar baja' })
+    await act(async () => {
+      confirmar.click()
+      confirmar.click()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Cláusula bajo prueba: el `catch` PROPIO del refresco (`react-async-state` regla 6). La baja ya
+   * commiteó: reportarla como fallida sería mentir sobre una escritura hecha.
+   */
+  it('un refresco fallido después de la baja no la reporta como fallida', async () => {
+    const usuario = userEvent.setup()
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/plataforma/tenants') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([tenantUno])
+
+      return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+    })
+
+    render(
+      <MemoryRouter>
+        <Tenants />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Se dio de baja el tenant "Comercio Sur". Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  /**
+   * Cláusula bajo prueba: `copiaDeFalloDeBaja(e, 'el tenant')` en vez del `e.message` pelado. El
+   * `codigo` elige la guía; el `mensaje` —que es lo único que nombra QUÉ bloquea— se rinde igual.
+   */
+  it('un 409 tenant_en_uso rinde su guía propia sin tragarse el mensaje del servidor', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'tenant_en_uso', 'No se puede dar de baja el tenant porque tiene 3 ventas.'),
+    )
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText(/porque tiene 3 ventas/)).toBeInTheDocument())
+    expect(screen.getByText(/Dá de baja o reasigná esos datos antes de eliminar el tenant\./)).toBeInTheDocument()
+    // La puerta queda abierta: el motivo se lee sin perder de vista qué se iba a dar de baja.
+    expect(screen.getByRole('button', { name: 'Confirmar baja' })).toBeEnabled()
+  })
+
+  /**
+   * Cláusula bajo prueba: la rama del 404 de `copiaDeFalloDeBaja`, que corre ANTES de mirar el
+   * código. Es el anti-oráculo de BO-R12 llevado a la UI: una fila fuera de alcance y una
+   * inexistente se rinden idénticas, y ninguna insinúa uso.
+   */
+  it('un 404 rinde la copia neutra de inexistencia, nunca una pista de uso', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(new ErrorApi(404, 'no_encontrado', 'No existe el tenant 1.'))
+    montar()
+    await waitFor(() => expect(screen.getByText('Comercio Sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBaja('Comercio Sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No se pudo dar de baja el tenant. Ya no existe o no está a tu alcance. Actualizá el listado.'),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/en uso|tiene \d+/)).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -1,18 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 import { ErrorApi } from '../api/cliente'
+import { arrastreDeTenant, copiaDeFalloDeBaja } from '../api/bajas'
 import { clienteDeOrganizacion } from '../api/organizacion'
 import type { EstadoTenant, TenantListado } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { ConfirmacionDeBaja } from '../componentes/ConfirmacionDeBaja'
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+const AVISO_REFRESCO_FALLIDO_BAJA =
+  'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
 /**
  * ABM (parcial) de tenants — plataforma-only. El alta completa (tenant + empresa + punto de
  * venta + plantilla + admin) vive en <c>NuevoTenant.tsx</c> (aprovisionamiento, ADR-16): acá
- * solo se lista, se edita el nombre y se suspende/reactiva. No hay baja: `EstadoTenant.Baja`
- * no tiene acción dedicada en esta etapa (ver `ServicioDeOrganizacion`).
+ * se lista, se edita el nombre, se suspende/reactiva y —desde la etapa 20— se da de baja
+ * lógicamente, con su empresa, sus puntos de venta y sus usuarios en la misma cascada.
  */
 export function Tenants() {
   const [items, setItems] = useState<TenantListado[]>([])
@@ -21,23 +25,44 @@ export function Tenants() {
   const [aviso, setAviso] = useState('')
   const [edicion, setEdicion] = useState<{ id: number; nombre: string } | null>(null)
   const [ocupado, setOcupado] = useState<number | null>(null)
+  /**
+   * Baja pendiente de confirmación, con el token de generación capturado al ABRIR la puerta: la
+   * ventana en la que el operador decide es asíncrona, así que el token de la escritura se toma
+   * antes de que la puerta se abra y no cuando confirma. Todo lo que supersede esa puerta
+   * —cancelar, abrirla sobre otra fila, cualquier otra escritura— incrementa la generación, deja
+   * este token viejo y hace que el DELETE que salga de una puerta superseded no aplique nada.
+   */
+  const [baja, setBaja] = useState<{ fila: TenantListado; token: number } | null>(null)
 
   /**
    * Contrato de invalidación (`react-async-state` reglas 2-4): toda operación que puede pisar una
-   * LECTURA en vuelo —el montaje y cada escritura— incrementa la generación ANTES de tocar el
-   * estado, y toda aplicación de estado posterior a un `await` la vuelve a chequear.
+   * LECTURA en vuelo —el montaje, cada escritura y la apertura/cierre de la puerta de baja—
+   * incrementa la generación ANTES de tocar el estado, y toda aplicación de estado posterior a un
+   * `await` la vuelve a chequear.
    *
    * Abrir el formulario de edición y cancelarlo NO la incrementan, a diferencia de lo que pide la
    * regla 3 en el caso general: formulario y tabla son porciones de estado INDEPENDIENTES, así que
    * ninguna lectura en vuelo queda superseded por abrirlo o cerrarlo. Incrementarla ahí
    * descartaría esa carga y, como el `finally` de `cargar` está gateado por generación, dejaría la
-   * pantalla clavada en "Cargando…" para siempre.
+   * pantalla clavada en "Cargando…" para siempre. La puerta de baja SÍ la incrementa porque su
+   * token es el de la escritura que va a salir de ella, y eso no puede clavar la pantalla: `cargar`
+   * apaga la tabla de forma síncrona, así que mientras hay una lectura en vuelo no hay ningún
+   * botón que apretar.
    *
    * Mientras hay una escritura en vuelo (`ocupado`) la pantalla bloquea todas las acciones que
-   * podrían supersederla (regla 9). Por eso el `finally` de `refrescarTrasEscribir` apaga
-   * `ocupado` SIN mirar la generación: la bandera no puede ser la de una operación más nueva.
+   * podrían supersederla (regla 9). Aun así, cada escritura apaga `ocupado` en un `finally`
+   * UNGATED que cubre todas sus salidas, incluidas las que se van por generación vieja: un `return`
+   * de generación adentro de la escritura dejaba la bandera prendida y la pantalla congelada.
    */
   const generacion = useRef(0)
+  /**
+   * Espejo SÍNCRONO de `ocupado`, y la ÚNICA guarda de re-entrancia válida. El estado no sirve:
+   * dos clicks del MISMO tick leen el mismo render y los dos ven `ocupado` en `null`, así que
+   * `if (ocupado !== null) return` los deja pasar a los dos y salen dos escrituras (regla 9 —
+   * el atributo `disabled` tampoco alcanza, porque solo existe después del re-render). El ref se
+   * escribe antes del primer `await` y se apaga en el mismo `finally` ungated.
+   */
+  const ocupadoRef = useRef(false)
 
   const cargar = useCallback(async (token: number, propagar = false) => {
     setCargando(true)
@@ -60,67 +85,130 @@ export function Tenants() {
   }, [cargar])
 
   /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
-   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). */
-  async function refrescarTrasEscribir(token: number, mensajeOk: string) {
-    try {
-      if (generacion.current !== token) return
+   * commiteó nunca se reporta como fallida (`react-async-state` regla 6). NO apaga `ocupado`: de
+   * eso se ocupa el `finally` ungated de cada escritura, que es el único punto de apagado y el
+   * que cubre también las salidas por generación vieja. */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string, avisoDeFallo: string) {
+    if (generacion.current !== token) return
 
-      setAviso(mensajeOk)
+    setAviso(mensajeOk)
+    try {
       await cargar(token, true)
     } catch {
-      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
-    } finally {
-      setOcupado(null)
+      if (generacion.current === token) setAviso(`${mensajeOk} ${avisoDeFallo}`)
     }
   }
 
   async function guardarNombre() {
-    if (!edicion || ocupado !== null) return
+    if (!edicion || ocupadoRef.current) return
 
     const { id, nombre } = edicion
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion.editarTenant(id, { nombre })
-    } catch (e) {
+      try {
+        await clienteDeOrganizacion.editarTenant(id, { nombre })
+      } catch (e) {
+        if (generacion.current === token) setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+
+        return
+      }
+
       if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
+
+      setEdicion(null)
+      await refrescarTrasEscribir(token, `Se actualizó el tenant "${nombre}".`, AVISO_REFRESCO_FALLIDO)
+    } finally {
+      ocupadoRef.current = false
       setOcupado(null)
-
-      return
     }
-
-    if (generacion.current !== token) return
-    setEdicion(null)
-    await refrescarTrasEscribir(token, `Se actualizó el tenant "${nombre}".`)
   }
 
   async function cambiarEstado(tenant: TenantListado, accion: 'suspenderTenant' | 'reactivarTenant') {
-    if (ocupado !== null) return
+    if (ocupadoRef.current) return
 
     const verbo = accion === 'suspenderTenant' ? 'suspender' : 'reactivar'
     if (!confirm(`¿${verbo === 'suspender' ? 'Suspender' : 'Reactivar'} el tenant "${tenant.nombre}"?`)) return
 
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(tenant.id)
     setError('')
     setAviso('')
     try {
-      await clienteDeOrganizacion[accion](tenant.id)
-    } catch (e) {
-      if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+      try {
+        await clienteDeOrganizacion[accion](tenant.id)
+      } catch (e) {
+        if (generacion.current === token) {
+          setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+        }
+
+        return
+      }
+
+      await refrescarTrasEscribir(
+        token,
+        `Tenant "${tenant.nombre}" ${verbo === 'suspender' ? 'suspendido' : 'reactivado'}.`,
+        AVISO_REFRESCO_FALLIDO,
+      )
+    } finally {
+      ocupadoRef.current = false
       setOcupado(null)
-
-      return
     }
+  }
 
-    await refrescarTrasEscribir(
-      token,
-      `Tenant "${tenant.nombre}" ${verbo === 'suspender' ? 'suspendido' : 'reactivado'}.`,
-    )
+  /** Abre la puerta de confirmación. Re-chequea `ocupado` además del `disabled` del botón: un
+   * doble click en el mismo tick le gana al re-render (`react-async-state` regla 9). */
+  function pedirBaja(tenant: TenantListado) {
+    if (ocupadoRef.current) return
+
+    setBaja({ fila: tenant, token: ++generacion.current })
+    setError('')
+    setAviso('')
+  }
+
+  function cancelarBaja() {
+    if (ocupadoRef.current) return
+
+    ++generacion.current
+    setBaja(null)
+  }
+
+  async function confirmarBaja() {
+    if (!baja || ocupadoRef.current) return
+
+    const { fila, token } = baja
+    ocupadoRef.current = true
+    setOcupado(fila.id)
+    setError('')
+    setAviso('')
+    try {
+      try {
+        await clienteDeOrganizacion.eliminarTenant(fila.id)
+      } catch (e) {
+        // La puerta queda ABIERTA con el motivo al lado: el operador ve por qué no se pudo sin
+        // perder de vista qué estaba por dar de baja. La copia la elige el `codigo`, nunca el
+        // `mensaje` — que igual se rinde, porque es lo único que nombra qué bloquea.
+        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el tenant'))
+
+        return
+      }
+
+      if (generacion.current !== token) return
+
+      setBaja(null)
+      await refrescarTrasEscribir(
+        token,
+        `Se dio de baja el tenant "${fila.nombre}".`,
+        AVISO_REFRESCO_FALLIDO_BAJA,
+      )
+    } finally {
+      ocupadoRef.current = false
+      setOcupado(null)
+    }
   }
 
   const herramientas = (
@@ -136,6 +224,16 @@ export function Tenants() {
       <Box titulo="Tenants" variante="inverse" herramientas={herramientas}>
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+
+        {baja && (
+          <ConfirmacionDeBaja
+            titulo={`el tenant "${baja.fila.nombre}"`}
+            arrastra={arrastreDeTenant(baja.fila)}
+            ocupado={ocupado !== null}
+            onConfirmar={confirmarBaja}
+            onCancelar={cancelarBaja}
+          />
+        )}
 
         {edicion && (
           <form
@@ -219,7 +317,7 @@ export function Tenants() {
                       {t.estado === 'Activo' && (
                         <button
                           type="button"
-                          className="btn btn-sm btn-outline-warning rounded-0"
+                          className="btn btn-sm btn-outline-warning rounded-0 me-1"
                           onClick={() => cambiarEstado(t, 'suspenderTenant')}
                           disabled={ocupado !== null}
                         >
@@ -229,13 +327,21 @@ export function Tenants() {
                       {t.estado === 'Suspendido' && (
                         <button
                           type="button"
-                          className="btn btn-sm btn-outline-success rounded-0"
+                          className="btn btn-sm btn-outline-success rounded-0 me-1"
                           onClick={() => cambiarEstado(t, 'reactivarTenant')}
                           disabled={ocupado !== null}
                         >
                           Reactivar
                         </button>
                       )}
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger rounded-0"
+                        onClick={() => pedirBaja(t)}
+                        disabled={ocupado !== null}
+                      >
+                        Baja
+                      </button>
                     </td>
                   </tr>
                 ))}

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -61,6 +61,10 @@ export function Tenants() {
    * escritura está en vuelo.
    */
   const [confirmacion, setConfirmacion] = useState<Confirmacion | null>(null)
+  /** Control que abrió la puerta, capturado en el `onClick` y no dentro de la puerta: ver
+   * `ConfirmacionDeBaja.tsx`. Para cuando el efecto de montaje corre, el control ya quedó
+   * `disabled` y el navegador se llevó el foco al `<body>`. */
+  const [disparadorDeLaPuerta, setDisparadorDeLaPuerta] = useState<HTMLElement | null>(null)
 
   /**
    * Contrato de invalidación (`react-async-state` reglas 2-4): toda operación que puede pisar una
@@ -182,9 +186,10 @@ export function Tenants() {
   /** Abre la puerta de confirmación. NO acuña generación —no hay escritura todavía— y re-chequea
    * `ocupadoRef` además del `disabled` del botón: un doble click en el mismo tick le gana al
    * re-render (`react-async-state` regla 9). */
-  function pedirConfirmacion(pendiente: Confirmacion) {
+  function pedirConfirmacion(pendiente: Confirmacion, disparador: HTMLElement | null) {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(disparador)
     setConfirmacion(pendiente)
     setError('')
     setAviso('')
@@ -197,6 +202,7 @@ export function Tenants() {
   function cancelarConfirmacion() {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(null)
     setConfirmacion(null)
     setError('')
     setAviso('')
@@ -241,6 +247,9 @@ export function Tenants() {
       // Un 204 SIEMPRE cierra la puerta y refresca. La generación solo gobierna el REFRESCO, que es
       // una lectura: nunca el desenlace de la escritura que acaba de commitear.
       setConfirmacion(null)
+      // La baja de la fila que se está editando se lleva también su formulario: dejarlo abierto
+      // ofrecía guardar sobre una entidad que ya no existe, y el PUT moría en 404.
+      setEdicion((prev) => (prev?.id === fila.id ? null : prev))
       await refrescarTrasEscribir(
         token,
         `Se dio de baja el tenant "${fila.nombre}".`,
@@ -257,8 +266,10 @@ export function Tenants() {
   const bloqueado = ocupado !== null || confirmacion !== null
 
   // Un `<Link>` no admite `disabled`: la clase `disabled` de Bootstrap le apaga los eventos de
-  // puntero y `tabIndex={-1}` lo saca del recorrido de tabulación, que es lo que la puerta modal
-  // necesita — nada alcanzable afuera mientras está abierta.
+  // puntero y `tabIndex={-1}` lo saca del recorrido de tabulación. Pero las dos cosas son
+  // presentación: `pointer-events: none` solo bloquea el hit-testing del mouse, y ni el Enter
+  // sobre un `<a>` enfocado por programa ni un click sintético pasan por ahí. El `preventDefault`
+  // es el que efectivamente cancela la navegación mientras la puerta está abierta.
   const herramientas = (
     <nav className="p-2">
       <Link
@@ -266,6 +277,9 @@ export function Tenants() {
         className={`btn btn-sm btn-success rounded-0 text-nowrap${bloqueado ? ' disabled' : ''}`}
         aria-disabled={bloqueado}
         tabIndex={bloqueado ? -1 : undefined}
+        onClick={(evento) => {
+          if (bloqueado) evento.preventDefault()
+        }}
       >
         Nuevo tenant
       </Link>
@@ -293,6 +307,7 @@ export function Tenants() {
               confirmacion.tipo === 'baja' ? undefined : COPIA_DE_ESTADO[confirmacion.accion].enCurso
             }
             ocupado={ocupado !== null}
+            disparador={disparadorDeLaPuerta}
             onConfirmar={confirmar}
             onCancelar={cancelarConfirmacion}
           />
@@ -381,7 +396,7 @@ export function Tenants() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-warning rounded-0 me-1"
-                          onClick={() => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'suspenderTenant' })}
+                          onClick={(evento) => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'suspenderTenant' }, evento.currentTarget)}
                           disabled={bloqueado}
                         >
                           Suspender
@@ -391,7 +406,7 @@ export function Tenants() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-success rounded-0 me-1"
-                          onClick={() => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'reactivarTenant' })}
+                          onClick={(evento) => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'reactivarTenant' }, evento.currentTarget)}
                           disabled={bloqueado}
                         >
                           Reactivar
@@ -400,7 +415,7 @@ export function Tenants() {
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-danger rounded-0"
-                        onClick={() => pedirConfirmacion({ tipo: 'baja', fila: t })}
+                        onClick={(evento) => pedirConfirmacion({ tipo: 'baja', fila: t }, evento.currentTarget)}
                         disabled={bloqueado}
                       >
                         Baja

--- a/src/Ways.Web/src/paginas/Tenants.tsx
+++ b/src/Ways.Web/src/paginas/Tenants.tsx
@@ -12,6 +12,31 @@ const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista.
 const AVISO_REFRESCO_FALLIDO_BAJA =
   'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
+type AccionDeEstado = 'suspenderTenant' | 'reactivarTenant'
+
+/** Lo que la puerta de confirmación tiene pendiente. Las tres acciones de esta pantalla que
+ * escriben sobre una fila entera pasan por ella; editar el nombre tiene su propio formulario. */
+type Confirmacion =
+  | { tipo: 'baja'; fila: TenantListado }
+  | { tipo: 'estado'; fila: TenantListado; accion: AccionDeEstado }
+
+const COPIA_DE_ESTADO: Readonly<
+  Record<AccionDeEstado, { pregunta: string; confirmar: string; enCurso: string; hecho: string }>
+> = {
+  suspenderTenant: {
+    pregunta: 'Suspender',
+    confirmar: 'Confirmar suspensión',
+    enCurso: 'Suspendiendo…',
+    hecho: 'suspendido',
+  },
+  reactivarTenant: {
+    pregunta: 'Reactivar',
+    confirmar: 'Confirmar reactivación',
+    enCurso: 'Reactivando…',
+    hecho: 'reactivado',
+  },
+}
+
 /**
  * ABM (parcial) de tenants — plataforma-only. El alta completa (tenant + empresa + punto de
  * venta + plantilla + admin) vive en <c>NuevoTenant.tsx</c> (aprovisionamiento, ADR-16): acá
@@ -26,33 +51,31 @@ export function Tenants() {
   const [edicion, setEdicion] = useState<{ id: number; nombre: string } | null>(null)
   const [ocupado, setOcupado] = useState<number | null>(null)
   /**
-   * Baja pendiente de confirmación, con el token de generación capturado al ABRIR la puerta: la
-   * ventana en la que el operador decide es asíncrona, así que el token de la escritura se toma
-   * antes de que la puerta se abra y no cuando confirma. Todo lo que supersede esa puerta
-   * —cancelar, abrirla sobre otra fila, cualquier otra escritura— incrementa la generación, deja
-   * este token viejo y hace que el DELETE que salga de una puerta superseded no aplique nada.
+   * Acción pendiente de confirmación. La puerta es MODAL: mientras hay una, `bloqueado` deja
+   * inerte todo el resto de la pantalla, así que nada puede supersederla. El token de la escritura
+   * NO se toma acá — la ventana en la que el operador decide es humana, y un token acuñado al
+   * abrir llega viejo a un DELETE que igual sale: se acuña al CONFIRMAR.
+   *
+   * Suspender y reactivar comparten la puerta con la baja (`react-async-state` regla 10 dentro de
+   * un mismo archivo): estaban con `confirm()` nativo, que no se puede dejar inerte mientras la
+   * escritura está en vuelo.
    */
-  const [baja, setBaja] = useState<{ fila: TenantListado; token: number } | null>(null)
+  const [confirmacion, setConfirmacion] = useState<Confirmacion | null>(null)
 
   /**
    * Contrato de invalidación (`react-async-state` reglas 2-4): toda operación que puede pisar una
-   * LECTURA en vuelo —el montaje, cada escritura y la apertura/cierre de la puerta de baja—
-   * incrementa la generación ANTES de tocar el estado, y toda aplicación de estado posterior a un
-   * `await` la vuelve a chequear.
+   * LECTURA en vuelo —el montaje y cada escritura— acuña una generación nueva ANTES de tocar el
+   * estado, y toda aplicación de estado posterior a un `await` la vuelve a chequear.
    *
-   * Abrir el formulario de edición y cancelarlo NO la incrementan, a diferencia de lo que pide la
-   * regla 3 en el caso general: formulario y tabla son porciones de estado INDEPENDIENTES, así que
-   * ninguna lectura en vuelo queda superseded por abrirlo o cerrarlo. Incrementarla ahí
-   * descartaría esa carga y, como el `finally` de `cargar` está gateado por generación, dejaría la
-   * pantalla clavada en "Cargando…" para siempre. La puerta de baja SÍ la incrementa porque su
-   * token es el de la escritura que va a salir de ella, y eso no puede clavar la pantalla: `cargar`
-   * apaga la tabla de forma síncrona, así que mientras hay una lectura en vuelo no hay ningún
-   * botón que apretar.
+   * Lo que NO la incrementa, y por qué: abrir o cerrar el formulario de edición, y abrir o cancelar
+   * la puerta de confirmación. Ninguna de las cuatro supersede nada —no hay escritura detrás de
+   * ellas— y sí podían clavar la pantalla: `cancelar` con una lectura en vuelo la descartaba y,
+   * como el `finally` de `cargar` está gateado por generación, "Cargando…" quedaba para siempre.
    *
-   * Mientras hay una escritura en vuelo (`ocupado`) la pantalla bloquea todas las acciones que
-   * podrían supersederla (regla 9). Aun así, cada escritura apaga `ocupado` en un `finally`
-   * UNGATED que cubre todas sus salidas, incluidas las que se van por generación vieja: un `return`
-   * de generación adentro de la escritura dejaba la bandera prendida y la pantalla congelada.
+   * Mientras hay una escritura en vuelo o una puerta abierta (`bloqueado`), la pantalla deja inerte
+   * TODA acción que podría supersederlas (regla 9). Aun así, cada escritura apaga `ocupado` en un
+   * `finally` UNGATED que cubre todas sus salidas: un `return` temprano adentro de la escritura
+   * dejaba la bandera prendida y la pantalla congelada.
    */
   const generacion = useRef(0)
   /**
@@ -127,11 +150,8 @@ export function Tenants() {
     }
   }
 
-  async function cambiarEstado(tenant: TenantListado, accion: 'suspenderTenant' | 'reactivarTenant') {
+  async function cambiarEstado(tenant: TenantListado, accion: AccionDeEstado) {
     if (ocupadoRef.current) return
-
-    const verbo = accion === 'suspenderTenant' ? 'suspender' : 'reactivar'
-    if (!confirm(`¿${verbo === 'suspender' ? 'Suspender' : 'Reactivar'} el tenant "${tenant.nombre}"?`)) return
 
     const token = ++generacion.current
     ocupadoRef.current = true
@@ -142,16 +162,15 @@ export function Tenants() {
       try {
         await clienteDeOrganizacion[accion](tenant.id)
       } catch (e) {
-        if (generacion.current === token) {
-          setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
-        }
+        setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
 
         return
       }
 
+      setConfirmacion(null)
       await refrescarTrasEscribir(
         token,
-        `Tenant "${tenant.nombre}" ${verbo === 'suspender' ? 'suspendido' : 'reactivado'}.`,
+        `Tenant "${tenant.nombre}" ${COPIA_DE_ESTADO[accion].hecho}.`,
         AVISO_REFRESCO_FALLIDO,
       )
     } finally {
@@ -160,27 +179,48 @@ export function Tenants() {
     }
   }
 
-  /** Abre la puerta de confirmación. Re-chequea `ocupado` además del `disabled` del botón: un
-   * doble click en el mismo tick le gana al re-render (`react-async-state` regla 9). */
-  function pedirBaja(tenant: TenantListado) {
+  /** Abre la puerta de confirmación. NO acuña generación —no hay escritura todavía— y re-chequea
+   * `ocupadoRef` además del `disabled` del botón: un doble click en el mismo tick le gana al
+   * re-render (`react-async-state` regla 9). */
+  function pedirConfirmacion(pendiente: Confirmacion) {
     if (ocupadoRef.current) return
 
-    setBaja({ fila: tenant, token: ++generacion.current })
+    setConfirmacion(pendiente)
     setError('')
     setAviso('')
   }
 
-  function cancelarBaja() {
+  /** Cancelar no supersede NADA: solo cierra la puerta. Por eso no acuña generación —hacerlo
+   * descartaba una lectura en vuelo y dejaba la pantalla clavada en "Cargando…"— y limpia los dos
+   * avisos, en simetría con la apertura: un 409 en rojo al lado de una puerta que ya no está es un
+   * banner huérfano. */
+  function cancelarConfirmacion() {
     if (ocupadoRef.current) return
 
-    ++generacion.current
-    setBaja(null)
+    setConfirmacion(null)
+    setError('')
+    setAviso('')
   }
 
-  async function confirmarBaja() {
-    if (!baja || ocupadoRef.current) return
+  function confirmar() {
+    if (!confirmacion) return
 
-    const { fila, token } = baja
+    if (confirmacion.tipo === 'baja') {
+      void darDeBaja(confirmacion.fila)
+
+      return
+    }
+
+    void cambiarEstado(confirmacion.fila, confirmacion.accion)
+  }
+
+  async function darDeBaja(fila: TenantListado) {
+    if (ocupadoRef.current) return
+
+    // El token se acuña ACÁ, como primera sentencia síncrona de la escritura (`react-async-state`
+    // regla 2): el que se acuñaba al abrir la puerta llegaba viejo a un DELETE que salía igual, y
+    // el chequeo posterior a la red se tragaba tanto el 204 como el 409.
+    const token = ++generacion.current
     ocupadoRef.current = true
     setOcupado(fila.id)
     setError('')
@@ -189,17 +229,18 @@ export function Tenants() {
       try {
         await clienteDeOrganizacion.eliminarTenant(fila.id)
       } catch (e) {
-        // La puerta queda ABIERTA con el motivo al lado: el operador ve por qué no se pudo sin
-        // perder de vista qué estaba por dar de baja. La copia la elige el `codigo`, nunca el
-        // `mensaje` — que igual se rinde, porque es lo único que nombra qué bloquea.
-        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el tenant'))
+        // Un rechazo SIEMPRE se rinde y la puerta queda ABIERTA con el motivo al lado: el operador
+        // ve por qué no se pudo sin perder de vista qué estaba por dar de baja. La copia la elige
+        // el `codigo`, nunca el `mensaje` — que igual se rinde, porque es lo único que nombra qué
+        // bloquea.
+        setError(copiaDeFalloDeBaja(e, 'el tenant'))
 
         return
       }
 
-      if (generacion.current !== token) return
-
-      setBaja(null)
+      // Un 204 SIEMPRE cierra la puerta y refresca. La generación solo gobierna el REFRESCO, que es
+      // una lectura: nunca el desenlace de la escritura que acaba de commitear.
+      setConfirmacion(null)
       await refrescarTrasEscribir(
         token,
         `Se dio de baja el tenant "${fila.nombre}".`,
@@ -211,9 +252,21 @@ export function Tenants() {
     }
   }
 
+  /** La puerta abierta bloquea la pantalla entera, no solo la escritura en vuelo: es lo que hace
+   * que nada pueda acuñar una generación nueva mientras el operador decide (regla 9). */
+  const bloqueado = ocupado !== null || confirmacion !== null
+
+  // Un `<Link>` no admite `disabled`: la clase `disabled` de Bootstrap le apaga los eventos de
+  // puntero y `tabIndex={-1}` lo saca del recorrido de tabulación, que es lo que la puerta modal
+  // necesita — nada alcanzable afuera mientras está abierta.
   const herramientas = (
     <nav className="p-2">
-      <Link to="/organizacion/nuevo-tenant" className="btn btn-sm btn-success rounded-0 text-nowrap">
+      <Link
+        to="/organizacion/nuevo-tenant"
+        className={`btn btn-sm btn-success rounded-0 text-nowrap${bloqueado ? ' disabled' : ''}`}
+        aria-disabled={bloqueado}
+        tabIndex={bloqueado ? -1 : undefined}
+      >
         Nuevo tenant
       </Link>
     </nav>
@@ -225,13 +278,23 @@ export function Tenants() {
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
 
-        {baja && (
+        {confirmacion && (
           <ConfirmacionDeBaja
-            titulo={`el tenant "${baja.fila.nombre}"`}
-            arrastra={arrastreDeTenant(baja.fila)}
+            titulo={`el tenant "${confirmacion.fila.nombre}"`}
+            pregunta={
+              confirmacion.tipo === 'baja' ? undefined : COPIA_DE_ESTADO[confirmacion.accion].pregunta
+            }
+            arrastra={confirmacion.tipo === 'baja' ? arrastreDeTenant(confirmacion.fila) : undefined}
+            nota={confirmacion.tipo === 'baja' ? undefined : null}
+            etiquetaConfirmar={
+              confirmacion.tipo === 'baja' ? undefined : COPIA_DE_ESTADO[confirmacion.accion].confirmar
+            }
+            etiquetaEnCurso={
+              confirmacion.tipo === 'baja' ? undefined : COPIA_DE_ESTADO[confirmacion.accion].enCurso
+            }
             ocupado={ocupado !== null}
-            onConfirmar={confirmarBaja}
-            onCancelar={cancelarBaja}
+            onConfirmar={confirmar}
+            onCancelar={cancelarConfirmacion}
           />
         )}
 
@@ -256,19 +319,19 @@ export function Tenants() {
                 maxLength={150}
                 value={edicion.nombre}
                 onChange={(e) => setEdicion({ ...edicion, nombre: e.target.value })}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
                 required
               />
             </div>
             <div className="col-12 d-flex gap-2">
-              <button type="submit" className="btn btn-success rounded-0" disabled={ocupado !== null}>
+              <button type="submit" className="btn btn-success rounded-0" disabled={bloqueado}>
                 {ocupado !== null ? 'Guardando…' : 'Guardar'}
               </button>
               <button
                 type="button"
                 className="btn btn-outline-secondary rounded-0"
                 onClick={() => setEdicion(null)}
-                disabled={ocupado !== null}
+                disabled={bloqueado}
               >
                 Cancelar
               </button>
@@ -310,7 +373,7 @@ export function Tenants() {
                         type="button"
                         className="btn btn-sm btn-outline-primary rounded-0 me-1"
                         onClick={() => setEdicion({ id: t.id, nombre: t.nombre })}
-                        disabled={ocupado !== null}
+                        disabled={bloqueado}
                       >
                         Editar
                       </button>
@@ -318,8 +381,8 @@ export function Tenants() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-warning rounded-0 me-1"
-                          onClick={() => cambiarEstado(t, 'suspenderTenant')}
-                          disabled={ocupado !== null}
+                          onClick={() => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'suspenderTenant' })}
+                          disabled={bloqueado}
                         >
                           Suspender
                         </button>
@@ -328,8 +391,8 @@ export function Tenants() {
                         <button
                           type="button"
                           className="btn btn-sm btn-outline-success rounded-0 me-1"
-                          onClick={() => cambiarEstado(t, 'reactivarTenant')}
-                          disabled={ocupado !== null}
+                          onClick={() => pedirConfirmacion({ tipo: 'estado', fila: t, accion: 'reactivarTenant' })}
+                          disabled={bloqueado}
                         >
                           Reactivar
                         </button>
@@ -337,8 +400,8 @@ export function Tenants() {
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-danger rounded-0"
-                        onClick={() => pedirBaja(t)}
-                        disabled={ocupado !== null}
+                        onClick={() => pedirConfirmacion({ tipo: 'baja', fila: t })}
+                        disabled={bloqueado}
                       >
                         Baja
                       </button>

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1292,6 +1292,52 @@ describe('Usuarios (slice 5 — cierre de las entradas arrastradas de la slice 2
   })
 
   /**
+   * Cláusula bajo prueba (ronda 2, R2-3): la AUSENCIA de `setErrorAlta('')` en `pedirBaja` y en
+   * `cancelarBaja`. El slot está documentado como precondición VIVA del formulario abierto —falta
+   * el universo de tenants, el alta sigue siendo imposible— y por eso `buscar()` ya lo respetaba;
+   * abrir y cancelar la puerta de baja de OTRA fila lo apagaba igual, escondiendo algo que seguía
+   * siendo cierto y dejando el botón "Guardar" inerte sin ningún cartel que lo explicara.
+   */
+  it('el rechazo del alta sobrevive a abrir y cancelar la puerta de baja', async () => {
+    const usuario = userEvent.setup()
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+    await act(async () => {
+      fireEvent.submit(screen.getByLabelText('Usuario').closest('form') as HTMLFormElement)
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(screen.getByText('No se puede crear el usuario: todavía falta la lista de tenants.')).toBeInTheDocument(),
+    )
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    expect(screen.getByText('No se puede crear el usuario: todavía falta la lista de tenants.')).toBeInTheDocument()
+
+    await usuario.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.getByText('No se puede crear el usuario: todavía falta la lista de tenants.')).toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /**
    * Cláusula bajo prueba (entrada 4): los `setErrorPassword('')` de Cancelar y de Buscar. El fallo
    * del cambio de contraseña quedaba prendido sobre una pantalla que el operador ya cerró o
    * reemplazó por otra búsqueda.
@@ -1410,6 +1456,13 @@ describe('Usuarios (slice 5, ronda 1 — la puerta es modal y el token se acuña
     expect(screen.getByRole('button', { name: 'Editar' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Baja' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
+    // Ronda 2 (R2-1): los CINCO campos del formulario, no solo sus botones. Eran los únicos
+    // controles de las cuatro pantallas raíz que se escapaban de la puerta modal — el resto de las
+    // pantallas ya deshabilitaba cada input—, así que el formulario seguía editable por debajo de
+    // un diálogo que reclama la pantalla entera (`react-async-state` regla 10).
+    for (const etiqueta of ['Usuario', 'Mail', 'Rol', 'Estado', 'Contraseña']) {
+      expect(screen.getByLabelText(etiqueta), `el campo "${etiqueta}" quedó alcanzable`).toBeDisabled()
+    }
     // El botón del formulario dice "Guardar", no "Guardando…": no hay ninguna escritura en vuelo,
     // solo una puerta abierta.
     expect(screen.queryByRole('button', { name: 'Guardando…' })).not.toBeInTheDocument()

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Usuarios } from './Usuarios'
@@ -783,7 +783,6 @@ describe('Usuarios (slice 2, ronda 1 — universo de tenants, filtro y escritura
    */
   it('el refresco post-escritura usa el término buscado, no el borrador tipeado', async () => {
     const usuario = userEvent.setup()
-    vi.stubGlobal('confirm', () => true)
     montar()
     await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
 
@@ -791,6 +790,7 @@ describe('Usuarios (slice 2, ronda 1 — universo de tenants, filtro y escritura
     await usuario.click(
       within(screen.getByRole('row', { name: /vendedor\.sur/ })).getByRole('button', { name: 'Baja' }),
     )
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
 
     await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/usuarios/50'))
     await waitFor(() => expect(screen.getByText(/dado de baja/)).toBeInTheDocument())
@@ -982,5 +982,384 @@ describe('Usuarios (slice 2, ronda 2 — slots de aviso separados y reintento de
 
     expect(screen.queryByText(/No se pudo cargar la lista de tenants/)).not.toBeInTheDocument()
     expect(intentos).toBe(2)
+  })
+})
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5 (tareas 5.6, 5.7 y 5.8), más las entradas
+// arrastradas de la slice 2 (puntos 2 y 4). El patrón de baja es el MISMO que el de `Tenants.tsx`
+// y se replica en la misma PR (`react-async-state` regla 10).
+
+function botonDeBajaDe(nombreDeUsuario: string) {
+  return within(screen.getByRole('row', { name: new RegExp(nombreDeUsuario) })).getByRole('button', {
+    name: 'Baja',
+  })
+}
+
+describe('Usuarios (stage-20, slice 5 — baja lógica tras la puerta de confirmación)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `{baja && <ConfirmacionDeBaja …>}` que reemplazó al `confirm()`
+   * nativo. El diálogo del navegador no se podía dejar inerte mientras el DELETE estaba en vuelo,
+   * y era la única de las cuatro pantallas que no compartía la puerta (regla 10).
+   */
+  it('el botón de baja no llama a la API hasta que se confirma', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog', { name: 'Confirmar baja' })).toHaveTextContent(
+      '¿Dar de baja al usuario "vendedor.sur"?',
+    )
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(apiDeleteMock).toHaveBeenCalledWith('/usuarios/50'))
+    await waitFor(() => expect(screen.getByText('Usuario "vendedor.sur" dado de baja.')).toBeInTheDocument())
+  })
+
+  it('cancelar cierra la puerta y no llama nunca a la API', async () => {
+    const usuario = userEvent.setup()
+    montar()
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /** Cláusula bajo prueba: la ventana inerte completa — ver el test gemelo de `Tenants.test.tsx`. */
+  it('durante el DELETE y su refresco no queda ninguna acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    let resolverDelete!: () => void
+    let resolverRefresco!: (pagina: PaginaDe<UsuarioListado>) => void
+
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.resolve(tenantsDesdeFilas([cuentaDeTenant]))
+      if (!ruta.startsWith('/usuarios')) return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+
+      cargas += 1
+      if (cargas === 1) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return new Promise<PaginaDe<UsuarioListado>>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+    apiDeleteMock.mockImplementation(
+      () =>
+        new Promise<void>((resolver) => {
+          resolverDelete = resolver
+        }),
+    )
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    expect(screen.getByRole('button', { name: 'Dando de baja…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Nuevo' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Buscar' })).toBeDisabled()
+    expect(screen.getByPlaceholderText('Buscar usuario o mail…')).toBeDisabled()
+    for (const boton of [
+      ...screen.getAllByRole('button', { name: 'Editar' }),
+      ...screen.getAllByRole('button', { name: 'Baja' }),
+    ]) {
+      expect(boton).toBeDisabled()
+    }
+
+    await act(async () => {
+      resolverDelete()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByText('Usuario "vendedor.sur" dado de baja.')).toBeInTheDocument())
+
+    await act(async () => {
+      resolverRefresco({ items: [], total: 0, pagina: 1, tamanio: 20 })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Nuevo' })).toBeEnabled())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /** Cláusula bajo prueba: `ocupadoRef`, la guarda de re-entrancia del mismo tick (regla 9). */
+  it('un segundo click sobre la confirmación en vuelo se descarta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockImplementation(() => new Promise<void>(() => {}))
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    const confirmar = screen.getByRole('button', { name: 'Confirmar baja' })
+    await act(async () => {
+      confirmar.click()
+      confirmar.click()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('un refresco fallido después de la baja no la reporta como fallida', async () => {
+    const usuario = userEvent.setup()
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.resolve(tenantsDesdeFilas([cuentaDeTenant]))
+      if (!ruta.startsWith('/usuarios')) return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+
+      cargas += 1
+      if (cargas === 1) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Usuario "vendedor.sur" dado de baja. Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  /**
+   * Cláusula bajo prueba: `copiaDeFalloDeBaja(e, 'el usuario')` en vez del `e.message` pelado que
+   * usaba el viejo `accion()`. `usuario_en_uso` es el cuarto código del set y tiene su propia guía.
+   */
+  it('un 409 usuario_en_uso rinde su guía propia sin tragarse el mensaje del servidor', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'usuario_en_uso', 'No se puede dar de baja el usuario porque hay 7 ventas a su nombre.'),
+    )
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText(/7 ventas a su nombre/)).toBeInTheDocument())
+    expect(
+      screen.getByText(/Reasigná o dá de baja esas operaciones antes de eliminar la cuenta\./),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * Cláusula bajo prueba: que los rechazos PREEXISTENTES de `PoliticaDeRoles` sigan llegando con
+   * su mensaje. No están en el mapa de códigos, así que caen por el fallback — que rinde el
+   * mensaje del servidor y no inventa ninguna guía.
+   */
+  it('un rechazo de PoliticaDeRoles se rinde con su propio mensaje, sin guía inventada', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(403, 'operacion_no_permitida', 'No podés dar de baja tu propia cuenta.'),
+    )
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('No podés dar de baja tu propia cuenta.')).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/Reasigná o dá de baja esas operaciones/)).not.toBeInTheDocument()
+  })
+
+  /** Anti-oráculo (BO-R12) en la capa de UI: un 404 nunca insinúa uso ni alcance. */
+  it('un 404 rinde la copia neutra de inexistencia, nunca una pista de uso', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(new ErrorApi(404, 'no_encontrado', 'No existe el usuario 50.'))
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No se pudo dar de baja el usuario. Ya no existe o no está a tu alcance. Actualizá el listado.'),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/en uso|a su nombre/)).not.toBeInTheDocument()
+  })
+})
+
+// Entradas arrastradas de la slice 2 que esta slice cierra (puntos 2 y 4 del bloque BINDING).
+
+describe('Usuarios (slice 5 — cierre de las entradas arrastradas de la slice 2)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  /**
+   * Cláusula bajo prueba (entrada 2): el slot PROPIO de `ERROR_ALTA_SIN_TENANTS`. En el slot
+   * compartido `error` lo borraba el `setError('')` de la siguiente carga con el universo todavía
+   * caído — el rechazo desaparecía y el alta seguía siendo imposible sin decir por qué.
+   *
+   * El disparo va por `fireEvent.submit` y NO por un click, y eso se dice en vez de disfrazarse:
+   * el botón "Guardar" está `disabled` en esta ventana (`sinTenantAsignable`), así que por click
+   * la rama es inalcanzable — es el superviviente M35 que la slice 2 registró como tal. El evento
+   * de submit es exactamente lo que produciría la carrera del mismo tick contra la que existe el
+   * re-chequeo, y lo que este test prueba es el SLOT: que una carga posterior de la tabla no se
+   * lo lleve puesto.
+   */
+  it('el rechazo del alta sin universo de tenants sobrevive a una carga posterior', async () => {
+    const usuario = userEvent.setup()
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Nuevo' }))
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
+
+    await act(async () => {
+      fireEvent.submit(screen.getByLabelText('Usuario').closest('form') as HTMLFormElement)
+      await Promise.resolve()
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('No se puede crear el usuario: todavía falta la lista de tenants.')).toBeInTheDocument(),
+    )
+    expect(apiPostMock).not.toHaveBeenCalled()
+
+    // Una carga posterior de la TABLA no puede llevárselo puesto: son dos slots con dueños
+    // distintos, y `cargar` termina con un `setError('')` que en el slot compartido lo borraba.
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('No se puede crear el usuario: todavía falta la lista de tenants.')).toBeInTheDocument(),
+    )
+  })
+
+  /**
+   * Cláusula bajo prueba (entrada 4): los `setErrorPassword('')` de Cancelar y de Buscar. El fallo
+   * del cambio de contraseña quedaba prendido sobre una pantalla que el operador ya cerró o
+   * reemplazó por otra búsqueda.
+   */
+  it('el fallo del cambio de contraseña se apaga al cancelar el formulario', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    apiPostMock.mockRejectedValue(new ErrorApi(400, 'password_debil', 'La contraseña es muy corta.'))
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.type(screen.getByLabelText('Contraseña'), 'corta')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await waitFor(() => expect(screen.getByText(/no se pudo cambiar la contraseña/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByText(/no se pudo cambiar la contraseña/)).not.toBeInTheDocument()
+  })
+
+  it('el fallo del cambio de contraseña se apaga al buscar de nuevo', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    apiPostMock.mockRejectedValue(new ErrorApi(400, 'password_debil', 'La contraseña es muy corta.'))
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.type(screen.getByLabelText('Contraseña'), 'corta')
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+    await waitFor(() => expect(screen.getByText(/no se pudo cambiar la contraseña/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Buscar' }))
+
+    await waitFor(() => expect(screen.queryByText(/no se pudo cambiar la contraseña/)).not.toBeInTheDocument())
+  })
+
+  /**
+   * Cláusula bajo prueba (entrada 4): el `esPlataforma &&` que gatea el banner del universo de
+   * tenants, en paridad con TODOS sus elementos hermanos. Para un admin de tenant ese `GET` ni se
+   * dispara, así que la bandera no puede prender: el gate es paridad estructural, y el test
+   * asserta la otra mitad —que para un actor de plataforma sí se rinde— para que borrar el gate no
+   * sea gratis.
+   */
+  it('el banner del universo de tenants es de plataforma, como todo lo que depende de él', async () => {
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.reject(new ErrorApi(500, 'error_interno', 'Se cayó.'))
+      if (ruta.startsWith('/usuarios')) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText(/No se pudo cargar la lista de tenants/)).toBeInTheDocument())
+
+    cleanup()
+    usuarioActual = autenticadoFixture({ id: 4, usuario: 'admin', rolId: ROL.Admin, rol: 'Admin', idTenant: 2 })
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    expect(screen.queryByText(/No se pudo cargar la lista de tenants/)).not.toBeInTheDocument()
   })
 })

--- a/src/Ways.Web/src/paginas/Usuarios.test.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.test.tsx
@@ -1363,3 +1363,166 @@ describe('Usuarios (slice 5 — cierre de las entradas arrastradas de la slice 2
     expect(screen.queryByText(/No se pudo cargar la lista de tenants/)).not.toBeInTheDocument()
   })
 })
+
+// stage-20-organizacion-relaciones-y-bajas, slice 5, judgment-day ronda 1 (C1, C2 y C4).
+
+/** Un `keydown` despachado DIRECTAMENTE sobre el buscador, que con la puerta abierta está
+ * deshabilitado. Ningún operador puede llegar acá —un input inerte no recibe teclas del navegador—
+ * y por eso mismo es la palanca POR DEBAJO del confound (`mutation-proof-tests` regla 3): es la
+ * única forma de acuñar una generación en la ventana en que la puerta está abierta y ver qué hace
+ * el token de la escritura. Con el bloqueo revertido, esta MISMA tecla es alcanzable a mano. */
+function enterEnElBuscador() {
+  fireEvent.keyDown(screen.getByPlaceholderText('Buscar usuario o mail…'), { key: 'Enter' })
+}
+
+describe('Usuarios (slice 5, ronda 1 — la puerta es modal y el token se acuña al confirmar)', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPostMock.mockResolvedValue(undefined)
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = autenticadoFixture()
+  })
+
+  /**
+   * Cláusula bajo prueba: `bloqueado = ocupado || baja !== null` en TODOS los `disabled` de la
+   * pantalla. Con `ocupado` solo, la puerta abierta dejaba vivos Guardar, Buscar, el buscador,
+   * Nuevo, Editar y Baja: cualquiera de ellos acuñaba una generación nueva y el DELETE que salía
+   * después ya no aplicaba nada (`react-async-state` regla 9 — bloquear la ventana, no reconciliar
+   * tokens).
+   */
+  it('con la puerta abierta no queda ninguna otra acción alcanzable', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+
+    const puerta = screen.getByRole('alertdialog', { name: 'Confirmar baja' })
+    expect(screen.getByPlaceholderText('Buscar usuario o mail…')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Buscar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Nuevo' })).toBeDisabled()
+    expect(screen.getByLabelText('Tenant')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Baja' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeDisabled()
+    // El botón del formulario dice "Guardar", no "Guardando…": no hay ninguna escritura en vuelo,
+    // solo una puerta abierta.
+    expect(screen.queryByRole('button', { name: 'Guardando…' })).not.toBeInTheDocument()
+    expect(within(puerta).getByRole('button', { name: 'Confirmar baja' })).toBeEnabled()
+    expect(within(puerta).getByRole('button', { name: 'Cancelar' })).toBeEnabled()
+
+    await usuario.click(within(puerta).getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+    expect(apiDeleteMock).toHaveBeenCalledWith('/usuarios/50')
+  })
+
+  /**
+   * Cláusula bajo prueba: `const token = ++generacion.current` como PRIMERA sentencia síncrona de
+   * `confirmarBaja`, y la ausencia del chequeo de generación posterior a la red. Con el token
+   * acuñado al ABRIR la puerta, una búsqueda en el medio lo dejaba viejo: el DELETE salía igual, el
+   * 204 volvía y el `if (generacion.current !== token) return` se lo tragaba — la fila seguía
+   * listada, la puerta seguía abierta y cada click repetía un DELETE silencioso.
+   */
+  it('una generación acuñada entre abrir y confirmar no se traga el 204', async () => {
+    const usuario = userEvent.setup()
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+
+    await act(async () => {
+      enterEnElBuscador()
+    })
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Usuario "vendedor.sur" dado de baja.')).toBeInTheDocument(),
+    )
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Cláusula bajo prueba: que `cancelarBaja` NO haga `++generacion.current`. Cancelar no supersede
+   * nada —solo cierra la puerta—, y el incremento descartaba una lectura en vuelo dejando sin
+   * ejecutar el `finally` gateado de `cargar`: la pantalla se quedaba en "Cargando…" para siempre,
+   * sin tabla, sin error y sin nada que apretar.
+   */
+  it('cancelar no clava la pantalla cuando hay una búsqueda en vuelo', async () => {
+    const usuario = userEvent.setup()
+    let resolverBusqueda!: (pagina: PaginaDe<UsuarioListado>) => void
+    let cargas = 0
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/roles') return Promise.resolve(ROLES)
+      if (ruta === '/plataforma/tenants') return Promise.resolve(tenantsDesdeFilas([cuentaDeTenant]))
+      if (!ruta.startsWith('/usuarios')) return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+
+      cargas += 1
+      if (cargas === 1) {
+        return Promise.resolve<PaginaDe<UsuarioListado>>({
+          items: [cuentaDeTenant],
+          total: 1,
+          pagina: 1,
+          tamanio: 20,
+        })
+      }
+
+      return new Promise<PaginaDe<UsuarioListado>>((resolver) => {
+        resolverBusqueda = resolver
+      })
+    })
+
+    render(<Usuarios />)
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await act(async () => {
+      enterEnElBuscador()
+    })
+    expect(screen.getByText('Cargando…')).toBeInTheDocument()
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolverBusqueda({ items: [cuentaDeTenant], total: 1, pagina: 1, tamanio: 20 })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.queryByText('Cargando…')).not.toBeInTheDocument())
+    expect(screen.getByText('vendedor.sur')).toBeInTheDocument()
+    expect(apiDeleteMock).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Cláusula bajo prueba: el `setError('')` de `cancelarBaja`. Tras un 409 la puerta queda abierta
+   * con el motivo en rojo al lado; cancelarla sin limpiarlo dejaba el banner huérfano, hablando de
+   * una baja que ya nadie está por hacer.
+   */
+  it('cancelar después de un rechazo se lleva el motivo con la puerta', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'usuario_en_uso', 'No se puede dar de baja el usuario porque hay 7 ventas a su nombre.'),
+    )
+    montar([cuentaDeTenant])
+    await waitFor(() => expect(screen.getByText('vendedor.sur')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('vendedor\\.sur'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+    await waitFor(() => expect(screen.getByText(/7 ventas a su nombre/)).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(screen.queryByText(/7 ventas a su nombre/)).not.toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -93,6 +93,10 @@ export function Usuarios() {
    * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
    * escritura, al confirmar. */
   const [baja, setBaja] = useState<UsuarioListado | null>(null)
+  /** Control que abrió la puerta, capturado en el `onClick` y no dentro de la puerta: ver
+   * `ConfirmacionDeBaja.tsx`. Para cuando el efecto de montaje corre, el control ya quedó
+   * `disabled` y el navegador se llevó el foco al `<body>`. */
+  const [disparadorDeLaPuerta, setDisparadorDeLaPuerta] = useState<HTMLElement | null>(null)
   const [tenantsDePlataforma, setTenantsDePlataforma] = useState<TenantListado[]>([])
   const [tenantsDePlataformaCargando, setTenantsDePlataformaCargando] = useState(false)
   const [tenantsDePlataformaFallo, setTenantsDePlataformaFallo] = useState(false)
@@ -315,28 +319,34 @@ export function Usuarios() {
   /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
    * Reemplaza al `confirm()` nativo: la puerta tiene que quedar inerte mientras el DELETE está en
    * vuelo, y un diálogo del navegador no puede. Abrir NO acuña generación: no hay escritura
-   * todavía. */
-  function pedirBaja(u: UsuarioListado) {
+   * todavía.
+   *
+   * `errorAlta` NO se apaga acá, igual que en `buscar()`: reporta una precondición VIVA del
+   * formulario abierto —falta el universo de tenants—, y abrir la puerta de baja de OTRA fila no
+   * la cambia. Apagarlo escondía algo que seguía siendo cierto. */
+  function pedirBaja(u: UsuarioListado, disparador: HTMLElement | null) {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(disparador)
     setBaja(u)
     setError('')
     setErrorPassword('')
-    setErrorAlta('')
     setAviso('')
   }
 
   /** Cancelar no supersede nada: solo cierra la puerta. Acá el `++generacion.current` era además el
    * único camino ALCANZABLE que clavaba la pantalla: con una búsqueda en vuelo, descartarla dejaba
    * sin ejecutar el `finally` gateado de `cargar` y "Cargando…" quedaba para siempre. Limpia los
-   * avisos en simetría con la apertura, para no dejar un 409 en rojo sin puerta al lado. */
+   * avisos en simetría con la apertura, para no dejar un 409 en rojo sin puerta al lado. `errorAlta`
+   * queda fuera de esa simetría por la misma razón que en `pedirBaja`: es del formulario, no de la
+   * puerta, y sigue siendo cierto después de cancelarla. */
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
+    setDisparadorDeLaPuerta(null)
     setBaja(null)
     setError('')
     setErrorPassword('')
-    setErrorAlta('')
     setAviso('')
   }
 
@@ -368,6 +378,9 @@ export function Usuarios() {
 
       // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
+      // La baja de la fila que se está editando se lleva también su formulario: dejarlo abierto
+      // ofrecía guardar sobre una entidad que ya no existe, y el PUT moría en 404.
+      setFormulario((prev) => (prev?.id === fila.id ? null : prev))
       await refrescarTrasEscribir(
         token,
         `Usuario "${fila.usuario}" dado de baja.`,
@@ -459,6 +472,7 @@ export function Usuarios() {
           <ConfirmacionDeBaja
             titulo={`al usuario "${baja.usuario}"`}
             ocupado={ocupado}
+            disparador={disparadorDeLaPuerta}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
           />
@@ -591,7 +605,7 @@ export function Usuarios() {
                           <button
                             type="button"
                             className="btn btn-sm btn-outline-danger rounded-0"
-                            onClick={() => pedirBaja(u)}
+                            onClick={(evento) => pedirBaja(u, evento.currentTarget)}
                             disabled={bloqueado}
                           >
                             Baja
@@ -697,6 +711,7 @@ function FormularioUsuario({
           maxLength={40}
           value={valor.usuario}
           onChange={(e) => onCambio({ ...valor, usuario: e.target.value })}
+          disabled={bloqueado}
           required
         />
       </div>
@@ -712,6 +727,7 @@ function FormularioUsuario({
           maxLength={255}
           value={valor.mail}
           onChange={(e) => onCambio({ ...valor, mail: e.target.value })}
+          disabled={bloqueado}
           required
         />
       </div>
@@ -730,6 +746,7 @@ function FormularioUsuario({
             const rolId = Number(e.target.value)
             onCambio({ ...valor, rolId, idTenant: rolId === ROL.Root ? null : valor.idTenant })
           }}
+          disabled={bloqueado}
         >
           {roles.map((r) => (
             <option key={r.id} value={r.id}>
@@ -781,6 +798,7 @@ function FormularioUsuario({
           className="form-select rounded-0"
           value={valor.estado}
           onChange={(e) => onCambio({ ...valor, estado: e.target.value as EstadoUsuario })}
+          disabled={bloqueado}
         >
           {ESTADOS_USUARIO.map((e) => (
             <option key={e} value={e}>
@@ -801,6 +819,7 @@ function FormularioUsuario({
           placeholder={esNuevo ? 'Mínimo 8 caracteres' : 'Dejar vacío para no cambiar'}
           value={valor.password}
           onChange={(e) => onCambio({ ...valor, password: e.target.value })}
+          disabled={bloqueado}
           required={esNuevo}
         />
       </div>

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, ErrorApi } from '../api/cliente'
+import { copiaDeFalloDeBaja } from '../api/bajas'
 import {
   clienteDeOrganizacion,
   etiquetaDeTenant,
@@ -22,6 +23,7 @@ import type {
 } from '../api/tipos'
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
+import { ConfirmacionDeBaja } from '../componentes/ConfirmacionDeBaja'
 import { useAuth } from '../auth/useAuth'
 
 type Formulario = {
@@ -47,6 +49,8 @@ const FORMULARIO_VACIO: Formulario = {
 }
 
 const AVISO_REFRESCO_FALLIDO = 'Se guardó, pero no se pudo actualizar la vista. Recargá la pantalla.'
+const AVISO_REFRESCO_FALLIDO_BAJA =
+  'Se eliminó, pero no se pudo actualizar la vista. Recargá la pantalla.'
 
 const ERROR_TENANTS =
   'No se pudo cargar la lista de tenants: no se pueden crear usuarios hasta que llegue. Abrí "Nuevo" para reintentar.'
@@ -77,10 +81,16 @@ export function Usuarios() {
    * puede viajar en `aviso` —el PUT sí commiteó, pero esto es un fallo y va en rojo— ni en `error`
    * —el refresco post-escritura lo limpia al terminar bien. */
   const [errorPassword, setErrorPassword] = useState('')
+  /** Slot PROPIO del rechazo LOCAL del alta sin universo de tenants. En el slot compartido `error`
+   * lo borraba el `setError('')` de cualquier carga posterior (misma clase que R2-1): es un aviso
+   * del FORMULARIO, no de la tabla, y comparte dueño con él — un slot, un dueño. */
+  const [errorAlta, setErrorAlta] = useState('')
   const [aviso, setAviso] = useState('')
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState(false)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
+  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
+  const [baja, setBaja] = useState<{ fila: UsuarioListado; token: number } | null>(null)
   const [tenantsDePlataforma, setTenantsDePlataforma] = useState<TenantListado[]>([])
   const [tenantsDePlataformaCargando, setTenantsDePlataformaCargando] = useState(false)
   const [tenantsDePlataformaFallo, setTenantsDePlataformaFallo] = useState(false)
@@ -90,6 +100,11 @@ export function Usuarios() {
   /** Generación propia: el universo de tenants no depende del ciclo búsqueda/escritura de
    * `generacion` y no debe descartarse por una acción no relacionada (ej. un alta en curso). */
   const generacionTenants = useRef(0)
+  /**
+   * Espejo SÍNCRONO de `ocupado`, y la ÚNICA guarda de re-entrancia válida: ver `Tenants.tsx`.
+   * Dos clicks del MISMO tick leen el mismo render, así que el estado los deja pasar a los dos.
+   */
+  const ocupadoRef = useRef(false)
 
   const cargar = useCallback(async (token: number, termino: string, propagar = false) => {
     setCargando(true)
@@ -110,7 +125,12 @@ export function Usuarios() {
   }, [])
 
   function buscar(termino: string) {
-    if (ocupado) return
+    if (ocupadoRef.current) return
+    // `errorPassword` reporta el fallo parcial de una escritura YA TERMINADA: una búsqueda nueva
+    // es una tabla nueva y arrastrarlo era ruido de la pantalla anterior. `errorAlta` NO se apaga
+    // acá a propósito — reporta una precondición VIVA del formulario abierto (falta el universo de
+    // tenants), que la búsqueda no cambia; apagarlo escondería algo que sigue siendo cierto.
+    setErrorPassword('')
     setBusquedaAplicada(termino)
     void cargar(++generacion.current, termino)
   }
@@ -172,70 +192,75 @@ export function Usuarios() {
     esPlataforma && (tenantsDePlataformaCargando || tenantsDePlataformaFallo)
 
   async function guardar() {
-    if (!formulario || ocupado) return
+    if (!formulario || ocupadoRef.current) return
     if (formulario.id === null && universoDeTenantsIndisponible) {
-      setError(ERROR_ALTA_SIN_TENANTS)
+      setErrorAlta(ERROR_ALTA_SIN_TENANTS)
 
       return
     }
 
     const datos = formulario
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(true)
     setError('')
     setErrorPassword('')
+    setErrorAlta('')
     setAviso('')
 
-    let mensajeOk: string
     try {
-      if (datos.id === null) {
-        const alta: CrearUsuario = {
-          usuario: datos.usuario,
-          mail: datos.mail,
-          rolId: datos.rolId,
-          password: datos.password,
-          estado: datos.estado,
-          idTenant: datos.idTenant,
-        }
-        await api.post('/usuarios', alta)
-        mensajeOk = `Usuario "${datos.usuario}" creado.`
-      } else {
-        const edicion: ActualizarUsuario = {
-          usuario: datos.usuario,
-          mail: datos.mail,
-          rolId: datos.rolId,
-          estado: datos.estado,
-        }
-        await api.put(`/usuarios/${datos.id}`, edicion)
-        mensajeOk = `Usuario "${datos.usuario}" actualizado.`
-      }
-    } catch (e) {
-      if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
-      setOcupado(false)
-
-      return
-    }
-
-    if (generacion.current !== token) return
-
-    // El cambio de contraseña es una SEGUNDA escritura y lleva su propio try: el PUT de arriba ya
-    // commiteó, así que un fallo acá no puede reportarse como "no se pudo guardar"
-    // (`react-async-state` regla 6). Las dos mitades se rinden POR SEPARADO y a la vez: la
-    // confirmación del PUT commiteado en el aviso verde, el fallo de la contraseña en rojo. Meter
-    // el fallo en el aviso verde lo anunciaba como parte de un éxito.
-    if (datos.id !== null && datos.password) {
+      let mensajeOk: string
       try {
-        await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
+        if (datos.id === null) {
+          const alta: CrearUsuario = {
+            usuario: datos.usuario,
+            mail: datos.mail,
+            rolId: datos.rolId,
+            password: datos.password,
+            estado: datos.estado,
+            idTenant: datos.idTenant,
+          }
+          await api.post('/usuarios', alta)
+          mensajeOk = `Usuario "${datos.usuario}" creado.`
+        } else {
+          const edicion: ActualizarUsuario = {
+            usuario: datos.usuario,
+            mail: datos.mail,
+            rolId: datos.rolId,
+            estado: datos.estado,
+          }
+          await api.put(`/usuarios/${datos.id}`, edicion)
+          mensajeOk = `Usuario "${datos.usuario}" actualizado.`
+        }
       } catch (e) {
-        if (generacion.current !== token) return
-        const detalle = e instanceof ErrorApi ? e.message : 'Reintentá el cambio de contraseña.'
-        setErrorPassword(`Se guardó el perfil, pero no se pudo cambiar la contraseña. ${detalle}`)
-      }
-    }
+        if (generacion.current === token) setError(e instanceof ErrorApi ? e.message : 'No se pudo guardar.')
 
-    setFormulario(null)
-    await refrescarTrasEscribir(token, mensajeOk)
+        return
+      }
+
+      if (generacion.current !== token) return
+
+      // El cambio de contraseña es una SEGUNDA escritura y lleva su propio try: el PUT de arriba ya
+      // commiteó, así que un fallo acá no puede reportarse como "no se pudo guardar"
+      // (`react-async-state` regla 6). Las dos mitades se rinden POR SEPARADO y a la vez: la
+      // confirmación del PUT commiteado en el aviso verde, el fallo de la contraseña en rojo. Meter
+      // el fallo en el aviso verde lo anunciaba como parte de un éxito.
+      if (datos.id !== null && datos.password) {
+        try {
+          await api.post(`/usuarios/${datos.id}/password`, { passwordNueva: datos.password })
+        } catch (e) {
+          if (generacion.current !== token) return
+          const detalle = e instanceof ErrorApi ? e.message : 'Reintentá el cambio de contraseña.'
+          setErrorPassword(`Se guardó el perfil, pero no se pudo cambiar la contraseña. ${detalle}`)
+        }
+      }
+
+      setFormulario(null)
+      await refrescarTrasEscribir(token, mensajeOk, AVISO_REFRESCO_FALLIDO)
+    } finally {
+      ocupadoRef.current = false
+      setOcupado(false)
+    }
   }
 
   /** El refresco post-escritura va fuera del try/catch de la escritura: una escritura que ya
@@ -243,48 +268,102 @@ export function Usuarios() {
    * REALMENTE aplicado, no con el borrador del input: tipear sin buscar y dar de baja una fila no
    * puede angostar la tabla por un texto que el operador nunca aplicó.
    *
-   * `ocupado` se apaga en el `finally` SIN mirar la generación, a diferencia del resto de las
-   * aplicaciones de estado: mientras hay una escritura en vuelo la pantalla bloquea todo lo que
-   * podría supersederla (regla 9), así que la bandera nunca puede ser la de una operación más
-   * nueva — y salir por el chequeo de generación la dejaría prendida para siempre. */
-  async function refrescarTrasEscribir(token: number, mensajeOk: string) {
-    try {
-      if (generacion.current !== token) return
+   * NO apaga `ocupado`: de eso se ocupa el `finally` ungated de cada escritura — ver `Tenants.tsx`. */
+  async function refrescarTrasEscribir(token: number, mensajeOk: string, avisoDeFallo: string) {
+    if (generacion.current !== token) return
 
-      setAviso(mensajeOk)
+    setAviso(mensajeOk)
+    try {
       await cargar(token, busquedaAplicada, true)
     } catch {
-      if (generacion.current === token) setAviso(`${mensajeOk} ${AVISO_REFRESCO_FALLIDO}`)
-    } finally {
-      setOcupado(false)
+      if (generacion.current === token) setAviso(`${mensajeOk} ${avisoDeFallo}`)
     }
   }
 
+  /** Acciones sin puerta de confirmación (hoy solo "Desbloquear"): la baja tiene la suya y su
+   * propia copia por `codigo`, así que no pasa por acá. */
   async function accion(construirPromesa: () => Promise<unknown>, mensajeOk: string) {
-    if (ocupado) return
+    if (ocupadoRef.current) return
 
     const token = ++generacion.current
+    ocupadoRef.current = true
     setOcupado(true)
     setError('')
     setErrorPassword('')
+    setErrorAlta('')
     setAviso('')
     try {
-      await construirPromesa()
-    } catch (e) {
-      if (generacion.current !== token) return
-      setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+      try {
+        await construirPromesa()
+      } catch (e) {
+        if (generacion.current === token) {
+          setError(e instanceof ErrorApi ? e.message : 'No se pudo completar la acción.')
+        }
+
+        return
+      }
+
+      await refrescarTrasEscribir(token, mensajeOk, AVISO_REFRESCO_FALLIDO)
+    } finally {
+      ocupadoRef.current = false
       setOcupado(false)
-
-      return
     }
-
-    await refrescarTrasEscribir(token, mensajeOk)
   }
 
-  function eliminar(u: UsuarioListado) {
-    if (ocupado) return
-    if (!confirm(`¿Dar de baja al usuario "${u.usuario}"?`)) return
-    void accion(() => api.delete(`/usuarios/${u.id}`), `Usuario "${u.usuario}" dado de baja.`)
+  /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
+   * Reemplaza al `confirm()` nativo: la puerta tiene que quedar inerte mientras el DELETE está en
+   * vuelo, y un diálogo del navegador no puede. */
+  function pedirBaja(u: UsuarioListado) {
+    if (ocupadoRef.current) return
+
+    setBaja({ fila: u, token: ++generacion.current })
+    setError('')
+    setErrorPassword('')
+    setErrorAlta('')
+    setAviso('')
+  }
+
+  function cancelarBaja() {
+    if (ocupadoRef.current) return
+
+    ++generacion.current
+    setBaja(null)
+  }
+
+  async function confirmarBaja() {
+    if (!baja || ocupadoRef.current) return
+
+    const { fila, token } = baja
+    ocupadoRef.current = true
+    setOcupado(true)
+    setError('')
+    setErrorPassword('')
+    setErrorAlta('')
+    setAviso('')
+    try {
+      try {
+        await api.delete(`/usuarios/${fila.id}`)
+      } catch (e) {
+        // La copia la elige el `codigo` (`usuario_en_uso` y los rechazos preexistentes de
+        // `PoliticaDeRoles`), nunca el `mensaje` — que igual se rinde porque es lo único que
+        // nombra QUÉ hay a nombre de la cuenta.
+        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el usuario'))
+
+        return
+      }
+
+      if (generacion.current !== token) return
+
+      setBaja(null)
+      await refrescarTrasEscribir(
+        token,
+        `Usuario "${fila.usuario}" dado de baja.`,
+        AVISO_REFRESCO_FALLIDO_BAJA,
+      )
+    } finally {
+      ocupadoRef.current = false
+      setOcupado(false)
+    }
   }
 
   // El backend valida igual; esto solo evita mostrar botones que van a fallar.
@@ -329,6 +408,7 @@ export function Usuarios() {
           setAviso('')
           setError('')
           setErrorPassword('')
+          setErrorAlta('')
           // Reintento del universo de tenants: abrir el alta es el único momento en que hace falta.
           // `!tenantsDePlataformaCargando` evita que reabrir "Nuevo" con el reintento EN VUELO
           // dispare un segundo `GET /plataforma/tenants` por click.
@@ -347,11 +427,24 @@ export function Usuarios() {
     <div className="container-fluid py-4">
       <Box titulo="Usuarios" variante="inverse" herramientas={herramientas}>
         {error && <div className="alert alert-danger rounded-0">{error}</div>}
-        {tenantsDePlataformaFallo && (
+        {/* Gateado en `esPlataforma` como todo lo demás que depende del universo de tenants: para
+            un admin de tenant ese `GET` ni se dispara, así que la bandera no puede prender — el
+            gate es paridad con sus elementos hermanos, no una rama viva. */}
+        {esPlataforma && tenantsDePlataformaFallo && (
           <div className="alert alert-danger rounded-0">{ERROR_TENANTS}</div>
         )}
+        {errorAlta && <div className="alert alert-danger rounded-0">{errorAlta}</div>}
         {errorPassword && <div className="alert alert-danger rounded-0">{errorPassword}</div>}
         {aviso && <div className="alert alert-success rounded-0">{aviso}</div>}
+
+        {baja && (
+          <ConfirmacionDeBaja
+            titulo={`al usuario "${baja.fila.usuario}"`}
+            ocupado={ocupado}
+            onConfirmar={confirmarBaja}
+            onCancelar={cancelarBaja}
+          />
+        )}
 
         {formulario && (
           <FormularioUsuario
@@ -365,7 +458,11 @@ export function Usuarios() {
             guardando={ocupado}
             onCambio={setFormulario}
             onGuardar={guardar}
-            onCancelar={() => setFormulario(null)}
+            onCancelar={() => {
+              setFormulario(null)
+              setErrorPassword('')
+              setErrorAlta('')
+            }}
           />
         )}
 
@@ -448,6 +545,7 @@ export function Usuarios() {
                               setAviso('')
                               setError('')
                               setErrorPassword('')
+                              setErrorAlta('')
                             }}
                             disabled={ocupado}
                           >
@@ -473,7 +571,7 @@ export function Usuarios() {
                           <button
                             type="button"
                             className="btn btn-sm btn-outline-danger rounded-0"
-                            onClick={() => eliminar(u)}
+                            onClick={() => pedirBaja(u)}
                             disabled={ocupado}
                           >
                             Baja

--- a/src/Ways.Web/src/paginas/Usuarios.tsx
+++ b/src/Ways.Web/src/paginas/Usuarios.tsx
@@ -89,8 +89,10 @@ export function Usuarios() {
   const [formulario, setFormulario] = useState<Formulario | null>(null)
   const [ocupado, setOcupado] = useState(false)
   const [filtroTenant, setFiltroTenant] = useState(SIN_FILTRO)
-  /** Baja pendiente de confirmación, con su token capturado al abrir la puerta: ver `Tenants.tsx`. */
-  const [baja, setBaja] = useState<{ fila: UsuarioListado; token: number } | null>(null)
+  /** Baja pendiente de confirmación: ver `Tenants.tsx`. La puerta es MODAL —`bloqueado` deja
+   * inerte el resto de la pantalla mientras está abierta— y NO acuña token: eso lo hace la
+   * escritura, al confirmar. */
+  const [baja, setBaja] = useState<UsuarioListado | null>(null)
   const [tenantsDePlataforma, setTenantsDePlataforma] = useState<TenantListado[]>([])
   const [tenantsDePlataformaCargando, setTenantsDePlataformaCargando] = useState(false)
   const [tenantsDePlataformaFallo, setTenantsDePlataformaFallo] = useState(false)
@@ -312,28 +314,39 @@ export function Usuarios() {
 
   /** Ver `Tenants.tsx`: mismo patrón de puerta, mismo contrato de invalidación, misma re-entrancia.
    * Reemplaza al `confirm()` nativo: la puerta tiene que quedar inerte mientras el DELETE está en
-   * vuelo, y un diálogo del navegador no puede. */
+   * vuelo, y un diálogo del navegador no puede. Abrir NO acuña generación: no hay escritura
+   * todavía. */
   function pedirBaja(u: UsuarioListado) {
     if (ocupadoRef.current) return
 
-    setBaja({ fila: u, token: ++generacion.current })
+    setBaja(u)
     setError('')
     setErrorPassword('')
     setErrorAlta('')
     setAviso('')
   }
 
+  /** Cancelar no supersede nada: solo cierra la puerta. Acá el `++generacion.current` era además el
+   * único camino ALCANZABLE que clavaba la pantalla: con una búsqueda en vuelo, descartarla dejaba
+   * sin ejecutar el `finally` gateado de `cargar` y "Cargando…" quedaba para siempre. Limpia los
+   * avisos en simetría con la apertura, para no dejar un 409 en rojo sin puerta al lado. */
   function cancelarBaja() {
     if (ocupadoRef.current) return
 
-    ++generacion.current
     setBaja(null)
+    setError('')
+    setErrorPassword('')
+    setErrorAlta('')
+    setAviso('')
   }
 
   async function confirmarBaja() {
     if (!baja || ocupadoRef.current) return
 
-    const { fila, token } = baja
+    // El token se acuña ACÁ, primera sentencia síncrona de la escritura (`react-async-state`
+    // regla 2): ver `Tenants.tsx`.
+    const fila = baja
+    const token = ++generacion.current
     ocupadoRef.current = true
     setOcupado(true)
     setError('')
@@ -344,16 +357,16 @@ export function Usuarios() {
       try {
         await api.delete(`/usuarios/${fila.id}`)
       } catch (e) {
-        // La copia la elige el `codigo` (`usuario_en_uso` y los rechazos preexistentes de
-        // `PoliticaDeRoles`), nunca el `mensaje` — que igual se rinde porque es lo único que
-        // nombra QUÉ hay a nombre de la cuenta.
-        if (generacion.current === token) setError(copiaDeFalloDeBaja(e, 'el usuario'))
+        // Un rechazo SIEMPRE se rinde, con la puerta abierta al lado del motivo. La copia la elige
+        // el `codigo` (`usuario_en_uso` y los rechazos preexistentes de `PoliticaDeRoles`), nunca
+        // el `mensaje` — que igual se rinde porque es lo único que nombra QUÉ hay a nombre de la
+        // cuenta.
+        setError(copiaDeFalloDeBaja(e, 'el usuario'))
 
         return
       }
 
-      if (generacion.current !== token) return
-
+      // Un 204 SIEMPRE cierra la puerta y refresca; la generación solo gobierna el REFRESCO.
       setBaja(null)
       await refrescarTrasEscribir(
         token,
@@ -365,6 +378,11 @@ export function Usuarios() {
       setOcupado(false)
     }
   }
+
+  /** La puerta abierta bloquea la pantalla entera, no solo la escritura en vuelo: ver `Tenants.tsx`.
+   * Es lo que hace que la búsqueda —el único bumper de generación que quedaba alcanzable con la
+   * puerta abierta— no pueda dispararse mientras el operador decide. */
+  const bloqueado = ocupado || baja !== null
 
   // El backend valida igual; esto solo evita mostrar botones que van a fallar.
   const puedeEditar = (u: UsuarioListado) =>
@@ -390,13 +408,13 @@ export function Usuarios() {
         value={busqueda}
         onChange={(e) => setBusqueda(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && buscar(busqueda)}
-        disabled={ocupado}
+        disabled={bloqueado}
       />
       <button
         type="button"
         className="btn btn-sm btn-outline-light rounded-0"
         onClick={() => buscar(busqueda)}
-        disabled={ocupado}
+        disabled={bloqueado}
       >
         Buscar
       </button>
@@ -416,7 +434,7 @@ export function Usuarios() {
             cargarTenantsDePlataforma()
           }
         }}
-        disabled={ocupado}
+        disabled={bloqueado}
       >
         Nuevo
       </button>
@@ -439,7 +457,7 @@ export function Usuarios() {
 
         {baja && (
           <ConfirmacionDeBaja
-            titulo={`al usuario "${baja.fila.usuario}"`}
+            titulo={`al usuario "${baja.usuario}"`}
             ocupado={ocupado}
             onConfirmar={confirmarBaja}
             onCancelar={cancelarBaja}
@@ -456,6 +474,7 @@ export function Usuarios() {
             tenantsCargando={esPlataforma ? tenantsDePlataformaCargando : cargando}
             tenantIndisponible={universoDeTenantsIndisponible}
             guardando={ocupado}
+            bloqueado={bloqueado}
             onCambio={setFormulario}
             onGuardar={guardar}
             onCancelar={() => {
@@ -485,6 +504,7 @@ export function Usuarios() {
                     className="form-select rounded-0"
                     value={tenantVigente}
                     onChange={(e) => setFiltroTenant(e.target.value)}
+                    disabled={bloqueado}
                   >
                     <option value={SIN_FILTRO}>Todos</option>
                     {opcionesTenant.map((o) => (
@@ -547,7 +567,7 @@ export function Usuarios() {
                               setErrorPassword('')
                               setErrorAlta('')
                             }}
-                            disabled={ocupado}
+                            disabled={bloqueado}
                           >
                             Editar
                           </button>
@@ -562,7 +582,7 @@ export function Usuarios() {
                                 `Usuario "${u.usuario}" desbloqueado.`,
                               )
                             }
-                            disabled={ocupado}
+                            disabled={bloqueado}
                           >
                             Desbloquear
                           </button>
@@ -572,7 +592,7 @@ export function Usuarios() {
                             type="button"
                             className="btn btn-sm btn-outline-danger rounded-0"
                             onClick={() => pedirBaja(u)}
-                            disabled={ocupado}
+                            disabled={bloqueado}
                           >
                             Baja
                           </button>
@@ -630,6 +650,7 @@ function FormularioUsuario({
   tenantsCargando,
   tenantIndisponible,
   guardando,
+  bloqueado,
   onCambio,
   onGuardar,
   onCancelar,
@@ -640,7 +661,11 @@ function FormularioUsuario({
   ofreceTenant: boolean
   tenantsCargando: boolean
   tenantIndisponible: boolean
+  /** Solo gobierna la ETIQUETA del botón: "Guardando…" es cierto de una escritura en vuelo, no de
+   * una puerta de confirmación abierta. */
   guardando: boolean
+  /** Escritura en vuelo O puerta de confirmación abierta: gobierna todo `disabled`. */
+  bloqueado: boolean
   onCambio: (f: Formulario) => void
   onGuardar: () => void
   onCancelar: () => void
@@ -726,7 +751,7 @@ function FormularioUsuario({
             onChange={(e) =>
               onCambio({ ...valor, idTenant: e.target.value === '' ? null : Number(e.target.value) })
             }
-            disabled={guardando || tenantsCargando || esRolDePlataforma || sinTenantAsignable}
+            disabled={bloqueado || tenantsCargando || esRolDePlataforma || sinTenantAsignable}
             required
           >
             <option value="">
@@ -784,7 +809,7 @@ function FormularioUsuario({
         <button
           type="submit"
           className="btn btn-success rounded-0"
-          disabled={guardando || sinTenantAsignable}
+          disabled={bloqueado || sinTenantAsignable}
         >
           {guardando ? 'Guardando…' : 'Guardar'}
         </button>
@@ -792,7 +817,7 @@ function FormularioUsuario({
           type="button"
           className="btn btn-outline-secondary rounded-0"
           onClick={onCancelar}
-          disabled={guardando}
+          disabled={bloqueado}
         >
           Cancelar
         </button>


### PR DESCRIPTION
Closes #172

## Resumen

Slice 5 de 5 — cierra la etapa 20. La UI raiz ya puede dar de baja tenants, empresas, puntos de venta y usuarios, y la guarda del backend (#171) le dice al operador exactamente que bloquea y donde.

- Accion **Baja** en las cuatro pantallas raiz, detras de **una** confirmacion en pantalla compartida (`ConfirmacionDeBaja`) que nombra lo que se va: un tenant arrastra sus empresas, puntos de venta y usuarios, con los contadores vivos del DTO.
- `api/bajas.ts`: los seis 409 mapeados a copia propia, rindiendo siempre el `mensaje` del servidor — que nombra la tabla que bloquea y el punto de venta cuando el bloqueo viene por puente. Un codigo desconocido cae al mensaje del servidor, jamas a un generico.
- Un 5xx despues de una baja dice **"No se pudo confirmar el resultado: verifica el listado antes de reintentar."** — sin retry del lado servidor, la baja puede haberse hecho.
- Disciplina completa `react-async-state` en las cuatro pantallas: token acunado **al confirmar**, ventana deshabilitada completa, refresh con el termino aplicado, `ocupado` liberado en `finally` sin gate, y un guard de reentrada **sincronico** en un ref.
- Suspender y Reactivar de tenants pasan por la misma puerta: dos confirmaciones hermanas en un mismo archivo no pueden usar dos mecanismos.
- Visibilidad por politica; un 404 para un admin de tenant dice "no existe" y nada mas.

Solo web. Cero backend, cero esquema. Docs 09 y 10 actualizados.

## Lo que encontraron los tests y los jueces

**El guard de reentrada leia estado.** `if (ocupado) return` — dos clicks en el mismo tick leen el mismo render, los dos pasan, salen **dos DELETE**. Fallo en la primera corrida; el fix es un espejo sincronico en un ref. Era el sobreviviente honesto del slice 2 que los botones de baja volvieron alcanzable.

**La puerta no era modal y acunaba el token al abrirse.** Dos criticos, ambos jueces, ambos alcanzables: una puerta superada por otra accion seguia mandando el DELETE y descartaba los dos desenlaces (fila listada, puerta abierta, cada click otro DELETE silencioso); y cancelar bumpeaba la generacion y clavaba Usuarios en "Cargando...". Cerrados en la raiz: `bloqueado` en cada control, token al confirmar, cancelar no bumpea nada, un 204 siempre cierra y refresca.

**El restore de foco era un no-op en navegador real.** Se capturaba `activeElement` en un efecto pasivo, despues del commit que deshabilita el disparador; el navegador mueve el foco a `<body>`, jsdom no. El test pasaba por una divergencia de jsdom. Ahora se captura en el click, antes de cualquier `setState`.

## Alcance honesto de la modalidad

La puerta deja **inerte cada pantalla** — cada control adentro esta detras de `bloqueado`, verificado control por control. **No** es modal a nivel documento: el navbar del layout sigue vivo, el banner del 409 se renderiza fuera del dialogo `aria-modal`, y el foco se pierde durante la escritura. Registrados como residuos con su arreglo, no como cerrados.

## Judgment-day: APROBADO en ronda limpia

Dos rondas de correccion y dos re-judgments. 40 mutaciones ejecutadas, 38 muertas, 2 sobrevivientes con argumento de construccion verificado por ambos jueces.

## Suites

```
npm test                65 archivos / 1102 tests
npm run build           tsc + vite limpio
npm run lint            exit 0 (5 warnings preexistentes)
dotnet build            0 errores; backend fuera del diff
```

Tamano ~2700 lineas contra 800; excepcion autorizada. Produccion ~800 sin reindentacion; tests ~1400.
