### PR TITLE
feat(web): cambio de punto de venta desde la cabecera (slice 5 de nav y punto de venta de sesion)

### DIFF
--- a/src/Ways.Web/src/App.tsx
+++ b/src/Ways.Web/src/App.tsx
@@ -6,6 +6,7 @@ import { Articulos } from './paginas/Articulos'
 import { Auditoria } from './paginas/Auditoria'
 import { Caja } from './paginas/Caja'
 import { CajaZ } from './paginas/CajaZ'
+import { CambiarPuntoDeVenta } from './paginas/CambiarPuntoDeVenta'
 import { CierreDeCaja } from './paginas/CierreDeCaja'
 import { Categorias } from './paginas/Categorias'
 import { CatalogosFiscales } from './paginas/CatalogosFiscales'
@@ -87,6 +88,17 @@ export function App() {
               element={
                 <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
                   <Pos />
+                </RutaProtegida>
+              }
+            />
+            {/* nav-y-pv (Slice 5, design B: cabecera): cambio del punto de venta de sesión,
+                se entra desde la insignia de la barra y se vuelve a la pantalla de origen.
+                Misma política que /pos (Politicas.OperacionDePos): Root no opera ninguno. */}
+            <Route
+              path="/punto-de-venta"
+              element={
+                <RutaProtegida rolesPermitidos={[ROL.Vendedor, ROL.Supervisor, ROL.Admin]}>
+                  <CambiarPuntoDeVenta />
                 </RutaProtegida>
               }
             />

--- a/src/Ways.Web/src/componentes/Layout.test.tsx
+++ b/src/Ways.Web/src/componentes/Layout.test.tsx
@@ -4,7 +4,8 @@ import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Layout } from './Layout'
 import { ROL } from '../api/tipos'
-import type { UsuarioAutenticado } from '../api/tipos'
+import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
 
 function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): UsuarioAutenticado {
   return {
@@ -19,16 +20,56 @@ function usuarioFixture(sobrescribir: Partial<UsuarioAutenticado> = {}): Usuario
   }
 }
 
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 100,
+    idTenant: 1,
+    idEmpresa: 10,
+    nombre: 'Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    nombreTenant: null,
+    razonSocialEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+const centro = puntoVentaFixture()
+const norte = puntoVentaFixture({ id: 101, nombre: 'Norte' })
+
+function estadoConPuntosVenta(
+  puntosVenta: PuntoVentaListado[],
+  puntoVenta: PuntoVentaListado | null,
+): EstadoDePuntoVenta {
+  return { puntosVenta, puntoVenta, elegir: vi.fn(), recargar: vi.fn(() => Promise.resolve()) }
+}
+
 let usuarioActual: UsuarioAutenticado | null = usuarioFixture()
+let estadoDePuntoVenta = estadoConPuntosVenta([centro, norte], centro)
 const cerrarSesionMock = vi.fn(async () => {})
 
 vi.mock('../auth/useAuth', () => ({
   useAuth: () => ({ usuario: usuarioActual, cargando: false, iniciarSesion: vi.fn(), cerrarSesion: cerrarSesionMock }),
 }))
 
+vi.mock('../puntoVenta/usePuntoVenta', () => ({ usePuntoVenta: () => estadoDePuntoVenta }))
+
+type EstadoDeRuta = { desde?: { pathname: string; search: string } }
+
 function Contenido() {
-  const { pathname } = useLocation()
-  return <main>Contenido de {pathname}</main>
+  const { pathname, state } = useLocation()
+  const desde = (state as EstadoDeRuta | null)?.desde
+
+  return (
+    <main>
+      Contenido de {pathname}
+      {desde && ` desde ${desde.pathname}${desde.search}`}
+    </main>
+  )
 }
 
 function renderLayout(ruta = '/') {
@@ -52,6 +93,13 @@ function barra() {
   return within(colapso)
 }
 
+/** La franja de color que antecede a la barra. */
+function franja() {
+  const elemento = document.querySelector('nav.ways-nav')
+  if (!elemento) throw new Error('no hay franja de color')
+  return elemento
+}
+
 const nombres = (elementos: HTMLElement[]) => elementos.map((elemento) => elemento.textContent)
 
 /** Entradas de primer nivel alcanzables (los ítems de un grupo cerrado quedan afuera por `hidden`)
@@ -65,6 +113,7 @@ function entradasActivas() {
 
 beforeEach(() => {
   usuarioActual = usuarioFixture()
+  estadoDePuntoVenta = estadoConPuntosVenta([centro, norte], centro)
   cerrarSesionMock.mockClear()
 })
 
@@ -122,6 +171,22 @@ describe('Layout — barra de navegación agrupada', () => {
     const [activa] = entradasActivas()
     expect(activa).toBe(screen.getByRole('button', { name: 'Reportes' }))
     expect(screen.queryByRole('link', { name: 'Caja' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('Vender anuncia la ruta actual con aria-current, nunca con la clase active del botón', () => {
+    renderLayout('/pos')
+
+    const vender = barra().getByRole('link', { name: 'Vender' })
+    expect(vender).toHaveAttribute('aria-current', 'page')
+    expect(vender).not.toHaveClass('active')
+  })
+
+  it('Caja anuncia la ruta actual con aria-current y con la clase active del nav-link', () => {
+    renderLayout('/caja')
+
+    const caja = barra().getByRole('link', { name: 'Caja' })
+    expect(caja).toHaveAttribute('aria-current', 'page')
+    expect(caja).toHaveClass('nav-link', 'active')
   })
 
   it('abrir Administración muestra las secciones del Admin con sus encabezados', async () => {
@@ -197,6 +262,23 @@ describe('Layout — barra de navegación agrupada', () => {
     expect(screen.getByRole('button', { name: 'Abrir menú' })).toHaveAttribute('aria-expanded', 'false')
   })
 
+  // Cláusula bajo prueba: el `onClick` de los links de primer nivel. Acá `pathname` no cambia,
+  // así que el efecto que cierra la barra al navegar no corre.
+  // Evidencia de mutación: sin el `onClick` el alternador queda con aria-expanded="true".
+  it('tocar el link de la ruta ya activa cierra el menú móvil abierto', async () => {
+    const usuario = userEvent.setup()
+    renderLayout('/caja')
+    const alternador = screen.getByRole('button', { name: 'Abrir menú' })
+
+    await usuario.click(alternador)
+    expect(alternador).toHaveAttribute('aria-expanded', 'true')
+
+    await usuario.click(screen.getByRole('link', { name: 'Caja' }))
+
+    expect(screen.getByText('Contenido de /caja')).toBeInTheDocument()
+    expect(alternador).toHaveAttribute('aria-expanded', 'false')
+  })
+
   it('Salir cierra la sesión y lleva a /login', async () => {
     const usuario = userEvent.setup()
     renderLayout('/pos')
@@ -220,5 +302,64 @@ describe('Layout — barra de navegación agrupada', () => {
 
     expect(cerrarSesionMock).toHaveBeenCalledTimes(1)
     expect(screen.getByText('Pantalla de login')).toBeInTheDocument()
+  })
+})
+
+describe('Layout — punto de venta en la cabecera', () => {
+  it('con más de un punto de venta el nombre es un link a /punto-de-venta que lleva la ubicación actual', async () => {
+    const usuario = userEvent.setup()
+    renderLayout('/caja?turno=3')
+
+    const insignia = screen.getByRole('link', { name: 'Punto de venta Centro, cambiar' })
+    expect(insignia).toHaveAttribute('href', '/punto-de-venta')
+    expect(insignia).toHaveTextContent('Centro')
+
+    await usuario.click(insignia)
+
+    expect(screen.getByText('Contenido de /punto-de-venta desde /caja?turno=3')).toBeInTheDocument()
+  })
+
+  it('en /punto-de-venta el nombre deja de ser link y marca la página actual', () => {
+    renderLayout('/punto-de-venta')
+
+    expect(screen.queryByRole('link', { name: /Punto de venta/ })).not.toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Centro')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('con un solo punto de venta muestra el nombre como texto, sin link para cambiarlo', () => {
+    estadoDePuntoVenta = estadoConPuntosVenta([centro], centro)
+    renderLayout()
+
+    expect(screen.queryByRole('link', { name: /Punto de venta/ })).not.toBeInTheDocument()
+    expect(screen.getByText('Punto de venta: Centro')).not.toHaveAttribute('aria-current')
+  })
+
+  it('sin punto de venta activo avisa a quien opera el POS', () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Vendedor, rol: 'Vendedor' })
+    estadoDePuntoVenta = estadoConPuntosVenta([], null)
+    renderLayout()
+
+    expect(screen.getByText('Sin punto de venta')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Punto de venta/ })).not.toBeInTheDocument()
+  })
+
+  it('Root no ve nada del punto de venta', () => {
+    usuarioActual = usuarioFixture({ rolId: ROL.Root, rol: 'Root', idTenant: null })
+    estadoDePuntoVenta = estadoConPuntosVenta([], null)
+    renderLayout()
+
+    expect(screen.queryByText('Sin punto de venta')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Punto de venta/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Punto de venta/ })).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { puntoVenta: centro, color: 'color_1' },
+    { puntoVenta: norte, color: 'color_2' },
+  ])('con $puntoVenta.nombre activo la franja lleva la clase $color', ({ puntoVenta, color }) => {
+    estadoDePuntoVenta = estadoConPuntosVenta([centro, norte], puntoVenta)
+    renderLayout()
+
+    expect(franja().className).toBe(`ways-nav ${color}`)
   })
 })

--- a/src/Ways.Web/src/componentes/Layout.tsx
+++ b/src/Ways.Web/src/componentes/Layout.tsx
@@ -1,27 +1,80 @@
 import { useEffect, useId, useRef, useState } from 'react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router'
+import type { Location } from 'react-router'
+import { puedeOperarPos } from '../api/tipos'
+import type { PuntoVentaListado, UsuarioAutenticado } from '../api/tipos'
 import { useAuth } from '../auth/useAuth'
+import { colorDePuntoVenta } from '../puntoVenta/colorDePuntoVenta'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
 import { MenuDesplegable } from './MenuDesplegable'
 import { construirMenu, esRutaActiva } from './menu'
 
+const RUTA_DE_CAMBIO_DE_PUNTO_VENTA = '/punto-de-venta'
+
+// El botón principal anuncia la ruta actual solo con `aria-current`: la clase `active` de
+// Bootstrap lo pintaría como "presionado".
 function claseDeEnlace(principal: boolean | undefined, activo: boolean) {
-  const base = principal ? 'btn btn-success rounded-0 fw-bold me-2' : 'nav-link'
-  return activo ? `${base} active` : base
+  if (principal) return 'btn btn-success rounded-0 fw-bold me-2'
+  return activo ? 'nav-link active' : 'nav-link'
+}
+
+type PropsDeInsignia = {
+  usuario: UsuarioAutenticado
+  puntoVenta: PuntoVentaListado | null
+  puntosVenta: PuntoVentaListado[]
+  ubicacion: Location
+}
+
+function InsigniaDePuntoVenta({ usuario, puntoVenta, puntosVenta, ubicacion }: PropsDeInsignia) {
+  if (!puedeOperarPos(usuario.rolId)) return null
+
+  if (!puntoVenta) {
+    return <span className="text-warning small">Sin punto de venta</span>
+  }
+
+  if (puntosVenta.length <= 1) {
+    return <span className="text-light small">Punto de venta: {puntoVenta.nombre}</span>
+  }
+
+  if (ubicacion.pathname === RUTA_DE_CAMBIO_DE_PUNTO_VENTA) {
+    return (
+      <span className="text-light small" aria-current="page">
+        Punto de venta: {puntoVenta.nombre}
+      </span>
+    )
+  }
+
+  return (
+    <Link
+      to={RUTA_DE_CAMBIO_DE_PUNTO_VENTA}
+      state={{ desde: ubicacion }}
+      className="btn btn-outline-light btn-sm rounded-0"
+      aria-label={`Punto de venta ${puntoVenta.nombre}, cambiar`}
+    >
+      {puntoVenta.nombre}
+    </Link>
+  )
 }
 
 export function Layout() {
   const { usuario, cerrarSesion } = useAuth()
+  const { puntoVenta, puntosVenta } = usePuntoVenta()
   const navegar = useNavigate()
-  const { pathname } = useLocation()
+  const ubicacion = useLocation()
+  const { pathname } = ubicacion
   const idColapso = useId()
   const [colapsoAbierto, setColapsoAbierto] = useState(false)
   const [grupoAbierto, setGrupoAbierto] = useState<string | null>(null)
   const saliendoRef = useRef(false)
 
-  // Cualquier navegación deja la barra en reposo: sin grupo desplegado ni menú móvil abierto.
-  useEffect(() => {
+  function dejarBarraEnReposo() {
     setGrupoAbierto(null)
     setColapsoAbierto(false)
+  }
+
+  // Cualquier navegación deja la barra en reposo: sin grupo desplegado ni menú móvil abierto.
+  useEffect(() => {
+    dejarBarraEnReposo()
   }, [pathname])
 
   async function salir() {
@@ -40,9 +93,7 @@ export function Layout() {
   return (
     <div id="wrap" className="bg-dark dk">
       <div id="top">
-        {/* Franja de color del punto de venta. Hoy es fija; cuando exista la tabla
-            de puntos de venta vuelve a pintar según el local activo. */}
-        <nav className="ways-nav color_1" />
+        <nav className={`ways-nav ${colorDePuntoVenta(puntoVenta, puntosVenta)}`} />
 
         <nav className="navbar navbar-dark navbar-expand-lg bg-dark border-top-0">
           <div className="container">
@@ -86,10 +137,13 @@ export function Layout() {
 
                   return (
                     <li className="nav-item" key={entrada.a}>
+                      {/* Elegir la ruta ya activa no cambia `pathname`, así que el efecto no
+                          alcanza para cerrar la barra: lo hace el propio clic. */}
                       <Link
                         to={entrada.a}
                         className={claseDeEnlace(entrada.principal, activo)}
                         aria-current={activo ? 'page' : undefined}
+                        onClick={dejarBarraEnReposo}
                       >
                         {entrada.etiqueta}
                       </Link>
@@ -103,6 +157,14 @@ export function Layout() {
               <span className="text-light small">
                 {usuario?.usuario} <span className="text-secondary">· {usuario?.rol}</span>
               </span>
+              {usuario && (
+                <InsigniaDePuntoVenta
+                  usuario={usuario}
+                  puntoVenta={puntoVenta}
+                  puntosVenta={puntosVenta}
+                  ubicacion={ubicacion}
+                />
+              )}
               <button
                 type="button"
                 className="btn btn-danger rounded-0"

--- a/src/Ways.Web/src/paginas/CambiarPuntoDeVenta.test.tsx
+++ b/src/Ways.Web/src/paginas/CambiarPuntoDeVenta.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
+import type { InitialEntry } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CambiarPuntoDeVenta } from './CambiarPuntoDeVenta'
+import type { PuntoVentaListado } from '../api/tipos'
+import type { EstadoDePuntoVenta } from '../puntoVenta/PuntoVentaContext'
+
+function puntoVentaFixture(sobrescribir: Partial<PuntoVentaListado> = {}): PuntoVentaListado {
+  return {
+    id: 100,
+    idTenant: 2,
+    idEmpresa: 20,
+    nombre: 'Local Centro',
+    domicilio: null,
+    horario: null,
+    whatsapp: null,
+    instagram: null,
+    facebook: null,
+    web: null,
+    nombreTenant: null,
+    razonSocialEmpresa: null,
+    ...sobrescribir,
+  }
+}
+
+const centro = puntoVentaFixture()
+const norte = puntoVentaFixture({ id: 101, nombre: 'Local Norte' })
+
+function estadoConPuntosVenta(
+  puntosVenta: PuntoVentaListado[],
+  puntoVenta: PuntoVentaListado | null,
+): EstadoDePuntoVenta {
+  return { puntosVenta, puntoVenta, elegir: vi.fn(), recargar: vi.fn(() => Promise.resolve()) }
+}
+
+let estadoDePuntoVenta = estadoConPuntosVenta([centro, norte], centro)
+
+vi.mock('../puntoVenta/usePuntoVenta', () => ({ usePuntoVenta: () => estadoDePuntoVenta }))
+
+/** Cualquier otra ruta: muestra dónde se llegó y permite volver atrás en el historial. */
+function Destino() {
+  const { pathname, search } = useLocation()
+  const navegar = useNavigate()
+
+  return (
+    <main>
+      <p>
+        Llegaste a {pathname}
+        {search}
+      </p>
+      <button type="button" onClick={() => navegar(-1)}>
+        Volver
+      </button>
+    </main>
+  )
+}
+
+function renderPagina(...entradas: InitialEntry[]) {
+  return render(
+    <MemoryRouter initialEntries={entradas}>
+      <Routes>
+        <Route path="/punto-de-venta" element={<CambiarPuntoDeVenta />} />
+        <Route path="*" element={<Destino />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+const selectorDesdeCaja: InitialEntry = {
+  pathname: '/punto-de-venta',
+  state: { desde: { pathname: '/caja', search: '?turno=3' } },
+}
+
+beforeEach(() => {
+  estadoDePuntoVenta = estadoConPuntosVenta([centro, norte], centro)
+})
+
+describe('CambiarPuntoDeVenta', () => {
+  it('elegir otro punto de venta lo activa y vuelve a la pantalla de origen con su query', async () => {
+    renderPagina(selectorDesdeCaja)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+
+    expect(estadoDePuntoVenta.elegir).toHaveBeenCalledTimes(1)
+    expect(estadoDePuntoVenta.elegir).toHaveBeenCalledWith(101)
+    expect(screen.getByText('Llegaste a /caja?turno=3')).toBeInTheDocument()
+  })
+
+  it('la vuelta reemplaza al selector en el historial: volver atrás no regresa a él', async () => {
+    renderPagina('/caja', selectorDesdeCaja)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Volver' }))
+
+    expect(screen.getByText('Llegaste a /caja')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Elegí el punto de venta' })).not.toBeInTheDocument()
+  })
+
+  // Cláusula bajo prueba: `desde.pathname !== RUTA_PROPIA` al calcular el destino.
+  // Evidencia de mutación: sin la cláusula el destino es el propio selector, la pantalla se queda
+  // en él y "Llegaste a /" nunca aparece.
+  it('si el origen guardado es el propio selector, vuelve al inicio', async () => {
+    renderPagina({
+      pathname: '/punto-de-venta',
+      state: { desde: { pathname: '/punto-de-venta', search: '' } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+
+    expect(screen.getByText('Llegaste a /')).toBeInTheDocument()
+  })
+
+  it('sin origen guardado vuelve al inicio', async () => {
+    renderPagina('/punto-de-venta')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Local Norte' }))
+
+    expect(estadoDePuntoVenta.elegir).toHaveBeenCalledWith(101)
+    expect(screen.getByText('Llegaste a /')).toBeInTheDocument()
+  })
+
+  it('marca el punto de venta activo como actual', () => {
+    renderPagina('/punto-de-venta')
+
+    expect(screen.getByRole('button', { name: 'Local Centro (actual)' })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('button', { name: 'Local Norte' })).not.toHaveAttribute('aria-current')
+  })
+
+  // Cláusula bajo prueba: `puntosVenta.length > 1` decide si se ofrece el selector.
+  // Evidencia de mutación: con `>= 1` el único punto de venta aparece como botón y el aviso no.
+  it('con un solo punto de venta muestra su nombre y avisa que no hay otro, sin botones', () => {
+    estadoDePuntoVenta = estadoConPuntosVenta([centro], centro)
+    renderPagina('/punto-de-venta')
+
+    expect(screen.getByText('Local Centro')).toBeInTheDocument()
+    expect(screen.getByText('Este es el único punto de venta disponible.')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toEqual([])
+    expect(estadoDePuntoVenta.elegir).not.toHaveBeenCalled()
+  })
+
+  it('sin puntos de venta lo avisa', () => {
+    estadoDePuntoVenta = estadoConPuntosVenta([], null)
+    renderPagina('/punto-de-venta')
+
+    expect(screen.getByText('Sin puntos de venta disponibles')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toEqual([])
+  })
+})

--- a/src/Ways.Web/src/paginas/CambiarPuntoDeVenta.tsx
+++ b/src/Ways.Web/src/paginas/CambiarPuntoDeVenta.tsx
@@ -1,0 +1,44 @@
+import { useLocation, useNavigate } from 'react-router'
+import { Box } from '../componentes/Box'
+import { ElegirPuntoDeVenta } from '../puntoVenta/ElegirPuntoDeVenta'
+import { usePuntoVenta } from '../puntoVenta/usePuntoVenta'
+
+type EstadoDeRuta = { desde?: { pathname: string; search: string } }
+
+const RUTA_PROPIA = '/punto-de-venta'
+
+export function CambiarPuntoDeVenta() {
+  const { puntosVenta, puntoVenta, elegir } = usePuntoVenta()
+  const navegar = useNavigate()
+  const ubicacion = useLocation()
+
+  const desde = (ubicacion.state as EstadoDeRuta | null)?.desde
+  // Se vuelve a la pantalla que pidió el cambio; si fue esta misma o no hubo ninguna, al inicio.
+  const destino = desde && desde.pathname !== RUTA_PROPIA ? `${desde.pathname}${desde.search ?? ''}` : '/'
+
+  function alElegir(id: number) {
+    elegir(id)
+    navegar(destino, { replace: true })
+  }
+
+  if (puntosVenta.length > 1) {
+    return <ElegirPuntoDeVenta puntosVenta={puntosVenta} actual={puntoVenta?.id ?? null} alElegir={alElegir} />
+  }
+
+  const unico = puntosVenta.at(0)
+
+  return (
+    <div className="container py-4">
+      <Box titulo="Punto de venta" variante="inverse">
+        {unico ? (
+          <>
+            <p className="h4 mb-2">{unico.nombre}</p>
+            <p className="text-muted mb-0">Este es el único punto de venta disponible.</p>
+          </>
+        ) : (
+          <div className="alert alert-warning rounded-0 mb-0">Sin puntos de venta disponibles</div>
+        )}
+      </Box>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #185

## Resumen

Slice 5 de 5, cierra la serie de navegacion y punto de venta de sesion.

- `Layout.tsx`: badge del punto de venta a la derecha, antes de Salir. Con varios puntos de venta es un `Link` a `/punto-de-venta` con `state.desde` y nombre accesible "Punto de venta Centro, cambiar"; parado en `/punto-de-venta` es un `span` con `aria-current`; con uno solo es texto "Punto de venta: Centro"; un operador sin punto de venta ve "Sin punto de venta"; Root no ve nada. La banda `ways-nav` toma `colorDePuntoVenta(puntoVenta, puntosVenta)`: naranja o violeta segun el punto de venta, como el sistema viejo.
- `paginas/CambiarPuntoDeVenta.tsx` + ruta `/punto-de-venta` (Vendedor, Supervisor, Admin): reusa `ElegirPuntoDeVenta` marcando el actual; al elegir llama `elegir(id)` y vuelve con `replace` a `state.desde` (ruta + query), o al inicio si no hay origen o el origen es el propio selector, asi "atras" nunca vuelve al selector. Con un solo punto de venta muestra el nombre y "Este es el unico punto de venta disponible."; sin ninguno, el aviso.
- Dos items informativos del judgment-day del slice 2 (#182): los enlaces planos (Vender, Caja) cierran el grupo abierto y el menu mobile al hacer click aunque la ruta ya este activa (el efecto por `pathname` no alcanzaba); Vender conserva `aria-current` pero ya no recibe la clase `active` del boton.
- Tests: Layout (+144: badge por rol, cantidad y ruta; banda por punto de venta; cierre del menu mobile en ruta activa; Vender sin `active`) y `CambiarPuntoDeVenta.test.tsx` (150: `desde` con query preservada, `replace` probado con un "Volver", autorreferencia, sin estado, actual marcado, uno y ninguno).

Elegir otro punto de venta es navegar: el POS y Caja se desmontan como con cualquier otro link de la barra, y al volver remontan con el punto de venta nuevo.

## Judgment-day: APROBADO en ronda limpia

Dos jueces ciegos sobre 89ece91 (mismo contenido que a27a550, rebaseado). Juez B: cero hallazgos (trazo el batching de `elegir` + `navegar` en el mismo click para descartar un flash del selector). Juez A: un WARNING y dos SUGGESTION, sin CRITICAL, registrados como info:

- WARNING: ningun test abre un grupo desplegable y despues clickea un enlace plano de la ruta ya activa; el `onClick` resetea grupo y collapse, pero solo el collapse esta probado por ese camino.
- SUGGESTION: `/punto-de-venta` como literal en tres archivos y el tipo `EstadoDeRuta` repetido en tres archivos; candidatos a un modulo compartido.

Evidencia de mutacion registrada: cuatro mutantes (autorreferencia, `length > 1`, `onClick` de los enlaces, `active` en Vender), cada uno muerto por exactamente un test.

## Suites

```
npx tsc -b        limpio
npx oxlint        exit 0 (5 warnings preexistentes, ninguno nuevo)
npx vitest run    76 archivos / 1237 tests (17 nuevos), dos corridas completas verdes
```

## Tamano

431 lineas: 420 agregadas y 11 borradas. Produccion ~126 (Layout +62, pagina 44, App +12); tests ~294. Apenas sobre el presupuesto por los tests; etiquetado `size:exception`.
