### PR TITLE
feat(web): modelo de menu por rol y menu desplegable accesible (slice 1 de nav y punto de venta de sesion)

### DIFF
--- a/src/Ways.Web/src/componentes/MenuDesplegable.test.tsx
+++ b/src/Ways.Web/src/componentes/MenuDesplegable.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+import { MenuDesplegable } from './MenuDesplegable'
+import type { GrupoDeMenu } from './menu'
+
+const administracion: GrupoDeMenu = {
+  tipo: 'grupo',
+  etiqueta: 'Administración',
+  secciones: [
+    {
+      titulo: 'Catálogo',
+      enlaces: [
+        { tipo: 'enlace', etiqueta: 'Artículos', a: '/articulos' },
+        { tipo: 'enlace', etiqueta: 'Marcas', a: '/catalogos/marcas' },
+      ],
+    },
+    { titulo: 'Terceros', enlaces: [{ tipo: 'enlace', etiqueta: 'Clientes', a: '/clientes' }] },
+  ],
+}
+
+/** Anfitrión con el estado de apertura levantado, como lo va a tener `Layout` (`grupoAbierto`);
+ * el botón "Afuera" es el destino de foco y de pointerdown externo. */
+function Anfitrion({ activo = false, alCerrar = () => {} }: { activo?: boolean; alCerrar?: () => void }) {
+  const [abierto, setAbierto] = useState(false)
+
+  return (
+    <>
+      <ul className="navbar-nav">
+        <MenuDesplegable
+          grupo={administracion}
+          abierto={abierto}
+          activo={activo}
+          alAlternar={() => setAbierto((previo) => !previo)}
+          alCerrar={() => {
+            setAbierto(false)
+            alCerrar()
+          }}
+        />
+      </ul>
+      <button type="button">Afuera</button>
+    </>
+  )
+}
+
+function renderMenu({ ruta = '/', activo = false, alCerrar }: { ruta?: string; activo?: boolean; alCerrar?: () => void } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[ruta]}>
+      <Anfitrion activo={activo} alCerrar={alCerrar} />
+    </MemoryRouter>,
+  )
+}
+
+const boton = () => screen.getByRole('button', { name: 'Administración' })
+const enlace = (nombre: string) => screen.getByRole('link', { name: nombre })
+
+describe('MenuDesplegable', () => {
+  it('arranca cerrado: aria-expanded=false y los ítems no son alcanzables', () => {
+    renderMenu()
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('link', { name: 'Artículos' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Catálogo' })).not.toBeInTheDocument()
+  })
+
+  it('un clic abre la lista que el botón controla y otro clic la cierra', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'true')
+    const lista = document.getElementById(boton().getAttribute('aria-controls') ?? '')
+    expect(lista).not.toBeNull()
+    expect(within(lista as HTMLElement).getByRole('link', { name: 'Artículos' })).toBeInTheDocument()
+
+    await usuario.click(boton())
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('link', { name: 'Artículos' })).not.toBeInTheDocument()
+  })
+
+  it('abierto, muestra los encabezados de sección y un separador entre secciones', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+
+    expect(screen.getByRole('heading', { name: 'Catálogo', level: 6 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Terceros', level: 6 })).toBeInTheDocument()
+    expect(screen.getAllByRole('separator')).toHaveLength(1)
+  })
+
+  it('Escape cierra y devuelve el foco al botón, aunque el foco estuviera en un ítem', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+    await usuario.keyboard('{ArrowDown}')
+    expect(enlace('Artículos')).toHaveFocus()
+
+    await usuario.keyboard('{Escape}')
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+    expect(boton()).toHaveFocus()
+    expect(screen.queryByRole('link', { name: 'Artículos' })).not.toBeInTheDocument()
+  })
+
+  it('elegir un ítem avisa alCerrar', async () => {
+    const usuario = userEvent.setup()
+    const alCerrar = vi.fn()
+    renderMenu({ alCerrar })
+
+    await usuario.click(boton())
+    await usuario.click(enlace('Artículos'))
+
+    expect(alCerrar).toHaveBeenCalledTimes(1)
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  /**
+   * jsdom deja enfocar un elemento aunque esté dentro de un `hidden`, así que acá no se puede
+   * probar que el foco se mueve DESPUÉS del commit que destapa la lista (lo que en un navegador
+   * real es la diferencia entre enfocar y no enfocar nada); lo observable es el estado final.
+   */
+  it('ArrowDown desde el botón abre y enfoca el primer ítem', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.tab()
+    expect(boton()).toHaveFocus()
+
+    await usuario.keyboard('{ArrowDown}')
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'true')
+    expect(enlace('Artículos')).toHaveFocus()
+  })
+
+  it('ArrowDown/ArrowUp recorren los ítems con vuelta y Home/End van a los extremos', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+    await usuario.keyboard('{ArrowDown}')
+    expect(enlace('Artículos')).toHaveFocus()
+
+    await usuario.keyboard('{ArrowUp}')
+    expect(enlace('Clientes')).toHaveFocus()
+
+    await usuario.keyboard('{ArrowDown}')
+    expect(enlace('Artículos')).toHaveFocus()
+
+    await usuario.keyboard('{End}')
+    expect(enlace('Clientes')).toHaveFocus()
+
+    await usuario.keyboard('{Home}')
+    expect(enlace('Artículos')).toHaveFocus()
+    expect(boton()).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('un pointerdown afuera cierra; uno adentro no', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+    fireEvent.pointerDown(boton())
+    expect(boton()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Afuera' }))
+
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('cuando el foco sale del menú con Tab, se cierra', async () => {
+    const usuario = userEvent.setup()
+    renderMenu()
+
+    await usuario.click(boton())
+    await usuario.tab()
+    await usuario.tab()
+    await usuario.tab()
+    expect(enlace('Clientes')).toHaveFocus()
+    expect(boton()).toHaveAttribute('aria-expanded', 'true')
+
+    await usuario.tab()
+
+    expect(screen.getByRole('button', { name: 'Afuera' })).toHaveFocus()
+    expect(boton()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('el ítem de la ruta actual lleva aria-current="page" y los demás no', async () => {
+    const usuario = userEvent.setup()
+    renderMenu({ ruta: '/catalogos/marcas' })
+
+    await usuario.click(boton())
+
+    expect(enlace('Marcas')).toHaveAttribute('aria-current', 'page')
+    expect(enlace('Artículos')).not.toHaveAttribute('aria-current')
+    expect(enlace('Clientes')).not.toHaveAttribute('aria-current')
+  })
+
+  it('con activo, el botón se marca como la entrada activa de la barra', () => {
+    renderMenu({ activo: true })
+
+    expect(boton()).toHaveClass('active')
+  })
+})

--- a/src/Ways.Web/src/componentes/MenuDesplegable.tsx
+++ b/src/Ways.Web/src/componentes/MenuDesplegable.tsx
@@ -1,0 +1,144 @@
+import { Fragment, useEffect, useId, useRef } from 'react'
+import type { FocusEvent, KeyboardEvent } from 'react'
+import { Link, useLocation } from 'react-router'
+import { esRutaActiva } from './menu'
+import type { GrupoDeMenu } from './menu'
+
+type Props = {
+  grupo: GrupoDeMenu
+  abierto: boolean
+  activo: boolean
+  alAlternar: () => void
+  alCerrar: () => void
+}
+
+function enlacesDe(item: HTMLLIElement | null): HTMLAnchorElement[] {
+  return Array.from(item?.querySelectorAll<HTMLAnchorElement>('a.dropdown-item') ?? [])
+}
+
+function destinoDe(tecla: string, actual: number, cantidad: number): number | null {
+  switch (tecla) {
+    case 'ArrowDown':
+      return (actual + 1) % cantidad
+    case 'ArrowUp':
+      return (actual - 1 + cantidad) % cantidad
+    case 'Home':
+      return 0
+    case 'End':
+      return cantidad - 1
+    default:
+      return null
+  }
+}
+
+/**
+ * Patrón WAI-ARIA de navegación con disclosure: un botón que muestra u oculta una lista de links
+ * comunes, sin `role="menu"`. La `<ul>` se renderiza siempre y se oculta con `hidden`, que es lo
+ * que hace coincidir producción (Bootstrap) y jsdom sin depender de ninguna hoja de estilos.
+ */
+export function MenuDesplegable({ grupo, abierto, activo, alAlternar, alCerrar }: Props) {
+  const idMenu = useId()
+  const { pathname } = useLocation()
+  const itemRef = useRef<HTMLLIElement>(null)
+  const botonRef = useRef<HTMLButtonElement>(null)
+  const enfocarPrimeroAlAbrirRef = useRef(false)
+
+  useEffect(() => {
+    if (!abierto) return
+    function alPresionarAfuera(evento: PointerEvent) {
+      if (evento.target instanceof Node && !itemRef.current?.contains(evento.target)) alCerrar()
+    }
+    document.addEventListener('pointerdown', alPresionarAfuera)
+    return () => document.removeEventListener('pointerdown', alPresionarAfuera)
+  }, [abierto, alCerrar])
+
+  // Los ítems recién son enfocables cuando el commit que abre la lista les quitó `hidden`.
+  useEffect(() => {
+    if (abierto && enfocarPrimeroAlAbrirRef.current) {
+      enfocarPrimeroAlAbrirRef.current = false
+      enlacesDe(itemRef.current)[0]?.focus()
+    }
+  }, [abierto])
+
+  function alTeclear(evento: KeyboardEvent<HTMLLIElement>) {
+    if (evento.key === 'Escape') {
+      if (!abierto) return
+      evento.preventDefault()
+      alCerrar()
+      botonRef.current?.focus()
+      return
+    }
+    const items = enlacesDe(itemRef.current)
+    if (evento.target === botonRef.current) {
+      if (evento.key !== 'ArrowDown') return
+      evento.preventDefault()
+      if (abierto) {
+        items[0]?.focus()
+      } else {
+        enfocarPrimeroAlAbrirRef.current = true
+        alAlternar()
+      }
+      return
+    }
+    const actual = items.indexOf(evento.target as HTMLAnchorElement)
+    if (actual === -1) return
+    const destino = destinoDe(evento.key, actual, items.length)
+    if (destino === null) return
+    evento.preventDefault()
+    items[destino]?.focus()
+  }
+
+  function alPerderFoco(evento: FocusEvent<HTMLLIElement>) {
+    if (abierto && !evento.currentTarget.contains(evento.relatedTarget)) alCerrar()
+  }
+
+  return (
+    <li ref={itemRef} className="nav-item dropdown" onKeyDown={alTeclear} onBlur={alPerderFoco}>
+      <button
+        ref={botonRef}
+        type="button"
+        className={`nav-link dropdown-toggle${activo ? ' active' : ''}`}
+        aria-expanded={abierto}
+        aria-controls={idMenu}
+        onClick={alAlternar}
+      >
+        {grupo.etiqueta}
+      </button>
+      <ul
+        id={idMenu}
+        className={abierto ? 'dropdown-menu dropdown-menu-dark show' : 'dropdown-menu dropdown-menu-dark'}
+        hidden={!abierto}
+      >
+        {grupo.secciones.map((seccion, indice) => (
+          <Fragment key={indice}>
+            {indice > 0 && (
+              <li>
+                <hr className="dropdown-divider" />
+              </li>
+            )}
+            {seccion.titulo && (
+              <li>
+                <h6 className="dropdown-header">{seccion.titulo}</h6>
+              </li>
+            )}
+            {seccion.enlaces.map((enlace) => {
+              const enlaceActivo = esRutaActiva(pathname, enlace)
+              return (
+                <li key={enlace.a}>
+                  <Link
+                    className={`dropdown-item${enlaceActivo ? ' active' : ''}`}
+                    aria-current={enlaceActivo ? 'page' : undefined}
+                    to={enlace.a}
+                    onClick={alCerrar}
+                  >
+                    {enlace.etiqueta}
+                  </Link>
+                </li>
+              )
+            })}
+          </Fragment>
+        ))}
+      </ul>
+    </li>
+  )
+}

--- a/src/Ways.Web/src/componentes/menu.test.ts
+++ b/src/Ways.Web/src/componentes/menu.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest'
+import { ROL } from '../api/tipos'
+import type { UsuarioAutenticado } from '../api/tipos'
+import { construirMenu, esRutaActiva } from './menu'
+import type { EnlaceDeMenu, EntradaDeMenu } from './menu'
+
+function usuarioConRol(rolId: number): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'alguien',
+    mail: 'alguien@ways.test',
+    rolId,
+    rol: 'Rol',
+    ultimaConexion: null,
+    idTenant: rolId === ROL.Root ? null : 1,
+  }
+}
+
+const ROLES_OPERATIVOS: [string, number][] = [
+  ['Admin', ROL.Admin],
+  ['Supervisor', ROL.Supervisor],
+  ['Vendedor', ROL.Vendedor],
+]
+const TODOS_LOS_ROLES: [string, number][] = [['Root', ROL.Root], ...ROLES_OPERATIVOS]
+
+type Resumen = [string, string] | { grupo: string; secciones: { titulo?: string; enlaces: [string, string][] }[] }
+
+function par(enlace: EnlaceDeMenu): [string, string] {
+  return [enlace.etiqueta, enlace.a]
+}
+
+/** Proyección exacta de etiquetas, rutas, secciones y orden: cualquier alta, baja o reorden de
+ * una entrada rompe la comparación. */
+function resumir(entradas: EntradaDeMenu[]): Resumen[] {
+  return entradas.map((entrada) =>
+    entrada.tipo === 'enlace'
+      ? par(entrada)
+      : {
+          grupo: entrada.etiqueta,
+          secciones: entrada.secciones.map((seccion) => ({ titulo: seccion.titulo, enlaces: seccion.enlaces.map(par) })),
+        },
+  )
+}
+
+function etiquetas(entradas: EntradaDeMenu[]): string[] {
+  return entradas.flatMap((entrada) =>
+    entrada.tipo === 'enlace'
+      ? [entrada.etiqueta]
+      : [entrada.etiqueta, ...entrada.secciones.flatMap((seccion) => seccion.enlaces.map((enlace) => enlace.etiqueta))],
+  )
+}
+
+function rutasHoja(entradas: EntradaDeMenu[]): string[] {
+  return entradas.flatMap((entrada) =>
+    entrada.tipo === 'enlace' ? [entrada.a] : entrada.secciones.flatMap((seccion) => seccion.enlaces.map((enlace) => enlace.a)),
+  )
+}
+
+const VENDER: Resumen = ['Vender', '/pos']
+const CAJA: Resumen = ['Caja', '/caja']
+const VENTAS: Resumen = {
+  grupo: 'Ventas',
+  secciones: [
+    {
+      enlaces: [
+        ['Presupuestos', '/presupuestos'],
+        ['Remitos', '/remitos'],
+        ['Consulta de precios', '/consulta-precios'],
+      ],
+    },
+  ],
+}
+const COMPRAS: Resumen = {
+  grupo: 'Compras',
+  secciones: [
+    {
+      enlaces: [
+        ['Compras', '/compras'],
+        ['Órdenes de compra', '/ordenes-compra'],
+      ],
+    },
+  ],
+}
+const REPORTES: Resumen = {
+  grupo: 'Reportes',
+  secciones: [
+    {
+      enlaces: [
+        ['Tablero', '/tablero'],
+        ['Histórico de cajas', '/caja/historico'],
+        ['Tesorería', '/caja/tesoreria'],
+        ['Existencias', '/reportes/existencias'],
+        ['Vencimientos', '/reportes/stock/vencimientos'],
+        ['Reposición', '/reportes/stock/reposicion'],
+      ],
+    },
+  ],
+}
+const ADMINISTRACION_DE_ADMIN: Resumen = {
+  grupo: 'Administración',
+  secciones: [
+    {
+      titulo: 'Catálogo',
+      enlaces: [
+        ['Artículos', '/articulos'],
+        ['Categorías', '/catalogos/categorias'],
+        ['Áreas', '/catalogos/areas'],
+        ['Marcas', '/catalogos/marcas'],
+        ['Grupos', '/catalogos/grupos'],
+        ['Medios de pago', '/catalogos/medios-pago'],
+        ['Listas de precio', '/listas-precio'],
+        ['Ofertas', '/ofertas'],
+        ['Catálogos fiscales', '/catalogos-fiscales'],
+      ],
+    },
+    {
+      titulo: 'Terceros',
+      enlaces: [
+        ['Clientes', '/clientes'],
+        ['Proveedores', '/proveedores'],
+      ],
+    },
+    {
+      titulo: 'Stock',
+      enlaces: [
+        ['Transferencias', '/stock/transferencias'],
+        ['Conteo de inventario', '/stock/conteo'],
+      ],
+    },
+    {
+      titulo: 'Configuración',
+      enlaces: [
+        ['Parámetros', '/parametros'],
+        ['Usuarios', '/usuarios'],
+        ['Auditoría', '/auditoria'],
+      ],
+    },
+    {
+      titulo: 'Organización',
+      enlaces: [
+        ['Empresas', '/organizacion/empresas'],
+        ['Puntos de venta', '/organizacion/puntos-venta'],
+      ],
+    },
+  ],
+}
+const ADMINISTRACION_DE_ROOT: Resumen = {
+  grupo: 'Administración',
+  secciones: [
+    { titulo: 'Configuración', enlaces: [['Usuarios', '/usuarios']] },
+    {
+      titulo: 'Organización',
+      enlaces: [
+        ['Empresas', '/organizacion/empresas'],
+        ['Puntos de venta', '/organizacion/puntos-venta'],
+        ['Tenants', '/organizacion/tenants'],
+        ['Nuevo tenant', '/organizacion/nuevo-tenant'],
+      ],
+    },
+  ],
+}
+
+describe('construirMenu', () => {
+  it('Vendedor: Vender, Caja, Ventas y Compras, sin Reportes ni Administración', () => {
+    expect(resumir(construirMenu(usuarioConRol(ROL.Vendedor)))).toEqual([VENDER, CAJA, VENTAS, COMPRAS])
+  })
+
+  it('Supervisor: lo mismo que Vendedor más Reportes', () => {
+    expect(resumir(construirMenu(usuarioConRol(ROL.Supervisor)))).toEqual([VENDER, CAJA, VENTAS, COMPRAS, REPORTES])
+  })
+
+  it('Admin: todo, con Administración completa salvo Tenants y Nuevo tenant', () => {
+    expect(resumir(construirMenu(usuarioConRol(ROL.Admin)))).toEqual([
+      VENDER,
+      CAJA,
+      VENTAS,
+      COMPRAS,
+      REPORTES,
+      ADMINISTRACION_DE_ADMIN,
+    ])
+  })
+
+  it('Root: solo Administración, con Usuarios y toda la organización', () => {
+    expect(resumir(construirMenu(usuarioConRol(ROL.Root)))).toEqual([ADMINISTRACION_DE_ROOT])
+  })
+
+  it.each(TODOS_LOS_ROLES)('%s: ninguna entrada se llama "Inicio" (el logo lleva al inicio)', (_nombre, rolId) => {
+    expect(etiquetas(construirMenu(usuarioConRol(rolId)))).not.toContain('Inicio')
+  })
+
+  it.each(ROLES_OPERATIVOS)('%s: la única entrada principal es Vender → /pos', (_nombre, rolId) => {
+    const principales = construirMenu(usuarioConRol(rolId)).filter((entrada) => entrada.tipo === 'enlace' && entrada.principal)
+
+    expect(principales).toEqual([expect.objectContaining({ etiqueta: 'Vender', a: '/pos' })])
+  })
+
+  it('Root no tiene entrada principal: no opera el POS', () => {
+    const principales = construirMenu(usuarioConRol(ROL.Root)).filter((entrada) => entrada.tipo === 'enlace' && entrada.principal)
+
+    expect(principales).toEqual([])
+  })
+
+  it.each([
+    ['Vendedor', ROL.Vendedor],
+    ['Supervisor', ROL.Supervisor],
+  ])('%s: no tiene Administración', (_nombre, rolId) => {
+    expect(construirMenu(usuarioConRol(rolId)).some((entrada) => entrada.etiqueta === 'Administración')).toBe(false)
+  })
+
+  it('Caja declara exactamente las rutas que la dejan activa', () => {
+    const caja = construirMenu(usuarioConRol(ROL.Vendedor)).find((entrada) => entrada.etiqueta === 'Caja')
+
+    expect(caja).toEqual({
+      tipo: 'enlace',
+      etiqueta: 'Caja',
+      a: '/caja',
+      rutasActivas: ['/caja', '/caja/cierre', '/caja/turnos'],
+    })
+  })
+})
+
+describe('esRutaActiva', () => {
+  const menuDeAdmin = construirMenu(usuarioConRol(ROL.Admin))
+  const activas = (pathname: string) => menuDeAdmin.filter((entrada) => esRutaActiva(pathname, entrada)).map((entrada) => entrada.etiqueta)
+
+  // Cláusula bajo prueba: con `rutasActivas` declaradas, la ruta propia del enlace matchea
+  // exacta. Evidencia de mutación: reemplazarla por el prefijo de segmento hace fallar los dos
+  // casos de `/caja/historico` y `/caja/tesoreria` (`['Caja', 'Reportes']`) y las dos corridas
+  // de unicidad de Admin y Supervisor.
+  const casos: [string, string[]][] = [
+    ['/caja/historico', ['Reportes']],
+    ['/caja/tesoreria', ['Reportes']],
+    ['/caja', ['Caja']],
+    ['/caja/cierre', ['Caja']],
+    ['/caja/turnos/7/z', ['Caja']],
+    ['/pos', ['Vender']],
+    ['/catalogos/marcas', ['Administración']],
+    ['/articulos/5', ['Administración']],
+    ['/', []],
+    ['/cajas', []],
+  ]
+
+  it.each(casos)('%s activa %j', (pathname, esperado) => {
+    expect(activas(pathname)).toEqual(esperado)
+  })
+
+  it.each(TODOS_LOS_ROLES)('%s: cada ruta del menú activa exactamente una entrada de primer nivel', (_nombre, rolId) => {
+    const menu = construirMenu(usuarioConRol(rolId))
+    const rutas = rutasHoja(menu)
+
+    expect(rutas.length).toBeGreaterThan(0)
+    for (const ruta of rutas) {
+      const entradasActivas = menu.filter((entrada) => esRutaActiva(ruta, entrada)).map((entrada) => entrada.etiqueta)
+      expect(entradasActivas, ruta).toHaveLength(1)
+    }
+  })
+})

--- a/src/Ways.Web/src/componentes/menu.ts
+++ b/src/Ways.Web/src/componentes/menu.ts
@@ -1,0 +1,178 @@
+import { DESCRIPTORES_DE_CATALOGO } from '../api/catalogos'
+import type { UsuarioAutenticado } from '../api/tipos'
+import {
+  ROL,
+  puedeAprovisionarTenants,
+  puedeGestionarCatalogos,
+  puedeGestionarUsuarios,
+  puedeOperarPos,
+  puedeVerAuditoria,
+  puedeVerReportes,
+} from '../api/tipos'
+
+export type EnlaceDeMenu = {
+  tipo: 'enlace'
+  etiqueta: string
+  a: string
+  /** La acción principal de la barra: se pinta como botón, no como link. */
+  principal?: boolean
+  /** Sin declarar, el enlace reclama `a` y todo lo que cuelga de ella (ver `esRutaActiva`). */
+  rutasActivas?: string[]
+}
+export type SeccionDeMenu = { titulo?: string; enlaces: EnlaceDeMenu[] }
+export type GrupoDeMenu = { tipo: 'grupo'; etiqueta: string; secciones: SeccionDeMenu[] }
+export type EntradaDeMenu = EnlaceDeMenu | GrupoDeMenu
+
+type Permiso = (rolId: number) => boolean
+
+type EnlaceDelModelo = { permiso: Permiso; enlace: EnlaceDeMenu }
+type SeccionDelModelo = { titulo?: string; enlaces: EnlaceDelModelo[] }
+type GrupoDelModelo = { etiqueta: string; secciones: SeccionDelModelo[] }
+type EntradaDelModelo = EnlaceDelModelo | GrupoDelModelo
+
+function enlace(
+  permiso: Permiso,
+  etiqueta: string,
+  a: string,
+  extra: Omit<EnlaceDeMenu, 'tipo' | 'etiqueta' | 'a'> = {},
+): EnlaceDelModelo {
+  return { permiso, enlace: { tipo: 'enlace', etiqueta, a, ...extra } }
+}
+
+/** Mismo criterio que el gate de Empresas/Puntos de venta que hoy tiene `Layout`. */
+const rootOAdmin: Permiso = (rolId) => rolId === ROL.Root || rolId === ROL.Admin
+
+/** El menú completo, en el orden en que se muestra; cada enlace lleva su permiso y
+ * `construirMenu` deja solo lo que el rol puede ver. */
+const MODELO: EntradaDelModelo[] = [
+  enlace(puedeOperarPos, 'Vender', '/pos', { principal: true }),
+  enlace(puedeOperarPos, 'Caja', '/caja', { rutasActivas: ['/caja', '/caja/cierre', '/caja/turnos'] }),
+  {
+    etiqueta: 'Ventas',
+    secciones: [
+      {
+        enlaces: [
+          enlace(puedeOperarPos, 'Presupuestos', '/presupuestos'),
+          enlace(puedeOperarPos, 'Remitos', '/remitos'),
+          enlace(puedeOperarPos, 'Consulta de precios', '/consulta-precios'),
+        ],
+      },
+    ],
+  },
+  {
+    etiqueta: 'Compras',
+    secciones: [
+      {
+        enlaces: [
+          enlace(puedeOperarPos, 'Compras', '/compras'),
+          enlace(puedeOperarPos, 'Órdenes de compra', '/ordenes-compra'),
+        ],
+      },
+    ],
+  },
+  {
+    etiqueta: 'Reportes',
+    secciones: [
+      {
+        enlaces: [
+          enlace(puedeVerReportes, 'Tablero', '/tablero'),
+          enlace(puedeVerReportes, 'Histórico de cajas', '/caja/historico'),
+          enlace(puedeVerReportes, 'Tesorería', '/caja/tesoreria'),
+          enlace(puedeVerReportes, 'Existencias', '/reportes/existencias'),
+          enlace(puedeVerReportes, 'Vencimientos', '/reportes/stock/vencimientos'),
+          enlace(puedeVerReportes, 'Reposición', '/reportes/stock/reposicion'),
+        ],
+      },
+    ],
+  },
+  {
+    etiqueta: 'Administración',
+    secciones: [
+      {
+        titulo: 'Catálogo',
+        enlaces: [
+          enlace(puedeGestionarCatalogos, 'Artículos', '/articulos'),
+          enlace(puedeGestionarCatalogos, 'Categorías', '/catalogos/categorias'),
+          ...Object.values(DESCRIPTORES_DE_CATALOGO).map((descriptor) =>
+            enlace(puedeGestionarCatalogos, descriptor.titulo, `/catalogos/${descriptor.recurso}`),
+          ),
+          enlace(puedeGestionarCatalogos, 'Listas de precio', '/listas-precio'),
+          enlace(puedeGestionarCatalogos, 'Ofertas', '/ofertas'),
+          enlace(puedeGestionarCatalogos, 'Catálogos fiscales', '/catalogos-fiscales'),
+        ],
+      },
+      {
+        titulo: 'Terceros',
+        enlaces: [
+          enlace(puedeGestionarCatalogos, 'Clientes', '/clientes'),
+          enlace(puedeGestionarCatalogos, 'Proveedores', '/proveedores'),
+        ],
+      },
+      {
+        titulo: 'Stock',
+        enlaces: [
+          enlace(puedeGestionarCatalogos, 'Transferencias', '/stock/transferencias'),
+          enlace(puedeGestionarCatalogos, 'Conteo de inventario', '/stock/conteo'),
+        ],
+      },
+      {
+        titulo: 'Configuración',
+        enlaces: [
+          enlace(puedeGestionarCatalogos, 'Parámetros', '/parametros'),
+          enlace(puedeGestionarUsuarios, 'Usuarios', '/usuarios'),
+          enlace(puedeVerAuditoria, 'Auditoría', '/auditoria'),
+        ],
+      },
+      {
+        titulo: 'Organización',
+        enlaces: [
+          enlace(rootOAdmin, 'Empresas', '/organizacion/empresas'),
+          enlace(rootOAdmin, 'Puntos de venta', '/organizacion/puntos-venta'),
+          enlace(puedeAprovisionarTenants, 'Tenants', '/organizacion/tenants'),
+          enlace(puedeAprovisionarTenants, 'Nuevo tenant', '/organizacion/nuevo-tenant'),
+        ],
+      },
+    ],
+  },
+]
+
+/** Entradas visibles para el usuario, en orden; un grupo sin enlaces visibles no se devuelve y
+ * una sección vacía tampoco. */
+export function construirMenu(usuario: UsuarioAutenticado): EntradaDeMenu[] {
+  const visible = (candidato: EnlaceDelModelo) => candidato.permiso(usuario.rolId)
+  const entradas: EntradaDeMenu[] = []
+
+  for (const entrada of MODELO) {
+    if ('enlace' in entrada) {
+      if (visible(entrada)) entradas.push(entrada.enlace)
+      continue
+    }
+    const secciones = entrada.secciones
+      .map((seccion) => ({
+        titulo: seccion.titulo,
+        enlaces: seccion.enlaces.filter(visible).map((candidato) => candidato.enlace),
+      }))
+      .filter((seccion) => seccion.enlaces.length > 0)
+    if (secciones.length > 0) entradas.push({ tipo: 'grupo', etiqueta: entrada.etiqueta, secciones })
+  }
+
+  return entradas
+}
+
+/**
+ * Un enlace sin `rutasActivas` reclama su ruta y todo lo que cuelga de ella (`/articulos/5`).
+ * Con `rutasActivas` declaradas reclama solo su propia ruta exacta más los subárboles listados:
+ * así `/caja/historico` y `/caja/tesoreria` quedan para Reportes aunque cuelguen de `/caja`, y
+ * para cualquier ruta hay a lo sumo una entrada de primer nivel activa.
+ */
+export function esRutaActiva(pathname: string, entrada: EntradaDeMenu): boolean {
+  if (entrada.tipo === 'grupo') {
+    return entrada.secciones.some((seccion) => seccion.enlaces.some((enlace) => esRutaActiva(pathname, enlace)))
+  }
+  if (!entrada.rutasActivas) return estaBajo(pathname, entrada.a)
+  return entrada.rutasActivas.some((ruta) => (ruta === entrada.a ? pathname === ruta : estaBajo(pathname, ruta)))
+}
+
+function estaBajo(pathname: string, ruta: string) {
+  return pathname === ruta || pathname.startsWith(`${ruta}/`)
+}


### PR DESCRIPTION
Closes #177

## Resumen

Slice 1 de 5 de la reorganizacion de la barra de navegacion y el punto de venta de sesion. Inerte: nada lo importa todavia; la barra actual sigue intacta hasta el slice 2.

- `componentes/menu.ts`: modelo puro del menu, ya filtrado por rol. `construirMenu(usuario)` arma Vender (entrada principal, `/pos`), Caja, Ventas, Compras, Reportes y Administracion con secciones (Catalogo, Terceros, Stock, Configuracion, Organizacion); los grupos y secciones vacios desaparecen. `esRutaActiva(pathname, entrada)` decide la entrada activa por prefijo de segmento; Caja declara `rutasActivas` para que `/caja/historico` y `/caja/tesoreria` activen solo Reportes y `/caja/cierre` o `/caja/turnos/:id/z` activen solo Caja.
- `componentes/MenuDesplegable.tsx`: patron WAI-ARIA de navegacion con disclosure, sin `role=menu`: `<button aria-expanded aria-controls>` y una `<ul>` siempre renderizada con `hidden` (los tests no cargan el CSS de Bootstrap, y el atributo es lo unico que hace coincidir jsdom con produccion). Escape cierra y devuelve el foco, blur y pointerdown afuera cierran, flechas/Home/End recorren los items. Bootstrap JS no esta cargado en la app, asi que todo es React.
- Tests: menus literales por rol (Root, Admin, Supervisor, Vendedor) que fallan si una entrada se agrega, quita o reordena; invariante de una sola entrada activa por cada ruta de cada rol; comportamiento del desplegable con queries por rol y nombre accesible.

Paridad: ninguna ruta del nav actual se pierde ni cambia de gate (cotejado contra `Layout.tsx` y `App.tsx`). La unica entrada nueva es "Ordenes de compra", ruta ya existente que no tenia acceso desde el nav.

## Judgment-day: APROBADO en ronda limpia

Dos jueces ciegos en paralelo sobre ff60389. Juez B: cero hallazgos. Juez A: un WARNING inferencial (pointerdown afuera y focusout pueden llamar `alCerrar` dos veces en la misma interaccion; inocuo porque el consumidor lo implementa como `setGrupoAbierto(null)`, idempotente). Sin CRITICAL, sin rondas de correccion.

Evidencia de mutacion registrada en `menu.test.ts`: reemplazar el match exacto de `rutasActivas` por prefijo plano hace fallar cuatro tests.

## Suites

```
npx tsc -b                       limpio
npx oxlint                       exit 0 (5 warnings preexistentes, ninguno nuevo)
npx vitest run src/componentes   8 archivos / 75 tests (29 + 11 nuevos)
```

## Tamano

788 lineas, todas nuevas: 322 de produccion y 466 de tests. Supera el presupuesto de 400 por los tests; los cuatro archivos son una sola unidad de trabajo (modelo + componente + sus tests) y separarlos dejaria un PR con codigo sin tests. Etiquetado `size:exception`; si preferis partirlo en modelo y componente, se puede.
