### PR TITLE
feat(web): infraestructura del punto de venta de sesion (slice 3 de nav y punto de venta de sesion)

### DIFF
--- a/src/Ways.Web/src/auth/AuthContext.test.tsx
+++ b/src/Ways.Web/src/auth/AuthContext.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider } from './AuthContext'
+import { useAuth } from './useAuth'
+import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type { UsuarioAutenticado } from '../api/tipos'
+import { CLAVE_PUNTO_VENTA_DE_SESION } from '../puntoVenta/almacenDePuntoVenta'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown])),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  alPerderLaSesion: () => () => undefined,
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+    get esNoAutenticado() {
+      return this.estado === 401
+    }
+  },
+}))
+
+const ana: UsuarioAutenticado = {
+  id: 9,
+  usuario: 'ana',
+  mail: 'ana@ways.test',
+  rolId: ROL.Vendedor,
+  rol: 'Vendedor',
+  ultimaConexion: null,
+  idTenant: 2,
+}
+
+function Sonda() {
+  const { usuario, cargando, iniciarSesion, cerrarSesion } = useAuth()
+
+  if (cargando) return <p>cargando</p>
+
+  return (
+    <div>
+      <p>{`Usuario: ${usuario?.usuario ?? 'nadie'}`}</p>
+      <button type="button" onClick={() => void iniciarSesion(ana.mail, 'secreto').catch(() => undefined)}>
+        Ingresar
+      </button>
+      <button type="button" onClick={() => void cerrarSesion().catch(() => undefined)}>
+        Salir
+      </button>
+    </div>
+  )
+}
+
+function montar() {
+  return render(
+    <AuthProvider>
+      <Sonda />
+    </AuthProvider>,
+  )
+}
+
+function guardarPuntoVentaAjeno() {
+  localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 9, idPuntoVenta: 100 }))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+})
+
+describe('AuthProvider — ciclo de vida del punto de venta de sesión', () => {
+  it('iniciar sesión olvida el punto de venta guardado y publica al usuario', async () => {
+    apiGetMock.mockRejectedValue(new ErrorApi(401, 'no_autenticado', 'Tu sesión expiró.'))
+    apiPostMock.mockResolvedValue(ana)
+    guardarPuntoVentaAjeno()
+    montar()
+    await screen.findByText('Usuario: nadie')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Ingresar' }))
+
+    expect(await screen.findByText('Usuario: ana')).toBeInTheDocument()
+    expect(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)).toBeNull()
+  })
+
+  it('un inicio de sesión rechazado no toca lo guardado', async () => {
+    apiGetMock.mockRejectedValue(new ErrorApi(401, 'no_autenticado', 'Tu sesión expiró.'))
+    apiPostMock.mockRejectedValue(new ErrorApi(401, 'credenciales_invalidas', 'Credenciales inválidas.'))
+    guardarPuntoVentaAjeno()
+    montar()
+    await screen.findByText('Usuario: nadie')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Ingresar' }))
+
+    expect(screen.getByText('Usuario: nadie')).toBeInTheDocument()
+    expect(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)).not.toBeNull()
+  })
+
+  it('cerrar sesión olvida el punto de venta guardado', async () => {
+    apiGetMock.mockResolvedValue(ana)
+    apiPostMock.mockResolvedValue(undefined)
+    montar()
+    await screen.findByText('Usuario: ana')
+    guardarPuntoVentaAjeno()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Salir' }))
+
+    expect(await screen.findByText('Usuario: nadie')).toBeInTheDocument()
+    expect(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)).toBeNull()
+  })
+
+  it('cerrar sesión lo olvida aunque el logout falle', async () => {
+    apiGetMock.mockResolvedValue(ana)
+    apiPostMock.mockRejectedValue(new ErrorApi(500, 'error', 'Falló el logout'))
+    montar()
+    await screen.findByText('Usuario: ana')
+    guardarPuntoVentaAjeno()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Salir' }))
+
+    expect(await screen.findByText('Usuario: nadie')).toBeInTheDocument()
+    expect(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)).toBeNull()
+  })
+})

--- a/src/Ways.Web/src/auth/AuthContext.tsx
+++ b/src/Ways.Web/src/auth/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { api, alPerderLaSesion, ErrorApi } from '../api/cliente'
 import type { UsuarioAutenticado } from '../api/tipos'
+import { olvidarPuntoVentaDeSesion } from '../puntoVenta/almacenDePuntoVenta'
 
 type EstadoAuth = {
   usuario: UsuarioAutenticado | null
@@ -40,6 +41,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       mail,
       password,
     })
+    // Cada inicio de sesión vuelve a elegir el punto de venta: se olvida antes de publicar el
+    // usuario para que nada alcance a leer la elección de la sesión anterior.
+    olvidarPuntoVentaDeSesion()
     setUsuario(autenticado)
   }, [])
 
@@ -50,6 +54,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Si ya estaba vencida no importa: igual limpiamos del lado del cliente.
       if (!(error instanceof ErrorApi && error.esNoAutenticado)) throw error
     } finally {
+      olvidarPuntoVentaDeSesion()
       setUsuario(null)
     }
   }, [])

--- a/src/Ways.Web/src/puntoVenta/ElegirPuntoDeVenta.test.tsx
+++ b/src/Ways.Web/src/puntoVenta/ElegirPuntoDeVenta.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ElegirPuntoDeVenta } from './ElegirPuntoDeVenta'
+import type { PuntoVentaListado } from '../api/tipos'
+
+function pvFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 100,
+    idTenant: 2,
+    idEmpresa: 20,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    nombreTenant: 'Comercio Sur',
+    razonSocialEmpresa: 'Sur SRL',
+    ...sobrescribir,
+  }
+}
+
+const centro = pvFixture({ domicilio: 'Av. Principal 123' })
+const norte = pvFixture({ id: 101, nombre: 'Local Norte' })
+
+describe('ElegirPuntoDeVenta', () => {
+  it('lista un ítem por punto de venta, cada uno con un botón alcanzable por nombre', () => {
+    render(<ElegirPuntoDeVenta puntosVenta={[centro, norte]} alElegir={vi.fn()} />)
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Elegí el punto de venta' })).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: /^Local Centro/ })).toHaveTextContent('Av. Principal 123')
+    expect(screen.getByRole('button', { name: 'Local Norte' })).toBeInTheDocument()
+  })
+
+  it('al hacer clic informa el id del punto de venta elegido', async () => {
+    const alElegir = vi.fn()
+    render(<ElegirPuntoDeVenta puntosVenta={[centro, norte]} alElegir={alElegir} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+
+    expect(alElegir).toHaveBeenCalledTimes(1)
+    expect(alElegir).toHaveBeenCalledWith(101)
+  })
+
+  it('marca el actual con aria-current y el sufijo "(actual)"', () => {
+    render(<ElegirPuntoDeVenta puntosVenta={[centro, norte]} actual={101} alElegir={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Local Norte (actual)' })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('button', { name: /^Local Centro/ })).not.toHaveAttribute('aria-current')
+  })
+
+  it('sin actual ningún botón lleva aria-current', () => {
+    render(<ElegirPuntoDeVenta puntosVenta={[centro, norte]} alElegir={vi.fn()} />)
+
+    for (const boton of screen.getAllByRole('button')) {
+      expect(boton).not.toHaveAttribute('aria-current')
+    }
+  })
+})

--- a/src/Ways.Web/src/puntoVenta/ElegirPuntoDeVenta.tsx
+++ b/src/Ways.Web/src/puntoVenta/ElegirPuntoDeVenta.tsx
@@ -1,0 +1,42 @@
+import type { PuntoVentaListado } from '../api/tipos'
+
+type Props = {
+  puntosVenta: PuntoVentaListado[]
+  /** Id del punto de venta activo, si ya hay uno: se marca y se muestra como "(actual)". */
+  actual?: number | null
+  alElegir: (id: number) => void
+}
+
+export function ElegirPuntoDeVenta({ puntosVenta, actual = null, alElegir }: Props) {
+  return (
+    <div className="d-flex align-items-center justify-content-center min-vh-100 p-3">
+      <div className="card rounded-0 w-100" style={{ maxWidth: 480 }}>
+        <div className="card-body">
+          <h1 className="h3 text-center mb-4">Elegí el punto de venta</h1>
+
+          <ul className="list-unstyled mb-0">
+            {puntosVenta.map((puntoVenta) => {
+              const esActual = puntoVenta.id === actual
+
+              return (
+                <li key={puntoVenta.id} className="mb-2">
+                  <button
+                    type="button"
+                    className="btn btn-outline-dark btn-lg w-100 rounded-0 text-start"
+                    aria-current={esActual ? 'true' : undefined}
+                    onClick={() => alElegir(puntoVenta.id)}
+                  >
+                    {esActual ? `${puntoVenta.nombre} (actual)` : puntoVenta.nombre}
+                    {puntoVenta.domicilio && (
+                      <small className="d-block text-muted">{puntoVenta.domicilio}</small>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/puntoVenta/PuertaDePuntoVenta.test.tsx
+++ b/src/Ways.Web/src/puntoVenta/PuertaDePuntoVenta.test.tsx
@@ -1,0 +1,543 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PuertaDePuntoVenta } from './PuertaDePuntoVenta'
+import { usePuntoVenta } from './usePuntoVenta'
+import { CLAVE_PUNTO_VENTA_DE_SESION } from './almacenDePuntoVenta'
+import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'ana',
+    mail: 'ana@ways.test',
+    rolId: ROL.Vendedor,
+    rol: 'Vendedor',
+    ultimaConexion: null,
+    idTenant: 2,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+const cerrarSesionMock = vi.fn()
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({
+    usuario: usuarioActual,
+    cargando: false,
+    iniciarSesion: vi.fn(),
+    cerrarSesion: cerrarSesionMock,
+  }),
+}))
+
+function pvFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 100,
+    idTenant: 2,
+    idEmpresa: 20,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    nombreTenant: 'Comercio Sur',
+    razonSocialEmpresa: 'Sur SRL',
+    ...sobrescribir,
+  }
+}
+
+const centro = pvFixture()
+const norte = pvFixture({ id: 101, nombre: 'Local Norte' })
+const sur = pvFixture({ id: 102, nombre: 'Local Sur' })
+
+type Respuesta = () => Promise<PuntoVentaListado[]>
+
+/** Respuestas de `GET /puntos-venta` en orden de llegada; una lectura sin respuesta encolada falla. */
+let respuestas: Respuesta[] = []
+
+function encolar(...nuevas: Respuesta[]) {
+  respuestas.push(...nuevas)
+}
+
+function listado(items: PuntoVentaListado[]): Respuesta {
+  return () => Promise.resolve(items)
+}
+
+function fallo(error: Error): Respuesta {
+  return () => Promise.reject(error)
+}
+
+function diferido<T>() {
+  let resolver!: (valor: T) => void
+  let rechazar!: (motivo: unknown) => void
+  const promesa = new Promise<T>((res, rej) => {
+    resolver = res
+    rechazar = rej
+  })
+
+  return { promesa, resolver, rechazar }
+}
+
+function guardado(): unknown {
+  const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)
+
+  return crudo ? JSON.parse(crudo) : null
+}
+
+/** Consumidor mínimo: expone el contexto como texto y como botones para accionarlo. */
+function Sonda() {
+  const { puntoVenta, puntosVenta, elegir, recargar } = usePuntoVenta()
+  const [resultado, setResultado] = useState('')
+
+  return (
+    <div>
+      <p>{`Punto de venta: ${puntoVenta?.nombre ?? 'ninguno'}`}</p>
+      <p>{`Cantidad: ${puntosVenta.length}`}</p>
+      {puntosVenta.map((p) => (
+        <button key={p.id} type="button" onClick={() => elegir(p.id)}>
+          {`Elegir ${p.nombre}`}
+        </button>
+      ))}
+      <button type="button" onClick={() => elegir(999)}>
+        Elegir inexistente
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          recargar().then(
+            () => setResultado('recarga ok'),
+            () => setResultado('recarga falló'),
+          )
+        }}
+      >
+        Recargar
+      </button>
+      <output>{resultado}</output>
+    </div>
+  )
+}
+
+function arbol() {
+  return (
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <PuertaDePuntoVenta>
+              <Sonda />
+            </PuertaDePuntoVenta>
+          }
+        />
+        <Route path="/login" element={<div>Login (redirigido)</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function montar() {
+  return render(arbol())
+}
+
+const TEXTO_ELEGIR = 'Elegí el punto de venta'
+
+beforeEach(() => {
+  localStorage.clear()
+  respuestas = []
+  usuarioActual = usuarioFixture()
+  cerrarSesionMock.mockReset()
+  cerrarSesionMock.mockResolvedValue(undefined)
+  apiGetMock.mockReset()
+  apiGetMock.mockImplementation((ruta: string) => {
+    if (ruta !== '/puntos-venta') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+
+    const siguiente = respuestas.shift()
+
+    return siguiente ? siguiente() : Promise.reject(new Error('listado sin respuesta encolada'))
+  })
+})
+
+describe('PuertaDePuntoVenta — root', () => {
+  it('no pide el listado, deja pasar con el contexto vacío y recargar resuelve sin pedir nada', async () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Root, rol: 'Root', idTenant: null })
+    montar()
+
+    expect(screen.getByText('Punto de venta: ninguno')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 0')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByText('recarga ok')).toBeInTheDocument()
+    expect(apiGetMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('PuertaDePuntoVenta — carga inicial', () => {
+  it('muestra el cargando mientras el listado está en vuelo, sin renderizar a los hijos', () => {
+    encolar(() => new Promise(() => undefined))
+    montar()
+
+    expect(screen.getByText('Cargando puntos de venta…')).toBeInTheDocument()
+    expect(screen.queryByText(/Punto de venta:/)).not.toBeInTheDocument()
+    expect(apiGetMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('sin puntos de venta deja pasar con la selección vacía', async () => {
+    encolar(listado([]))
+    montar()
+
+    expect(await screen.findByText('Punto de venta: ninguno')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 0')).toBeInTheDocument()
+    expect(guardado()).toBeNull()
+  })
+
+  it('con uno solo lo elige sin preguntar y lo guarda', async () => {
+    encolar(listado([centro]))
+    montar()
+
+    expect(await screen.findByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: TEXTO_ELEGIR })).not.toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 100 }))
+  })
+
+  it('con varios y un guardado vigente lo elige sin preguntar', async () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 9, idPuntoVenta: 101 }))
+    encolar(listado([centro, norte]))
+    montar()
+
+    expect(await screen.findByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: TEXTO_ELEGIR })).not.toBeInTheDocument()
+  })
+
+  it('con varios y nada guardado pregunta a pantalla completa, sin renderizar a los hijos', async () => {
+    encolar(listado([centro, norte]))
+    montar()
+
+    expect(await screen.findByRole('heading', { level: 1, name: TEXTO_ELEGIR })).toBeInTheDocument()
+    expect(screen.queryByText(/Punto de venta:/)).not.toBeInTheDocument()
+  })
+
+  it('con varios y un guardado de otro usuario pregunta igual', async () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 77, idPuntoVenta: 101 }))
+    encolar(listado([centro, norte]))
+    montar()
+
+    expect(await screen.findByRole('heading', { name: TEXTO_ELEGIR })).toBeInTheDocument()
+  })
+
+  it('con varios y un guardado que ya no existe pregunta, y al elegir deja pasar y guarda', async () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 9, idPuntoVenta: 555 }))
+    encolar(listado([centro, norte]))
+    montar()
+
+    await screen.findByRole('heading', { name: TEXTO_ELEGIR })
+    await waitFor(() => expect(guardado()).toBeNull())
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+
+    expect(await screen.findByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 2')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: TEXTO_ELEGIR })).not.toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 101 }))
+  })
+
+  it('una respuesta que llega después de desmontar se ignora', async () => {
+    const lectura = diferido<PuntoVentaListado[]>()
+    encolar(() => lectura.promesa)
+    const { unmount } = montar()
+
+    unmount()
+    await act(async () => {
+      lectura.resolver([centro])
+    })
+
+    expect(guardado()).toBeNull()
+    expect(screen.queryByText(/Punto de venta:/)).not.toBeInTheDocument()
+  })
+
+  it('al cambiar de usuario descarta la lectura de la cuenta anterior y pide la propia', async () => {
+    const lecturaDeAna = diferido<PuntoVentaListado[]>()
+    encolar(() => lecturaDeAna.promesa, listado([norte]))
+    const { rerender } = montar()
+
+    usuarioActual = usuarioFixture({ id: 10, usuario: 'beto', mail: 'beto@ways.test' })
+    rerender(arbol())
+
+    expect(await screen.findByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    expect(apiGetMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      lecturaDeAna.resolver([centro])
+    })
+
+    expect(screen.getByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    expect(guardado()).toEqual({ idUsuario: 10, idPuntoVenta: 101 })
+  })
+})
+
+describe('PuertaDePuntoVenta — error de carga', () => {
+  it('muestra el mensaje de la API en un alert con Reintentar y Salir habilitados', async () => {
+    encolar(fallo(new ErrorApi(500, 'error', 'Falló la base')))
+    montar()
+
+    const alerta = await screen.findByRole('alert')
+
+    expect(alerta).toHaveTextContent('Falló la base')
+    expect(within(alerta).getByRole('button', { name: 'Reintentar' })).toBeEnabled()
+    expect(within(alerta).getByRole('button', { name: 'Salir' })).toBeEnabled()
+    expect(screen.queryByText(/Punto de venta:/)).not.toBeInTheDocument()
+  })
+
+  it('usa el mensaje genérico ante un error que no es de la API', async () => {
+    encolar(fallo(new Error('boom')))
+    montar()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No se pudieron cargar los puntos de venta.')
+  })
+
+  it('Reintentar vuelve a pedir el listado, deshabilita los dos botones en vuelo y deja pasar al resolver', async () => {
+    const reintento = diferido<PuntoVentaListado[]>()
+    encolar(fallo(new ErrorApi(500, 'error', 'Falló')), () => reintento.promesa)
+    montar()
+    await screen.findByRole('alert')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reintentar' }))
+
+    expect(apiGetMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Salir' })).toBeDisabled()
+
+    await act(async () => {
+      reintento.resolver([centro])
+    })
+
+    expect(await screen.findByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('un segundo clic en Reintentar en el mismo tick no dispara otra lectura', async () => {
+    const reintento = diferido<PuntoVentaListado[]>()
+    encolar(fallo(new ErrorApi(500, 'error', 'Falló')), () => reintento.promesa)
+    montar()
+    const boton = await screen.findByRole('button', { name: 'Reintentar' })
+
+    await act(async () => {
+      boton.click()
+      boton.click()
+    })
+
+    expect(apiGetMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      reintento.resolver([centro])
+    })
+
+    expect(await screen.findByText('Punto de venta: Local Centro')).toBeInTheDocument()
+  })
+
+  it('un reintento fallido vuelve a mostrar el error nuevo con los botones habilitados', async () => {
+    encolar(fallo(new ErrorApi(500, 'error', 'Primero')), fallo(new ErrorApi(503, 'error', 'Segundo')))
+    montar()
+    await screen.findByRole('alert')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reintentar' }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Segundo'))
+    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Salir' })).toBeEnabled()
+  })
+
+  it('Salir cierra la sesión con los botones deshabilitados en vuelo y navega a /login', async () => {
+    const salida = diferido<void>()
+    cerrarSesionMock.mockReturnValue(salida.promesa)
+    encolar(fallo(new ErrorApi(500, 'error', 'Falló')))
+    montar()
+    await screen.findByRole('alert')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Salir' }))
+
+    expect(cerrarSesionMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Salir' })).toBeDisabled()
+
+    await act(async () => {
+      salida.resolver()
+    })
+
+    expect(await screen.findByText('Login (redirigido)')).toBeInTheDocument()
+  })
+})
+
+describe('PuertaDePuntoVenta — elegir y recargar', () => {
+  /** Dos puntos de venta con el Centro guardado y ya activo. */
+  async function montarConDos() {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 9, idPuntoVenta: 100 }))
+    encolar(listado([centro, norte]))
+    const resultado = montar()
+    await screen.findByText('Punto de venta: Local Centro')
+
+    return resultado
+  }
+
+  it('elegir cambia el activo y lo guarda', async () => {
+    await montarConDos()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir Local Norte' }))
+
+    expect(screen.getByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 101 }))
+  })
+
+  it('elegir con un id que no está en la lista se ignora', async () => {
+    await montarConDos()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir inexistente' }))
+
+    expect(screen.getByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 100 })
+  })
+
+  it('recargar reemplaza la lista y refresca la fila del activo', async () => {
+    await montarConDos()
+    encolar(listado([{ ...centro, nombre: 'Local Centro Renombrado' }, norte, sur]))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByText('recarga ok')).toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Local Centro Renombrado')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 3')).toBeInTheDocument()
+    expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 100 })
+  })
+
+  it('si el activo desapareció y quedan varios, vacía la selección, olvida el guardado y vuelve a preguntar', async () => {
+    await montarConDos()
+    encolar(listado([norte, sur]))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByRole('heading', { name: TEXTO_ELEGIR })).toBeInTheDocument()
+    expect(screen.queryByText(/Punto de venta:/)).not.toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toBeNull())
+  })
+
+  it('si el activo desapareció y queda uno solo, lo elige y lo guarda', async () => {
+    await montarConDos()
+    encolar(listado([norte]))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByText('Punto de venta: Local Norte')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 1')).toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 101 }))
+  })
+
+  it('si no queda ninguno deja pasar con la selección vacía y olvida el guardado', async () => {
+    await montarConDos()
+    encolar(listado([]))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByText('Punto de venta: ninguno')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 0')).toBeInTheDocument()
+    await waitFor(() => expect(guardado()).toBeNull())
+  })
+
+  it('ante un fallo conserva el estado anterior, no toca la pantalla de error y rechaza al llamador', async () => {
+    await montarConDos()
+    encolar(fallo(new ErrorApi(500, 'error', 'Falló')))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    expect(await screen.findByText('recarga falló')).toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(screen.getByText('Cantidad: 2')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 100 })
+  })
+
+  it('entre dos recargas en vuelo gana la última que arrancó, y la superada ni aplica ni rechaza', async () => {
+    await montarConDos()
+    const primera = diferido<PuntoVentaListado[]>()
+    const segunda = diferido<PuntoVentaListado[]>()
+    encolar(() => primera.promesa, () => segunda.promesa)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+    expect(apiGetMock).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      segunda.resolver([centro, norte, sur])
+    })
+
+    expect(screen.getByText('Cantidad: 3')).toBeInTheDocument()
+    expect(screen.getByText('recarga ok')).toBeInTheDocument()
+
+    // La primera llega tarde y con una lista que, de aplicarse, elegiría sola al único restante.
+    await act(async () => {
+      primera.rechazar(new ErrorApi(500, 'error', 'Tarde'))
+    })
+
+    expect(screen.getByText('Cantidad: 3')).toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(screen.getByText('recarga ok')).toBeInTheDocument()
+    expect(screen.queryByText('recarga falló')).not.toBeInTheDocument()
+  })
+
+  it('una recarga superada que resuelve tarde tampoco pisa la lista vigente', async () => {
+    await montarConDos()
+    const primera = diferido<PuntoVentaListado[]>()
+    const segunda = diferido<PuntoVentaListado[]>()
+    encolar(() => primera.promesa, () => segunda.promesa)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Recargar' }))
+
+    await act(async () => {
+      segunda.resolver([centro, norte, sur])
+    })
+    await act(async () => {
+      primera.resolver([norte])
+    })
+
+    expect(screen.getByText('Cantidad: 3')).toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Local Centro')).toBeInTheDocument()
+    expect(guardado()).toEqual({ idUsuario: 9, idPuntoVenta: 100 })
+  })
+})
+
+describe('usePuntoVenta', () => {
+  it('fuera del proveedor lanza', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() => render(<Sonda />)).toThrow('usePuntoVenta tiene que usarse dentro de una PuertaDePuntoVenta.')
+
+    errorSpy.mockRestore()
+  })
+})

--- a/src/Ways.Web/src/puntoVenta/PuertaDePuntoVenta.tsx
+++ b/src/Ways.Web/src/puntoVenta/PuertaDePuntoVenta.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useNavigate } from 'react-router'
+import { ErrorApi } from '../api/cliente'
+import { clienteDeOrganizacion } from '../api/organizacion'
+import { puedeOperarPos } from '../api/tipos'
+import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import { useAuth } from '../auth/useAuth'
+import { Cargando } from '../componentes/Cargando'
+import {
+  guardarPuntoVentaDeSesion,
+  leerPuntoVentaDeSesion,
+  olvidarPuntoVentaDeSesion,
+} from './almacenDePuntoVenta'
+import { ElegirPuntoDeVenta } from './ElegirPuntoDeVenta'
+import { PuntoVentaContext } from './PuntoVentaContext'
+import type { EstadoDePuntoVenta } from './PuntoVentaContext'
+
+type Estado =
+  | { fase: 'cargando' }
+  | { fase: 'error'; mensaje: string }
+  | { fase: 'listo'; puntosVenta: PuntoVentaListado[]; puntoVenta: PuntoVentaListado | null }
+
+const MENSAJE_GENERICO = 'No se pudieron cargar los puntos de venta.'
+
+/** Root no opera ningún punto de venta: el contexto existe igual para que los consumidores no
+ * tengan que preguntar por el rol, pero está vacío y `recargar` no pide nada. */
+const SIN_PUNTOS_VENTA: EstadoDePuntoVenta = {
+  puntosVenta: [],
+  puntoVenta: null,
+  elegir: () => undefined,
+  recargar: () => Promise.resolve(),
+}
+
+/**
+ * Selección a partir de una lista recién recibida: con un solo punto de venta se elige solo;
+ * con varios, el preferido (el guardado o el que estaba activo) solo si sigue en la lista.
+ */
+function listoCon(puntosVenta: PuntoVentaListado[], idPreferido: number | null): Estado {
+  const puntoVenta =
+    puntosVenta.length === 1 ? puntosVenta[0] : (puntosVenta.find((p) => p.id === idPreferido) ?? null)
+
+  return { fase: 'listo', puntosVenta, puntoVenta }
+}
+
+function mensajeDe(error: unknown): string {
+  return error instanceof ErrorApi ? error.message : MENSAJE_GENERICO
+}
+
+type Props = { children: ReactNode }
+
+/**
+ * Resuelve el punto de venta de la sesión antes de dejar entrar a la aplicación: con uno solo lo
+ * elige, con varios ofrece la pantalla de elección hasta que haya uno (o recupera el guardado), y
+ * sin ninguno deja pasar con la selección vacía. Se monta dentro de `RutaProtegida`.
+ */
+export function PuertaDePuntoVenta({ children }: Props) {
+  const { usuario } = useAuth()
+
+  if (!usuario) {
+    throw new Error('PuertaDePuntoVenta tiene que montarse dentro de una RutaProtegida.')
+  }
+
+  if (!puedeOperarPos(usuario.rolId)) {
+    return <PuntoVentaContext.Provider value={SIN_PUNTOS_VENTA}>{children}</PuntoVentaContext.Provider>
+  }
+
+  // La clave por usuario remonta el proveedor al cambiar la cuenta: el estado y las lecturas en
+  // vuelo de la anterior se descartan por construcción en vez de reconciliarse a mano.
+  return (
+    <ProveedorDePuntoVenta key={usuario.id} usuario={usuario}>
+      {children}
+    </ProveedorDePuntoVenta>
+  )
+}
+
+function ProveedorDePuntoVenta({ usuario, children }: Props & { usuario: UsuarioAutenticado }) {
+  const { cerrarSesion } = useAuth()
+  const navegar = useNavigate()
+  const idUsuario = usuario.id
+
+  const [estado, setEstado] = useState<Estado>({ fase: 'cargando' })
+  const [ocupado, setOcupado] = useState(false)
+
+  /**
+   * Generación compartida por la carga inicial, "Reintentar" y `recargar`: cada lectura acuña la
+   * suya y solo la última que arrancó aplica su resultado. Se invalida al desmontar, que es
+   * también lo que pasa al cambiar de usuario porque el proveedor va con `key`.
+   */
+  const generacionRef = useRef(0)
+  /** Guarda de reentrancia de la pantalla de error, compartida por "Reintentar" y "Salir": un
+   * segundo clic en el mismo tick no dispara nada, aunque el `disabled` todavía no se haya pintado. */
+  const ocupadoRef = useRef(false)
+
+  /** Acuña la generación siguiente; toda lectura en vuelo con una anterior queda superada. */
+  const avanzarGeneracion = useCallback(() => ++generacionRef.current, [])
+
+  const cargar = useCallback(
+    async (generacion: number) => {
+      let siguiente: Estado
+      try {
+        const puntosVenta = await clienteDeOrganizacion.listarPuntosVenta()
+        siguiente = listoCon(puntosVenta, leerPuntoVentaDeSesion(idUsuario))
+      } catch (error) {
+        siguiente = { fase: 'error', mensaje: mensajeDe(error) }
+      }
+
+      if (generacionRef.current === generacion) setEstado(siguiente)
+    },
+    [idUsuario],
+  )
+
+  useEffect(() => {
+    void cargar(avanzarGeneracion())
+
+    return () => {
+      avanzarGeneracion()
+    }
+  }, [cargar, avanzarGeneracion])
+
+  // El almacén es una proyección de la selección vigente: cada estado listo la escribe (o la borra
+  // cuando no hay ninguna), así el refresco de página la recupera y un id que dejó de existir no
+  // sobrevive.
+  useEffect(() => {
+    if (estado.fase !== 'listo') return
+
+    if (estado.puntoVenta) guardarPuntoVentaDeSesion(idUsuario, estado.puntoVenta.id)
+    else olvidarPuntoVentaDeSesion()
+  }, [estado, idUsuario])
+
+  const elegir = useCallback((id: number) => {
+    setEstado((previo) => {
+      if (previo.fase !== 'listo') return previo
+
+      const elegido = previo.puntosVenta.find((p) => p.id === id)
+
+      return elegido ? { ...previo, puntoVenta: elegido } : previo
+    })
+  }, [])
+
+  const recargar = useCallback(async () => {
+    const generacion = avanzarGeneracion()
+    try {
+      const puntosVenta = await clienteDeOrganizacion.listarPuntosVenta()
+      if (generacionRef.current !== generacion) return
+
+      setEstado((previo) =>
+        previo.fase === 'listo' ? listoCon(puntosVenta, previo.puntoVenta?.id ?? null) : previo,
+      )
+    } catch (error) {
+      // Una lectura superada por otra más nueva no tiene resultado que informar: ni estado ni rechazo.
+      if (generacionRef.current === generacion) throw error
+    }
+  }, [avanzarGeneracion])
+
+  async function reintentar() {
+    if (ocupadoRef.current) return
+    ocupadoRef.current = true
+    setOcupado(true)
+
+    const generacion = avanzarGeneracion()
+    try {
+      await cargar(generacion)
+    } finally {
+      ocupadoRef.current = false
+      if (generacionRef.current === generacion) setOcupado(false)
+    }
+  }
+
+  async function salir() {
+    if (ocupadoRef.current) return
+    ocupadoRef.current = true
+    setOcupado(true)
+
+    const generacion = generacionRef.current
+    try {
+      await cerrarSesion()
+      navegar('/login', { replace: true })
+    } finally {
+      ocupadoRef.current = false
+      if (generacionRef.current === generacion) setOcupado(false)
+    }
+  }
+
+  const valor = useMemo<EstadoDePuntoVenta>(
+    () => ({
+      puntosVenta: estado.fase === 'listo' ? estado.puntosVenta : [],
+      puntoVenta: estado.fase === 'listo' ? estado.puntoVenta : null,
+      elegir,
+      recargar,
+    }),
+    [estado, elegir, recargar],
+  )
+
+  if (estado.fase === 'cargando') {
+    return <Cargando texto="Cargando puntos de venta…" />
+  }
+
+  if (estado.fase === 'error') {
+    return <PantallaDeError mensaje={estado.mensaje} ocupado={ocupado} alReintentar={reintentar} alSalir={salir} />
+  }
+
+  if (!estado.puntoVenta && estado.puntosVenta.length > 1) {
+    return <ElegirPuntoDeVenta puntosVenta={estado.puntosVenta} alElegir={elegir} />
+  }
+
+  return <PuntoVentaContext.Provider value={valor}>{children}</PuntoVentaContext.Provider>
+}
+
+type PropsDeError = {
+  mensaje: string
+  ocupado: boolean
+  alReintentar: () => void
+  alSalir: () => void
+}
+
+function PantallaDeError({ mensaje, ocupado, alReintentar, alSalir }: PropsDeError) {
+  return (
+    <div className="d-flex align-items-center justify-content-center min-vh-100 p-3">
+      <div role="alert" className="alert alert-danger rounded-0 text-center w-100" style={{ maxWidth: 480 }}>
+        <p>{mensaje}</p>
+        <button type="button" className="btn btn-outline-dark rounded-0 me-2" disabled={ocupado} onClick={alReintentar}>
+          Reintentar
+        </button>
+        <button type="button" className="btn btn-outline-secondary rounded-0" disabled={ocupado} onClick={alSalir}>
+          Salir
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/Ways.Web/src/puntoVenta/PuntoVentaContext.tsx
+++ b/src/Ways.Web/src/puntoVenta/PuntoVentaContext.tsx
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+import type { PuntoVentaListado } from '../api/tipos'
+
+export type EstadoDePuntoVenta = {
+  puntosVenta: PuntoVentaListado[]
+  puntoVenta: PuntoVentaListado | null
+  /** Cambia el punto de venta activo; un id que no está en la lista se ignora. */
+  elegir: (id: number) => void
+  /** Vuelve a pedir la lista y reconcilia la selección; si falla, rechaza sin tocar el estado. */
+  recargar: () => Promise<void>
+}
+
+export const PuntoVentaContext = createContext<EstadoDePuntoVenta | null>(null)

--- a/src/Ways.Web/src/puntoVenta/almacenDePuntoVenta.test.ts
+++ b/src/Ways.Web/src/puntoVenta/almacenDePuntoVenta.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  CLAVE_PUNTO_VENTA_DE_SESION,
+  guardarPuntoVentaDeSesion,
+  leerPuntoVentaDeSesion,
+  olvidarPuntoVentaDeSesion,
+} from './almacenDePuntoVenta'
+
+describe('almacenDePuntoVenta', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('guarda el par usuario/punto de venta y lo recupera para el mismo usuario', () => {
+    guardarPuntoVentaDeSesion(9, 100)
+
+    expect(JSON.parse(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION) ?? '')).toEqual({
+      idUsuario: 9,
+      idPuntoVenta: 100,
+    })
+    expect(leerPuntoVentaDeSesion(9)).toBe(100)
+  })
+
+  it('otro usuario no hereda la elección', () => {
+    guardarPuntoVentaDeSesion(9, 100)
+
+    expect(leerPuntoVentaDeSesion(10)).toBeNull()
+  })
+
+  it('devuelve null cuando no hay nada guardado', () => {
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+  })
+
+  it('devuelve null ante un JSON ilegible', () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, '{no es json')
+
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+  })
+
+  it('devuelve null cuando lo guardado no es un objeto', () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, 'null')
+
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+  })
+
+  it('devuelve null cuando el id guardado no es numérico', () => {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario: 9, idPuntoVenta: '100' }))
+
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+  })
+
+  it('olvidar borra la clave', () => {
+    guardarPuntoVentaDeSesion(9, 100)
+    olvidarPuntoVentaDeSesion()
+
+    expect(localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)).toBeNull()
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+  })
+
+  it('no propaga cuando el almacenamiento no está disponible', () => {
+    const sinAlmacenamiento = () => {
+      throw new Error('sin almacenamiento')
+    }
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(sinAlmacenamiento)
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(sinAlmacenamiento)
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(sinAlmacenamiento)
+
+    expect(() => guardarPuntoVentaDeSesion(9, 100)).not.toThrow()
+    expect(leerPuntoVentaDeSesion(9)).toBeNull()
+    expect(() => olvidarPuntoVentaDeSesion()).not.toThrow()
+  })
+})

--- a/src/Ways.Web/src/puntoVenta/almacenDePuntoVenta.ts
+++ b/src/Ways.Web/src/puntoVenta/almacenDePuntoVenta.ts
@@ -1,0 +1,42 @@
+/**
+ * Punto de venta de la sesión, persistido en `localStorage` para sobrevivir al refresco de la
+ * página. Se guarda junto al id del usuario: otra cuenta en el mismo navegador nunca hereda la
+ * elección de la anterior (`leerPuntoVentaDeSesion` devuelve `null` si el usuario no coincide).
+ */
+
+export const CLAVE_PUNTO_VENTA_DE_SESION = 'ways.sesion.puntoVenta'
+
+type PuntoVentaDeSesion = { idUsuario: number; idPuntoVenta: number }
+
+export function leerPuntoVentaDeSesion(idUsuario: number): number | null {
+  try {
+    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA_DE_SESION)
+    if (!crudo) return null
+
+    const guardado = JSON.parse(crudo) as Partial<PuntoVentaDeSesion> | null
+    if (!guardado || guardado.idUsuario !== idUsuario) return null
+
+    return typeof guardado.idPuntoVenta === 'number' && Number.isFinite(guardado.idPuntoVenta)
+      ? guardado.idPuntoVenta
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function guardarPuntoVentaDeSesion(idUsuario: number, idPuntoVenta: number): void {
+  try {
+    localStorage.setItem(CLAVE_PUNTO_VENTA_DE_SESION, JSON.stringify({ idUsuario, idPuntoVenta }))
+  } catch {
+    // Sin almacenamiento (modo privado, cuota agotada) la elección no sobrevive al refresco;
+    // la sesión sigue funcionando igual.
+  }
+}
+
+export function olvidarPuntoVentaDeSesion(): void {
+  try {
+    localStorage.removeItem(CLAVE_PUNTO_VENTA_DE_SESION)
+  } catch {
+    // Mismo criterio que al guardar: no hay nada que olvidar si el almacenamiento no existe.
+  }
+}

--- a/src/Ways.Web/src/puntoVenta/colorDePuntoVenta.test.ts
+++ b/src/Ways.Web/src/puntoVenta/colorDePuntoVenta.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { colorDePuntoVenta } from './colorDePuntoVenta'
+
+const centro = { id: 5, nombre: 'Local Centro' }
+const norte = { id: 12, nombre: 'Local Norte' }
+const sur = { id: 30, nombre: 'Local Sur' }
+
+describe('colorDePuntoVenta', () => {
+  it('sin punto de venta activo pinta color_1', () => {
+    expect(colorDePuntoVenta(null, [centro, norte])).toBe('color_1')
+  })
+
+  it('los dos ids más bajos reciben colores distintos, sin importar el orden de la lista', () => {
+    expect(colorDePuntoVenta(centro, [norte, centro])).toBe('color_1')
+    expect(colorDePuntoVenta(norte, [norte, centro])).toBe('color_2')
+  })
+
+  it('renombrar un punto de venta no cambia su color', () => {
+    const norteRenombrado = { ...norte, nombre: 'Sucursal Norte' }
+
+    expect(colorDePuntoVenta(norteRenombrado, [centro, norteRenombrado])).toBe(
+      colorDePuntoVenta(norte, [centro, norte]),
+    )
+  })
+
+  it('agregar un punto de venta con id mayor conserva los colores de los existentes', () => {
+    expect(colorDePuntoVenta(centro, [centro, norte, sur])).toBe(colorDePuntoVenta(centro, [centro, norte]))
+    expect(colorDePuntoVenta(norte, [centro, norte, sur])).toBe(colorDePuntoVenta(norte, [centro, norte]))
+    expect(colorDePuntoVenta(sur, [centro, norte, sur])).toBe('color_1')
+  })
+
+  it('un punto de venta que no está en la lista cae a color_1', () => {
+    expect(colorDePuntoVenta(sur, [centro, norte])).toBe('color_1')
+  })
+
+  it('no muta la lista recibida', () => {
+    const lista = [sur, centro, norte]
+
+    colorDePuntoVenta(centro, lista)
+
+    expect(lista).toEqual([sur, centro, norte])
+  })
+})

--- a/src/Ways.Web/src/puntoVenta/colorDePuntoVenta.ts
+++ b/src/Ways.Web/src/puntoVenta/colorDePuntoVenta.ts
@@ -1,0 +1,20 @@
+import type { PuntoVentaListado } from '../api/tipos'
+
+export type ColorDePuntoVenta = 'color_1' | 'color_2'
+
+/**
+ * Color de la franja de cabecera según el punto de venta activo (paridad con el legacy, que
+ * pinta `color_<id>`). Se decide por la POSICIÓN del punto de venta en la lista ordenada por id:
+ * renombrar o agregar puntos de venta no cambia el color de los que ya existían.
+ */
+export function colorDePuntoVenta(
+  puntoVenta: Pick<PuntoVentaListado, 'id'> | null,
+  puntosVenta: readonly Pick<PuntoVentaListado, 'id'>[],
+): ColorDePuntoVenta {
+  if (!puntoVenta) return 'color_1'
+
+  const ordenados = [...puntosVenta].sort((a, b) => a.id - b.id)
+  const posicion = ordenados.findIndex((p) => p.id === puntoVenta.id)
+
+  return posicion % 2 === 1 ? 'color_2' : 'color_1'
+}

--- a/src/Ways.Web/src/puntoVenta/usePuntoVenta.ts
+++ b/src/Ways.Web/src/puntoVenta/usePuntoVenta.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { PuntoVentaContext } from './PuntoVentaContext'
+
+export function usePuntoVenta() {
+  const contexto = useContext(PuntoVentaContext)
+
+  if (!contexto) {
+    throw new Error('usePuntoVenta tiene que usarse dentro de una PuertaDePuntoVenta.')
+  }
+
+  return contexto
+}


### PR DESCRIPTION
Closes #179

## Resumen

Slice 3 de 5. Infraestructura completa del punto de venta de sesion, inerte: `App.tsx` no la monta todavia. El montaje llega en el slice 4 junto con la migracion de POS, Caja y Consulta de precios, para que en main nunca convivan dos fuentes del punto de venta (el selector propio de cada pantalla y el de sesion).

- `puntoVenta/almacenDePuntoVenta.ts`: clave `ways.sesion.puntoVenta` con `{ idUsuario, idPuntoVenta }`; devuelve `null` si el usuario no coincide, el valor no es numerico o el storage rompe.
- `puntoVenta/PuntoVentaContext.tsx` + `usePuntoVenta.ts`: `{ puntosVenta, puntoVenta, elegir, recargar }`; el hook lanza fuera del proveedor, igual que `useAuth`.
- `puntoVenta/PuertaDePuntoVenta.tsx`: Root pasa sin pedir nada (su lista seria la de todos los tenants); 0 puntos de venta pasa con `null`; 1 se elige y se guarda solo; varios usan el guardado si sigue en la lista o muestran `ElegirPuntoDeVenta` a pantalla completa, sin Layout, como el `elegirLocal` viejo; el error inicial muestra un alert con Reintentar y Salir. `recargar()` comparte la generacion con la carga inicial (gana la ultima que arranco), reconcilia el actual (rename propaga; si desaparecio queda `null` y se olvida; si queda uno solo se elige) y nunca toca los slots de carga inicial.
- `puntoVenta/colorDePuntoVenta.ts`: el color de banda es propiedad del punto de venta, no de su posicion en la lista ordenada por nombre: orden por id, par naranja, impar violeta. Renombrar o agregar un punto de venta no cambia el color de los existentes.
- `AuthContext`: olvida el punto de venta guardado al iniciar sesion (antes de `setUsuario`) y en el `finally` de cerrar sesion. Cada login vuelve a elegir; un refresh lo conserva; otro usuario en el mismo navegador nunca lo hereda.

Disciplina `react-async-state`: generacion en cada setter despues de cada `await`, remonte por `key={usuario.id}`, guard de reentrada en un ref para Reintentar/Salir con `finally` sin gate, un solo dueno por slot de error, updaters funcionales sin leer estado.

## Judgment-day: APROBADO en ronda limpia

Dos jueces ciegos en paralelo sobre ccffbd0 (mismo contenido que 9e8eac9, rebaseado sobre main): cero hallazgos en ambos. Verificaron que el id guardado nunca se confia sin `find()` contra la lista recien traida, que `recargar` es inalcanzable mientras se muestra carga, error o selector (los hijos solo montan en `listo`), y que el efecto de persistencia solo escribe desde un estado ya asentado.

## Suites

```
npx tsc -b        limpio
npx oxlint        exit 0 (5 warnings preexistentes, ninguno nuevo)
npx vitest run    72 archivos / 1190 tests (48 nuevos)
```

## Tamano

1223 lineas nuevas: ~360 de produccion y ~860 de tests. `PuertaDePuntoVenta` y su suite son una sola unidad (231 + 543) y no se pueden partir sin dejar la puerta sin sus carreras probadas. Etiquetado `size:exception`.
