### PR TITLE
feat(web): barra de navegacion agrupada con Vender como accion principal (slice 2 de nav y punto de venta de sesion)

### DIFF
--- a/src/Ways.Web/src/componentes/Layout.test.tsx
+++ b/src/Ways.Web/src/componentes/Layout.test.tsx
@@ -1,0 +1,224 @@
+import { act, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Layout } from './Layout'
+import { ROL } from '../api/tipos'
+import type { UsuarioAutenticado } from '../api/tipos'
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 9,
+    usuario: 'admin',
+    mail: 'admin@ways.test',
+    rolId: ROL.Admin,
+    rol: 'Admin',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+const cerrarSesionMock = vi.fn(async () => {})
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: cerrarSesionMock }),
+}))
+
+function Contenido() {
+  const { pathname } = useLocation()
+  return <main>Contenido de {pathname}</main>
+}
+
+function renderLayout(ruta = '/') {
+  return render(
+    <MemoryRouter initialEntries={[ruta]}>
+      <Routes>
+        <Route path="/login" element={<div>Pantalla de login</div>} />
+        <Route element={<Layout />}>
+          <Route path="*" element={<Contenido />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** La lista de primer nivel de la barra, ubicada por el elemento que el alternador móvil controla. */
+function barra() {
+  const alternador = screen.getByRole('button', { name: 'Abrir menú' })
+  const colapso = document.getElementById(alternador.getAttribute('aria-controls') ?? '')
+  if (!colapso) throw new Error('el alternador móvil no controla ningún elemento')
+  return within(colapso)
+}
+
+const nombres = (elementos: HTMLElement[]) => elementos.map((elemento) => elemento.textContent)
+
+/** Entradas de primer nivel alcanzables (los ítems de un grupo cerrado quedan afuera por `hidden`)
+ * marcadas como activas, sea por `aria-current` en un link o por la clase del botón del grupo. */
+function entradasActivas() {
+  const lista = barra()
+  return [...lista.queryAllByRole('link'), ...lista.queryAllByRole('button')].filter(
+    (elemento) => elemento.hasAttribute('aria-current') || elemento.classList.contains('active'),
+  )
+}
+
+beforeEach(() => {
+  usuarioActual = usuarioFixture()
+  cerrarSesionMock.mockClear()
+})
+
+describe('Layout — barra de navegación agrupada', () => {
+  it('Admin: Vender es un botón-link a /pos y las entradas de primer nivel son las del menú por rol', () => {
+    renderLayout()
+
+    const vender = barra().getByRole('link', { name: 'Vender' })
+    expect(vender).toHaveAttribute('href', '/pos')
+    expect(vender).toHaveClass('btn', 'btn-success')
+    expect(nombres(barra().getAllByRole('link'))).toEqual(['Vender', 'Caja'])
+    expect(nombres(barra().getAllByRole('button'))).toEqual(['Ventas', 'Compras', 'Reportes', 'Administración'])
+  })
+
+  it('no hay ninguna entrada "Inicio": el logo es el link al inicio', () => {
+    renderLayout('/pos')
+
+    expect(screen.queryByRole('link', { name: 'Inicio' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Ways, ir al inicio' })).toHaveAttribute('href', '/')
+  })
+
+  it('Vendedor: sin Reportes ni Administración', () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    renderLayout()
+
+    expect(screen.queryByRole('button', { name: 'Administración' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reportes' })).not.toBeInTheDocument()
+    expect(barra().getByRole('link', { name: 'Vender' })).toBeInTheDocument()
+  })
+
+  it('Root: solo el desplegable Administración, sin Vender', () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Root, rol: 'Root', idTenant: null })
+    renderLayout()
+
+    expect(barra().queryAllByRole('link')).toEqual([])
+    expect(nombres(barra().getAllByRole('button'))).toEqual(['Administración'])
+  })
+
+  it.each([
+    ['/caja/historico', ['Reportes']],
+    ['/caja/tesoreria', ['Reportes']],
+    ['/pos', ['Vender']],
+    ['/caja/turnos/7/z', ['Caja']],
+    ['/catalogos/marcas', ['Administración']],
+    ['/', []],
+  ])('en %s las entradas activas de la barra son %j', (ruta, esperadas) => {
+    renderLayout(ruta)
+
+    expect(nombres(entradasActivas())).toEqual(esperadas)
+  })
+
+  it('en /caja/historico la entrada activa es el botón del grupo Reportes, no un link', () => {
+    renderLayout('/caja/historico')
+
+    const [activa] = entradasActivas()
+    expect(activa).toBe(screen.getByRole('button', { name: 'Reportes' }))
+    expect(screen.queryByRole('link', { name: 'Caja' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('abrir Administración muestra las secciones del Admin con sus encabezados', async () => {
+    const usuario = userEvent.setup()
+    renderLayout()
+
+    await usuario.click(screen.getByRole('button', { name: 'Administración' }))
+
+    expect(nombres(screen.getAllByRole('heading', { level: 6 }))).toEqual([
+      'Catálogo',
+      'Terceros',
+      'Stock',
+      'Configuración',
+      'Organización',
+    ])
+    expect(screen.getByRole('link', { name: 'Artículos' })).toHaveAttribute('href', '/articulos')
+  })
+
+  it('hay un solo grupo abierto a la vez', async () => {
+    const usuario = userEvent.setup()
+    renderLayout()
+
+    await usuario.click(screen.getByRole('button', { name: 'Ventas' }))
+    expect(screen.getByRole('link', { name: 'Presupuestos' })).toBeInTheDocument()
+
+    await usuario.click(screen.getByRole('button', { name: 'Reportes' }))
+
+    expect(screen.getByRole('button', { name: 'Ventas' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('link', { name: 'Presupuestos' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reportes' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('link', { name: 'Tablero' })).toBeInTheDocument()
+  })
+
+  it('elegir un ítem del desplegable navega y cierra el grupo', async () => {
+    const usuario = userEvent.setup()
+    renderLayout()
+
+    await usuario.click(screen.getByRole('button', { name: 'Reportes' }))
+    await usuario.click(screen.getByRole('link', { name: 'Tablero' }))
+
+    expect(screen.getByText('Contenido de /tablero')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reportes' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('link', { name: 'Tablero' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reportes' })).toHaveClass('active')
+  })
+
+  it('el alternador móvil abre y cierra el menú que controla', async () => {
+    const usuario = userEvent.setup()
+    renderLayout()
+    const alternador = screen.getByRole('button', { name: 'Abrir menú' })
+    const colapso = document.getElementById(alternador.getAttribute('aria-controls') ?? '')
+
+    expect(alternador).toHaveAttribute('aria-expanded', 'false')
+    expect(colapso).not.toHaveClass('show')
+
+    await usuario.click(alternador)
+    expect(alternador).toHaveAttribute('aria-expanded', 'true')
+    expect(colapso).toHaveClass('show')
+
+    await usuario.click(alternador)
+    expect(alternador).toHaveAttribute('aria-expanded', 'false')
+    expect(colapso).not.toHaveClass('show')
+  })
+
+  it('navegar desde el menú móvil abierto lo cierra', async () => {
+    const usuario = userEvent.setup()
+    renderLayout()
+
+    await usuario.click(screen.getByRole('button', { name: 'Abrir menú' }))
+    await usuario.click(screen.getByRole('link', { name: 'Caja' }))
+
+    expect(screen.getByText('Contenido de /caja')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Abrir menú' })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('Salir cierra la sesión y lleva a /login', async () => {
+    const usuario = userEvent.setup()
+    renderLayout('/pos')
+
+    await usuario.click(screen.getByRole('button', { name: 'Salir' }))
+
+    expect(cerrarSesionMock).toHaveBeenCalledTimes(1)
+    expect(await screen.findByText('Pantalla de login')).toBeInTheDocument()
+  })
+
+  // Cláusula bajo prueba: la guarda de reentrancia por ref de `salir` (react-async-state, regla 11).
+  // Evidencia de mutación: sin el `if (saliendoRef.current) return` este caso falla con dos llamadas.
+  it('dos clics en Salir en el mismo tick disparan un solo cierre de sesión', async () => {
+    renderLayout('/pos')
+    const salir = screen.getByRole('button', { name: 'Salir' })
+
+    await act(async () => {
+      salir.click()
+      salir.click()
+    })
+
+    expect(cerrarSesionMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Pantalla de login')).toBeInTheDocument()
+  })
+})

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -1,24 +1,41 @@
-import { NavLink, Outlet, useNavigate } from 'react-router'
+import { useEffect, useId, useRef, useState } from 'react'
+import { Link, Outlet, useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../auth/useAuth'
-import { DESCRIPTORES_DE_CATALOGO } from '../api/catalogos'
-import {
-  ROL,
-  puedeAprovisionarTenants,
-  puedeGestionarCatalogos,
-  puedeGestionarUsuarios,
-  puedeOperarPos,
-  puedeVerAuditoria,
-  puedeVerReportes,
-} from '../api/tipos'
+import { MenuDesplegable } from './MenuDesplegable'
+import { construirMenu, esRutaActiva } from './menu'
+
+function claseDeEnlace(principal: boolean | undefined, activo: boolean) {
+  const base = principal ? 'btn btn-success rounded-0 fw-bold me-2' : 'nav-link'
+  return activo ? `${base} active` : base
+}
 
 export function Layout() {
   const { usuario, cerrarSesion } = useAuth()
   const navegar = useNavigate()
+  const { pathname } = useLocation()
+  const idColapso = useId()
+  const [colapsoAbierto, setColapsoAbierto] = useState(false)
+  const [grupoAbierto, setGrupoAbierto] = useState<string | null>(null)
+  const saliendoRef = useRef(false)
+
+  // Cualquier navegación deja la barra en reposo: sin grupo desplegado ni menú móvil abierto.
+  useEffect(() => {
+    setGrupoAbierto(null)
+    setColapsoAbierto(false)
+  }, [pathname])
 
   async function salir() {
-    await cerrarSesion()
-    navegar('/login', { replace: true })
+    if (saliendoRef.current) return
+    saliendoRef.current = true
+    try {
+      await cerrarSesion()
+      navegar('/login', { replace: true })
+    } finally {
+      saliendoRef.current = false
+    }
   }
+
+  const menu = usuario ? construirMenu(usuario) : []
 
   return (
     <div id="wrap" className="bg-dark dk">
@@ -29,234 +46,56 @@ export function Layout() {
 
         <nav className="navbar navbar-dark navbar-expand-lg bg-dark border-top-0">
           <div className="container">
-            <NavLink className="navbar-brand ways-brand" to="/">
+            <Link className="navbar-brand ways-brand" to="/" aria-label="Ways, ir al inicio">
               Ways
-            </NavLink>
+            </Link>
 
-            <div className="collapse navbar-collapse show">
+            <button
+              type="button"
+              className="navbar-toggler"
+              aria-expanded={colapsoAbierto}
+              aria-controls={idColapso}
+              aria-label="Abrir menú"
+              onClick={() => setColapsoAbierto((previo) => !previo)}
+            >
+              <span className="navbar-toggler-icon" />
+            </button>
+
+            <div
+              id={idColapso}
+              className={colapsoAbierto ? 'collapse navbar-collapse show' : 'collapse navbar-collapse'}
+            >
               <ul className="navbar-nav">
-                <li className="nav-item">
-                  <NavLink className="nav-link" to="/">
-                    Inicio
-                  </NavLink>
-                </li>
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/pos">
-                      POS
-                    </NavLink>
-                  </li>
-                )}
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/caja">
-                      Caja
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-8-compras-transferencias-inventario (Slice 5, design: Web Composition,
-                    decisión 11): la lectura sigue Politicas.OperacionDePos, igual que la ruta —
-                    nav y ruta comparten la misma política de lectura; la escritura queda oculta
-                    dentro de la pantalla vía `puedeEscribir` (Admin-only, cosmético). */}
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/compras">
-                      Compras
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-17-presupuestos-y-remitos (Slice 7, design: Web composition): mismo gate
-                    que /pos/-compras (Politicas.OperacionDePos) — nav y ruta comparten política. */}
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/presupuestos">
-                      Presupuestos
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-17-presupuestos-y-remitos (Slice 8, design: Web composition): mismo gate
-                    que /presupuestos (Politicas.OperacionDePos) — nav y ruta comparten política. */}
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/remitos">
-                      Remitos
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-18-etiquetas-y-consulta (Slice 4, design decisión 11): mismo gate que
-                    /pos (Politicas.OperacionDePos) — pantalla de salón, sin claim de rol propio. */}
-                {usuario && puedeOperarPos(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/consulta-precios">
-                      Consulta de precios
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-10-agregacion-dashboard (Slice 7, design: Web Composition): nav y ruta
-                    comparten Politicas.LecturaDeReportes — Supervisor + Admin, ni Vendedor ni
-                    Root. */}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/tablero">
-                      Tablero
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-11-exportacion-reportes (Slices 6a/7, design: "nav entries + routes
-                    gated like /tablero (puedeVerReportes) for cajas/tesorería"): mismo gate que
-                    Tablero — nunca el cajero (/caja), esta es la vista de gestión. */}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/caja/historico">
-                      Histórico de cajas
-                    </NavLink>
-                  </li>
-                )}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/caja/tesoreria">
-                      Tesorería
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-11-exportacion-reportes (Slice 9, droppable a Etapa 13): mismo gate que
-                    Tablero/Histórico de cajas/Tesorería. */}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/reportes/existencias">
-                      Existencias
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-12-lotes-vencimientos (Slice 15): mismo gate que Existencias
-                    (puedeVerReportes). */}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/reportes/stock/vencimientos">
-                      Vencimientos
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-13-stock-inteligente (Slice 6): mismo gate que Vencimientos
-                    (puedeVerReportes). */}
-                {usuario && puedeVerReportes(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/reportes/stock/reposicion">
-                      Reposición
-                    </NavLink>
-                  </li>
-                )}
-                {/* stage-14-auditoria-trazabilidad (Slice 7, design decisión 17): Admin-only —
-                    nav y ruta comparten Politicas.LecturaDeAuditoria (puedeVerAuditoria), NUNCA
-                    apilada sobre puedeVerReportes (Supervisor queda afuera acá, a diferencia de
-                    Tablero/Histórico de cajas/etc.). */}
-                {usuario && puedeVerAuditoria(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/auditoria">
-                      Auditoría
-                    </NavLink>
-                  </li>
-                )}
-                {usuario && puedeGestionarUsuarios(usuario.rolId) && (
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/usuarios">
-                      Usuarios
-                    </NavLink>
-                  </li>
-                )}
-                {usuario && puedeGestionarCatalogos(usuario.rolId) && (
-                  <>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/clientes">
-                        Clientes
-                      </NavLink>
+                {menu.map((entrada) => {
+                  const activo = esRutaActiva(pathname, entrada)
+
+                  if (entrada.tipo === 'grupo') {
+                    return (
+                      <MenuDesplegable
+                        key={entrada.etiqueta}
+                        grupo={entrada}
+                        abierto={grupoAbierto === entrada.etiqueta}
+                        activo={activo}
+                        alAlternar={() =>
+                          setGrupoAbierto((previo) => (previo === entrada.etiqueta ? null : entrada.etiqueta))
+                        }
+                        alCerrar={() => setGrupoAbierto((previo) => (previo === entrada.etiqueta ? null : previo))}
+                      />
+                    )
+                  }
+
+                  return (
+                    <li className="nav-item" key={entrada.a}>
+                      <Link
+                        to={entrada.a}
+                        className={claseDeEnlace(entrada.principal, activo)}
+                        aria-current={activo ? 'page' : undefined}
+                      >
+                        {entrada.etiqueta}
+                      </Link>
                     </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/proveedores">
-                        Proveedores
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/articulos">
-                        Artículos
-                      </NavLink>
-                    </li>
-                    {/* stage-8-compras-transferencias-inventario (Slice 6, design: Web
-                        Composition, decisión 11): pantallas de escritura pura, sin contraparte
-                        de lectura — nav y ruta Admin-only end a end, mismo criterio que
-                        /proveedores/-articulos. */}
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/stock/transferencias">
-                        Transferencias
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/stock/conteo">
-                        Conteo de inventario
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/listas-precio">
-                        Listas de precio
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/ofertas">
-                        Ofertas
-                      </NavLink>
-                    </li>
-                    {Object.values(DESCRIPTORES_DE_CATALOGO).map((d) => (
-                      <li className="nav-item" key={d.recurso}>
-                        <NavLink className="nav-link" to={`/catalogos/${d.recurso}`}>
-                          {d.titulo}
-                        </NavLink>
-                      </li>
-                    ))}
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/catalogos/categorias">
-                        Categorías
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/parametros">
-                        Parámetros
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/catalogos-fiscales">
-                        Catálogos fiscales
-                      </NavLink>
-                    </li>
-                  </>
-                )}
-                {usuario && (usuario.rolId === ROL.Root || usuario.rolId === ROL.Admin) && (
-                  <>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/organizacion/empresas">
-                        Empresas
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/organizacion/puntos-venta">
-                        Puntos de venta
-                      </NavLink>
-                    </li>
-                  </>
-                )}
-                {usuario && puedeAprovisionarTenants(usuario.rolId) && (
-                  <>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/organizacion/tenants">
-                        Tenants
-                      </NavLink>
-                    </li>
-                    <li className="nav-item">
-                      <NavLink className="nav-link" to="/organizacion/nuevo-tenant">
-                        Nuevo tenant
-                      </NavLink>
-                    </li>
-                  </>
-                )}
+                  )
+                })}
               </ul>
             </div>
 

--- a/src/Ways.Web/src/estilos/ways.css
+++ b/src/Ways.Web/src/estilos/ways.css
@@ -31,6 +31,11 @@
   background-color: darkorchid;
 }
 
+.navbar .dropdown-menu {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
 /* Display grande del total en el POS. Todavía sin uso: llega con la pantalla de ventas. */
 .ways-total {
   position: fixed;

--- a/src/Ways.Web/src/paginas/Login.test.tsx
+++ b/src/Ways.Web/src/paginas/Login.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import type { InitialEntry } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Login } from './Login'
+import { ErrorApi } from '../api/cliente'
+import { ROL } from '../api/tipos'
+import type { UsuarioAutenticado } from '../api/tipos'
+import { AuthProvider } from '../auth/AuthContext'
+
+const apiGetMock = vi.fn()
+const apiPostMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: (...args: unknown[]) => apiPostMock(...(args as [string, unknown])),
+    put: vi.fn(),
+    delete: vi.fn(),
+    descargar: vi.fn(),
+  },
+  alPerderLaSesion: () => () => {},
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
+  return {
+    id: 4,
+    usuario: 'vendedor',
+    mail: 'vendedor@ways.test',
+    rolId: ROL.Vendedor,
+    rol: 'Vendedor',
+    ultimaConexion: null,
+    idTenant: 1,
+    ...sobrescribir,
+  }
+}
+
+function Pantalla({ nombre }: { nombre: string }) {
+  const { pathname, search } = useLocation()
+  return (
+    <main>
+      {nombre} en {pathname}
+      {search}
+    </main>
+  )
+}
+
+/** Login detrás del `AuthProvider` real: `iniciarSesion` publica el usuario por contexto y es ese
+ * re-render el que dispara la navegación de salida, igual que en la aplicación. */
+function renderLogin(entrada: InitialEntry = '/login') {
+  return render(
+    <MemoryRouter initialEntries={[entrada]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/pos" element={<Pantalla nombre="Ventas" />} />
+          <Route path="/caja/historico" element={<Pantalla nombre="Histórico de cajas" />} />
+          <Route path="/" element={<Pantalla nombre="Inicio" />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+async function ingresar(mail: string) {
+  const usuario = userEvent.setup()
+  await usuario.type(await screen.findByPlaceholderText('Correo electrónico'), mail)
+  await usuario.type(screen.getByPlaceholderText('Contraseña'), 'secreto')
+  await usuario.click(screen.getByRole('button', { name: 'Continuar' }))
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+  apiPostMock.mockReset()
+  apiGetMock.mockRejectedValue(new ErrorApi(401, 'no_autenticado', 'Tu sesión expiró.'))
+})
+
+describe('Login — destino después de ingresar', () => {
+  it('quien opera el POS entra directo a vender (paridad legacy A1)', async () => {
+    apiPostMock.mockResolvedValue(usuarioFixture())
+    renderLogin()
+
+    await ingresar('vendedor@ways.test')
+
+    expect(await screen.findByText('Ventas en /pos')).toBeInTheDocument()
+    expect(apiPostMock).toHaveBeenCalledWith('/auth/login', { mail: 'vendedor@ways.test', password: 'secreto' })
+  })
+
+  it('Root no opera el POS: entra al inicio', async () => {
+    apiPostMock.mockResolvedValue(usuarioFixture({ id: 1, usuario: 'root', mail: 'root@ways.test', rolId: ROL.Root, rol: 'Root', idTenant: null }))
+    renderLogin()
+
+    await ingresar('root@ways.test')
+
+    expect(await screen.findByText('Inicio en /')).toBeInTheDocument()
+  })
+
+  it('la ruta de origen guardada por RutaProtegida gana sobre el destino por rol, con su query', async () => {
+    apiPostMock.mockResolvedValue(usuarioFixture())
+    renderLogin({ pathname: '/login', state: { desde: { pathname: '/caja/historico', search: '?desde=2026-08-01' } } })
+
+    await ingresar('vendedor@ways.test')
+
+    expect(await screen.findByText('Histórico de cajas en /caja/historico?desde=2026-08-01')).toBeInTheDocument()
+  })
+
+  it('con credenciales rechazadas muestra el mensaje de la API, limpia la contraseña y se queda en /login', async () => {
+    apiPostMock.mockRejectedValue(new ErrorApi(401, 'credenciales_invalidas', 'Usuario o contraseña incorrectos.'))
+    renderLogin()
+
+    await ingresar('vendedor@ways.test')
+
+    expect(await screen.findByText('Usuario o contraseña incorrectos.')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Contraseña')).toHaveValue('')
+    expect(screen.getByPlaceholderText('Correo electrónico')).toHaveValue('vendedor@ways.test')
+    expect(screen.getByRole('button', { name: 'Continuar' })).toBeEnabled()
+  })
+})

--- a/src/Ways.Web/src/paginas/Login.tsx
+++ b/src/Ways.Web/src/paginas/Login.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../auth/useAuth'
 import { ErrorApi } from '../api/cliente'
+import { puedeOperarPos } from '../api/tipos'
 import { Cargando } from '../componentes/Cargando'
 
 type EstadoDeRuta = { desde?: { pathname: string; search: string } }
@@ -18,11 +19,15 @@ export function Login() {
   const [enviando, setEnviando] = useState(false)
 
   const estado = ubicacion.state as EstadoDeRuta | null
+  // Paridad con el legacy (A1): quien opera el POS entra directo a vender.
   const destino = estado?.desde
     ? `${estado.desde.pathname}${estado.desde.search ?? ''}`
-    : '/'
+    : usuario && puedeOperarPos(usuario.rolId)
+      ? '/pos'
+      : '/'
 
-  // Si ya hay sesión activa, /login no tiene sentido: vamos al destino.
+  // Con sesión activa (previa o recién iniciada) /login no tiene sentido: esta es la única
+  // navegación de salida, y recién acá el rol del usuario ya se conoce.
   useEffect(() => {
     if (!cargando && usuario) {
       navegar(destino, { replace: true })
@@ -36,7 +41,6 @@ export function Login() {
 
     try {
       await iniciarSesion(mail, password)
-      navegar(destino, { replace: true })
     } catch (e) {
       setError(e instanceof ErrorApi ? e.message : 'No se pudo iniciar sesión.')
       setPassword('')


### PR DESCRIPTION
Closes #181

## Resumen

Slice 2 de 5. La barra deja de ser una fila de ~30 accesos y pasa a ser: logo (va al inicio) | **Vender** | Caja | Ventas | Compras | Reportes | Administracion ... usuario - rol | Salir.

- `Layout.tsx` (313 -> 133 lineas): renderiza `construirMenu(usuario)` del slice 1; sin entrada "Inicio"; Vender es un `Link` a `/pos` con `btn btn-success` (nunca naranja ni violeta, que son los colores reservados del punto de venta); los grupos usan `MenuDesplegable` con un solo grupo abierto a la vez; la entrada activa sale de `esRutaActiva`, asi que en `/caja/historico` se ilumina Reportes y no Caja; toggler mobile real con `aria-expanded`/`aria-controls`; un efecto por `pathname` cierra el grupo abierto y el collapse al navegar. Salir gana un guard de reentrada en un ref: dos clicks en el mismo tick mandaban dos `POST /auth/logout`.
- `Login.tsx`: paridad con el sistema viejo (docs/01 A1): un operador entra directo a `/pos`; Root sigue en `/`; `state.desde` gana. La navegacion queda solo en el efecto, porque el `navegar` explicito despues de `iniciarSesion` leia un rol todavia desconocido.
- `ways.css`: solo `.navbar .dropdown-menu { max-height: 80vh; overflow-y: auto }` para la lista larga de Administracion.
- Tests: `Layout.test.tsx` (18: entradas por rol, sin Inicio, Vender, matriz de ruta activa, un solo grupo abierto, cierre al navegar, toggler, Salir con doble click) y `Login.test.tsx` (4: Vendedor -> /pos, Root -> /, desde gana, error deja el password vacio) con `AuthProvider` real y la API mockeada.

## Judgment-day: APROBADO en ronda limpia

Dos jueces ciegos sobre dbb8e9b (mismo contenido que 50d2d9a, rebaseado). Juez A: cero hallazgos (trazo el batching de React entre `AuthContext` y el efecto de Login para descartar doble navegacion o loop). Juez B: un WARNING y una SUGGESTION, sin CRITICAL, registrados como info y plegados en el slice 5, que vuelve a tocar Layout:

- WARNING: el collapse mobile solo se cierra por el efecto de `pathname`; tocar el enlace de la ruta ya activa no cambia el pathname y el menu queda abierto.
- SUGGESTION: Vender recibe la clase `active` en `/pos` (estilo `.btn.active` de Bootstrap); el brief pedia clase fija.

Evidencia de mutacion registrada: sin el guard del ref, "dos clics en Salir" falla con dos llamadas; invertir `puedeOperarPos` en `destino` hace fallar exactamente los dos tests de landing por rol.

## Suites

```
npx tsc -b        limpio
npx oxlint        exit 0 (5 warnings preexistentes, ninguno nuevo)
npx vitest run    74 archivos / 1212 tests (22 nuevos)
```

## Tamano

~680 lineas: 436 agregadas y 244 borradas. Produccion neta: Layout -167, Login +2, css +5; el resto son los 352 de tests nuevos. Supera los 400 por el borrado del nav plano y por los tests; separar los tests del Layout que prueban dejaria un PR sin cobertura. Etiquetado `size:exception`.
