### PR TITLE
refactor(web): el POS, Caja y Consulta de precios usan el punto de venta de sesion (slice 4 de nav y punto de venta de sesion)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -43,6 +43,7 @@ import { Tesoreria } from './paginas/Tesoreria'
 import { Transferencias } from './paginas/Transferencias'
 import { Usuarios } from './paginas/Usuarios'
 import { Vencimientos } from './paginas/Vencimientos'
+import { PuertaDePuntoVenta } from './puntoVenta/PuertaDePuntoVenta'
 import { descriptorListasPrecio } from './api/catalogos'
 import { ROL } from './api/tipos'
 
@@ -57,7 +58,9 @@ export function App() {
           <Route
             element={
               <RutaProtegida>
-                <Layout />
+                <PuertaDePuntoVenta>
+                  <Layout />
+                </PuertaDePuntoVenta>
               </RutaProtegida>
             }
           >

--- a/src/Ways.Web/src/componentes/SelectorDeLote.test.tsx
+++ b/src/Ways.Web/src/componentes/SelectorDeLote.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SelectorDeLote } from './SelectorDeLote'
+import type { LoteListado } from '../api/tipos'
+
+const apiGetMock = vi.fn()
+
+vi.mock('../api/cliente', () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...(args as [string])),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ErrorApi: class ErrorApiMock extends Error {
+    estado: number
+    codigo: string
+    constructor(estado: number, codigo: string, mensaje: string) {
+      super(mensaje)
+      this.estado = estado
+      this.codigo = codigo
+    }
+  },
+}))
+
+function loteFixture(sobrescribir: Partial<LoteListado> = {}): LoteListado {
+  return {
+    idLote: 1,
+    idArticulo: 1,
+    codigo: '2026-09-01',
+    fechaVencimiento: '2026-09-01',
+    esSinIdentificar: false,
+    cantidad: 5,
+    estado: 'Vigente',
+    sugerido: false,
+    ...sobrescribir,
+  }
+}
+
+function propsDe(idPuntoVenta: number) {
+  return {
+    idPuntoVenta,
+    idArticulo: 1,
+    nombreArticulo: 'Coca Cola 1L',
+    idLoteElegido: null,
+    disabled: false,
+    onElegir: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset()
+})
+
+describe('SelectorDeLote — cambio de punto de venta con un fetch en vuelo (react-async-state regla 3)', () => {
+  /**
+   * Cláusula bajo prueba: el guard `tokenRef.current !== miToken` que sigue al `await` de
+   * `listarLotes`, junto con el bump de `tokenRef` del efecto keyed en `[idPuntoVenta, idArticulo]`.
+   * Escenario que vivía en `Pos.test.tsx` cuando el POS tenía su propio selector de punto de venta;
+   * con el punto de venta en la sesión, `Pos()` remonta la pantalla entera por `key` y esta carrera
+   * ya no es alcanzable desde ahí — se prueba acá, directamente contra el componente.
+   *
+   * Evidencia de mutación (mutation-proof-tests regla 2): con `if (tokenRef.current !== miToken)
+   * return` borrado del camino de éxito de `cargar`, este test falla ("Lote de Coca Cola 1L" aparece
+   * con el lote STALE y el botón "Elegir lote" desaparece); restaurado, vuelve a verde.
+   */
+  it('una respuesta stale que llega DESPUÉS de cambiar de punto de venta no pinta el picker (mutation-proof-tests regla 7)', async () => {
+    let resolverLotesPv7: (valor: LoteListado[]) => void = () => {}
+    let promesaLotesPv7: Promise<LoteListado[]> = Promise.resolve([])
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta === '/stock/lotes?idPuntoVenta=7&idArticulo=1') {
+        promesaLotesPv7 = new Promise((resolve) => (resolverLotesPv7 = resolve))
+        return promesaLotesPv7
+      }
+      if (ruta.startsWith('/stock/lotes?')) return Promise.resolve<LoteListado[]>([])
+      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+    })
+
+    const { rerender } = render(<SelectorDeLote {...propsDe(7)} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
+    // el fetch del punto de venta 7 queda en vuelo — `resolverLotesPv7` todavía no se llamó.
+    expect(screen.getByRole('button', { name: 'Cargando…' })).toBeDisabled()
+
+    rerender(<SelectorDeLote {...propsDe(8)} />)
+    expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeEnabled()
+
+    // regla 7: el flush del microtask va DENTRO de `act` — un `waitFor` pasaría en su primer
+    // tick, antes de que el `.then` stale aterrice, y saldría verde sin probar nada.
+    await act(async () => {
+      resolverLotesPv7([loteFixture({ idLote: 99, codigo: 'STALE' })])
+      await promesaLotesPv7
+    })
+
+    expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeEnabled()
+    expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
+    expect(apiGetMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Ways.Web/src/paginas/Caja.test.tsx
+++ b/src/Ways.Web/src/paginas/Caja.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Caja } from './Caja'
 import { ErrorApi } from '../api/cliente'
 import type { MedioPagoListado, MovimientoRegistrado, PuntoVentaListado, ResumenDeTurno, TurnoResumen } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
@@ -105,11 +106,28 @@ function movimientoFixture(sobrescribir: Partial<MovimientoRegistrado> = {}): Mo
 const medioEfectivo = medioFixture()
 const puntoVentaCentro = puntoVentaFixture()
 
-/** Rutas comunes a toda la pantalla (puntos de venta + medios de pago) — cada test suma encima
- * las rutas de caja que le hacen falta (`/caja/turnos/...`). */
+/** El punto de venta viene de la sesión (`PuertaDePuntoVenta`), no de un fetch de esta pantalla:
+ * el hook se mockea con un estado mutable que cada test puede reemplazar antes de montar (o
+ * mutar y `rerender` para simular un cambio de punto de venta). */
+function estadoDePuntoVentaPorDefecto(): EstadoDePuntoVenta {
+  return {
+    puntosVenta: [puntoVentaCentro],
+    puntoVenta: puntoVentaCentro,
+    elegir: vi.fn(),
+    recargar: vi.fn(() => Promise.resolve()),
+  }
+}
+
+let estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
+
+vi.mock('../puntoVenta/usePuntoVenta', () => ({
+  usePuntoVenta: () => estadoDePuntoVenta,
+}))
+
+/** Rutas comunes a toda la pantalla (medios de pago) — cada test suma encima las rutas de caja
+ * que le hacen falta (`/caja/turnos/...`). */
 function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> | undefined) {
   apiGetMock.mockImplementation((ruta: string) => {
-    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
     if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
     const propia = sobrescribirGet?.(ruta)
     if (propia) return propia
@@ -120,6 +138,7 @@ function mockearRutasBase(sobrescribirGet?: (ruta: string) => Promise<unknown> |
 beforeEach(() => {
   apiGetMock.mockReset()
   apiPostMock.mockReset()
+  estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
 })
 
 describe('Caja — apertura', () => {
@@ -415,74 +434,41 @@ describe('Caja — movimientos', () => {
   })
 })
 
-describe('Caja — selector de punto de venta bloqueado durante una escritura en vuelo (react-async-state regla 9)', () => {
-  it('queda deshabilitado mientras la apertura del turno está en vuelo', async () => {
+describe('Caja — punto de venta de sesión', () => {
+  it('muestra el nombre del punto de venta de la sesión como texto, sin selector', async () => {
     mockearRutasBase((ruta) => {
       if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(null)
       return undefined
     })
 
-    let resolverApertura: (t: TurnoResumen) => void = () => {}
-    const aperturaPendiente = new Promise<TurnoResumen>((resolve) => {
-      resolverApertura = resolve
-    })
-    apiPostMock.mockImplementation((ruta: string) => {
-      if (ruta === '/caja/turnos') return aperturaPendiente
-      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
-    })
-
     render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('No hay un turno abierto en este punto de venta.')
 
-    await userEvent.type(screen.getByLabelText('Fondo inicial'), '500')
-    await userEvent.click(screen.getByRole('button', { name: 'Abrir turno' }))
-
-    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
-
-    await act(async () => {
-      resolverApertura(turnoFixture())
-      await Promise.resolve()
-    })
+    expect(screen.getByText('Local Centro')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Punto de venta')).not.toBeInTheDocument()
   })
 
-  it('queda deshabilitado mientras un movimiento de caja está en vuelo', async () => {
-    mockearRutasBase((ruta) => {
-      if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
-      if (ruta === '/caja/turnos/501/resumen') return Promise.resolve<ResumenDeTurno>(resumenFixture())
-      return undefined
-    })
-
-    let resolverMovimiento: (m: MovimientoRegistrado) => void = () => {}
-    const movimientoPendiente = new Promise<MovimientoRegistrado>((resolve) => {
-      resolverMovimiento = resolve
-    })
-    apiPostMock.mockImplementation((ruta: string) => {
-      if (ruta === '/caja/turnos/501/movimientos') return movimientoPendiente
-      return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
-    })
+  it('sin punto de venta en la sesión muestra el aviso y no consulta ningún turno', async () => {
+    estadoDePuntoVenta.puntosVenta = []
+    estadoDePuntoVenta.puntoVenta = null
+    mockearRutasBase()
 
     render(<Caja />, { wrapper: MemoryRouter })
-    await screen.findByText('Turno abierto')
-    await userEvent.type(screen.getByLabelText('Importe'), '100')
-    await userEvent.type(screen.getByLabelText('Motivo'), 'retiro de prueba')
-    await userEvent.click(screen.getByRole('button', { name: 'Registrar movimiento' }))
+    await screen.findByText('Sin puntos de venta disponibles')
 
-    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
-
-    await act(async () => {
-      resolverMovimiento(movimientoFixture())
-      await Promise.resolve()
-    })
+    expect(screen.queryByText('Consultando el turno…')).not.toBeInTheDocument()
+    expect(screen.queryByText('No hay un turno abierto en este punto de venta.')).not.toBeInTheDocument()
+    expect(apiGetMock).not.toHaveBeenCalledWith(expect.stringContaining('/caja/turnos/abierto'))
   })
 })
 
 describe('Caja — turno nuevo no hereda el estado del anterior (react-async-state regla 8)', () => {
-  it('cambiar de punto de venta a uno con otro turno abierto resetea el formulario de movimiento y el resumen mostrado', async () => {
+  it('cambiar el punto de venta de sesión a uno con otro turno abierto remonta la pantalla: resetea el formulario de movimiento y el resumen mostrado', async () => {
     const puntoVentaNorte = puntoVentaFixture({ id: 8, nombre: 'Local Norte' })
     const turnoNorte = turnoFixture({ id: 900, idPuntoVenta: 8, fondoInicial: 1000 })
+    estadoDePuntoVenta.puntosVenta = [puntoVentaCentro, puntoVentaNorte]
 
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro, puntoVentaNorte])
       if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
       if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') return Promise.resolve<TurnoResumen | null>(turnoFixture())
       if (ruta === '/caja/turnos/abierto?idPuntoVenta=8') return Promise.resolve<TurnoResumen | null>(turnoNorte)
@@ -495,14 +481,18 @@ describe('Caja — turno nuevo no hereda el estado del anterior (react-async-sta
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
-    render(<Caja />, { wrapper: MemoryRouter })
+    const { rerender } = render(<Caja />, { wrapper: MemoryRouter })
     await screen.findByText('Turno abierto')
     await waitFor(() => expect(screen.getByText('$640,00')).toBeInTheDocument())
+    expect(screen.getByText('Local Centro')).toBeInTheDocument()
 
     await userEvent.type(screen.getByLabelText('Motivo'), 'algo que no debería sobrevivir al cambio de turno')
 
-    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), 'Local Norte')
+    estadoDePuntoVenta.puntoVenta = puntoVentaNorte
+    rerender(<Caja />)
 
+    expect(screen.getByText('Local Norte')).toBeInTheDocument()
+    expect(screen.queryByText('Local Centro')).not.toBeInTheDocument()
     await waitFor(() => expect(screen.getByText('$999,00')).toBeInTheDocument())
     expect(screen.queryByText('$640,00')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Motivo')).toHaveValue('')
@@ -512,7 +502,6 @@ describe('Caja — turno nuevo no hereda el estado del anterior (react-async-sta
 describe('Caja — errores', () => {
   it('un turno abierto que falla al consultarse muestra el mensaje del servidor', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/catalogos/medios-pago') return Promise.resolve<MedioPagoListado[]>([medioEfectivo])
       if (ruta === '/caja/turnos/abierto?idPuntoVenta=7') {
         return Promise.reject(new ErrorApi(500, 'error', 'No se pudo consultar el turno.'))

--- a/src/Ways.Web/src/paginas/Caja.tsx
+++ b/src/Ways.Web/src/paginas/Caja.tsx
@@ -3,41 +3,20 @@ import { Link } from 'react-router'
 import { aSolicitudDeMovimiento, clienteDeCaja, importeValidoParaTipo, motivoValido } from '../api/caja'
 import { clienteDeCatalogo } from '../api/catalogos'
 import { ErrorApi } from '../api/cliente'
-import { clienteDeOrganizacion } from '../api/organizacion'
 import {
   CATEGORIAS_GASTO,
   TIPOS_MOVIMIENTO_CAJA,
   type CategoriaGasto,
   type MedioPagoAlta,
   type MedioPagoListado,
-  type PuntoVentaListado,
   type ResumenDeTurno,
   type TipoMovimientoCaja,
   type TurnoResumen,
 } from '../api/tipos'
 import { Box } from '../componentes/Box'
-
-const CLAVE_PUNTO_VENTA = 'ways.caja.idPuntoVenta'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
 
 const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
-
-function leerPuntoVentaGuardado(): number | null {
-  try {
-    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
-    return crudo ? Number(crudo) : null
-  } catch {
-    return null
-  }
-}
-
-function guardarPuntoVentaSeleccionado(id: number) {
-  try {
-    localStorage.setItem(CLAVE_PUNTO_VENTA, String(id))
-  } catch {
-    // localStorage puede no estar disponible (modo privado del navegador) — la selección
-    // simplemente no persiste entre sesiones, el resto de la pantalla sigue funcionando.
-  }
-}
 
 function formatearMoneda(valor: number): string {
   const signo = valor < 0 ? '-' : ''
@@ -55,13 +34,12 @@ function etiquetaCategoriaGasto(categoria: CategoriaGasto): string {
 type PropsFormularioApertura = {
   idPuntoVenta: number
   onAbierto: (turno: TurnoResumen) => void
-  onEscribiendoCambio: (valor: boolean) => void
 }
 
 /** Apertura de turno (spec: turnos-de-caja / Apertura Creates An Open Turno With Its Fondo):
- * fondo inicial + observaciones opcionales, `idPuntoVenta` siempre lo trae la selección de
- * arriba, nunca un campo editable acá. */
-function FormularioApertura({ idPuntoVenta, onAbierto, onEscribiendoCambio }: PropsFormularioApertura) {
+ * fondo inicial + observaciones opcionales, `idPuntoVenta` siempre es el punto de venta de la
+ * sesión, nunca un campo editable acá. */
+function FormularioApertura({ idPuntoVenta, onAbierto }: PropsFormularioApertura) {
   const [fondoInicial, setFondoInicial] = useState('')
   const [observaciones, setObservaciones] = useState('')
   const [abriendo, setAbriendo] = useState(false)
@@ -81,7 +59,6 @@ function FormularioApertura({ idPuntoVenta, onAbierto, onEscribiendoCambio }: Pr
 
     abriendoRef.current = true
     setAbriendo(true)
-    onEscribiendoCambio(true)
     setError('')
 
     try {
@@ -113,7 +90,6 @@ function FormularioApertura({ idPuntoVenta, onAbierto, onEscribiendoCambio }: Pr
     } finally {
       abriendoRef.current = false
       setAbriendo(false)
-      onEscribiendoCambio(false)
     }
   }
 
@@ -167,14 +143,13 @@ type PropsPanelTurnoAbierto = {
   turno: TurnoResumen
   medios: MedioPagoListado[] | null
   errorMedios: string
-  onEscribiendoCambio: (valor: boolean) => void
 }
 
 /** Turno abierto: movimientos (retiro/refuerzo/apertura de cajón) + resumen parcial — misma
  * derivación que el cierre (spec: arqueo-de-cierre / Resumen Parcial Uses The Same Derivation As
  * Cierre). El componente entero se remonta por `key={turno.id}` en el padre (regla 8): ningún
  * estado de acá (formulario de movimiento, resumen, generación) sobrevive a un cambio de turno. */
-function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: PropsPanelTurnoAbierto) {
+function PanelTurnoAbierto({ turno, medios, errorMedios }: PropsPanelTurnoAbierto) {
   const [resumen, setResumen] = useState<ResumenDeTurno | null>(null)
   const [cargandoResumen, setCargandoResumen] = useState(false)
   const [errorResumen, setErrorResumen] = useState('')
@@ -245,7 +220,6 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
 
     registrandoRef.current = true
     setRegistrando(true)
-    onEscribiendoCambio(true)
     setErrorMovimiento('')
 
     // regla 3: bumpear la generación del resumen ANTES de la escritura — cualquier resumen en
@@ -265,7 +239,6 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
     } finally {
       registrandoRef.current = false
       setRegistrando(false)
-      onEscribiendoCambio(false)
     }
 
     // regla 6: el refetch del resumen queda aislado del try/catch de la escritura — corre tanto en
@@ -548,17 +521,17 @@ function PanelTurnoAbierto({ turno, medios, errorMedios, onEscribiendoCambio }: 
 
 /**
  * Pantalla de caja (stage-6-turnos-caja, Slice 6, design: Web Composition): estado del turno del
- * punto de venta seleccionado, apertura cuando no hay uno abierto, movimientos físicos fuera de
+ * punto de venta de la sesión, apertura cuando no hay uno abierto, movimientos físicos fuera de
  * la venta y el resumen parcial en vivo — misma derivación que el cierre (Slice 7). Precedente de
  * forma: `Pos.tsx`. El resumen (`ServicioDeResumenDeTurno`) también expone el contenido D6
  * (cantidad de tickets, primer/último ticket, ingresos por área y egresos por categoría/área +
  * retiros; follow-up "Resumen parcial D6-content enrichment") — ver el doc-comment de
- * `ResumenDeTurno` en `api/tipos.ts`.
+ * `ResumenDeTurno` en `api/tipos.ts`. Remontada íntegra por `key` desde `Caja()` cuando cambia el
+ * punto de venta (regla 8): el punto de venta es fijo durante toda la vida de una instancia.
  */
-export function Caja() {
-  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
-  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
-  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+function PantallaCaja() {
+  const { puntoVenta } = usePuntoVenta()
+  const idPuntoVenta = puntoVenta?.id ?? ''
 
   const [medios, setMedios] = useState<MedioPagoListado[] | null>(null)
   const [errorMedios, setErrorMedios] = useState('')
@@ -568,33 +541,9 @@ export function Caja() {
   const [errorTurno, setErrorTurno] = useState('')
   const generacionTurnoRef = useRef(0)
 
-  // regla 9: mientras la apertura o un movimiento tienen una escritura en vuelo, el selector de
-  // punto de venta —el único recurso que ambos formularios podrían superponer, porque cambiarlo
-  // reemplaza el turno entero de abajo— queda inerte. Cada formulario sigue dueño de su propio
-  // flag de "en curso" (regla 5); esto es solo la señal combinada para ese selector puntual.
-  const [escribiendo, setEscribiendo] = useState(false)
-
-  // Carga inicial: puntos de venta (selector explícito, mismo criterio que Pos.tsx) y medios de
-  // pago (para etiquetar el resumen parcial) — cada uno con su propio try/catch.
+  // Carga inicial: medios de pago, para etiquetar el resumen parcial.
   useEffect(() => {
     let vigente = true
-
-    clienteDeOrganizacion
-      .listarPuntosVenta()
-      .then((lista) => {
-        if (!vigente) return
-        setPuntosVenta(lista)
-        const guardado = leerPuntoVentaGuardado()
-        const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
-        setIdPuntoVenta(porDefecto ? porDefecto.id : '')
-      })
-      .catch((e) => {
-        if (!vigente) return
-        setPuntosVenta([])
-        setErrorPuntosVenta(
-          e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta. Seleccioná uno para operar.',
-        )
-      })
 
     clienteMediosPago
       .listar(false)
@@ -613,9 +562,10 @@ export function Caja() {
     }
   }, [])
 
-  // regla 2: cada cambio de punto de venta dispara una nueva consulta del turno abierto — una
-  // respuesta desactualizada (de un punto de venta que el cajero ya dejó de mirar) nunca puede
-  // pisar la más reciente.
+  // regla 2: la consulta del turno abierto va gateada por generación — `turnoAbierto` la bumpea
+  // para que un GET …/abierto en vuelo desde antes de la apertura nunca pise el turno recién
+  // confirmado. El punto de venta no cambia dentro de una instancia (`Caja()` la remonta por
+  // `key`), así que este efecto corre una sola vez por montaje.
   useEffect(() => {
     if (idPuntoVenta === '') {
       setTurno(null)
@@ -651,12 +601,6 @@ export function Caja() {
     }
   }, [idPuntoVenta])
 
-  function cambiarPuntoVenta(id: number) {
-    if (escribiendo) return
-    setIdPuntoVenta(id)
-    guardarPuntoVentaSeleccionado(id)
-  }
-
   function turnoAbierto(nuevoTurno: TurnoResumen) {
     // La apertura recién confirmada es la fuente más autoritativa posible: bumpear la
     // generación invalida cualquier GET …/abierto que siguiera en vuelo desde antes.
@@ -670,29 +614,14 @@ export function Caja() {
       <div className="row g-3">
         <div className="col-12">
           <Box titulo="Caja">
-            {errorPuntosVenta && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
-
-            <div className="mb-3" style={{ maxWidth: 320 }}>
-              <label className="form-label" htmlFor="caja-punto-venta">
-                Punto de venta
-              </label>
-              <select
-                id="caja-punto-venta"
-                className="form-select rounded-0"
-                value={idPuntoVenta}
-                disabled={puntosVenta === null || escribiendo}
-                onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
-              >
-                {puntosVenta === null && <option value="">Cargando…</option>}
-                {puntosVenta !== null && puntosVenta.length === 0 && (
-                  <option value="">Sin puntos de venta disponibles</option>
-                )}
-                {puntosVenta?.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.nombre}
-                  </option>
-                ))}
-              </select>
+            <div className="mb-3">
+              {puntoVenta ? (
+                <>
+                  <span className="text-muted small">Punto de venta:</span> <strong>{puntoVenta.nombre}</strong>
+                </>
+              ) : (
+                <div className="alert alert-warning rounded-0 py-1 px-2 small">Sin puntos de venta disponibles</div>
+              )}
             </div>
 
             {errorTurno && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorTurno}</div>}
@@ -704,21 +633,10 @@ export function Caja() {
               <div key={turno?.id ?? 'sin-turno'}>
                 {cargandoTurno && <p className="text-muted">Consultando el turno…</p>}
 
-                {!cargandoTurno && turno === null && (
-                  <FormularioApertura
-                    idPuntoVenta={idPuntoVenta}
-                    onAbierto={turnoAbierto}
-                    onEscribiendoCambio={setEscribiendo}
-                  />
-                )}
+                {!cargandoTurno && turno === null && <FormularioApertura idPuntoVenta={idPuntoVenta} onAbierto={turnoAbierto} />}
 
                 {!cargandoTurno && turno !== null && (
-                  <PanelTurnoAbierto
-                    turno={turno}
-                    medios={medios}
-                    errorMedios={errorMedios}
-                    onEscribiendoCambio={setEscribiendo}
-                  />
+                  <PanelTurnoAbierto turno={turno} medios={medios} errorMedios={errorMedios} />
                 )}
               </div>
             )}
@@ -727,4 +645,15 @@ export function Caja() {
       </div>
     </div>
   )
+}
+
+/**
+ * `/caja`: remonta `PantallaCaja` entera por `key` cuando cambia el punto de venta de la sesión
+ * (react-async-state regla 8, mismo mecanismo que `Pos()`) — ningún turno, formulario ni resumen
+ * de un punto de venta sobrevive al cambio a otro.
+ */
+export function Caja() {
+  const { puntoVenta } = usePuntoVenta()
+
+  return <PantallaCaja key={puntoVenta?.id ?? 'sin-pv'} />
 }

--- a/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
+++ b/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
@@ -249,6 +249,42 @@ describe('ConsultaPrecios — punto de venta de sesión', () => {
     expect(screen.getByLabelText('Código escaneado')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Consultar' })).toBeDisabled()
   })
+
+  /**
+   * Cláusula bajo prueba: el `:${puntoVenta?.id}` del `key={puntoVenta?.id ?? 'sin-pv'}` de
+   * `ConsultaPrecios()` (mismo mecanismo de `Pos()`/`Caja()`, react-async-state regla 8). Sin esa
+   * mitad del key, un cambio de punto de venta de sesión NO remonta `PantallaConsultaPrecios` y el
+   * resultado escaneado (más cualquier texto sin confirmar en el input) sobrevive al cambio.
+   * Evidencia de mutación (mutation-proof-tests regla 2): con el key reemplazado por la constante
+   * `"fijo"` en `ConsultaPrecios.tsx:302`, este test falla ("Coca Cola 1L" sigue en pantalla y el
+   * input conserva "999"); revertido byte a byte, vuelve a verde.
+   */
+  it('un cambio del punto de venta de sesión remonta la pantalla y descarta el resultado anterior', async () => {
+    const puntoVentaNorte = puntoVentaFixture({ id: 8, nombre: 'Sucursal Norte' })
+    estadoDePuntoVenta.puntosVenta = [puntoVentaCentro, puntoVentaNorte]
+
+    const { rerender } = await renderYEsperarSelectores()
+    await escanear('7790001234567')
+    await screen.findByTestId('resultado-resuelto')
+    expect(screen.getByTestId('resultado-resuelto')).toHaveTextContent('Coca Cola 1L')
+
+    // Texto sin confirmar en el input: si el remount fuera parcial (por ejemplo, solo el
+    // `resultado` limpiado a mano), este texto sobreviviría igual — es el discriminante contra
+    // un remount incompleto.
+    const entrada = screen.getByLabelText('Código escaneado') as HTMLInputElement
+    fireEvent.change(entrada, { target: { value: '999' } })
+    expect(entrada.value).toBe('999')
+
+    estadoDePuntoVenta.puntoVenta = puntoVentaNorte
+    rerender(<ConsultaPrecios />)
+
+    await screen.findByRole('option', { name: 'Lista Mostrador' })
+    expect(screen.getByText('Sucursal Norte')).toBeInTheDocument()
+    expect(screen.queryByText('Local Centro')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('resultado-resuelto')).not.toBeInTheDocument()
+    expect(screen.queryByText('Coca Cola 1L')).not.toBeInTheDocument()
+    expect((screen.getByLabelText('Código escaneado') as HTMLInputElement).value).toBe('')
+  })
 })
 
 describe('aResultadoDeConsulta — mapper puro (web-descriptor-tests)', () => {

--- a/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
+++ b/src/Ways.Web/src/paginas/ConsultaPrecios.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { aResultadoDeConsulta, ConsultaPrecios } from './ConsultaPrecios'
 import { ErrorApi } from '../api/cliente'
 import type { ArticuloEscaneado, ListaPrecioAsignable, PuntoVentaListado, ResultadoDeResolucion } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
 
 const apiGetMock = vi.fn()
 const apiPostMock = vi.fn()
@@ -67,9 +68,25 @@ function resolucionFixture(sobrescribir: Partial<ResultadoDeResolucion> = {}): R
 const puntoVentaCentro = puntoVentaFixture()
 const listaMostrador = listaFixture()
 
+/** El punto de venta viene de la sesión (`PuertaDePuntoVenta`), no de un fetch de esta pantalla:
+ * el hook se mockea con un estado mutable que cada test puede reemplazar antes de montar. */
+function estadoDePuntoVentaPorDefecto(): EstadoDePuntoVenta {
+  return {
+    puntosVenta: [puntoVentaCentro],
+    puntoVenta: puntoVentaCentro,
+    elegir: vi.fn(),
+    recargar: vi.fn(() => Promise.resolve()),
+  }
+}
+
+let estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
+
+vi.mock('../puntoVenta/usePuntoVenta', () => ({
+  usePuntoVenta: () => estadoDePuntoVenta,
+}))
+
 function mockPorDefecto() {
   apiGetMock.mockImplementation((ruta: string) => {
-    if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
     if (ruta === '/listas-precio') return Promise.resolve<ListaPrecioAsignable[]>([listaMostrador])
     if (ruta.startsWith('/articulos/escaneo?entrada=')) return Promise.resolve(articuloEscaneadoFixture())
     return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
@@ -84,13 +101,16 @@ beforeEach(() => {
   apiGetMock.mockReset()
   apiPostMock.mockReset()
   localStorage.clear()
+  estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
   mockPorDefecto()
 })
 
+/** Espera la lista de precio (el único selector que queda) y verifica que el punto de venta de la
+ * sesión se rinde como texto. */
 async function renderYEsperarSelectores() {
   const resultado = render(<ConsultaPrecios />)
-  await screen.findByRole('option', { name: 'Local Centro' })
   await screen.findByRole('option', { name: 'Lista Mostrador' })
+  expect(screen.getByText('Local Centro')).toBeInTheDocument()
   return resultado
 }
 
@@ -149,7 +169,6 @@ describe('ConsultaPrecios — exactamente dos llamados por escaneo (mutation tar
 describe('ConsultaPrecios — las cuatro ramas de despliegue (guard enumeration)', () => {
   it('código desconocido (404) muestra "no encontrado" y NO dispara ninguna resolución de precio', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/listas-precio') return Promise.resolve<ListaPrecioAsignable[]>([listaMostrador])
       if (ruta.startsWith('/articulos/escaneo?entrada=')) {
         return Promise.reject(new ErrorApi(404, 'no_encontrado', 'No se encontró un artículo activo para el código 999.'))
@@ -214,6 +233,21 @@ describe('ConsultaPrecios — las cuatro ramas de despliegue (guard enumeration)
     await screen.findByTestId('resultado-resuelto')
     expect(screen.queryByTestId('precio-original-tachado')).not.toBeInTheDocument()
     expect(screen.getByTestId('precio-final')).toHaveTextContent('$100,00')
+  })
+})
+
+describe('ConsultaPrecios — punto de venta de sesión', () => {
+  it('sin punto de venta en la sesión muestra el aviso y la consulta queda deshabilitada', async () => {
+    estadoDePuntoVenta.puntosVenta = []
+    estadoDePuntoVenta.puntoVenta = null
+
+    render(<ConsultaPrecios />)
+    await screen.findByRole('option', { name: 'Lista Mostrador' })
+
+    expect(screen.getByText('Sin puntos de venta disponibles')).toBeInTheDocument()
+    expect(screen.queryByText('Local Centro')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Código escaneado')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Consultar' })).toBeDisabled()
   })
 })
 
@@ -521,7 +555,6 @@ describe('ConsultaPrecios — reentrancia de consultar() (guard `buscando`, judg
 describe('ConsultaPrecios — ninguna superficie sin sesión (OD2, consulta-de-precios/spec.md:108-112)', () => {
   it('un 401 en el escaneo (sesión inexistente) se muestra como error, sin reintento ni llamado alternativo, y JAMÁS dispara la resolución', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/listas-precio') return Promise.resolve<ListaPrecioAsignable[]>([listaMostrador])
       if (ruta.startsWith('/articulos/escaneo?entrada=')) return Promise.reject(new ErrorApi(401, 'no_autenticado', 'Tu sesión expiró.'))
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))

--- a/src/Ways.Web/src/paginas/ConsultaPrecios.tsx
+++ b/src/Ways.Web/src/paginas/ConsultaPrecios.tsx
@@ -3,10 +3,9 @@ import { clienteDeArticulos } from '../api/articulos'
 import { ErrorApi } from '../api/cliente'
 import { clienteDeClientes } from '../api/clientes'
 import { clienteDeOfertas } from '../api/ofertas'
-import { clienteDeOrganizacion } from '../api/organizacion'
-import type { ArticuloEscaneado, ListaPrecioAsignable, PuntoVentaListado, ResultadoDeResolucion } from '../api/tipos'
+import type { ArticuloEscaneado, ListaPrecioAsignable, ResultadoDeResolucion } from '../api/tipos'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
 
-const CLAVE_PUNTO_VENTA = 'ways.consultaPrecios.idPuntoVenta'
 const CLAVE_LISTA_PRECIO = 'ways.consultaPrecios.idListaPrecio'
 
 /**
@@ -75,14 +74,14 @@ export function aResultadoDeConsulta(articulo: ArticuloEscaneado, resolucion: Re
  * Consulta de precios del salón (stage-18-etiquetas-y-consulta, Slice 4, design decisión 11):
  * `autoFocus` + `Enter` (`Pos.tsx:1068-1078`), exactamente DOS llamadas por escaneo
  * (`GET /api/articulos/escaneo` → identidad, `POST /api/ofertas/resolver` @ `cantidad = 1` →
- * precio), CERO escrituras, CERO estado persistido más allá de los selectores de PV/lista (mismo
- * criterio que `Pos.tsx`). La pantalla no lee ningún claim de rol ni muestra identidad de usuario
- * (OD2) — el gate de acceso vive enteramente en la ruta (`App.tsx`).
+ * precio), CERO escrituras, CERO estado persistido más allá del selector de lista (el punto de
+ * venta es el de la sesión, mismo criterio que `Pos.tsx`). La pantalla no lee ningún claim de rol
+ * ni muestra identidad de usuario (OD2) — el gate de acceso vive enteramente en la ruta
+ * (`App.tsx`). Remontada íntegra por `key` desde `ConsultaPrecios()` cuando cambia el punto de
+ * venta (react-async-state regla 8): ningún resultado ni resolución en vuelo sobrevive al cambio.
  */
-export function ConsultaPrecios() {
-  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
-  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
-  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+function PantallaConsultaPrecios() {
+  const { puntoVenta: puntoVentaSeleccionado } = usePuntoVenta()
 
   const [listas, setListas] = useState<ListaPrecioAsignable[] | null>(null)
   const [idListaPrecio, setIdListaPrecio] = useState<number | ''>('')
@@ -101,21 +100,6 @@ export function ConsultaPrecios() {
 
   useEffect(() => {
     let vigente = true
-
-    clienteDeOrganizacion
-      .listarPuntosVenta()
-      .then((lista) => {
-        if (!vigente) return
-        setPuntosVenta(lista)
-        const guardado = leerNumeroGuardado(CLAVE_PUNTO_VENTA)
-        const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
-        setIdPuntoVenta(porDefecto ? porDefecto.id : '')
-      })
-      .catch(() => {
-        if (!vigente) return
-        setPuntosVenta([])
-        setErrorPuntosVenta('No se pudieron cargar los puntos de venta.')
-      })
 
     clienteDeClientes
       .listasDePrecioAsignables()
@@ -157,17 +141,11 @@ export function ConsultaPrecios() {
     return () => clearTimeout(temporizador)
   }, [resultado])
 
-  function cambiarPuntoVenta(id: number) {
-    setIdPuntoVenta(id)
-    guardarNumeroSeleccionado(CLAVE_PUNTO_VENTA, id)
-  }
-
   function cambiarListaPrecio(id: number) {
     setIdListaPrecio(id)
     guardarNumeroSeleccionado(CLAVE_LISTA_PRECIO, id)
   }
 
-  const puntoVentaSeleccionado = puntosVenta?.find((p) => p.id === idPuntoVenta) ?? null
   const selectoresListos = puntoVentaSeleccionado !== null && idListaPrecio !== ''
 
   async function consultar() {
@@ -226,25 +204,13 @@ export function ConsultaPrecios() {
 
       <div className="row g-3 mb-4">
         <div className="col-12 col-md-6">
-          <label className="form-label" htmlFor="consulta-precios-punto-venta">
-            Punto de venta
-          </label>
-          <select
-            id="consulta-precios-punto-venta"
-            className="form-select rounded-0"
-            value={idPuntoVenta}
-            disabled={puntosVenta === null}
-            onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
-          >
-            {puntosVenta === null && <option value="">Cargando…</option>}
-            {puntosVenta !== null && puntosVenta.length === 0 && <option value="">Sin puntos de venta disponibles</option>}
-            {puntosVenta?.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.nombre}
-              </option>
-            ))}
-          </select>
-          {errorPuntosVenta && <div className="form-text text-danger">{errorPuntosVenta}</div>}
+          {puntoVentaSeleccionado ? (
+            <>
+              <span className="text-muted small">Punto de venta:</span> <strong>{puntoVentaSeleccionado.nombre}</strong>
+            </>
+          ) : (
+            <div className="alert alert-warning rounded-0 py-1 px-2 small">Sin puntos de venta disponibles</div>
+          )}
         </div>
 
         <div className="col-12 col-md-6">
@@ -324,4 +290,14 @@ export function ConsultaPrecios() {
       )}
     </div>
   )
+}
+
+/**
+ * `/consulta-precios`: remonta `PantallaConsultaPrecios` entera por `key` cuando cambia el punto
+ * de venta de la sesión (react-async-state regla 8, mismo mecanismo que `Pos()` y `Caja()`).
+ */
+export function ConsultaPrecios() {
+  const { puntoVenta } = usePuntoVenta()
+
+  return <PantallaConsultaPrecios key={puntoVenta?.id ?? 'sin-pv'} />
 }

--- a/src/Ways.Web/src/paginas/Pos.test.tsx
+++ b/src/Ways.Web/src/paginas/Pos.test.tsx
@@ -16,20 +16,26 @@ import type {
   PuntoVentaListado,
   ResultadoDeResolucion,
 } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
 
 /** `Pos()` (stage-17-presupuestos-y-remitos, Slice 7) lee `useSearchParams` — necesita un Router
  * para montar, mismo criterio que `OrdenDeCompra.test.tsx`/`CompraEditor.test.tsx`. `ruta` por
  * defecto es la libre (`/pos`, sin `?idPresupuesto=`) para que los tests preexistentes no
- * cambien de comportamiento. */
-function renderPos(ruta = '/pos') {
-  return render(
+ * cambien de comportamiento. El árbol se expone aparte para poder `rerender` el mismo árbol
+ * después de mutar el punto de venta de la sesión. */
+function arbolDePos(ruta = '/pos') {
+  return (
     <MemoryRouter initialEntries={[ruta]}>
       <Routes>
         <Route path="/pos" element={<Pos />} />
         <Route path="/presupuestos" element={<div>Presupuestos</div>} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   )
+}
+
+function renderPos(ruta = '/pos') {
+  return render(arbolDePos(ruta))
 }
 
 const apiGetMock = vi.fn()
@@ -180,11 +186,28 @@ const consumidorFinal = clienteFixture()
 const otroCliente = clienteFixture({ id: 2, numero: 2, nombre: 'Juan', apellido: 'Pérez', esConsumidorFinal: false })
 const puntoVentaCentro = puntoVentaFixture()
 
+/** El punto de venta viene de la sesión (`PuertaDePuntoVenta`), no de un fetch de esta pantalla:
+ * el hook se mockea con un estado mutable que cada test puede reemplazar antes de montar (o
+ * mutar y `rerender` para simular un cambio de punto de venta). */
+function estadoDePuntoVentaPorDefecto(): EstadoDePuntoVenta {
+  return {
+    puntosVenta: [puntoVentaCentro],
+    puntoVenta: puntoVentaCentro,
+    elegir: vi.fn(),
+    recargar: vi.fn(() => Promise.resolve()),
+  }
+}
+
+let estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
+
+vi.mock('../puntoVenta/usePuntoVenta', () => ({
+  usePuntoVenta: () => estadoDePuntoVenta,
+}))
+
 /** Rutas GET comunes a casi todos los tests — devuelve `undefined` (no `Promise`) para una ruta
  * que no reconoce, así un test puede extender la tabla sin duplicarla entera (mismo criterio que
  * `mockearReferencia` en CompraEditor.test.tsx). */
-function rutaBaseDePos(ruta: string, puntosVenta: PuntoVentaListado[] = [puntoVentaCentro]): Promise<unknown> | undefined {
-  if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>(puntosVenta)
+function rutaBaseDePos(ruta: string): Promise<unknown> | undefined {
   if (ruta === '/clientes') {
     const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
     return Promise.resolve(pagina)
@@ -222,6 +245,7 @@ function mockearApiGet(sobrescribir?: (ruta: string) => Promise<unknown> | undef
 beforeEach(() => {
   apiGetMock.mockReset()
   apiPostMock.mockReset()
+  estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
   mockearApiGet()
   apiPostMock.mockImplementation((ruta: string) => {
     if (ruta === '/ofertas/resolver') {
@@ -255,6 +279,17 @@ async function armarVentaLista() {
   await waitFor(() => expect(screen.getByRole('button', { name: /Cobrar/ })).toBeEnabled())
 }
 
+/** Deja el carrito con una sola línea de Coca Cola, sin pasar por el panel de pagos — punto de
+ * partida de los tests del picker de lote y del remount por punto de venta. */
+async function armarCarritoConUnaLinea() {
+  const resultado = renderPos()
+  await screen.findByRole('option', { name: /Consumidor Final/ })
+  await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+  await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+  await screen.findByText('Coca Cola 1L')
+  return resultado
+}
+
 describe('Pos — formato de moneda negativa (regresión, INFO recurrente desde slice 6)', () => {
   it('un total negativo en el ticket antepone el signo al símbolo ($): "-$50,00", nunca "$-50,00"', async () => {
     apiPostMock.mockImplementation((ruta: string) => {
@@ -280,12 +315,61 @@ describe('Pos — formato de moneda negativa (regresión, INFO recurrente desde 
 })
 
 describe('Pos — carga inicial', () => {
-  it('selecciona el Consumidor Final por defecto y el único punto de venta disponible', async () => {
+  it('selecciona el Consumidor Final por defecto y muestra el punto de venta de la sesión', async () => {
     renderPos()
 
     expect(await screen.findByRole('option', { name: /Consumidor Final/ })).toBeInTheDocument()
     expect(screen.getByLabelText('Cliente')).toHaveValue(String(consumidorFinal.id))
-    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(puntoVentaCentro.id)))
+    expect(screen.getByText('Local Centro')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Punto de venta')).not.toBeInTheDocument()
+  })
+})
+
+describe('Pos — punto de venta de sesión (react-async-state regla 8)', () => {
+  /**
+   * Cláusula bajo prueba: la mitad `:${puntoVenta?.id}` del `key` de `PantallaPos` en `Pos()`.
+   * El nombre nuevo se pintaría igual sin ella (la pantalla lee el contexto directo), así que la
+   * aserción discriminante es el carrito vacío. Evidencia de mutación (mutation-proof-tests regla
+   * 2): con el `key` reducido a `idPresupuesto ?? 'libre'`, este test falla ("Coca Cola 1L" sigue
+   * en el carrito); restaurado, vuelve a verde.
+   */
+  it('un cambio del punto de venta de sesión remonta la pantalla: el carrito se vacía y se muestra el nombre nuevo', async () => {
+    const puntoVentaNorte = puntoVentaFixture({ id: 8, nombre: 'Sucursal Norte' })
+    estadoDePuntoVenta.puntosVenta = [puntoVentaCentro, puntoVentaNorte]
+    const { rerender } = await armarCarritoConUnaLinea()
+    expect(screen.getByText('Local Centro')).toBeInTheDocument()
+
+    estadoDePuntoVenta.puntoVenta = puntoVentaNorte
+    rerender(arbolDePos())
+
+    expect(screen.getByText('Sucursal Norte')).toBeInTheDocument()
+    expect(screen.queryByText('Local Centro')).not.toBeInTheDocument()
+    expect(screen.queryByText('Coca Cola 1L')).not.toBeInTheDocument()
+    expect(screen.getByText('Escaneá o tipeá un código para empezar la venta.')).toBeInTheDocument()
+
+    // La instancia nueva vuelve a cargar clientes y parámetros contra el punto de venta 8.
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+    await waitFor(() =>
+      expect(apiGetMock).toHaveBeenCalledWith('/parametros/tolerancia_pago?idEmpresa=1&idPuntoVenta=8'),
+    )
+  })
+
+  it('sin punto de venta en la sesión muestra el aviso y Cobrar queda deshabilitado', async () => {
+    estadoDePuntoVenta.puntosVenta = []
+    estadoDePuntoVenta.puntoVenta = null
+    renderPos()
+    await screen.findByRole('option', { name: /Consumidor Final/ })
+
+    expect(screen.getByText('Sin puntos de venta disponibles')).toBeInTheDocument()
+    expect(screen.queryByText('Local Centro')).not.toBeInTheDocument()
+
+    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
+    await screen.findByText('Coca Cola 1L')
+
+    expect(screen.getByRole('button', { name: /Cobrar/ })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Elegir lote' })).not.toBeInTheDocument()
+    expect(apiGetMock).not.toHaveBeenCalledWith(expect.stringContaining('/parametros/'))
   })
 })
 
@@ -333,7 +417,6 @@ describe('Pos — escaneo', () => {
 
   it('un código no encontrado muestra un error y no agrega ninguna línea', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/clientes') {
         const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
         return Promise.resolve(pagina)
@@ -378,7 +461,6 @@ describe('Pos — regresión: carga inicial de clientes vs. selección del usuar
     })
 
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/clientes') return montajePendiente
       if (ruta.startsWith('/clientes?busqueda=')) {
         const pagina: PaginaDe<ClienteListado> = { items: [otroCliente], total: 1, pagina: 1, tamanio: 25 }
@@ -618,7 +700,6 @@ describe('Pos — panel de pagos: precondiciones', () => {
 
   it('medios de pago o parámetros que fallan al cargar dejan Cobrar deshabilitado con un aviso legible', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/clientes') {
         const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
         return Promise.resolve(pagina)
@@ -779,7 +860,6 @@ describe('Pos — checkout', () => {
 
   it('nuevaVenta limpia el error de escaneo que haya quedado de antes de cobrar', async () => {
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/clientes') {
         const pagina: PaginaDe<ClienteListado> = { items: [consumidorFinal], total: 1, pagina: 1, tamanio: 25 }
         return Promise.resolve(pagina)
@@ -1197,7 +1277,6 @@ describe('Pos — debounce de la resolución de precios', () => {
     })
 
     apiGetMock.mockImplementation((ruta: string) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro])
       if (ruta === '/clientes') return clientesPendientes
       if (ruta.startsWith('/articulos/escaneo?entrada=')) return Promise.resolve(articuloEscaneadoFixture())
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
@@ -1316,16 +1395,6 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
     }
   }
 
-  /** Deja el carrito con una sola línea de Coca Cola, sin pasar por el panel de pagos — punto de
-   * partida de los tests del picker. */
-  async function armarCarritoConUnaLinea() {
-    renderPos()
-    await screen.findByRole('option', { name: /Consumidor Final/ })
-    await userEvent.type(screen.getByLabelText('Código escaneado'), '7790001234567')
-    await userEvent.click(screen.getByRole('button', { name: 'Agregar' }))
-    await screen.findByText('Coca Cola 1L')
-  }
-
   it('el camino feliz nunca pide los lotes — el botón "Elegir lote" no dispara ningún fetch solo por aparecer', async () => {
     await armarCarritoConUnaLinea()
 
@@ -1384,38 +1453,6 @@ describe('Pos — picker de lote (stage-12-lotes-vencimientos, Slice 14, design 
 
     const llamadas = apiGetMock.mock.calls.filter((call: unknown[]) => (call[0] as string).startsWith('/stock/lotes?'))
     expect(llamadas).toHaveLength(1)
-  })
-
-  it('una respuesta stale que llega DESPUÉS de cambiar de punto de venta no pinta el picker (mutation-proof-tests regla 7)', async () => {
-    const puntoVentaSucursal = puntoVentaFixture({ id: 8, nombre: 'Sucursal Norte' })
-    let resolverLotesPv1: (valor: LoteListado[]) => void = () => {}
-    let promesaLotesPv1: Promise<LoteListado[]> = Promise.resolve([])
-    mockearApiGet((ruta) => {
-      if (ruta === '/puntos-venta') return Promise.resolve<PuntoVentaListado[]>([puntoVentaCentro, puntoVentaSucursal])
-      if (ruta.startsWith('/stock/lotes?') && ruta.includes(`idPuntoVenta=${puntoVentaCentro.id}`)) {
-        promesaLotesPv1 = new Promise((resolve) => (resolverLotesPv1 = resolve))
-        return promesaLotesPv1
-      }
-      if (ruta.startsWith('/stock/lotes?')) return Promise.resolve<LoteListado[]>([])
-      return undefined
-    })
-    await armarCarritoConUnaLinea()
-    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(puntoVentaCentro.id)))
-
-    await userEvent.click(screen.getByRole('button', { name: 'Elegir lote' }))
-    // el fetch de PV1 queda en vuelo — `resolverLotesPv1` todavía no se llamó.
-
-    await userEvent.selectOptions(screen.getByLabelText('Punto de venta'), String(puntoVentaSucursal.id))
-
-    // regla 7: el flush del microtask va DENTRO de `act` — un `waitFor` pasaría en su primer
-    // tick, antes de que el `.then` stale aterrice, y saldría verde sin probar nada.
-    await act(async () => {
-      resolverLotesPv1([loteFixture({ idLote: 99, codigo: 'STALE' })])
-      await promesaLotesPv1
-    })
-
-    expect(screen.getByRole('button', { name: 'Elegir lote' })).toBeInTheDocument()
-    expect(screen.queryByLabelText('Lote de Coca Cola 1L')).not.toBeInTheDocument()
   })
 
   it('un fetch de lotes rechazado muestra "No se pudieron cargar los lotes."', async () => {
@@ -1520,11 +1557,21 @@ describe('Pos — conversión de presupuesto (stage-17-presupuestos-y-remitos, S
     }
   }
 
+  const puntoVentaDelPresupuesto = puntoVentaFixture({ id: 7 })
+  const puntoVentaDeLaSesion = puntoVentaFixture({ id: 8, nombre: 'Sucursal Norte' })
+
+  /** El presupuesto fija el punto de venta 7; la sesión está parada en otro (8) a propósito, así
+   * que "Local Centro" en pantalla solo puede salir del presupuesto, nunca de la sesión. */
+  beforeEach(() => {
+    estadoDePuntoVenta.puntosVenta = [puntoVentaDelPresupuesto, puntoVentaDeLaSesion]
+    estadoDePuntoVenta.puntoVenta = puntoVentaDeLaSesion
+  })
+
   function mockearApiGetPresupuesto(sobrescribir?: (ruta: string) => Promise<unknown> | undefined) {
     apiGetMock.mockImplementation((ruta: string) => {
       if (ruta === '/presupuestos/1/para-venta') return Promise.resolve(presupuestoParaVentaFixture())
       if (ruta === '/clientes/2') return Promise.resolve(otroCliente)
-      const propia = sobrescribir?.(ruta) ?? rutaBaseDePos(ruta, [puntoVentaFixture({ id: 7 })])
+      const propia = sobrescribir?.(ruta) ?? rutaBaseDePos(ruta)
       if (propia) return propia
       return Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
@@ -1544,9 +1591,10 @@ describe('Pos — conversión de presupuesto (stage-17-presupuestos-y-remitos, S
     expect(screen.queryByRole('button', { name: 'Quitar' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Vaciar carrito' })).not.toBeInTheDocument()
 
-    // Punto de venta y cliente quedan fijados por el presupuesto, ambos deshabilitados.
-    await waitFor(() => expect(screen.getByLabelText('Punto de venta')).toHaveValue(String(7)))
-    expect(screen.getByLabelText('Punto de venta')).toBeDisabled()
+    // El punto de venta lo fija el presupuesto (texto de solo lectura, nunca el de la sesión) y
+    // el cliente queda deshabilitado.
+    expect(await screen.findByText('Local Centro')).toBeInTheDocument()
+    expect(screen.queryByText('Sucursal Norte')).not.toBeInTheDocument()
     await waitFor(() => expect(screen.getByLabelText('Cliente')).toHaveValue(String(otroCliente.id)))
     expect(screen.getByLabelText('Cliente')).toBeDisabled()
 
@@ -1643,7 +1691,7 @@ describe('Pos — conversión de presupuesto (stage-17-presupuestos-y-remitos, S
     apiGetMock.mockImplementation((ruta: string) => {
       if (ruta === '/presupuestos/1/para-venta') return pendiente
       if (ruta === '/clientes/2') return Promise.resolve(otroCliente)
-      return rutaBaseDePos(ruta, [puntoVentaFixture({ id: 7 })]) ?? Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
+      return rutaBaseDePos(ruta) ?? Promise.reject(new Error(`ruta no mockeada en el test: ${ruta}`))
     })
 
     const { unmount } = renderPos('/pos?idPresupuesto=1')

--- a/src/Ways.Web/src/paginas/Pos.tsx
+++ b/src/Ways.Web/src/paginas/Pos.tsx
@@ -7,7 +7,6 @@ import { clienteDeCatalogo } from '../api/catalogos'
 import { api, ErrorApi } from '../api/cliente'
 import { clienteDeClientes } from '../api/clientes'
 import { clienteDeOfertas } from '../api/ofertas'
-import { clienteDeOrganizacion } from '../api/organizacion'
 import {
   aPagosDeVenta,
   calcularExcedente,
@@ -28,7 +27,6 @@ import type {
   MedioPagoListado,
   ParametroResuelto,
   PresupuestoParaVenta,
-  PuntoVentaListado,
   ResultadoDeResolucion,
 } from '../api/tipos'
 import {
@@ -44,8 +42,7 @@ import {
 import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 import { SelectorDeLote } from '../componentes/SelectorDeLote'
-
-const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
 
 /** Piso de cantidad por línea, compartido entre el guard de edición y los atributos
  * `min`/`step` del input — evita que ambos se desincronicen (ej. el guard aceptando
@@ -53,24 +50,6 @@ const CLAVE_PUNTO_VENTA = 'ways.pos.idPuntoVenta'
 const CANTIDAD_MINIMA = 0.001
 
 const clienteMediosPago = clienteDeCatalogo<MedioPagoListado, MedioPagoAlta>('medios-pago')
-
-function leerPuntoVentaGuardado(): number | null {
-  try {
-    const crudo = localStorage.getItem(CLAVE_PUNTO_VENTA)
-    return crudo ? Number(crudo) : null
-  } catch {
-    return null
-  }
-}
-
-function guardarPuntoVentaSeleccionado(id: number) {
-  try {
-    localStorage.setItem(CLAVE_PUNTO_VENTA, String(id))
-  } catch {
-    // localStorage puede no estar disponible (modo privado del navegador) — la selección
-    // simplemente no persiste entre sesiones, el resto de la pantalla sigue funcionando.
-  }
-}
 
 function fusionarOpcionesCliente(opciones: ClienteListado[], seleccionado: ClienteListado | null): ClienteListado[] {
   if (!seleccionado) return opciones
@@ -225,15 +204,12 @@ type PropsPantallaPos = { idPresupuesto: number | null }
  * pantalla entera opera en modo conversión — carrito congelado de solo lectura, sin resolución de
  * precio, `POST /api/ventas` con `idPresupuestoOrigen`. Remontada íntegra por `key` desde `Pos()`
  * (react-async-state regla 8) — ningún estado de una venta libre o de otro presupuesto sobrevive
- * al cambio de `?idPresupuesto=`.
+ * al cambio de `?idPresupuesto=`, ni al cambio del punto de venta de la sesión.
  */
 function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
   const modoPresupuesto = idPresupuesto !== null
   const navigate = useNavigate()
-
-  const [puntosVenta, setPuntosVenta] = useState<PuntoVentaListado[] | null>(null)
-  const [idPuntoVenta, setIdPuntoVenta] = useState<number | ''>('')
-  const [errorPuntosVenta, setErrorPuntosVenta] = useState('')
+  const { puntoVenta: puntoVentaDeSesion, puntosVenta } = usePuntoVenta()
 
   const [opcionesClientes, setOpcionesClientes] = useState<ClienteListado[]>([])
   const [clienteSeleccionado, setClienteSeleccionado] = useState<ClienteListado | null>(null)
@@ -253,8 +229,8 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
 
   // stage-12-lotes-vencimientos (Slice 14): elección explícita de lote por línea, indexada por
   // `idArticulo` — una línea ausente acá viaja con `idLote: null` (design decisión 19, camino
-  // feliz de cero tecleo). Los saldos de lote son por punto de venta: cambiar de PV invalida
-  // cualquier elección hecha (`cambiarPuntoVenta` la resetea entera).
+  // feliz de cero tecleo). Los saldos de lote son por punto de venta: un cambio de PV remonta la
+  // pantalla entera por `key` desde `Pos()`, así que ninguna elección sobrevive al PV anterior.
   const [lotesSeleccionados, setLotesSeleccionados] = useState<LotesSeleccionados>({})
 
   const [entradaEscaneo, setEntradaEscaneo] = useState('')
@@ -273,7 +249,7 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
   const [filasPago, setFilasPago] = useState<FilaPago[]>(() => [filaPagoVacia(proximaFilaPagoIdRef.current++)])
 
   // react-async-state regla 9: mientras el checkout está en vuelo, TODO lo que podría
-  // superponerse (escaneo, edición de carrito, cliente/punto de venta, filas de pago) queda
+  // superponerse (escaneo, edición de carrito, cliente, filas de pago) queda
   // inerte — `cobrandoRef` es el guard de reentrancia de primera línea (un doble click en el
   // mismo tick le gana al re-render que deshabilita el botón), `cobrando` es lo que deshabilita
   // los controles en pantalla.
@@ -325,14 +301,6 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
     }
   }, [modoPresupuesto, idPresupuesto])
 
-  // El punto de venta lo fija el presupuesto — nunca lo elige el cajero bajo este modo (el
-  // servidor recibe `idPuntoVenta` del body igual que siempre, pero acá viaja el del presupuesto,
-  // nunca uno distinto que el operador pudiera tipear).
-  useEffect(() => {
-    if (!presupuesto) return
-    setIdPuntoVenta(presupuesto.idPuntoVenta)
-  }, [presupuesto])
-
   // El cliente lo trae el presupuesto por id — se hidrata el registro completo (no solo el id)
   // porque el panel de pagos necesita `esConsumidorFinal`/`saldo`/`limiteCredito`/`creditoIlimitado`
   // para su validación local, los mismos campos que la selección manual ya provee.
@@ -358,7 +326,12 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
     }
   }, [presupuesto])
 
-  const puntoVentaSeleccionada = puntosVenta?.find((p) => p.id === idPuntoVenta) ?? null
+  // Bajo `?idPresupuesto=` el punto de venta lo fija el propio presupuesto, nunca la sesión (el
+  // servidor recibe `idPuntoVenta` del body igual que siempre, pero acá viaja el del presupuesto).
+  const idPuntoVentaDelPresupuesto = presupuesto?.idPuntoVenta ?? null
+  const puntoVentaSeleccionada = modoPresupuesto
+    ? (puntosVenta.find((p) => p.id === idPuntoVentaDelPresupuesto) ?? null)
+    : puntoVentaDeSesion
 
   const medioPorId = useMemo(() => {
     const indice: Record<number, MedioPagoListado> = {}
@@ -366,36 +339,11 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
     return indice
   }, [medios])
 
-  // Carga inicial: puntos de venta (para el selector explícito de la operación, proposal
-  // decisión 3 — sin sesión de "punto de venta actual" en el servidor), clientes (para
-  // encontrar el Consumidor Final por defecto, spec: "Omitted idCliente defaults to Consumidor
-  // Final") y medios de pago (panel de pagos, Slice 7). Cada uno con su propio try/catch: que
-  // uno falle no bloquea a los otros.
+  // Carga inicial: clientes (para encontrar el Consumidor Final por defecto, spec: "Omitted
+  // idCliente defaults to Consumidor Final") y medios de pago (panel de pagos, Slice 7). Cada uno
+  // con su propio try/catch: que uno falle no bloquea al otro.
   useEffect(() => {
     let vigente = true
-
-    clienteDeOrganizacion
-      .listarPuntosVenta()
-      .then((lista) => {
-        if (!vigente) return
-        setPuntosVenta(lista)
-        // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=` el punto de venta lo
-        // fija el propio presupuesto (efecto dedicado más abajo) — este default NUNCA escribe
-        // acá, o ganaría una carrera contra esa asignación según cuál de las dos respuestas
-        // llegue primero.
-        if (!modoPresupuesto) {
-          const guardado = leerPuntoVentaGuardado()
-          const porDefecto = lista.find((p) => p.id === guardado) ?? lista[0] ?? null
-          setIdPuntoVenta(porDefecto ? porDefecto.id : '')
-        }
-      })
-      .catch((e) => {
-        if (!vigente) return
-        setPuntosVenta([])
-        setErrorPuntosVenta(
-          e instanceof ErrorApi ? e.message : 'No se pudieron cargar los puntos de venta. Seleccioná uno para operar.',
-        )
-      })
 
     const generacionClientes = (generacionClientesRef.current += 1)
 
@@ -407,7 +355,7 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
         // stage-17-presupuestos-y-remitos (Slice 7): bajo `?idPresupuesto=` el cliente lo trae el
         // presupuesto (efecto dedicado más abajo, hidrata el registro completo por id) — el
         // default de Consumidor Final NUNCA escribe acá bajo este modo, mismo criterio que el
-        // punto de venta.
+        // punto de venta (que bajo este modo sale del presupuesto y no de la sesión).
         if (!modoPresupuesto) {
           const consumidorFinal = pagina.items.find((c) => c.esConsumidorFinal) ?? null
           setClienteSeleccionado(consumidorFinal)
@@ -690,16 +638,6 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
     } finally {
       if (generacionClientesRef.current === generacion) setBuscandoClientes(false)
     }
-  }
-
-  function cambiarPuntoVenta(id: number) {
-    if (cobrandoRef.current) return
-    setIdPuntoVenta(id)
-    guardarPuntoVentaSeleccionado(id)
-    // Los saldos de lote son por punto de venta (stage-12-lotes-vencimientos, Slice 14): una
-    // elección hecha contra el PV anterior no tiene sentido en el nuevo — cada `SelectorDeLote`
-    // ya se resetea solo por su propio efecto, esto limpia el lado del carrito.
-    setLotesSeleccionados({})
   }
 
   /** Elección explícita de un lote en la línea de `idArticulo`, o `null` para volver al camino
@@ -1210,27 +1148,14 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
 
         <div className="col-lg-4">
           <Box titulo="Datos de la venta">
-            {errorPuntosVenta && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorPuntosVenta}</div>}
-
             <div className="mb-3">
-              <label className="form-label" htmlFor="pos-punto-venta">
-                Punto de venta
-              </label>
-              <select
-                id="pos-punto-venta"
-                className="form-select rounded-0"
-                value={idPuntoVenta}
-                disabled={puntosVenta === null || cobrando || modoPresupuesto}
-                onChange={(e) => cambiarPuntoVenta(Number(e.target.value))}
-              >
-                {puntosVenta === null && <option value="">Cargando…</option>}
-                {puntosVenta !== null && puntosVenta.length === 0 && <option value="">Sin puntos de venta disponibles</option>}
-                {puntosVenta?.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.nombre}
-                  </option>
-                ))}
-              </select>
+              {puntoVentaSeleccionada ? (
+                <>
+                  <span className="text-muted small">Punto de venta:</span> <strong>{puntoVentaSeleccionada.nombre}</strong>
+                </>
+              ) : (
+                <div className="alert alert-warning rounded-0 py-1 px-2 small">Sin puntos de venta disponibles</div>
+              )}
             </div>
 
             {errorClientes && <div className="alert alert-danger rounded-0 py-1 px-2 small">{errorClientes}</div>}
@@ -1406,14 +1331,18 @@ function PantallaPos({ idPresupuesto }: PropsPantallaPos) {
 
 /**
  * `/pos` (stage-17-presupuestos-y-remitos, Slice 7, design: Web composition — `react-async-state`
- * regla 8): lee `?idPresupuesto=` de la URL y remonta `PantallaPos` entera por `key` cuando
- * cambia — un `idPresupuesto` inválido o ausente se trata como el camino libre, nunca un error
- * bloqueante (la ruta sin query sigue siendo el POS de siempre).
+ * regla 8): lee `?idPresupuesto=` de la URL y el punto de venta de la sesión, y remonta
+ * `PantallaPos` entera por `key` cuando cualquiera de los dos cambia — un `idPresupuesto` inválido
+ * o ausente se trata como el camino libre, nunca un error bloqueante (la ruta sin query sigue
+ * siendo el POS de siempre).
  */
 export function Pos() {
   const [searchParams] = useSearchParams()
+  const { puntoVenta } = usePuntoVenta()
   const crudo = searchParams.get('idPresupuesto')
   const idPresupuesto = crudo !== null && Number.isFinite(Number(crudo)) ? Number(crudo) : null
 
-  return <PantallaPos key={idPresupuesto ?? 'libre'} idPresupuesto={idPresupuesto} />
+  return (
+    <PantallaPos key={`${idPresupuesto ?? 'libre'}:${puntoVenta?.id ?? 'sin-pv'}`} idPresupuesto={idPresupuesto} />
+  )
 }

--- a/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.test.tsx
@@ -6,6 +6,7 @@ import { ErrorApi } from '../api/cliente'
 import { ETIQUETA_SIN_DUENIO } from '../api/organizacion'
 import { ROL } from '../api/tipos'
 import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
 
 // stage-20-organizacion-relaciones-y-bajas, slice 2 (tareas 2.11 y 2.13) y slice 5 (5.5, 5.7, 5.8).
 
@@ -79,6 +80,27 @@ const pvEste = pvFixture({
   nombre: 'PV Este',
   nombreTenant: 'Almacén Este',
   razonSocialEmpresa: 'Este SRL',
+})
+
+/** La pantalla vive bajo `PuertaDePuntoVenta` y le pide `recargar` a la sesión tras cada escritura
+ * exitosa: el hook se mockea con un estado mutable que se reinicia antes de cada test. */
+function estadoDePuntoVentaPorDefecto(): EstadoDePuntoVenta {
+  return {
+    puntosVenta: [pvSurCentro],
+    puntoVenta: pvSurCentro,
+    elegir: vi.fn(),
+    recargar: vi.fn(() => Promise.resolve()),
+  }
+}
+
+let estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
+
+vi.mock('../puntoVenta/usePuntoVenta', () => ({
+  usePuntoVenta: () => estadoDePuntoVenta,
+}))
+
+beforeEach(() => {
+  estadoDePuntoVenta = estadoDePuntoVentaPorDefecto()
 })
 
 function montar(items: PuntoVentaListado[] = [pvSurCentro, pvSurAnexo, pvEste]) {
@@ -430,6 +452,8 @@ describe('PuntosVenta (stage-20, slice 5 — baja lógica)', () => {
         ),
       ).toBeInTheDocument(),
     )
+    // La sesión se recarga recién DESPUÉS de un refresco exitoso: con el refresco caído, nada.
+    expect(estadoDePuntoVenta.recargar).not.toHaveBeenCalled()
   })
 
   /**
@@ -604,5 +628,100 @@ describe('PuntosVenta (slice 5, ronda 1 — la puerta es modal y el token se acu
 
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     expect(screen.queryByText(/porque tiene 5 ventas/)).not.toBeInTheDocument()
+  })
+})
+
+// Punto de venta de sesión (slice 4): la sesión mira el mismo listado que esta pantalla edita, así
+// que un rename o una baja se propagan con `recargar` — una sola vez, y solo después de que el
+// refresco propio de la pantalla resolvió bien (`react-async-state` regla 6: fuera del try/catch
+// de la escritura, sin reportar nunca una escritura confirmada como fallida).
+
+describe('PuntosVenta — propagación al punto de venta de sesión', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset()
+    apiPutMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPutMock.mockResolvedValue(undefined)
+    apiDeleteMock.mockResolvedValue(undefined)
+    usuarioActual = usuarioFixture()
+  })
+
+  /** Cláusula bajo prueba: la posición de `recargar` DESPUÉS del `await cargar(token, true)`. Con
+   * el refresco todavía en vuelo no se llamó; recién al resolver, exactamente una vez. */
+  it('una edición exitosa recarga la sesión exactamente una vez, y recién después del refresco', async () => {
+    const usuario = userEvent.setup()
+    let cargas = 0
+    let resolverRefresco!: (items: PuntoVentaListado[]) => void
+    apiGetMock.mockImplementation((ruta: string) => {
+      if (ruta !== '/puntos-venta') return Promise.reject(new Error(`ruta inesperada: ${ruta}`))
+      cargas += 1
+      if (cargas === 1) return Promise.resolve([pvSurCentro])
+
+      return new Promise<PuntoVentaListado[]>((resolver) => {
+        resolverRefresco = resolver
+      })
+    })
+
+    render(<PuntosVenta />)
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(cargas).toBe(2))
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+    expect(estadoDePuntoVenta.recargar).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolverRefresco([pvFixture({ nombre: 'PV Centro renombrado' })])
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByText('PV Centro renombrado')).toBeInTheDocument())
+    expect(estadoDePuntoVenta.recargar).toHaveBeenCalledTimes(1)
+  })
+
+  it('una baja exitosa recarga la sesión exactamente una vez', async () => {
+    const usuario = userEvent.setup()
+    montar([pvSurCentro, pvEste])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Se dio de baja el punto de venta "PV Centro".')).toBeInTheDocument(),
+    )
+    await waitFor(() => expect(estadoDePuntoVenta.recargar).toHaveBeenCalledTimes(1))
+  })
+
+  it('una edición rechazada no recarga la sesión', async () => {
+    const usuario = userEvent.setup()
+    apiPutMock.mockRejectedValue(new ErrorApi(400, 'validacion', 'El nombre no puede quedar vacío.'))
+    montar([pvSurCentro])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(screen.getByRole('button', { name: 'Editar' }))
+    await usuario.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(screen.getByText('El nombre no puede quedar vacío.')).toBeInTheDocument())
+    expect(apiPutMock).toHaveBeenCalledTimes(1)
+    expect(estadoDePuntoVenta.recargar).not.toHaveBeenCalled()
+  })
+
+  it('una baja rechazada no recarga la sesión', async () => {
+    const usuario = userEvent.setup()
+    apiDeleteMock.mockRejectedValue(
+      new ErrorApi(409, 'punto_venta_en_uso', 'No se puede dar de baja el punto de venta porque tiene 5 ventas.'),
+    )
+    montar([pvSurCentro])
+    await waitFor(() => expect(screen.getByText('PV Centro')).toBeInTheDocument())
+
+    await usuario.click(botonDeBajaDe('PV Centro'))
+    await usuario.click(screen.getByRole('button', { name: 'Confirmar baja' }))
+
+    await waitFor(() => expect(screen.getByText(/porque tiene 5 ventas/)).toBeInTheDocument())
+    expect(apiDeleteMock).toHaveBeenCalledTimes(1)
+    expect(estadoDePuntoVenta.recargar).not.toHaveBeenCalled()
   })
 })

--- a/src/Ways.Web/src/paginas/PuntosVenta.tsx
+++ b/src/Ways.Web/src/paginas/PuntosVenta.tsx
@@ -17,6 +17,7 @@ import { Box } from '../componentes/Box'
 import { Cargando } from '../componentes/Cargando'
 import { ConfirmacionDeBaja } from '../componentes/ConfirmacionDeBaja'
 import { useAuth } from '../auth/useAuth'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
 import { ROL } from '../api/tipos'
 
 type Formulario = {
@@ -45,6 +46,7 @@ const AVISO_REFRESCO_FALLIDO_BAJA =
  */
 export function PuntosVenta() {
   const { usuario } = useAuth()
+  const { recargar } = usePuntoVenta()
   const esPlataforma = usuario?.rolId === ROL.Root
 
   const [items, setItems] = useState<PuntoVentaListado[]>([])
@@ -116,7 +118,14 @@ export function PuntosVenta() {
       await cargar(token, true)
     } catch {
       if (generacion.current === token) setAviso(`${mensajeOk} ${avisoDeFallo}`)
+
+      return
     }
+
+    // La sesión mira el mismo listado: un rename o una baja se propagan al punto de venta activo
+    // sin esperar un refresco de página. Sin `await` y con el rechazo tragado: esta pantalla no
+    // depende de ese resultado y un fallo ahí no cambia lo que ya se rindió.
+    void recargar().catch(() => {})
   }
 
   async function guardar() {


### PR DESCRIPTION
Closes #183

## Resumen

Slice 4 de 5. Monta la puerta del punto de venta de sesion y migra en el mismo cambio a las tres pantallas que tenian selector propio, para que en main nunca convivan dos fuentes del punto de venta.

- `App.tsx`: `<RutaProtegida><PuertaDePuntoVenta><Layout/></PuertaDePuntoVenta></RutaProtegida>`. Desde aca, al iniciar sesion un punto de venta se elige solo, varios piden elegir a pantalla completa, Root pasa sin pedir nada.
- `Pos.tsx` (+31/−102), `Caja.tsx` (+37/−108), `ConsultaPrecios.tsx` (+26/−50): sin selector, sin fetch de `/puntos-venta`, sin clave de localStorage. El punto de venta viene de `usePuntoVenta()` y se muestra como texto ("Punto de venta: Centro"); si no hay ninguno, un aviso y la operacion bloqueada. Cada pantalla remonta por `key` del id de punto de venta (`react-async-state` reglas 8 y 10): carrito, lotes elegidos, gate de turno, formularios de caja y resultado de consulta no sobreviven a un cambio. En modo presupuesto el POS sigue fijando el punto de venta del presupuesto, buscado en la lista de sesion. Todos los send-sites de `idPuntoVenta`/`idEmpresa` quedan como estaban (verificado por ambos jueces uno por uno).
- `Caja.tsx` pierde el `escribiendo` levantado y `onEscribiendoCambio`: solo los leian `cambiarPuntoVenta` y el `disabled` del selector. Cada formulario conserva su `abriendoRef`/`registrandoRef`.
- `PuntosVenta.tsx`: `recargar()` del contexto tras un refresh exitoso de edicion o baja (fuera del try/catch de la escritura, fire-and-forget), asi el nombre de sesion no queda viejo.
- Tests: mock del hook en las cuatro suites; tests de remonte por cambio de punto de venta en POS, Caja y Consulta de precios con evidencia de mutacion; el test de lotes stale del POS migra a `componentes/SelectorDeLote.test.tsx` (la clausula bajo prueba era del selector, no del POS); `recargar` probado en edicion, baja y sus fallos; se borra el describe de Caja que probaba el `disabled` de un selector que ya no existe.

## Judgment-day: APROBADO en ronda 1

Ronda 0 (dos jueces ciegos sobre fc03cec): un hallazgo confirmado por ambos, S4-1, Consulta de precios remontaba por `key` igual que POS y Caja pero era la unica sin el test que lo prueba (quitar el segmento del id de la `key` dejaba la suite verde). Correccion acotada solo a ese test (2d7abcb, produccion intacta), mutante muerto exactamente por el test nuevo. Re-judicacion acotada: cero hallazgos en ambos.

Quedan como info, sin corregir aca:

- S4-2: en modo presupuesto, si el punto de venta del presupuesto ya no esta en la lista de sesion, el aviso dice "Sin puntos de venta disponibles" aunque la sesion tenga otros; el cobro queda bloqueado igual que antes. Follow-up de copy.
- S4-3: si un Admin da de baja su propio punto de venta activo y quedan varios, la puerta reemplaza la pagina por el selector (por diseno del slice 3) y el aviso "Se dio de baja..." no llega a verse. Follow-up de UX: una nota en el selector cuando llega por reconciliacion.

## Suites

```
npx tsc -b        limpio
npx oxlint        exit 0 (5 warnings preexistentes, ninguno nuevo)
npx vitest run    75 archivos / 1220 tests
```

Flakes preexistentes vistos una vez cada uno durante el trabajo (Reposicion, Vencimientos, OrdenDeCompra: leen el mock antes de que termine la carga), verdes al reintentar; anotados como tarea aparte.

## Tamano

~900 lineas: 513 agregadas y 378 borradas en el primer commit, mas ~50 del test de la ronda 1. No se puede partir: `usePuntoVenta` lanza fuera del proveedor, asi que ninguna pantalla migrada puede aterrizar antes del montaje, y el montaje no puede aterrizar mientras alguna pantalla conserve su selector. Etiquetado `size:exception`.
