### PR TITLE
chore(tests): sube Testcontainers.PostgreSql a 4.14.0 para dejar atras el advisory de SSH.NET

### DIFF
--- a/tests/Ways.IntegrationTests/Ways.IntegrationTests.csproj
+++ b/tests/Ways.IntegrationTests/Ways.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>


### PR DESCRIPTION
Closes #174

## Resumen

`Testcontainers.PostgreSql` 4.1.0 -> 4.14.0 en el proyecto de tests de integracion. Un solo renglon.

## Por que

El transitivo `SSH.NET 2024.1.0` carga GHSA-q939-rpr3-3284 (CVSS 7.1): path traversal en `ScpClient.Download` recursivo, un servidor SCP malicioso devuelve nombres con `../` y el cliente escribe fuera del directorio. Parchado en `2026.0.0`.

**Exposicion real: nula.** El paquete vive solo en `tests/`, ningun artefacto desplegado lo referencia, el fixture habla con un Docker daemon local y el repo nunca configura Docker-over-SSH — la superficie vulnerable no es alcanzable ni antes ni despues. Se arregla porque el `NU1903` ensuciaba cada build y el costo es cero.

## Por que 4.14.0 y no otra cosa

- **Es la minima parchada.** Verificado nuspec por nuspec: toda 4.x anterior trae SSH.NET <= 2025.1.0, y el advisory cubre `<= 2025.1.0`. 4.14.0 es la primera que exige `2026.0.0`.
- **No un pin directo de SSH.NET.** Testcontainers 4.1.0 se compilo contra 2024.1.0; 2026.0.0 es un salto de mayor con cambios de API. Forzar esa combinacion es correr un binario contra una dependencia que nunca probo.
- `WaysApiFixture` fija `WithImage("postgres:17-alpine")`, igual que `compose.dev.yml`: el bump no cambia la version de Postgres contra la que corren los tests.

## Judgment-day: APROBADO, ronda limpia

Cero hallazgos confirmados. Los jueces verificaron que el grafo resuelto no trae ningun advisory nuevo (incluidos los cinco sub-paquetes nuevos de `Docker.DotNet.Enhanced 4.3.3`, todos MIT del mismo org), que no hay lock file que regenerar, y que ningun API de Testcontainers sensible a cambios entre 4.1 y 4.14 se usa en el fixture.

## Verificacion

```
dotnet build Ways.slnx          0 errores, 0 NU1903
dotnet restore --force          cero advertencias NuGet
dotnet list package --vulnerable   "no tiene paquetes vulnerables"
Ways.IntegrationTests           1780/1780, 13 m 33 s, una sola vez, sola
```
